### PR TITLE
feat: add provider-neutral Agent Runtime

### DIFF
--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -1,0 +1,131 @@
+# Agent Runtime and Codex Provider Test Plan
+
+Status: active quality gate
+
+Last updated: 2026-08-19
+
+## Goal and Scope
+
+This plan verifies that the provider-neutral Agent Runtime contract and the first
+Codex Provider implementation are safe to use as the lowest Client execution
+layer. It covers these production boundaries:
+
+- `src/agent-runtime/base-agent-runtime.ts`
+- `src/agent-runtime/errors.ts`
+- `src/agent-runtime/types.ts`
+- `src/agent-runtime/validation.ts`
+- `src/providers/codex/agent-runtime.ts`
+- `src/providers/codex/app-server-wire.ts`
+
+The coverage gate requires 100% statements, branches, functions, and lines for
+that exact source set. Coverage is a floor, not the acceptance criterion by
+itself: protocol behavior and a live local Codex session are tested separately.
+
+There are no file-level or broad range exclusions. Four local V8 annotations in
+the Codex implementation document non-executable invariant branches: one
+synthetic `finally` branch reported by V8, and three defensive guards already
+fenced by Base admission plus the serial Provider envelope queue. Their normal
+and failure semantics are exercised at the public boundary; the annotations do
+not omit a supported Provider outcome.
+
+## Local Codex Artifact Boundary
+
+The Client does not declare a Codex package, SDK, CLI, or bundled-binary
+dependency and does not contain an installer or download fallback. In normal
+operation the Provider launches the literal `codex` command without a shell;
+the operating system resolves it from the allow-listed `PATH` inherited from
+the user environment. An explicit command override remains available only for
+a caller-supplied local executable or deterministic process test double.
+
+Readiness probes invoke that same local executable with `--version` and
+`app-server --help`. If it is missing or incompatible, readiness fails with a
+typed issue; the Client never installs or fetches Codex. The offline suite locks
+this boundary by checking the root and Client dependency manifests and by
+asserting the default process launch command and inherited `PATH`. The live E2E
+then proves that the actual user-installed executable can create and resume a
+Runtime session.
+
+## Test Layers
+
+### 1. Agent Runtime contract tests
+
+The Base implementation is exercised with deterministic Provider subclasses.
+Required cases are:
+
+- manifest, capability, binding, and state immutability;
+- prompt admission and strict single-active-Run behavior;
+- strict FIFO follow-ups and independent typed results;
+- Run ID, input, configuration, binding, and JSON validation limits;
+- ordered, awaited event delivery before Promise settlement;
+- steer, respond, abort, and interaction Run fences;
+- caller `AbortSignal` handling for active and queued Runs;
+- completed, failed, aborted, and cancelled terminal mappings;
+- event-sink failure fallback and irrecoverable Runtime shutdown;
+- provider failure versus caller close semantics;
+- idempotent close, close failures, wait-for-idle, and race behavior.
+
+### 2. Codex Provider translation tests
+
+A scripted interactive App Server client verifies:
+
+- `thread/start` create and exact `thread/resume`;
+- `turn/start`, `turn/steer(expectedTurnId)`, and `turn/interrupt`;
+- workspace, sandbox, network, approval, model, effort, and Provider config mapping;
+- fail-closed rejection of policy combinations Codex cannot enforce;
+- ordered message, tool, usage, warning, Provider extension, and terminal events;
+- approval, permissions, structured question, and MCP elicitation responses;
+- foreign Thread/Turn events, duplicate requests, malformed data, and process failure;
+- probe outcomes, credential discovery, process environment allow-listing, and cleanup.
+
+### 3. Real JSONL process tests
+
+The wire client runs against a child-process fixture rather than an in-memory
+mock. It verifies initialization ordering, JSONL framing and bounds, request
+timeouts and cancellation, server-initiated requests, duplicate IDs, malformed
+and truncated output, unexpected exits, write failures, and process-tree cleanup.
+
+These tests remain part of the normal offline unit suite and require neither a
+public network nor Provider credentials.
+
+### 4. Live local end-to-end test
+
+The explicit `test:e2e:codex-agent-runtime` command uses the installed and
+authenticated local Codex CLI. It performs:
+
+1. deterministic local readiness probing;
+2. real App Server initialization and `thread/start`;
+3. one text-only Agent Runtime prompt and terminal-result assertion;
+4. Runtime close without deleting the persistent Codex Thread;
+5. a new process with exact binding `thread/resume`;
+6. a second prompt proving conversation continuity;
+7. ordered-event and clean-close assertions.
+
+The live test uses a temporary read-only workspace, disabled network policy,
+`approvalPolicy: never`, no tool request, and bounded Run timeouts. It makes real
+model requests and is therefore intentionally excluded from the default test
+command.
+
+## Commands and Acceptance
+
+```bash
+pnpm --filter @opentag/client test:agent-runtime:coverage
+pnpm --filter @opentag/client test:e2e:codex-agent-runtime
+pnpm check
+pnpm build
+pnpm typecheck
+pnpm test
+```
+
+Acceptance requires all commands to pass, all four scoped coverage metrics to
+equal 100%, the local probe to report ready, both live Runs to complete, exact
+resume to preserve the Thread ID, and no unhandled rejection or leaked child
+process. A failed or unavailable live Provider check must be reported as a
+failure; it is never converted into a skipped success.
+
+## Latest Local Execution
+
+On 2026-08-19 the final scoped suite passed 75 tests with 100% statements,
+branches, functions, and lines. The live test passed against `codex-cli 0.144.1`:
+both create and resumed Runs completed, the opaque binding was preserved, and
+each Run produced 16 ordered events. The full monorepo quality commands also
+passed after the live run.

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -21,12 +21,13 @@ The coverage gate requires 100% statements, branches, functions, and lines for
 that exact source set. Coverage is a floor, not the acceptance criterion by
 itself: protocol behavior and a live local Codex session are tested separately.
 
-There are no file-level or broad range exclusions. Four local V8 annotations in
+There are no file-level or broad range exclusions. Five local V8 annotations in
 the Codex implementation document non-executable invariant branches: one
-synthetic `finally` branch reported by V8, and three defensive guards already
-fenced by Base admission plus the serial Provider envelope queue. Their normal
-and failure semantics are exercised at the public boundary; the annotations do
-not omit a supported Provider outcome.
+synthetic `finally` branch reported by V8, three defensive Codex guards already
+fenced by Base admission plus the serial Provider envelope queue, and one stale
+queued-signal callback guard fenced by synchronous queue ownership and listener
+detachment. Their normal and failure semantics are exercised at the public
+boundary; the annotations do not omit a supported Provider outcome.
 
 ## Local Codex Artifact Boundary
 
@@ -124,8 +125,8 @@ failure; it is never converted into a skipped success.
 
 ## Latest Local Execution
 
-On 2026-08-19 the final scoped suite passed 75 tests with 100% statements,
+On 2026-08-19 the final scoped suite passed 79 tests with 100% statements,
 branches, functions, and lines. The live test passed against `codex-cli 0.144.1`:
 both create and resumed Runs completed, the opaque binding was preserved, and
-each Run produced 16 ordered events. The full monorepo quality commands also
-passed after the live run.
+each Run produced 16 ordered events. The monorepo formatting, build, and
+type-check commands also passed after the live run.

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -60,6 +60,7 @@ Required cases are:
 - ordered, awaited event delivery before Promise settlement;
 - steer, respond, abort, and interaction Run fences;
 - caller `AbortSignal` handling for active and queued Runs;
+- rejected interrupts before and after an authoritative Provider terminal claim;
 - completed, failed, aborted, and cancelled terminal mappings;
 - event-sink failure fallback and irrecoverable Runtime shutdown;
 - provider failure versus caller close semantics;
@@ -74,6 +75,7 @@ A scripted interactive App Server client verifies:
 - workspace, sandbox, network, approval, model, effort, and Provider config mapping;
 - fail-closed rejection of policy combinations Codex cannot enforce;
 - ordered message, tool, usage, warning, Provider extension, and terminal events;
+- terminal notification precedence over a late interrupt rejection while trailing events drain;
 - approval, permissions, structured question, and MCP elicitation responses;
 - foreign Thread/Turn events, duplicate requests, malformed data, and process failure;
 - probe outcomes, credential discovery, process environment allow-listing, and cleanup.
@@ -125,7 +127,7 @@ failure; it is never converted into a skipped success.
 
 ## Latest Local Execution
 
-On 2026-08-19 the final scoped suite passed 79 tests with 100% statements,
+On 2026-08-19 the final scoped suite passed 80 tests with 100% statements,
 branches, functions, and lines. The live test passed against `codex-cli 0.144.1`:
 both create and resumed Runs completed, the opaque binding was preserved, and
 each Run produced 16 ordered events. The monorepo formatting, build, and

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -75,7 +75,7 @@ A scripted interactive App Server client verifies:
 - workspace, sandbox, network, approval, model, effort, and Provider config mapping;
 - fail-closed rejection of policy combinations Codex cannot enforce;
 - ordered message, tool, usage, warning, Provider extension, and terminal events;
-- terminal notification precedence over a late interrupt rejection while trailing events drain;
+- terminal ingress precedence over a following interrupt rejection while prior event delivery is blocked;
 - approval, permissions, structured question, and MCP elicitation responses;
 - foreign Thread/Turn events, duplicate requests, malformed data, and process failure;
 - probe outcomes, credential discovery, process environment allow-listing, and cleanup.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.0",
     "@types/node": "^22.15.0",
+    "@vitest/coverage-v8": "3.2.7",
     "tsdown": "^0.21.4",
     "tsx": "^4.21.0",
     "turbo": "^2.5.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,8 @@
     "build": "tsdown src/index.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --maxWorkers=1",
+    "test:agent-runtime:coverage": "vitest run --config vitest.agent-runtime.config.ts",
+    "test:e2e:codex-agent-runtime": "tsx src/smoke/codex-agent-runtime-e2e.ts",
     "test:smoke:codex": "tsx src/smoke/codex-smoke.ts"
   },
   "dependencies": {

--- a/packages/client/src/__tests__/agent-runtime-contract.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-contract.test.ts
@@ -229,9 +229,11 @@ describe("BaseAgentRuntime contract", () => {
       },
     });
     const active = runtime.prompt(prompt("run-1", "one"));
-    const queued = runtime.followUp(prompt("run-2", "two"));
+    const queuedController = new AbortController();
+    const queued = runtime.followUp({ ...prompt("run-2", "two"), signal: queuedController.signal });
 
     const closing = runtime.close();
+    queuedController.abort();
     await expect(active).resolves.toMatchObject({ status: "aborted" });
     await expect(queued).resolves.toMatchObject({ status: "cancelled", error: { code: "runtime_closed" } });
     await closing;
@@ -241,6 +243,7 @@ describe("BaseAgentRuntime contract", () => {
     expect(runtime.providerCloses).toBe(1);
     expect(runtime.state).toEqual({ phase: "closed", queuedRunCount: 0 });
     expect(events.at(-1)?.type).toBe("runtime_closed");
+    expect(events.filter((event) => event.type === "run_cancelled" && event.runId === "run-2")).toHaveLength(1);
   });
 
   it("fences steer and abort against a stale run id", async () => {

--- a/packages/client/src/__tests__/agent-runtime-contract.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-contract.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it, vi } from "vitest";
+import { BaseAgentRuntime } from "../agent-runtime/base-agent-runtime.js";
+import type {
+  AgentAbortRequest,
+  AgentInteractionResponse,
+  AgentPromptRequest,
+  AgentProviderRunContext,
+  AgentProviderRunResult,
+  AgentRuntimeCapabilities,
+  AgentRuntimeEvent,
+  AgentSteerRequest,
+} from "../agent-runtime/types.js";
+
+const manifest = {
+  providerId: "test",
+  displayName: "Test",
+  contractVersion: 1 as const,
+  bindingSchemaVersion: 1,
+};
+
+describe("BaseAgentRuntime contract", () => {
+  it("settles a run only after its ordered terminal event", async () => {
+    const events: string[] = [];
+    const runtime = new TestRuntime({
+      eventSink: async (event) => {
+        await Promise.resolve();
+        events.push(event.type);
+      },
+      execute: async (_request, context) => {
+        await context.emit({ type: "message_started", messageId: "message-1" });
+        await context.emit({ type: "message_delta", messageId: "message-1", delta: "answer" });
+        await context.emit({ type: "message_completed", messageId: "message-1", text: "answer" });
+        return { status: "completed", output: [{ type: "text", text: "answer" }] };
+      },
+    });
+
+    const result = await runtime.prompt(prompt("run-1", "hello"));
+
+    expect(result).toMatchObject({ runId: "run-1", status: "completed", output: [{ text: "answer" }] });
+    expect(events).toEqual(["run_started", "message_started", "message_delta", "message_completed", "run_completed"]);
+    expect(runtime.state).toEqual({ phase: "idle", queuedRunCount: 0 });
+    await expect(runtime.waitForIdle()).resolves.toBeUndefined();
+    await runtime.close();
+  });
+
+  it("owns a strict FIFO follow-up queue with independent run results", async () => {
+    const events: Array<{ type: string; runId?: string }> = [];
+    const gates = new Map([
+      ["run-1", deferred<void>()],
+      ["run-2", deferred<void>()],
+      ["run-3", deferred<void>()],
+    ]);
+    const starts: string[] = [];
+    const runtime = new TestRuntime({
+      eventSink: (event) => {
+        events.push(event);
+      },
+      execute: async (request) => {
+        starts.push(request.runId);
+        await gates.get(request.runId)?.promise;
+        return { status: "completed", output: [{ type: "text", text: request.runId }] };
+      },
+    });
+
+    const first = runtime.prompt(prompt("run-1", "one"));
+    const second = runtime.followUp(prompt("run-2", "two"));
+    const third = runtime.followUp(prompt("run-3", "three"));
+    expect(runtime.state).toEqual({ phase: "running", activeRunId: "run-1", queuedRunCount: 2 });
+
+    gates.get("run-1")?.resolve();
+    await expect(first).resolves.toMatchObject({ runId: "run-1", status: "completed" });
+    await vi.waitFor(() => expect(starts).toEqual(["run-1", "run-2"]));
+    gates.get("run-2")?.resolve();
+    await expect(second).resolves.toMatchObject({ runId: "run-2", status: "completed" });
+    await vi.waitFor(() => expect(starts).toEqual(["run-1", "run-2", "run-3"]));
+    gates.get("run-3")?.resolve();
+    await expect(third).resolves.toMatchObject({ runId: "run-3", status: "completed" });
+
+    expect(starts).toEqual(["run-1", "run-2", "run-3"]);
+    expect(events.filter((event) => event.type === "run_queued").map((event) => event.runId)).toEqual([
+      "run-2",
+      "run-3",
+    ]);
+    expect(runtime.state.phase).toBe("idle");
+    await runtime.close();
+  });
+
+  it("rejects invalid admissions without creating run events", async () => {
+    const gate = deferred<void>();
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = new TestRuntime({
+      eventSink: (event) => {
+        events.push(event);
+      },
+      execute: async () => {
+        await gate.promise;
+        return { status: "completed" };
+      },
+    });
+    const abort = new AbortController();
+    abort.abort();
+
+    await expect(runtime.followUp(prompt("idle-follow-up", "no"))).rejects.toMatchObject({ code: "busy" });
+    await expect(runtime.prompt({ ...prompt("pre-aborted", "no"), signal: abort.signal })).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+    const active = runtime.prompt(prompt("run-1", "one"));
+    await expect(runtime.prompt(prompt("run-2", "two"))).rejects.toMatchObject({ code: "busy" });
+    await expect(runtime.followUp(prompt("run-1", "duplicate"))).rejects.toMatchObject({
+      code: "duplicate_run_id",
+    });
+    gate.resolve();
+    await active;
+
+    expect(events.some((event) => "runId" in event && event.runId === "idle-follow-up")).toBe(false);
+    expect(events.some((event) => "runId" in event && event.runId === "pre-aborted")).toBe(false);
+    expect(events.some((event) => "runId" in event && event.runId === "run-2")).toBe(false);
+    await runtime.close();
+  });
+
+  it("allows respond to be awaited reentrantly from the ordered sink", async () => {
+    const eventTypes: string[] = [];
+    let runtime: TestRuntime;
+    runtime = new TestRuntime({
+      eventSink: async (event) => {
+        eventTypes.push(event.type);
+        if (event.type === "interaction_requested") {
+          await runtime.respond({
+            kind: "approval",
+            expectedRunId: event.runId,
+            requestId: event.request.requestId,
+            decision: "accept",
+          });
+        }
+      },
+      execute: async (_request, context) => {
+        await context.requestInteraction({
+          requestId: "approval-1",
+          kind: "approval",
+          title: "Approve",
+        });
+        return { status: "completed" };
+      },
+    });
+
+    await expect(runtime.prompt(prompt("run-1", "hello"))).resolves.toMatchObject({ status: "completed" });
+    expect(runtime.responses).toHaveLength(1);
+    expect(eventTypes).toEqual(["run_started", "interaction_requested", "interaction_resolved", "run_completed"]);
+    await runtime.close();
+  });
+
+  it("fails the active run and closes when the ordered sink rejects", async () => {
+    const delivered: string[] = [];
+    const runtime = new TestRuntime({
+      eventSink: (event) => {
+        delivered.push(event.type);
+        if (event.type === "message_started") throw new Error("sink unavailable");
+      },
+      execute: async (_request, context) => {
+        await context.emit({ type: "message_started", messageId: "message-1" });
+        return { status: "completed" };
+      },
+    });
+
+    await expect(runtime.prompt(prompt("run-1", "hello"))).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "event_delivery_failed" },
+    });
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+    expect(delivered).toEqual(["run_started", "message_started"]);
+    expect(runtime.providerCloses).toBe(1);
+  });
+
+  it("keeps provider output in the Promise fallback when terminal event delivery fails", async () => {
+    const runtime = new TestRuntime({
+      eventSink: (event) => {
+        if (event.type === "run_completed") throw new Error("terminal delivery failed");
+      },
+      execute: async () => ({
+        status: "completed",
+        output: [{ type: "text", text: "authoritative answer" }],
+        usage: { outputTokens: 3 },
+      }),
+    });
+
+    await expect(runtime.prompt(prompt("run-1", "hello"))).resolves.toMatchObject({
+      status: "failed",
+      output: [{ type: "text", text: "authoritative answer" }],
+      usage: { outputTokens: 3 },
+      error: { code: "event_delivery_failed" },
+    });
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+  });
+
+  it("rejects unsupported capabilities before invoking provider hooks", async () => {
+    const gate = deferred<void>();
+    const runtime = new TestRuntime({
+      capabilities: { steer: "unsupported", interactions: "unsupported" },
+      eventSink: () => undefined,
+      execute: async () => {
+        await gate.promise;
+        return { status: "completed" };
+      },
+    });
+    const run = runtime.prompt(prompt("run-1", "hello"));
+
+    await expect(runtime.steer({ expectedRunId: "run-1", input: input("change") })).rejects.toMatchObject({
+      code: "unsupported_capability",
+    });
+    expect(runtime.steers).toHaveLength(0);
+    gate.resolve();
+    await run;
+    await runtime.close();
+  });
+
+  it("close aborts the active run, cancels queued runs, and is idempotent", async () => {
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = new TestRuntime({
+      eventSink: (event) => {
+        events.push(event);
+      },
+      execute: async (_request, context) => {
+        if (!context.signal.aborted) {
+          await new Promise<void>((resolve) =>
+            context.signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+        }
+        return { status: "aborted" };
+      },
+    });
+    const active = runtime.prompt(prompt("run-1", "one"));
+    const queued = runtime.followUp(prompt("run-2", "two"));
+
+    const closing = runtime.close();
+    await expect(active).resolves.toMatchObject({ status: "aborted" });
+    await expect(queued).resolves.toMatchObject({ status: "cancelled", error: { code: "runtime_closed" } });
+    await closing;
+    await runtime.close();
+
+    expect(runtime.aborts).toBe(1);
+    expect(runtime.providerCloses).toBe(1);
+    expect(runtime.state).toEqual({ phase: "closed", queuedRunCount: 0 });
+    expect(events.at(-1)?.type).toBe("runtime_closed");
+  });
+
+  it("fences steer and abort against a stale run id", async () => {
+    const gate = deferred<void>();
+    const runtime = new TestRuntime({
+      eventSink: () => undefined,
+      execute: async () => {
+        await gate.promise;
+        return { status: "completed" };
+      },
+    });
+    const run = runtime.prompt(prompt("run-1", "one"));
+
+    await expect(runtime.steer({ expectedRunId: "stale", input: input("change") })).rejects.toMatchObject({
+      code: "run_mismatch",
+    });
+    await expect(runtime.abort({ expectedRunId: "stale" })).rejects.toMatchObject({ code: "run_mismatch" });
+    await runtime.steer({ expectedRunId: "run-1", input: input("change") });
+    expect(runtime.steers).toHaveLength(1);
+
+    gate.resolve();
+    await run;
+    await runtime.close();
+  });
+});
+
+interface TestRuntimeOptions {
+  readonly capabilities?: AgentRuntimeCapabilities;
+  readonly eventSink: (event: AgentRuntimeEvent) => void | Promise<void>;
+  readonly execute: (request: AgentPromptRequest, context: AgentProviderRunContext) => Promise<AgentProviderRunResult>;
+}
+
+class TestRuntime extends BaseAgentRuntime {
+  readonly #executeHandler: TestRuntimeOptions["execute"];
+  readonly responses: AgentInteractionResponse[] = [];
+  readonly steers: AgentSteerRequest[] = [];
+  aborts = 0;
+  providerCloses = 0;
+
+  constructor(options: TestRuntimeOptions) {
+    super({
+      manifest,
+      capabilities: options.capabilities ?? { steer: "supported", interactions: "supported" },
+      eventSink: options.eventSink,
+    });
+    this.#executeHandler = options.execute;
+  }
+
+  protected executeRun(request: AgentPromptRequest, context: AgentProviderRunContext): Promise<AgentProviderRunResult> {
+    return this.#executeHandler(request, context);
+  }
+
+  protected override async steerProvider(request: AgentSteerRequest): Promise<void> {
+    this.steers.push(request);
+  }
+
+  protected override async respondProvider(response: AgentInteractionResponse): Promise<void> {
+    this.responses.push(response);
+  }
+
+  protected override async abortProvider(_request: AgentAbortRequest): Promise<void> {
+    this.aborts += 1;
+  }
+
+  protected async closeProvider(): Promise<void> {
+    this.providerCloses += 1;
+  }
+}
+
+function input(text: string) {
+  return { items: [{ type: "text" as const, text }] };
+}
+
+function prompt(runId: string, text: string): AgentPromptRequest {
+  return { runId, input: input(text) };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value?: T) => void } {
+  let resolveValue: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveValue = resolve;
+  });
+  if (!resolveValue) throw new Error("could not create deferred promise");
+  return { promise, resolve: (value?: T) => resolveValue?.(value as T) };
+}

--- a/packages/client/src/__tests__/agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-exhaustive.test.ts
@@ -499,22 +499,27 @@ describe("BaseAgentRuntime exhaustive behavior", () => {
     await runtime.close();
   });
 
