### PR TITLE
fix: make staging release versions sequential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           node scripts/release-versions.mjs \
             --channel staging \
             --source-version "$SOURCE_VERSION" \
-            --run-number "${{ github.run_number }}" \
+            --sequence "${{ github.run_number }}" \
             --run-attempt "${{ github.run_attempt }}"
 
       - name: Smoke source tarball

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -4,6 +4,8 @@ on:
   workflow_run:
     workflows:
       - CI
+    branches:
+      - main
     types:
       - completed
   workflow_dispatch:
@@ -25,6 +27,9 @@ jobs:
        github.event.workflow_run.head_branch == 'main') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
+    concurrency:
+      group: npm-publish-staging
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write
@@ -45,6 +50,9 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
           cache: pnpm
+
+      - name: Verify staging revision is current main
+        run: node scripts/check-staging-revision.mjs
 
       - name: Use trusted-publishing npm client
         run: npm install --global npm@11.5.1
@@ -69,10 +77,9 @@ jobs:
         id: version
         run: |
           SOURCE_VERSION=$(node -p "require('./apps/cli/package.json').version")
-          node scripts/release-versions.mjs \
-            --channel staging \
+          node scripts/resolve-staging-release.mjs \
             --source-version "$SOURCE_VERSION" \
-            --run-number "${{ github.run_number }}" \
+            --git-head "${{ steps.revision.outputs.sha }}" \
             --run-attempt "${{ github.run_attempt }}"
 
       - name: Check npm coordinate
@@ -102,6 +109,9 @@ jobs:
           --name "${{ steps.version.outputs.package_name }}"
           --version "${{ steps.version.outputs.version }}"
           --binary "${{ steps.version.outputs.binary_name }}"
