### PR TITLE
ci: enforce Node.js compatibility matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  PRIMARY_NODE_VERSION: "24"
+
 jobs:
   checks:
     name: Checks
@@ -47,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.13.1
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies
@@ -65,6 +68,38 @@ jobs:
       - name: Test
         run: pnpm test
 
+  node-compatibility:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - node: "22.13.0"
+            name: Node 22.13.0 Compatibility
+          - node: "26"
+            name: Node 26 Compatibility
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.12.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --config.engine-strict=true
+
+      - name: Run compatibility smokes
+        run: pnpm check:node-compat
+
   cli-pack-smoke:
     name: CLI Pack Smoke
     runs-on: ubuntu-latest
@@ -80,7 +115,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.13.1
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies
@@ -176,6 +211,7 @@ jobs:
     if: always()
     needs:
       - checks
+      - node-compatibility
       - cli-pack-smoke
       - container-smoke
     runs-on: ubuntu-latest
@@ -183,10 +219,11 @@ jobs:
       - name: Verify required jobs
         env:
           CHECKS_RESULT: ${{ needs.checks.result }}
+          NODE_COMPATIBILITY_RESULT: ${{ needs.node-compatibility.result }}
           CLI_PACK_RESULT: ${{ needs.cli-pack-smoke.result }}
           CONTAINER_RESULT: ${{ needs.container-smoke.result }}
         run: |
-          for result in "$CHECKS_RESULT" "$CLI_PACK_RESULT" "$CONTAINER_RESULT"; do
+          for result in "$CHECKS_RESULT" "$NODE_COMPATIBILITY_RESULT" "$CLI_PACK_RESULT" "$CONTAINER_RESULT"; do
             if [ "$result" != "success" ]; then
               echo "Required CI job did not succeed: $result" >&2
               exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ historical feature with the same name in the First Tree repository. Do not copy 
 
 ## Toolchain
 
-- Node.js `>=22.13.0` (Node.js 24 recommended), ESM, strict TypeScript
+- Node.js `^22.13.0 || ^24.0.0 || ^26.0.0` (Node.js 24 primary), ESM, strict TypeScript
 - pnpm 10.12.1 and Turborepo
 - Biome for formatting and linting
 - tsdown for ESM builds and Vitest for tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-- Node.js 22.13 or newer (Node.js 24 is recommended)
+- Node.js 22.13 or newer on 22.x, Node.js 24.x, or Node.js 26.x (use the latest patch; Node.js 24 is primary)
 - Corepack and pnpm 10.12.1
 - Docker with Compose support, only when running the local PostgreSQL service
 
@@ -29,8 +29,10 @@ pnpm test
 Use `pnpm lint` for lint-only feedback. Use `pnpm format` to apply Biome formatting.
 
 The required pull request check is the stable `CI` fan-in job. It covers the commands above, source and staging CLI
-tarball installation, and a production-container health smoke. To exercise the current source tarball locally after a
-build:
+tarball installation, a production-container health smoke, and the supported Node.js lines. Full validation and releases
+run on Node.js 24. Compatibility jobs run `pnpm check:node-compat` on the exact Node.js 22.13.0 floor and the latest
+Node.js 26 release; that command builds, tests, and installs the packed CLI. Node.js 23 and 25 are end-of-life and are not
+supported. To exercise the current source tarball locally after a build:
 
 ~~~bash
 node scripts/cli-pack-smoke.mjs \

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -1,11 +1,11 @@
 # OpenTag 开发指南
 
 > Canonical source: [DEVELOPMENT.md](./DEVELOPMENT.md)
-> Last synced with: 2026-08-17
+> Last synced with: 2026-08-18
 
 ## 前置要求
 
-- Node.js 22.13 或更高版本（推荐 Node.js 24）
+- Node.js 22.x（最低 22.13）、Node.js 24.x 或 Node.js 26.x（使用最新补丁版本；主力版本为 Node.js 24）
 - Corepack 和 pnpm 10.12.1
 - Docker 及 Compose 支持（仅运行本地 PostgreSQL 服务时需要）
 
@@ -29,8 +29,10 @@ pnpm test
 
 仅检查 lint 可运行 `pnpm lint`；应用 Biome 格式化可运行 `pnpm format`。
 