-  it("keeps an already claimed Provider result when a late interrupt rejects", async () => {
+  it("keeps an authoritative Provider terminal when an in-flight interrupt rejects before result settlement", async () => {
     const abortGate = deferred<void>();
-    const finish = deferred<void>();
+    const terminalClaimed = deferred<void>();
+    const releaseResult = deferred<void>();
     const runtime = new HarnessRuntime({
       abort: async () => abortGate.promise,
-      execute: async () => {
-        await finish.promise;
+      execute: async (_request, context) => {
+        context.claimTerminal();
+        terminalClaimed.resolve();
+        await releaseResult.promise;
         return { status: "completed" };
       },
     });
-    const run = runtime.prompt(prompt("late-abort-failure"));
-    const abort = runtime.abort({ expectedRunId: "late-abort-failure" });
-    finish.resolve();
-    await expect(run).resolves.toMatchObject({ status: "completed" });
+    const run = runtime.prompt(prompt("claimed-terminal"));
+    const abort = runtime.abort({ expectedRunId: "claimed-terminal" });
+    await terminalClaimed.promise;
     abortGate.reject(new Error("late interrupt failure"));
     await expect(abort).rejects.toThrow("late interrupt failure");
+    expect(runtime.state.phase).toBe("running");
+    releaseResult.resolve();
+    await expect(run).resolves.toMatchObject({ status: "completed" });
     expect(runtime.state.phase).toBe("idle");
     await runtime.close();
   });

--- a/packages/client/src/__tests__/agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-exhaustive.test.ts
@@ -114,7 +114,12 @@ describe("BaseAgentRuntime exhaustive behavior", () => {
     expect(Object.isFrozen(runtime.manifest)).toBe(true);
     expect(Object.isFrozen(runtime.capabilities)).toBe(true);
     expect(Object.isFrozen(runtime.state)).toBe(true);
-    expect(runtime.binding).toBe(binding);
+    expect(runtime.binding).toEqual(binding);
+    expect(runtime.binding).not.toBe(binding);
+    expect(Object.isFrozen(runtime.binding)).toBe(true);
+    expect(Object.isFrozen(runtime.binding?.payload)).toBe(true);
+    (binding.payload as { threadId: string }).threadId = "caller-mutated";
+    expect(runtime.binding).toEqual(testBinding("thread-1"));
     expect(
       () =>
         new HarnessRuntime({
@@ -131,6 +136,67 @@ describe("BaseAgentRuntime exhaustive behavior", () => {
     });
     await expect(runtime.respond(approval("closed", "approval"))).rejects.toMatchObject({ code: "closed" });
     await expect(runtime.abort({ expectedRunId: "closed" })).rejects.toMatchObject({ code: "closed" });
+  });
+
+  it("snapshots admitted requests, binding updates, events, and terminal results", async () => {
+    const release = deferred<void>();
+    const events: AgentRuntimeEvent[] = [];
+    const updatedBinding = testBinding("thread-updated");
+    let providerRequest: AgentPromptRequest | undefined;
+    const runtime = new HarnessRuntime({
+      eventSink: (event) => {
+        events.push(event);
+      },
+      execute: async (request, context) => {
+        providerRequest = request;
+        await context.updateBinding(updatedBinding);
+        (updatedBinding.payload as { threadId: string }).threadId = "provider-mutated";
+        await release.promise;
+        return { status: "completed", output: [{ type: "text", text: request.input.items[0]?.text ?? "" }] };
+      },
+    });
+    const request = {
+      runId: "stable-run",
+      input: { items: [{ type: "text" as const, text: "stable-input" }] },
+      configuration: { model: "stable-model", provider: { mode: "stable" } },
+    };
+
+    const run = runtime.prompt(request);
+    request.runId = "caller-mutated";
+    const firstItem = request.input.items[0];
+    if (!firstItem) throw new Error("missing request item");
+    firstItem.text = "caller-mutated";
+    request.configuration.model = "caller-mutated";
+    request.configuration.provider.mode = "caller-mutated";
+    await vi.waitFor(() => expect(providerRequest).toBeDefined());
+
+    expect(providerRequest).toEqual({
+      runId: "stable-run",
+      input: { items: [{ type: "text", text: "stable-input" }] },
+      configuration: { model: "stable-model", provider: { mode: "stable" } },
+    });
+    expect(Object.isFrozen(providerRequest)).toBe(true);
+    expect(Object.isFrozen(providerRequest?.input.items)).toBe(true);
+    expect(runtime.binding).toEqual(testBinding("thread-updated"));
+    const bindingEvent = events.find((event) => event.type === "binding_changed");
+    if (bindingEvent?.type !== "binding_changed") throw new Error("missing binding event");
+    expect(Object.isFrozen(bindingEvent)).toBe(true);
+    expect(Object.isFrozen(bindingEvent.binding.payload)).toBe(true);
+    expect(() => {
+      (bindingEvent.binding.payload as { threadId: string }).threadId = "observer-mutated";
+    }).toThrow(TypeError);
+
+    release.resolve();
+    const result = await run;
+    expect(result).toMatchObject({
+      runId: "stable-run",
+      status: "completed",
+      output: [{ text: "stable-input" }],
+      binding: testBinding("thread-updated"),
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.output)).toBe(true);
+    await runtime.close();
   });
 
   it("maps all Provider result and thrown-error forms to typed terminal results", async () => {
@@ -400,6 +466,57 @@ describe("BaseAgentRuntime exhaustive behavior", () => {
     executeGate.resolve();
     await expect(run).resolves.toMatchObject({ status: "completed" });
     await abortRuntime.close();
+  });
+
+  it("fails and closes an active Run when caller-signal Provider interruption fails", async () => {
+    const started = deferred<void>();
+    const controller = new AbortController();
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = new HarnessRuntime({
+      abort: async () => {
+        throw new Error("interrupt unavailable");
+      },
+      eventSink: (event) => {
+        events.push(event);
+      },
+      execute: async () => {
+        started.resolve();
+        return new Promise<AgentProviderRunResult>(() => undefined);
+      },
+    });
+    const run = runtime.prompt({ ...prompt("signal-abort-failure"), signal: controller.signal });
+    await started.promise;
+
+    controller.abort();
+
+    await expect(run).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "provider_error", message: "provider interrupt failed" },
+    });
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+    expect(events.filter((event) => event.type === "run_failed")).toHaveLength(1);
+    expect(runtime.aborts).toHaveLength(1);
+    await runtime.close();
+  });
+
+  it("keeps an already claimed Provider result when a late interrupt rejects", async () => {
+    const abortGate = deferred<void>();
+    const finish = deferred<void>();
+    const runtime = new HarnessRuntime({
+      abort: async () => abortGate.promise,
+      execute: async () => {
+        await finish.promise;
+        return { status: "completed" };
+      },
+    });
+    const run = runtime.prompt(prompt("late-abort-failure"));
+    const abort = runtime.abort({ expectedRunId: "late-abort-failure" });
+    finish.resolve();
+    await expect(run).resolves.toMatchObject({ status: "completed" });
+    abortGate.reject(new Error("late interrupt failure"));
+    await expect(abort).rejects.toThrow("late interrupt failure");
+    expect(runtime.state.phase).toBe("idle");
+    await runtime.close();
   });
 
   it("fails closed when queued admission or concurrent event delivery rejects with a non-Error", async () => {

--- a/packages/client/src/__tests__/agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-exhaustive.test.ts
@@ -1,0 +1,669 @@
+import { describe, expect, it, vi } from "vitest";
+import { BaseAgentRuntime } from "../agent-runtime/base-agent-runtime.js";
+import { AgentProviderError } from "../agent-runtime/errors.js";
+import type {
+  AgentAbortRequest,
+  AgentInteractionResponse,
+  AgentPromptRequest,
+  AgentProviderRunContext,
+  AgentProviderRunResult,
+  AgentRuntimeBinding,
+  AgentRuntimeCapabilities,
+  AgentRuntimeEvent,
+  AgentSteerRequest,
+} from "../agent-runtime/types.js";
+
+const manifest = {
+  providerId: "test",
+  displayName: "Test",
+  contractVersion: 1 as const,
+  bindingSchemaVersion: 1,
+};
+
+interface HarnessOptions {
+  readonly abort?: (request: AgentAbortRequest, runtime: HarnessRuntime) => Promise<void>;
+  readonly binding?: AgentRuntimeBinding;
+  readonly capabilities?: AgentRuntimeCapabilities;
+  readonly close?: (runtime: HarnessRuntime) => Promise<void>;
+  readonly eventSink?: (event: AgentRuntimeEvent) => void | Promise<void>;
+  readonly execute: (
+    request: AgentPromptRequest,
+    context: AgentProviderRunContext,
+    runtime: HarnessRuntime,
+  ) => Promise<AgentProviderRunResult>;
+  readonly respond?: (response: AgentInteractionResponse, runtime: HarnessRuntime) => Promise<void>;
+  readonly steer?: (request: AgentSteerRequest, runtime: HarnessRuntime) => Promise<void>;
+}
+
+class HarnessRuntime extends BaseAgentRuntime {
+  readonly aborts: AgentAbortRequest[] = [];
+  readonly responses: AgentInteractionResponse[] = [];
+  readonly steers: AgentSteerRequest[] = [];
+  readonly #options: HarnessOptions;
+  context?: AgentProviderRunContext;
+  closes = 0;
+
+  constructor(options: HarnessOptions) {
+    super({
+      manifest,
+      capabilities: options.capabilities ?? { steer: "supported", interactions: "supported" },
+      eventSink: options.eventSink ?? (() => undefined),
+      binding: options.binding,
+    });
+    this.#options = options;
+  }
+
+  failProvider(): void {
+    this.closeForProviderFailure();
+  }
+
+  protected executeRun(request: AgentPromptRequest, context: AgentProviderRunContext): Promise<AgentProviderRunResult> {
+    this.context = context;
+    return this.#options.execute(request, context, this);
+  }
+
+  protected override async steerProvider(request: AgentSteerRequest): Promise<void> {
+    this.steers.push(request);
+    await this.#options.steer?.(request, this);
+  }
+
+  protected override async respondProvider(response: AgentInteractionResponse): Promise<void> {
+    this.responses.push(response);
+    await this.#options.respond?.(response, this);
+  }
+
+  protected override async abortProvider(request: AgentAbortRequest): Promise<void> {
+    this.aborts.push(request);
+    await this.#options.abort?.(request, this);
+  }
+
+  protected async closeProvider(): Promise<void> {
+    this.closes += 1;
+    await this.#options.close?.(this);
+  }
+}
+
+class DefaultHooksRuntime extends BaseAgentRuntime {
+  context?: AgentProviderRunContext;
+
+  constructor(eventSink: (event: AgentRuntimeEvent) => void | Promise<void>) {
+    super({ manifest, capabilities: { steer: "supported", interactions: "supported" }, eventSink });
+  }
+
+  protected async executeRun(
+    _request: AgentPromptRequest,
+    context: AgentProviderRunContext,
+  ): Promise<AgentProviderRunResult> {
+    this.context = context;
+    await context.requestInteraction({ requestId: "approval", kind: "approval", title: "Approve" });
+    if (!context.signal.aborted) {
+      await new Promise<void>((resolve) => context.signal.addEventListener("abort", () => resolve(), { once: true }));
+    }
+    return { status: "aborted" };
+  }
+
+  protected async closeProvider(): Promise<void> {}
+}
+
+describe("BaseAgentRuntime exhaustive behavior", () => {
+  it("freezes public metadata, accepts an initial binding, and rejects an incompatible binding", async () => {
+    const binding = testBinding("thread-1");
+    const runtime = new HarnessRuntime({ binding, execute: async () => ({ status: "completed" }) });
+    expect(runtime.manifest).toEqual(manifest);
+    expect(runtime.capabilities).toEqual({ steer: "supported", interactions: "supported" });
+    expect(Object.isFrozen(runtime.manifest)).toBe(true);
+    expect(Object.isFrozen(runtime.capabilities)).toBe(true);
+    expect(Object.isFrozen(runtime.state)).toBe(true);
+    expect(runtime.binding).toBe(binding);
+    expect(
+      () =>
+        new HarnessRuntime({
+          binding: { ...binding, providerId: "wrong" },
+          execute: async () => ({ status: "completed" }),
+        }),
+    ).toThrowError(expect.objectContaining({ code: "binding_incompatible" }));
+    await runtime.close();
+    await expect(runtime.waitForIdle()).resolves.toBeUndefined();
+    await expect(runtime.prompt(prompt("closed"))).rejects.toMatchObject({ code: "closed" });
+    await expect(runtime.followUp(prompt("closed-follow-up"))).rejects.toMatchObject({ code: "closed" });
+    await expect(runtime.steer({ expectedRunId: "closed", input: input("x") })).rejects.toMatchObject({
+      code: "closed",
+    });
+    await expect(runtime.respond(approval("closed", "approval"))).rejects.toMatchObject({ code: "closed" });
+    await expect(runtime.abort({ expectedRunId: "closed" })).rejects.toMatchObject({ code: "closed" });
+  });
+
+  it("maps all Provider result and thrown-error forms to typed terminal results", async () => {
+    const events: AgentRuntimeEvent[] = [];
+    const contexts: AgentProviderRunContext[] = [];
+    const runtime = new HarnessRuntime({
+      eventSink: (event) => {
+        events.push(event);
+      },
+      execute: async (request, context) => {
+        contexts.push(context);
+        if (request.runId === "completed") {
+          await context.updateBinding(testBinding("thread-2"));
+          await context.updateBinding(testBinding("thread-2"));
+          return { status: "completed", diagnostics: null };
+        }
+        if (request.runId === "failed-default") return { status: "failed" };
+        if (request.runId === "aborted-default") return { status: "aborted" };
+        if (request.runId === "failed-explicit") {
+          return {
+            status: "failed",
+            output: [{ type: "text", text: "partial" }],
+            usage: { outputTokens: 1 },
+            error: { code: "provider_protocol_error", message: "bad wire" },
+            diagnostics: { detail: true },
+          };
+        }
+        if (request.runId === "provider-throw") throw new AgentProviderError("provider_protocol_error", "protocol");
+        if (request.runId === "error-throw") throw new Error("ordinary");
+        throw "non-error";
+      },
+    });
+
+    await expect(runtime.prompt(prompt("completed"))).resolves.toMatchObject({
+      status: "completed",
+      output: [],
+      binding: testBinding("thread-2"),
+      providerDiagnostics: null,
+    });
+    await expect(runtime.prompt(prompt("failed-default"))).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "provider_error", message: "provider run failed" },
+    });
+    await expect(runtime.prompt(prompt("aborted-default"))).resolves.toMatchObject({
+      status: "aborted",
+      error: { code: "run_aborted", message: "provider run was interrupted" },
+    });
+    await expect(runtime.prompt(prompt("failed-explicit"))).resolves.toMatchObject({
+      status: "failed",
+      output: [{ text: "partial" }],
+      usage: { outputTokens: 1 },
+      providerDiagnostics: { detail: true },
+      error: { code: "provider_protocol_error" },
+    });
+    await expect(runtime.prompt(prompt("provider-throw"))).resolves.toMatchObject({
+      error: { code: "provider_protocol_error", message: "protocol" },
+    });
+    await expect(runtime.prompt(prompt("error-throw"))).resolves.toMatchObject({
+      error: { code: "provider_error", message: "ordinary" },
+    });
+    await expect(runtime.prompt(prompt("other-throw"))).resolves.toMatchObject({
+      error: { code: "provider_error", message: "provider run failed" },
+    });
+    expect(events.filter((event) => event.type === "binding_changed")).toHaveLength(1);
+    expect(
+      events
+        .filter((event) => event.type.startsWith("run_") && event.type !== "run_started")
+        .map((event) => event.type),
+    ).toEqual(["run_completed", "run_failed", "run_aborted", "run_failed", "run_failed", "run_failed", "run_failed"]);
+
+    const stale = contexts[0];
+    if (!stale) throw new Error("missing Provider context");
+    await expect(stale.emit({ type: "provider_warning", code: "late", message: "late" })).rejects.toMatchObject({
+      code: "run_mismatch",
+    });
+    await expect(stale.updateBinding(testBinding("late"))).rejects.toMatchObject({ code: "run_mismatch" });
+    await expect(
+      stale.requestInteraction({ requestId: "late", kind: "question", title: "Late" }),
+    ).rejects.toMatchObject({ code: "run_mismatch" });
+    await expect(stale.resolveInteraction("late", "expired")).rejects.toMatchObject({ code: "run_mismatch" });
+    await runtime.close();
+  });
+
+  it("uses the Base default hooks and validates command shapes", async () => {
+    const interactions = deferred<void>();
+    const runtime = new DefaultHooksRuntime((event) => {
+      if (event.type === "interaction_requested") interactions.resolve();
+    });
+    const run = runtime.prompt(prompt("run-1"));
+    await interactions.promise;
+
+    await expect(runtime.steer(undefined as never)).rejects.toMatchObject({ code: "invalid_request" });
+    await expect(runtime.steer({ expectedRunId: "run-1", input: { items: [] } })).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+    await expect(runtime.steer({ expectedRunId: "run-1", input: input("steer") })).rejects.toMatchObject({
+      code: "unsupported_capability",
+    });
+    await expect(runtime.respond(undefined as never)).rejects.toMatchObject({ code: "invalid_request" });
+    await expect(runtime.respond({ ...approval("run-1", "approval"), value: Number.NaN })).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+    await expect(runtime.respond(approval("run-1", "unknown"))).rejects.toMatchObject({
+      code: "interaction_not_found",
+    });
+    await expect(
+      runtime.respond({
+        kind: "question",
+        expectedRunId: "run-1",
+        requestId: "approval",
+        decision: "cancel",
+      }),
+    ).rejects.toMatchObject({ code: "interaction_not_found" });
+    await expect(runtime.respond(approval("run-1", "approval"))).rejects.toMatchObject({
+      code: "unsupported_capability",
+    });
+    await expect(runtime.abort(undefined as never)).rejects.toMatchObject({ code: "invalid_request" });
+    await runtime.abort({ expectedRunId: "run-1" });
+    await expect(run).resolves.toMatchObject({ status: "aborted" });
+    await runtime.close();
+  });
+
+  it("rejects unsupported interaction commands and Provider interaction requests", async () => {
+    const gate = deferred<void>();
+    const runtime = new HarnessRuntime({
+      capabilities: { steer: "unsupported", interactions: "unsupported" },
+      execute: async (_request, context) => {
+        await context.requestInteraction({ requestId: "question", kind: "question", title: "Question" });
+        await gate.promise;
+        return { status: "completed" };
+      },
+    });
+    const run = runtime.prompt(prompt("run-1"));
+    await expect(runtime.respond(approval("run-1", "question"))).rejects.toMatchObject({
+      code: "unsupported_capability",
+    });
+    await expect(run).resolves.toMatchObject({
+      status: "failed",
+      error: { message: "provider requested an unsupported interaction" },
+    });
+    gate.resolve();
+    await runtime.close();
+  });
+
+  it("supports Provider-resolved interactions and fences expired responses", async () => {
+    const requested = deferred<void>();
+    const release = deferred<void>();
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = new HarnessRuntime({
+      eventSink: (event) => {
+        events.push(event);
+        if (event.type === "interaction_requested" && event.request.requestId === "question") requested.resolve();
+      },
+      respond: async () => {
+        release.resolve();
+        await new Promise((resolve) => setImmediate(resolve));
+      },
+      execute: async (_request, context) => {
+        await expect(
+          context.requestInteraction({ requestId: "", kind: "question", title: "Invalid" }),
+        ).rejects.toMatchObject({ code: "invalid_request" });
+        await context.resolveInteraction("missing", "ignored");
+        await context.requestInteraction({ requestId: "provider", kind: "question", title: "Provider" });
+        await context.resolveInteraction("provider", "provider-expired");
+        await context.requestInteraction({ requestId: "question", kind: "question", title: "Question" });
+        await expect(
+          context.requestInteraction({ requestId: "question", kind: "question", title: "Duplicate" }),
+        ).rejects.toMatchObject({ code: "invalid_request" });
+        await release.promise;
+        return { status: "completed" };
+      },
+    });
+    const run = runtime.prompt(prompt("run-1"));
+    await requested.promise;
+    await expect(
+      runtime.respond({
+        kind: "question",
+        expectedRunId: "run-1",
+        requestId: "question",
+        decision: "answer",
+        value: { answer: "yes" },
+      }),
+    ).rejects.toMatchObject({ code: "interaction_not_found" });
+    expect(events.some((event) => event.type === "interaction_resolved" && event.decision === "provider-expired")).toBe(
+      true,
+    );
+    await run;
+    await runtime.close();
+  });
+
+  it("fences a steer whose Provider acceptance loses the completion race", async () => {
+    const gate = deferred<void>();
+    const runtime = new HarnessRuntime({
+      execute: async () => {
+        await gate.promise;
+        return { status: "completed" };
+      },
+      steer: async () => {
+        gate.resolve();
+        await new Promise((resolve) => setImmediate(resolve));
+      },
+    });
+    const run = runtime.prompt(prompt("run-1"));
+    await expect(runtime.steer({ expectedRunId: "run-1", input: input("late") })).rejects.toMatchObject({
+      code: "run_mismatch",
+    });
+    await run;
+    await runtime.close();
+  });
+
+  it("handles active and queued caller signals and deduplicates abort requests", async () => {
+    const activeStarted = deferred<void>();
+    const activeController = new AbortController();
+    const runtime = new HarnessRuntime({
+      execute: async (request, context) => {
+        activeStarted.resolve();
+        if (!context.signal.aborted) {
+          await new Promise<void>((resolve) =>
+            context.signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+        }
+        return { status: request.runId === "active" ? "aborted" : "completed" };
+      },
+    });
+    const active = runtime.prompt({ ...prompt("active"), signal: activeController.signal });
+    await activeStarted.promise;
+    activeController.abort();
+    await expect(active).resolves.toMatchObject({ status: "aborted" });
+    expect(runtime.aborts).toHaveLength(1);
+
+    const mainGate = deferred<void>();
+    const queuedController = new AbortController();
+    const queuedEvents: AgentRuntimeEvent[] = [];
+    const queueRuntime = new HarnessRuntime({
+      eventSink: (event) => {
+        queuedEvents.push(event);
+      },
+      execute: async () => {
+        await mainGate.promise;
+        return { status: "completed" };
+      },
+    });
+    const main = queueRuntime.prompt(prompt("main"));
+    const queued = queueRuntime.followUp({ ...prompt("queued"), signal: queuedController.signal });
+    queuedController.abort();
+    await expect(queued).resolves.toMatchObject({ status: "cancelled", error: { code: "run_cancelled" } });
+    expect(queuedEvents.some((event) => event.type === "run_cancelled" && event.runId === "queued")).toBe(true);
+    mainGate.resolve();
+    await main;
+    await queueRuntime.close();
+
+    const abortGate = deferred<void>();
+    const executeGate = deferred<void>();
+    const abortRuntime = new HarnessRuntime({
+      abort: async () => abortGate.promise,
+      execute: async () => {
+        await executeGate.promise;
+        return { status: "completed" };
+      },
+    });
+    const run = abortRuntime.prompt(prompt("dedupe"));
+    const one = abortRuntime.abort({ expectedRunId: "dedupe", reason: "one" });
+    const two = abortRuntime.abort({ expectedRunId: "dedupe", reason: "two" });
+    expect(abortRuntime.aborts).toHaveLength(1);
+    abortGate.resolve();
+    await Promise.all([one, two]);
+    executeGate.resolve();
+    await expect(run).resolves.toMatchObject({ status: "completed" });
+    await abortRuntime.close();
+  });
+
+  it("fails closed when queued admission or concurrent event delivery rejects with a non-Error", async () => {
+    const gate = deferred<void>();
+    const queueRuntime = new HarnessRuntime({
+      eventSink: (event) => {
+        if (event.type === "run_queued") throw "queue sink failed";
+      },
+      execute: async () => {
+        await gate.promise;
+        return { status: "completed" };
+      },
+    });
+    const active = queueRuntime.prompt(prompt("active"));
+    const queued = queueRuntime.followUp(prompt("queued"));
+    await expect(queued).resolves.toMatchObject({ status: "cancelled", error: { code: "event_delivery_failed" } });
+    gate.resolve();
+    await expect(active).resolves.toMatchObject({ status: "failed", error: { code: "event_delivery_failed" } });
+    await vi.waitFor(() => expect(queueRuntime.state.phase).toBe("closed"));
+
+    const boundGate = deferred<void>();
+    const boundQueueRuntime = new HarnessRuntime({
+      binding: testBinding("failed-queue-binding"),
+      eventSink: (event) => {
+        if (event.type === "run_queued") throw new Error("bound queue sink failed");
+      },
+      execute: async () => {
+        await boundGate.promise;
+        return { status: "completed" };
+      },
+    });
+    const boundActive = boundQueueRuntime.prompt(prompt("bound-active"));
+    const boundQueued = boundQueueRuntime.followUp(prompt("bound-queued"));
+    await expect(boundQueued).resolves.toMatchObject({ binding: testBinding("failed-queue-binding") });
+    boundGate.resolve();
+    await boundActive;
+    await vi.waitFor(() => expect(boundQueueRuntime.state.phase).toBe("closed"));
+
+    const concurrent = new HarnessRuntime({
+      eventSink: (event) => {
+        if (event.type === "message_started") throw "non-error sink failure";
+      },
+      execute: async (_request, context) => {
+        await Promise.all([
+          context.emit({ type: "message_started", messageId: "one" }),
+          context.emit({ type: "message_delta", messageId: "one", delta: "x" }),
+        ]);
+        return { status: "completed" };
+      },
+    });
+    await expect(concurrent.prompt(prompt("concurrent"))).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "event_delivery_failed" },
+    });
+    await vi.waitFor(() => expect(concurrent.state.phase).toBe("closed"));
+
+    const immediateFailure = new HarnessRuntime({
+      eventSink: (event) => {
+        if (event.type === "message_started") throw new Error("first failure");
+      },
+      execute: async (_request, context) => {
+        await context.emit({ type: "message_started", messageId: "one" }).catch(() => undefined);
+        await context.emit({ type: "message_delta", messageId: "one", delta: "late" });
+        return { status: "completed" };
+      },
+    });
+    await expect(immediateFailure.prompt(prompt("immediate"))).resolves.toMatchObject({
+      error: { code: "event_delivery_failed" },
+    });
+    await vi.waitFor(() => expect(immediateFailure.state.phase).toBe("closed"));
+  });
+
+  it("cleans up a rejected interaction event and maps an interrupted Provider throw to aborted", async () => {
+    const interactionRuntime = new HarnessRuntime({
+      eventSink: (event) => {
+        if (event.type === "interaction_requested") throw new Error("cannot deliver interaction");
+      },
+      execute: async (_request, context) => {
+        await context.requestInteraction({ requestId: "approval", kind: "approval", title: "Approve" });
+        return { status: "completed" };
+      },
+    });
+    await expect(interactionRuntime.prompt(prompt("interaction"))).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "event_delivery_failed" },
+    });
+    await vi.waitFor(() => expect(interactionRuntime.state.phase).toBe("closed"));
+
+    const started = deferred<void>();
+    const controller = new AbortController();
+    const abortRuntime = new HarnessRuntime({
+      binding: testBinding("abort-binding"),
+      execute: async (_request, context) => {
+        started.resolve();
+        if (!context.signal.aborted) {
+          await new Promise<void>((resolve) =>
+            context.signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+        }
+        throw new Error("interrupted work");
+      },
+    });
+    const run = abortRuntime.prompt({ ...prompt("abort-throw"), signal: controller.signal });
+    await started.promise;
+    controller.abort();
+    await expect(run).resolves.toMatchObject({ status: "aborted", error: { code: "run_aborted" } });
+    await abortRuntime.close();
+
+    const unboundStarted = deferred<void>();
+    const unboundController = new AbortController();
+    const unboundRuntime = new HarnessRuntime({
+      execute: async (_request, context) => {
+        unboundStarted.resolve();
+        if (!context.signal.aborted) {
+          await new Promise<void>((resolve) =>
+            context.signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+        }
+        throw new Error("interrupted unbound work");
+      },
+    });
+    const unboundRun = unboundRuntime.prompt({ ...prompt("unbound-abort"), signal: unboundController.signal });
+    await unboundStarted.promise;
+    unboundController.abort();
+    const unboundResult = await unboundRun;
+    expect(unboundResult).toMatchObject({ status: "aborted" });
+    expect(unboundResult).not.toHaveProperty("binding");
+    await unboundRuntime.close();
+  });
+
+  it("returns event-delivery failure when queued signal cancellation loses its terminal sink", async () => {
+    const gate = deferred<void>();
+    const controller = new AbortController();
+    const runtime = new HarnessRuntime({
+      binding: testBinding("cancel-binding"),
+      eventSink: (event) => {
+        if (event.type === "run_cancelled") throw new Error("terminal unavailable");
+      },
+      execute: async () => {
+        await gate.promise;
+        return { status: "completed" };
+      },
+    });
+    const active = runtime.prompt(prompt("active"));
+    const queued = runtime.followUp({ ...prompt("queued"), signal: controller.signal });
+    controller.abort();
+    await expect(queued).resolves.toMatchObject({ error: { code: "event_delivery_failed" } });
+    gate.resolve();
+    await expect(active).resolves.toMatchObject({ error: { code: "event_delivery_failed" } });
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+  });
+
+  it("reports close failures and handles queued terminal sink failure without leaking Runs", async () => {
+    const closeErrorRuntime = new HarnessRuntime({
+      close: async () => {
+        throw new Error("close failed");
+      },
+      execute: async () => ({ status: "completed" }),
+    });
+    await expect(closeErrorRuntime.close()).rejects.toMatchObject({ code: "close_failed" });
+    expect(closeErrorRuntime.state.phase).toBe("closed");
+
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = new HarnessRuntime({
+      binding: testBinding("close-binding"),
+      eventSink: (event) => {
+        events.push(event);
+        if (event.type === "run_cancelled" && event.runId === "queued-1") throw new Error("terminal failed");
+      },
+      execute: async (_request, context) => {
+        if (!context.signal.aborted) {
+          await new Promise<void>((resolve) =>
+            context.signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+        }
+        return { status: "aborted" };
+      },
+      abort: async () => {
+        throw new Error("interrupt failed");
+      },
+    });
+    const active = runtime.prompt(prompt("active"));
+    const queuedOne = runtime.followUp(prompt("queued-1"));
+    const queuedTwo = runtime.followUp(prompt("queued-2"));
+    const idle = runtime.waitForIdle();
+    const closing = runtime.close();
+    await expect(active).resolves.toMatchObject({ status: "aborted" });
+    await expect(queuedOne).resolves.toMatchObject({ error: { code: "event_delivery_failed" } });
+    await expect(queuedTwo).resolves.toMatchObject({ error: { code: "event_delivery_failed" } });
+    await closing;
+    await idle;
+    expect(runtime.state).toEqual({ phase: "closed", queuedRunCount: 0 });
+  });
+
+  it("treats Provider-failure close as failed rather than caller-aborted", async () => {
+    const execution = deferred<void>();
+    const runtime = new HarnessRuntime({
+      execute: async () => {
+        await execution.promise;
+        throw new Error("provider disconnected");
+      },
+      close: async () => execution.resolve(),
+    });
+    const run = runtime.prompt(prompt("run-1"));
+    runtime.failProvider();
+    await expect(run).resolves.toMatchObject({ status: "failed", error: { message: "provider disconnected" } });
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+  });
+
+  it("survives a rejected runtime_closed event because close already owns cleanup", async () => {
+    const runtime = new HarnessRuntime({
+      eventSink: (event) => {
+        if (event.type === "runtime_closed") throw new Error("observer disappeared");
+      },
+      execute: async () => ({ status: "completed" }),
+    });
+    await runtime.close();
+    expect(runtime.state.phase).toBe("closed");
+    await runtime.close();
+  });
+
+  it("retains Provider diagnostics when terminal event delivery fails", async () => {
+    const runtime = new HarnessRuntime({
+      eventSink: (event) => {
+        if (event.type === "run_completed") throw new Error("terminal failed");
+      },
+      execute: async () => ({ status: "completed", diagnostics: { traceId: "trace" } }),
+    });
+    await expect(runtime.prompt(prompt("diagnostics"))).resolves.toMatchObject({
+      status: "failed",
+      providerDiagnostics: { traceId: "trace" },
+      error: { code: "event_delivery_failed" },
+    });
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+  });
+});
+
+function input(text = "hello") {
+  return { items: [{ type: "text" as const, text }] };
+}
+
+function prompt(runId: string): AgentPromptRequest {
+  return { runId, input: input() };
+}
+
+function approval(expectedRunId: string, requestId: string): AgentInteractionResponse {
+  return { kind: "approval", expectedRunId, requestId, decision: "accept" };
+}
+
+function testBinding(threadId: string): AgentRuntimeBinding {
+  return { providerId: "test", schemaVersion: 1, payload: { threadId } };
+}
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (value?: T) => void; reject: (error: Error) => void } {
+  let resolveValue: ((value: T) => void) | undefined;
+  let rejectValue: ((error: Error) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveValue = resolve;
+    rejectValue = reject;
+  });
+  if (!resolveValue || !rejectValue) throw new Error("could not create deferred promise");
+  return {
+    promise,
+    resolve: (value?: T) => resolveValue?.(value as T),
+    reject: (error) => rejectValue?.(error),
+  };
+}

--- a/packages/client/src/__tests__/agent-runtime-validation.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-validation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_RUNTIME_BINDING_MAX_BYTES,
+  AGENT_RUNTIME_ID_MAX_BYTES,
+  AGENT_RUNTIME_TEXT_MAX_BYTES,
+  type AgentPromptRequest,
+  type AgentRuntimeBinding,
+} from "../agent-runtime/types.js";
+import {
+  assertAgentInput,
+  assertBinding,
+  assertIdentifier,
+  assertJsonValue,
+  assertPromptRequest,
+  sameBinding,
+} from "../agent-runtime/validation.js";
+
+const manifest = {
+  providerId: "test",
+  displayName: "Test",
+  contractVersion: 1 as const,
+  bindingSchemaVersion: 1,
+};
+
+describe("Agent Runtime validation", () => {
+  it("accepts bounded identifiers and rejects every invalid identifier shape", () => {
+    expect(() => assertIdentifier("run-1", "runId")).not.toThrow();
+    expect(() => assertIdentifier("界".repeat(Math.floor(AGENT_RUNTIME_ID_MAX_BYTES / 3)), "runId")).not.toThrow();
+
+    for (const value of [undefined, 1, "", "   ", "x".repeat(AGENT_RUNTIME_ID_MAX_BYTES + 1)]) {
+      expect(() => assertIdentifier(value as string, "runId")).toThrowError(
+        expect.objectContaining({ code: "invalid_request" }),
+      );
+    }
+  });
+
+  it("accepts text input and rejects missing, malformed, empty, and oversized items", () => {
+    expect(() => assertAgentInput({ items: [{ type: "text", text: "hello" }] })).not.toThrow();
+    for (const candidate of [
+      undefined,
+      {},
+      { items: "text" },
+      { items: [] },
+      { items: [undefined] },
+      { items: [{ type: "image", text: "x" }] },
+      { items: [{ type: "text", text: 1 }] },
+      { items: [{ type: "text", text: "" }] },
+      { items: [{ type: "text", text: "x".repeat(AGENT_RUNTIME_TEXT_MAX_BYTES + 1) }] },
+    ]) {
+      expect(() => assertAgentInput(candidate as never)).toThrowError(
+        expect.objectContaining({ code: "invalid_request" }),
+      );
+    }
+  });
+
+  it("validates prompt signals and every optional configuration field", () => {
+    const valid: AgentPromptRequest = {
+      runId: "run-1",
+      input: { items: [{ type: "text", text: "hello" }] },
+      configuration: {
+        model: "model",
+        reasoningEffort: "high",
+        provider: { nested: [null, true, 1, "value"] },
+      },
+    };
+    expect(() => assertPromptRequest(valid)).not.toThrow();
+    expect(() => assertPromptRequest(undefined as never)).toThrowError(
+      expect.objectContaining({ code: "invalid_request" }),
+    );
+
+    const controller = new AbortController();
+    controller.abort();
+    expect(() => assertPromptRequest({ ...valid, signal: controller.signal })).toThrowError(
+      expect.objectContaining({ code: "invalid_request" }),
+    );
+    expect(() => assertPromptRequest({ ...valid, configuration: { model: "" } })).toThrow();
+    expect(() => assertPromptRequest({ ...valid, configuration: { reasoningEffort: "" } })).toThrow();
+    expect(() => assertPromptRequest({ ...valid, configuration: { provider: Number.NaN } })).toThrow();
+    expect(() => assertPromptRequest({ runId: "run-2", input: valid.input })).not.toThrow();
+  });
+
+  it("validates binding identity, JSON shape, and encoded size", () => {
+    const valid: AgentRuntimeBinding = { providerId: "test", schemaVersion: 1, payload: { threadId: "one" } };
+    expect(() => assertBinding(valid, manifest)).not.toThrow();
+    expect(() => assertBinding(undefined as never, manifest)).toThrowError(
+      expect.objectContaining({ code: "binding_incompatible" }),
+    );
+    expect(() => assertBinding({ ...valid, providerId: "other" }, manifest)).toThrowError(
+      expect.objectContaining({ code: "binding_incompatible" }),
+    );
+    expect(() => assertBinding({ ...valid, schemaVersion: 2 }, manifest)).toThrowError(
+      expect.objectContaining({ code: "binding_incompatible" }),
+    );
+    expect(() => assertBinding({ ...valid, payload: Number.POSITIVE_INFINITY }, manifest)).toThrowError(
+      expect.objectContaining({ code: "binding_incompatible" }),
+    );
+    expect(() =>
+      assertBinding({ ...valid, payload: { value: "x".repeat(AGENT_RUNTIME_BINDING_MAX_BYTES) } }, manifest),
+    ).toThrowError(expect.objectContaining({ code: "binding_incompatible" }));
+  });
+
+  it("accepts JSON values and rejects non-finite, unsupported, and cyclic values", () => {
+    for (const value of [null, "text", true, false, 0, -1, { value: [1, "two", null] }]) {
+      expect(() => assertJsonValue(value, "value")).not.toThrow();
+    }
+    const shared = { value: true };
+    expect(() => assertJsonValue({ left: shared, right: shared }, "value")).not.toThrow();
+
+    for (const value of [Number.NaN, Number.POSITIVE_INFINITY, undefined, 1n, () => undefined]) {
+      expect(() => assertJsonValue(value, "value")).toThrowError(expect.objectContaining({ code: "invalid_request" }));
+    }
+    const cycle: { self?: unknown } = {};
+    cycle.self = cycle;
+    expect(() => assertJsonValue(cycle, "value", "binding_incompatible")).toThrowError(
+      expect.objectContaining({ code: "binding_incompatible" }),
+    );
+  });
+
+  it("compares bindings structurally", () => {
+    const binding: AgentRuntimeBinding = { providerId: "test", schemaVersion: 1, payload: { id: "one" } };
+    expect(sameBinding(undefined, binding)).toBe(false);
+    expect(sameBinding(binding, { ...binding, payload: { id: "one" } })).toBe(true);
+    expect(sameBinding(binding, { ...binding, payload: { id: "two" } })).toBe(false);
+  });
+});

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -496,6 +496,42 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
     await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
   });
 
