### PR TITLE
chore: enforce workspace architecture contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "check": "biome check . && node scripts/third-party-notices.mjs --check",
+    "check": "biome check . && node scripts/verify-workspace-contracts.mjs && node scripts/third-party-notices.mjs --check",
+    "check:workspace": "node scripts/verify-workspace-contracts.mjs",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.0",
     "@types/node": "^22.15.0",
+    "semver": "^7.8.5",
     "tsdown": "^0.21.4",
     "tsx": "^4.21.0",
     "turbo": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@types/node':
         specifier: ^22.15.0
         version: 22.20.1
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       tsdown:
         specifier: 0.21.4
         version: 0.21.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)

--- a/scripts/__tests__/workspace-contracts.test.mjs
+++ b/scripts/__tests__/workspace-contracts.test.mjs
@@ -80,6 +80,13 @@ const workspaceManifests = {
   },
 };
 
+const workspaceReferences = {
+  "apps/cli": [{ path: "../../packages/client" }, { path: "../../packages/shared" }],
+  "packages/client": [{ path: "../shared" }],
+  "packages/server": [{ path: "../shared" }],
+  "packages/shared": [],
+};
+
 async function writeJson(filePath, value) {
   await mkdir(dirname(filePath), { recursive: true });
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
@@ -92,6 +99,9 @@ async function createFixture() {
 
   for (const [workspacePath, manifest] of Object.entries(workspaceManifests)) {
     await writeJson(join(rootDirectory, workspacePath, "package.json"), manifest);
+    await writeJson(join(rootDirectory, workspacePath, "tsconfig.json"), {
+      references: workspaceReferences[workspacePath],
+    });
     await mkdir(join(rootDirectory, workspacePath, "src"), { recursive: true });
     await writeFile(join(rootDirectory, workspacePath, "src/index.ts"), "export {};\n");
   }
@@ -146,6 +156,20 @@ test("rejects forbidden workspace dependencies and non-workspace ranges", async 
   });
 });
 
