### PR TITLE
fix: bundle websocket runtime in CLI

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@opentag/client": "workspace:*",
     "@opentag/shared": "workspace:*",
-    "commander": "^13.1.0"
+    "commander": "^13.1.0",
+    "ws": "^8.21.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      ws:
+        specifier: ^8.21.3
+        version: 8.21.3
 
   packages/client:
     dependencies:

--- a/scripts/__tests__/release-scripts.test.mjs
+++ b/scripts/__tests__/release-scripts.test.mjs
@@ -25,6 +25,7 @@ const sourceManifest = {
     "@opentag/client": "workspace:*",
     "@opentag/shared": "workspace:*",
     commander: "^13.1.0",
+    ws: "^8.21.3",
   },
 };
 
@@ -57,7 +58,7 @@ test("rewrites the staging identity without losing release metadata", async () =
     assert.equal(manifest.private, undefined);
     assert.equal(manifest.license, "Apache-2.0");
     assert.equal(manifest.repository.url, sourceManifest.repository.url);
-    assert.deepEqual(manifest.devDependencies, { commander: "^13.1.0" });
+    assert.deepEqual(manifest.devDependencies, { commander: "^13.1.0", ws: "^8.21.3" });
   });
 });
 

--- a/scripts/third-party-notices.mjs
+++ b/scripts/third-party-notices.mjs
@@ -9,7 +9,7 @@ const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const noticePath = resolve(projectRoot, "apps/cli/THIRD_PARTY_NOTICES");
 const bundledPackages = [
   { name: "commander", consumerManifest: "apps/cli/package.json" },
-  { name: "ws", consumerManifest: "packages/client/package.json" },
+  { name: "ws", consumerManifest: "apps/cli/package.json" },
   { name: "zod", consumerManifest: "packages/shared/package.json" },
 ];
 


### PR DESCRIPTION
## Summary

- declare `ws` directly in the CLI build dependencies so tsdown resolves and bundles the WebSocket runtime deterministically
- resolve the `ws` third-party notice from the CLI consumer manifest
- preserve the dependency through staging and production release preparation fixtures

## Problem

After PR #13, a workspace build could emit a CLI chunk with an unresolved external `import "ws"`. Since `apps/cli` did not install `ws`, `opentag-dev daemon run` then failed at module loading with `ERR_MODULE_NOT_FOUND` before reading credentials or connecting to the Server.

## Validation

- `pnpm install --frozen-lockfile --config.engine-strict=true`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- forced CLI rebuild with no external `from "ws"` import
- source CLI tarball pack/install smoke
- built `daemon run` with an empty home reaches the expected not-logged-in boundary instead of failing module loading

## Non-goals

- no daemon protocol, Server, database, or runtime behavior changes