+  it("keeps a received Codex terminal when an in-flight interrupt rejects while event delivery drains", async () => {
+    const interruptResponse = deferred<void>();
+    const releaseWarning = deferred<void>();
+    const client = new ManualCodexClient({ interruptResponse: interruptResponse.promise });
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = await factory(client).create(
+      createRequest(async (event) => {
+        events.push(event);
+        if (event.type === "provider_warning" && event.message === "after terminal") {
+          await releaseWarning.promise;
+        }
+      }),
+    );
+    const run = runtime.prompt({ runId: "terminal-before-interrupt-error", input: input("finish") });
+    await client.called("turn/start");
+    const aborting = runtime.abort({ expectedRunId: "terminal-before-interrupt-error" });
+    await vi.waitFor(() => expect(client.interrupts).toHaveLength(1));
+
+    client.complete();
+    client.emit({ method: "warning", params: { message: "after terminal" } });
+    await vi.waitFor(() =>
+      expect(events.some((event) => event.type === "provider_warning" && event.message === "after terminal")).toBe(
+        true,
+      ),
+    );
+    interruptResponse.reject(new Error("turn is already terminal"));
+
+    await expect(aborting).rejects.toThrow("turn is already terminal");
+    expect(runtime.state.phase).toBe("running");
+    expect(client.closed).toBe(false);
+    releaseWarning.resolve();
+    await expect(run).resolves.toMatchObject({ status: "completed" });
+    expect(runtime.state.phase).toBe("idle");
+    await runtime.close();
+  });
+
   it("rejects malformed turn/start responses and accepts buffered notifications", async () => {
     for (const response of [
       null,
@@ -862,6 +898,7 @@ interface ManualClientOptions {
   readonly beforeTurnStartResponse?: (client: ManualCodexClient) => void;
   readonly closeError?: boolean;
   readonly initializeError?: Error;
+  readonly interruptResponse?: Promise<void>;
   readonly steerTurnId?: string;
   readonly threadStartResponse?: unknown;
   readonly turnStartResponse?: unknown | Promise<unknown>;
@@ -936,6 +973,7 @@ class ManualCodexClient implements InteractiveCodexAppServerClient {
 
   async interrupt(threadId: string, turnId: string): Promise<void> {
     this.interrupts.push({ threadId, turnId });
+    await this.#options.interruptResponse;
   }
 
   async close(): Promise<void> {
@@ -1056,11 +1094,13 @@ async function temporaryDirectory(prefix: string): Promise<string> {
   return directory;
 }
 
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: Error) => void } {
   let resolveValue: ((value: T) => void) | undefined;
-  const promise = new Promise<T>((resolve) => {
+  let rejectValue: ((error: Error) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
     resolveValue = resolve;
+    rejectValue = reject;
   });
-  if (!resolveValue) throw new Error("could not create deferred promise");
-  return { promise, resolve: resolveValue };
+  if (!resolveValue || !rejectValue) throw new Error("could not create deferred promise");
+  return { promise, resolve: resolveValue, reject: rejectValue };
 }

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -496,7 +496,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
     await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
   });
 
-  it("keeps a received Codex terminal when an in-flight interrupt rejects while event delivery drains", async () => {
+  it("claims a Codex terminal at ingress before a following interrupt error while a prior event is blocked", async () => {
     const interruptResponse = deferred<void>();
     const releaseWarning = deferred<void>();
     const client = new ManualCodexClient({ interruptResponse: interruptResponse.promise });
@@ -504,23 +504,22 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
     const runtime = await factory(client).create(
       createRequest(async (event) => {
         events.push(event);
-        if (event.type === "provider_warning" && event.message === "after terminal") {
+        if (event.type === "provider_warning" && event.message === "before terminal") {
           await releaseWarning.promise;
         }
       }),
     );
     const run = runtime.prompt({ runId: "terminal-before-interrupt-error", input: input("finish") });
     await client.called("turn/start");
-    const aborting = runtime.abort({ expectedRunId: "terminal-before-interrupt-error" });
-    await vi.waitFor(() => expect(client.interrupts).toHaveLength(1));
-
-    client.complete();
-    client.emit({ method: "warning", params: { message: "after terminal" } });
+    client.emit({ method: "warning", params: { message: "before terminal" } });
     await vi.waitFor(() =>
-      expect(events.some((event) => event.type === "provider_warning" && event.message === "after terminal")).toBe(
+      expect(events.some((event) => event.type === "provider_warning" && event.message === "before terminal")).toBe(
         true,
       ),
     );
+    const aborting = runtime.abort({ expectedRunId: "terminal-before-interrupt-error" });
+    await vi.waitFor(() => expect(client.interrupts).toHaveLength(1));
+    client.complete();
     interruptResponse.reject(new Error("turn is already terminal"));
 
     await expect(aborting).rejects.toThrow("turn is already terminal");

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -1,0 +1,1066 @@
+import { spawn } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentRuntimeError } from "../agent-runtime/errors.js";
+import type {
+  AgentApprovalResponse,
+  AgentInteractionResponse,
+  AgentQuestionResponse,
+  AgentRuntime,
+  AgentRuntimeEvent,
+  CreateAgentRuntimeRequest,
+} from "../agent-runtime/types.js";
+import { CodexAgentRuntimeFactory, codexAgentRuntimeEnvironment } from "../providers/codex/agent-runtime.js";
+import type {
+  CodexAppServerMessage,
+  CodexAppServerRequest,
+  InteractiveCodexAppServerClient,
+} from "../providers/codex/app-server-wire.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/codex-app-server.mjs", import.meta.url));
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("CodexAgentRuntime exhaustive behavior", () => {
+  it("maps all supported factory, Turn, policy, and Provider configuration variants", async () => {
+    const client = new ManualCodexClient();
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = await factory(client).create({
+      ...createRequest((event) => {
+        events.push(event);
+      }),
+      workspace: { cwd: "/workspace", writableRoots: ["/workspace/one", "/workspace/two"] },
+      policy: {
+        fileSystem: "workspace-write",
+        network: "enabled",
+        approvals: "unless-trusted",
+        tools: { mode: "provider-default" },
+      },
+      configuration: {
+        model: "base-model",
+        reasoningEffort: "high",
+        provider: { personality: "friendly", serviceName: "opentag", summary: "concise" },
+      },
+    });
+    expect(client.call("thread/start")?.params).toEqual({
+      cwd: "/workspace",
+      approvalPolicy: "unlessTrusted",
+      sandbox: "workspace-write",
+      model: "base-model",
+      personality: "friendly",
+      serviceName: "opentag",
+    });
+
+    const first = runtime.prompt({
+      runId: "configured",
+      input: input("hello"),
+      configuration: {
+        model: "override-model",
+        reasoningEffort: "minimal",
+        provider: { summary: "detailed" },
+      },
+    });
+    await client.called("turn/start");
+    expect(client.lastCall("turn/start")?.params).toEqual({
+      threadId: "thread-1",
+      input: [{ type: "text", text: "hello" }],
+      cwd: "/workspace",
+      approvalPolicy: "unlessTrusted",
+      sandboxPolicy: {
+        type: "workspaceWrite",
+        writableRoots: ["/workspace/one", "/workspace/two"],
+        networkAccess: true,
+      },
+      model: "override-model",
+      effort: "minimal",
+      personality: "friendly",
+      summary: "detailed",
+    });
+    client.complete({ items: [] });
+    await expect(first).resolves.toMatchObject({ status: "completed", output: [] });
+
+    const second = runtime.prompt({ runId: "base-only", input: input("again") });
+    await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(2));
+    expect(client.lastCall("turn/start")?.params).toMatchObject({ model: "base-model", effort: "high" });
+    client.complete({ id: "turn-2", items: [] });
+    await second;
+    await runtime.close();
+
+    const readOnlyClient = new ManualCodexClient();
+    const readOnly = await factory(readOnlyClient).create({
+      ...createRequest(() => undefined),
+      policy: {
+        fileSystem: "read-only",
+        network: "disabled",
+        approvals: "never",
+        tools: { mode: "provider-default" },
+      },
+    });
+    expect(readOnlyClient.call("thread/start")?.params).toMatchObject({
+      sandbox: "read-only",
+      approvalPolicy: "never",
+    });
+    const readRun = readOnly.prompt({
+      runId: "read-only",
+      input: input("read"),
+      configuration: { model: "prompt-model", provider: { personality: "pragmatic" } },
+    });
+    await readOnlyClient.called("turn/start");
+    expect(readOnlyClient.lastCall("turn/start")?.params).toMatchObject({
+      sandboxPolicy: { type: "readOnly" },
+      model: "prompt-model",
+      personality: "pragmatic",
+    });
+    readOnlyClient.complete();
+    await readRun;
+    await readOnly.close();
+
+    const unrestrictedClient = new ManualCodexClient();
+    const unrestricted = await factory(unrestrictedClient).create({
+      ...createRequest(() => undefined),
+      policy: {
+        fileSystem: "unrestricted",
+        network: "enabled",
+        approvals: "never",
+        tools: { mode: "provider-default" },
+      },
+    });
+    expect(unrestrictedClient.call("thread/start")?.params).toMatchObject({ sandbox: "danger-full-access" });
+    const unrestrictedRun = unrestricted.prompt({ runId: "unrestricted", input: input("work") });
+    await unrestrictedClient.called("turn/start");
+    expect(unrestrictedClient.lastCall("turn/start")?.params).toMatchObject({
+      sandboxPolicy: { type: "dangerFullAccess" },
+    });
+    unrestrictedClient.complete();
+    await unrestrictedRun;
+    await unrestricted.close();
+    expect(events.some((event) => event.type === "binding_changed")).toBe(true);
+  });
+
+  it("translates the complete Codex notification and item event surface", async () => {
+    const client = new ManualCodexClient();
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = await factory(client).create(
+      createRequest((event) => {
+        events.push(event);
+      }),
+    );
+    const run = runtime.prompt({ runId: "events", input: input("events") });
+    await client.called("turn/start");
+
+    client.emit({ method: "turn/started", params: { turn: activeTurn() } });
+    client.emit({ method: "warning", params: { message: "warning message" } });
+    client.emit({ method: "configWarning", params: { summary: "config summary" } });
+    client.emit({ method: "serverRequest/resolved", params: { requestId: "missing" } });
+    client.emit({ method: "thread/closed", params: { threadId: "another-thread" } });
+    client.emit({
+      method: "thread/tokenUsage/updated",
+      params: { turnId: "another-turn", tokenUsage: { total: { inputTokens: 999 } } },
+    });
+    client.emit({
+      method: "thread/tokenUsage/updated",
+      params: { turnId: "turn-1", tokenUsage: { total: { inputTokens: 8, cachedInputTokens: 2, outputTokens: 4 } } },
+    });
+    client.emit({
+      method: "item/agentMessage/delta",
+      params: { threadId: "thread-1", turnId: "turn-1", itemId: "message-1", delta: "delta" },
+    });
+    client.emit({
+      method: "item/commandExecution/outputDelta",
+      params: { threadId: "thread-1", turnId: "turn-1", itemId: "command", delta: "stdout" },
+    });
+    client.emitItem("item/started", { id: "message-1", type: "agentMessage" });
+    client.emitItem("item/completed", { id: "message-1", type: "agentMessage", text: "fallback" });
+    client.emitItem("item/completed", {
+      id: "commentary",
+      type: "agentMessage",
+      phase: "commentary",
+      text: "thinking",
+    });
+    client.emitItem("item/started", { id: "ignored", type: "unknown" });
+    client.emitItem("item/started", { id: "collab", type: "collabToolCall" });
+    client.emitItem("item/completed", { id: "collab", type: "collabToolCall", status: "declined" });
+    client.emitItem("item/started", { id: "dynamic", type: "dynamicToolCall", tool: "custom" });
+    client.emitItem("item/completed", { id: "dynamic", type: "dynamicToolCall", status: "failed" });
+    client.emitItem("item/started", { id: "dynamic-default", type: "dynamicToolCall" });
+    client.emitItem("item/completed", { id: "file", type: "fileChange" });
+    client.emitItem("item/completed", { id: "image", type: "imageView" });
+    client.emitItem("item/started", { id: "mcp", type: "mcpToolCall", server: "server", tool: "tool" });
+    client.emitItem("item/completed", { id: "mcp-default", type: "mcpToolCall" });
+    client.emitItem("item/completed", { id: "web", type: "webSearch" });
+    client.emit({ method: "error", params: { error: { message: "turn warning" } } });
+    client.emit({ method: "error", params: {} });
+    client.emit({ method: "turn/plan/updated", params: { plan: [] } });
+    client.emit({ method: "turn/diff/updated", params: { diff: "" } });
+    client.emit({ method: "model/rerouted", params: null });
+    client.emit({ method: "unhandled/notification", params: {} });
+    client.complete({
+      items: [
+        { id: "bad", type: "other", text: "ignored" },
+        { id: "terminal", type: "agentMessage", phase: "final_answer", text: "terminal answer" },
+      ],
+    });
+
+    await expect(run).resolves.toMatchObject({
+      status: "completed",
+      output: [{ text: "terminal answer" }],
+      usage: { inputTokens: 8, cachedInputTokens: 2, outputTokens: 4 },
+    });
+    expect(events.map((event) => event.type)).toEqual(
+      expect.arrayContaining([
+        "provider_warning",
+        "usage_updated",
+        "message_started",
+        "message_delta",
+        "message_completed",
+        "tool_started",
+        "tool_updated",
+        "tool_completed",
+        "provider_event",
+      ]),
+    );
+    expect(events.filter((event) => event.type === "tool_completed").map((event) => event.status)).toEqual(
+      expect.arrayContaining(["declined", "failed", "completed"]),
+    );
+    await runtime.close();
+  });
+
+  it("maps completed fallback, interrupted, and failed Turn terminal forms", async () => {
+    const client = new ManualCodexClient();
+    const runtime = await factory(client).create(createRequest(() => undefined));
+
+    const fallback = runtime.prompt({ runId: "fallback", input: input("one") });
+    await client.called("turn/start");
+    client.emitItem("item/completed", { id: "commentary", type: "agentMessage", phase: "commentary", text: "no" });
+    client.emitItem("item/completed", { id: "answer", type: "agentMessage", phase: "answer", text: "fallback answer" });
+    client.emit({ method: "thread/tokenUsage/updated", params: { tokenUsage: { inputTokens: 1, outputTokens: -1 } } });
+    client.complete({ items: [] });
+    await expect(fallback).resolves.toMatchObject({ output: [{ text: "fallback answer" }], usage: { inputTokens: 1 } });
+
+    const interrupted = runtime.prompt({ runId: "interrupted", input: input("two") });
+    await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(2));
+    client.emit({
+      method: "thread/tokenUsage/updated",
+      params: { turnId: "turn-2", tokenUsage: { total: { inputTokens: 1, outputTokens: 1 } } },
+    });
+    client.complete({ id: "turn-2", status: "interrupted", items: [] });
+    await expect(interrupted).resolves.toMatchObject({
+      status: "aborted",
+      usage: { inputTokens: 1, outputTokens: 1 },
+      error: { code: "run_aborted" },
+    });
+
+    const failed = runtime.prompt({ runId: "failed", input: input("three") });
+    await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(3));
+    client.emit({
+      method: "thread/tokenUsage/updated",
+      params: { turnId: "turn-3", tokenUsage: { last: { inputTokens: 2, cachedInputTokens: 0, outputTokens: 1 } } },
+    });
+    client.complete({ id: "turn-3", status: "failed", error: { message: "model failed" }, items: [] });
+    await expect(failed).resolves.toMatchObject({
+      status: "failed",
+      usage: { inputTokens: 2, cachedInputTokens: 0, outputTokens: 1 },
+      error: { message: "model failed" },
+    });
+
+    const failedDefault = runtime.prompt({ runId: "failed-default", input: input("four") });
+    await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(4));
+    client.complete({ id: "turn-4", status: "failed", error: {}, items: [] });
+    await expect(failedDefault).resolves.toMatchObject({ status: "failed", error: { message: "Codex turn failed" } });
+    await runtime.close();
+  });
+
+  it("translates every supported approval and question interaction response", async () => {
+    const client = new ManualCodexClient();
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = await factory(client).create(
+      createRequest((event) => {
+        events.push(event);
+      }),
+    );
+    const run = runtime.prompt({ runId: "interactions", input: input("interact") });
+    await client.called("turn/start");
+
+    await interact(runtime, client, events, 1, "item/commandExecution/requestApproval", {
+      kind: "approval",
+      decision: "accept",
+      scope: "run",
+    });
+    await interact(runtime, client, events, 2, "item/fileChange/requestApproval", {
+      kind: "approval",
+      decision: "decline",
+    });
+    await interact(
+      runtime,
+      client,
+      events,
+      11,
+      "item/commandExecution/requestApproval",
+      {
+        kind: "approval",
+        decision: "cancel",
+      },
+      false,
+    );
+    await interact(runtime, client, events, 3, "item/permissions/requestApproval", {
+      kind: "approval",
+      decision: "accept",
+      scope: "runtime",
+      value: { permissions: ["network"] },
+    });
+    await interact(runtime, client, events, 4, "item/permissions/requestApproval", {
+      kind: "approval",
+      decision: "accept",
+      value: null,
+    });
+    await interact(runtime, client, events, 5, "item/permissions/requestApproval", {
+      kind: "approval",
+      decision: "cancel",
+    });
+    await interact(runtime, client, events, 6, "item/tool/requestUserInput", {
+      kind: "question",
+      decision: "answer",
+      value: { answer: "yes" },
+    });
+    await interact(runtime, client, events, 7, "item/tool/requestUserInput", {
+      kind: "question",
+      decision: "cancel",
+    });
+    await interact(runtime, client, events, 12, "item/tool/requestUserInput", {
+      kind: "question",
+      decision: "answer",
+    });
+    await interact(runtime, client, events, 8, "mcpServer/elicitation/request", {
+      kind: "question",
+      decision: "answer",
+      value: { field: "value" },
+    });
+    await interact(runtime, client, events, 9, "mcpServer/elicitation/request", {
+      kind: "question",
+      decision: "answer",
+    });
+    await interact(runtime, client, events, 10, "mcpServer/elicitation/request", {
+      kind: "question",
+      decision: "cancel",
+    });
+
+    expect(client.serverResponses.map((response) => response.result)).toEqual([
+      { decision: "accept" },
+      { decision: "decline" },
+      { decision: "cancel" },
+      { permissions: ["network"], scope: "session" },
+      { permissions: [], scope: "turn" },
+      { permissions: [], scope: "turn" },
+      { answers: { answer: "yes" } },
+      { answers: {} },
+      { answers: {} },
+      { action: "accept", content: { field: "value" } },
+      { action: "accept", content: null },
+      { action: "cancel", content: null },
+    ]);
+    client.complete();
+    await run;
+    await runtime.close();
+  });
+
+  it("expires interactions and rejects unsupported, duplicate, and foreign server requests", async () => {
+    const expiringClient = new ManualCodexClient();
+    const events: AgentRuntimeEvent[] = [];
+    const expiring = await factory(expiringClient).create(
+      createRequest((event) => {
+        events.push(event);
+      }),
+    );
+    const expiringRun = expiring.prompt({ runId: "expire", input: input("expire") });
+    await expiringClient.called("turn/start");
+    expiringClient.emitRequest({
+      id: "expire",
+      method: "item/tool/requestUserInput",
+      params: { threadId: "thread-1", turnId: "turn-1", message: "Question" },
+    });
+    await vi.waitFor(() => expect(events.some((event) => event.type === "interaction_requested")).toBe(true));
+    expiringClient.emit({ method: "serverRequest/resolved", params: { requestId: "expire" } });
+    await vi.waitFor(() => expect(events.some((event) => event.type === "interaction_resolved")).toBe(true));
+    await expect(
+      expiring.respond({
+        kind: "question",
+        expectedRunId: "expire",
+        requestId: "string:expire",
+        decision: "cancel",
+      }),
+    ).rejects.toMatchObject({ code: "interaction_not_found" });
+    expiringClient.complete();
+    await expiringRun;
+    await expiring.close();
+
+    for (const request of [
+      { id: "bad", method: "unsupported/request", params: {} },
+      {
+        id: "foreign-thread",
+        method: "item/tool/requestUserInput",
+        params: { threadId: "foreign", turnId: "turn-1" },
+      },
+      {
+        id: "foreign-turn",
+        method: "item/tool/requestUserInput",
+        params: { threadId: "thread-1", turnId: "foreign" },
+      },
+      { id: "invalid", method: "item/tool/requestUserInput", params: null },
+    ] satisfies CodexAppServerRequest[]) {
+      const client = new ManualCodexClient();
+      const runtime = await factory(client).create(createRequest(() => undefined));
+      const run = runtime.prompt({ runId: request.id, input: input("bad") });
+      await client.called("turn/start");
+      client.emitRequest(request);
+      await expect(run).resolves.toMatchObject({ status: "failed", error: { code: "provider_protocol_error" } });
+      await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+    }
+
+    const duplicateClient = new ManualCodexClient();
+    const duplicate = await factory(duplicateClient).create(createRequest(() => undefined));
+    const duplicateRun = duplicate.prompt({ runId: "duplicate", input: input("duplicate") });
+    await duplicateClient.called("turn/start");
+    const duplicateRequest = {
+      id: 42,
+      method: "item/tool/requestUserInput",
+      params: { threadId: "thread-1", turnId: "turn-1" },
+    } as const;
+    duplicateClient.emitRequest(duplicateRequest);
+    duplicateClient.emitRequest(duplicateRequest);
+    await expect(duplicateRun).resolves.toMatchObject({ status: "failed" });
+    await vi.waitFor(() => expect(duplicate.state.phase).toBe("closed"));
+  });
+
+  it("fails active Runs for malformed, crossed, and fatal Codex notifications", async () => {
+    const cases: Array<{ name: string; message: CodexAppServerMessage }> = [
+      { name: "process error fallback", message: { method: "opentag/processError", params: {} } },
+      { name: "missing method", message: { params: {} } },
+      { name: "closed thread", message: { method: "thread/closed", params: { threadId: "thread-1" } } },
+      { name: "wrong started turn", message: { method: "turn/started", params: { turn: activeTurn("wrong") } } },
+      {
+        name: "active completed notification",
+        message: { method: "turn/completed", params: { turn: activeTurn() } },
+      },
+      {
+        name: "wrong message thread",
+        message: {
+          method: "item/agentMessage/delta",
+          params: { threadId: "wrong", turnId: "turn-1", itemId: "message", delta: "x" },
+        },
+      },
+      {
+        name: "wrong message turn",
+        message: {
+          method: "item/agentMessage/delta",
+          params: { threadId: "thread-1", turnId: "wrong", itemId: "message", delta: "x" },
+        },
+      },
+      {
+        name: "invalid usage",
+        message: { method: "thread/tokenUsage/updated", params: { tokenUsage: null } },
+      },
+      {
+        name: "invalid item",
+        message: { method: "item/started", params: { threadId: "thread-1", turnId: "turn-1", item: null } },
+      },
+      {
+        name: "invalid Provider event JSON",
+        message: { method: "turn/plan/updated", params: { value: Number.NaN } },
+      },
+    ];
+    for (const entry of cases) {
+      const client = new ManualCodexClient();
+      const runtime = await factory(client).create(createRequest(() => undefined));
+      const run = runtime.prompt({ runId: entry.name, input: input("fail") });
+      await client.called("turn/start");
+      client.emit(entry.message);
+      await expect(run, entry.name).resolves.toMatchObject({ status: "failed" });
+      await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+    }
+  });
+
+  it("fails when a trailing notification breaks after Codex emits terminal", async () => {
+    const client = new ManualCodexClient();
+    const runtime = await factory(client).create(createRequest(() => undefined));
+    const run = runtime.prompt({ runId: "trailing-failure", input: input("fail late") });
+    await client.called("turn/start");
+    client.complete();
+    queueMicrotask(() => client.emit({ method: "turn/plan/updated", params: { invalid: Number.NaN } }));
+    await expect(run).resolves.toMatchObject({ status: "failed", error: { code: "provider_error" } });
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+  });
+
+  it("rejects malformed turn/start responses and accepts buffered notifications", async () => {
+    for (const response of [
+      null,
+      {},
+      { turn: null },
+      { turn: { status: "inProgress", items: [] } },
+      { turn: { id: "turn-1", status: "unknown", items: [] } },
+      { turn: { id: "turn-1", status: "completed", items: [] } },
+      { turn: { id: "turn-1", status: "inProgress", items: [null] } },
+    ]) {
+      const client = new ManualCodexClient({ turnStartResponse: response });
+      const runtime = await factory(client).create(createRequest(() => undefined));
+      await expect(
+        runtime.prompt({ runId: `invalid-${client.instanceId}`, input: input("bad") }),
+      ).resolves.toMatchObject({
+        status: "failed",
+      });
+      await runtime.close().catch(() => undefined);
+    }
+
+    const bufferedClient = new ManualCodexClient({
+      beforeTurnStartResponse: (client) => {
+        client.emit({ method: "warning", params: { message: "buffered warning" } });
+      },
+    });
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = await factory(bufferedClient).create(
+      createRequest((event) => {
+        events.push(event);
+      }),
+    );
+    const run = runtime.prompt({ runId: "buffered", input: input("buffer") });
+    await bufferedClient.called("turn/start");
+    bufferedClient.complete();
+    await expect(run).resolves.toMatchObject({ status: "completed" });
+    expect(events.some((event) => event.type === "provider_warning")).toBe(true);
+    await runtime.close();
+
+    const noItemsClient = new ManualCodexClient({
+      turnStartResponse: { turn: { id: "turn-1", status: "inProgress" } },
+    });
+    const noItems = await factory(noItemsClient).create(createRequest(() => undefined));
+    const noItemsRun = noItems.prompt({ runId: "no-items", input: input("none") });
+    await noItemsClient.called("turn/start");
+    noItemsClient.emit({
+      method: "turn/completed",
+      params: {
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [{ id: "fallback", type: "agentMessage", text: "terminal fallback" }],
+        },
+      },
+    });
+    await expect(noItemsRun).resolves.toMatchObject({ output: [{ text: "terminal fallback" }] });
+    await noItems.close();
+  });
+
+  it("rejects undeliverable interactions back to Codex and handles non-Error stream failures", async () => {
+    const client = new ManualCodexClient();
+    const runtime = await factory(client).create(
+      createRequest((event) => {
+        if (event.type === "interaction_requested") throw new Error("sink rejected interaction");
+      }),
+    );
+    const run = runtime.prompt({ runId: "interaction-sink", input: input("interact") });
+    await client.called("turn/start");
+    client.emitRequest({
+      id: "approval",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-1", turnId: "turn-1" },
+    });
+    await expect(run).resolves.toMatchObject({ status: "failed", error: { code: "event_delivery_failed" } });
+    expect(client.serverRejections).toEqual([
+      { id: "approval", code: -32000, message: "OpenTag could not deliver the interaction" },
+    ]);
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+
+    const nonErrorClient = new ManualCodexClient();
+    const nonError = await factory(nonErrorClient).create(
+      createRequest((event) => {
+        if (event.type === "provider_warning") throw "non-error sink failure";
+      }),
+    );
+    nonErrorClient.emit({ method: "warning", params: { message: "outside run" } });
+    await Promise.resolve();
+    const nonErrorRun = nonError.prompt({ runId: "non-error", input: input("fail") });
+    await nonErrorClient.called("turn/start");
+    nonErrorClient.emit({ method: "warning", params: { message: "inside run" } });
+    nonErrorClient.emit({ method: "warning", params: { message: "second failure" } });
+    await expect(nonErrorRun).resolves.toMatchObject({ status: "failed", error: { code: "event_delivery_failed" } });
+    await vi.waitFor(() => expect(nonError.state.phase).toBe("closed"));
+  });
+
+  it("queues steer and abort until turn/start returns and rejects a crossed steer", async () => {
+    const turnResponse = deferred<unknown>();
+    const client = new ManualCodexClient({ turnStartResponse: turnResponse.promise });
+    const runtime = await factory(client).create(createRequest(() => undefined));
+    const run = runtime.prompt({ runId: "control", input: input("start") });
+    await client.called("turn/start");
+    const steering = runtime.steer({ expectedRunId: "control", input: input("steer") });
+    const aborting = runtime.abort({ expectedRunId: "control", reason: "stop" });
+    expect(client.call("turn/steer")).toBeUndefined();
+    turnResponse.resolve({ turn: activeTurn() });
+    await steering;
+    await aborting;
+    expect(client.call("turn/steer")?.params).toMatchObject({ expectedTurnId: "turn-1" });
+    expect(client.interrupts).toEqual([{ threadId: "thread-1", turnId: "turn-1" }]);
+    client.complete({ status: "interrupted" });
+    await run;
+    await runtime.close();
+
+    const crossedClient = new ManualCodexClient({ steerTurnId: "another-turn" });
+    const crossed = await factory(crossedClient).create(createRequest(() => undefined));
+    const crossedRun = crossed.prompt({ runId: "crossed", input: input("start") });
+    await crossedClient.called("turn/start");
+    await expect(crossed.steer({ expectedRunId: "crossed", input: input("steer") })).rejects.toMatchObject({
+      code: "provider_protocol_error",
+    });
+    crossedClient.complete();
+    await crossedRun;
+    await crossed.close();
+
+    const immediateClient = new ManualCodexClient();
+    const immediate = await factory(immediateClient).create(createRequest(() => undefined));
+    const immediateRun = immediate.prompt({ runId: "immediate", input: input("start") });
+    await expect(immediate.abort({ expectedRunId: "immediate" })).rejects.toMatchObject({ code: "run_mismatch" });
+    await immediateClient.called("turn/start");
+    immediateClient.complete();
+    await immediateRun;
+    await immediate.close();
+  });
+
+  it("validates all factory request, policy, configuration, binding, and probe failures", async () => {
+    const client = new ManualCodexClient();
+    const runtimeFactory = factory(client);
+    const valid = createRequest(() => undefined);
+    const invalidRequests: unknown[] = [
+      undefined,
+      { ...valid, eventSink: undefined },
+      { ...valid, workspace: undefined },
+      { ...valid, workspace: { cwd: "relative" } },
+      { ...valid, workspace: { cwd: "/workspace", writableRoots: ["relative"] } },
+      { ...valid, policy: { ...valid.policy, tools: { mode: "allow-list", names: ["read"] } } },
+      {
+        ...valid,
+        workspace: { cwd: "/workspace", writableRoots: ["/workspace"] },
+        policy: { ...valid.policy, fileSystem: "read-only" },
+      },
+      { ...valid, policy: { ...valid.policy, fileSystem: "read-only", network: "enabled" } },
+      { ...valid, policy: { ...valid.policy, fileSystem: "unrestricted", network: "disabled" } },
+      { ...valid, configuration: { model: " " } },
+      { ...valid, configuration: { reasoningEffort: "extreme" } },
+      { ...valid, configuration: { provider: "not-object" } },
+      { ...valid, configuration: { provider: { unknown: true } } },
+      { ...valid, configuration: { provider: { personality: "" } } },
+      { ...valid, configuration: { provider: { serviceName: 1 } } },
+    ];
+    for (const request of invalidRequests) {
+      await expect(runtimeFactory.create(request as never)).rejects.toMatchObject({ code: "configuration_invalid" });
+    }
+
+    await expect(
+      runtimeFactory.resume({ ...valid, binding: { providerId: "other", schemaVersion: 1, payload: {} } }),
+    ).rejects.toMatchObject({ code: "binding_incompatible" });
+    for (const payload of [[], {}, { threadId: "" }, { threadId: 1 }, { threadId: "x".repeat(1024 * 1024 + 1) }]) {
+      await expect(
+        runtimeFactory.resume({
+          ...valid,
+          binding: { providerId: "codex", schemaVersion: 1, payload: payload as never },
+        }),
+      ).rejects.toMatchObject({ code: "binding_incompatible" });
+    }
+
+    const invalidProviderProbe = new CodexAgentRuntimeFactory({
+      clientVersion: "test",
+      probeRunner: async () => ({ appServer: false, credential: false, version: "version" }),
+    });
+    await expect(invalidProviderProbe.probe({ configuration: { model: " " } })).resolves.toMatchObject({
+      ready: false,
+      version: "version",
+      issues: [{ code: "configuration_invalid" }, { code: "version_incompatible" }, { code: "credential_missing" }],
+    });
+    const missing = new CodexAgentRuntimeFactory({
+      clientVersion: "test",
+      probeRunner: async () => {
+        throw new Error("missing");
+      },
+    });
+    await expect(missing.probe({})).resolves.toEqual({
+      ready: false,
+      issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }],
+    });
+  });
+
+  it("cleans up factory failures without hiding typed errors", async () => {
+    const valid = createRequest(() => undefined);
+    const typedClient = new ManualCodexClient({
+      initializeError: new AgentRuntimeError("configuration_invalid", "typed"),
+    });
+    await expect(factory(typedClient).create(valid)).rejects.toMatchObject({ code: "configuration_invalid" });
+    expect(typedClient.closed).toBe(true);
+
+    const initializeClient = new ManualCodexClient({
+      initializeError: new Error("initialize failed"),
+      closeError: true,
+    });
+    await expect(factory(initializeClient).create(valid)).rejects.toMatchObject({ code: "create_failed" });
+
+    for (const response of [null, {}, { thread: null }, { thread: {} }, { thread: { id: "" } }]) {
+      const client = new ManualCodexClient({ threadStartResponse: response });
+      await expect(factory(client).create(valid)).rejects.toMatchObject({ code: "create_failed" });
+      expect(client.closed).toBe(true);
+    }
+
+    const nonErrorClient = new ManualCodexClient({ turnStartResponse: Promise.reject("non-error turn failure") });
+    const nonError = await factory(nonErrorClient).create(valid);
+    await expect(nonError.prompt({ runId: "non-error", input: input("fail") })).resolves.toMatchObject({
+      status: "failed",
+      error: { message: "Codex run failed" },
+    });
+    await nonError.close();
+  });
+
+  it("uses only the user-installed local Codex executable boundary", async () => {
+    const dependencyFields = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"] as const;
+    const manifestUrls = [
+      new URL("../../../../package.json", import.meta.url),
+      new URL("../../package.json", import.meta.url),
+    ];
+    const manifests = await Promise.all(
+      manifestUrls.map(async (url) => JSON.parse(await readFile(url, "utf8")) as PackageManifest),
+    );
+    const codexDependencies = manifests.flatMap((manifest) =>
+      dependencyFields.flatMap((field) =>
+        Object.keys(manifest[field] ?? {}).filter((name) => name.toLowerCase().includes("codex")),
+      ),
+    );
+    expect(codexDependencies).toEqual([]);
+
+    const cwd = await temporaryDirectory("opentag-codex-local-artifact-");
+    const launches: Array<{ command: string; args: readonly string[]; path: string | undefined }> = [];
+    const runtimeFactory = new CodexAgentRuntimeFactory({
+      clientVersion: "0.0.1-test",
+      process: {
+        env: { PATH: process.env.PATH, CODEX_FIXTURE_SCENARIO: "normal" },
+        requestTimeoutMs: 2_000,
+        spawnProcess: (command, args, options) => {
+          launches.push({ command, args: [...args], path: options.env?.PATH });
+          return spawn(process.execPath, [fixture], { ...options, stdio: "pipe" });
+        },
+      },
+      probeRunner: async () => ({ appServer: true, credential: true, version: "fixture" }),
+    });
+    const runtime = await runtimeFactory.create({ ...createRequest(() => undefined), workspace: { cwd } });
+    await runtime.close();
+
+    expect(launches).toEqual([{ command: "codex", args: ["app-server"], path: process.env.PATH }]);
+  });
+
+  it("runs the full Provider through a real offline App Server process", async () => {
+    const cwd = await temporaryDirectory("opentag-codex-provider-process-");
+    const runtimeFactory = new CodexAgentRuntimeFactory({
+      clientVersion: "0.0.1-test",
+      process: {
+        command: process.execPath,
+        args: [fixture],
+        env: { PATH: process.env.PATH, CODEX_FIXTURE_SCENARIO: "normal" },
+        requestTimeoutMs: 2_000,
+      },
+      probeRunner: async () => ({ appServer: true, credential: true, version: "fixture" }),
+    });
+    const runtime = await runtimeFactory.create({ ...createRequest(() => undefined), workspace: { cwd } });
+    await expect(runtime.prompt({ runId: "process", input: input("hello") })).resolves.toMatchObject({
+      status: "completed",
+      output: [{ text: "fixture answer" }],
+    });
+    const binding = runtime.binding;
+    await runtime.close();
+    if (!binding) throw new Error("fixture did not create a binding");
+    const resumed = await runtimeFactory.resume({
+      ...createRequest(() => undefined),
+      workspace: { cwd },
+      binding,
+    });
+    expect(resumed.binding).toEqual(binding);
+    await resumed.close();
+
+    const defaultArgsFactory = new CodexAgentRuntimeFactory({
+      clientVersion: "0.0.1-test",
+      process: {
+        command: "ignored-by-test-spawn",
+        env: { PATH: process.env.PATH, CODEX_FIXTURE_SCENARIO: "normal" },
+        requestTimeoutMs: 2_000,
+        spawnProcess: (_command, _args, options) => spawn(process.execPath, [fixture], { ...options, stdio: "pipe" }),
+      },
+      probeRunner: async () => ({ appServer: true, credential: true, version: "fixture" }),
+    });
+    const defaultArgs = await defaultArgsFactory.create({ ...createRequest(() => undefined), workspace: { cwd } });
+    await defaultArgs.close();
+  });
+
+  it("runs the default local probe against controlled CLI artifacts and credential sources", async () => {
+    const directory = await temporaryDirectory("opentag-codex-probe-");
+    const command = join(directory, "codex-fixture");
+    await writeFile(
+      command,
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then echo \'codex-cli test\'; exit 0; fi\nif [ "$1" = "app-server" ] && [ "$2" = "--help" ]; then exit 0; fi\nexit 1\n',
+      "utf8",
+    );
+    await chmod(command, 0o755);
+    const codexHome = join(directory, "codex-home");
+    await mkdir(codexHome);
+    await writeFile(join(codexHome, "auth.json"), "{}", "utf8");
+
+    const withFile = new CodexAgentRuntimeFactory({
+      clientVersion: "test",
+      process: { command, env: { PATH: process.env.PATH, CODEX_HOME: codexHome }, expectedCodexHome: codexHome },
+    });
+    await expect(withFile.probe({})).resolves.toEqual({ ready: true, version: "codex-cli test", issues: [] });
+
+    const withKey = new CodexAgentRuntimeFactory({
+      clientVersion: "test",
+      process: { command, env: { PATH: process.env.PATH, OPENAI_API_KEY: "test-key" } },
+    });
+    await expect(withKey.probe({})).resolves.toMatchObject({ ready: true });
+
+    const missingCredential = new CodexAgentRuntimeFactory({
+      clientVersion: "test",
+      process: { command, env: { PATH: process.env.PATH, HOME: directory } },
+    });
+    await expect(missingCredential.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "credential_missing" }],
+    });
+    const noHome = new CodexAgentRuntimeFactory({
+      clientVersion: "test",
+      process: { command, env: { PATH: process.env.PATH } },
+    });
+    await expect(noHome.probe({})).resolves.toMatchObject({ ready: false, issues: [{ code: "credential_missing" }] });
+
+    const emptyVersionCommand = join(directory, "codex-empty-version");
+    await writeFile(
+      emptyVersionCommand,
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then exit 0; fi\nif [ "$1" = "app-server" ]; then exit 0; fi\n',
+      "utf8",
+    );
+    await chmod(emptyVersionCommand, 0o755);
+    const emptyVersion = new CodexAgentRuntimeFactory({
+      clientVersion: "test",
+      process: { command: emptyVersionCommand, env: { PATH: process.env.PATH, OPENAI_API_KEY: "key" } },
+    });
+    await expect(emptyVersion.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "artifact_missing" }],
+    });
+    expect(codexAgentRuntimeEnvironment()).toEqual(expect.any(Object));
+  });
+});
+
+let clientSequence = 0;
+
+interface ManualClientOptions {
+  readonly beforeTurnStartResponse?: (client: ManualCodexClient) => void;
+  readonly closeError?: boolean;
+  readonly initializeError?: Error;
+  readonly steerTurnId?: string;
+  readonly threadStartResponse?: unknown;
+  readonly turnStartResponse?: unknown | Promise<unknown>;
+}
+
+interface PackageManifest {
+  readonly dependencies?: Readonly<Record<string, string>>;
+  readonly devDependencies?: Readonly<Record<string, string>>;
+  readonly optionalDependencies?: Readonly<Record<string, string>>;
+  readonly peerDependencies?: Readonly<Record<string, string>>;
+}
+
+class ManualCodexClient implements InteractiveCodexAppServerClient {
+  readonly calls: Array<{ method: string; params: unknown }> = [];
+  readonly interrupts: Array<{ threadId: string; turnId: string }> = [];
+  readonly serverRejections: Array<{ id: number | string; code: number; message: string }> = [];
+  readonly serverResponses: Array<{ id: number | string; result: unknown }> = [];
+  readonly instanceId = ++clientSequence;
+  readonly #notifications = new Set<(message: CodexAppServerMessage) => void>();
+  readonly #requests = new Set<(request: CodexAppServerRequest) => void>();
+  readonly #options: ManualClientOptions;
+  closed = false;
+  turn = 0;
+
+  constructor(options: ManualClientOptions = {}) {
+    this.#options = options;
+  }
+
+  async initialize(clientVersion: string): Promise<void> {
+    this.calls.push({ method: "initialize", params: { clientVersion } });
+    if (this.#options.initializeError) throw this.#options.initializeError;
+  }
+
+  async request(method: string, params: unknown): Promise<unknown> {
+    this.calls.push({ method, params });
+    if (method === "thread/start") {
+      return Object.hasOwn(this.#options, "threadStartResponse")
+        ? this.#options.threadStartResponse
+        : { thread: { id: "thread-1" } };
+    }
+    if (method === "thread/resume") return { thread: { id: (params as { threadId: string }).threadId } };
+    if (method === "turn/steer") return { turnId: this.#options.steerTurnId ?? `turn-${this.turn}` };
+    if (method !== "turn/start") throw new Error(`unexpected request: ${method}`);
+    this.turn += 1;
+    this.#options.beforeTurnStartResponse?.(this);
+    return Object.hasOwn(this.#options, "turnStartResponse")
+      ? await this.#options.turnStartResponse
+      : { turn: activeTurn(`turn-${this.turn}`) };
+  }
+
+  async notify(method: string, params: unknown): Promise<void> {
+    this.calls.push({ method, params });
+  }
+
+  subscribe(listener: (message: CodexAppServerMessage) => void): () => void {
+    this.#notifications.add(listener);
+    return () => this.#notifications.delete(listener);
+  }
+
+  subscribeServerRequests(listener: (request: CodexAppServerRequest) => void): () => void {
+    this.#requests.add(listener);
+    return () => this.#requests.delete(listener);
+  }
+
+  async respondServerRequest(id: number | string, result: unknown): Promise<void> {
+    this.serverResponses.push({ id, result });
+  }
+
+  async rejectServerRequest(id: number | string, code: number, message: string): Promise<void> {
+    this.serverRejections.push({ id, code, message });
+  }
+
+  async interrupt(threadId: string, turnId: string): Promise<void> {
+    this.interrupts.push({ threadId, turnId });
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    if (this.#options.closeError) throw new Error("close failed");
+  }
+
+  call(method: string): { method: string; params: unknown } | undefined {
+    return this.calls.find((call) => call.method === method);
+  }
+
+  lastCall(method: string): { method: string; params: unknown } | undefined {
+    return this.calls.filter((call) => call.method === method).at(-1);
+  }
+
+  async called(method: string): Promise<void> {
+    await vi.waitFor(() => expect(this.call(method)).toBeDefined());
+  }
+
+  emit(message: CodexAppServerMessage): void {
+    for (const listener of this.#notifications) listener(message);
+  }
+
+  emitRequest(request: CodexAppServerRequest): void {
+    for (const listener of this.#requests) listener(request);
+  }
+
+  emitItem(method: "item/started" | "item/completed", item: Record<string, unknown>): void {
+    this.emit({ method, params: { threadId: "thread-1", turnId: `turn-${this.turn}`, item } });
+  }
+
+  complete(
+    turn: {
+      id?: string;
+      status?: "completed" | "failed" | "inProgress" | "interrupted";
+      items?: unknown[];
+      error?: unknown;
+    } = {},
+  ): void {
+    this.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: {
+          id: turn.id ?? `turn-${this.turn}`,
+          status: turn.status ?? "completed",
+          items: turn.items ?? [],
+          ...(turn.error !== undefined ? { error: turn.error } : {}),
+        },
+      },
+    });
+  }
+}
+
+function factory(client: ManualCodexClient): CodexAgentRuntimeFactory {
+  return new CodexAgentRuntimeFactory({
+    clientVersion: "0.0.1-test",
+    createClient: () => client,
+    probeRunner: async () => ({ appServer: true, credential: true, version: "test" }),
+  });
+}
+
+function createRequest(eventSink: CreateAgentRuntimeRequest["eventSink"]): CreateAgentRuntimeRequest {
+  return {
+    eventSink,
+    workspace: { cwd: "/workspace" },
+    policy: {
+      fileSystem: "workspace-write",
+      network: "disabled",
+      approvals: "on-request",
+      tools: { mode: "provider-default" },
+    },
+  };
+}
+
+function input(text: string) {
+  return { items: [{ type: "text" as const, text }] };
+}
+
+function activeTurn(id = "turn-1") {
+  return { id, status: "inProgress", items: [] };
+}
+
+async function interact(
+  runtime: AgentRuntime,
+  client: ManualCodexClient,
+  events: AgentRuntimeEvent[],
+  id: number,
+  method: string,
+  response:
+    | Omit<AgentApprovalResponse, "expectedRunId" | "requestId">
+    | Omit<AgentQuestionResponse, "expectedRunId" | "requestId">,
+  includeMessage = true,
+): Promise<void> {
+  const before = events.filter((event) => event.type === "interaction_requested").length;
+  client.emitRequest({
+    id,
+    method,
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      ...(includeMessage ? { reason: "reason", message: "message" } : {}),
+    },
+  });
+  await vi.waitFor(() =>
+    expect(events.filter((event) => event.type === "interaction_requested")).toHaveLength(before + 1),
+  );
+  await runtime.respond({
+    ...response,
+    expectedRunId: "interactions",
+    requestId: `number:${id}`,
+  } as AgentInteractionResponse);
+}
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  directories.push(directory);
+  return directory;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolveValue: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveValue = resolve;
+  });
+  if (!resolveValue) throw new Error("could not create deferred promise");
+  return { promise, resolve: resolveValue };
+}

