### PR TITLE
fix: align Computer listing with ownership scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ pnpm --filter open-tag start agent list
 This records the Agent identity and Computer binding only; it does not start a Codex or Claude Code turn.
 
 Configure `OPENTAG_GOOGLE_CLIENT_ID` and `OPENTAG_GOOGLE_CLIENT_SECRET` to enable Google sign-in, then open
-`http://127.0.0.1:8000/admin/`. Team admins can inspect current members, Agents, referenced Computers, the current
-invitation, and timestamped diagnostics. Every active member can generate a short-lived Computer install/login command
-from the user-scoped admin landing page; admins also have the same action on the Computers page. Membership and
-invitation changes remain explicit CLI operations:
+`http://127.0.0.1:8000/admin/`. Team admins can inspect current members, Agents, the current invitation, and timestamped
+diagnostics. On the Computers page, **Your computers** lists every Computer owned by the current user, while **Team
+computers** lists every Computer owned by other active, non-suspended Team members. Agent bindings are supplementary
+information, not a condition for listing a Computer. Every active member can generate a short-lived Computer
+install/login command from the user-scoped admin landing page; admins also have the same action on the Computers page.
+Membership and invitation changes remain explicit CLI operations:
 
 For loopback development without Google credentials, set `OPENTAG_DEV_AUTH_BYPASS_ENABLED=true` and
 `OPENTAG_DEV_AUTH_EMAIL` to the unique email of an existing bootstrap user. This bypass is rejected outside the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,9 +70,11 @@ pnpm --filter open-tag start agent list
 这只会记录 Agent identity 和 Computer binding，不会启动 Codex 或 Claude Code turn。
 
 配置 `OPENTAG_GOOGLE_CLIENT_ID` 和 `OPENTAG_GOOGLE_CLIENT_SECRET` 后即可启用 Google 登录，然后打开
-`http://127.0.0.1:8000/admin/`。Team admin 可以查看当前成员、Agent、实际被引用的 Computer、当前邀请链接和
-带时间戳的诊断快照。每个 active member 都可以从用户级 admin 首页生成短期有效的 Computer 安装/login
-命令，admin 也可以从 Computers 页面执行同一操作。membership 与邀请变更仍通过显式 CLI 操作完成：
+`http://127.0.0.1:8000/admin/`。Team admin 可以查看当前成员、Agent、当前邀请链接和带时间戳的诊断快照。
+在 Computers 页面，**Your computers** 会列出当前用户拥有的全部 Computer，**Team computers** 会列出其他
+active、非 suspended Team member 拥有的全部 Computer。Agent binding 只是附加信息，不是 Computer 进入
+列表的条件。每个 active member 都可以从用户级 admin 首页生成短期有效的 Computer 安装/login 命令，admin
+也可以从 Computers 页面执行同一操作。membership 与邀请变更仍通过显式 CLI 操作完成：
 
 若 loopback 开发环境没有 Google 凭据，可设置 `OPENTAG_DEV_AUTH_BYPASS_ENABLED=true`，并将
 `OPENTAG_DEV_AUTH_EMAIL` 设为已有 bootstrap 用户的唯一 email。该 bypass 在 `dev` 以外的环境会被拒绝，

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -27,6 +27,23 @@ const connectedComputer = {
   lastSeenAt: "2030-01-01T00:00:03.000Z",
 };
 