-Pull Request 的必过检查是稳定的 `CI` fan-in job。它会覆盖上述命令、source/staging CLI tarball 安装和生产容器
-健康检查。构建后可在本地验证当前 source tarball：
+Pull Request 的必过检查是稳定的 `CI` fan-in job。它会覆盖上述命令、source/staging CLI tarball 安装、生产容器
+健康检查和受支持的 Node.js 版本。完整验证与发布使用 Node.js 24；兼容 job 会在精确下限 Node.js 22.13.0 和
+最新 Node.js 26 上运行 `pnpm check:node-compat`，完成构建、测试和 CLI tarball 安装。Node.js 23 与 25 已 EOL，
+不在支持范围内。构建后可在本地验证当前 source tarball：
 
 ~~~bash
 node scripts/cli-pack-smoke.mjs \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ No messaging integration, agent provider, session runtime, or database schema is
 
 ## Quick start
 
-Prerequisites: Node.js 22.13 or newer, Corepack, and pnpm 10.12.1.
+Prerequisites: Node.js 22.13 or newer on the 22.x line, Node.js 24.x, or Node.js 26.x; Corepack; and pnpm 10.12.1.
 
 ```bash
 corepack enable

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 # OpenTag
 
 > Canonical source: [README.md](./README.md)
-> Last synced with: 2026-08-17
+> Last synced with: 2026-08-18
 
 OpenTag 是一个全新的独立开源产品，用于连接团队即时通信与 AI 编码 Agent。项目目前处于 **pre-alpha**
 阶段：产品工作流仍在开发中，尚不适合生产使用。
@@ -18,7 +18,7 @@ OpenTag 是一个全新的独立开源产品，用于连接团队即时通信与
 
 ## 快速开始
 
-前置要求：Node.js 22.13 或更高版本、Corepack 和 pnpm 10.12.1。
+前置要求：Node.js 22.x（最低 22.13）、Node.js 24.x 或 Node.js 26.x，以及 Corepack 和 pnpm 10.12.1。
 
 ```bash
 corepack enable

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -39,7 +39,7 @@
     "THIRD_PARTY_NOTICES"
   ],
   "engines": {
-    "node": ">=22.13.0"
+    "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.12.1",
   "engines": {
-    "node": ">=22.13.0"
+    "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
   },
   "scripts": {
     "build": "turbo run build",
@@ -15,6 +15,7 @@
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck",
     "test": "node --test --test-concurrency=1 scripts/__tests__/*.test.mjs && turbo run test --concurrency=2",
+    "check:node-compat": "pnpm build && pnpm test && node scripts/node-compat-smoke.mjs",
     "notices:write": "node scripts/third-party-notices.mjs --write"
   },
   "devDependencies": {

--- a/scripts/node-compat-smoke.mjs
+++ b/scripts/node-compat-smoke.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { runCliPackSmoke } from "./cli-pack-smoke.mjs";
+
+async function main() {
+  const rootManifest = JSON.parse(await readFile(resolve("package.json"), "utf8"));
+  const manifest = JSON.parse(await readFile(resolve("apps/cli/package.json"), "utf8"));
+  const binaries = Object.keys(manifest.bin ?? {});
+
+  if (typeof manifest.name !== "string" || typeof manifest.version !== "string" || binaries.length !== 1) {
+    throw new Error("apps/cli/package.json must declare a name, version, and exactly one binary");
+  }
+  if (manifest.engines?.node !== rootManifest.engines?.node) {
+    throw new Error("the CLI and root Node.js engine ranges must match");
+  }
+
+  await runCliPackSmoke({
+    channel: "source",
+    expectedName: manifest.name,
+    expectedVersion: manifest.version,
+    expectedBinary: binaries[0],
+  });
+}
+
+main().catch((error) => {
+  console.error(`[node-compat-smoke] ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- declare Node.js 22.13+ on 22.x, 24.x, and 26.x as the supported runtime lines in the root and CLI engine contracts
- use Node.js 24 as the primary full-validation runtime
- add blocking compatibility lanes for the exact Node.js 22.13.0 floor and the latest Node.js 26 release
- run strict frozen installs, workspace build/tests, and a packed-CLI runtime smoke in compatibility lanes
- synchronize English and Chinese contributor documentation

## Why

This adopts the useful DeepSeek Harness pattern of separating one primary runtime from focused blocking compatibility lanes, while preserving OpenTag's existing Node.js 22.13 support contract. Node.js 23 and 25 are end-of-life and are intentionally excluded.

No dependency versions or lockfile entries change in this PR.

## Validation

- Node.js 22.13.0: engine-strict frozen install, forced build/tests, and packed CLI smoke
- Node.js 24.19.0: engine-strict frozen install, check, forced typecheck, and compatibility smoke
- Node.js 26.7.0: engine-strict frozen install and compatibility smoke
- local Node.js 24.7.0: `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test`, and `pnpm check:node-compat`

## Context Tree

Paired context record: first-tree-ai/first-tree-context#957 (draft, stacked on first-tree-ai/first-tree-context#953).
