### PR TITLE
chore: establish release foundation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.turbo
+**/.turbo
+node_modules
+**/node_modules
+dist
+**/dist
+coverage
+**/coverage
+.env
+.env.*
+!.env.example
+*.log
+*.tsbuildinfo
+Dockerfile*
+docker-compose*.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      development-tooling:
+        dependency-type: development
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,36 +15,43 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    name: CI
+  checks:
+    name: Checks
     runs-on: ubuntu-latest
     steps:
       - name: Validate pull request branch name
         if: github.event_name == 'pull_request'
         env:
+          ACTOR: ${{ github.actor }}
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
           case "$BRANCH_NAME" in
             feat/*|fix/*|refactor/*|test/*|docs/*|chore/*|merge/*) ;;
+            dependabot/npm_and_yarn/*|dependabot/github_actions/*)
+              if [ "$ACTOR" != "dependabot[bot]" ]; then
+                echo "Dependabot branch prefix is reserved for dependabot[bot]" >&2
+                exit 1
+              fi
+              ;;
             *) echo "Invalid branch name: $BRANCH_NAME" >&2; exit 1 ;;
           esac
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.12.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.13.1
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --config.engine-strict=true
 
       - name: Check formatting and lint rules
         run: pnpm check
@@ -57,3 +64,131 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  cli-pack-smoke:
+    name: CLI Pack Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.12.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.13.1
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --config.engine-strict=true
+
+      - name: Build source CLI and dependencies
+        run: pnpm exec turbo run build --filter=open-tag...
+
+      - name: Resolve deterministic pack coordinates
+        id: version
+        run: |
+          SOURCE_NAME=$(node -p "require('./apps/cli/package.json').name")
+          SOURCE_VERSION=$(node -p "require('./apps/cli/package.json').version")
+          SOURCE_BINARY=$(node -p "Object.keys(require('./apps/cli/package.json').bin)[0]")
+          printf 'source_name=%s\nsource_version=%s\nsource_binary=%s\n' \
+            "$SOURCE_NAME" "$SOURCE_VERSION" "$SOURCE_BINARY" >> "$GITHUB_OUTPUT"
+          node scripts/release-versions.mjs \
+            --channel staging \
+            --source-version "$SOURCE_VERSION" \
+            --run-number "${{ github.run_number }}" \
+            --run-attempt "${{ github.run_attempt }}"
+
+      - name: Smoke source tarball
+        run: >-
+          node scripts/cli-pack-smoke.mjs
+          --channel source
+          --name "${{ steps.version.outputs.source_name }}"
+          --version "${{ steps.version.outputs.source_version }}"
+          --binary "${{ steps.version.outputs.source_binary }}"
+
+      - name: Prepare deterministic staging identity
+        run: >-
+          node scripts/prepare-cli-release.mjs
+          --channel staging
+          --version "${{ steps.version.outputs.version }}"
+
+      - name: Rebuild staging CLI
+        run: pnpm --dir apps/cli build
+
+      - name: Smoke staging tarball
+        run: >-
+          node scripts/cli-pack-smoke.mjs
+          --channel staging
+          --name "${{ steps.version.outputs.package_name }}"
+          --version "${{ steps.version.outputs.version }}"
+          --binary "${{ steps.version.outputs.binary_name }}"
+
+  container-smoke:
+    name: Container Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Build image
+        run: docker build --tag opentag-server:ci .
+
+      - name: Start container
+        run: docker run --detach --name opentag-server-ci --publish 18000:8000 opentag-server:ci
+
+      - name: Wait for health endpoint
+        run: |
+          for attempt in $(seq 1 30); do
+            if response=$(curl --fail --silent http://127.0.0.1:18000/healthz); then
+              node -e '
+                const health = JSON.parse(process.argv[1]);
+                if (health.status !== "ok" || health.service !== "opentag-server") {
+                  throw new Error(`Unexpected health response: ${process.argv[1]}`);
+                }
+              ' "$response"
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs opentag-server-ci
+          exit 1
+
+      - name: Verify runtime boundary
+        run: |
+          test "$(docker inspect --format '{{.Config.User}}' opentag-server-ci)" = "opentag"
+          if docker exec opentag-server-ci test -e /app/apps/cli; then
+            echo "CLI artifact must not be present in the server image" >&2
+            exit 1
+          fi
+          docker exec opentag-server-ci test -f /app/LICENSE
+
+      - name: Stop container
+        if: always()
+        run: docker rm --force opentag-server-ci
+
+  ci:
+    name: CI
+    if: always()
+    needs:
+      - checks
+      - cli-pack-smoke
+      - container-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          CHECKS_RESULT: ${{ needs.checks.result }}
+          CLI_PACK_RESULT: ${{ needs.cli-pack-smoke.result }}
+          CONTAINER_RESULT: ${{ needs.container-smoke.result }}
+        run: |
+          for result in "$CHECKS_RESULT" "$CLI_PACK_RESULT" "$CONTAINER_RESULT"; do
+            if [ "$result" != "success" ]; then
+              echo "Required CI job did not succeed: $result" >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,70 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish GHCR Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate production release coordinate
+        env:
+          REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REPOSITORY_VISIBILITY" != "public" ]; then
+            echo "Production images require a public source repository" >&2
+            exit 1
+          fi
+          SOURCE_VERSION=$(node -p "require('./apps/cli/package.json').version")
+          node scripts/release-versions.mjs \
+            --channel prod \
+            --source-version "$SOURCE_VERSION" \
+            --tag "$TAG_NAME"
+          git fetch origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
+            echo "Production tag must point to a commit in main history" >&2
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image metadata
+        id: metadata
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and publish image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          provenance: mode=max
+          sbom: true

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -1,0 +1,211 @@
+name: npm Publish
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  staging:
+    name: Publish CLI Staging
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       github.event.workflow_run.head_branch == 'main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the successful main revision
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.12.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Use trusted-publishing npm client
+        run: npm install --global npm@11.5.1
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --config.engine-strict=true
+
+      - name: Check source formatting and lint rules
+        run: pnpm check
+
+      - name: Build source workspaces
+        run: pnpm build
+
+      - name: Type-check source workspaces
+        run: pnpm typecheck
+
+      - name: Resolve release revision
+        id: revision
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve staging version
+        id: version
+        run: |
+          SOURCE_VERSION=$(node -p "require('./apps/cli/package.json').version")
+          node scripts/release-versions.mjs \
+            --channel staging \
+            --source-version "$SOURCE_VERSION" \
+            --run-number "${{ github.run_number }}" \
+            --run-attempt "${{ github.run_attempt }}"
+
+      - name: Check npm coordinate
+        id: registry
+        run: >-
+          node scripts/check-npm-version.mjs
+          --package "${{ steps.version.outputs.package_name }}"
+          --version "${{ steps.version.outputs.version }}"
+          --git-head "${{ steps.revision.outputs.sha }}"
+
+      - name: Prepare staging package identity
+        run: >-
+          node scripts/prepare-cli-release.mjs
+          --channel staging
+          --version "${{ steps.version.outputs.version }}"
+
+      - name: Build staging CLI
+        run: pnpm --dir apps/cli build
+
+      - name: Type-check staging CLI
+        run: pnpm --dir apps/cli typecheck
+
+      - name: Smoke staging tarball
+        run: >-
+          node scripts/cli-pack-smoke.mjs
+          --channel staging
+          --name "${{ steps.version.outputs.package_name }}"
+          --version "${{ steps.version.outputs.version }}"
+          --binary "${{ steps.version.outputs.binary_name }}"
+
+      - name: Publish staging package
+        if: steps.registry.outputs.publish == 'true'
+        working-directory: apps/cli
+        run: npm publish --tag latest --access public
+
+  production:
+    name: Publish CLI Production
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.12.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Use trusted-publishing npm client
+        run: npm install --global npm@11.5.1
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --config.engine-strict=true
+
+      - name: Check source formatting and lint rules
+        run: pnpm check
+
+      - name: Build source workspaces
+        run: pnpm build
+
+      - name: Type-check source workspaces
+        run: pnpm typecheck
+
+      - name: Validate production source and tag
+        id: version
+        env:
+          REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REPOSITORY_VISIBILITY" != "public" ]; then
+            echo "Production npm publishing requires a public source repository" >&2
+            exit 1
+          fi
+          if [ "$(node -p "require('./apps/cli/package.json').name")" != "open-tag" ]; then
+            echo "Unexpected source package identity" >&2
+            exit 1
+          fi
+          SOURCE_VERSION=$(node -p "require('./apps/cli/package.json').version")
+          node scripts/release-versions.mjs \
+            --channel prod \
+            --source-version "$SOURCE_VERSION" \
+            --tag "$TAG_NAME"
+          git fetch origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor HEAD refs/remotes/origin/main; then
+            echo "Production tag must point to a commit in main history" >&2
+            exit 1
+          fi
+
+      - name: Resolve release revision
+        id: revision
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check npm coordinate
+        id: registry
+        run: >-
+          node scripts/check-npm-version.mjs
+          --package "${{ steps.version.outputs.package_name }}"
+          --version "${{ steps.version.outputs.version }}"
+          --git-head "${{ steps.revision.outputs.sha }}"
+
+      - name: Prepare production package identity
+        run: >-
+          node scripts/prepare-cli-release.mjs
+          --channel prod
+          --version "${{ steps.version.outputs.version }}"
+
+      - name: Build production CLI
+        run: pnpm --dir apps/cli build
+
+      - name: Type-check production CLI
+        run: pnpm --dir apps/cli typecheck
+
+      - name: Smoke production tarball
+        run: >-
+          node scripts/cli-pack-smoke.mjs
+          --channel prod
+          --name "${{ steps.version.outputs.package_name }}"
+          --version "${{ steps.version.outputs.version }}"
+          --binary "${{ steps.version.outputs.binary_name }}"
+
+      - name: Publish production package
+        if: steps.registry.outputs.publish == 'true'
+        working-directory: apps/cli
+        run: npm publish --tag latest --access public --provenance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,6 @@ canonical document has a Chinese mirror, update both in the same pull request an
 
 Never commit credentials, local environment files, generated build output, or vulnerability details. Report security
 issues through the private process in [SECURITY.md](./SECURITY.md).
+
+Maintainers must use the repository release workflows described in [docs/releasing.md](./docs/releasing.md). Local npm
+publishing, production tags outside the protected release process, and token-based fallback publishing are not accepted.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -29,3 +29,6 @@ Pull Request 应说明改动、验证方式、破坏性行为和重要非目标�
 
 请勿提交 credentials、本地环境文件、构建产物或漏洞详情。安全问题请按 [SECURITY.zh-CN.md](./SECURITY.zh-CN.md)
 中的私密流程报告。
+
+维护者必须使用 [docs/zh-CN/releasing.md](./docs/zh-CN/releasing.md) 中说明的仓库 release workflow。禁止本地
+npm 发布、绕开受保护流程创建 production tag，以及回退到 token 发布。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,6 +28,18 @@ pnpm test
 
 Use `pnpm lint` for lint-only feedback. Use `pnpm format` to apply Biome formatting.
 
+The required pull request check is the stable `CI` fan-in job. It covers the commands above, source and staging CLI
+tarball installation, and a production-container health smoke. To exercise the current source tarball locally after a
+build:
+
+~~~bash
+node scripts/cli-pack-smoke.mjs \
+  --channel source \
+  --name open-tag \
+  --version 0.0.1 \
+  --binary opentag
+~~~
+
 ## Run the health-check path
 
 Build the workspaces, then start the server:
@@ -74,3 +86,9 @@ processes.
 
 If `doctor` fails, its error category distinguishes configuration, network, HTTP, and invalid-response failures. Confirm
 the server is running and that the configured URL points to its base address.
+
+## Releases
+
+Release publishing belongs to GitHub Actions and npm trusted publishing. Never publish either channel from a maintainer
+machine and never add a long-lived npm token to the repository. See [docs/releasing.md](./docs/releasing.md) for channel
+identities, release guards, package smoke checks, and recovery steps.

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -29,6 +29,17 @@ pnpm test
 
 仅检查 lint 可运行 `pnpm lint`；应用 Biome 格式化可运行 `pnpm format`。
 
+Pull Request 的必过检查是稳定的 `CI` fan-in job。它会覆盖上述命令、source/staging CLI tarball 安装和生产容器
+健康检查。构建后可在本地验证当前 source tarball：
+
+~~~bash
+node scripts/cli-pack-smoke.mjs \
+  --channel source \
+  --name open-tag \
+  --version 0.0.1 \
+  --binary opentag
+~~~
+
 ## 运行健康检查链路
 
 构建 workspace 后启动 Server：
@@ -73,3 +84,9 @@ docker compose down
 | `OPENTAG_DATABASE_URL` | 本地 PostgreSQL URL | 为后续持久化工作预留 |
 
 如果 `doctor` 失败，其错误类别会区分配置、网络、HTTP 和无效响应。请确认 Server 已启动，且配置的 URL 指向其基础地址。
+
+## 发布
+
+发布只能由 GitHub Actions 和 npm trusted publishing 执行。禁止从维护者机器发布任一 channel，也禁止向仓库
+添加长期 npm token。channel identity、发布 guard、package smoke 和恢复步骤请参阅
+[docs/zh-CN/releasing.md](./docs/zh-CN/releasing.md)。

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM node:24-alpine AS deps
+
+WORKDIR /app
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/server/package.json packages/server/package.json
+RUN pnpm install --frozen-lockfile --config.engine-strict=true --filter @opentag/server...
+
+FROM deps AS build
+
+COPY tsconfig.json ./
+COPY packages/shared packages/shared
+COPY packages/server packages/server
+RUN pnpm --filter @opentag/shared build
+RUN pnpm --filter @opentag/server build
+
+FROM node:24-alpine AS prod-deps
+
+WORKDIR /app
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/server/package.json packages/server/package.json
+RUN pnpm install --frozen-lockfile --config.engine-strict=true --prod --filter @opentag/server...
+
+FROM node:24-alpine AS runtime
+
+WORKDIR /app
+COPY --from=prod-deps /app ./
+COPY --from=build /app/packages/shared/dist packages/shared/dist
+COPY --from=build /app/packages/server/dist packages/server/dist
+COPY LICENSE /app/LICENSE
+
+RUN addgroup -S opentag && adduser -S -G opentag opentag
+
+ENV NODE_ENV=production
+ENV OPENTAG_HOST=0.0.0.0
+ENV OPENTAG_PORT=8000
+
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8000/healthz >/dev/null || exit 1
+
+USER opentag
+
+CMD ["node", "packages/server/dist/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ first stable release. The current code proves only the repository toolchain and 
 
 - [Development guide](./DEVELOPMENT.md)
 - [Contributing guide](./CONTRIBUTING.md)
+- [Release guide](./docs/releasing.md)
 - [Security policy](./SECURITY.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,7 @@ OpenTag 正通过小型、可验证的纵向切片逐步构建。首个稳定版
 
 - [开发指南](./DEVELOPMENT.zh-CN.md)
 - [贡献指南](./CONTRIBUTING.zh-CN.md)
+- [发布指南](./docs/zh-CN/releasing.md)
 - [安全政策](./SECURITY.zh-CN.md)
 - [行为准则](./CODE_OF_CONDUCT.zh-CN.md)
 

--- a/apps/cli/LICENSE
+++ b/apps/cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,10 @@
+# OpenTag CLI
+
+The OpenTag CLI connects local OpenTag clients to the OpenTag server. The project is pre-alpha and currently exposes only
+the `doctor` health check.
+
+The production npm package is `open-tag` with the `opentag` binary. Preview builds use the separate
+`open-tag-staging` package and `opentag-staging` binary.
+
+See the [OpenTag repository](https://github.com/first-tree-ai/opentag) for setup, contribution, security, and release
+documentation.

--- a/apps/cli/THIRD_PARTY_NOTICES
+++ b/apps/cli/THIRD_PARTY_NOTICES
@@ -1,0 +1,60 @@
+OpenTag Third-Party Notices
+
+This distribution includes source code from the following packages.
+
+## commander@13.1.0
+
+Source: https://github.com/tj/commander.js
+License: MIT
+
+(The MIT License)
+
+Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+## zod@4.4.3
+
+Source: https://github.com/colinhacks/zod
+License: MIT
+
+MIT License
+
+Copyright (c) 2025 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,25 @@
 {
   "name": "open-tag",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
+  "description": "OpenTag command-line interface for connecting team messaging with AI coding agents.",
+  "keywords": [
+    "ai",
+    "cli",
+    "coding-agent",
+    "messaging",
+    "opentag"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/first-tree-ai/opentag#readme",
+  "bugs": {
+    "url": "https://github.com/first-tree-ai/opentag/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/first-tree-ai/opentag.git",
+    "directory": "apps/cli"
+  },
   "type": "module",
   "bin": {
     "opentag": "./dist/cli/index.mjs"
@@ -13,15 +31,26 @@
     }
   },
   "files": [
-    "dist"
+    "dist/**/*.d.mts",
+    "dist/**/*.map",
+    "dist/**/*.mjs",
+    "LICENSE",
+    "README.md",
+    "THIRD_PARTY_NOTICES"
   ],
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsdown src/index.ts src/cli/index.ts --format esm --dts",
     "start": "node dist/cli/index.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --maxWorkers=1"
   },
