### PR TITLE
fix: bind Admin Web fetch implementation

### DIFF
--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -10,6 +10,27 @@ function setDocumentCookie(value: string): void {
 }
 
 describe("BrowserApi", () => {
+  it("binds the default fetch implementation to the browser global", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            user: {
+              id: "498ee47d-16dc-4798-8e20-3608a2973dcf",
+              email: "admin@example.com",
+              displayName: "Admin",
+            },
+            memberships: [],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+
+    await expect(new BrowserApi().me()).resolves.toMatchObject({ user: { email: "admin@example.com" } });
+    expect(fetchImpl.mock.contexts).toEqual([globalThis]);
+  });
+
   it("rebuilds mutation CSRF headers after refreshing an expired access token", async () => {
     setDocumentCookie("opentag_csrf=old-token; Path=/");
     const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -35,7 +35,7 @@ export class ApiError extends Error {
 }
 
 export class BrowserApi {
-  constructor(readonly fetchImpl: typeof fetch = fetch) {}
+  constructor(readonly fetchImpl: typeof fetch = globalThis.fetch.bind(globalThis)) {}
 
   me(): Promise<MeResponse> {
     return this.request("/api/v1/me", MeResponseSchema);


### PR DESCRIPTION
## Summary

- bind the Admin Web's default `fetch` implementation to the browser global
- add a receiver-sensitive regression test that fails when `fetch` is invoked with the `BrowserApi` instance as its receiver

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- focused Admin Web API test, typecheck, build, and Biome checks
- `git diff --check`

## E2E

Momentic browser validation is not available yet because this repository does not define the required `local` environment in `momentic.config.yaml`. The regression is covered at the browser API boundary with a receiver-sensitive jsdom test.