--- a/packages/client/src/__tests__/codex-agent-runtime.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRuntimeEvent, CreateAgentRuntimeRequest } from "../agent-runtime/types.js";
+import {
+  CodexAgentRuntime,
+  CodexAgentRuntimeFactory,
+  codexAgentRuntimeEnvironment,
+} from "../providers/codex/agent-runtime.js";
+import type {
+  CodexAppServerMessage,
+  CodexAppServerRequest,
+  InteractiveCodexAppServerClient,
+} from "../providers/codex/app-server-wire.js";
+
+describe("CodexAgentRuntime", () => {
+  it("creates a persistent thread and maps one Codex turn to one Agent run", async () => {
+    const client = new ScriptedCodexClient("complete");
+    const events: AgentRuntimeEvent[] = [];
+    const factory = codexFactory(client);
+    const runtime = await factory.create(
+      createRequest((event) => {
+        events.push(event);
+      }),
+    );
+
+    const result = await runtime.prompt({ runId: "run-1", input: input("hello") });
+
+    expect(runtime).toBeInstanceOf(CodexAgentRuntime);
+    expect(runtime.binding).toEqual({ providerId: "codex", schemaVersion: 1, payload: { threadId: "thread-1" } });
+    expect(result).toMatchObject({
+      runId: "run-1",
+      status: "completed",
+      output: [{ type: "text", text: "final answer" }],
+      usage: { inputTokens: 10, cachedInputTokens: 2, outputTokens: 3 },
+      providerDiagnostics: { providerThreadId: "thread-1", providerTurnId: "turn-1" },
+    });
+    expect(events.map((event) => event.type)).toEqual([
+      "binding_changed",
+      "run_started",
+      "message_started",
+      "message_delta",
+      "message_completed",
+      "usage_updated",
+      "run_completed",
+    ]);
+    expect(client.call("thread/start")?.params).toMatchObject({
+      cwd: "/workspace",
+      approvalPolicy: "onRequest",
+      sandbox: "workspace-write",
+      model: "gpt-test",
+    });
+    expect(client.call("turn/start")?.params).toMatchObject({
+      threadId: "thread-1",
+      input: [{ type: "text", text: "hello" }],
+      approvalPolicy: "onRequest",
+      sandboxPolicy: {
+        type: "workspaceWrite",
+        writableRoots: ["/workspace"],
+        networkAccess: false,
+      },
+      model: "gpt-test",
+      effort: "high",
+    });
+    await runtime.close();
+  });
+
+  it("resumes only the exact thread encoded by the binding", async () => {
+    const client = new ScriptedCodexClient("complete");
+    const factory = codexFactory(client);
+    const runtime = await factory.resume({
+      ...createRequest(() => undefined),
+      binding: { providerId: "codex", schemaVersion: 1, payload: { threadId: "thread-exact" } },
+    });
+
+    expect(client.call("thread/resume")?.params).toMatchObject({ threadId: "thread-exact" });
+    expect(client.call("thread/start")).toBeUndefined();
+    expect(runtime.binding?.payload).toEqual({ threadId: "thread-exact" });
+    await runtime.close();
+
+    const wrongClient = new ScriptedCodexClient("complete", { resumeThreadId: "another-thread" });
+    await expect(
+      codexFactory(wrongClient).resume({
+        ...createRequest(() => undefined),
+        binding: { providerId: "codex", schemaVersion: 1, payload: { threadId: "thread-exact" } },
+      }),
+    ).rejects.toMatchObject({ code: "resume_failed" });
+    expect(wrongClient.closed).toBe(true);
+    expect(wrongClient.call("thread/start")).toBeUndefined();
+  });
+
+  it("uses Codex expectedTurnId for same-run steer", async () => {
+    const client = new ScriptedCodexClient("hold");
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = await codexFactory(client).create(
+      createRequest((event) => {
+        events.push(event);
+      }),
+    );
+    const run = runtime.prompt({ runId: "run-1", input: input("start") });
+    await vi.waitFor(() => expect(client.call("turn/start")).toBeDefined());
+
+    await runtime.steer({ expectedRunId: "run-1", input: input("focus tests") });
+    expect(client.call("turn/steer")?.params).toMatchObject({
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "focus tests" }],
+    });
+    expect(events.some((event) => event.type === "input_accepted")).toBe(true);
+
+    client.complete();
+    await expect(run).resolves.toMatchObject({ status: "completed" });
+    await runtime.close();
+  });
+
+  it("bridges a Codex approval through a reentrant interaction response", async () => {
+    const client = new ScriptedCodexClient("interaction");
+    const events: AgentRuntimeEvent[] = [];
+    let runtime: CodexAgentRuntime;
+    runtime = await codexFactory(client).create(
+      createRequest(async (event) => {
+        events.push(event);
+        if (event.type === "interaction_requested") {
+          await runtime.respond({
+            kind: "approval",
+            expectedRunId: event.runId,
+            requestId: event.request.requestId,
+            decision: "accept",
+            scope: "runtime",
+          });
+        }
+      }),
+    );
+
+    await expect(runtime.prompt({ runId: "run-1", input: input("run command") })).resolves.toMatchObject({
+      status: "completed",
+    });
+    expect(client.serverResponses).toEqual([{ id: "approval-1", result: { decision: "acceptForSession" } }]);
+    expect(events.map((event) => event.type)).toContain("interaction_requested");
+    expect(events.map((event) => event.type)).toContain("interaction_resolved");
+    await runtime.close();
+  });
+
+  it("settles aborted only when Codex completes the turn as interrupted", async () => {
+    const client = new ScriptedCodexClient("hold");
+    const runtime = await codexFactory(client).create(createRequest(() => undefined));
+    const run = runtime.prompt({ runId: "run-1", input: input("long task") });
+    await vi.waitFor(() => expect(client.call("turn/start")).toBeDefined());
+
+    await runtime.abort({ expectedRunId: "run-1", reason: "stop" });
+
+    await expect(run).resolves.toMatchObject({ status: "aborted", error: { code: "run_aborted" } });
+    expect(client.interrupts).toEqual([{ threadId: "thread-1", turnId: "turn-1" }]);
+    await runtime.close();
+  });
+
+  it("reports a fatal provider failure as failed while closing the damaged runtime", async () => {
+    const client = new ScriptedCodexClient("failure");
+    const runtime = await codexFactory(client).create(createRequest(() => undefined));
+
+    await expect(runtime.prompt({ runId: "run-1", input: input("fail") })).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "provider_error", message: "process exited" },
+    });
+    await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
+    expect(client.closed).toBe(true);
+  });
+
+  it("cleans up and rejects when the initial binding event cannot be delivered", async () => {
+    const client = new ScriptedCodexClient("complete");
+    await expect(
+      codexFactory(client).create(
+        createRequest(() => {
+          throw new Error("sink failed");
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "create_failed" });
+    expect(client.closed).toBe(true);
+  });
+
+  it("probes local readiness without making a provider network request", async () => {
+    const ready = new CodexAgentRuntimeFactory({
+      clientVersion: "0.0.1",
+      probeRunner: async () => ({ appServer: true, credential: true, version: "codex-cli 1.2.3" }),
+    });
+    await expect(ready.probe({})).resolves.toEqual({ ready: true, version: "codex-cli 1.2.3", issues: [] });
+
+    const missingCredential = new CodexAgentRuntimeFactory({
+      clientVersion: "0.0.1",
+      probeRunner: async () => ({ appServer: true, credential: false, version: "codex-cli 1.2.3" }),
+    });
+    await expect(missingCredential.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "credential_missing" }],
+    });
+  });
+
+  it("passes only provider-owned environment variables to Codex", () => {
+    expect(
+      codexAgentRuntimeEnvironment({
+        HOME: "/home/provider",
+        PATH: "/bin",
+        OPENAI_API_KEY: "provider-key",
+        OPENTAG_ACCESS_TOKEN: "opentag-secret",
+        RANDOM_SECRET: "other-secret",
+      }),
+    ).toEqual({ HOME: "/home/provider", PATH: "/bin", OPENAI_API_KEY: "provider-key" });
+  });
+});
+
+type Scenario = "complete" | "failure" | "hold" | "interaction";
+
+class ScriptedCodexClient implements InteractiveCodexAppServerClient {
+  readonly calls: Array<{ method: string; params: unknown }> = [];
+  readonly interrupts: Array<{ threadId: string; turnId: string }> = [];
+  readonly serverResponses: Array<{ id: number | string; result: unknown }> = [];
+  readonly #notifications = new Set<(message: CodexAppServerMessage) => void>();
+  readonly #requests = new Set<(request: CodexAppServerRequest) => void>();
+  readonly #scenario: Scenario;
+  readonly #resumeThreadId?: string;
+  closed = false;
+
+  constructor(scenario: Scenario, options: { resumeThreadId?: string } = {}) {
+    this.#scenario = scenario;
+    this.#resumeThreadId = options.resumeThreadId;
+  }
+
+  async initialize(clientVersion: string): Promise<void> {
+    this.calls.push({ method: "initialize", params: { clientVersion } });
+  }
+
+  async request(method: string, params: unknown): Promise<unknown> {
+    this.calls.push({ method, params });
+    if (method === "thread/start") return { thread: { id: "thread-1" } };
+    if (method === "thread/resume") {
+      const requested = (params as { threadId?: string }).threadId;
+      return { thread: { id: this.#resumeThreadId ?? requested } };
+    }
+    if (method === "turn/steer") return { turnId: "turn-1" };
+    if (method !== "turn/start") throw new Error(`unexpected Codex request: ${method}`);
+
+    this.#emit({ method: "turn/started", params: { turn: activeTurn() } });
+    if (this.#scenario === "complete") this.#emitCompleteMessages();
+    if (this.#scenario === "failure") {
+      this.#emit({ method: "opentag/processError", params: { error: new Error("process exited") } });
+    }
+    if (this.#scenario === "interaction") {
+      this.#emit({
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "command-1", type: "commandExecution", command: ["pnpm", "test"], status: "inProgress" },
+        },
+      });
+      this.#emitRequest({
+        id: "approval-1",
+        method: "item/commandExecution/requestApproval",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: "command-1", reason: "Run tests" },
+      });
+    }
+    return { turn: activeTurn() };
+  }
+
+  async notify(method: string, params: unknown): Promise<void> {
+    this.calls.push({ method, params });
+  }
+
+  subscribe(listener: (message: CodexAppServerMessage) => void): () => void {
+    this.#notifications.add(listener);
+    return () => this.#notifications.delete(listener);
+  }
+
+  subscribeServerRequests(listener: (request: CodexAppServerRequest) => void): () => void {
+    this.#requests.add(listener);
+    return () => this.#requests.delete(listener);
+  }
+
+  async respondServerRequest(id: number | string, result: unknown): Promise<void> {
+    this.serverResponses.push({ id, result });
+    this.#emit({ method: "serverRequest/resolved", params: { threadId: "thread-1", requestId: id } });
+    this.#emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "command-1", type: "commandExecution", command: ["pnpm", "test"], status: "completed" },
+      },
+    });
+    this.complete();
+  }
+
+  async rejectServerRequest(id: number | string, code: number, message: string): Promise<void> {
+    this.serverResponses.push({ id, result: { error: { code, message } } });
+  }
+
+  async interrupt(threadId: string, turnId: string): Promise<void> {
+    this.interrupts.push({ threadId, turnId });
+    this.#emit({
+      method: "turn/completed",
+      params: { threadId, turn: { id: turnId, status: "interrupted", items: [] } },
+    });
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+
+  call(method: string): { method: string; params: unknown } | undefined {
+    return this.calls.find((call) => call.method === method);
+  }
+
+  complete(): void {
+    this.#emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [{ id: "message-1", type: "agentMessage", phase: "final_answer", text: "final answer" }],
+        },
+      },
+    });
+  }
+
+  #emitCompleteMessages(): void {
+    this.#emit({
+      method: "item/started",
+      params: { threadId: "thread-1", turnId: "turn-1", item: { id: "message-1", type: "agentMessage", text: "" } },
+    });
+    this.#emit({
+      method: "item/agentMessage/delta",
+      params: { threadId: "thread-1", turnId: "turn-1", itemId: "message-1", delta: "final answer" },
+    });
+    this.#emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "message-1", type: "agentMessage", phase: "final_answer", text: "final answer" },
+      },
+    });
+    this.#emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: { last: { inputTokens: 10, cachedInputTokens: 2, outputTokens: 3 } },
+      },
+    });
+    this.complete();
+  }
+
+  #emit(message: CodexAppServerMessage): void {
+    for (const listener of this.#notifications) listener(message);
+  }
+
+  #emitRequest(request: CodexAppServerRequest): void {
+    for (const listener of this.#requests) listener(request);
+  }
+}
+
+function codexFactory(client: ScriptedCodexClient): CodexAgentRuntimeFactory {
+  return new CodexAgentRuntimeFactory({
+    clientVersion: "0.0.1",
+    createClient: () => client,
+    probeRunner: async () => ({ appServer: true, credential: true, version: "test" }),
+  });
+}
+
+function createRequest(eventSink: CreateAgentRuntimeRequest["eventSink"]): CreateAgentRuntimeRequest {
+  return {
+    eventSink,
+    workspace: { cwd: "/workspace" },
+    policy: {
+      fileSystem: "workspace-write",
+      network: "disabled",
+      approvals: "on-request",
+      tools: { mode: "provider-default" },
+    },
+    configuration: { model: "gpt-test", reasoningEffort: "high" },
+  };
+}
+
+function input(text: string) {
+  return { items: [{ type: "text" as const, text }] };
+}
+
+function activeTurn() {
+  return { id: "turn-1", status: "inProgress", items: [] };
+}

--- a/packages/client/src/__tests__/codex-app-server-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-exhaustive.test.ts
@@ -215,6 +215,43 @@ describe("CodexAppServerProcess exhaustive behavior", () => {
     await listenerProcess.close();
   });
 