-  "dependencies": {
+  "devDependencies": {
     "@opentag/client": "workspace:*",
     "@opentag/shared": "workspace:*",
     "commander": "^13.1.0"

--- a/apps/cli/src/__tests__/build-info.test.ts
+++ b/apps/cli/src/__tests__/build-info.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import packageManifest from "../../package.json" with { type: "json" };
+import { CLI_BINARY_NAME, CLI_PACKAGE_NAME, CLI_VERSION } from "../build-info.js";
+import { createProgram } from "../cli/program.js";
+
+describe("CLI build information", () => {
+  it("derives the source identity from the package manifest", () => {
+    expect(CLI_PACKAGE_NAME).toBe(packageManifest.name);
+    expect(CLI_BINARY_NAME).toBe(Object.keys(packageManifest.bin)[0]);
+    expect(CLI_VERSION).toBe(packageManifest.version);
+  });
+
+  it("configures Commander from the same build information", () => {
+    const program = createProgram();
+
+    expect(program.name()).toBe(CLI_BINARY_NAME);
+    expect(program.version()).toBe(CLI_VERSION);
+  });
+});

--- a/apps/cli/src/build-info.ts
+++ b/apps/cli/src/build-info.ts
@@ -1,0 +1,12 @@
+import packageManifest from "../package.json" with { type: "json" };
+
+const SOURCE_PACKAGE_NAME = "open-tag";
+const STAGING_PACKAGE_NAME = "open-tag-staging";
+
+if (packageManifest.name !== SOURCE_PACKAGE_NAME && packageManifest.name !== STAGING_PACKAGE_NAME) {
+  throw new Error(`Unsupported OpenTag CLI package identity: ${packageManifest.name}`);
+}
+
+export const CLI_PACKAGE_NAME = packageManifest.name;
+export const CLI_VERSION = packageManifest.version;
+export const CLI_BINARY_NAME = packageManifest.name === STAGING_PACKAGE_NAME ? "opentag-staging" : "opentag";

--- a/apps/cli/src/cli/program.ts
+++ b/apps/cli/src/cli/program.ts
@@ -1,9 +1,10 @@
 import { Command } from "commander";
+import { CLI_BINARY_NAME, CLI_VERSION } from "../build-info.js";
 import { registerDoctorCommand } from "../commands/doctor.js";
 
 export function createProgram(): Command {
   const program = new Command();
-  program.name("opentag").description("OpenTag command-line interface").version("0.0.0").showHelpAfterError();
+  program.name(CLI_BINARY_NAME).description("OpenTag command-line interface").version(CLI_VERSION).showHelpAfterError();
   registerDoctorCommand(program);
   return program;
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,2 +1,3 @@
+export { CLI_BINARY_NAME, CLI_PACKAGE_NAME, CLI_VERSION } from "./build-info.js";
 export { createProgram } from "./cli/program.js";
 export { type DoctorOptions, type DoctorResult, resolveServerUrl, runDoctor } from "./core/doctor.js";

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "resolveJsonModule": true,
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
   },
   "references": [{ "path": "../../packages/shared" }, { "path": "../../packages/client" }],

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,79 @@
+# OpenTag release guide
+
+[简体中文](./zh-CN/releasing.md)
+
+OpenTag publishes one self-contained CLI artifact in two isolated npm package identities:
+
+| Channel | Package | Binary | Source trigger |
+| --- | --- | --- | --- |
+| Staging | `open-tag-staging` | `opentag-staging` | Successful `CI` on `main`, or an intentional manual rerun on `main` |
+| Production | `open-tag` | `opentag` | A protected stable `vX.Y.Z` tag |
+
+The internal `@opentag/client`, `@opentag/shared`, and `@opentag/server` workspaces remain private. Client and Shared
+code is bundled into the CLI tarball, and the packed manifest must not expose an `@opentag/*` runtime dependency.
+`THIRD_PARTY_NOTICES` is generated from the exact third-party packages bundled into the CLI and contains their complete
+license texts. Run `pnpm notices:write` after a bundled dependency changes; `pnpm check` rejects stale notices.
+
+## Release authority
+
+GitHub Actions is the only release authority. npm publishing uses trusted publishing with `id-token: write`; the
+repository must not contain an npm access token or a token fallback. Configure the staging package publisher in npm with
+these exact fields:
+
+- Provider: GitHub Actions
+- Organization or owner: `first-tree-ai`
+- Repository: `opentag`
+- Workflow filename: `publish-npm-package.yml`
+- Environment: none
+
+The source manifest stays `open-tag`, has `private: true`, and carries a stable base version. The workflow rewrites
+identity only in its ephemeral checkout by calling `scripts/prepare-cli-release.mjs`.
+
+## Staging
+
+After successful `main` CI, the npm workflow computes the next patch and publishes:
+
+~~~text
+X.Y.(Z+1)-staging.<github_run_number>.<github_run_attempt>
+~~~
+
+It checks the registry before publishing. An absent coordinate may be published; an existing coordinate is accepted only
+when its `gitHead` matches the release commit. A registry failure or a coordinate owned by another commit fails closed.
+
+If the first run fails because npm trusted publishing is not configured, configure the publisher above and manually
+dispatch the workflow from `main`. Do not add a token. After publishing, verify package metadata and install the exact
+registry version into an empty directory before treating the staging release as usable.
+
+## Production
+
+Production publishing is intentionally stricter:
+
+- the repository must be public;
+- the tag must match `vX.Y.Z`;
+- the tag version must equal `apps/cli/package.json`;
+- the tagged commit must belong to `main`;
+- the version must be `0.0.2` or newer and absent from npm; and
+- the `v*` tag must be created through the protected release-tag ruleset.
+
+The same tag publishes the npm CLI and the GHCR server image. The image carries full-commit, SemVer, and `latest` tags,
+and includes the OpenTag Apache-2.0 license at `/app/LICENSE`. Creating a production tag is an irreversible release action
+and requires an explicit release decision; testing the workflow is not authorization to create one.
+
+## Contributor smoke
+
+Build dependencies and the source CLI, then test the real tarball:
+
+~~~bash
+pnpm exec turbo run build --filter=open-tag...
+SOURCE_NAME=$(node -p "require('./apps/cli/package.json').name")
+SOURCE_VERSION=$(node -p "require('./apps/cli/package.json').version")
+SOURCE_BINARY=$(node -p "Object.keys(require('./apps/cli/package.json').bin)[0]")
+node scripts/cli-pack-smoke.mjs \
+  --channel source \
+  --name "$SOURCE_NAME" \
+  --version "$SOURCE_VERSION" \
+  --binary "$SOURCE_BINARY"
+~~~
+
+CI additionally derives a deterministic next-patch staging coordinate from the source manifest and CI run identity,
+rewrites an isolated checkout, rebuilds it, and runs the same pack, empty-install, version, help, and doctor-failure checks.

--- a/docs/zh-CN/releasing.md
+++ b/docs/zh-CN/releasing.md
@@ -1,0 +1,79 @@
+# OpenTag 发布指南
+
+> Canonical source: [../releasing.md](../releasing.md)
+> Last synced with: 2026-08-17
+
+OpenTag 以两个相互隔离的 npm package identity 发布一个自包含 CLI artifact：
+
+| Channel | Package | Binary | Source trigger |
+| --- | --- | --- | --- |
+| Staging | `open-tag-staging` | `opentag-staging` | `main` 的 `CI` 成功，或在 `main` 上有意手动重跑 |
+| Production | `open-tag` | `opentag` | 受保护的稳定 `vX.Y.Z` tag |
+
+内部 `@opentag/client`、`@opentag/shared` 和 `@opentag/server` workspace 永久保持 private。Client 与 Shared
+代码会 bundle 进 CLI tarball，pack 后的 manifest 不得暴露任何 `@opentag/*` runtime dependency。
+`THIRD_PARTY_NOTICES` 从实际 bundle 进 CLI 的精确第三方 package 生成，并包含完整许可证正文。bundle dependency
+发生变化后运行 `pnpm notices:write`；`pnpm check` 会拒绝过期 notices。
+
+## 发布权限
+
+GitHub Actions 是唯一 release authority。npm 通过具备 `id-token: write` 的 trusted publishing 发布；仓库
+不得保存 npm access token，也不得提供 token fallback。请在 npm 为 staging package 配置以下精确字段：
+
+- Provider：GitHub Actions
+- Organization 或 owner：`first-tree-ai`
+- Repository：`opentag`
+- Workflow filename：`publish-npm-package.yml`
+- Environment：不填写
+
+source manifest 保持 `open-tag`、`private: true` 和稳定 base version。workflow 只在临时 checkout 中调用
+`scripts/prepare-cli-release.mjs` 改写 identity。
+
+## Staging
+
+`main` CI 成功后，npm workflow 会计算 next patch 并发布：
+
+~~~text
+X.Y.(Z+1)-staging.<github_run_number>.<github_run_attempt>
+~~~
+
+发布前会查询 registry。不存在的坐标可以发布；已存在的坐标只有在 `gitHead` 与 release commit 相同时才作为
+幂等成功。registry 失败或坐标属于其他 commit 时会硬失败。
+
+如果首次运行因为 npm trusted publishing 未配置而失败，请先按上述字段配置 publisher，再从 `main` 手动
+dispatch workflow；不要添加 token。发布后应核对 package metadata，并在空目录安装 registry 中的精确版本，
+通过后才能把该 staging release 视为可用。
+
+## Production
+
+Production 发布有更严格的门槛：
+
+- repository 必须为 public；
+- tag 必须匹配 `vX.Y.Z`；
+- tag version 必须等于 `apps/cli/package.json`；
+- tagged commit 必须属于 `main`；
+- version 必须不低于 `0.0.2` 且未存在于 npm；
+- `v*` tag 必须通过受保护的 release-tag ruleset 创建。
+
+同一个 tag 会发布 npm CLI 与 GHCR server image。image 带 full commit、SemVer 和 `latest` tag，并在
+`/app/LICENSE` 携带 OpenTag 的 Apache-2.0 许可证。创建 production tag 是不可逆的发布动作，必须获得明确
+release 决策；验证 workflow 不代表获得创建 tag 的授权。
+
+## Contributor smoke
+
+构建依赖和 source CLI，然后验证真实 tarball：
+
+~~~bash
+pnpm exec turbo run build --filter=open-tag...
+SOURCE_NAME=$(node -p "require('./apps/cli/package.json').name")
+SOURCE_VERSION=$(node -p "require('./apps/cli/package.json').version")
+SOURCE_BINARY=$(node -p "Object.keys(require('./apps/cli/package.json').bin)[0]")
+node scripts/cli-pack-smoke.mjs \
+  --channel source \
+  --name "$SOURCE_NAME" \
+  --version "$SOURCE_VERSION" \
+  --binary "$SOURCE_BINARY"
+~~~
+
+CI 还会从 source manifest 和 CI run identity 派生确定性的 next-patch staging coordinate，在隔离 checkout 中
+改写、重新构建，并执行相同的 pack、空目录安装、version、help 和 doctor failure 检查。

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "check": "biome check .",
+    "check": "biome check . && node scripts/third-party-notices.mjs --check",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck",
-    "test": "turbo run test --concurrency=2"
+    "test": "node --test --test-concurrency=1 scripts/__tests__/*.test.mjs && turbo run test --concurrency=2",
+    "notices:write": "node scripts/third-party-notices.mjs --write"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 3.2.7(@types/node@22.20.1)(tsx@4.23.12)
 
   apps/cli:
-    dependencies:
+    devDependencies:
       '@opentag/client':
         specifier: workspace:*
         version: link:../../packages/client

--- a/scripts/__tests__/release-scripts.test.mjs
+++ b/scripts/__tests__/release-scripts.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { classifyRegistryLookup } from "../check-npm-version.mjs";
+import { prepareCliRelease } from "../prepare-cli-release.mjs";
+import { resolveProductionVersion, resolveStagingVersion } from "../release-versions.mjs";
+import { generateThirdPartyNotices } from "../third-party-notices.mjs";
+
+const sourceManifest = {
+  name: "open-tag",
+  version: "0.0.1",
+  private: true,
+  license: "Apache-2.0",
+  repository: {
+    type: "git",
+    url: "git+https://github.com/first-tree-ai/opentag.git",
+    directory: "apps/cli",
+  },
+  bin: {
+    opentag: "./dist/cli/index.mjs",
+  },
+  devDependencies: {
+    "@opentag/client": "workspace:*",
+    "@opentag/shared": "workspace:*",
+    commander: "^13.1.0",
+  },
+};
+
+async function withManifest(manifest, callback) {
+  const directory = await mkdtemp(join(tmpdir(), "opentag-release-test-"));
+  const manifestPath = join(directory, "package.json");
+  try {
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    await callback(manifestPath);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("resolves next-patch staging versions and matching production tags", () => {
+  assert.equal(resolveStagingVersion("0.0.1", "42", "3"), "0.0.2-staging.42.3");
+  assert.equal(resolveProductionVersion("1.2.3", "v1.2.3"), "1.2.3");
+  assert.throws(() => resolveProductionVersion("1.2.3", "v1.2.4"), /does not match source version/);
+  assert.throws(() => resolveProductionVersion("0.0.1", "v0.0.1"), /0\.0\.2 or newer/);
+});
+
+test("rewrites the staging identity without losing release metadata", async () => {
+  await withManifest(sourceManifest, async (manifestPath) => {
+    await prepareCliRelease({ channel: "staging", version: "0.0.2-staging.0.0", manifestPath });
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+
+    assert.equal(manifest.name, "open-tag-staging");
+    assert.equal(manifest.version, "0.0.2-staging.0.0");
+    assert.deepEqual(manifest.bin, { "opentag-staging": "./dist/cli/index.mjs" });
+    assert.equal(manifest.private, undefined);
+    assert.equal(manifest.license, "Apache-2.0");
+    assert.equal(manifest.repository.url, sourceManifest.repository.url);
+    assert.deepEqual(manifest.devDependencies, { commander: "^13.1.0" });
+  });
+});
+
+test("rejects an unsafe source identity and invalid staging coordinates", async () => {
+  await withManifest({ ...sourceManifest, name: "open-tag-staging" }, async (manifestPath) => {
+    await assert.rejects(
+      prepareCliRelease({ channel: "staging", version: "0.0.2-staging.1.1", manifestPath }),
+      /source package name/,
+    );
+  });
+  await withManifest(sourceManifest, async (manifestPath) => {
+    await assert.rejects(
+      prepareCliRelease({ channel: "staging", version: "0.0.1-staging.1.1", manifestPath }),
+      /staging version must match/,
+    );
+  });
+  await withManifest(
+    { ...sourceManifest, dependencies: { "@opentag/client": "workspace:*" } },
+    async (manifestPath) => {
+      await assert.rejects(
+        prepareCliRelease({ channel: "staging", version: "0.0.2-staging.1.1", manifestPath }),
+        /private runtime dependency/,
+      );
+    },
+  );
+});
+
+test("keeps production publishing at a matching stable source version", async () => {
+  await withManifest({ ...sourceManifest, version: "0.0.2" }, async (manifestPath) => {
+    await prepareCliRelease({ channel: "prod", version: "0.0.2", manifestPath });
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+
+    assert.equal(manifest.name, "open-tag");
+    assert.deepEqual(manifest.bin, { opentag: "./dist/cli/index.mjs" });
+    assert.equal(manifest.private, undefined);
+  });
+});
+
+test("classifies npm registry lookups without treating errors as absence", () => {
+  assert.deepEqual(
+    classifyRegistryLookup({ status: 1, stdout: "", stderr: "npm error code E404", expectedGitHead: "abc" }),
+    { publish: true },
+  );
+  assert.deepEqual(
+    classifyRegistryLookup({
+      status: 0,
+      stdout: '{"gitHead":"abc"}',
+      stderr: "",
+      expectedGitHead: "abc",
+    }),
+    { publish: false },
+  );
+  assert.throws(
+    () =>
+      classifyRegistryLookup({
+        status: 0,
+        stdout: '{"gitHead":"other"}',
+        stderr: "",
+        expectedGitHead: "abc",
+      }),
+    /expected "abc"/,
+  );
+  assert.throws(
+    () => classifyRegistryLookup({ status: 1, stdout: "", stderr: "ECONNRESET", expectedGitHead: "abc" }),
+    /registry lookup failed/,
+  );
+});
+
+test("generates complete notices for bundled CLI dependencies", async () => {
+  const notices = await generateThirdPartyNotices();
+
+  assert.match(notices, /^## commander@\d+\.\d+\.\d+$/m);
+  assert.match(notices, /^## zod@\d+\.\d+\.\d+$/m);
+  assert.match(notices, /Copyright \(c\) 2011 TJ Holowaychuk/);
+  assert.match(notices, /Copyright \(c\) 2025 Colin McDonnell/);
+  assert.equal((notices.match(/Permission is hereby granted/g) ?? []).length, 2);
+});

--- a/scripts/check-npm-version.mjs
+++ b/scripts/check-npm-version.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { appendFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function classifyRegistryLookup({ status, stdout, stderr, expectedGitHead }) {
+  if (status === 0) {
+    let metadata;
+    try {
+      metadata = JSON.parse(stdout);
+    } catch (error) {
+      throw new Error("npm registry returned invalid JSON", { cause: error });
+    }
+    if (metadata.gitHead !== expectedGitHead) {
+      throw new Error(
+        `published version has gitHead "${metadata.gitHead ?? "missing"}", expected "${expectedGitHead}"`,
+      );
+    }
+    return { publish: false };
+  }
+
+  if (/\bE404\b/.test(stderr)) {
+    return { publish: true };
+  }
+  throw new Error(`npm registry lookup failed: ${stderr.trim() || `exit status ${status}`}`);
+}
+
+function parseArguments(arguments_) {
+  const values = new Map();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument sequence near "${key ?? ""}"`);
+    }
+    values.set(key.slice(2), value);
+  }
+  return values;
+}
+
+async function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  const packageName = arguments_.get("package");
+  const version = arguments_.get("version");
+  const gitHead = arguments_.get("git-head");
+  if (!packageName || !version || !gitHead) {
+    throw new Error("--package, --version, and --git-head are required");
+  }
+
+  const lookup = spawnSync("npm", ["view", `${packageName}@${version}`, "--json"], {
+    encoding: "utf8",
+  });
+  const result = classifyRegistryLookup({
+    status: lookup.status,
+    stdout: lookup.stdout,
+    stderr: lookup.stderr,
+    expectedGitHead: gitHead,
+  });
+
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `publish=${result.publish}\n`);
+  }
+  console.log(
+    result.publish
+      ? `${packageName}@${version} is available for publication`
+      : `${packageName}@${version} already exists at ${gitHead}; publication is idempotently skipped`,
+  );
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  main().catch((error) => {
+    console.error(`[npm-registry-check] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/cli-pack-smoke.mjs
+++ b/scripts/cli-pack-smoke.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function run(command, arguments_, options = {}) {
+  const result = spawnSync(command, arguments_, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...options.env },
+  });
+  if (result.status !== (options.expectedStatus ?? 0)) {
+    throw new Error(
+      `${command} ${arguments_.join(" ")} exited with ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+  return result;
+}
+
+function assertReleaseManifest(manifest, { channel, expectedName, expectedVersion, expectedBinary }) {
+  if (manifest.name !== expectedName || manifest.version !== expectedVersion) {
+    throw new Error(
+      `packed identity mismatch: expected ${expectedName}@${expectedVersion}, got ${manifest.name}@${manifest.version}`,
+    );
+  }
+  if (manifest.bin?.[expectedBinary] !== "./dist/cli/index.mjs" || Object.keys(manifest.bin ?? {}).length !== 1) {
+    throw new Error(`packed binary must contain only ${expectedBinary} -> ./dist/cli/index.mjs`);
+  }
+  if (channel === "source" && manifest.private !== true) {
+    throw new Error("source tarball must retain private: true");
+  }
+  if (channel !== "source" && "private" in manifest) {
+    throw new Error("release tarball must not contain the private field");
+  }
+  if (manifest.license !== "Apache-2.0") {
+    throw new Error('packed license must be "Apache-2.0"');
+  }
+  if (manifest.repository?.url !== "git+https://github.com/first-tree-ai/opentag.git") {
+    throw new Error("packed repository metadata must point to first-tree-ai/opentag");
+  }
+
+  const dependencyFields =
+    channel === "source"
+      ? ["dependencies", "optionalDependencies", "peerDependencies"]
+      : ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"];
+  for (const dependencyField of dependencyFields) {
+    const internalDependency = Object.keys(manifest[dependencyField] ?? {}).find((name) =>
+      name.startsWith("@opentag/"),
+    );
+    if (internalDependency) {
+      throw new Error(`packed manifest exposes private runtime dependency ${internalDependency}`);
+    }
+  }
+}
+
+function bundledCoordinates(sourceMaps) {
+  const coordinates = new Set();
+  for (const sourceMap of sourceMaps) {
+    for (const source of sourceMap.sources ?? []) {
+      const match = source.match(/node_modules\/\.pnpm\/(.+?)\/node_modules\/((?:@[^/]+\/)?[^/]+)/);
+      if (!match) {
+        continue;
+      }
+      const storeLocator = match[1];
+      const packageName = match[2];
+      const versionSeparator = storeLocator.lastIndexOf("@");
+      if (versionSeparator <= 0) {
+        throw new Error(`cannot parse bundled dependency locator ${storeLocator}`);
+      }
+      const version = storeLocator.slice(versionSeparator + 1).split("_")[0];
+      coordinates.add(`${packageName}@${version}`);
+    }
+  }
+  return [...coordinates].sort();
+}
+
+function noticeCoordinates(notices) {
+  return [...notices.matchAll(/^## (.+@[^\s]+)$/gm)].map((match) => match[1]).sort();
+}
+
+function parseArguments(arguments_) {
+  const values = new Map();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument sequence near "${key ?? ""}"`);
+    }
+    values.set(key.slice(2), value);
+  }
+  return values;
+}
+
+export async function runCliPackSmoke({ channel, expectedName, expectedVersion, expectedBinary }) {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "opentag-cli-pack-"));
+  try {
+    const pack = run("npm", ["pack", "--json", "--pack-destination", temporaryRoot], { cwd: resolve("apps/cli") });
+    const packResult = JSON.parse(pack.stdout);
+    const tarballName = packResult[0]?.filename;
+    if (!tarballName) {
+      throw new Error("npm pack did not report a tarball filename");
+    }
+    const packedPaths = (packResult[0].files ?? []).map((file) => file.path);
+    for (const requiredPath of ["LICENSE", "README.md", "THIRD_PARTY_NOTICES", "dist/cli/index.mjs"]) {
+      if (!packedPaths.includes(requiredPath)) {
+        throw new Error(`npm tarball is missing required path ${requiredPath}`);
+      }
+    }
+    if (packedPaths.some((path) => path.endsWith(".tsbuildinfo"))) {
+      throw new Error("npm tarball must not include TypeScript build metadata");
+    }
+    const tarballPath = join(temporaryRoot, tarballName);
+    const notices = run("tar", ["-xOf", tarballPath, "package/THIRD_PARTY_NOTICES"]).stdout;
+    const sourceMaps = packedPaths
+      .filter((path) => path.endsWith(".map"))
+      .map((path) => JSON.parse(run("tar", ["-xOf", tarballPath, `package/${path}`]).stdout));
+    const bundled = bundledCoordinates(sourceMaps);
+    const attributed = noticeCoordinates(notices);
+    if (JSON.stringify(attributed) !== JSON.stringify(bundled)) {
+      throw new Error(
+        `third-party notices do not match bundled dependencies: expected ${bundled.join(", ")}, got ${attributed.join(", ")}`,
+      );
+    }
+    if (!notices.includes("Permission is hereby granted") || !notices.includes("Copyright")) {
+      throw new Error("third-party notices must include complete copyright and license text");
+    }
+    const packedManifestResult = run("tar", ["-xOf", tarballPath, "package/package.json"]);
+    const packedManifest = JSON.parse(packedManifestResult.stdout);
+    assertReleaseManifest(packedManifest, { channel, expectedName, expectedVersion, expectedBinary });
+
+    const consumer = join(temporaryRoot, "consumer");
+    await mkdir(consumer);
+    await writeFile(join(consumer, "package.json"), '{"name":"consumer","private":true}\n');
+    run("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", tarballPath], { cwd: consumer });
+
+    const binaryPath = join(consumer, "node_modules", ".bin", expectedBinary);
+    const version = run(binaryPath, ["--version"]);
+    if (version.stdout.trim() !== expectedVersion) {
+      throw new Error(`CLI version mismatch: expected ${expectedVersion}, got ${version.stdout.trim()}`);
+    }
+    const help = run(binaryPath, ["--help"]);
+    if (!help.stdout.includes(`Usage: ${expectedBinary}`)) {
+      throw new Error(`CLI help does not use expected binary name ${expectedBinary}`);
+    }
+    const doctor = run(binaryPath, ["doctor", "--server-url", "http://127.0.0.1:1"], { expectedStatus: 1 });
+    if (!doctor.stderr.includes("Network error:")) {
+      throw new Error("CLI doctor smoke did not report the expected network failure");
+    }
+
+    const installedManifest = JSON.parse(
+      await readFile(join(consumer, "node_modules", expectedName, "package.json"), "utf8"),
+    );
+    assertReleaseManifest(installedManifest, { channel, expectedName, expectedVersion, expectedBinary });
+    console.log(`Verified ${expectedName}@${expectedVersion} through ${expectedBinary}`);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  const channel = arguments_.get("channel");
+  const expectedName = arguments_.get("name");
+  const expectedVersion = arguments_.get("version");
+  const expectedBinary = arguments_.get("binary");
+  if (!channel || !expectedName || !expectedVersion || !expectedBinary) {
+    throw new Error("--channel, --name, --version, and --binary are required");
+  }
+  if (!["source", "staging", "prod"].includes(channel)) {
+    throw new Error('--channel must be "source", "staging", or "prod"');
+  }
+
+  await runCliPackSmoke({ channel, expectedName, expectedVersion, expectedBinary });
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  main().catch((error) => {
+    console.error(`[cli-pack-smoke] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/prepare-cli-release.mjs
+++ b/scripts/prepare-cli-release.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { compareStableVersions, parseStableVersion } from "./release-versions.mjs";
+
+const SOURCE_PACKAGE_NAME = "open-tag";
+const STAGING_PACKAGE_NAME = "open-tag-staging";
+const EXPECTED_REPOSITORY_URL = "git+https://github.com/first-tree-ai/opentag.git";
+
+export async function prepareCliRelease({ channel, version, manifestPath = "apps/cli/package.json" }) {
+  const resolvedManifestPath = resolve(manifestPath);
+  const manifest = JSON.parse(await readFile(resolvedManifestPath, "utf8"));
+
+  if (manifest.name !== SOURCE_PACKAGE_NAME) {
+    throw new Error(`source package name must be ${SOURCE_PACKAGE_NAME}, got "${manifest.name ?? ""}"`);
+  }
+  if (manifest.private !== true) {
+    throw new Error("source package must have private: true");
+  }
+  const source = parseStableVersion(manifest.version, "source version");
+  if (manifest.license !== "Apache-2.0") {
+    throw new Error('source package license must be "Apache-2.0"');
+  }
+  if (manifest.repository?.url !== EXPECTED_REPOSITORY_URL) {
+    throw new Error(`source package repository must be ${EXPECTED_REPOSITORY_URL}`);
+  }
+  for (const dependencyField of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+    const internalDependency = Object.keys(manifest[dependencyField] ?? {}).find((name) =>
+      name.startsWith("@opentag/"),
+    );
+    if (internalDependency) {
+      throw new Error(`source package exposes private runtime dependency ${internalDependency}`);
+    }
+  }
+
+  if (channel === "staging") {
+    const expectedPrefix = `${source.major}.${source.minor}.${source.patch + 1}-staging.`;
+    if (!new RegExp(`^${expectedPrefix.replaceAll(".", "\\.")}(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$`).test(version)) {
+      throw new Error(`staging version must match ${expectedPrefix}<run>.<attempt>, got "${version}"`);
+    }
+    manifest.name = STAGING_PACKAGE_NAME;
+    manifest.bin = { "opentag-staging": "./dist/cli/index.mjs" };
+  } else if (channel === "prod") {
+    parseStableVersion(version, "production version");
+    if (version !== manifest.version) {
+      throw new Error(`production version ${version} must match source version ${manifest.version}`);
+    }
+    if (compareStableVersions(version, "0.0.2") < 0) {
+      throw new Error("the first production release must be version 0.0.2 or newer");
+    }
+    manifest.name = SOURCE_PACKAGE_NAME;
+    manifest.bin = { opentag: "./dist/cli/index.mjs" };
+  } else {
+    throw new Error('channel must be either "staging" or "prod"');
+  }
+
+  manifest.version = version;
+  delete manifest.private;
+  for (const dependencyName of Object.keys(manifest.devDependencies ?? {})) {
+    if (dependencyName.startsWith("@opentag/")) {
+      delete manifest.devDependencies[dependencyName];
+    }
+  }
+  await writeFile(resolvedManifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+function parseArguments(arguments_) {
+  const values = new Map();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument sequence near "${key ?? ""}"`);
+    }
+    values.set(key.slice(2), value);
+  }
+  return values;
+}
+
+async function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  const channel = arguments_.get("channel");
+  const version = arguments_.get("version");
+  if (!channel || !version) {
+    throw new Error("--channel and --version are required");
+  }
+
+  const manifest = await prepareCliRelease({
+    channel,
+    version,
+    manifestPath: arguments_.get("manifest") ?? "apps/cli/package.json",
+  });
+  console.log(`Prepared ${manifest.name}@${manifest.version}`);
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  main().catch((error) => {
+    console.error(`[release-preparation] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-versions.mjs
+++ b/scripts/release-versions.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { appendFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const STABLE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/;
+
+export function parseStableVersion(version, label = "version") {
+  const match = STABLE_VERSION_PATTERN.exec(version);
+  if (!match) {
+    throw new Error(`${label} must be a stable semantic version, got "${version}"`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+export function compareStableVersions(left, right) {
+  const leftParts = parseStableVersion(left, "left version");
+  const rightParts = parseStableVersion(right, "right version");
+
+  return leftParts.major - rightParts.major || leftParts.minor - rightParts.minor || leftParts.patch - rightParts.patch;
+}
+
+export function resolveStagingVersion(sourceVersion, runNumber, runAttempt) {
+  const source = parseStableVersion(sourceVersion, "source version");
+  if (!POSITIVE_INTEGER_PATTERN.test(String(runNumber)) || !POSITIVE_INTEGER_PATTERN.test(String(runAttempt))) {
+    throw new Error("GitHub run number and attempt must be positive integers");
+  }
+
+  return `${source.major}.${source.minor}.${source.patch + 1}-staging.${runNumber}.${runAttempt}`;
+}
+
+export function resolveProductionVersion(sourceVersion, tag) {
+  parseStableVersion(sourceVersion, "source version");
+  const tagMatch = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(tag);
+  if (!tagMatch) {
+    throw new Error(`production tag must match vX.Y.Z, got "${tag}"`);
+  }
+
+  const tagVersion = tag.slice(1);
+  if (tagVersion !== sourceVersion) {
+    throw new Error(`production tag version ${tagVersion} does not match source version ${sourceVersion}`);
+  }
+  if (compareStableVersions(tagVersion, "0.0.2") < 0) {
+    throw new Error("the first production release must be version 0.0.2 or newer");
+  }
+
+  return tagVersion;
+}
+
+function parseArguments(arguments_) {
+  const values = new Map();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument sequence near "${key ?? ""}"`);
+    }
+    values.set(key.slice(2), value);
+  }
+  return values;
+}
+
+async function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  const channel = arguments_.get("channel");
+  const sourceVersion = arguments_.get("source-version");
+  if (!sourceVersion) {
+    throw new Error("--source-version is required");
+  }
+
+  let output;
+  if (channel === "staging") {
+    output = {
+      package_name: "open-tag-staging",
+      binary_name: "opentag-staging",
+      source_version: sourceVersion,
+      version: resolveStagingVersion(sourceVersion, arguments_.get("run-number"), arguments_.get("run-attempt")),
+    };
+  } else if (channel === "prod") {
+    output = {
+      package_name: "open-tag",
+      binary_name: "opentag",
+      source_version: sourceVersion,
+      version: resolveProductionVersion(sourceVersion, arguments_.get("tag") ?? ""),
+    };
+  } else {
+    throw new Error('--channel must be either "staging" or "prod"');
+  }
+
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    await appendFile(
+      outputPath,
+      `${Object.entries(output)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("\n")}\n`,
+    );
+  }
+  console.log(JSON.stringify(output));
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  main().catch((error) => {
+    console.error(`[release-version] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/third-party-notices.mjs
+++ b/scripts/third-party-notices.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const noticePath = resolve(projectRoot, "apps/cli/THIRD_PARTY_NOTICES");
+const bundledPackages = [
+  { name: "commander", consumerManifest: "apps/cli/package.json" },
+  { name: "zod", consumerManifest: "packages/shared/package.json" },
+];
+
+async function readLicense(packageDirectory) {
+  for (const filename of ["LICENSE", "LICENSE.md", "LICENSE.txt"]) {
+    try {
+      return (await readFile(resolve(packageDirectory, filename), "utf8")).trimEnd();
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  throw new Error(`no license file found in ${packageDirectory}`);
+}
+
+function repositoryUrl(repository) {
+  const value = typeof repository === "string" ? repository : repository?.url;
+  return value?.replace(/^git\+/, "").replace(/\.git$/, "") ?? "unknown";
+}
+
+async function findPackageManifest(packageRequire, packageName) {
+  let directory = dirname(packageRequire.resolve(packageName));
+  for (;;) {
+    const manifestPath = resolve(directory, "package.json");
+    try {
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+      if (manifest.name === packageName) {
+        return { manifest, manifestPath };
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+    }
+    const parent = dirname(directory);
+    if (parent === directory) {
+      throw new Error(`could not locate package manifest for ${packageName}`);
+    }
+    directory = parent;
+  }
+}
+
+export async function generateThirdPartyNotices() {
+  const sections = [];
+  for (const bundledPackage of bundledPackages) {
+    const consumerPath = resolve(projectRoot, bundledPackage.consumerManifest);
+    const packageRequire = createRequire(pathToFileURL(consumerPath));
+    const { manifest, manifestPath } = await findPackageManifest(packageRequire, bundledPackage.name);
+    const license = await readLicense(dirname(manifestPath));
+    sections.push(
+      `## ${manifest.name}@${manifest.version}\n\nSource: ${repositoryUrl(manifest.repository)}\nLicense: ${manifest.license}\n\n${license}`,
+    );
+  }
+
+  return `OpenTag Third-Party Notices\n\nThis distribution includes source code from the following packages.\n\n${sections.join("\n\n---\n\n")}\n`;
+}
+
+async function main() {
+  const mode = process.argv[2] ?? "--check";
+  const generated = await generateThirdPartyNotices();
+  if (mode === "--write") {
+    await writeFile(noticePath, generated);
+    console.log(`Wrote ${noticePath}`);
+    return;
+  }
+  if (mode !== "--check") {
+    throw new Error("usage: third-party-notices.mjs [--check|--write]");
+  }
+
+  const committed = await readFile(noticePath, "utf8");
+  if (committed !== generated) {
+    throw new Error(
+      "apps/cli/THIRD_PARTY_NOTICES does not match bundled dependency versions and licenses; run pnpm notices:write",
+    );
+  }
+  console.log("Verified CLI third-party notices");
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  main().catch((error) => {
+    console.error(`[third-party-notices] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": ["GITHUB_OUTPUT"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- establish a stable `CI` fan-in merge gate with minimum-Node checks, source/staging CLI pack smoke, and production-container smoke
- make the CLI release artifact self-contained while preserving isolated `open-tag` / `open-tag-staging` package and binary identities
- add deterministic version, registry idempotency, package preparation, and third-party license guards
- add tag-only npm and GHCR release workflows with OIDC/minimum permissions, public-repository, tag/version, and main-ancestry gates
- add the non-root server Docker image, Dependabot configuration, and synchronized English/Chinese release documentation

## GitHub settings applied

- squash-only merging, automatic branch deletion, update-branch support, and read-only default Actions permissions
- Dependabot alerts/security updates and secret scanning/push protection
- `protect main` ruleset with PR/CODEOWNER approval, resolved threads, strict required `CI`, and no deletion or force-push
- `protect release tags` ruleset for `v*`, with creation bypass scoped to the existing `core-maintainers` team

No repository team binding or permission was added.

## Validation

- `pnpm install --frozen-lockfile --config.engine-strict=true`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- clean Node 22.13.1 container: frozen engine-strict install, check, build, typecheck, tests, and source pack smoke
- source and isolated staging tarball pack/install/version/help/doctor smoke
- bundled source-map coordinates exactly match generated `THIRD_PARTY_NOTICES`
- Docker build and container health/non-root/license/CLI-exclusion smoke
- workflow/Dependabot YAML parsing, Action SHA pin checks, branch/fan-in gate cases, Compose config, and `git diff --check`

## Release boundary

- this PR does not publish or alter `open-tag`, create a production tag or GitHub Release, or push a GHCR image
- after merge, only `open-tag-staging` may be published, through npm OIDC trusted publishing; there is no token fallback
- the first staging run may fail until npm configures `publish-npm-package.yml` as the trusted publisher for `open-tag-staging`
