### PR TITLE
test: make ciphertext tamper assertion deterministic

### DIFF
--- a/packages/server/src/__tests__/crypto.test.ts
+++ b/packages/server/src/__tests__/crypto.test.ts
@@ -13,8 +13,11 @@ describe("ApplicationCipher", () => {
   it("fails closed for tampered or malformed ciphertext", () => {
     const cipher = new ApplicationCipher(new Uint8Array(32).fill(7));
     const encrypted = cipher.encrypt("invite-secret");
-    const replacement = encrypted.endsWith("A") ? "B" : "A";
-    expect(() => cipher.decrypt(`${encrypted.slice(0, -1)}${replacement}`)).toThrow(/authenticated/);
+    const tagSeparator = encrypted.lastIndexOf(".");
+    const tag = Buffer.from(encrypted.slice(tagSeparator + 1), "base64url");
+    tag.writeUInt8(tag.readUInt8(0) ^ 1, 0);
+    const tampered = `${encrypted.slice(0, tagSeparator + 1)}${tag.toString("base64url")}`;
+    expect(() => cipher.decrypt(tampered)).toThrow(/authenticated/);
     expect(() => cipher.decrypt("v2.invalid")).toThrow(/unsupported/);
   });
 });


### PR DESCRIPTION
## Summary

- mutate a decoded AES-GCM authentication tag byte instead of changing Base64URL padding bits
- make the authentication-failure assertion deterministic across Node versions and random tag endings

## Root cause

The final character of a 16-byte tag's unpadded Base64URL encoding contains only two data bits. Replacing canonical `A` with `B` changes the text but not the decoded bytes, so the prior randomized test failed about 25% of runs.

## Validation

- targeted crypto test
- 20 sequential repetitions of the targeted test
- `pnpm check`
- `pnpm typecheck`
- `git diff --check`