+  it("retains interactive request ownership across response write failures", async () => {
+    const child = new FakeChild();
+    const process = processWith(child);
+    process.subscribeServerRequests(() => undefined);
+
+    child.send({ id: "response-retry", method: "item/tool/requestUserInput", params: {} });
+    child.failWrites = true;
+    await expect(process.respondServerRequest("response-retry", { answer: "first" })).rejects.toMatchObject({
+      code: "write",
+    });
+    child.failWrites = false;
+    await process.respondServerRequest("response-retry", { answer: "retry" });
+    expect(child.messages.at(-1)).toEqual({ id: "response-retry", result: { answer: "retry" } });
+
+    child.send({ id: "rejection-retry", method: "item/tool/requestUserInput", params: {} });
+    child.failWrites = true;
+    await expect(process.rejectServerRequest("rejection-retry", -32000, "first")).rejects.toMatchObject({
+      code: "write",
+    });
+    child.failWrites = false;
+    await process.rejectServerRequest("rejection-retry", -32000, "retry");
+    expect(child.messages.at(-1)).toEqual({
+      id: "rejection-retry",
+      error: { code: -32000, message: "retry" },
+    });
+
+    child.send({ id: "in-flight", method: "item/tool/requestUserInput", params: {} });
+    child.holdWrites = true;
+    const first = process.respondServerRequest("in-flight", { answer: "only" });
+    await expect(process.respondServerRequest("in-flight", { answer: "duplicate" })).rejects.toMatchObject({
+      code: "protocol",
+    });
+    child.releaseWrites();
+    await first;
+    await process.close();
+  });
+
   it("handles unattended file approvals, questions, and unsupported requests", async () => {
     const child = new FakeChild();
     const process = processWith(child);
@@ -309,7 +346,9 @@ class FakeChild extends EventEmitter {
   readonly #options: Required<Pick<FakeChildOptions, "exitOnEnd">> & Pick<FakeChildOptions, "exitOnSignal">;
   #buffer = "";
   #exited = false;
+  readonly #heldWrites: Array<() => void> = [];
   failWrites = false;
+  holdWrites = false;
   handle?: (message: Record<string, unknown>) => void;
 
   constructor(options: FakeChildOptions = {}) {
@@ -319,6 +358,13 @@ class FakeChild extends EventEmitter {
     this.stdin.write = ((chunk: string | Uint8Array, callback?: (error?: Error | null) => void) => {
       if (this.failWrites) {
         queueMicrotask(() => callback?.(new Error("write failed")));
+        return false;
+      }
+      if (this.holdWrites) {
+        this.#heldWrites.push(() => {
+          originalWrite(chunk);
+          callback?.(null);
+        });
         return false;
       }
       const result = originalWrite(chunk);
@@ -339,6 +385,11 @@ class FakeChild extends EventEmitter {
     this.kills.push(signal);
     if (this.#options.exitOnSignal === signal) queueMicrotask(() => this.exit());
     return true;
+  }
+
+  releaseWrites(): void {
+    this.holdWrites = false;
+    for (const write of this.#heldWrites.splice(0)) write();
   }
 
   exit(): void {

--- a/packages/client/src/__tests__/codex-app-server-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-exhaustive.test.ts
@@ -1,0 +1,415 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CODEX_APP_SERVER_MAX_LINE_BYTES,
+  CODEX_APP_SERVER_REQUEST_TIMEOUT_MS,
+  CodexAppServerError,
+  CodexAppServerProcess,
+} from "../providers/codex/app-server-wire.js";
+
+describe("CodexAppServerProcess exhaustive behavior", () => {
+  it("validates constructor limits and wraps synchronous spawn failures", () => {
+    for (const maxLineBytes of [0, 1023, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => processWith(new FakeChild(), { maxLineBytes })).toThrowError(
+        "maxLineBytes must be a safe integer of at least 1024",
+      );
+    }
+    for (const requestTimeoutMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => processWith(new FakeChild(), { requestTimeoutMs })).toThrowError(
+        "requestTimeoutMs must be a positive safe integer",
+      );
+    }
+    expect(
+      () =>
+        new CodexAppServerProcess({
+          cwd: "/tmp",
+          env: {},
+          spawnProcess: () => {
+            throw new Error("spawn exploded");
+          },
+        }),
+    ).toThrowError(expect.objectContaining({ code: "spawn", message: "spawn exploded" }));
+    expect(
+      () =>
+        new CodexAppServerProcess({
+          cwd: "/tmp",
+          env: {},
+          spawnProcess: () => {
+            throw "non-error spawn";
+          },
+        }),
+    ).toThrowError(expect.objectContaining({ code: "spawn", message: "Codex could not be started" }));
+  });
+
+  it("uses default process options, exposes pid, initializes, notifies, interrupts, and rejects request errors", async () => {
+    const child = new FakeChild();
+    const spawn = vi.fn((_command, _args, _options) => child.asChildProcess());
+    const process = new CodexAppServerProcess({ cwd: "/tmp", env: { TEST: "one" }, spawnProcess: spawn });
+    child.handle = (message) => {
+      if (message.method === "initialize") child.respond(message.id, initializeResult());
+      else if (message.method === "turn/interrupt") child.respond(message.id, {});
+      else if (message.method === "fixture/error") child.respondError(message.id);
+      else if (message.method === "fixture/error-raw") child.send({ id: message.id, error: true });
+    };
+
+    expect(spawn).toHaveBeenCalledWith(
+      "codex",
+      ["app-server", "--stdio"],
+      expect.objectContaining({ cwd: "/tmp", env: { TEST: "one" }, detached: globalThis.process.platform !== "win32" }),
+    );
+    expect(process.pid).toBe(child.pid);
+    await process.initialize("1.2.3");
+    expect(child.messages.at(-1)).toEqual({ method: "initialized", params: {} });
+    await process.interrupt("thread", "turn");
+    await expect(process.request("fixture/error", {})).rejects.toMatchObject({
+      code: "protocol",
+      message: "Codex returned a request error: request failed",
+    });
+    await expect(process.request("fixture/error-raw", {})).rejects.toMatchObject({
+      message: "Codex returned a request error",
+    });
+    await process.close();
+    await process.close();
+  });
+
+  it("validates every initialize response field and expected Home", async () => {
+    const invalidResults = [
+      null,
+      {},
+      { ...initializeResult(), userAgent: "" },
+      { ...initializeResult(), platformFamily: 1 },
+      { ...initializeResult(), platformOs: "" },
+      { ...initializeResult(), codexHome: "x".repeat(4097) },
+    ];
+    for (const result of invalidResults) {
+      const child = new FakeChild();
+      child.handle = (message) => child.respond(message.id, result);
+      const process = processWith(child);
+      await expect(process.initialize("test")).rejects.toMatchObject({ code: "protocol" });
+      await process.close();
+    }
+
+    const child = new FakeChild();
+    child.handle = (message) => child.respond(message.id, initializeResult());
+    const process = processWith(child, { expectedCodexHome: "/different" });
+    await expect(process.initialize("test")).rejects.toMatchObject({ code: "protocol" });
+    await process.close();
+  });
+
+  it("handles pre-aborted, in-flight aborted, timed-out, and close-cancelled requests", async () => {
+    const child = new FakeChild();
+    const process = processWith(child, { requestTimeoutMs: 15 });
+    const preAborted = new AbortController();
+    preAborted.abort();
+    await expect(process.request("fixture/pre-abort", {}, preAborted.signal)).rejects.toMatchObject({
+      code: "aborted",
+    });
+
+    const controller = new AbortController();
+    const inFlight = process.request("fixture/abort", {}, controller.signal);
+    controller.abort();
+    await expect(inFlight).rejects.toMatchObject({ code: "aborted" });
+    await expect(process.request("fixture/timeout", {})).rejects.toMatchObject({ code: "timeout" });
+
+    const closing = process.request("fixture/closing", {});
+    const close = process.close();
+    await expect(closing).rejects.toMatchObject({ code: "aborted" });
+    await close;
+    await expect(process.request("fixture/closed", {})).rejects.toMatchObject({ code: "exited" });
+    await expect(process.notify("fixture/closed", {})).rejects.toMatchObject({ code: "write" });
+  });
+
+  it("handles unavailable stdin, oversized requests, and write callback errors", async () => {
+    const unavailable = new FakeChild();
+    const unavailableProcess = processWith(unavailable);
+    unavailable.stdin.destroy();
+    await expect(unavailableProcess.notify("fixture/write", {})).rejects.toMatchObject({ code: "write" });
+    unavailable.exit();
+    await unavailableProcess.close();
+
+    const oversized = new FakeChild();
+    const oversizedProcess = processWith(oversized, { maxLineBytes: 1024 });
+    await expect(oversizedProcess.notify("fixture/large", { value: "x".repeat(2048) })).rejects.toMatchObject({
+      code: "protocol",
+    });
+    await oversizedProcess.close();
+
+    const failedWrite = new FakeChild();
+    failedWrite.failWrites = true;
+    const failedWriteProcess = processWith(failedWrite);
+    await expect(failedWriteProcess.request("fixture/write", {})).rejects.toMatchObject({ code: "write" });
+    await failedWriteProcess.close();
+  });
+
+  it("fails closed for every malformed stdout framing and message shape", async () => {
+    const chunks = [
+      Buffer.from("x".repeat(1025)),
+      Buffer.from(`${"x".repeat(1025)}\n`),
+      Buffer.from("not-json\n"),
+      Buffer.from("null\n"),
+      Buffer.from("[]\n"),
+      Buffer.from("{}\n"),
+      Buffer.from(`\n${"x".repeat(1025)}`),
+    ];
+    for (const chunk of chunks) {
+      const child = new FakeChild();
+      const process = processWith(child, { maxLineBytes: 1024 });
+      const failure = processFailure(process);
+      child.stdout.write(chunk);
+      await expect(failure).resolves.toMatchObject({ code: "protocol" });
+      child.stdout.write(Buffer.from("ignored-after-failure\n"));
+      await process.close().catch(() => undefined);
+    }
+  });
+
+  it("rejects unknown, duplicate, and errored response IDs", async () => {
+    const unknownChild = new FakeChild();
+    const unknownProcess = processWith(unknownChild);
+    const unknownFailure = processFailure(unknownProcess);
+    unknownChild.send({ id: 999, result: {} });
+    await expect(unknownFailure).resolves.toMatchObject({ code: "protocol" });
+    await unknownProcess.close();
+
+    const duplicateChild = new FakeChild();
+    const duplicateProcess = processWith(duplicateChild);
+    const request = duplicateProcess.request("fixture/one", {});
+    const id = duplicateChild.messages[0]?.id;
+    duplicateChild.respond(id, { ok: true });
+    await expect(request).resolves.toEqual({ ok: true });
+    const duplicateFailure = processFailure(duplicateProcess);
+    duplicateChild.respond(id, { ok: true });
+    await expect(duplicateFailure).resolves.toMatchObject({ code: "protocol" });
+    await duplicateProcess.close();
+  });
+
+  it("handles explicit interactive responses, rejections, duplicates, and listener failures", async () => {
+    const child = new FakeChild();
+    const process = processWith(child);
+    const requests: CodexAppServerRequest[] = [];
+    const unsubscribe = process.subscribeServerRequests((request) => requests.push(request));
+    child.send({ id: "request-1", method: "item/tool/requestUserInput", params: { question: true } });
+    expect(requests).toEqual([{ id: "request-1", method: "item/tool/requestUserInput", params: { question: true } }]);
+    await process.rejectServerRequest("request-1", -32000, "declined");
+    expect(child.messages.at(-1)).toEqual({ id: "request-1", error: { code: -32000, message: "declined" } });
+    await expect(process.rejectServerRequest("request-1", -32000, "again")).rejects.toMatchObject({
+      code: "protocol",
+    });
+
+    child.send({ id: 2, method: "item/tool/requestUserInput", params: {} });
+    const failure = processFailure(process);
+    child.send({ id: 2, method: "item/tool/requestUserInput", params: {} });
+    await expect(failure).resolves.toMatchObject({ code: "protocol" });
+    unsubscribe();
+    await process.close();
+
+    const listenerChild = new FakeChild();
+    const listenerProcess = processWith(listenerChild);
+    listenerProcess.subscribeServerRequests(() => {
+      throw new Error("listener failed");
+    });
+    const listenerFailure = processFailure(listenerProcess);
+    listenerChild.send({ id: "listener", method: "item/tool/requestUserInput", params: {} });
+    await expect(listenerFailure).resolves.toMatchObject({ code: "protocol" });
+    await listenerProcess.close();
+  });
+
+  it("handles unattended file approvals, questions, and unsupported requests", async () => {
+    const child = new FakeChild();
+    const process = processWith(child);
+    child.send({ id: "file", method: "item/fileChange/requestApproval", params: {} });
+    await vi.waitFor(() => expect(child.messages).toContainEqual({ id: "file", result: { decision: "cancel" } }));
+    child.send({ id: "question", method: "item/tool/requestUserInput", params: {} });
+    await vi.waitFor(() => expect(child.messages).toContainEqual({ id: "question", result: { answers: {} } }));
+    const failure = processFailure(process);
+    child.send({ id: "unknown", method: "unknown/request", params: {} });
+    await expect(failure).resolves.toMatchObject({ code: "protocol" });
+    await process.close();
+  });
+
+  it("fails when notification listeners throw and tolerates failure listeners throwing", async () => {
+    const child = new FakeChild();
+    const process = processWith(child);
+    process.subscribe(() => {
+      throw new Error("notification listener failed");
+    });
+    child.send({ method: "notification", params: {} });
+    await vi.waitFor(() => expect(child.kills).toContain("SIGTERM"));
+    await process.close();
+
+    const failureChild = new FakeChild();
+    const failureProcess = processWith(failureChild);
+    failureProcess.subscribe(() => {
+      throw new Error("failure listener failed");
+    });
+    failureChild.send({ invalid: true });
+    failureChild.emit("error", new Error("second failure"));
+    await vi.waitFor(() => expect(failureChild.kills).toContain("SIGTERM"));
+    await failureProcess.close();
+  });
+
+  it("distinguishes clean exit, truncated exit, child errors, forced kill, and unkillable process trees", async () => {
+    for (const truncated of [false, true]) {
+      const child = new FakeChild({ exitOnEnd: false });
+      const process = processWith(child);
+      const failure = processFailure(process);
+      if (truncated) child.stdout.write("partial");
+      child.exit();
+      await expect(failure).resolves.toMatchObject({ code: truncated ? "protocol" : "exited" });
+      await process.close();
+    }
+
+    const errored = new FakeChild({ exitOnEnd: false });
+    const erroredProcess = processWith(errored);
+    const erroredFailure = processFailure(erroredProcess);
+    errored.emit("error", new Error("child error"));
+    await expect(erroredFailure).resolves.toMatchObject({ code: "spawn", message: "child error" });
+    errored.exit();
+    await erroredProcess.close();
+
+    const forceKilled = new FakeChild({ exitOnEnd: false, exitOnSignal: "SIGKILL" });
+    const forceKilledProcess = processWith(forceKilled);
+    await forceKilledProcess.close(5);
+    expect(forceKilled.kills).toEqual(["SIGTERM", "SIGKILL"]);
+
+    const unkillable = new FakeChild({ exitOnEnd: false });
+    const unkillableProcess = processWith(unkillable);
+    await expect(unkillableProcess.close(5)).rejects.toMatchObject({ code: "exited" });
+  });
+
+  it("escalates a failed process from TERM to KILL after the failure grace period", async () => {
+    vi.useFakeTimers();
+    try {
+      const child = new FakeChild({ exitOnEnd: false });
+      const process = processWith(child);
+      child.send({ invalid: true });
+      await vi.advanceTimersByTimeAsync(1_001);
+      expect(child.kills).toEqual(["SIGTERM", "SIGKILL"]);
+      child.exit();
+      await process.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+interface FakeChildOptions {
+  readonly exitOnEnd?: boolean;
+  readonly exitOnSignal?: "SIGTERM" | "SIGKILL";
+}
+
+class FakeChild extends EventEmitter {
+  readonly pid = 999_999_999;
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly messages: Array<Record<string, unknown>> = [];
+  readonly kills: NodeJS.Signals[] = [];
+  readonly #options: Required<Pick<FakeChildOptions, "exitOnEnd">> & Pick<FakeChildOptions, "exitOnSignal">;
+  #buffer = "";
+  #exited = false;
+  failWrites = false;
+  handle?: (message: Record<string, unknown>) => void;
+
+  constructor(options: FakeChildOptions = {}) {
+    super();
+    this.#options = { exitOnEnd: options.exitOnEnd ?? true, exitOnSignal: options.exitOnSignal };
+    const originalWrite = this.stdin.write.bind(this.stdin);
+    this.stdin.write = ((chunk: string | Uint8Array, callback?: (error?: Error | null) => void) => {
+      if (this.failWrites) {
+        queueMicrotask(() => callback?.(new Error("write failed")));
+        return false;
+      }
+      const result = originalWrite(chunk);
+      queueMicrotask(() => callback?.(null));
+      return result;
+    }) as typeof this.stdin.write;
+    this.stdin.on("data", (chunk: Buffer) => this.#read(chunk));
+    this.stdin.on("finish", () => {
+      if (this.#options.exitOnEnd) queueMicrotask(() => this.exit());
+    });
+  }
+
+  asChildProcess(): ChildProcessWithoutNullStreams {
+    return this as unknown as ChildProcessWithoutNullStreams;
+  }
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.kills.push(signal);
+    if (this.#options.exitOnSignal === signal) queueMicrotask(() => this.exit());
+    return true;
+  }
+
+  exit(): void {
+    if (this.#exited) return;
+    this.#exited = true;
+    this.emit("exit", 0, null);
+  }
+
+  send(message: unknown): void {
+    this.stdout.write(`${JSON.stringify(message)}\n`);
+  }
+
+  respond(id: unknown, result: unknown): void {
+    this.send({ id, result });
+  }
+
+  respondError(id: unknown): void {
+    this.send({ id, error: { code: -32000, message: "request failed" } });
+  }
+
+  #read(chunk: Buffer): void {
+    this.#buffer += chunk.toString("utf8");
+    while (true) {
+      const newline = this.#buffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = this.#buffer.slice(0, newline);
+      this.#buffer = this.#buffer.slice(newline + 1);
+      if (!line) continue;
+      const message = JSON.parse(line) as Record<string, unknown>;
+      this.messages.push(message);
+      this.handle?.(message);
+    }
+  }
+}
+
+function processWith(
+  child: FakeChild,
+  options: {
+    expectedCodexHome?: string;
+    maxLineBytes?: number;
+    requestTimeoutMs?: number;
+  } = {},
+): CodexAppServerProcess {
+  return new CodexAppServerProcess({
+    cwd: "/tmp",
+    env: {},
+    ...options,
+    spawnProcess: () => child.asChildProcess(),
+  });
+}
+
+function initializeResult() {
+  return {
+    userAgent: "codex-test",
+    platformFamily: "unix",
+    platformOs: "macos",
+    codexHome: "/codex-home",
+  };
+}
+
+function processFailure(process: CodexAppServerProcess): Promise<CodexAppServerError> {
+  return new Promise((resolve) => {
+    process.subscribe((message) => {
+      if (message.method !== "opentag/processError") return;
+      const error = (message.params as { error?: unknown }).error;
+      if (error instanceof CodexAppServerError) resolve(error);
+    });
+  });
+}
+
+type CodexAppServerRequest = import("../providers/codex/app-server-wire.js").CodexAppServerRequest;
+
+expect(CODEX_APP_SERVER_MAX_LINE_BYTES).toBe(1024 * 1024);
+expect(CODEX_APP_SERVER_REQUEST_TIMEOUT_MS).toBe(60_000);

--- a/packages/client/src/__tests__/codex-app-server.test.ts
+++ b/packages/client/src/__tests__/codex-app-server.test.ts
@@ -44,6 +44,28 @@ describe("CodexAppServerProcess", () => {
     await process.close();
   });
 
+  it("delegates server requests and writes exactly one explicit response for interactive runtimes", async () => {
+    const process = await appServer("normal");
+    await process.initialize("0.0.1");
+    const requestReceived = new Promise<{ id: number | string; method: string }>((resolve) => {
+      const unsubscribe = process.subscribeServerRequests((request) => {
+        unsubscribe();
+        resolve(request);
+      });
+    });
+
+    const approval = process.request("fixture/approval", {});
+    const request = await requestReceived;
+    expect(request).toMatchObject({ id: "approval-1", method: "item/commandExecution/requestApproval" });
+    await process.respondServerRequest(request.id, { decision: "accept" });
+
+    await expect(approval).resolves.toEqual({ decision: "accept" });
+    await expect(process.respondServerRequest(request.id, { decision: "accept" })).rejects.toMatchObject({
+      code: "protocol",
+    });
+    await process.close();
+  });
+
   it("D-06 rejects unknown server requests", async () => {
     const process = await appServer("normal");
     await process.initialize("0.0.1");

--- a/packages/client/src/__tests__/fixtures/codex-app-server.mjs
+++ b/packages/client/src/__tests__/fixtures/codex-app-server.mjs
@@ -3,6 +3,7 @@ import { createInterface } from "node:readline";
 
 const scenario = process.env.CODEX_FIXTURE_SCENARIO ?? "normal";
 let pendingApproval;
+let threadSequence = 0;
 
 const send = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
 
@@ -37,6 +38,42 @@ createInterface({ input: process.stdin }).on("line", (line) => {
   }
   if (message.method === "fixture/echo") {
     send({ id: message.id, result: message.params });
+    return;
+  }
+  if (message.method === "thread/start") {
+    threadSequence += 1;
+    send({ id: message.id, result: { thread: { id: `thread-${threadSequence}` } } });
+    return;
+  }
+  if (message.method === "thread/resume") {
+    send({ id: message.id, result: { thread: { id: message.params.threadId } } });
+    return;
+  }
+  if (message.method === "turn/start") {
+    const turn = { id: "turn-fixture", status: "inProgress", items: [] };
+    send({ id: message.id, result: { turn } });
+    queueMicrotask(() => {
+      send({ method: "turn/started", params: { threadId: message.params.threadId, turn } });
+      send({
+        method: "turn/completed",
+        params: {
+          threadId: message.params.threadId,
+          turn: {
+            id: turn.id,
+            status: "completed",
+            items: [{ id: "message-fixture", type: "agentMessage", phase: "final_answer", text: "fixture answer" }],
+          },
+        },
+      });
+    });
+    return;
+  }
+  if (message.method === "turn/steer") {
+    send({ id: message.id, result: { turnId: message.params.expectedTurnId } });
+    return;
+  }
+  if (message.method === "turn/interrupt") {
+    send({ id: message.id, result: {} });
     return;
   }
   if (message.method === "fixture/approval") {

--- a/packages/client/src/agent-runtime/base-agent-runtime.ts
+++ b/packages/client/src/agent-runtime/base-agent-runtime.ts
@@ -1,0 +1,544 @@
+import { AgentProviderError, AgentRuntimeError } from "./errors.js";
+import type {
+  AgentAbortRequest,
+  AgentInteractionRequest,
+  AgentInteractionResponse,
+  AgentPromptRequest,
+  AgentProviderRunContext,
+  AgentProviderRunEvent,
+  AgentProviderRunResult,
+  AgentRunResult,
+  AgentRuntime,
+  AgentRuntimeBinding,
+  AgentRuntimeCapabilities,
+  AgentRuntimeEvent,
+  AgentRuntimeEventSink,
+  AgentRuntimeManifest,
+  AgentRuntimeState,
+  AgentSteerRequest,
+} from "./types.js";
+import {
+  assertAgentInput,
+  assertBinding,
+  assertIdentifier,
+  assertJsonValue,
+  assertPromptRequest,
+  sameBinding,
+} from "./validation.js";
+
+export interface BaseAgentRuntimeOptions {
+  readonly manifest: AgentRuntimeManifest;
+  readonly capabilities: AgentRuntimeCapabilities;
+  readonly eventSink: AgentRuntimeEventSink;
+  readonly binding?: AgentRuntimeBinding;
+}
+
+interface RunRecord {
+  readonly request: AgentPromptRequest;
+  readonly controller: AbortController;
+  readonly promise: Promise<AgentRunResult>;
+  readonly resolve: (result: AgentRunResult) => void;
+  state: "queued" | "active" | "settled";
+  admissionEvent?: Promise<void>;
+  signalCleanup?: () => void;
+  abortPromise?: Promise<void>;
+}
+
+interface OutstandingInteraction {
+  readonly kind: AgentInteractionRequest["kind"];
+}
+
+export abstract class BaseAgentRuntime implements AgentRuntime {
+  readonly manifest: AgentRuntimeManifest;
+  readonly capabilities: AgentRuntimeCapabilities;
+
+  readonly #eventSink: AgentRuntimeEventSink;
+  readonly #queued: RunRecord[] = [];
+  readonly #knownRunIds = new Set<string>();
+  readonly #interactions = new Map<string, OutstandingInteraction>();
+  readonly #idleWaiters = new Set<() => void>();
+  #phase: AgentRuntimeState["phase"] = "idle";
+  #active?: RunRecord;
+  #binding?: AgentRuntimeBinding;
+  #dispatchTail: Promise<void> = Promise.resolve();
+  #sinkFailure?: Error;
+  #closePromise?: Promise<void>;
+  #providerFailureClosing = false;
+
+  protected constructor(options: BaseAgentRuntimeOptions) {
+    this.manifest = Object.freeze({ ...options.manifest });
+    this.capabilities = Object.freeze({ ...options.capabilities });
+    this.#eventSink = options.eventSink;
+    if (options.binding) {
+      assertBinding(options.binding, options.manifest);
+      this.#binding = options.binding;
+    }
+  }
+
+  get state(): Readonly<AgentRuntimeState> {
+    return Object.freeze({
+      phase: this.#phase,
+      ...(this.#active ? { activeRunId: this.#active.request.runId } : {}),
+      queuedRunCount: this.#queued.length,
+    });
+  }
+
+  get binding(): AgentRuntimeBinding | undefined {
+    return this.#binding;
+  }
+
+  async prompt(request: AgentPromptRequest): Promise<AgentRunResult> {
+    assertPromptRequest(request);
+    this.#assertOpen();
+    if (this.#phase !== "idle" || this.#active || this.#queued.length > 0) {
+      throw new AgentRuntimeError("busy", "prompt requires an idle runtime");
+    }
+    const record = this.#admit(request, "active");
+    this.#phase = "running";
+    this.#active = record;
+    void this.#execute(record);
+    return record.promise;
+  }
+
+  async followUp(request: AgentPromptRequest): Promise<AgentRunResult> {
+    assertPromptRequest(request);
+    this.#assertOpen();
+    if (this.#phase !== "running") {
+      throw new AgentRuntimeError("busy", "followUp requires an active run or follow-up chain");
+    }
+    const record = this.#admit(request, "queued");
+    this.#queued.push(record);
+    record.admissionEvent = this.#dispatch({ type: "run_queued", runId: request.runId, position: this.#queued.length });
+    void record.admissionEvent.catch(() => undefined);
+    return record.promise;
+  }
+
+  async steer(request: AgentSteerRequest): Promise<void> {
+    this.#assertOpen();
+    if (this.capabilities.steer !== "supported") {
+      throw new AgentRuntimeError("unsupported_capability", "this runtime does not support steer");
+    }
+    if (!request || typeof request !== "object") {
+      throw new AgentRuntimeError("invalid_request", "steer request is required");
+    }
+    assertIdentifier(request.expectedRunId, "expectedRunId");
+    assertAgentInput(request.input);
+    const active = this.#requireActive(request.expectedRunId);
+    await this.steerProvider(request);
+    if (active.state !== "active" || this.#active !== active) {
+      throw new AgentRuntimeError("run_mismatch", "the active run completed before steer was accepted");
+    }
+    await this.#dispatch({ type: "input_accepted", runId: active.request.runId, input: request.input });
+  }
+
+  async respond(response: AgentInteractionResponse): Promise<void> {
+    this.#assertOpen();
+    if (this.capabilities.interactions !== "supported") {
+      throw new AgentRuntimeError("unsupported_capability", "this runtime does not support interactions");
+    }
+    if (!response || typeof response !== "object") {
+      throw new AgentRuntimeError("invalid_request", "interaction response is required");
+    }
+    assertIdentifier(response.expectedRunId, "expectedRunId");
+    assertIdentifier(response.requestId, "requestId");
+    if (response.value !== undefined) assertJsonValue(response.value, "interaction.value");
+    const active = this.#requireActive(response.expectedRunId);
+    const interaction = this.#interactions.get(response.requestId);
+    if (!interaction || interaction.kind !== response.kind) {
+      throw new AgentRuntimeError("interaction_not_found", "the interaction is unknown, expired, or has another kind");
+    }
+    await this.respondProvider(response);
+    if (active.state !== "active" || this.#active !== active || !this.#interactions.delete(response.requestId)) {
+      throw new AgentRuntimeError("interaction_not_found", "the interaction expired before the response was accepted");
+    }
+    const event = this.#dispatch({
+      type: "interaction_resolved",
+      runId: active.request.runId,
+      requestId: response.requestId,
+      decision: response.decision,
+    });
+    void event.catch(() => undefined);
+  }
+
+  async abort(request: AgentAbortRequest): Promise<void> {
+    this.#assertOpen();
+    if (!request || typeof request !== "object") {
+      throw new AgentRuntimeError("invalid_request", "abort request is required");
+    }
+    assertIdentifier(request.expectedRunId, "expectedRunId");
+    const active = this.#requireActive(request.expectedRunId);
+    await this.#requestAbort(active, request.reason ?? "run aborted");
+  }
+
+  waitForIdle(): Promise<void> {
+    if (this.#phase === "idle" || this.#phase === "closed") return Promise.resolve();
+    return new Promise<void>((resolve) => this.#idleWaiters.add(resolve));
+  }
+
+  close(): Promise<void> {
+    if (this.#closePromise) return this.#closePromise;
+    this.#closePromise = this.#closeInternal();
+    return this.#closePromise;
+  }
+
+  protected abstract executeRun(
+    request: AgentPromptRequest,
+    context: AgentProviderRunContext,
+  ): Promise<AgentProviderRunResult>;
+
+  protected steerProvider(_request: AgentSteerRequest): Promise<void> {
+    return Promise.reject(new AgentRuntimeError("unsupported_capability", "this runtime does not support steer"));
+  }
+
+  protected respondProvider(_response: AgentInteractionResponse): Promise<void> {
+    return Promise.reject(
+      new AgentRuntimeError("unsupported_capability", "this runtime does not support interactions"),
+    );
+  }
+
+  protected abortProvider(_request: AgentAbortRequest): Promise<void> {
+    return Promise.resolve();
+  }
+
+  protected abstract closeProvider(): Promise<void>;
+
+  protected closeForProviderFailure(): void {
+    this.#providerFailureClosing = true;
+    void this.close().catch(() => undefined);
+  }
+
+  #admit(request: AgentPromptRequest, state: RunRecord["state"]): RunRecord {
+    if (this.#knownRunIds.has(request.runId)) {
+      throw new AgentRuntimeError("duplicate_run_id", "runId is already active or queued");
+    }
+    let resolveResult!: (result: AgentRunResult) => void;
+    const promise = new Promise<AgentRunResult>((resolve) => {
+      resolveResult = resolve;
+    });
+    const record: RunRecord = {
+      request,
+      controller: new AbortController(),
+      promise,
+      resolve: resolveResult,
+      state,
+    };
+    this.#knownRunIds.add(request.runId);
+    if (request.signal) {
+      const onAbort = () => {
+        if (record.state === "queued") void this.#cancelQueued(record, "run signal aborted");
+        else if (record.state === "active")
+          void this.#requestAbort(record, "run signal aborted").catch(() => undefined);
+      };
+      request.signal.addEventListener("abort", onAbort, { once: true });
+      record.signalCleanup = () => request.signal?.removeEventListener("abort", onAbort);
+    }
+    return record;
+  }
+
+  async #execute(record: RunRecord): Promise<void> {
+    if (record.admissionEvent) {
+      await record.admissionEvent;
+    }
+    let result: AgentRunResult;
+    try {
+      await this.#dispatch({ type: "run_started", runId: record.request.runId });
+      const providerResult = await this.executeRun(record.request, this.#context(record));
+      result = this.#providerResult(record.request.runId, providerResult);
+    } catch (error) {
+      result = this.#resultForThrownError(record, error);
+    }
+    this.#interactions.clear();
+    if (!this.#sinkFailure) {
+      try {
+        await this.#dispatch(this.#terminalEvent(result));
+      } catch {
+        result = this.#eventDeliveryFailure(record.request.runId, result);
+      }
+    } else {
+      result = this.#eventDeliveryFailure(record.request.runId, result);
+    }
+    this.#settle(record, result);
+    this.#finishActive();
+  }
+
+  #context(record: RunRecord): AgentProviderRunContext {
+    const assertCurrent = () => {
+      if (record.state !== "active" || this.#active !== record) {
+        throw new AgentRuntimeError("run_mismatch", "provider event does not belong to the active run");
+      }
+    };
+    return {
+      runId: record.request.runId,
+      signal: record.controller.signal,
+      emit: async (event: AgentProviderRunEvent) => {
+        assertCurrent();
+        await this.#dispatch({ ...event, runId: record.request.runId } as AgentRuntimeEvent);
+      },
+      updateBinding: async (binding: AgentRuntimeBinding) => {
+        assertCurrent();
+        assertBinding(binding, this.manifest);
+        if (sameBinding(this.#binding, binding)) return;
+        this.#binding = binding;
+        await this.#dispatch({ type: "binding_changed", binding, runId: record.request.runId });
+      },
+      requestInteraction: async (request: AgentInteractionRequest) => {
+        assertCurrent();
+        if (this.capabilities.interactions !== "supported") {
+          throw new AgentRuntimeError("unsupported_capability", "provider requested an unsupported interaction");
+        }
+        assertIdentifier(request.requestId, "interaction.requestId");
+        if (this.#interactions.has(request.requestId)) {
+          throw new AgentRuntimeError("invalid_request", "provider emitted a duplicate interaction requestId");
+        }
+        this.#interactions.set(request.requestId, { kind: request.kind });
+        try {
+          await this.#dispatch({ type: "interaction_requested", runId: record.request.runId, request });
+        } catch (error) {
+          this.#interactions.delete(request.requestId);
+          throw error;
+        }
+      },
+      resolveInteraction: async (requestId: string, decision: string) => {
+        assertCurrent();
+        if (!this.#interactions.delete(requestId)) return;
+        await this.#dispatch({
+          type: "interaction_resolved",
+          runId: record.request.runId,
+          requestId,
+          decision,
+        });
+      },
+    };
+  }
+
+  #providerResult(runId: string, result: AgentProviderRunResult): AgentRunResult {
+    const error =
+      result.error ??
+      (result.status === "failed"
+        ? { code: "provider_error" as const, message: "provider run failed" }
+        : result.status === "aborted"
+          ? { code: "run_aborted" as const, message: "provider run was interrupted" }
+          : undefined);
+    return {
+      runId,
+      status: result.status,
+      output: result.output ?? [],
+      ...(result.usage ? { usage: result.usage } : {}),
+      ...(this.#binding ? { binding: this.#binding } : {}),
+      ...(error ? { error } : {}),
+      ...(result.diagnostics !== undefined ? { providerDiagnostics: result.diagnostics } : {}),
+    };
+  }
+
+  #resultForThrownError(record: RunRecord, error: unknown): AgentRunResult {
+    if (this.#sinkFailure) return this.#eventDeliveryFailure(record.request.runId);
+    if (record.controller.signal.aborted) {
+      return {
+        runId: record.request.runId,
+        status: "aborted",
+        output: [],
+        ...(this.#binding ? { binding: this.#binding } : {}),
+        error: { code: "run_aborted", message: "run was interrupted" },
+      };
+    }
+    const providerError = error instanceof AgentProviderError ? error : undefined;
+    return {
+      runId: record.request.runId,
+      status: "failed",
+      output: [],
+      ...(this.#binding ? { binding: this.#binding } : {}),
+      error: {
+        code: providerError?.code ?? "provider_error",
+        message: providerError?.message ?? (error instanceof Error ? error.message : "provider run failed"),
+      },
+    };
+  }
+
+  #eventDeliveryFailure(runId: string, previous?: AgentRunResult): AgentRunResult {
+    return {
+      runId,
+      status: "failed",
+      output: previous?.output ?? [],
+      ...(previous?.usage ? { usage: previous.usage } : {}),
+      ...(this.#binding ? { binding: this.#binding } : {}),
+      error: { code: "event_delivery_failed", message: "the ordered event sink rejected an event" },
+      ...(previous?.providerDiagnostics !== undefined ? { providerDiagnostics: previous.providerDiagnostics } : {}),
+    };
+  }
+
+  #terminalEvent(result: AgentRunResult): AgentRuntimeEvent {
+    const type =
+      result.status === "completed"
+        ? "run_completed"
+        : result.status === "failed"
+          ? "run_failed"
+          : result.status === "aborted"
+            ? "run_aborted"
+            : "run_cancelled";
+    return { type, runId: result.runId, result } as AgentRuntimeEvent;
+  }
+
+  #settle(record: RunRecord, result: AgentRunResult): void {
+    record.state = "settled";
+    record.signalCleanup?.();
+    this.#knownRunIds.delete(record.request.runId);
+    record.resolve(result);
+  }
+
+  #finishActive(): void {
+    this.#active = undefined;
+    if (this.#phase === "closing" || this.#sinkFailure) return;
+    while (this.#queued.length > 0) {
+      const next = this.#queued.shift() as RunRecord;
+      next.state = "active";
+      this.#active = next;
+      void this.#execute(next);
+      return;
+    }
+    this.#phase = "idle";
+    this.#resolveIdleWaiters();
+  }
+
+  async #cancelQueued(record: RunRecord, message: string): Promise<void> {
+    const index = this.#queued.indexOf(record);
+    this.#queued.splice(index, 1);
+    let result: AgentRunResult = {
+      runId: record.request.runId,
+      status: "cancelled",
+      output: [],
+      ...(this.#binding ? { binding: this.#binding } : {}),
+      error: { code: "run_cancelled", message },
+    };
+    if (!this.#sinkFailure) {
+      try {
+        await record.admissionEvent;
+        await this.#dispatch(this.#terminalEvent(result));
+      } catch {
+        result = {
+          ...result,
+          error: { code: "event_delivery_failed", message: "the ordered event sink rejected an event" },
+        };
+      }
+    }
+    this.#settle(record, result);
+  }
+
+  #requestAbort(record: RunRecord, reason: string): Promise<void> {
+    if (record.abortPromise) return record.abortPromise;
+    record.abortPromise = this.abortProvider({ expectedRunId: record.request.runId, reason }).then(() => {
+      if (!record.controller.signal.aborted) record.controller.abort(reason);
+    });
+    return record.abortPromise;
+  }
+
+  #requireActive(expectedRunId: string): RunRecord {
+    const active = this.#active;
+    if (!active || active.request.runId !== expectedRunId || active.state !== "active") {
+      throw new AgentRuntimeError("run_mismatch", "expectedRunId does not match the active run");
+    }
+    return active;
+  }
+
+  #assertOpen(): void {
+    if (this.#phase === "closing" || this.#phase === "closed") {
+      throw new AgentRuntimeError("closed", "runtime is closing or closed");
+    }
+  }
+
+  #dispatch(event: AgentRuntimeEvent): Promise<void> {
+    if (this.#sinkFailure) return Promise.reject(this.#sinkFailure);
+    const delivery = this.#dispatchTail.then(async () => {
+      if (this.#sinkFailure) throw this.#sinkFailure;
+      await this.#eventSink(event);
+    });
+    this.#dispatchTail = delivery.catch((error: unknown) => {
+      this.#breakEventSink(error instanceof Error ? error : new Error("event sink rejected an event"));
+    });
+    return delivery;
+  }
+
+  #breakEventSink(error: Error): void {
+    if (this.#sinkFailure) return;
+    this.#sinkFailure = error;
+    this.#phase = "closing";
+    if (this.#active && !this.#active.controller.signal.aborted) {
+      this.#active.controller.abort("event delivery failed");
+    }
+    const queued = this.#queued.splice(0);
+    for (const record of queued) {
+      this.#settle(record, {
+        runId: record.request.runId,
+        status: "cancelled",
+        output: [],
+        ...(this.#binding ? { binding: this.#binding } : {}),
+        error: { code: "event_delivery_failed", message: "the ordered event sink rejected an event" },
+      });
+    }
+    void this.close().catch(() => undefined);
+  }
+
+  async #closeInternal(): Promise<void> {
+    this.#phase = "closing";
+    const active = this.#active;
+    if (active && !this.#providerFailureClosing && !active.controller.signal.aborted) {
+      active.controller.abort("runtime closing");
+    }
+    const aborting =
+      active && !this.#providerFailureClosing
+        ? this.#requestAbort(active, "runtime closing").catch(() => undefined)
+        : Promise.resolve();
+    let closeError: unknown;
+    const providerClosing = this.closeProvider().catch((error: unknown) => {
+      closeError = error;
+    });
+    const queued = this.#queued.splice(0);
+    let queueSinkHealthy = !this.#sinkFailure;
+    for (const record of queued) {
+      let result: AgentRunResult = {
+        runId: record.request.runId,
+        status: "cancelled",
+        output: [],
+        ...(this.#binding ? { binding: this.#binding } : {}),
+        error: {
+          code: queueSinkHealthy ? "runtime_closed" : "event_delivery_failed",
+          message: queueSinkHealthy ? "runtime closed before the queued run started" : "event delivery failed",
+        },
+      };
+      if (queueSinkHealthy) {
+        try {
+          await record.admissionEvent;
+          await this.#dispatch(this.#terminalEvent(result));
+        } catch {
+          queueSinkHealthy = false;
+          result = {
+            ...result,
+            error: { code: "event_delivery_failed", message: "the ordered event sink rejected an event" },
+          };
+        }
+      }
+      this.#settle(record, result);
+    }
+
+    await aborting;
+    await providerClosing;
+    await active?.promise;
+    await this.#dispatchTail;
+    if (!this.#sinkFailure) {
+      await this.#dispatch({ type: "runtime_closed" }).catch(() => undefined);
+    }
+    this.#phase = "closed";
+    this.#active = undefined;
+    this.#interactions.clear();
+    this.#resolveIdleWaiters();
+    if (closeError) {
+      throw new AgentRuntimeError("close_failed", "provider resources could not be closed", {
+        cause: closeError,
+      });
+    }
+  }
+
+  #resolveIdleWaiters(): void {
+    for (const resolve of this.#idleWaiters) resolve();
+    this.#idleWaiters.clear();
+  }
+}

--- a/packages/client/src/agent-runtime/base-agent-runtime.ts
+++ b/packages/client/src/agent-runtime/base-agent-runtime.ts
@@ -13,8 +13,8 @@ import type {
   AgentRuntimeCapabilities,
   AgentRuntimeEvent,
   AgentRuntimeEventSink,
+  AgentRuntimeLifecycleState,
   AgentRuntimeManifest,
-  AgentRuntimeState,
   AgentSteerRequest,
 } from "./types.js";
 import {
@@ -36,9 +36,11 @@ export interface BaseAgentRuntimeOptions {
 interface RunRecord {
   readonly request: AgentPromptRequest;
   readonly controller: AbortController;
+  readonly executionFailure: Promise<never>;
+  readonly failExecution: (error: Error) => void;
   readonly promise: Promise<AgentRunResult>;
   readonly resolve: (result: AgentRunResult) => void;
-  state: "queued" | "active" | "settled";
+  state: "queued" | "active" | "settling" | "settled";
   admissionEvent?: Promise<void>;
   signalCleanup?: () => void;
   abortPromise?: Promise<void>;
@@ -57,7 +59,7 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
   readonly #knownRunIds = new Set<string>();
   readonly #interactions = new Map<string, OutstandingInteraction>();
   readonly #idleWaiters = new Set<() => void>();
-  #phase: AgentRuntimeState["phase"] = "idle";
+  #phase: AgentRuntimeLifecycleState["phase"] = "idle";
   #active?: RunRecord;
   #binding?: AgentRuntimeBinding;
   #dispatchTail: Promise<void> = Promise.resolve();
@@ -71,11 +73,11 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
     this.#eventSink = options.eventSink;
     if (options.binding) {
       assertBinding(options.binding, options.manifest);
-      this.#binding = options.binding;
+      this.#binding = snapshotBinding(options.binding);
     }
   }
 
-  get state(): Readonly<AgentRuntimeState> {
+  get state(): Readonly<AgentRuntimeLifecycleState> {
     return Object.freeze({
       phase: this.#phase,
       ...(this.#active ? { activeRunId: this.#active.request.runId } : {}),
@@ -108,7 +110,11 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
     }
     const record = this.#admit(request, "queued");
     this.#queued.push(record);
-    record.admissionEvent = this.#dispatch({ type: "run_queued", runId: request.runId, position: this.#queued.length });
+    record.admissionEvent = this.#dispatch({
+      type: "run_queued",
+      runId: record.request.runId,
+      position: this.#queued.length,
+    });
     void record.admissionEvent.catch(() => undefined);
     return record.promise;
   }
@@ -123,12 +129,13 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
     }
     assertIdentifier(request.expectedRunId, "expectedRunId");
     assertAgentInput(request.input);
-    const active = this.#requireActive(request.expectedRunId);
-    await this.steerProvider(request);
+    const snapshot = immutableSnapshot(request);
+    const active = this.#requireActive(snapshot.expectedRunId);
+    await this.steerProvider(snapshot);
     if (active.state !== "active" || this.#active !== active) {
       throw new AgentRuntimeError("run_mismatch", "the active run completed before steer was accepted");
     }
-    await this.#dispatch({ type: "input_accepted", runId: active.request.runId, input: request.input });
+    await this.#dispatch({ type: "input_accepted", runId: active.request.runId, input: snapshot.input });
   }
 
   async respond(response: AgentInteractionResponse): Promise<void> {
@@ -142,20 +149,21 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
     assertIdentifier(response.expectedRunId, "expectedRunId");
     assertIdentifier(response.requestId, "requestId");
     if (response.value !== undefined) assertJsonValue(response.value, "interaction.value");
-    const active = this.#requireActive(response.expectedRunId);
-    const interaction = this.#interactions.get(response.requestId);
-    if (!interaction || interaction.kind !== response.kind) {
+    const snapshot = immutableSnapshot(response);
+    const active = this.#requireActive(snapshot.expectedRunId);
+    const interaction = this.#interactions.get(snapshot.requestId);
+    if (!interaction || interaction.kind !== snapshot.kind) {
       throw new AgentRuntimeError("interaction_not_found", "the interaction is unknown, expired, or has another kind");
     }
-    await this.respondProvider(response);
-    if (active.state !== "active" || this.#active !== active || !this.#interactions.delete(response.requestId)) {
+    await this.respondProvider(snapshot);
+    if (active.state !== "active" || this.#active !== active || !this.#interactions.delete(snapshot.requestId)) {
       throw new AgentRuntimeError("interaction_not_found", "the interaction expired before the response was accepted");
     }
     const event = this.#dispatch({
       type: "interaction_resolved",
       runId: active.request.runId,
-      requestId: response.requestId,
-      decision: response.decision,
+      requestId: snapshot.requestId,
+      decision: snapshot.decision,
     });
     void event.catch(() => undefined);
   }
@@ -208,29 +216,37 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
   }
 
   #admit(request: AgentPromptRequest, state: RunRecord["state"]): RunRecord {
-    if (this.#knownRunIds.has(request.runId)) {
+    const snapshot = snapshotPromptRequest(request);
+    if (this.#knownRunIds.has(snapshot.runId)) {
       throw new AgentRuntimeError("duplicate_run_id", "runId is already active or queued");
     }
     let resolveResult!: (result: AgentRunResult) => void;
+    let failExecution!: (error: Error) => void;
     const promise = new Promise<AgentRunResult>((resolve) => {
       resolveResult = resolve;
     });
+    const executionFailure = new Promise<never>((_resolve, reject) => {
+      failExecution = reject;
+    });
+    void executionFailure.catch(() => undefined);
     const record: RunRecord = {
-      request,
+      request: snapshot,
       controller: new AbortController(),
+      executionFailure,
+      failExecution,
       promise,
       resolve: resolveResult,
       state,
     };
-    this.#knownRunIds.add(request.runId);
-    if (request.signal) {
+    this.#knownRunIds.add(snapshot.runId);
+    if (snapshot.signal) {
       const onAbort = () => {
         if (record.state === "queued") void this.#cancelQueued(record, "run signal aborted");
         else if (record.state === "active")
           void this.#requestAbort(record, "run signal aborted").catch(() => undefined);
       };
-      request.signal.addEventListener("abort", onAbort, { once: true });
-      record.signalCleanup = () => request.signal?.removeEventListener("abort", onAbort);
+      snapshot.signal.addEventListener("abort", onAbort, { once: true });
+      record.signalCleanup = () => snapshot.signal?.removeEventListener("abort", onAbort);
     }
     return record;
   }
@@ -242,11 +258,13 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
     let result: AgentRunResult;
     try {
       await this.#dispatch({ type: "run_started", runId: record.request.runId });
-      const providerResult = await this.executeRun(record.request, this.#context(record));
+      const providerExecution = Promise.resolve().then(() => this.executeRun(record.request, this.#context(record)));
+      const providerResult = await Promise.race([providerExecution, record.executionFailure]);
       result = this.#providerResult(record.request.runId, providerResult);
     } catch (error) {
       result = this.#resultForThrownError(record, error);
     }
+    record.state = "settling";
     this.#interactions.clear();
     if (!this.#sinkFailure) {
       try {
@@ -278,8 +296,9 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
         assertCurrent();
         assertBinding(binding, this.manifest);
         if (sameBinding(this.#binding, binding)) return;
-        this.#binding = binding;
-        await this.#dispatch({ type: "binding_changed", binding, runId: record.request.runId });
+        const snapshot = snapshotBinding(binding);
+        this.#binding = snapshot;
+        await this.#dispatch({ type: "binding_changed", binding: snapshot, runId: record.request.runId });
       },
       requestInteraction: async (request: AgentInteractionRequest) => {
         assertCurrent();
@@ -319,7 +338,7 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
         : result.status === "aborted"
           ? { code: "run_aborted" as const, message: "provider run was interrupted" }
           : undefined);
-    return {
+    return immutableSnapshot({
       runId,
       status: result.status,
       output: result.output ?? [],
@@ -327,22 +346,22 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
       ...(this.#binding ? { binding: this.#binding } : {}),
       ...(error ? { error } : {}),
       ...(result.diagnostics !== undefined ? { providerDiagnostics: result.diagnostics } : {}),
-    };
+    });
   }
 
   #resultForThrownError(record: RunRecord, error: unknown): AgentRunResult {
     if (this.#sinkFailure) return this.#eventDeliveryFailure(record.request.runId);
     if (record.controller.signal.aborted) {
-      return {
+      return immutableSnapshot({
         runId: record.request.runId,
         status: "aborted",
         output: [],
         ...(this.#binding ? { binding: this.#binding } : {}),
         error: { code: "run_aborted", message: "run was interrupted" },
-      };
+      });
     }
     const providerError = error instanceof AgentProviderError ? error : undefined;
-    return {
+    return immutableSnapshot({
       runId: record.request.runId,
       status: "failed",
       output: [],
@@ -351,11 +370,11 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
         code: providerError?.code ?? "provider_error",
         message: providerError?.message ?? (error instanceof Error ? error.message : "provider run failed"),
       },
-    };
+    });
   }
 
   #eventDeliveryFailure(runId: string, previous?: AgentRunResult): AgentRunResult {
-    return {
+    return immutableSnapshot({
       runId,
       status: "failed",
       output: previous?.output ?? [],
@@ -363,7 +382,7 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
       ...(this.#binding ? { binding: this.#binding } : {}),
       error: { code: "event_delivery_failed", message: "the ordered event sink rejected an event" },
       ...(previous?.providerDiagnostics !== undefined ? { providerDiagnostics: previous.providerDiagnostics } : {}),
-    };
+    });
   }
 
   #terminalEvent(result: AgentRunResult): AgentRuntimeEvent {
@@ -381,8 +400,9 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
   #settle(record: RunRecord, result: AgentRunResult): void {
     record.state = "settled";
     record.signalCleanup?.();
+    record.signalCleanup = undefined;
     this.#knownRunIds.delete(record.request.runId);
-    record.resolve(result);
+    record.resolve(immutableSnapshot(result));
   }
 
   #finishActive(): void {
@@ -401,7 +421,10 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
 
   async #cancelQueued(record: RunRecord, message: string): Promise<void> {
     const index = this.#queued.indexOf(record);
+    /* v8 ignore next -- queue claims detach this listener; the guard defends a stale callback already in flight. */
+    if (record.state !== "queued" || index < 0) return;
     this.#queued.splice(index, 1);
+    this.#claimQueued(record);
     let result: AgentRunResult = {
       runId: record.request.runId,
       status: "cancelled",
@@ -425,10 +448,26 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
 
   #requestAbort(record: RunRecord, reason: string): Promise<void> {
     if (record.abortPromise) return record.abortPromise;
-    record.abortPromise = this.abortProvider({ expectedRunId: record.request.runId, reason }).then(() => {
-      if (!record.controller.signal.aborted) record.controller.abort(reason);
-    });
+    record.abortPromise = this.abortProvider({ expectedRunId: record.request.runId, reason }).then(
+      () => {
+        if (!record.controller.signal.aborted) record.controller.abort(reason);
+      },
+      (error: unknown) => {
+        this.#failAbort(record, error);
+        throw error;
+      },
+    );
     return record.abortPromise;
+  }
+
+  #failAbort(record: RunRecord, error: unknown): void {
+    if (record.state !== "active" || this.#active !== record) return;
+    record.failExecution(
+      new AgentProviderError("provider_error", "provider interrupt failed", {
+        cause: error,
+      }),
+    );
+    this.closeForProviderFailure();
   }
 
   #requireActive(expectedRunId: string): RunRecord {
@@ -447,9 +486,10 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
 
   #dispatch(event: AgentRuntimeEvent): Promise<void> {
     if (this.#sinkFailure) return Promise.reject(this.#sinkFailure);
+    const snapshot = immutableSnapshot(event);
     const delivery = this.#dispatchTail.then(async () => {
       if (this.#sinkFailure) throw this.#sinkFailure;
-      await this.#eventSink(event);
+      await this.#eventSink(snapshot);
     });
     this.#dispatchTail = delivery.catch((error: unknown) => {
       this.#breakEventSink(error instanceof Error ? error : new Error("event sink rejected an event"));
@@ -480,6 +520,8 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
   async #closeInternal(): Promise<void> {
     this.#phase = "closing";
     const active = this.#active;
+    const queued = this.#queued.splice(0);
+    for (const record of queued) this.#claimQueued(record);
     if (active && !this.#providerFailureClosing && !active.controller.signal.aborted) {
       active.controller.abort("runtime closing");
     }
@@ -491,7 +533,6 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
     const providerClosing = this.closeProvider().catch((error: unknown) => {
       closeError = error;
     });
-    const queued = this.#queued.splice(0);
     let queueSinkHealthy = !this.#sinkFailure;
     for (const record of queued) {
       let result: AgentRunResult = {
@@ -541,4 +582,33 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
     for (const resolve of this.#idleWaiters) resolve();
     this.#idleWaiters.clear();
   }
+
+  #claimQueued(record: RunRecord): void {
+    record.state = "settling";
+    record.signalCleanup?.();
+    record.signalCleanup = undefined;
+  }
+}
+
+function snapshotPromptRequest(request: AgentPromptRequest): AgentPromptRequest {
+  return Object.freeze({
+    runId: request.runId,
+    input: immutableSnapshot(request.input),
+    ...(request.configuration ? { configuration: immutableSnapshot(request.configuration) } : {}),
+    ...(request.signal ? { signal: request.signal } : {}),
+  });
+}
+
+function snapshotBinding(binding: AgentRuntimeBinding): AgentRuntimeBinding {
+  return immutableSnapshot(binding);
+}
+
+function immutableSnapshot<T>(value: T): T {
+  if (Array.isArray(value)) return Object.freeze(value.map((item) => immutableSnapshot(item))) as T;
+  if (value !== null && typeof value === "object") {
+    return Object.freeze(
+      Object.fromEntries(Object.entries(value).map(([key, item]) => [key, immutableSnapshot(item)])),
+    ) as T;
+  }
+  return value;
 }

--- a/packages/client/src/agent-runtime/base-agent-runtime.ts
+++ b/packages/client/src/agent-runtime/base-agent-runtime.ts
@@ -44,6 +44,7 @@ interface RunRecord {
   admissionEvent?: Promise<void>;
   signalCleanup?: () => void;
   abortPromise?: Promise<void>;
+  providerTerminalClaimed?: boolean;
 }
 
 interface OutstandingInteraction {
@@ -288,6 +289,10 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
     return {
       runId: record.request.runId,
       signal: record.controller.signal,
+      claimTerminal: () => {
+        assertCurrent();
+        record.providerTerminalClaimed = true;
+      },
       emit: async (event: AgentProviderRunEvent) => {
         assertCurrent();
         await this.#dispatch({ ...event, runId: record.request.runId } as AgentRuntimeEvent);
@@ -461,7 +466,7 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
   }
 
   #failAbort(record: RunRecord, error: unknown): void {
-    if (record.state !== "active" || this.#active !== record) return;
+    if (record.state !== "active" || this.#active !== record || record.providerTerminalClaimed) return;
     record.failExecution(
       new AgentProviderError("provider_error", "provider interrupt failed", {
         cause: error,

--- a/packages/client/src/agent-runtime/errors.ts
+++ b/packages/client/src/agent-runtime/errors.ts
@@ -1,0 +1,36 @@
+export type AgentRuntimeErrorCode =
+  | "binding_incompatible"
+  | "busy"
+  | "closed"
+  | "configuration_invalid"
+  | "close_failed"
+  | "create_failed"
+  | "duplicate_run_id"
+  | "interaction_not_found"
+  | "invalid_request"
+  | "provider_unavailable"
+  | "resume_failed"
+  | "run_mismatch"
+  | "unsupported_capability";
+
+export class AgentRuntimeError extends Error {
+  constructor(
+    readonly code: AgentRuntimeErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "AgentRuntimeError";
+  }
+}
+
+export class AgentProviderError extends Error {
+  constructor(
+    readonly code: "provider_error" | "provider_protocol_error",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "AgentProviderError";
+  }
+}

--- a/packages/client/src/agent-runtime/types.ts
+++ b/packages/client/src/agent-runtime/types.ts
@@ -20,7 +20,7 @@ export interface AgentRuntimeCapabilities {
   readonly interactions: "supported" | "unsupported";
 }
 
-export interface AgentRuntimeState {
+export interface AgentRuntimeLifecycleState {
   readonly phase: "idle" | "running" | "closing" | "closed";
   readonly activeRunId?: AgentRunId;
   readonly queuedRunCount: number;
@@ -243,7 +243,7 @@ export interface AgentProviderRunContext {
 export interface AgentRuntime {
   readonly manifest: AgentRuntimeManifest;
   readonly capabilities: AgentRuntimeCapabilities;
-  readonly state: Readonly<AgentRuntimeState>;
+  readonly state: Readonly<AgentRuntimeLifecycleState>;
   readonly binding: AgentRuntimeBinding | undefined;
 
   prompt(request: AgentPromptRequest): Promise<AgentRunResult>;

--- a/packages/client/src/agent-runtime/types.ts
+++ b/packages/client/src/agent-runtime/types.ts
@@ -234,6 +234,8 @@ export interface AgentProviderRunResult {
 export interface AgentProviderRunContext {
   readonly runId: AgentRunId;
   readonly signal: AbortSignal;
+  /** Marks that the authoritative Provider terminal arrived; public settlement still waits for executeRun. */
+  claimTerminal(): void;
   emit(event: AgentProviderRunEvent): Promise<void>;
   updateBinding(binding: AgentRuntimeBinding): Promise<void>;
   requestInteraction(request: AgentInteractionRequest): Promise<void>;

--- a/packages/client/src/agent-runtime/types.ts
+++ b/packages/client/src/agent-runtime/types.ts
@@ -1,0 +1,263 @@
+export const AGENT_RUNTIME_CONTRACT_VERSION = 1;
+export const AGENT_RUNTIME_BINDING_MAX_BYTES = 64 * 1024;
+export const AGENT_RUNTIME_ID_MAX_BYTES = 256;
+export const AGENT_RUNTIME_TEXT_MAX_BYTES = 1024 * 1024;
+
+export type JsonPrimitive = boolean | number | string | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type AgentRunId = string;
+
+export interface AgentRuntimeManifest {
+  readonly providerId: string;
+  readonly displayName: string;
+  readonly contractVersion: typeof AGENT_RUNTIME_CONTRACT_VERSION;
+  readonly bindingSchemaVersion: number;
+}
+
+export interface AgentRuntimeCapabilities {
+  readonly steer: "supported" | "unsupported";
+  readonly interactions: "supported" | "unsupported";
+}
+
+export interface AgentRuntimeState {
+  readonly phase: "idle" | "running" | "closing" | "closed";
+  readonly activeRunId?: AgentRunId;
+  readonly queuedRunCount: number;
+}
+
+export interface AgentRuntimeBinding {
+  readonly providerId: string;
+  readonly schemaVersion: number;
+  readonly payload: JsonValue;
+}
+
+export interface AgentTextInputItem {
+  readonly type: "text";
+  readonly text: string;
+}
+
+export type AgentInputItem = AgentTextInputItem;
+
+export interface AgentInput {
+  readonly items: readonly AgentInputItem[];
+}
+
+export interface AgentRunConfiguration {
+  readonly model?: string;
+  readonly reasoningEffort?: string;
+  readonly provider?: JsonValue;
+}
+
+export interface AgentPromptRequest {
+  readonly runId: AgentRunId;
+  readonly input: AgentInput;
+  readonly configuration?: AgentRunConfiguration;
+  readonly signal?: AbortSignal;
+}
+
+export interface AgentSteerRequest {
+  readonly expectedRunId: AgentRunId;
+  readonly input: AgentInput;
+}
+
+export interface AgentAbortRequest {
+  readonly expectedRunId: AgentRunId;
+  readonly reason?: string;
+}
+
+export interface AgentInteractionIdentity {
+  readonly expectedRunId: AgentRunId;
+  readonly requestId: string;
+}
+
+export interface AgentApprovalResponse extends AgentInteractionIdentity {
+  readonly kind: "approval";
+  readonly decision: "accept" | "decline" | "cancel";
+  readonly scope?: "run" | "runtime";
+  readonly value?: JsonValue;
+}
+
+export interface AgentQuestionResponse extends AgentInteractionIdentity {
+  readonly kind: "question";
+  readonly decision: "answer" | "cancel";
+  readonly value?: JsonValue;
+}
+
+export type AgentInteractionResponse = AgentApprovalResponse | AgentQuestionResponse;
+
+export interface AgentUsage {
+  readonly inputTokens?: number;
+  readonly cachedInputTokens?: number;
+  readonly outputTokens?: number;
+}
+
+export interface AgentTextOutputItem {
+  readonly type: "text";
+  readonly text: string;
+}
+
+export type AgentOutputItem = AgentTextOutputItem;
+
+export type AgentRunStatus = "completed" | "failed" | "aborted" | "cancelled";
+
+export type AgentRunErrorCode =
+  | "event_delivery_failed"
+  | "provider_error"
+  | "provider_protocol_error"
+  | "runtime_closed"
+  | "run_aborted"
+  | "run_cancelled";
+
+export interface AgentRunError {
+  readonly code: AgentRunErrorCode;
+  readonly message: string;
+}
+
+export interface AgentRunResult {
+  readonly runId: AgentRunId;
+  readonly status: AgentRunStatus;
+  readonly output: readonly AgentOutputItem[];
+  readonly usage?: AgentUsage;
+  readonly binding?: AgentRuntimeBinding;
+  readonly error?: AgentRunError;
+  readonly providerDiagnostics?: JsonValue;
+}
+
+export interface AgentRuntimeWorkspace {
+  readonly cwd: string;
+  readonly writableRoots?: readonly string[];
+}
+
+export interface AgentRuntimePolicy {
+  readonly fileSystem: "read-only" | "workspace-write" | "unrestricted";
+  readonly network: "disabled" | "enabled";
+  readonly approvals: "never" | "on-request" | "unless-trusted";
+  readonly tools:
+    | { readonly mode: "provider-default" }
+    | { readonly mode: "allow-list"; readonly names: readonly string[] };
+}
+
+export type AgentRuntimeEventSink = (event: AgentRuntimeEvent) => void | Promise<void>;
+
+export interface CreateAgentRuntimeRequest {
+  readonly eventSink: AgentRuntimeEventSink;
+  readonly workspace: AgentRuntimeWorkspace;
+  readonly policy: AgentRuntimePolicy;
+  readonly configuration?: AgentRunConfiguration;
+}
+
+export interface ResumeAgentRuntimeRequest extends CreateAgentRuntimeRequest {
+  readonly binding: AgentRuntimeBinding;
+}
+
+export interface AgentRuntimeProbeRequest {
+  readonly configuration?: AgentRunConfiguration;
+}
+
+export interface AgentRuntimeProbeIssue {
+  readonly code: "artifact_missing" | "credential_missing" | "configuration_invalid" | "version_incompatible";
+  readonly message: string;
+}
+
+export interface AgentRuntimeProbeResult {
+  readonly ready: boolean;
+  readonly version?: string;
+  readonly issues: readonly AgentRuntimeProbeIssue[];
+}
+
+export interface AgentInteractionRequest {
+  readonly requestId: string;
+  readonly kind: "approval" | "question";
+  readonly title: string;
+  readonly message?: string;
+  readonly options?: readonly string[];
+  readonly details?: JsonValue;
+}
+
+export type AgentProviderRunEvent =
+  | { readonly type: "model_turn_started"; readonly modelTurnId: string }
+  | { readonly type: "model_turn_completed"; readonly modelTurnId: string }
+  | { readonly type: "message_started"; readonly messageId: string }
+  | { readonly type: "message_delta"; readonly messageId: string; readonly delta: string }
+  | { readonly type: "message_completed"; readonly messageId: string; readonly text: string }
+  | {
+      readonly type: "tool_started";
+      readonly toolCallId: string;
+      readonly name: string;
+      readonly input?: JsonValue;
+    }
+  | { readonly type: "tool_updated"; readonly toolCallId: string; readonly update: JsonValue }
+  | {
+      readonly type: "tool_completed";
+      readonly toolCallId: string;
+      readonly name: string;
+      readonly status: "completed" | "failed" | "declined";
+      readonly output?: JsonValue;
+    }
+  | { readonly type: "usage_updated"; readonly usage: AgentUsage }
+  | { readonly type: "provider_warning"; readonly code: string; readonly message: string }
+  | {
+      readonly type: "provider_event";
+      readonly providerId: string;
+      readonly schemaVersion: number;
+      readonly payload: JsonValue;
+    };
+
+export type AgentRuntimeEvent =
+  | { readonly type: "binding_changed"; readonly binding: AgentRuntimeBinding; readonly runId?: AgentRunId }
+  | { readonly type: "run_queued"; readonly runId: AgentRunId; readonly position: number }
+  | { readonly type: "run_started"; readonly runId: AgentRunId }
+  | ({ readonly runId: AgentRunId } & AgentProviderRunEvent)
+  | { readonly type: "interaction_requested"; readonly runId: AgentRunId; readonly request: AgentInteractionRequest }
+  | {
+      readonly type: "interaction_resolved";
+      readonly runId: AgentRunId;
+      readonly requestId: string;
+      readonly decision: string;
+    }
+  | { readonly type: "input_accepted"; readonly runId: AgentRunId; readonly input: AgentInput }
+  | { readonly type: "run_completed"; readonly runId: AgentRunId; readonly result: AgentRunResult }
+  | { readonly type: "run_failed"; readonly runId: AgentRunId; readonly result: AgentRunResult }
+  | { readonly type: "run_aborted"; readonly runId: AgentRunId; readonly result: AgentRunResult }
+  | { readonly type: "run_cancelled"; readonly runId: AgentRunId; readonly result: AgentRunResult }
+  | { readonly type: "runtime_closed" };
+
+export interface AgentProviderRunResult {
+  readonly status: "completed" | "failed" | "aborted";
+  readonly output?: readonly AgentOutputItem[];
+  readonly usage?: AgentUsage;
+  readonly error?: AgentRunError;
+  readonly diagnostics?: JsonValue;
+}
+
+export interface AgentProviderRunContext {
+  readonly runId: AgentRunId;
+  readonly signal: AbortSignal;
+  emit(event: AgentProviderRunEvent): Promise<void>;
+  updateBinding(binding: AgentRuntimeBinding): Promise<void>;
+  requestInteraction(request: AgentInteractionRequest): Promise<void>;
+  resolveInteraction(requestId: string, decision: string): Promise<void>;
+}
+
+export interface AgentRuntime {
+  readonly manifest: AgentRuntimeManifest;
+  readonly capabilities: AgentRuntimeCapabilities;
+  readonly state: Readonly<AgentRuntimeState>;
+  readonly binding: AgentRuntimeBinding | undefined;
+
+  prompt(request: AgentPromptRequest): Promise<AgentRunResult>;
+  steer(request: AgentSteerRequest): Promise<void>;
+  followUp(request: AgentPromptRequest): Promise<AgentRunResult>;
+  respond(response: AgentInteractionResponse): Promise<void>;
+  abort(request: AgentAbortRequest): Promise<void>;
+  waitForIdle(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface AgentRuntimeFactory {
+  readonly manifest: AgentRuntimeManifest;
+  probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult>;
+  create(request: CreateAgentRuntimeRequest): Promise<AgentRuntime>;
+  resume(request: ResumeAgentRuntimeRequest): Promise<AgentRuntime>;
+}

--- a/packages/client/src/agent-runtime/validation.ts
+++ b/packages/client/src/agent-runtime/validation.ts
@@ -1,0 +1,95 @@
+import { AgentRuntimeError } from "./errors.js";
+import {
+  AGENT_RUNTIME_BINDING_MAX_BYTES,
+  AGENT_RUNTIME_ID_MAX_BYTES,
+  AGENT_RUNTIME_TEXT_MAX_BYTES,
+  type AgentInput,
+  type AgentPromptRequest,
+  type AgentRuntimeBinding,
+  type AgentRuntimeManifest,
+} from "./types.js";
+
+export function assertIdentifier(value: string, field: string): void {
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    Buffer.byteLength(value, "utf8") > AGENT_RUNTIME_ID_MAX_BYTES
+  ) {
+    throw new AgentRuntimeError("invalid_request", `${field} must be a non-empty bounded string`);
+  }
+}
+
+export function assertAgentInput(input: AgentInput): void {
+  if (!input || !Array.isArray(input.items) || input.items.length === 0) {
+    throw new AgentRuntimeError("invalid_request", "input must contain at least one item");
+  }
+  let bytes = 0;
+  for (const item of input.items) {
+    if (item?.type !== "text" || typeof item.text !== "string" || item.text.length === 0) {
+      throw new AgentRuntimeError("invalid_request", "input contains an invalid text item");
+    }
+    bytes += Buffer.byteLength(item.text, "utf8");
+  }
+  if (bytes > AGENT_RUNTIME_TEXT_MAX_BYTES) {
+    throw new AgentRuntimeError("invalid_request", "input exceeds the text size limit");
+  }
+}
+
+export function assertPromptRequest(request: AgentPromptRequest): void {
+  if (!request || typeof request !== "object") {
+    throw new AgentRuntimeError("invalid_request", "prompt request is required");
+  }
+  assertIdentifier(request.runId, "runId");
+  assertAgentInput(request.input);
+  if (request.signal?.aborted) {
+    throw new AgentRuntimeError("invalid_request", "the run signal is already aborted");
+  }
+  const configuration = request.configuration;
+  if (configuration?.model !== undefined) assertIdentifier(configuration.model, "configuration.model");
+  if (configuration?.reasoningEffort !== undefined) {
+    assertIdentifier(configuration.reasoningEffort, "configuration.reasoningEffort");
+  }
+  if (configuration?.provider !== undefined) assertJsonValue(configuration.provider, "configuration.provider");
+}
+
+export function assertBinding(binding: AgentRuntimeBinding, manifest: AgentRuntimeManifest): void {
+  if (!binding || typeof binding !== "object") {
+    throw new AgentRuntimeError("binding_incompatible", "binding is required");
+  }
+  if (binding.providerId !== manifest.providerId || binding.schemaVersion !== manifest.bindingSchemaVersion) {
+    throw new AgentRuntimeError("binding_incompatible", "binding provider or schema version is incompatible");
+  }
+  assertJsonValue(binding.payload, "binding.payload", "binding_incompatible");
+  if (Buffer.byteLength(JSON.stringify(binding), "utf8") > AGENT_RUNTIME_BINDING_MAX_BYTES) {
+    throw new AgentRuntimeError("binding_incompatible", "binding exceeds the size limit");
+  }
+}
+
+export function assertJsonValue(
+  value: unknown,
+  field: string,
+  code: "binding_incompatible" | "invalid_request" = "invalid_request",
+): void {
+  const seen = new Set<object>();
+  const visit = (candidate: unknown): void => {
+    if (candidate === null || typeof candidate === "string" || typeof candidate === "boolean") return;
+    if (typeof candidate === "number") {
+      if (Number.isFinite(candidate)) return;
+      throw new AgentRuntimeError(code, `${field} must contain finite JSON numbers`);
+    }
+    if (typeof candidate !== "object") throw new AgentRuntimeError(code, `${field} must be JSON-compatible`);
+    if (seen.has(candidate)) throw new AgentRuntimeError(code, `${field} must not contain cycles`);
+    seen.add(candidate);
+    if (Array.isArray(candidate)) {
+      for (const item of candidate) visit(item);
+    } else {
+      for (const item of Object.values(candidate)) visit(item);
+    }
+    seen.delete(candidate);
+  };
+  visit(value);
+}
+
+export function sameBinding(left: AgentRuntimeBinding | undefined, right: AgentRuntimeBinding): boolean {
+  return left !== undefined && JSON.stringify(left) === JSON.stringify(right);
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -29,12 +29,12 @@ export {
   type AgentRuntimeEvent,
   type AgentRuntimeEventSink,
   type AgentRuntimeFactory,
+  type AgentRuntimeLifecycleState,
   type AgentRuntimeManifest,
   type AgentRuntimePolicy,
   type AgentRuntimeProbeIssue,
   type AgentRuntimeProbeRequest,
   type AgentRuntimeProbeResult,
-  type AgentRuntimeState,
   type AgentRuntimeWorkspace,
   type AgentSteerRequest,
   type AgentTextInputItem,
@@ -166,7 +166,7 @@ export {
   type UnresolvedTurnPhase,
 } from "./runtime/session-binding-store.js";
 export {
-  type AgentRuntimeState as SessionReconcilerAgentRuntimeState,
+  type AgentRuntimeState,
   type RuntimeLocalPolicy,
   type RuntimePreparation,
   type SessionActivity,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,3 +1,50 @@
+export { BaseAgentRuntime, type BaseAgentRuntimeOptions } from "./agent-runtime/base-agent-runtime.js";
+export { AgentProviderError, AgentRuntimeError, type AgentRuntimeErrorCode } from "./agent-runtime/errors.js";
+export {
+  AGENT_RUNTIME_BINDING_MAX_BYTES,
+  AGENT_RUNTIME_CONTRACT_VERSION,
+  AGENT_RUNTIME_ID_MAX_BYTES,
+  AGENT_RUNTIME_TEXT_MAX_BYTES,
+  type AgentAbortRequest,
+  type AgentApprovalResponse,
+  type AgentInput,
+  type AgentInputItem,
+  type AgentInteractionRequest,
+  type AgentInteractionResponse,
+  type AgentOutputItem,
+  type AgentPromptRequest,
+  type AgentProviderRunContext,
+  type AgentProviderRunEvent,
+  type AgentProviderRunResult,
+  type AgentQuestionResponse,
+  type AgentRunConfiguration,
+  type AgentRunError,
+  type AgentRunErrorCode,
+  type AgentRunId,
+  type AgentRunResult,
+  type AgentRunStatus,
+  type AgentRuntime,
+  type AgentRuntimeBinding,
+  type AgentRuntimeCapabilities,
+  type AgentRuntimeEvent,
+  type AgentRuntimeEventSink,
+  type AgentRuntimeFactory,
+  type AgentRuntimeManifest,
+  type AgentRuntimePolicy,
+  type AgentRuntimeProbeIssue,
+  type AgentRuntimeProbeRequest,
+  type AgentRuntimeProbeResult,
+  type AgentRuntimeState,
+  type AgentRuntimeWorkspace,
+  type AgentSteerRequest,
+  type AgentTextInputItem,
+  type AgentTextOutputItem,
+  type AgentUsage,
+  type CreateAgentRuntimeRequest,
+  type JsonPrimitive,
+  type JsonValue,
+  type ResumeAgentRuntimeRequest,
+} from "./agent-runtime/types.js";
 export { normalizeServerUrl, OpenTagApi, OpenTagApiError } from "./api.js";
 export {
   CREDENTIALS_FILE_NAME,
@@ -35,14 +82,23 @@ export {
   safeRelativeTracePath,
 } from "./providers/codex/adapter.js";
 export {
+  CODEX_AGENT_RUNTIME_MANIFEST,
+  CodexAgentRuntime,
+  CodexAgentRuntimeFactory,
+  type CodexAgentRuntimeFactoryOptions,
+  codexAgentRuntimeEnvironment,
+} from "./providers/codex/agent-runtime.js";
+export {
   CODEX_APP_SERVER_MAX_LINE_BYTES,
   CODEX_APP_SERVER_REQUEST_TIMEOUT_MS,
   type CodexAppServerClient,
   CodexAppServerError,
   type CodexAppServerMessage,
   CodexAppServerProcess,
+  type CodexAppServerRequest,
   type CodexProcessSpawnOptions,
   type CodexSpawnOptions,
+  type InteractiveCodexAppServerClient,
 } from "./providers/codex/app-server-wire.js";
 export {
   AdmissionController,
@@ -110,7 +166,7 @@ export {
   type UnresolvedTurnPhase,
 } from "./runtime/session-binding-store.js";
 export {
-  type AgentRuntimeState,
+  type AgentRuntimeState as SessionReconcilerAgentRuntimeState,
   type RuntimeLocalPolicy,
   type RuntimePreparation,
   type SessionActivity,

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -289,6 +289,7 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
       const turn = parseTurn(params?.turn, "turn/completed");
       this.#assertTurn(turn.id);
       if (turn.status === "inProgress") throw protocolError("turn/completed carried an active turn");
+      context.claimTerminal();
       this.#terminal?.resolve(turn);
       return;
     }

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -1,0 +1,955 @@
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
+import { isAbsolute, join } from "node:path";
+import { promisify } from "node:util";
+import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
+import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
+import {
+  AGENT_RUNTIME_CONTRACT_VERSION,
+  type AgentAbortRequest,
+  type AgentApprovalResponse,
+  type AgentInteractionRequest,
+  type AgentInteractionResponse,
+  type AgentPromptRequest,
+  type AgentProviderRunContext,
+  type AgentProviderRunResult,
+  type AgentQuestionResponse,
+  type AgentRunConfiguration,
+  type AgentRuntimeBinding,
+  type AgentRuntimeEventSink,
+  type AgentRuntimeFactory,
+  type AgentRuntimeManifest,
+  type AgentRuntimePolicy,
+  type AgentRuntimeProbeRequest,
+  type AgentRuntimeProbeResult,
+  type AgentRuntimeWorkspace,
+  type AgentSteerRequest,
+  type CreateAgentRuntimeRequest,
+  type JsonValue,
+  type ResumeAgentRuntimeRequest,
+} from "../../agent-runtime/types.js";
+import { assertBinding, assertJsonValue } from "../../agent-runtime/validation.js";
+import {
+  type CodexAppServerMessage,
+  CodexAppServerProcess,
+  type CodexAppServerRequest,
+  type CodexSpawnOptions,
+  type InteractiveCodexAppServerClient,
+} from "./app-server-wire.js";
+
+const execFileAsync = promisify(execFile);
+const CODEX_BINDING_SCHEMA_VERSION = 1;
+const CODEX_PROVIDER_ID = "codex";
+const CODEX_APP_SERVER_ARGS = ["app-server"] as const;
+const CODEX_REASONING_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh"]);
+const TOOL_ITEM_TYPES = new Set([
+  "collabToolCall",
+  "commandExecution",
+  "dynamicToolCall",
+  "fileChange",
+  "imageView",
+  "mcpToolCall",
+  "webSearch",
+]);
+
+export const CODEX_AGENT_RUNTIME_MANIFEST: AgentRuntimeManifest = Object.freeze({
+  providerId: CODEX_PROVIDER_ID,
+  displayName: "Codex",
+  contractVersion: AGENT_RUNTIME_CONTRACT_VERSION,
+  bindingSchemaVersion: CODEX_BINDING_SCHEMA_VERSION,
+});
+
+interface CodexProviderConfiguration {
+  readonly personality?: string;
+  readonly serviceName?: string;
+  readonly summary?: string;
+}
+
+interface CodexRuntimeOptions {
+  readonly client: InteractiveCodexAppServerClient;
+  readonly threadId: string;
+  readonly eventSink: AgentRuntimeEventSink;
+  readonly binding: AgentRuntimeBinding;
+  readonly workspace: AgentRuntimeWorkspace;
+  readonly policy: AgentRuntimePolicy;
+  readonly configuration?: AgentRunConfiguration;
+}
+
+export interface CodexAgentRuntimeFactoryOptions {
+  readonly clientVersion: string;
+  readonly createClient?: (cwd: string) => InteractiveCodexAppServerClient;
+  readonly process?: Omit<CodexSpawnOptions, "cwd" | "env"> & { readonly env?: NodeJS.ProcessEnv };
+  readonly probeRunner?: () => Promise<{
+    readonly appServer: boolean;
+    readonly credential: boolean;
+    readonly version: string;
+  }>;
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (error: Error) => void;
+}
+
+type CodexEnvelope =
+  | { readonly type: "notification"; readonly message: CodexAppServerMessage }
+  | { readonly type: "request"; readonly request: CodexAppServerRequest };
+
+interface ParsedTurn {
+  readonly error?: string;
+  readonly id: string;
+  readonly items: readonly Record<string, unknown>[];
+  readonly status: "completed" | "failed" | "inProgress" | "interrupted";
+}
+
+export class CodexAgentRuntime extends BaseAgentRuntime {
+  readonly #client: InteractiveCodexAppServerClient;
+  readonly #threadId: string;
+  readonly #workspace: AgentRuntimeWorkspace;
+  readonly #policy: AgentRuntimePolicy;
+  readonly #configuration?: AgentRunConfiguration;
+  readonly #unsubscribeNotifications: () => void;
+  readonly #unsubscribeRequests: () => void;
+  readonly #wireInteractions = new Map<string, CodexAppServerRequest>();
+  readonly #completedMessages = new Map<string, { readonly phase?: string; readonly text: string }>();
+  #eventTail: Promise<void> = Promise.resolve();
+  #buffering = false;
+  #buffered: CodexEnvelope[] = [];
+  #context?: AgentProviderRunContext;
+  #providerTurnId?: string;
+  #turnIdReady?: Deferred<string>;
+  #terminal?: Deferred<ParsedTurn>;
+  #latestUsage?: { readonly inputTokens?: number; readonly cachedInputTokens?: number; readonly outputTokens?: number };
+  #providerFailure?: Error;
+
+  constructor(options: CodexRuntimeOptions) {
+    super({
+      manifest: CODEX_AGENT_RUNTIME_MANIFEST,
+      capabilities: { steer: "supported", interactions: "supported" },
+      eventSink: options.eventSink,
+      binding: options.binding,
+    });
+    this.#client = options.client;
+    this.#threadId = options.threadId;
+    this.#workspace = options.workspace;
+    this.#policy = options.policy;
+    this.#configuration = options.configuration;
+    this.#unsubscribeNotifications = this.#client.subscribe((message) => {
+      this.#enqueue({ type: "notification", message });
+    });
+    this.#unsubscribeRequests = this.#client.subscribeServerRequests((request) => {
+      this.#enqueue({ type: "request", request });
+    });
+  }
+
+  protected async executeRun(
+    request: AgentPromptRequest,
+    context: AgentProviderRunContext,
+  ): Promise<AgentProviderRunResult> {
+    this.#context = context;
+    this.#providerTurnId = undefined;
+    this.#providerFailure = undefined;
+    this.#latestUsage = undefined;
+    this.#completedMessages.clear();
+    this.#wireInteractions.clear();
+    this.#buffered = [];
+    this.#buffering = true;
+    this.#turnIdReady = deferred<string>();
+    this.#terminal = deferred<ParsedTurn>();
+    void this.#turnIdReady.promise.catch(() => undefined);
+    void this.#terminal.promise.catch(() => undefined);
+
+    try {
+      const response = await this.#client.request("turn/start", this.#turnStartParams(request));
+      const started = parseTurnResponse(response, "turn/start");
+      if (started.status !== "inProgress") throw protocolError("turn/start returned a terminal turn");
+      this.#providerTurnId = started.id;
+      this.#turnIdReady.resolve(started.id);
+      this.#buffering = false;
+      const buffered = this.#buffered.splice(0);
+      for (const envelope of buffered) this.#enqueue(envelope);
+      await this.#eventTail;
+      if (this.#providerFailure) throw this.#providerFailure;
+      const terminal = await this.#terminal.promise;
+      await this.#eventTail;
+      if (this.#providerFailure) throw this.#providerFailure;
+      return this.#runResult(terminal);
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error("Codex run failed");
+      this.#turnIdReady.reject(failure);
+      throw failure;
+      /* v8 ignore next -- finally is mandatory cleanup; V8 reports a synthetic branch for its closing token. */
+    } finally {
+      this.#buffering = false;
+      this.#buffered = [];
+      this.#context = undefined;
+      this.#providerTurnId = undefined;
+      this.#turnIdReady = undefined;
+      this.#terminal = undefined;
+      this.#wireInteractions.clear();
+    }
+  }
+
+  protected async steerProvider(request: AgentSteerRequest): Promise<void> {
+    const turnId = await this.#activeTurnId();
+    const response = requireRecord(
+      await this.#client.request("turn/steer", {
+        threadId: this.#threadId,
+        input: codexInput(request.input.items),
+        expectedTurnId: turnId,
+      }),
+      "turn/steer returned an invalid response",
+    );
+    if (requireString(response.turnId, "turn/steer returned no turnId") !== turnId) {
+      throw protocolError("turn/steer accepted another turn");
+    }
+  }
+
+  protected async respondProvider(response: AgentInteractionResponse): Promise<void> {
+    const request = this.#wireInteractions.get(response.requestId);
+    /* v8 ignore next -- Base and the serial Codex envelope queue fence this map with the public interaction. */
+    if (!request) throw new AgentRuntimeError("interaction_not_found", "Codex interaction is no longer pending");
+    const result = codexInteractionResult(request.method, response);
+    await this.#client.respondServerRequest(request.id, result);
+    this.#wireInteractions.delete(response.requestId);
+  }
+
+  protected async abortProvider(request: AgentAbortRequest): Promise<void> {
+    const turnId = await this.#activeTurnId();
+    /* v8 ignore next 3 -- Base validates expectedRunId before entering the Provider hook. */
+    if (request.expectedRunId !== this.#context?.runId) {
+      throw new AgentRuntimeError("run_mismatch", "abort no longer belongs to the active Codex turn");
+    }
+    await this.#client.interrupt(this.#threadId, turnId);
+  }
+
+  protected async closeProvider(): Promise<void> {
+    if (this.#context) {
+      const failure = new AgentProviderError("provider_error", "Codex runtime is closing");
+      this.#providerFailure ??= failure;
+      this.#terminal?.reject(failure);
+      this.#turnIdReady?.reject(failure);
+    }
+    this.#unsubscribeRequests();
+    this.#unsubscribeNotifications();
+    await this.#client.close();
+  }
+
+  #enqueue(envelope: CodexEnvelope): void {
+    const next = this.#eventTail.then(async () => {
+      if (!this.#context) return;
+      if (this.#buffering) {
+        this.#buffered.push(envelope);
+        return;
+      }
+      if (envelope.type === "notification") await this.#handleNotification(envelope.message);
+      else await this.#handleServerRequest(envelope.request);
+    });
+    this.#eventTail = next.catch((error: unknown) => {
+      this.#failProvider(error instanceof Error ? error : protocolError("Codex event processing failed"));
+    });
+  }
+
+  async #handleNotification(message: CodexAppServerMessage): Promise<void> {
+    const method = message.method;
+    if (method === "opentag/processError") {
+      const params = record(message.params);
+      throw params?.error instanceof Error
+        ? params.error
+        : new AgentProviderError("provider_error", "Codex process failed");
+    }
+    if (typeof method !== "string") throw protocolError("Codex emitted a notification without a method");
+    const context = this.#requireContext();
+    const params = record(message.params);
+
+    if (method === "warning" || method === "configWarning") {
+      const text = requireString(params?.message ?? params?.summary, `${method} has no message`);
+      await context.emit({ type: "provider_warning", code: method, message: text });
+      return;
+    }
+    if (method === "serverRequest/resolved") {
+      const wireId = params?.requestId;
+      const interactionId = this.#interactionIdForWireId(wireId);
+      if (!interactionId) return;
+      this.#wireInteractions.delete(interactionId);
+      await context.resolveInteraction(interactionId, "expired");
+      return;
+    }
+    if (method === "thread/closed") {
+      if (params?.threadId !== undefined && params.threadId !== this.#threadId) return;
+      throw new AgentProviderError("provider_error", "Codex thread closed during an active run");
+    }
+    if (method === "turn/started") {
+      const turn = parseTurn(params?.turn, "turn/started");
+      this.#assertTurn(turn.id);
+      return;
+    }
+    if (method === "turn/completed") {
+      const turn = parseTurn(params?.turn, "turn/completed");
+      this.#assertTurn(turn.id);
+      if (turn.status === "inProgress") throw protocolError("turn/completed carried an active turn");
+      this.#terminal?.resolve(turn);
+      return;
+    }
+    if (method === "thread/tokenUsage/updated") {
+      if (params?.turnId !== undefined && params.turnId !== this.#providerTurnId) return;
+      const usage = parseUsage(params?.tokenUsage);
+      this.#latestUsage = usage;
+      await context.emit({ type: "usage_updated", usage });
+      return;
+    }
+    if (method === "item/agentMessage/delta") {
+      this.#assertNotificationTurn(params);
+      await context.emit({
+        type: "message_delta",
+        messageId: requireString(params?.itemId, "agent message delta has no itemId"),
+        delta: requireString(params?.delta, "agent message delta has no text", true),
+      });
+      return;
+    }
+    if (method === "item/commandExecution/outputDelta") {
+      this.#assertNotificationTurn(params);
+      await context.emit({
+        type: "tool_updated",
+        toolCallId: requireString(params?.itemId, "command output delta has no itemId"),
+        update: { delta: requireString(params?.delta, "command output delta has no text", true) },
+      });
+      return;
+    }
+    if (method === "item/started" || method === "item/completed") {
+      this.#assertNotificationTurn(params);
+      const item = requireRecord(params?.item, `${method} has no item`);
+      await this.#handleItem(method, item);
+      return;
+    }
+    if (method === "error") {
+      const error = record(params?.error);
+      await context.emit({
+        type: "provider_warning",
+        code: "codex_turn_error",
+        message: typeof error?.message === "string" ? error.message : "Codex reported a turn error",
+      });
+      return;
+    }
+    if (method === "turn/plan/updated" || method === "turn/diff/updated" || method.startsWith("model/")) {
+      await context.emit({
+        type: "provider_event",
+        providerId: CODEX_PROVIDER_ID,
+        schemaVersion: 1,
+        payload: { method, params: toJsonValue(params ?? {}) },
+      });
+    }
+  }
+
+  async #handleItem(method: "item/completed" | "item/started", item: Record<string, unknown>): Promise<void> {
+    const context = this.#requireContext();
+    const id = requireString(item.id, `${method} item has no id`);
+    const type = requireString(item.type, `${method} item has no type`);
+    if (type === "agentMessage") {
+      if (method === "item/started") {
+        await context.emit({ type: "message_started", messageId: id });
+        return;
+      }
+      const text = requireString(item.text, "completed agent message has no text", true);
+      const phase = typeof item.phase === "string" ? item.phase : undefined;
+      this.#completedMessages.set(id, { text, ...(phase ? { phase } : {}) });
+      await context.emit({ type: "message_completed", messageId: id, text });
+      return;
+    }
+    if (!TOOL_ITEM_TYPES.has(type)) return;
+    const name = toolName(item, type);
+    if (method === "item/started") {
+      await context.emit({ type: "tool_started", toolCallId: id, name, input: toJsonValue(item) });
+      return;
+    }
+    const status = item.status === "declined" ? "declined" : item.status === "failed" ? "failed" : "completed";
+    await context.emit({
+      type: "tool_completed",
+      toolCallId: id,
+      name,
+      status,
+      output: toJsonValue(item),
+    });
+  }
+
+  async #handleServerRequest(request: CodexAppServerRequest): Promise<void> {
+    const context = this.#requireContext();
+    const params = requireRecord(request.params, `${request.method} has invalid params`);
+    if (params.threadId !== undefined && params.threadId !== this.#threadId) {
+      throw protocolError("Codex server request belongs to another thread");
+    }
+    if (params.turnId !== undefined && params.turnId !== this.#providerTurnId) {
+      throw protocolError("Codex server request belongs to another turn");
+    }
+    const interaction = codexInteractionRequest(request, params);
+    if (!interaction) {
+      await this.#client.rejectServerRequest(request.id, -32601, "Unsupported Codex server request");
+      throw protocolError(`Codex requested an unsupported method: ${request.method}`);
+    }
+    const requestId = interaction.requestId;
+    if (this.#wireInteractions.has(requestId)) throw protocolError("Codex reused a pending server request ID");
+    this.#wireInteractions.set(requestId, request);
+    try {
+      await context.requestInteraction(interaction);
+    } catch (error) {
+      this.#wireInteractions.delete(requestId);
+      await this.#client
+        .rejectServerRequest(request.id, -32000, "OpenTag could not deliver the interaction")
+        .catch(() => undefined);
+      throw error;
+    }
+  }
+
+  #turnStartParams(request: AgentPromptRequest): Record<string, unknown> {
+    const configuration = mergeConfiguration(this.#configuration, request.configuration);
+    const provider = parseProviderConfiguration(configuration?.provider);
+    return {
+      threadId: this.#threadId,
+      input: codexInput(request.input.items),
+      cwd: this.#workspace.cwd,
+      approvalPolicy: codexApprovalPolicy(this.#policy.approvals),
+      sandboxPolicy: codexSandboxPolicy(this.#workspace, this.#policy),
+      ...(configuration?.model ? { model: configuration.model } : {}),
+      ...(configuration?.reasoningEffort ? { effort: configuration.reasoningEffort } : {}),
+      ...(provider.personality ? { personality: provider.personality } : {}),
+      ...(provider.summary ? { summary: provider.summary } : {}),
+    };
+  }
+
+  #runResult(turn: ParsedTurn): AgentProviderRunResult {
+    const finalText = selectFinalText(turn.items, this.#completedMessages);
+    const output = finalText === undefined ? [] : [{ type: "text" as const, text: finalText }];
+    const diagnostics: JsonValue = { providerThreadId: this.#threadId, providerTurnId: turn.id };
+    if (turn.status === "completed") {
+      return {
+        status: "completed",
+        output,
+        ...(this.#latestUsage ? { usage: this.#latestUsage } : {}),
+        diagnostics,
+      };
+    }
+    if (turn.status === "interrupted") {
+      return {
+        status: "aborted",
+        output,
+        ...(this.#latestUsage ? { usage: this.#latestUsage } : {}),
+        error: { code: "run_aborted", message: "Codex turn was interrupted" },
+        diagnostics,
+      };
+    }
+    return {
+      status: "failed",
+      output,
+      ...(this.#latestUsage ? { usage: this.#latestUsage } : {}),
+      error: { code: "provider_error", message: turn.error ?? "Codex turn failed" },
+      diagnostics,
+    };
+  }
+
+  async #activeTurnId(): Promise<string> {
+    if (this.#providerTurnId) return this.#providerTurnId;
+    if (!this.#turnIdReady) throw new AgentRuntimeError("run_mismatch", "there is no active Codex turn");
+    return this.#turnIdReady.promise;
+  }
+
+  #assertNotificationTurn(params: Record<string, unknown> | undefined): void {
+    if (params?.threadId !== undefined && params.threadId !== this.#threadId) {
+      throw protocolError("Codex notification belongs to another thread");
+    }
+    if (params?.turnId !== this.#providerTurnId) throw protocolError("Codex notification belongs to another turn");
+  }
+
+  #assertTurn(turnId: string): void {
+    if (turnId !== this.#providerTurnId) throw protocolError("Codex turn identity changed during a run");
+  }
+
+  #requireContext(): AgentProviderRunContext {
+    /* v8 ignore next -- #enqueue drops envelopes before a Run context exists. */
+    if (!this.#context) throw protocolError("Codex event arrived without an active run");
+    return this.#context;
+  }
+
+  #failProvider(error: Error): void {
+    if (this.#providerFailure) return;
+    this.#providerFailure = error;
+    this.#terminal?.reject(error);
+    this.#turnIdReady?.reject(error);
+    this.closeForProviderFailure();
+  }
+
+  #interactionIdForWireId(wireId: unknown): string | undefined {
+    for (const [interactionId, request] of this.#wireInteractions) {
+      if (request.id === wireId) return interactionId;
+    }
+    return undefined;
+  }
+}
+
+export class CodexAgentRuntimeFactory implements AgentRuntimeFactory {
+  readonly manifest = CODEX_AGENT_RUNTIME_MANIFEST;
+  readonly #clientVersion: string;
+  readonly #createClient: (cwd: string) => InteractiveCodexAppServerClient;
+  readonly #probeRunner: () => Promise<{
+    readonly appServer: boolean;
+    readonly credential: boolean;
+    readonly version: string;
+  }>;
+
+  constructor(options: CodexAgentRuntimeFactoryOptions) {
+    this.#clientVersion = options.clientVersion;
+    const environment = options.process?.env ?? codexAgentRuntimeEnvironment();
+    const command = options.process?.command ?? "codex";
+    this.#createClient =
+      options.createClient ??
+      ((cwd) =>
+        new CodexAppServerProcess({
+          command,
+          args: options.process?.args ?? [...CODEX_APP_SERVER_ARGS],
+          cwd,
+          env: environment,
+          expectedCodexHome: options.process?.expectedCodexHome,
+          maxLineBytes: options.process?.maxLineBytes,
+          requestTimeoutMs: options.process?.requestTimeoutMs,
+          spawnProcess: options.process?.spawnProcess,
+        }));
+    this.#probeRunner =
+      options.probeRunner ?? (() => probeCodex(command, environment, options.process?.expectedCodexHome));
+  }
+
+  async probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult> {
+    const issues: AgentRuntimeProbeResult["issues"][number][] = [];
+    try {
+      validateConfiguration(request.configuration);
+    } catch (error) {
+      issues.push({
+        code: "configuration_invalid",
+        message: (error as Error).message,
+      });
+    }
+    let version: string | undefined;
+    try {
+      const result = await this.#probeRunner();
+      version = result.version;
+      if (!result.appServer) issues.push({ code: "version_incompatible", message: "Codex App Server is unavailable" });
+      if (!result.credential) issues.push({ code: "credential_missing", message: "Codex credentials were not found" });
+    } catch {
+      issues.push({ code: "artifact_missing", message: "Codex CLI could not be executed" });
+    }
+    return { ready: issues.length === 0, ...(version ? { version } : {}), issues };
+  }
+
+  create(request: CreateAgentRuntimeRequest): Promise<CodexAgentRuntime> {
+    return this.#open(request, "create");
+  }
+
+  resume(request: ResumeAgentRuntimeRequest): Promise<CodexAgentRuntime> {
+    return this.#open(request, "resume");
+  }
+
+  async #open(
+    request: CreateAgentRuntimeRequest | ResumeAgentRuntimeRequest,
+    mode: "create" | "resume",
+  ): Promise<CodexAgentRuntime> {
+    validateFactoryRequest(request);
+    validateConfiguration(request.configuration);
+    const providerConfiguration = parseProviderConfiguration(request.configuration?.provider);
+    const binding = mode === "resume" && "binding" in request ? request.binding : undefined;
+    if (binding) assertBinding(binding, this.manifest);
+    const expectedThreadId = binding ? parseCodexBinding(binding) : undefined;
+    const client = this.#createClient(request.workspace.cwd);
+    try {
+      await client.initialize(this.#clientVersion);
+      const method = mode === "create" ? "thread/start" : "thread/resume";
+      const response = requireRecord(
+        await client.request(method, {
+          ...(expectedThreadId ? { threadId: expectedThreadId } : {}),
+          cwd: request.workspace.cwd,
+          approvalPolicy: codexApprovalPolicy(request.policy.approvals),
+          sandbox: codexSandboxMode(request.policy.fileSystem),
+          ...(request.configuration?.model ? { model: request.configuration.model } : {}),
+          ...(providerConfiguration.personality ? { personality: providerConfiguration.personality } : {}),
+          ...(providerConfiguration.serviceName ? { serviceName: providerConfiguration.serviceName } : {}),
+        }),
+        `${method} returned an invalid response`,
+      );
+      const thread = requireRecord(response.thread, `${method} returned no thread`);
+      const threadId = requireString(thread.id, `${method} returned no thread id`);
+      if (expectedThreadId && threadId !== expectedThreadId)
+        throw protocolError("thread/resume restored another thread");
+      const runtimeBinding: AgentRuntimeBinding = {
+        providerId: CODEX_PROVIDER_ID,
+        schemaVersion: CODEX_BINDING_SCHEMA_VERSION,
+        payload: { threadId },
+      };
+      assertBinding(runtimeBinding, this.manifest);
+      await request.eventSink({ type: "binding_changed", binding: runtimeBinding });
+      return new CodexAgentRuntime({
+        client,
+        threadId,
+        eventSink: request.eventSink,
+        binding: runtimeBinding,
+        workspace: request.workspace,
+        policy: request.policy,
+        configuration: request.configuration,
+      });
+    } catch (error) {
+      await client.close().catch(() => undefined);
+      if (error instanceof AgentRuntimeError) throw error;
+      throw new AgentRuntimeError(mode === "create" ? "create_failed" : "resume_failed", `Codex ${mode} failed`, {
+        cause: error,
+      });
+    }
+  }
+}
+
+export function codexAgentRuntimeEnvironment(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const keys = [
+    "CODEX_HOME",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LOGNAME",
+    "OPENAI_API_KEY",
+    "PATH",
+    "PATHEXT",
+    "SHELL",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+    "SystemRoot",
+    "TMPDIR",
+    "USER",
+    "WINDIR",
+  ] as const;
+  const environment: NodeJS.ProcessEnv = {};
+  for (const key of keys) {
+    if (source[key] !== undefined) environment[key] = source[key];
+  }
+  return environment;
+}
+
+async function probeCodex(
+  command: string,
+  environment: NodeJS.ProcessEnv,
+  expectedCodexHome?: string,
+): Promise<{ readonly appServer: boolean; readonly credential: boolean; readonly version: string }> {
+  const execution = { encoding: "utf8" as const, env: environment, timeout: 5_000, windowsHide: true };
+  const versionResult = await execFileAsync(command, ["--version"], execution);
+  const version = versionResult.stdout.trim();
+  if (!version) throw new Error("Codex CLI returned no version");
+  await execFileAsync(command, ["app-server", "--help"], execution);
+  const codexHome =
+    expectedCodexHome ?? environment.CODEX_HOME ?? (environment.HOME ? join(environment.HOME, ".codex") : undefined);
+  const credential =
+    Boolean(environment.OPENAI_API_KEY) || (codexHome ? await fileExists(join(codexHome, "auth.json")) : false);
+  return { appServer: true, credential, version };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validateFactoryRequest(request: CreateAgentRuntimeRequest): void {
+  if (!request || typeof request !== "object" || typeof request.eventSink !== "function") {
+    throw new AgentRuntimeError("configuration_invalid", "eventSink is required");
+  }
+  if (!request.workspace || !isAbsolute(request.workspace.cwd)) {
+    throw new AgentRuntimeError("configuration_invalid", "workspace.cwd must be absolute");
+  }
+  for (const root of request.workspace.writableRoots ?? []) {
+    if (!isAbsolute(root)) throw new AgentRuntimeError("configuration_invalid", "writable roots must be absolute");
+  }
+  if (request.policy.tools.mode !== "provider-default") {
+    throw new AgentRuntimeError(
+      "configuration_invalid",
+      "Codex does not implement the common tool allow-list contract",
+    );
+  }
+  if (request.policy.fileSystem === "read-only" && (request.workspace.writableRoots?.length ?? 0) > 0) {
+    throw new AgentRuntimeError("configuration_invalid", "read-only policy cannot have writable roots");
+  }
+  if (request.policy.fileSystem === "read-only" && request.policy.network === "enabled") {
+    throw new AgentRuntimeError(
+      "configuration_invalid",
+      "Codex cannot guarantee read-only filesystem with enabled network",
+    );
+  }
+  if (request.policy.fileSystem === "unrestricted" && request.policy.network === "disabled") {
+    throw new AgentRuntimeError(
+      "configuration_invalid",
+      "Codex cannot restrict network in unrestricted filesystem mode",
+    );
+  }
+}
+
+function validateConfiguration(configuration: AgentRunConfiguration | undefined): void {
+  if (!configuration) return;
+  if (configuration.model !== undefined && configuration.model.trim().length === 0) {
+    throw new AgentRuntimeError("configuration_invalid", "model must be non-empty");
+  }
+  if (configuration.reasoningEffort && !CODEX_REASONING_EFFORTS.has(configuration.reasoningEffort)) {
+    throw new AgentRuntimeError("configuration_invalid", "Codex reasoning effort is unsupported");
+  }
+  parseProviderConfiguration(configuration.provider);
+}
+
+function parseProviderConfiguration(value: JsonValue | undefined): CodexProviderConfiguration {
+  if (value === undefined) return {};
+  assertJsonValue(value, "configuration.provider");
+  const object = record(value);
+  if (!object) throw new AgentRuntimeError("configuration_invalid", "Codex provider configuration must be an object");
+  const allowed = new Set(["personality", "serviceName", "summary"]);
+  for (const key of Object.keys(object)) {
+    if (!allowed.has(key))
+      throw new AgentRuntimeError("configuration_invalid", `unknown Codex configuration field: ${key}`);
+  }
+  const result: { personality?: string; serviceName?: string; summary?: string } = {};
+  for (const key of allowed) {
+    const item = object[key];
+    if (item === undefined) continue;
+    if (typeof item !== "string" || item.trim().length === 0) {
+      throw new AgentRuntimeError("configuration_invalid", `Codex configuration ${key} must be non-empty`);
+    }
+    result[key as keyof CodexProviderConfiguration] = item;
+  }
+  return result;
+}
+
+function parseCodexBinding(binding: AgentRuntimeBinding): string {
+  const payload = record(binding.payload);
+  if (!payload) throw new AgentRuntimeError("binding_incompatible", "Codex binding payload is invalid");
+  const threadId = payload.threadId;
+  if (typeof threadId !== "string" || threadId.length === 0 || Buffer.byteLength(threadId, "utf8") > 1024 * 1024) {
+    throw new AgentRuntimeError("binding_incompatible", "Codex binding has no valid threadId");
+  }
+  return threadId;
+}
+
+function mergeConfiguration(
+  base: AgentRunConfiguration | undefined,
+  override: AgentRunConfiguration | undefined,
+): AgentRunConfiguration | undefined {
+  if (!base) {
+    validateConfiguration(override);
+    return override;
+  }
+  if (!override) return base;
+  const provider = {
+    ...parseProviderConfiguration(base.provider),
+    ...parseProviderConfiguration(override.provider),
+  };
+  const merged: AgentRunConfiguration = {
+    ...base,
+    ...override,
+    provider,
+  };
+  validateConfiguration(merged);
+  return merged;
+}
+
+function codexInput(items: readonly { readonly type: "text"; readonly text: string }[]): Array<Record<string, string>> {
+  return items.map((item) => ({ type: "text", text: item.text }));
+}
+
+function codexApprovalPolicy(policy: AgentRuntimePolicy["approvals"]): string {
+  if (policy === "on-request") return "onRequest";
+  if (policy === "unless-trusted") return "unlessTrusted";
+  return "never";
+}
+
+function codexSandboxMode(mode: AgentRuntimePolicy["fileSystem"]): string {
+  if (mode === "read-only") return "read-only";
+  if (mode === "workspace-write") return "workspace-write";
+  return "danger-full-access";
+}
+
+function codexSandboxPolicy(workspace: AgentRuntimeWorkspace, policy: AgentRuntimePolicy): Record<string, unknown> {
+  if (policy.fileSystem === "read-only") return { type: "readOnly" };
+  if (policy.fileSystem === "unrestricted") return { type: "dangerFullAccess" };
+  return {
+    type: "workspaceWrite",
+    writableRoots: [...(workspace.writableRoots ?? [workspace.cwd])],
+    networkAccess: policy.network === "enabled",
+  };
+}
+
+function codexInteractionRequest(
+  request: CodexAppServerRequest,
+  params: Record<string, unknown>,
+): AgentInteractionRequest | undefined {
+  const requestId = wireInteractionId(request.id);
+  const details = toJsonValue(params);
+  if (
+    request.method === "item/commandExecution/requestApproval" ||
+    request.method === "item/fileChange/requestApproval" ||
+    request.method === "item/permissions/requestApproval"
+  ) {
+    return {
+      requestId,
+      kind: "approval",
+      title: request.method === "item/fileChange/requestApproval" ? "Approve file changes" : "Approve tool action",
+      ...(typeof params.reason === "string" ? { message: params.reason } : {}),
+      details,
+    };
+  }
+  if (request.method === "item/tool/requestUserInput" || request.method === "mcpServer/elicitation/request") {
+    const message = typeof params.message === "string" ? params.message : undefined;
+    return {
+      requestId,
+      kind: "question",
+      title: "Codex needs input",
+      ...(message ? { message } : {}),
+      details,
+    };
+  }
+  return undefined;
+}
+
+function codexInteractionResult(method: string, response: AgentInteractionResponse): unknown {
+  if (response.kind === "approval") return codexApprovalResult(method, response);
+  return codexQuestionResult(method, response);
+}
+
+function codexApprovalResult(method: string, response: AgentApprovalResponse): unknown {
+  if (method === "item/permissions/requestApproval") {
+    if (response.decision !== "accept") return { permissions: [], scope: "turn" };
+    const value = record(response.value);
+    const permissions = Array.isArray(value?.permissions) ? value.permissions : [];
+    return { permissions, scope: response.scope === "runtime" ? "session" : "turn" };
+  }
+  const decision =
+    response.decision === "accept" ? (response.scope === "runtime" ? "acceptForSession" : "accept") : response.decision;
+  return { decision };
+}
+
+function codexQuestionResult(method: string, response: AgentQuestionResponse): unknown {
+  if (method === "mcpServer/elicitation/request") {
+    return response.decision === "answer"
+      ? { action: "accept", content: response.value ?? null }
+      : { action: "cancel", content: null };
+  }
+  return { answers: response.decision === "answer" ? (response.value ?? {}) : {} };
+}
+
+function parseTurnResponse(value: unknown, source: string): ParsedTurn {
+  const response = requireRecord(value, `${source} returned an invalid response`);
+  return parseTurn(response.turn, source);
+}
+
+function parseTurn(value: unknown, source: string): ParsedTurn {
+  const turn = requireRecord(value, `${source} has no turn`);
+  const id = requireString(turn.id, `${source} turn has no id`);
+  const status = turn.status;
+  if (status !== "completed" && status !== "failed" && status !== "inProgress" && status !== "interrupted") {
+    throw protocolError(`${source} turn has an invalid status`);
+  }
+  const items = Array.isArray(turn.items)
+    ? turn.items.map((item) => requireRecord(item, `${source} has an invalid item`))
+    : [];
+  const error = record(turn.error);
+  return {
+    id,
+    status,
+    items,
+    ...(typeof error?.message === "string" ? { error: error.message } : {}),
+  };
+}
+
+function parseUsage(value: unknown): {
+  readonly inputTokens?: number;
+  readonly cachedInputTokens?: number;
+  readonly outputTokens?: number;
+} {
+  const tokenUsage = requireRecord(value, "token usage is invalid");
+  const source = record(tokenUsage.last) ?? record(tokenUsage.total) ?? tokenUsage;
+  const usage: { inputTokens?: number; cachedInputTokens?: number; outputTokens?: number } = {};
+  if (isNonNegativeNumber(source.inputTokens)) usage.inputTokens = source.inputTokens;
+  if (isNonNegativeNumber(source.cachedInputTokens)) usage.cachedInputTokens = source.cachedInputTokens;
+  if (isNonNegativeNumber(source.outputTokens)) usage.outputTokens = source.outputTokens;
+  return usage;
+}
+
+function selectFinalText(
+  terminalItems: readonly Record<string, unknown>[],
+  completed: ReadonlyMap<string, { readonly phase?: string; readonly text: string }>,
+): string | undefined {
+  const messages = new Map(completed);
+  for (const item of terminalItems) {
+    if (item.type !== "agentMessage" || typeof item.id !== "string" || typeof item.text !== "string") continue;
+    messages.set(item.id, {
+      text: item.text,
+      ...(typeof item.phase === "string" ? { phase: item.phase } : {}),
+    });
+  }
+  let fallback: string | undefined;
+  for (const message of messages.values()) {
+    if (message.phase === "final_answer") return message.text;
+    if (message.phase !== "commentary") fallback = message.text;
+  }
+  return fallback;
+}
+
+function toolName(item: Record<string, unknown>, type: string): string {
+  if (type === "mcpToolCall") {
+    const server = typeof item.server === "string" ? item.server : "mcp";
+    const tool = typeof item.tool === "string" ? item.tool : "tool";
+    return `${server}/${tool}`;
+  }
+  if (type === "dynamicToolCall" && typeof item.tool === "string") return item.tool;
+  return type;
+}
+
+function wireInteractionId(id: number | string): string {
+  return `${typeof id}:${String(id)}`;
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  assertJsonValue(value, "Codex event payload");
+  return value as JsonValue;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolveValue!: (value: T) => void;
+  let rejectValue!: (error: Error) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveValue = resolve;
+    rejectValue = reject;
+  });
+  return { promise, resolve: resolveValue, reject: rejectValue };
+}
+
+function protocolError(message: string): AgentProviderError {
+  return new AgentProviderError("provider_protocol_error", message);
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function requireRecord(value: unknown, message: string): Record<string, unknown> {
+  const result = record(value);
+  if (!result) throw protocolError(message);
+  return result;
+}
+
+function requireString(value: unknown, message: string, allowEmpty = false): string {
+  if (
+    typeof value !== "string" ||
+    (!allowEmpty && value.length === 0) ||
+    Buffer.byteLength(value, "utf8") > 1024 * 1024
+  ) {
+    throw protocolError(message);
+  }
+  return value;
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -237,6 +237,7 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
   }
 
   #enqueue(envelope: CodexEnvelope): void {
+    this.#claimTerminalAtIngress(envelope);
     const next = this.#eventTail.then(async () => {
       if (!this.#context) return;
       if (this.#buffering) {
@@ -286,9 +287,7 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
       return;
     }
     if (method === "turn/completed") {
-      const turn = parseTurn(params?.turn, "turn/completed");
-      this.#assertTurn(turn.id);
-      if (turn.status === "inProgress") throw protocolError("turn/completed carried an active turn");
+      const turn = this.#parseCompletedTurn(params);
       context.claimTerminal();
       this.#terminal?.resolve(turn);
       return;
@@ -469,6 +468,30 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
     /* v8 ignore next -- #enqueue drops envelopes before a Run context exists. */
     if (!this.#context) throw protocolError("Codex event arrived without an active run");
     return this.#context;
+  }
+
+  #claimTerminalAtIngress(envelope: CodexEnvelope): void {
+    if (
+      envelope.type !== "notification" ||
+      envelope.message.method !== "turn/completed" ||
+      this.#buffering ||
+      !this.#context
+    ) {
+      return;
+    }
+    try {
+      this.#parseCompletedTurn(record(envelope.message.params));
+      this.#context.claimTerminal();
+    } catch {
+      // The serial event queue preserves the authoritative fail-closed error path.
+    }
+  }
+
+  #parseCompletedTurn(params: Record<string, unknown> | undefined): ParsedTurn {
+    const turn = parseTurn(params?.turn, "turn/completed");
+    this.#assertTurn(turn.id);
+    if (turn.status === "inProgress") throw protocolError("turn/completed carried an active turn");
+    return turn;
   }
 
   #failProvider(error: Error): void {

--- a/packages/client/src/providers/codex/app-server-wire.ts
+++ b/packages/client/src/providers/codex/app-server-wire.ts
@@ -78,6 +78,7 @@ export class CodexAppServerProcess implements InteractiveCodexAppServerClient {
   readonly #listeners = new Set<(message: CodexAppServerMessage) => void>();
   readonly #serverRequestListeners = new Set<(request: CodexAppServerRequest) => void>();
   readonly #pendingServerRequests = new Set<number | string>();
+  readonly #respondingServerRequests = new Set<number | string>();
   readonly #exit: Promise<void>;
   #resolveExit: (() => void) | undefined;
   #buffer = Buffer.alloc(0);
@@ -140,17 +141,11 @@ export class CodexAppServerProcess implements InteractiveCodexAppServerClient {
   }
 
   async respondServerRequest(id: number | string, result: unknown): Promise<void> {
-    if (!this.#pendingServerRequests.delete(id)) {
-      throw new CodexAppServerError("protocol", "Codex server request is unknown or already resolved");
-    }
-    await this.#write({ id, result });
+    await this.#writeServerResponse(id, { id, result });
   }
 
   async rejectServerRequest(id: number | string, code: number, message: string): Promise<void> {
-    if (!this.#pendingServerRequests.delete(id)) {
-      throw new CodexAppServerError("protocol", "Codex server request is unknown or already resolved");
-    }
-    await this.#write({ id, error: { code, message } });
+    await this.#writeServerResponse(id, { id, error: { code, message } });
   }
 
   async initialize(clientVersion: string, signal?: AbortSignal): Promise<void> {
@@ -230,6 +225,7 @@ export class CodexAppServerProcess implements InteractiveCodexAppServerClient {
     const closingError = new CodexAppServerError("aborted", "Codex App Server is closing");
     for (const pending of [...this.#pending.values()]) pending.reject(closingError);
     this.#pendingServerRequests.clear();
+    this.#respondingServerRequests.clear();
     this.#child.stdin.end();
     signalWatchedProcess(this.#child, "SIGTERM");
     if (await settlesWithin(this.#exit, graceMs)) return;
@@ -252,6 +248,19 @@ export class CodexAppServerProcess implements InteractiveCodexAppServerClient {
         error ? reject(new CodexAppServerError("write", "Codex request could not be written")) : resolve();
       });
     });
+  }
+
+  async #writeServerResponse(id: number | string, message: unknown): Promise<void> {
+    if (!this.#pendingServerRequests.has(id) || this.#respondingServerRequests.has(id)) {
+      throw new CodexAppServerError("protocol", "Codex server request is unknown or already resolved");
+    }
+    this.#respondingServerRequests.add(id);
+    try {
+      await this.#write(message);
+      this.#pendingServerRequests.delete(id);
+    } finally {
+      this.#respondingServerRequests.delete(id);
+    }
   }
 
   #onStdout(chunk: Buffer): void {
@@ -361,6 +370,7 @@ export class CodexAppServerProcess implements InteractiveCodexAppServerClient {
     this.#failure = error;
     for (const pending of [...this.#pending.values()]) pending.reject(error);
     this.#pendingServerRequests.clear();
+    this.#respondingServerRequests.clear();
     for (const listener of this.#listeners) {
       try {
         listener({ method: "opentag/processError", params: { error } });

--- a/packages/client/src/providers/codex/app-server-wire.ts
+++ b/packages/client/src/providers/codex/app-server-wire.ts
@@ -18,6 +18,12 @@ export interface CodexAppServerMessage {
   [key: string]: unknown;
 }
 
+export interface CodexAppServerRequest {
+  readonly id: number | string;
+  readonly method: string;
+  readonly params: unknown;
+}
+
 export interface CodexSpawnOptions {
   args?: string[];
   command?: string;
@@ -48,6 +54,12 @@ export interface CodexAppServerClient {
   subscribe(listener: (message: CodexAppServerMessage) => void): () => void;
 }
 
+export interface InteractiveCodexAppServerClient extends CodexAppServerClient {
+  rejectServerRequest(id: number | string, code: number, message: string): Promise<void>;
+  respondServerRequest(id: number | string, result: unknown): Promise<void>;
+  subscribeServerRequests(listener: (request: CodexAppServerRequest) => void): () => void;
+}
+
 interface PendingRequest {
   reject(error: Error): void;
   resolve(value: unknown): void;
@@ -57,13 +69,15 @@ interface PendingRequest {
 const defaultSpawn = (command: string, args: readonly string[], options: CodexProcessSpawnOptions) =>
   spawnWatchedProcess(command, args, options);
 
-export class CodexAppServerProcess implements CodexAppServerClient {
+export class CodexAppServerProcess implements InteractiveCodexAppServerClient {
   readonly #child: ChildProcessWithoutNullStreams;
   readonly #expectedCodexHome?: string;
   readonly #maxLineBytes: number;
   readonly #requestTimeoutMs: number;
   readonly #pending = new Map<number, PendingRequest>();
   readonly #listeners = new Set<(message: CodexAppServerMessage) => void>();
+  readonly #serverRequestListeners = new Set<(request: CodexAppServerRequest) => void>();
+  readonly #pendingServerRequests = new Set<number | string>();
   readonly #exit: Promise<void>;
   #resolveExit: (() => void) | undefined;
   #buffer = Buffer.alloc(0);
@@ -118,6 +132,25 @@ export class CodexAppServerProcess implements CodexAppServerClient {
   subscribe(listener: (message: CodexAppServerMessage) => void): () => void {
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);
+  }
+
+  subscribeServerRequests(listener: (request: CodexAppServerRequest) => void): () => void {
+    this.#serverRequestListeners.add(listener);
+    return () => this.#serverRequestListeners.delete(listener);
+  }
+
+  async respondServerRequest(id: number | string, result: unknown): Promise<void> {
+    if (!this.#pendingServerRequests.delete(id)) {
+      throw new CodexAppServerError("protocol", "Codex server request is unknown or already resolved");
+    }
+    await this.#write({ id, result });
+  }
+
+  async rejectServerRequest(id: number | string, code: number, message: string): Promise<void> {
+    if (!this.#pendingServerRequests.delete(id)) {
+      throw new CodexAppServerError("protocol", "Codex server request is unknown or already resolved");
+    }
+    await this.#write({ id, error: { code, message } });
   }
 
   async initialize(clientVersion: string, signal?: AbortSignal): Promise<void> {
@@ -177,9 +210,7 @@ export class CodexAppServerProcess implements CodexAppServerClient {
       signal?.addEventListener("abort", onAbort, { once: true });
       void this.#write({ id, method, params }).catch((error: unknown) => {
         const pending = this.#pending.get(id);
-        pending?.reject(
-          error instanceof Error ? error : new CodexAppServerError("write", "Codex request write failed"),
-        );
+        pending?.reject(error as Error);
       });
     });
   }
@@ -189,7 +220,7 @@ export class CodexAppServerProcess implements CodexAppServerClient {
   }
 
   async interrupt(threadId: string, turnId: string): Promise<void> {
-    await this.request("turn/interrupt", { threadId, turnId }, AbortSignal.timeout(500)).catch(() => undefined);
+    await this.request("turn/interrupt", { threadId, turnId }, AbortSignal.timeout(2_000));
   }
 
   async close(graceMs = 1_000): Promise<void> {
@@ -198,6 +229,7 @@ export class CodexAppServerProcess implements CodexAppServerClient {
     this.#closed = true;
     const closingError = new CodexAppServerError("aborted", "Codex App Server is closing");
     for (const pending of [...this.#pending.values()]) pending.reject(closingError);
+    this.#pendingServerRequests.clear();
     this.#child.stdin.end();
     signalWatchedProcess(this.#child, "SIGTERM");
     if (await settlesWithin(this.#exit, graceMs)) return;
@@ -265,13 +297,33 @@ export class CodexAppServerProcess implements CodexAppServerClient {
         return;
       }
       if (message.error !== undefined) {
-        pending.reject(new CodexAppServerError("protocol", "Codex returned a request error"));
+        const error = isRecord(message.error) ? message.error : undefined;
+        const detail = typeof error?.message === "string" ? `: ${error.message}` : "";
+        pending.reject(new CodexAppServerError("protocol", `Codex returned a request error${detail}`));
       } else {
         pending.resolve(message.result);
       }
       return;
     }
     if ((typeof message.id === "number" || typeof message.id === "string") && typeof message.method === "string") {
+      if (this.#serverRequestListeners.size > 0) {
+        if (this.#pendingServerRequests.has(message.id)) {
+          this.#fail(new CodexAppServerError("protocol", "Codex emitted a duplicate server request ID"));
+          return;
+        }
+        this.#pendingServerRequests.add(message.id);
+        const request = { id: message.id, method: message.method, params: message.params };
+        for (const listener of this.#serverRequestListeners) {
+          try {
+            listener(request);
+          } catch {
+            this.#pendingServerRequests.delete(message.id);
+            this.#fail(new CodexAppServerError("protocol", "A Codex server request listener failed"));
+            return;
+          }
+        }
+        return;
+      }
       void this.#handleServerRequest(message.id, message.method);
       return;
     }
@@ -308,6 +360,7 @@ export class CodexAppServerProcess implements CodexAppServerClient {
     if (this.#failure) return;
     this.#failure = error;
     for (const pending of [...this.#pending.values()]) pending.reject(error);
+    this.#pendingServerRequests.clear();
     for (const listener of this.#listeners) {
       try {
         listener({ method: "opentag/processError", params: { error } });

--- a/packages/client/src/smoke/codex-agent-runtime-e2e.ts
+++ b/packages/client/src/smoke/codex-agent-runtime-e2e.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRunResult, AgentRuntime, AgentRuntimeEvent } from "../agent-runtime/types.js";
+import { CodexAgentRuntimeFactory } from "../providers/codex/agent-runtime.js";
+
+const FIRST_TOKEN = "OPENTAG_AGENT_RUNTIME_E2E_ONE";
+const SECOND_TOKEN = "OPENTAG_AGENT_RUNTIME_E2E_TWO";
+const RUN_TIMEOUT_MS = 180_000;
+
+const workspace = await mkdtemp(join(tmpdir(), "opentag-agent-runtime-e2e-"));
+const events: AgentRuntimeEvent[] = [];
+const factory = new CodexAgentRuntimeFactory({ clientVersion: "0.0.1-e2e" });
+let runtime: AgentRuntime | undefined;
+
+try {
+  const probe = await factory.probe({});
+  if (!probe.ready) {
+    throw new Error(`Codex Agent Runtime probe failed: ${JSON.stringify(probe.issues)}`);
+  }
+
+  const request = {
+    eventSink: (event: AgentRuntimeEvent) => {
+      events.push(event);
+    },
+    workspace: { cwd: workspace },
+    policy: {
+      fileSystem: "read-only" as const,
+      network: "disabled" as const,
+      approvals: "never" as const,
+      tools: { mode: "provider-default" as const },
+    },
+  };
+
+  runtime = await factory.create(request);
+  const binding = runtime.binding;
+  if (!binding) throw new Error("Codex create did not produce a binding");
+
+  const first = await runtime.prompt({
+    runId: "e2e-create-run",
+    input: {
+      items: [
+        {
+          type: "text",
+          text: `Reply with exactly ${FIRST_TOKEN}. Do not use tools and do not add punctuation.`,
+        },
+      ],
+    },
+    signal: AbortSignal.timeout(RUN_TIMEOUT_MS),
+  });
+  assertCompletedWithToken(first, FIRST_TOKEN);
+  assertTerminalOrdering(events, first.runId);
+  await runtime.close();
+  runtime = undefined;
+
+  const resumedEvents: AgentRuntimeEvent[] = [];
+  runtime = await factory.resume({
+    ...request,
+    binding,
+    eventSink: (event) => {
+      resumedEvents.push(event);
+    },
+  });
+  if (JSON.stringify(runtime.binding) !== JSON.stringify(binding)) {
+    throw new Error("Codex exact resume changed the binding");
+  }
+
+  const second = await runtime.prompt({
+    runId: "e2e-resume-run",
+    input: {
+      items: [
+        {
+          type: "text",
+          text: `You previously returned ${FIRST_TOKEN}. Reply with exactly ${SECOND_TOKEN}. Do not use tools and do not add punctuation.`,
+        },
+      ],
+    },
+    signal: AbortSignal.timeout(RUN_TIMEOUT_MS),
+  });
+  assertCompletedWithToken(second, SECOND_TOKEN);
+  assertTerminalOrdering(resumedEvents, second.runId);
+  await runtime.close();
+  runtime = undefined;
+
+  process.stdout.write(
+    `${JSON.stringify({
+      ready: probe.ready,
+      version: probe.version,
+      providerId: binding.providerId,
+      bindingPreserved: true,
+      createRun: first.status,
+      resumeRun: second.status,
+      createEvents: events.length,
+      resumeEvents: resumedEvents.length,
+    })}\n`,
+  );
+} finally {
+  await runtime?.close().catch(() => undefined);
+  await rm(workspace, { recursive: true, force: true });
+}
+
+function assertCompletedWithToken(result: AgentRunResult, token: string): void {
+  if (result.status !== "completed") {
+    throw new Error(`Agent Run ${result.runId} did not complete: ${JSON.stringify(result.error)}`);
+  }
+  const text = result.output
+    .filter((item) => item.type === "text")
+    .map((item) => item.text.trim())
+    .join("\n");
+  if (text !== token) {
+    throw new Error(`Agent Run ${result.runId} returned unexpected text: ${JSON.stringify(text)}`);
+  }
+}
+
+function assertTerminalOrdering(eventsToCheck: readonly AgentRuntimeEvent[], runId: string): void {
+  const runEvents = eventsToCheck.filter((event) => "runId" in event && event.runId === runId);
+  if (runEvents[0]?.type !== "run_started" || runEvents.at(-1)?.type !== "run_completed") {
+    throw new Error(`Agent Run ${runId} event ordering is invalid`);
+  }
+  if (runEvents.filter((event) => event.type.startsWith("run_") && event.type !== "run_started").length !== 1) {
+    throw new Error(`Agent Run ${runId} did not emit exactly one terminal event`);
+  }
+}

--- a/packages/client/vitest.agent-runtime.config.ts
+++ b/packages/client/vitest.agent-runtime.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [
+      "src/__tests__/agent-runtime-contract.test.ts",
+      "src/__tests__/agent-runtime-exhaustive.test.ts",
+      "src/__tests__/agent-runtime-validation.test.ts",
+      "src/__tests__/codex-agent-runtime.test.ts",
+      "src/__tests__/codex-agent-runtime-exhaustive.test.ts",
+      "src/__tests__/codex-app-server.test.ts",
+      "src/__tests__/codex-app-server-exhaustive.test.ts",
+    ],
+    maxWorkers: 1,
+    coverage: {
+      enabled: true,
+      provider: "v8",
+      include: [
+        "src/agent-runtime/**/*.ts",
+        "src/providers/codex/agent-runtime.ts",
+        "src/providers/codex/app-server-wire.ts",
+      ],
+      reporter: ["text", "json", "json-summary", "html"],
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@types/node':
         specifier: ^22.15.0
         version: 22.20.1
+      '@vitest/coverage-v8':
+        specifier: 3.2.7
+        version: 3.2.7(vitest@3.2.7(@types/node@22.20.1)(jsdom@26.1.0)(tsx@4.23.12)(yaml@2.9.0))
       tsdown:
         specifier: 0.21.4
         version: 0.21.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)
@@ -146,6 +149,10 @@ importers:
 
 packages:
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -242,6 +249,10 @@ packages:
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.5.8':
     resolution: {integrity: sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==}
@@ -840,6 +851,10 @@ packages:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
 
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1351,6 +1366,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+    peerDependencies:
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
@@ -1447,6 +1471,9 @@ packages:
   ast-kit@3.0.0-beta.1:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
@@ -1949,12 +1976,19 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2003,6 +2037,22 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -2012,6 +2062,9 @@ packages:
 
   jose@6.2.9:
     resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2079,6 +2132,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -2462,6 +2522,10 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -2480,6 +2544,10 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   testcontainers@11.14.0:
     resolution: {integrity: sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg==}
@@ -2796,6 +2864,11 @@ packages:
 
 snapshots:
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -2928,6 +3001,8 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.0-rc.2
 
   '@balena/dockerignore@1.0.2': {}
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.5.8':
     optionalDependencies:
@@ -3314,6 +3389,8 @@ snapshots:
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/cliui@9.0.0': {}
+
+  '@istanbuljs/schema@0.1.6': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3709,6 +3786,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@22.20.1)(jsdom@26.1.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(@types/node@22.20.1)(jsdom@26.1.0)(tsx@4.23.12)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -3823,6 +3919,12 @@ snapshots:
       '@babel/parser': 8.0.0-rc.2
       estree-walker: 3.0.3
       pathe: 2.0.3
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-lock@1.4.1: {}
 
@@ -4283,11 +4385,15 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  has-flag@4.0.0: {}
+
   hookable@6.1.1: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4333,6 +4439,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -4344,6 +4471,8 @@ snapshots:
       '@isaacs/cliui': 9.0.0
 
   jose@6.2.9: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -4417,6 +4546,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.2
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   mime@3.0.0: {}
 
@@ -4836,6 +4975,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   symbol-tree@3.2.4: {}
 
   tar-fs@2.1.5:
@@ -4882,6 +5025,12 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.6
 
   testcontainers@11.14.0:
     dependencies:


### PR DESCRIPTION
## Summary

- add a provider-neutral Agent Runtime contract and Base implementation with strict Run admission, FIFO follow-ups, ordered event settlement, interaction fences, typed terminal outcomes, and exact opaque bindings
- add the first Codex Provider over App Server with create/resume, prompt/steer/abort, approvals and questions, policy translation, fail-closed validation, and process cleanup
- use only the locally installed `codex` executable resolved from the user PATH; no Codex package, SDK, bundled binary, installer, or download fallback is introduced
- add a dedicated 100 percent coverage gate, exhaustive protocol and process tests, a live local create/resume E2E command, and the test plan
- canonical contract context: https://github.com/first-tree-ai/first-tree-context/pull/961 (merged)

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/client test`: 22 files, 165 tests passed
- `pnpm --filter @opentag/client test:agent-runtime:coverage`: 7 files, 80 tests passed; statements, branches, functions, and lines all 100 percent
- `pnpm --filter @opentag/client test:e2e:codex-agent-runtime`: passed with local `codex-cli 0.144.1`; create and exact resume both completed with 16 ordered events each
- GitHub CI on ingress-fix head `0140c38` passed Checks, Node 22.13.0 Compatibility, Node 26 Compatibility, CLI Pack Smoke, Container Smoke, and aggregate CI

The default local macOS `pnpm test` run also exposes two latest-main `/tmp` versus `/private/tmp` assertions in unrelated CLI service tests. Linux CI passes those tests. The first Node 26 run had an unrelated SessionBindingStore timeout; its rerun passed without code changes.

## Breaking changes

None. This adds a new public runtime surface and preserves the existing public `AgentRuntimeState` session-reconciler type. The new lifecycle state is named `AgentRuntimeLifecycleState`.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass in required CI.
- [x] No credentials, private data, generated build output, or Codex dependency is included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