+test("rejects TypeScript project references that drift from the contract", async () => {
+  await withFixture(async (rootDirectory) => {
+    await writeJson(join(rootDirectory, "packages/client/tsconfig.json"), {
+      references: [{ path: "../server" }],
+    });
+
+    await assert.rejects(verifyWorkspaceContracts({ rootDirectory }), (error) => {
+      assert.match(error.message, /references forbidden workspace package "@opentag\/server"/);
+      assert.match(error.message, /missing reference to allowed workspace package "@opentag\/shared"/);
+      return true;
+    });
+  });
+});
+
 test("rejects package metadata that weakens the artifact boundary", async () => {
   await withFixture(async (rootDirectory) => {
     const manifestPath = join(rootDirectory, "packages/shared/package.json");
@@ -162,6 +186,34 @@ test("rejects package metadata that weakens the artifact boundary", async () => 
   });
 });
 
+test("rejects a null root export", async () => {
+  await withFixture(async (rootDirectory) => {
+    const manifestPath = join(rootDirectory, "packages/shared/package.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    manifest.exports["."] = null;
+    await writeJson(manifestPath, manifest);
+
+    await assert.rejects(
+      verifyWorkspaceContracts({ rootDirectory }),
+      /exports "\." must resolve to at least one artifact target/,
+    );
+  });
+});
+
+test("rejects root export targets outside the files boundary", async () => {
+  await withFixture(async (rootDirectory) => {
+    const manifestPath = join(rootDirectory, "packages/shared/package.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    manifest.files = ["README.md"];
+    await writeJson(manifestPath, manifest);
+
+    await assert.rejects(
+      verifyWorkspaceContracts({ rootDirectory }),
+      /root export target "\.\/dist\/index\.mjs" is not covered by files/,
+    );
+  });
+});
+
 test("rejects package deep imports", async () => {
   await withFixture(async (rootDirectory) => {
     await writeFile(
@@ -173,6 +225,35 @@ test("rejects package deep imports", async () => {
       verifyWorkspaceContracts({ rootDirectory }),
       /import "@opentag\/shared\/internal" bypasses the public root export/,
     );
+  });
+});
+
+test("rejects deep imports in TypeScript import types", async () => {
+  await withFixture(async (rootDirectory) => {
+    await writeFile(
+      join(rootDirectory, "packages/client/src/index.ts"),
+      'export type SharedValue = import("@opentag/shared/internal").SharedValue;\n',
+    );
+
+    await assert.rejects(
+      verifyWorkspaceContracts({ rootDirectory }),
+      /import "@opentag\/shared\/internal" bypasses the public root export/,
+    );
+  });
+});
+
+test("rejects dynamic imports with an options argument", async () => {
+  await withFixture(async (rootDirectory) => {
+    await writeFile(
+      join(rootDirectory, "packages/client/src/index.ts"),
+      'void import("@opentag/server/internal", { with: { type: "json" } });\n',
+    );
+
+    await assert.rejects(verifyWorkspaceContracts({ rootDirectory }), (error) => {
+      assert.match(error.message, /import "@opentag\/server\/internal" bypasses the public root export/);
+      assert.match(error.message, /imports forbidden workspace package "@opentag\/server"/);
+      return true;
+    });
   });
 });
 

--- a/scripts/__tests__/workspace-contracts.test.mjs
+++ b/scripts/__tests__/workspace-contracts.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { verifyWorkspaceContracts } from "../verify-workspace-contracts.mjs";
+
+const workspaceContracts = {
+  schemaVersion: 1,
+  workspaces: {
+    "apps/cli": {
+      name: "open-tag",
+      private: true,
+      requiresRootExport: true,
+      requiresFiles: true,
+      allowedWorkspaceDependencies: ["@opentag/client", "@opentag/shared"],
+    },
+    "packages/client": {
+      name: "@opentag/client",
+      private: true,
+      requiresRootExport: true,
+      requiresFiles: true,
+      allowedWorkspaceDependencies: ["@opentag/shared"],
+    },
+    "packages/server": {
+      name: "@opentag/server",
+      private: true,
+      requiresRootExport: true,
+      requiresFiles: true,
+      allowedWorkspaceDependencies: ["@opentag/shared"],
+    },
+    "packages/shared": {
+      name: "@opentag/shared",
+      private: true,
+      requiresRootExport: true,
+      requiresFiles: true,
+      allowedWorkspaceDependencies: [],
+    },
+  },
+};
+
+const workspaceManifests = {
+  "apps/cli": {
+    name: "open-tag",
+    version: "0.0.1",
+    private: true,
+    type: "module",
+    exports: { ".": "./dist/index.mjs" },
+    files: ["dist"],
+    devDependencies: {
+      "@opentag/client": "workspace:*",
+      "@opentag/shared": "workspace:*",
+    },
+  },
+  "packages/client": {
+    name: "@opentag/client",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    exports: { ".": "./dist/index.mjs" },
+    files: ["dist"],
+    dependencies: { "@opentag/shared": "workspace:*" },
+  },
+  "packages/server": {
+    name: "@opentag/server",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    exports: { ".": "./dist/index.mjs" },
+    files: ["dist"],
+    dependencies: { "@opentag/shared": "workspace:*" },
+  },
+  "packages/shared": {
+    name: "@opentag/shared",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    exports: { ".": "./dist/index.mjs" },
+    files: ["dist"],
+  },
+};
+
+async function writeJson(filePath, value) {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function createFixture() {
+  const rootDirectory = await mkdtemp(join(tmpdir(), "opentag-workspace-contracts-"));
+  await writeFile(join(rootDirectory, "pnpm-workspace.yaml"), "packages:\n  - apps/cli\n  - packages/*\n");
+  await writeJson(join(rootDirectory, "workspace-contracts.json"), workspaceContracts);
+
+  for (const [workspacePath, manifest] of Object.entries(workspaceManifests)) {
+    await writeJson(join(rootDirectory, workspacePath, "package.json"), manifest);
+    await mkdir(join(rootDirectory, workspacePath, "src"), { recursive: true });
+    await writeFile(join(rootDirectory, workspacePath, "src/index.ts"), "export {};\n");
+  }
+
+  return rootDirectory;
+}
+
+async function withFixture(callback) {
+  const rootDirectory = await createFixture();
+  try {
+    await callback(rootDirectory);
+  } finally {
+    await rm(rootDirectory, { recursive: true, force: true });
+  }
+}
+
+test("accepts the declared OpenTag workspace graph", async () => {
+  await withFixture(async (rootDirectory) => {
+    assert.deepEqual(await verifyWorkspaceContracts({ rootDirectory }), {
+      allowedDependencyCount: 4,
+      workspaceCount: 4,
+    });
+  });
+});
+
+test("rejects unregistered workspaces", async () => {
+  await withFixture(async (rootDirectory) => {
+    await writeJson(join(rootDirectory, "packages/rogue/package.json"), {
+      name: "@opentag/rogue",
+      version: "0.0.0",
+    });
+
+    await assert.rejects(
+      verifyWorkspaceContracts({ rootDirectory }),
+      /packages\/rogue\/package\.json: workspace is not registered/,
+    );
+  });
+});
+
+test("rejects forbidden workspace dependencies and non-workspace ranges", async () => {
+  await withFixture(async (rootDirectory) => {
+    const manifestPath = join(rootDirectory, "packages/client/package.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    manifest.dependencies["@opentag/server"] = "^0.0.0";
+    await writeJson(manifestPath, manifest);
+
+    await assert.rejects(verifyWorkspaceContracts({ rootDirectory }), (error) => {
+      assert.match(error.message, /cannot depend on workspace package "@opentag\/server"/);
+      assert.match(error.message, /must use the workspace: protocol/);
+      return true;
+    });
+  });
+});
+
+test("rejects package metadata that weakens the artifact boundary", async () => {
+  await withFixture(async (rootDirectory) => {
+    const manifestPath = join(rootDirectory, "packages/shared/package.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    delete manifest.exports;
+    delete manifest.files;
+    await writeJson(manifestPath, manifest);
+
+    await assert.rejects(verifyWorkspaceContracts({ rootDirectory }), (error) => {
+      assert.match(error.message, /exports must define the public "\." entry point/);
+      assert.match(error.message, /files must declare the published artifact boundary/);
+      return true;
+    });
+  });
+});
+
+test("rejects package deep imports", async () => {
+  await withFixture(async (rootDirectory) => {
+    await writeFile(
+      join(rootDirectory, "packages/client/src/index.ts"),
+      'export { value } from "@opentag/shared/internal";\n',
+    );
+
+    await assert.rejects(
+      verifyWorkspaceContracts({ rootDirectory }),
+      /import "@opentag\/shared\/internal" bypasses the public root export/,
+    );
+  });
+});
+
+test("rejects relative imports that cross workspace boundaries", async () => {
+  await withFixture(async (rootDirectory) => {
+    await writeFile(
+      join(rootDirectory, "packages/client/src/index.ts"),
+      'export { value } from "../../shared/src/index.ts";\n',
+    );
+
+    await assert.rejects(
+      verifyWorkspaceContracts({ rootDirectory }),
+      /relative import "\.\.\/\.\.\/shared\/src\/index\.ts" crosses into workspace "@opentag\/shared"/,
+    );
+  });
+});

--- a/scripts/__tests__/workspace-contracts.test.mjs
+++ b/scripts/__tests__/workspace-contracts.test.mjs
@@ -214,6 +214,51 @@ test("rejects root export targets outside the files boundary", async () => {
   });
 });
 
+test("rejects invalid package export target segments", async () => {
+  for (const target of [
+    "./dist/../private.mjs",
+    "./dist/./index.mjs",
+    "./dist/node_modules/private.mjs",
+    "./dist/%2e%2e/private.mjs",
+  ]) {
+    await withFixture(async (rootDirectory) => {
+      const manifestPath = join(rootDirectory, "packages/shared/package.json");
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+      manifest.exports["."] = target;
+      await writeJson(manifestPath, manifest);
+
+      await assert.rejects(
+        verifyWorkspaceContracts({ rootDirectory }),
+        /root export target .* contains an invalid package target segment/,
+      );
+    });
+  }
+});
+
+test("rejects package versions that node-semver does not accept", async () => {
+  for (const version of ["01.0.0", "1.0.0-alpha..1", "1.0.0-01"]) {
+    await withFixture(async (rootDirectory) => {
+      const manifestPath = join(rootDirectory, "packages/shared/package.json");
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+      manifest.version = version;
+      await writeJson(manifestPath, manifest);
+
+      await assert.rejects(verifyWorkspaceContracts({ rootDirectory }), /version must be a valid semantic version/);
+    });
+  }
+});
+
+test("accepts SemVer build metadata", async () => {
+  await withFixture(async (rootDirectory) => {
+    const manifestPath = join(rootDirectory, "packages/shared/package.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    manifest.version = "1.0.0+build.1";
+    await writeJson(manifestPath, manifest);
+
+    await assert.doesNotReject(verifyWorkspaceContracts({ rootDirectory }));
+  });
+});
+
 test("rejects package deep imports", async () => {
   await withFixture(async (rootDirectory) => {
     await writeFile(

--- a/scripts/verify-workspace-contracts.mjs
+++ b/scripts/verify-workspace-contracts.mjs
@@ -2,13 +2,14 @@ import { access, readdir, readFile } from "node:fs/promises";
 import { dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import semver from "semver";
 import ts from "typescript";
 
 const CONTRACT_FILENAME = "workspace-contracts.json";
 const DEPENDENCY_FIELDS = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"];
 const SOURCE_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"]);
 const SKIPPED_DIRECTORIES = new Set([".turbo", "coverage", "dist", "node_modules"]);
-const SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const INVALID_PACKAGE_TARGET_SEGMENT = /^(?:\.{1,2}|node_modules)$/i;
 
 export class WorkspaceContractError extends Error {
   constructor(violations) {
@@ -267,6 +268,19 @@ function filesEntryCoversTarget(filesEntry, target) {
   return normalizedTarget === normalizedEntry || normalizedTarget.startsWith(`${normalizedEntry}/`);
 }
 
+function isValidPackageExportTarget(target) {
+  if (!target.startsWith("./") || target.includes("\\") || /%2f|%5c/i.test(target)) {
+    return false;
+  }
+  try {
+    return !decodeURIComponent(target.slice(2))
+      .split("/")
+      .some((segment) => INVALID_PACKAGE_TARGET_SEGMENT.test(segment));
+  } catch {
+    return false;
+  }
+}
+
 function declaredDependencies(manifest) {
   const dependencies = new Map();
   for (const field of DEPENDENCY_FIELDS) {
@@ -353,7 +367,7 @@ function validateManifest(workspace, workspaceNames, violations) {
   if (manifest.name !== contract.name) {
     violations.push(`${manifestPath}: name must be "${contract.name}", found "${manifest.name ?? "missing"}"`);
   }
-  if (typeof manifest.version !== "string" || !SEMVER_PATTERN.test(manifest.version)) {
+  if (typeof manifest.version !== "string" || semver.valid(manifest.version) === null) {
     violations.push(`${manifestPath}: version must be a valid semantic version`);
   }
   if (manifest.private !== contract.private) {
@@ -386,6 +400,8 @@ function validateManifest(workspace, workspaceNames, violations) {
     for (const target of exportTargets) {
       if (!target.startsWith("./")) {
         violations.push(`${manifestPath}: root export target "${target}" must be package-relative`);
+      } else if (!isValidPackageExportTarget(target)) {
+        violations.push(`${manifestPath}: root export target "${target}" contains an invalid package target segment`);
       } else if (
         contract.requiresFiles &&
         hasFilesBoundary &&

--- a/scripts/verify-workspace-contracts.mjs
+++ b/scripts/verify-workspace-contracts.mjs
@@ -1,0 +1,444 @@
+import { access, readdir, readFile } from "node:fs/promises";
+import { dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const CONTRACT_FILENAME = "workspace-contracts.json";
+const DEPENDENCY_FIELDS = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"];
+const SOURCE_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"]);
+const SKIPPED_DIRECTORIES = new Set([".turbo", "coverage", "dist", "node_modules"]);
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export class WorkspaceContractError extends Error {
+  constructor(violations) {
+    super(`Workspace architecture violations:\n${violations.map((violation) => `- ${violation}`).join("\n")}`);
+    this.name = "WorkspaceContractError";
+    this.violations = violations;
+  }
+}
+
+function toPosix(filePath) {
+  return filePath.split(sep).join("/");
+}
+
+function isInside(parentDirectory, candidatePath) {
+  const relativePath = relative(parentDirectory, candidatePath);
+  return (
+    relativePath === "" || (!relativePath.startsWith(`..${sep}`) && relativePath !== ".." && !isAbsolute(relativePath))
+  );
+}
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+export function parseWorkspacePatterns(source) {
+  const patterns = [];
+  let packagesIndent;
+
+  for (const line of source.split(/\r?\n/)) {
+    if (packagesIndent === undefined) {
+      const packagesMatch = line.match(/^(\s*)packages:\s*(?:#.*)?$/);
+      if (packagesMatch) {
+        packagesIndent = packagesMatch[1].length;
+      }
+      continue;
+    }
+
+    if (/^\s*(?:#.*)?$/.test(line)) {
+      continue;
+    }
+
+    const indentation = line.match(/^\s*/)[0].length;
+    if (indentation <= packagesIndent) {
+      break;
+    }
+
+    const itemMatch = line.match(/^\s*-\s*(?:"([^"]+)"|'([^']+)'|([^#]+?))\s*(?:#.*)?$/);
+    if (!itemMatch) {
+      throw new Error(`Unsupported pnpm workspace entry: ${line.trim()}`);
+    }
+    patterns.push((itemMatch[1] ?? itemMatch[2] ?? itemMatch[3]).trim());
+  }
+
+  if (patterns.length === 0) {
+    throw new Error("pnpm-workspace.yaml must define at least one package pattern");
+  }
+
+  return patterns;
+}
+
+async function expandWorkspacePattern(rootDirectory, pattern) {
+  const normalizedPattern = pattern.replace(/^\.\//, "").replace(/\/$/, "");
+  if (normalizedPattern.startsWith("!") || /[?{}[\]]/.test(normalizedPattern)) {
+    throw new Error(`Unsupported pnpm workspace pattern: ${pattern}`);
+  }
+
+  let candidates = [rootDirectory];
+  for (const segment of normalizedPattern.split("/")) {
+    if (segment === "*") {
+      const expanded = [];
+      for (const candidate of candidates) {
+        if (!(await exists(candidate))) {
+          continue;
+        }
+        const entries = await readdir(candidate, { withFileTypes: true });
+        expanded.push(
+          ...entries
+            .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+            .map((entry) => join(candidate, entry.name)),
+        );
+      }
+      candidates = expanded;
+      continue;
+    }
+
+    if (segment.includes("*")) {
+      throw new Error(`Unsupported pnpm workspace pattern: ${pattern}`);
+    }
+    candidates = candidates.map((candidate) => join(candidate, segment));
+  }
+
+  const matches = [];
+  for (const candidate of candidates) {
+    if (await exists(join(candidate, "package.json"))) {
+      matches.push(toPosix(relative(rootDirectory, candidate)));
+    }
+  }
+  return matches;
+}
+
+async function discoverWorkspaces(rootDirectory) {
+  const workspaceSource = await readFile(join(rootDirectory, "pnpm-workspace.yaml"), "utf8");
+  const patterns = parseWorkspacePatterns(workspaceSource);
+  const workspacePaths = new Set();
+  const unmatchedPatterns = [];
+
+  for (const pattern of patterns) {
+    const matches = await expandWorkspacePattern(rootDirectory, pattern);
+    if (matches.length === 0) {
+      unmatchedPatterns.push(pattern);
+    }
+    for (const match of matches) {
+      workspacePaths.add(match);
+    }
+  }
+
+  return { patterns, unmatchedPatterns, workspacePaths: [...workspacePaths].sort() };
+}
+
+async function collectSourceFiles(directory) {
+  const sourceFiles = [];
+  const entries = await readdir(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+        sourceFiles.push(...(await collectSourceFiles(entryPath)));
+      }
+      continue;
+    }
+    if (entry.isFile() && SOURCE_EXTENSIONS.has(extname(entry.name))) {
+      sourceFiles.push(entryPath);
+    }
+  }
+
+  return sourceFiles;
+}
+
+function collectModuleSpecifiers(source, filePath) {
+  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
+  const specifiers = [];
+
+  function visit(node) {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteralLike(node.moduleReference.expression)
+    ) {
+      specifiers.push(node.moduleReference.expression.text);
+    } else if (
+      ts.isCallExpression(node) &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteralLike(node.arguments[0]) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === "require"))
+    ) {
+      specifiers.push(node.arguments[0].text);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return specifiers;
+}
+
+function declaredDependencies(manifest) {
+  const dependencies = new Map();
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const [name, range] of Object.entries(manifest[field] ?? {})) {
+      dependencies.set(name, { field, range });
+    }
+  }
+  return dependencies;
+}
+
+function validateContractConfiguration(contract, violations) {
+  if (contract.schemaVersion !== 1) {
+    violations.push(`${CONTRACT_FILENAME}: schemaVersion must be 1`);
+  }
+  if (!contract.workspaces || typeof contract.workspaces !== "object" || Array.isArray(contract.workspaces)) {
+    violations.push(`${CONTRACT_FILENAME}: workspaces must be an object keyed by workspace path`);
+    return;
+  }
+
+  const names = new Set();
+  for (const [workspacePath, workspaceContract] of Object.entries(contract.workspaces)) {
+    if (
+      workspacePath.includes("\\") ||
+      isAbsolute(workspacePath) ||
+      workspacePath.split("/").some((segment) => segment === "." || segment === "..")
+    ) {
+      violations.push(`${CONTRACT_FILENAME}: invalid workspace path "${workspacePath}"`);
+    }
+    if (!workspaceContract || typeof workspaceContract !== "object" || Array.isArray(workspaceContract)) {
+      violations.push(`${CONTRACT_FILENAME}: contract for "${workspacePath}" must be an object`);
+      continue;
+    }
+    if (typeof workspaceContract.name !== "string" || workspaceContract.name.length === 0) {
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" must declare a package name`);
+    } else if (names.has(workspaceContract.name)) {
+      violations.push(`${CONTRACT_FILENAME}: duplicate package name "${workspaceContract.name}"`);
+    } else {
+      names.add(workspaceContract.name);
+    }
+    if (!Array.isArray(workspaceContract.allowedWorkspaceDependencies)) {
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" must declare allowedWorkspaceDependencies`);
+    } else if (
+      workspaceContract.allowedWorkspaceDependencies.some((dependencyName) => typeof dependencyName !== "string")
+    ) {
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" contains a non-string workspace dependency`);
+    } else if (
+      new Set(workspaceContract.allowedWorkspaceDependencies).size !==
+      workspaceContract.allowedWorkspaceDependencies.length
+    ) {
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" contains duplicate workspace dependencies`);
+    }
+    if (typeof workspaceContract.private !== "boolean") {
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" must declare private as a boolean`);
+    }
+    if (typeof workspaceContract.requiresRootExport !== "boolean") {
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" must declare requiresRootExport as a boolean`);
+    }
+    if (typeof workspaceContract.requiresFiles !== "boolean") {
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" must declare requiresFiles as a boolean`);
+    }
+  }
+
+  for (const [workspacePath, workspaceContract] of Object.entries(contract.workspaces)) {
+    if (!workspaceContract || typeof workspaceContract !== "object" || Array.isArray(workspaceContract)) {
+      continue;
+    }
+    for (const dependencyName of workspaceContract.allowedWorkspaceDependencies ?? []) {
+      if (!names.has(dependencyName)) {
+        violations.push(
+          `${CONTRACT_FILENAME}: "${workspacePath}" allows unknown workspace dependency "${dependencyName}"`,
+        );
+      }
+      if (dependencyName === workspaceContract.name) {
+        violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" cannot depend on itself`);
+      }
+    }
+  }
+}
+
+function validateManifest(workspace, workspaceNames, violations) {
+  const { contract, manifest, workspacePath } = workspace;
+  const manifestPath = `${workspacePath}/package.json`;
+
+  if (manifest.name !== contract.name) {
+    violations.push(`${manifestPath}: name must be "${contract.name}", found "${manifest.name ?? "missing"}"`);
+  }
+  if (typeof manifest.version !== "string" || !SEMVER_PATTERN.test(manifest.version)) {
+    violations.push(`${manifestPath}: version must be a valid semantic version`);
+  }
+  if (manifest.private !== contract.private) {
+    violations.push(`${manifestPath}: private must be ${String(contract.private)}`);
+  }
+  if (manifest.type !== "module") {
+    violations.push(`${manifestPath}: type must be "module"`);
+  }
+  if (contract.requiresRootExport && (!manifest.exports || !("." in manifest.exports))) {
+    violations.push(`${manifestPath}: exports must define the public "." entry point`);
+  }
+  if (contract.requiresFiles && (!Array.isArray(manifest.files) || manifest.files.length === 0)) {
+    violations.push(`${manifestPath}: files must declare the published artifact boundary`);
+  }
+
+  const allowedDependencies = new Set(contract.allowedWorkspaceDependencies ?? []);
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const [dependencyName, range] of Object.entries(manifest[field] ?? {})) {
+      if (!workspaceNames.has(dependencyName)) {
+        continue;
+      }
+      if (!allowedDependencies.has(dependencyName)) {
+        violations.push(`${manifestPath}: ${field} cannot depend on workspace package "${dependencyName}"`);
+      }
+      if (typeof range !== "string" || !range.startsWith("workspace:")) {
+        violations.push(`${manifestPath}: internal dependency "${dependencyName}" must use the workspace: protocol`);
+      }
+    }
+  }
+}
+
+async function validateImports(rootDirectory, workspaces, violations) {
+  const byName = new Map(
+    workspaces
+      .filter((workspace) => typeof workspace.manifest.name === "string")
+      .map((workspace) => [workspace.manifest.name, workspace]),
+  );
+  const namesByLength = [...byName.keys()].sort((left, right) => right.length - left.length);
+
+  for (const workspace of workspaces) {
+    const declared = declaredDependencies(workspace.manifest);
+    const allowed = new Set(workspace.contract.allowedWorkspaceDependencies ?? []);
+    const sourceFiles = await collectSourceFiles(workspace.directory);
+
+    for (const sourceFile of sourceFiles) {
+      const source = await readFile(sourceFile, "utf8");
+      const displayPath = toPosix(relative(rootDirectory, sourceFile));
+      for (const specifier of collectModuleSpecifiers(source, sourceFile)) {
+        if (specifier.startsWith(".")) {
+          const resolvedImport = resolve(dirname(sourceFile), specifier);
+          const targetWorkspace = workspaces.find(
+            (candidate) => candidate !== workspace && isInside(candidate.directory, resolvedImport),
+          );
+          if (targetWorkspace) {
+            violations.push(
+              `${displayPath}: relative import "${specifier}" crosses into workspace "${targetWorkspace.manifest.name}"`,
+            );
+          }
+          continue;
+        }
+
+        const targetName = namesByLength.find(
+          (workspaceName) => specifier === workspaceName || specifier.startsWith(`${workspaceName}/`),
+        );
+        if (!targetName || targetName === workspace.manifest.name) {
+          continue;
+        }
+
+        if (specifier !== targetName) {
+          violations.push(`${displayPath}: import "${specifier}" bypasses the public root export of "${targetName}"`);
+        }
+        if (!allowed.has(targetName)) {
+          violations.push(`${displayPath}: imports forbidden workspace package "${targetName}"`);
+        }
+        if (!declared.has(targetName)) {
+          violations.push(`${displayPath}: imports undeclared workspace package "${targetName}"`);
+        }
+      }
+    }
+  }
+}
+
+export async function verifyWorkspaceContracts({
+  rootDirectory = process.cwd(),
+  contractPath = join(rootDirectory, CONTRACT_FILENAME),
+} = {}) {
+  const resolvedRoot = resolve(rootDirectory);
+  const contract = await readJson(contractPath);
+  const discovery = await discoverWorkspaces(resolvedRoot);
+  const violations = [];
+  validateContractConfiguration(contract, violations);
+
+  for (const pattern of discovery.unmatchedPatterns) {
+    violations.push(`pnpm-workspace.yaml: pattern "${pattern}" does not match a package.json`);
+  }
+
+  const contractPaths = Object.keys(contract.workspaces ?? {}).sort();
+  const discoveredPaths = new Set(discovery.workspacePaths);
+  for (const workspacePath of discovery.workspacePaths) {
+    if (!contract.workspaces?.[workspacePath]) {
+      violations.push(`${workspacePath}/package.json: workspace is not registered in ${CONTRACT_FILENAME}`);
+    }
+  }
+  for (const workspacePath of contractPaths) {
+    if (!discoveredPaths.has(workspacePath)) {
+      violations.push(
+        `${CONTRACT_FILENAME}: registered workspace "${workspacePath}" is not selected by pnpm-workspace.yaml`,
+      );
+    }
+  }
+
+  const workspaces = [];
+  for (const workspacePath of discovery.workspacePaths) {
+    const workspaceContract = contract.workspaces?.[workspacePath];
+    if (!workspaceContract) {
+      continue;
+    }
+    const directory = join(resolvedRoot, workspacePath);
+    workspaces.push({
+      contract: workspaceContract,
+      directory,
+      manifest: await readJson(join(directory, "package.json")),
+      workspacePath,
+    });
+  }
+
+  const manifestNames = workspaces
+    .map((workspace) => workspace.manifest.name)
+    .filter((packageName) => typeof packageName === "string");
+  const workspaceNames = new Set(manifestNames);
+  if (manifestNames.length === workspaces.length && workspaceNames.size !== workspaces.length) {
+    violations.push("workspace package names must be unique");
+  }
+  for (const workspace of workspaces) {
+    validateManifest(workspace, workspaceNames, violations);
+  }
+  await validateImports(resolvedRoot, workspaces, violations);
+
+  if (violations.length > 0) {
+    throw new WorkspaceContractError([...new Set(violations)].sort());
+  }
+
+  return {
+    allowedDependencyCount: contractPaths.reduce(
+      (count, workspacePath) => count + contract.workspaces[workspacePath].allowedWorkspaceDependencies.length,
+      0,
+    ),
+    workspaceCount: workspaces.length,
+  };
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    const result = await verifyWorkspaceContracts();
+    console.log(
+      `Workspace architecture verified (${result.workspaceCount} workspaces, ${result.allowedDependencyCount} allowed dependency edges).`,
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-workspace-contracts.mjs
+++ b/scripts/verify-workspace-contracts.mjs
@@ -176,8 +176,14 @@ function collectModuleSpecifiers(source, filePath) {
     ) {
       specifiers.push(node.moduleReference.expression.text);
     } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteralLike(node.argument.literal)
+    ) {
+      specifiers.push(node.argument.literal.text);
+    } else if (
       ts.isCallExpression(node) &&
-      node.arguments.length === 1 &&
+      node.arguments.length >= 1 &&
       ts.isStringLiteralLike(node.arguments[0]) &&
       (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
         (ts.isIdentifier(node.expression) && node.expression.text === "require"))
@@ -190,6 +196,75 @@ function collectModuleSpecifiers(source, filePath) {
 
   visit(sourceFile);
   return specifiers;
+}
+
+function rootExportValue(exportsField) {
+  if (typeof exportsField === "string" || exportsField === null || Array.isArray(exportsField)) {
+    return { defined: exportsField !== undefined, value: exportsField };
+  }
+  if (!exportsField || typeof exportsField !== "object") {
+    return { defined: false, value: undefined };
+  }
+  if ("." in exportsField) {
+    return { defined: true, value: exportsField["."] };
+  }
+  if (Object.keys(exportsField).every((key) => !key.startsWith("."))) {
+    return { defined: true, value: exportsField };
+  }
+  return { defined: false, value: undefined };
+}
+
+function collectExportTargets(value, targets) {
+  if (typeof value === "string") {
+    targets.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectExportTargets(item, targets);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const target of Object.values(value)) {
+      collectExportTargets(target, targets);
+    }
+  }
+}
+
+function globPatternToRegExp(pattern) {
+  let source = "^";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (character === "*" && pattern[index + 1] === "*") {
+      if (pattern[index + 2] === "/") {
+        source += "(?:[^/]+/)*";
+        index += 2;
+      } else {
+        source += ".*";
+        index += 1;
+      }
+    } else if (character === "*") {
+      source += "[^/]*";
+    } else if (character === "?") {
+      source += "[^/]";
+    } else {
+      source += character.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+    }
+  }
+  return new RegExp(`${source}$`);
+}
+
+function filesEntryCoversTarget(filesEntry, target) {
+  const normalizedEntry = filesEntry.replace(/^\.\//, "").replace(/\/$/, "");
+  const normalizedTarget = target.replace(/^\.\//, "");
+  if (normalizedEntry.length === 0 || normalizedEntry.startsWith("!")) {
+    return false;
+  }
+  if (/[*?]/.test(normalizedEntry)) {
+    return globPatternToRegExp(normalizedEntry).test(normalizedTarget);
+  }
+  return normalizedTarget === normalizedEntry || normalizedTarget.startsWith(`${normalizedEntry}/`);
 }
 
 function declaredDependencies(manifest) {
@@ -287,11 +362,38 @@ function validateManifest(workspace, workspaceNames, violations) {
   if (manifest.type !== "module") {
     violations.push(`${manifestPath}: type must be "module"`);
   }
-  if (contract.requiresRootExport && (!manifest.exports || !("." in manifest.exports))) {
+  const rootExport = rootExportValue(manifest.exports);
+  if (contract.requiresRootExport && !rootExport.defined) {
     violations.push(`${manifestPath}: exports must define the public "." entry point`);
   }
-  if (contract.requiresFiles && (!Array.isArray(manifest.files) || manifest.files.length === 0)) {
+
+  const hasFilesBoundary = Array.isArray(manifest.files) && manifest.files.length > 0;
+  const validFilesEntries = hasFilesBoundary
+    ? manifest.files.filter((entry) => typeof entry === "string" && entry.length > 0)
+    : [];
+  if (contract.requiresFiles && !hasFilesBoundary) {
     violations.push(`${manifestPath}: files must declare the published artifact boundary`);
+  } else if (contract.requiresFiles && validFilesEntries.length !== manifest.files.length) {
+    violations.push(`${manifestPath}: files entries must be non-empty strings`);
+  }
+
+  if (contract.requiresRootExport && rootExport.defined) {
+    const exportTargets = [];
+    collectExportTargets(rootExport.value, exportTargets);
+    if (exportTargets.length === 0) {
+      violations.push(`${manifestPath}: exports "." must resolve to at least one artifact target`);
+    }
+    for (const target of exportTargets) {
+      if (!target.startsWith("./")) {
+        violations.push(`${manifestPath}: root export target "${target}" must be package-relative`);
+      } else if (
+        contract.requiresFiles &&
+        hasFilesBoundary &&
+        !validFilesEntries.some((entry) => filesEntryCoversTarget(entry, target))
+      ) {
+        violations.push(`${manifestPath}: root export target "${target}" is not covered by files`);
+      }
+    }
   }
 
   const allowedDependencies = new Set(contract.allowedWorkspaceDependencies ?? []);
@@ -305,6 +407,59 @@ function validateManifest(workspace, workspaceNames, violations) {
       }
       if (typeof range !== "string" || !range.startsWith("workspace:")) {
         violations.push(`${manifestPath}: internal dependency "${dependencyName}" must use the workspace: protocol`);
+      }
+    }
+  }
+}
+
+async function validateTypeScriptReferences(workspaces, violations) {
+  const byDirectory = new Map(workspaces.map((workspace) => [resolve(workspace.directory), workspace]));
+
+  for (const workspace of workspaces) {
+    const tsconfigPath = join(workspace.directory, "tsconfig.json");
+    const displayPath = `${workspace.workspacePath}/tsconfig.json`;
+    if (!(await exists(tsconfigPath))) {
+      violations.push(`${displayPath}: file is required to validate workspace project references`);
+      continue;
+    }
+
+    const tsconfig = await readJson(tsconfigPath);
+    if (tsconfig.references !== undefined && !Array.isArray(tsconfig.references)) {
+      violations.push(`${displayPath}: references must be an array`);
+      continue;
+    }
+
+    const referencedNames = new Set();
+    for (const reference of tsconfig.references ?? []) {
+      if (!reference || typeof reference !== "object" || typeof reference.path !== "string") {
+        violations.push(`${displayPath}: each project reference must declare a string path`);
+        continue;
+      }
+      const resolvedReference = resolve(workspace.directory, reference.path);
+      const referencedDirectory =
+        extname(resolvedReference) === ".json" ? dirname(resolvedReference) : resolvedReference;
+      const referencedWorkspace = byDirectory.get(referencedDirectory);
+      if (!referencedWorkspace) {
+        violations.push(`${displayPath}: reference "${reference.path}" does not target a registered workspace root`);
+        continue;
+      }
+      if (referencedNames.has(referencedWorkspace.manifest.name)) {
+        violations.push(
+          `${displayPath}: contains duplicate reference to workspace package "${referencedWorkspace.manifest.name}"`,
+        );
+      }
+      referencedNames.add(referencedWorkspace.manifest.name);
+    }
+
+    const allowedNames = new Set(workspace.contract.allowedWorkspaceDependencies ?? []);
+    for (const referencedName of referencedNames) {
+      if (!allowedNames.has(referencedName)) {
+        violations.push(`${displayPath}: references forbidden workspace package "${referencedName}"`);
+      }
+    }
+    for (const allowedName of allowedNames) {
+      if (!referencedNames.has(allowedName)) {
+        violations.push(`${displayPath}: missing reference to allowed workspace package "${allowedName}"`);
       }
     }
   }
@@ -415,6 +570,7 @@ export async function verifyWorkspaceContracts({
   for (const workspace of workspaces) {
     validateManifest(workspace, workspaceNames, violations);
   }
+  await validateTypeScriptReferences(workspaces, violations);
   await validateImports(resolvedRoot, workspaces, violations);
 
   if (violations.length > 0) {

--- a/workspace-contracts.json
+++ b/workspace-contracts.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "workspaces": {
+    "apps/cli": {
+      "name": "open-tag",
+      "private": true,
+      "requiresRootExport": true,
+      "requiresFiles": true,
+      "allowedWorkspaceDependencies": ["@opentag/client", "@opentag/shared"]
+    },
+    "packages/client": {
+      "name": "@opentag/client",
+      "private": true,
+      "requiresRootExport": true,
+      "requiresFiles": true,
+      "allowedWorkspaceDependencies": ["@opentag/shared"]
+    },
+    "packages/server": {
+      "name": "@opentag/server",
+      "private": true,
+      "requiresRootExport": true,
+      "requiresFiles": true,
+      "allowedWorkspaceDependencies": ["@opentag/shared"]
+    },
+    "packages/shared": {
+      "name": "@opentag/shared",
+      "private": true,
+      "requiresRootExport": true,
+      "requiresFiles": true,
+      "allowedWorkspaceDependencies": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a declarative contract for all pnpm workspaces and permitted internal dependency edges
- reject unregistered workspaces, invalid internal version ranges, forbidden dependencies, deep imports, and cross-workspace relative imports
- validate package identity and artifact metadata, with six focused fixture tests
- run the architecture verifier from the existing required `pnpm check` CI path

## Why

OpenTag previously documented its package boundaries but relied on review discipline to preserve them. This change turns those boundaries into a deterministic repository gate while keeping the current four-workspace graph unchanged.

## Context Tree

- Paired draft PR: https://github.com/first-tree-ai/first-tree-context/pull/953

The Context Tree PR follows the code-first workflow: merge this code PR first, then reconcile and mark the tree PR ready.

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`

All 12 script tests and 19 workspace tests pass.

## Non-goals

- no runtime behavior or dependency versions change
- no new workspace or package is introduced