+const ownTeamComputer = {
+  ...connectedComputer,
+  ownerDisplayName: "Ada",
+  observedAt: "2030-01-01T00:00:04.000Z",
+  agentIds: [],
+};
+
+const teammateComputer = {
+  ...ownTeamComputer,
+  id: "33333333-3333-4333-8333-333333333333",
+  ownerUserId: "22222222-2222-4222-8222-222222222222",
+  ownerDisplayName: "Grace",
+  displayName: "Grace's Linux",
+  platform: "linux",
+  arch: "x64",
+};
+
 afterEach(() => vi.useRealTimers());
 
 describe("Admin Web", () => {
@@ -118,10 +135,12 @@ describe("Admin Web", () => {
     vi.mocked(fetch).mockImplementation(async (input) => {
       const url = String(input);
       if (url === "/api/v1/me") return response(me("admin"));
-      if (url === `/api/v1/teams/${teamId}/computers`) return response({ computers: [] });
+      if (url === `/api/v1/teams/${teamId}/computers`) {
+        return response({ computers: [ownTeamComputer, teammateComputer] });
+      }
       if (url === "/api/v1/me/computers") {
         ownComputerReads += 1;
-        return response({ computers: ownComputerReads === 1 ? [] : [connectedComputer] });
+        return response({ computers: ownComputerReads <= 2 ? [] : [connectedComputer] });
       }
       if (url === "/api/v1/me/connect-codes") {
         return response(
@@ -137,6 +156,8 @@ describe("Admin Web", () => {
     });
 
     render(<App />);
+    expect(await screen.findByRole("cell", { name: "Grace's Linux" })).toBeTruthy();
+    expect(screen.queryByRole("cell", { name: "Ada's Mac" })).toBeNull();
     const connectButton = await screen.findByRole("button", { name: "Connect computer" });
     vi.useFakeTimers();
     await act(async () => {
@@ -156,7 +177,9 @@ describe("Admin Web", () => {
       await Promise.resolve();
     });
     expect(screen.getByRole("status").textContent).toContain("Ada's Mac connected");
-    expect(ownComputerReads).toBe(2);
+    vi.useRealTimers();
+    expect(await screen.findByRole("cell", { name: "Ada's Mac" })).toBeTruthy();
+    expect(ownComputerReads).toBe(4);
   });
 
   it("ignores a reconnect before the Server-issued command boundary", async () => {
@@ -174,8 +197,8 @@ describe("Admin Web", () => {
       if (url === `/api/v1/teams/${teamId}/computers`) return response({ computers: [] });
       if (url === "/api/v1/me/computers") {
         ownComputerReads += 1;
-        if (ownComputerReads === 1) return response({ computers: [baselineComputer] });
-        if (ownComputerReads === 2) return response({ computers: [preIssueReconnect] });
+        if (ownComputerReads <= 2) return response({ computers: [baselineComputer] });
+        if (ownComputerReads === 3) return response({ computers: [preIssueReconnect] });
         return response({ computers: [connectedComputer] });
       }
       if (url === "/api/v1/me/connect-codes") {
@@ -267,7 +290,7 @@ describe("Admin Web", () => {
       if (url === `/api/v1/teams/${teamId}/computers`) return response({ computers: [] });
       if (url === "/api/v1/me/computers") {
         baselineReads += 1;
-        if (baselineReads === 1) return oldBaseline;
+        if (baselineReads === 2) return oldBaseline;
         return response({ computers: [] });
       }
       if (url === "/api/v1/me/connect-codes") {
@@ -285,10 +308,13 @@ describe("Admin Web", () => {
     });
 
     render(<App />);
+    expect(await screen.findByText("No computers connected to your account.")).toBeTruthy();
+    expect(await screen.findByText("No other active Team members have connected computers.")).toBeTruthy();
     fireEvent.click(await screen.findByRole("button", { name: "Connect computer" }));
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     fireEvent.click(screen.getByRole("button", { name: "Connect computer" }));
     expect(await screen.findByText(/login current_code/)).toBeTruthy();
+    expect(baselineReads).toBe(3);
     resolveOldBaseline?.(response({ computers: [] }));
     await act(async () => Promise.resolve());
     expect(issueCount).toBe(1);

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -139,7 +139,7 @@ function AdminApp() {
         const membership = value.memberships.find((item) => item.teamId === decodeURIComponent(teamId));
         if (!membership) return <div className="notice error">This Team is not available to your account.</div>;
         if (membership.role !== "admin") return <Forbidden membership={membership} />;
-        return <TeamShell membership={membership} />;
+        return <TeamShell membership={membership} viewerUserId={value.user.id} />;
       }}
     </Resource>
   );
@@ -169,14 +169,14 @@ function TeamSelector({ memberships, displayName }: { memberships: MeMembership[
   );
 }
 
-function ConnectComputerAction() {
+function ConnectComputerAction({ onConnected }: { onConnected?: (computer: Computer) => void } = {}) {
   const [showConnect, setShowConnect] = useState(false);
   return (
     <>
       <button type="button" onClick={() => setShowConnect(true)}>
         Connect computer
       </button>
-      {showConnect ? <ConnectComputerDialog onClose={() => setShowConnect(false)} /> : null}
+      {showConnect ? <ConnectComputerDialog onClose={() => setShowConnect(false)} onConnected={onConnected} /> : null}
     </>
   );
 }
@@ -192,7 +192,7 @@ function Forbidden({ membership }: { membership: MeMembership }) {
   );
 }
 
-function TeamShell({ membership }: { membership: MeMembership }) {
+function TeamShell({ membership, viewerUserId }: { membership: MeMembership; viewerUserId: string }) {
   const section = window.location.pathname.split("/")[4] || "overview";
   const base = `/admin/teams/${membership.teamId}`;
   return (
@@ -221,16 +221,24 @@ function TeamShell({ membership }: { membership: MeMembership }) {
         </nav>
       </aside>
       <main className="content">
-        <TeamPage section={section} membership={membership} />
+        <TeamPage section={section} membership={membership} viewerUserId={viewerUserId} />
       </main>
     </div>
   );
 }
 
-function TeamPage({ section, membership }: { section: string; membership: MeMembership }) {
+function TeamPage({
+  section,
+  membership,
+  viewerUserId,
+}: {
+  section: string;
+  membership: MeMembership;
+  viewerUserId: string;
+}) {
   if (section === "members") return <MembersPage teamId={membership.teamId} />;
   if (section === "agents") return <AgentsPage teamId={membership.teamId} />;
-  if (section === "computers") return <ComputersPage teamId={membership.teamId} />;
+  if (section === "computers") return <ComputersPage teamId={membership.teamId} viewerUserId={viewerUserId} />;
   if (section === "diagnostics") return <DiagnosticsPage />;
   return <OverviewPage membership={membership} />;
 }
@@ -324,29 +332,58 @@ function AgentsPage({ teamId }: { teamId: string }) {
   );
 }
 
-function ComputersPage({ teamId }: { teamId: string }) {
-  const state = useResource(() => browserApi.computers(teamId), teamId);
+function ComputersPage({ teamId, viewerUserId }: { teamId: string; viewerUserId: string }) {
+  const [ownComputersRevision, setOwnComputersRevision] = useState(0);
+  const ownComputers = useResource(() => browserApi.ownComputers(), `own-computers:${ownComputersRevision}`);
+  const teamComputers = useResource(() => browserApi.computers(teamId), `team-computers:${teamId}`);
+  const refreshOwnComputers = useCallback(() => setOwnComputersRevision((revision) => revision + 1), []);
   return (
     <>
       <div className="page-heading-row">
-        <PageHeader title="Computers" subtitle="Only Computers referenced by active Team Agents" />
-        <ConnectComputerAction />
+        <PageHeader title="Computers" subtitle="Your connections and this Team's member computers" />
+        <ConnectComputerAction onConnected={refreshOwnComputers} />
       </div>
-      <Resource state={state}>
-        {(value) => (
-          <Table
-            headers={["Computer", "Owner", "Platform", "Connection snapshot", "Last seen", "Observed"]}
-            rows={value.computers.map((computer) => [
-              computer.displayName,
-              computer.ownerDisplayName,
-              `${computer.platform}/${computer.arch} · ${computer.clientVersion}`,
-              computer.connectionStatus,
-              formatDate(computer.lastSeenAt),
-              formatDate(computer.observedAt),
-            ])}
-          />
-        )}
-      </Resource>
+      <section aria-labelledby="your-computers-title" className="computer-section">
+        <h2 id="your-computers-title">Your computers</h2>
+        <p className="muted">All computers connected to your account, whether or not an Agent uses them yet.</p>
+        <Resource state={ownComputers}>
+          {(value) => (
+            <Table
+              emptyMessage="No computers connected to your account."
+              headers={["Computer", "Platform", "Connection", "Last seen"]}
+              rows={value.computers.map((computer) => [
+                computer.displayName,
+                `${computer.platform}/${computer.arch} · ${computer.clientVersion}`,
+                computer.connectionStatus,
+                formatDate(computer.lastSeenAt),
+              ])}
+            />
+          )}
+        </Resource>
+      </section>
+      <section aria-labelledby="team-computers-title" className="computer-section">
+        <h2 id="team-computers-title">Team computers</h2>
+        <p className="muted">Computers owned by other active Team members; Agent bindings are shown separately.</p>
+        <Resource state={teamComputers}>
+          {(value) => (
+            <Table
+              emptyMessage="No other active Team members have connected computers."
+              headers={["Computer", "Owner", "Platform", "Connection snapshot", "Agents", "Last seen", "Observed"]}
+              rows={value.computers
+                .filter((computer) => computer.ownerUserId !== viewerUserId)
+                .map((computer) => [
+                  computer.displayName,
+                  computer.ownerDisplayName,
+                  `${computer.platform}/${computer.arch} · ${computer.clientVersion}`,
+                  computer.connectionStatus,
+                  String(computer.agentIds.length),
+                  formatDate(computer.lastSeenAt),
+                  formatDate(computer.observedAt),
+                ])}
+            />
+          )}
+        </Resource>
+      </section>
     </>
   );
 }
@@ -358,7 +395,13 @@ type ConnectDialogState =
   | { kind: "expired" }
   | { kind: "success"; computer: Computer };
 
-function ConnectComputerDialog({ onClose }: { onClose: () => void }) {
+function ConnectComputerDialog({
+  onClose,
+  onConnected,
+}: {
+  onClose: () => void;
+  onConnected?: (computer: Computer) => void;
+}) {
   const [state, setState] = useState<ConnectDialogState>({ kind: "loading" });
   const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "error">("idle");
   const [remainingSeconds, setRemainingSeconds] = useState(0);
@@ -429,7 +472,10 @@ function ConnectComputerDialog({ onClose }: { onClose: () => void }) {
             Date.parse(computer.connectedAt) >= state.issuedAtMs &&
             baseline.current.get(computer.id) !== computer.connectedAt,
         );
-        if (connected) setState({ kind: "success", computer: connected });
+        if (connected) {
+          onConnected?.(connected);
+          setState({ kind: "success", computer: connected });
+        }
       } catch {
         // A transient poll failure does not invalidate the already-issued command.
       } finally {
@@ -438,7 +484,7 @@ function ConnectComputerDialog({ onClose }: { onClose: () => void }) {
     };
     const timer = window.setInterval(() => void poll(), 2000);
     return () => window.clearInterval(timer);
-  }, [state]);
+  }, [onConnected, state]);
 
   async function copyCommand(command: string) {
     try {
@@ -557,8 +603,16 @@ function Metric({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
-function Table({ headers, rows }: { headers: string[]; rows: string[][] }) {
-  if (rows.length === 0) return <div className="notice">No records in this snapshot.</div>;
+function Table({
+  headers,
+  rows,
+  emptyMessage = "No records in this snapshot.",
+}: {
+  headers: string[];
+  rows: string[][];
+  emptyMessage?: string;
+}) {
+  if (rows.length === 0) return <div className="notice">{emptyMessage}</div>;
   return (
     <div className="table-wrap">
       <table>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -160,6 +160,15 @@ nav a.active {
 .panel {
   margin-top: 1rem;
 }
+.computer-section + .computer-section {
+  margin-top: 2rem;
+}
+.computer-section h2 {
+  margin-bottom: 0.35rem;
+}
+.computer-section > p {
+  margin-top: 0;
+}
 code {
   display: inline-block;
   max-width: 100%;

--- a/packages/server/src/__tests__/integration/account-team-foundation.test.ts
+++ b/packages/server/src/__tests__/integration/account-team-foundation.test.ts
@@ -157,6 +157,102 @@ describe("account identity and Team foundation persistence", () => {
     }
   });
 
+  it("lists every Computer owned by an active Team member independently of Agent binding", async () => {
+    const value = await fixture();
+    try {
+      const [activeMember, removedMember, suspendedMember] = await value.database
+        .insert(users)
+        .values([
+          { email: "active-computer@example.com", displayName: "Active Member" },
+          { email: "removed-computer@example.com", displayName: "Removed Member" },
+          { email: "suspended-computer@example.com", displayName: "Suspended Member", suspendedAt: now },
+        ])
+        .returning();
+      if (!activeMember || !removedMember || !suspendedMember) throw new Error("User fixtures were not created");
+      await value.database.insert(memberships).values([
+        { teamId: value.bootstrap.teamId, userId: activeMember.id, role: "member", status: "active" },
+        { teamId: value.bootstrap.teamId, userId: removedMember.id, role: "member", status: "removed" },
+        { teamId: value.bootstrap.teamId, userId: suspendedMember.id, role: "member", status: "active" },
+      ]);
+
+      const adminComputerId = crypto.randomUUID();
+      const activeComputerId = crypto.randomUUID();
+      const removedComputerId = crypto.randomUUID();
+      const suspendedComputerId = crypto.randomUUID();
+      await value.database.insert(computers).values([
+        {
+          id: adminComputerId,
+          ownerUserId: value.bootstrap.userId,
+          displayName: "admin-unbound",
+          platform: "linux",
+          arch: "x64",
+          clientVersion: "0.0.1",
+          currentInstanceId: crypto.randomUUID(),
+          connectedAt: now,
+          lastSeenAt: now,
+        },
+        {
+          id: activeComputerId,
+          ownerUserId: activeMember.id,
+          displayName: "active-bound",
+          platform: "darwin",
+          arch: "arm64",
+          clientVersion: "0.0.1",
+          currentInstanceId: crypto.randomUUID(),
+          connectedAt: now,
+          lastSeenAt: now,
+        },
+        {
+          id: removedComputerId,
+          ownerUserId: removedMember.id,
+          displayName: "removed-unbound",
+          platform: "win32",
+          arch: "x64",
+          clientVersion: "0.0.1",
+          lastSeenAt: now,
+        },
+        {
+          id: suspendedComputerId,
+          ownerUserId: suspendedMember.id,
+          displayName: "suspended-unbound",
+          platform: "linux",
+          arch: "x64",
+          clientVersion: "0.0.1",
+          lastSeenAt: now,
+        },
+      ]);
+      const [agent] = await value.database
+        .insert(agents)
+        .values({
+          teamId: value.bootstrap.teamId,
+          managerUserId: activeMember.id,
+          computerId: activeComputerId,
+          name: "active-computer-agent",
+          displayName: "Active Computer Agent",
+          runtimeProvider: "codex",
+        })
+        .returning();
+      if (!agent) throw new Error("Agent fixture was not created");
+
+      const result = await value.teamService.listComputers(value.bootstrap.userId, value.bootstrap.teamId);
+      expect(result.computers.map((computer) => computer.id)).toEqual([activeComputerId, adminComputerId]);
+      expect(result.computers.find((computer) => computer.id === adminComputerId)).toMatchObject({
+        ownerUserId: value.bootstrap.userId,
+        connectionStatus: "online",
+        agentIds: [],
+      });
+      expect(result.computers.find((computer) => computer.id === activeComputerId)).toMatchObject({
+        ownerUserId: activeMember.id,
+        connectionStatus: "online",
+        agentIds: [agent.id],
+      });
+      expect(result.computers.map((computer) => computer.id)).not.toContain(removedComputerId);
+      expect(result.computers.map((computer) => computer.id)).not.toContain(suspendedComputerId);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
   it("joins an invited Team without creating a personal Team and rotates bearer links", async () => {
     const value = await fixture();
     try {

--- a/packages/server/src/services/teams/team-membership-service.ts
+++ b/packages/server/src/services/teams/team-membership-service.ts
@@ -220,14 +220,22 @@ export class TeamMembershipService {
     });
   }
 
+  /**
+   * Lists every Computer owned by an active, non-suspended Team member.
+   * Agent bindings decorate the Computer projection; they do not determine membership in it.
+   */
   async listComputers(callerUserId: string, teamId: string): Promise<ListTeamComputersResponse> {
     await this.requireActiveMembership(this.#database, callerUserId, teamId, "admin");
     const rows = await this.#database
       .select({ agentId: agents.id, computer: computers, ownerDisplayName: users.displayName })
-      .from(agents)
-      .innerJoin(computers, eq(computers.id, agents.computerId))
-      .innerJoin(users, eq(users.id, computers.ownerUserId))
-      .where(and(eq(agents.teamId, teamId), isNull(agents.deletedAt)))
+      .from(memberships)
+      .innerJoin(users, eq(users.id, memberships.userId))
+      .innerJoin(computers, eq(computers.ownerUserId, memberships.userId))
+      .leftJoin(
+        agents,
+        and(eq(agents.teamId, memberships.teamId), eq(agents.computerId, computers.id), isNull(agents.deletedAt)),
+      )
+      .where(and(eq(memberships.teamId, teamId), eq(memberships.status, "active"), isNull(users.suspendedAt)))
       .orderBy(asc(computers.displayName), asc(computers.id), asc(agents.id));
     const observedAt = this.#now();
     const cutoff = observedAt.getTime() - this.#presenceTimeoutMs;
@@ -235,7 +243,7 @@ export class TeamMembershipService {
     for (const row of rows) {
       const existing = byId.get(row.computer.id);
       if (existing) {
-        existing.agentIds.push(row.agentId);
+        if (row.agentId) existing.agentIds.push(row.agentId);
         continue;
       }
       byId.set(row.computer.id, {
@@ -251,7 +259,7 @@ export class TeamMembershipService {
         connectedAt: row.computer.connectedAt?.toISOString() ?? null,
         lastSeenAt: row.computer.lastSeenAt.toISOString(),
         observedAt: observedAt.toISOString(),
-        agentIds: [row.agentId],
+        agentIds: row.agentId ? [row.agentId] : [],
       });
     }
     return { computers: [...byId.values()] };


### PR DESCRIPTION
## Summary

- list every Computer owned by an active, non-suspended Team member instead of requiring an active Agent binding
- keep Agent bindings as supplemental `agentIds` data and return an empty list for unbound Computers
- split the admin Computers page into deduplicated `Your computers` and `Team computers` sections
- refresh the user-owned list immediately after a new connection succeeds
- synchronize the English README and Chinese mirror with the ownership-based visibility model

## Security and behavior

- the Team Computer endpoint remains admin-only
- the Team projection excludes removed memberships and suspended users
- the user projection remains scoped to the authenticated caller
- no database schema changes or migrations

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/server test:integration`
- `git diff --check`
- independent code review completed with no blockers

## E2E

Momentic E2E is **BLOCKED** because the repository does not define a `local` environment in `momentic.config.yaml`. The affected Web behavior is covered by DOM tests; no Momentic run is claimed.