+
+      - name: Recheck staging revision is current main
+        run: node scripts/check-staging-revision.mjs
 
       - name: Publish staging package
         if: steps.registry.outputs.publish == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,11 +34,17 @@ identity only in its ephemeral checkout by calling `scripts/prepare-cli-release.
 After successful `main` CI, the npm workflow computes the next patch and publishes:
 
 ~~~text
-X.Y.(Z+1)-staging.<github_run_number>.<github_run_attempt>
+X.Y.(Z+1)-staging.<release_sequence>.<github_run_attempt>
 ~~~
 
-It checks the registry before publishing. An absent coordinate may be published; an existing coordinate is accepted only
-when its `gitHead` matches the release commit. A registry failure or a coordinate owned by another commit fails closed.
+The first prerelease component is a registry-backed release sequence, not a GitHub workflow run number. Publishing jobs
+are serialized, read the highest published sequence for the target release line, and increment it by one. A new release
+line starts at sequence `1`. A retry for the same commit reuses its existing coordinate, while a stale run whose commit is
+no longer current `main` fails before publishing.
+
+The workflow checks the registry before publishing. An absent coordinate may be published; an existing coordinate is
+accepted only when its `gitHead` matches the release commit. A registry failure, unsupported published version, stale
+revision, or coordinate owned by another commit fails closed.
 
 If the first run fails because npm trusted publishing is not configured, configure the publisher above and manually
 dispatch the workflow from `main`. Do not add a token. After publishing, verify package metadata and install the exact

--- a/docs/zh-CN/releasing.md
+++ b/docs/zh-CN/releasing.md
@@ -1,7 +1,7 @@
 # OpenTag 发布指南
 
 > Canonical source: [../releasing.md](../releasing.md)
-> Last synced with: 2026-08-17
+> Last synced with: 2026-08-19
 
 OpenTag 以两个相互隔离的 npm package identity 发布一个自包含 CLI artifact：
 
@@ -34,11 +34,15 @@ source manifest 保持 `open-tag`、`private: true` 和稳定 base version。wor
 `main` CI 成功后，npm workflow 会计算 next patch 并发布：
 
 ~~~text
-X.Y.(Z+1)-staging.<github_run_number>.<github_run_attempt>
+X.Y.(Z+1)-staging.<release_sequence>.<github_run_attempt>
 ~~~
 
+第一个 prerelease 分量是由 registry 驱动的发布序号，不再使用 GitHub workflow run number。发布 job 会串行
+执行，读取目标 release line 已发布的最大序号并加一；新的 release line 从序号 `1` 开始。同一 commit 重试时
+复用已有坐标，旧 run 的 commit 如果已不是当前 `main`，则会在发布前失败。
+
 发布前会查询 registry。不存在的坐标可以发布；已存在的坐标只有在 `gitHead` 与 release commit 相同时才作为
-幂等成功。registry 失败或坐标属于其他 commit 时会硬失败。
+幂等成功。registry 查询失败、出现不支持的已发布版本、revision 已过期或坐标属于其他 commit 时都会硬失败。
 
 如果首次运行因为 npm trusted publishing 未配置而失败，请先按上述字段配置 publisher，再从 `main` 手动
 dispatch workflow；不要添加 token。发布后应核对 package metadata，并在空目录安装 registry 中的精确版本，

--- a/scripts/__tests__/release-scripts.test.mjs
+++ b/scripts/__tests__/release-scripts.test.mjs
@@ -4,8 +4,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { classifyRegistryLookup } from "../check-npm-version.mjs";
+import { assertCurrentStagingRevision } from "../check-staging-revision.mjs";
 import { prepareCliRelease } from "../prepare-cli-release.mjs";
-import { resolveProductionVersion, resolveStagingVersion } from "../release-versions.mjs";
+import {
+  findLatestStagingVersion,
+  formatStagingVersion,
+  resolveNextPublishedStagingVersion,
+  resolveProductionVersion,
+} from "../release-versions.mjs";
+import { classifyPublishedMetadataLookup, classifyPublishedVersionsLookup } from "../resolve-staging-release.mjs";
 import { generateThirdPartyNotices } from "../third-party-notices.mjs";
 
 const sourceManifest = {
@@ -41,10 +48,78 @@ async function withManifest(manifest, callback) {
 }
 
 test("resolves next-patch staging versions and matching production tags", () => {
-  assert.equal(resolveStagingVersion("0.0.1", "42", "3"), "0.0.2-staging.42.3");
+  assert.equal(formatStagingVersion("0.0.1", "42", "3"), "0.0.2-staging.42.3");
   assert.equal(resolveProductionVersion("1.2.3", "v1.2.3"), "1.2.3");
   assert.throws(() => resolveProductionVersion("1.2.3", "v1.2.4"), /does not match source version/);
   assert.throws(() => resolveProductionVersion("0.0.1", "v0.0.1"), /0\.0\.2 or newer/);
+});
+
+test("increments the registry staging sequence and keeps same-commit retries idempotent", () => {
+  const publishedVersions = ["0.0.1", "0.0.2-staging.42.1", "0.0.2-staging.48.1", "0.0.2-staging.48.2"];
+  assert.equal(findLatestStagingVersion("0.0.1", publishedVersions), "0.0.2-staging.48.2");
+  assert.equal(
+    resolveNextPublishedStagingVersion({
+      sourceVersion: "0.0.1",
+      publishedVersions,
+      latestGitHead: "newer-commit",
+      releaseGitHead: "next-commit",
+      runAttempt: "1",
+    }),
+    "0.0.2-staging.49.1",
+  );
+  assert.equal(
+    resolveNextPublishedStagingVersion({
+      sourceVersion: "0.0.1",
+      publishedVersions,
+      latestGitHead: "next-commit",
+      releaseGitHead: "next-commit",
+      runAttempt: "2",
+    }),
+    "0.0.2-staging.48.2",
+  );
+});
+
+test("starts a new staging release line at one and rejects registry lines ahead of source", () => {
+  assert.equal(
+    resolveNextPublishedStagingVersion({
+      sourceVersion: "0.0.2",
+      publishedVersions: ["0.0.1", "0.0.2-staging.48.1"],
+      releaseGitHead: "next-commit",
+      runAttempt: "3",
+    }),
+    "0.0.3-staging.1.3",
+  );
+  assert.throws(() => findLatestStagingVersion("0.0.1", ["0.0.3-staging.1.1"]), /ahead of the target release line/);
+  assert.throws(() => findLatestStagingVersion("0.0.1", ["0.0.2"]), /not below the target staging release line/);
+});
+
+test("rejects stale staging revisions before an old run can publish", () => {
+  assert.doesNotThrow(() => assertCurrentStagingRevision("current-commit", "current-commit"));
+  assert.throws(
+    () => assertCurrentStagingRevision("old-commit", "current-commit"),
+    /old-commit is stale; current origin\/main is current-commit/,
+  );
+});
+
+test("classifies staging registry version and metadata lookups", () => {
+  assert.deepEqual(
+    classifyPublishedVersionsLookup({ status: 0, stdout: '["0.0.1","0.0.2-staging.1.1"]', stderr: "" }),
+    ["0.0.1", "0.0.2-staging.1.1"],
+  );
+  assert.deepEqual(classifyPublishedVersionsLookup({ status: 1, stdout: "", stderr: "npm error code E404" }), []);
+  assert.deepEqual(
+    classifyPublishedMetadataLookup({
+      status: 0,
+      stdout: '{"version":"0.0.2-staging.1.1","gitHead":"commit"}',
+      stderr: "",
+      expectedVersion: "0.0.2-staging.1.1",
+    }),
+    { version: "0.0.2-staging.1.1", gitHead: "commit" },
+  );
+  assert.throws(
+    () => classifyPublishedVersionsLookup({ status: 1, stdout: "", stderr: "ECONNRESET" }),
+    /versions lookup failed/,
+  );
 });
 
 test("rewrites the staging identity without losing release metadata", async () => {

--- a/scripts/check-staging-revision.mjs
+++ b/scripts/check-staging-revision.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function assertCurrentStagingRevision(releaseGitHead, mainGitHead) {
+  if (releaseGitHead !== mainGitHead) {
+    throw new Error(`staging revision ${releaseGitHead} is stale; current origin/main is ${mainGitHead}`);
+  }
+}
+
+function runGit(arguments_) {
+  const result = spawnSync("git", arguments_, { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ${arguments_.join(" ")} failed: ${result.stderr.trim() || `exit status ${result.status}`}`);
+  }
+  return result.stdout.trim();
+}
+
+function main() {
+  runGit(["fetch", "origin", "main:refs/remotes/origin/main"]);
+  const releaseGitHead = runGit(["rev-parse", "HEAD"]);
+  const mainGitHead = runGit(["rev-parse", "refs/remotes/origin/main"]);
+  assertCurrentStagingRevision(releaseGitHead, mainGitHead);
+  console.log(`Staging revision ${releaseGitHead} is current origin/main`);
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[staging-revision] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-versions.mjs
+++ b/scripts/release-versions.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import { CHANNEL_CONFIG } from "./channel-config.mjs";
 
 const STABLE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const STAGING_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-staging\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/;
 
 export function parseStableVersion(version, label = "version") {
@@ -28,13 +29,105 @@ export function compareStableVersions(left, right) {
   return leftParts.major - rightParts.major || leftParts.minor - rightParts.minor || leftParts.patch - rightParts.patch;
 }
 
-export function resolveStagingVersion(sourceVersion, runNumber, runAttempt) {
+export function formatStagingVersion(sourceVersion, sequence, runAttempt) {
   const source = parseStableVersion(sourceVersion, "source version");
-  if (!POSITIVE_INTEGER_PATTERN.test(String(runNumber)) || !POSITIVE_INTEGER_PATTERN.test(String(runAttempt))) {
-    throw new Error("GitHub run number and attempt must be positive integers");
+  if (!POSITIVE_INTEGER_PATTERN.test(String(sequence)) || !POSITIVE_INTEGER_PATTERN.test(String(runAttempt))) {
+    throw new Error("staging sequence and GitHub run attempt must be positive integers");
   }
 
-  return `${source.major}.${source.minor}.${source.patch + 1}-staging.${runNumber}.${runAttempt}`;
+  return `${source.major}.${source.minor}.${source.patch + 1}-staging.${sequence}.${runAttempt}`;
+}
+
+export function parseStagingVersion(version, label = "staging version") {
+  const match = STAGING_VERSION_PATTERN.exec(version);
+  if (!match) {
+    throw new Error(`${label} must be a staging semantic version, got "${version}"`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    sequence: Number(match[4]),
+    attempt: Number(match[5]),
+  };
+}
+
+function compareVersionParts(left, right) {
+  return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+}
+
+function targetStagingLine(sourceVersion) {
+  const source = parseStableVersion(sourceVersion, "source version");
+  return { major: source.major, minor: source.minor, patch: source.patch + 1 };
+}
+
+export function findLatestStagingVersion(sourceVersion, publishedVersions) {
+  if (!Array.isArray(publishedVersions) || publishedVersions.some((version) => typeof version !== "string")) {
+    throw new Error("published versions must be an array of strings");
+  }
+
+  const target = targetStagingLine(sourceVersion);
+  let latest;
+  for (const version of publishedVersions) {
+    const stagingMatch = STAGING_VERSION_PATTERN.exec(version);
+    if (stagingMatch) {
+      const parsed = parseStagingVersion(version, "published version");
+      const lineComparison = compareVersionParts(parsed, target);
+      if (lineComparison > 0) {
+        throw new Error(`published staging version ${version} is ahead of the target release line`);
+      }
+      if (
+        lineComparison === 0 &&
+        (!latest ||
+          parsed.sequence > latest.sequence ||
+          (parsed.sequence === latest.sequence && parsed.attempt > latest.attempt))
+      ) {
+        latest = { ...parsed, version };
+      }
+      continue;
+    }
+
+    const stableMatch = STABLE_VERSION_PATTERN.exec(version);
+    if (!stableMatch) {
+      throw new Error(`published version ${version} is not a supported stable or staging version`);
+    }
+    const stable = parseStableVersion(version, "published version");
+    if (compareVersionParts(stable, target) >= 0) {
+      throw new Error(`published stable version ${version} is not below the target staging release line`);
+    }
+  }
+
+  return latest?.version;
+}
+
+export function resolveNextPublishedStagingVersion({
+  sourceVersion,
+  publishedVersions,
+  latestGitHead,
+  releaseGitHead,
+  runAttempt,
+}) {
+  if (!POSITIVE_INTEGER_PATTERN.test(String(runAttempt))) {
+    throw new Error("GitHub run attempt must be a positive integer");
+  }
+  if (typeof releaseGitHead !== "string" || releaseGitHead.length === 0) {
+    throw new Error("release git head is required");
+  }
+
+  const latestVersion = findLatestStagingVersion(sourceVersion, publishedVersions);
+  if (!latestVersion) {
+    return formatStagingVersion(sourceVersion, 1, runAttempt);
+  }
+  if (typeof latestGitHead !== "string" || latestGitHead.length === 0) {
+    throw new Error(`published version ${latestVersion} is missing gitHead`);
+  }
+  if (latestGitHead === releaseGitHead) {
+    return latestVersion;
+  }
+
+  const latest = parseStagingVersion(latestVersion);
+  return formatStagingVersion(sourceVersion, latest.sequence + 1, runAttempt);
 }
 
 export function resolveProductionVersion(sourceVersion, tag) {
@@ -82,7 +175,7 @@ async function main() {
       package_name: CHANNEL_CONFIG.staging.packageName,
       binary_name: CHANNEL_CONFIG.staging.binName,
       source_version: sourceVersion,
-      version: resolveStagingVersion(sourceVersion, arguments_.get("run-number"), arguments_.get("run-attempt")),
+      version: formatStagingVersion(sourceVersion, arguments_.get("sequence"), arguments_.get("run-attempt")),
     };
   } else if (channel === "prod") {
     output = {

--- a/scripts/resolve-staging-release.mjs
+++ b/scripts/resolve-staging-release.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { appendFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { CHANNEL_CONFIG } from "./channel-config.mjs";
+import { findLatestStagingVersion, resolveNextPublishedStagingVersion } from "./release-versions.mjs";
+
+export function classifyPublishedVersionsLookup({ status, stdout, stderr }) {
+  if (status === 0) {
+    let value;
+    try {
+      value = JSON.parse(stdout);
+    } catch (error) {
+      throw new Error("npm registry returned invalid versions JSON", { cause: error });
+    }
+    const versions = typeof value === "string" ? [value] : value;
+    if (!Array.isArray(versions) || versions.some((version) => typeof version !== "string")) {
+      throw new Error("npm registry returned an invalid versions list");
+    }
+    return versions;
+  }
+  if (/\bE404\b/.test(stderr)) {
+    return [];
+  }
+  throw new Error(`npm registry versions lookup failed: ${stderr.trim() || `exit status ${status}`}`);
+}
+
+export function classifyPublishedMetadataLookup({ status, stdout, stderr, expectedVersion }) {
+  if (status !== 0) {
+    throw new Error(`npm registry metadata lookup failed: ${stderr.trim() || `exit status ${status}`}`);
+  }
+
+  let metadata;
+  try {
+    metadata = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error("npm registry returned invalid metadata JSON", { cause: error });
+  }
+  if (metadata.version !== expectedVersion) {
+    throw new Error(`npm registry returned version "${metadata.version ?? "missing"}", expected "${expectedVersion}"`);
+  }
+  if (typeof metadata.gitHead !== "string" || metadata.gitHead.length === 0) {
+    throw new Error(`published version ${expectedVersion} is missing gitHead`);
+  }
+  return metadata;
+}
+
+function parseArguments(arguments_) {
+  const values = new Map();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument sequence near "${key ?? ""}"`);
+    }
+    values.set(key.slice(2), value);
+  }
+  return values;
+}
+
+async function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  const sourceVersion = arguments_.get("source-version");
+  const releaseGitHead = arguments_.get("git-head");
+  const runAttempt = arguments_.get("run-attempt");
+  if (!sourceVersion || !releaseGitHead || !runAttempt) {
+    throw new Error("--source-version, --git-head, and --run-attempt are required");
+  }
+
+  const packageName = CHANNEL_CONFIG.staging.packageName;
+  const versionsLookup = spawnSync("npm", ["view", packageName, "versions", "--json"], { encoding: "utf8" });
+  const publishedVersions = classifyPublishedVersionsLookup({
+    status: versionsLookup.status,
+    stdout: versionsLookup.stdout,
+    stderr: versionsLookup.stderr,
+  });
+  const latestVersion = findLatestStagingVersion(sourceVersion, publishedVersions);
+  let latestGitHead;
+  if (latestVersion) {
+    const metadataLookup = spawnSync(
+      "npm",
+      ["view", `${packageName}@${latestVersion}`, "version", "gitHead", "--json"],
+      { encoding: "utf8" },
+    );
+    latestGitHead = classifyPublishedMetadataLookup({
+      status: metadataLookup.status,
+      stdout: metadataLookup.stdout,
+      stderr: metadataLookup.stderr,
+      expectedVersion: latestVersion,
+    }).gitHead;
+  }
+
+  const version = resolveNextPublishedStagingVersion({
+    sourceVersion,
+    publishedVersions,
+    latestGitHead,
+    releaseGitHead,
+    runAttempt,
+  });
+  const output = {
+    package_name: packageName,
+    binary_name: CHANNEL_CONFIG.staging.binName,
+    source_version: sourceVersion,
+    version,
+  };
+
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      `${Object.entries(output)
+        .map(([key, value]) => `${key}=${value}`)
+        .join("\n")}\n`,
+    );
+  }
+  console.log(JSON.stringify(output));
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  main().catch((error) => {
+    console.error(`[staging-release] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- derive staging release sequences from the highest published npm version in the target release line, with serialized publish jobs and idempotent same-commit retries
- reject stale release revisions before version resolution and immediately before publishing, while filtering `workflow_run` events to `main`
- add registry and stale-run coverage, update the English and Chinese release guides, and add the root `CLAUDE.md -> AGENTS.md` symlink

## Local validation

- `node --test --test-concurrency=1 scripts/__tests__/release-scripts.test.mjs` (10/10 passed)
- `pnpm check`
- `git diff --check`
- parsed both modified workflow YAML files
- live npm registry dry run: current release commit reused `0.0.2-staging.50.1`; a new commit resolved to `0.0.2-staging.51.1`

Full build, typecheck, and repository-wide tests are left to GitHub CI per the workspace validation policy.
