### PR TITLE
feat: add structured client logging

### DIFF
--- a/apps/cli/THIRD_PARTY_NOTICES
+++ b/apps/cli/THIRD_PARTY_NOTICES
@@ -32,6 +32,253 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
+## pino@10.3.1
+
+Source: https://github.com/pinojs/pino
+License: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2016-2025 Matteo Collina, David Mark Clements and the Pino contributors listed at <https://github.com/pinojs/pino#the-team> and in the README file.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## @pinojs/redact@0.4.0
+
+Source: https://github.com/pinojs/redact
+License: MIT
+
+MIT License
+
+Copyright (c) 2025 pinojs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## atomic-sleep@1.0.0
+
+Source: https://github.com/davidmarkclements/atomic-sleep
+License: MIT
+
+The MIT License (MIT)
+Copyright (c) 2020 David Mark Clements
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+## on-exit-leak-free@2.1.2
+
+Source: https://github.com/mcollina/on-exit-or-gc
+License: MIT
+
+MIT License
+
+Copyright (c) 2021 Matteo Collina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## pino-std-serializers@7.1.0
+
+Source: ssh://git@github.com/pinojs/pino-std-serializers
+License: MIT
+
+Copyright Mateo Collina, David Mark Clements, James Sumners
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+## quick-format-unescaped@4.0.4
+
+Source: https://github.com/davidmarkclements/quick-format
+License: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2016-2019 David Mark Clements
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## safe-stable-stringify@2.5.0
+
+Source: https://github.com/BridgeAR/safe-stable-stringify
+License: MIT
+
+The MIT License (MIT)
+
+Copyright (c) Ruben Bridgewater
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## sonic-boom@4.2.1
+
+Source: https://github.com/pinojs/sonic-boom
+License: MIT
+
+MIT License
+
+Copyright (c) 2017 Matteo Collina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## thread-stream@4.2.0
+
+Source: https://github.com/mcollina/thread-stream
+License: MIT
+
+MIT License
+
+Copyright (c) 2021 Matteo Collina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 ## ws@8.21.3
 
 Source: https://github.com/websockets/ws

--- a/apps/cli/src/__tests__/daemon-service-commands.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-commands.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ClientLogBindings, ClientLogger } from "@opentag/client";
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
 import { registerDaemonCommand } from "../commands/daemon/index.js";
@@ -45,32 +46,40 @@ describe("daemon service commands", () => {
   });
 
   it("treats deterministic service configuration failures as clean service exits", async () => {
-    const messages: string[] = [];
+    const messages: Array<{ fields: ClientLogBindings; message: string }> = [];
     const home = await mkdtemp(join(tmpdir(), "opentag-service-entry-"));
     try {
       const exitCode = await runDaemonServiceEntry({
         home,
-        log: (message) => messages.push(message),
+        logger: recordingLogger(messages),
       });
       expect(exitCode).toBe(0);
-      expect(messages.join(" ")).toContain("not logged in");
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          fields: expect.objectContaining({ category: "configuration", instanceId: expect.any(String) }),
+        }),
+      );
     } finally {
       await rm(home, { recursive: true, force: true });
     }
   });
 
   it("treats a live daemon owner conflict as a clean service exit", async () => {
-    const messages: string[] = [];
+    const messages: Array<{ fields: ClientLogBindings; message: string }> = [];
     const home = await mkdtemp(join(tmpdir(), "opentag-service-owner-busy-"));
     const owner = await acquireDaemonOwner(home, "existing-instance");
     try {
       await expect(
         runDaemonServiceEntry({
           home,
-          log: (message) => messages.push(message),
+          logger: recordingLogger(messages),
         }),
       ).resolves.toBe(0);
-      expect(messages.join(" ")).toContain("already running");
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          fields: expect.objectContaining({ category: "ownership", instanceId: expect.any(String) }),
+        }),
+      );
     } finally {
       await owner.release();
       await rm(home, { recursive: true, force: true });
@@ -78,17 +87,19 @@ describe("daemon service commands", () => {
   });
 
   it("treats a malformed daemon owner as a clean service exit", async () => {
-    const messages: string[] = [];
+    const messages: Array<{ fields: ClientLogBindings; message: string }> = [];
     const home = await mkdtemp(join(tmpdir(), "opentag-service-owner-malformed-"));
     try {
       await writeFile(join(home, "daemon-owner.json"), "{}\n", { mode: 0o600 });
       await expect(
         runDaemonServiceEntry({
           home,
-          log: (message) => messages.push(message),
+          logger: recordingLogger(messages),
         }),
       ).resolves.toBe(0);
-      expect(messages.join(" ")).toContain("malformed");
+      expect(messages).toContainEqual(
+        expect.objectContaining({ fields: expect.objectContaining({ category: "ownership" }) }),
+      );
     } finally {
       await rm(home, { recursive: true, force: true });
     }
@@ -148,5 +159,20 @@ function fakeManager(state: "active" | "inactive"): DaemonServiceManager {
     status: vi.fn(async () => info),
     stop: vi.fn(async () => ({ ...info, state: "inactive" as const })),
     uninstall: vi.fn(async () => ({ ...info, state: "not-installed" as const })),
+  };
+}
+
+function recordingLogger(
+  entries: Array<{ fields: ClientLogBindings; message: string }>,
+  bindings: ClientLogBindings = {},
+): ClientLogger {
+  const record = (fields: ClientLogBindings, message: string) =>
+    entries.push({ fields: { ...bindings, ...fields }, message });
+  return {
+    child: (childBindings) => recordingLogger(entries, { ...bindings, ...childBindings }),
+    debug: record,
+    error: record,
+    info: record,
+    warn: record,
   };
 }

--- a/apps/cli/src/__tests__/daemon-service-renderers.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-renderers.test.ts
@@ -98,6 +98,7 @@ describe("systemd service backend", () => {
     });
     const info = await backend.installAndStart();
     expect(info).toMatchObject({ pid: 321, state: "active" });
+    expect(info.logHint).toBe("/tmp/opentag home/logs/client.log (fallback: journalctl --user -u opentag.service -f)");
     expect(info.detail).toContain("enable lingering manually");
     expect(calls).toEqual(
       expect.arrayContaining([
@@ -488,7 +489,11 @@ describe("launchd service backend", () => {
       uid: 501,
       userHome,
     });
-    await expect(backend.installAndStart()).resolves.toMatchObject({ pid: 77, state: "active" });
+    await expect(backend.installAndStart()).resolves.toMatchObject({
+      logHint: `${join(home, "logs", "client.log")} (fallback: ${join(home, "logs", "daemon.stdout.log")} / ${join(home, "logs", "daemon.stderr.log")})`,
+      pid: 77,
+      state: "active",
+    });
     const bootstrapIndex = calls.findIndex((value) => value.startsWith("bootstrap "));
     const evictionPrints = calls.slice(0, bootstrapIndex).filter((value) => value === "print gui/501/opentag");
     expect(bootstrapIndex).toBeGreaterThan(0);

--- a/apps/cli/src/__tests__/daemon-service-runtime.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-runtime.test.ts
@@ -2,14 +2,19 @@ import { EventEmitter } from "node:events";
 import { access, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ClientLogBindings, ClientLogger } from "@opentag/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const clientMocks = vi.hoisted(() => ({
+  configureClientLoggerForService: vi.fn(),
   createCodexClientRuntime: vi.fn(),
   getAccessTokenLease: vi.fn(),
   me: vi.fn(),
   readCredentials: vi.fn(),
   resolveComputerIdentity: vi.fn(),
+}));
+const ownershipMocks = vi.hoisted(() => ({
+  acquireDaemonOwner: vi.fn(),
 }));
 
 vi.mock("@opentag/client", async (importOriginal) => {
@@ -19,6 +24,7 @@ vi.mock("@opentag/client", async (importOriginal) => {
     AccessTokenProvider: class {
       getAccessTokenLease = clientMocks.getAccessTokenLease;
     },
+    configureClientLoggerForService: clientMocks.configureClientLoggerForService,
     OpenTagApi: class {
       me = clientMocks.me;
     },
@@ -28,15 +34,61 @@ vi.mock("@opentag/client", async (importOriginal) => {
   };
 });
 
-import { runDaemonLifecycle, runDaemonService } from "../core/daemon/runtime.js";
+vi.mock("../core/daemon/ownership.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../core/daemon/ownership.js")>();
+  ownershipMocks.acquireDaemonOwner.mockImplementation(original.acquireDaemonOwner);
+  return { ...original, acquireDaemonOwner: ownershipMocks.acquireDaemonOwner };
+});
+
+import { acquireDaemonOwner } from "../core/daemon/ownership.js";
+import { runDaemonLifecycle, runDaemonService, runDaemonServiceEntry } from "../core/daemon/runtime.js";
 
 const directories: string[] = [];
 afterEach(async () => {
   vi.clearAllMocks();
+  delete process.env.OPENTAG_SERVICE_MODE;
   await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
 });
 
 describe("daemon service runtime", () => {
+  it("configures the Client-owned service log before daemon startup", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-daemon-log-"));
+    directories.push(home);
+    process.env.OPENTAG_SERVICE_MODE = "1";
+    clientMocks.readCredentials.mockResolvedValue(undefined);
+
+    await expect(runDaemonService({ home, logger: noopLogger() })).rejects.toThrow("not logged in");
+
+    expect(clientMocks.configureClientLoggerForService).toHaveBeenCalledOnce();
+    expect(clientMocks.configureClientLoggerForService).toHaveBeenCalledWith(join(home, "logs"));
+  });
+
+  it("does not configure or touch the service log when daemon ownership is already held", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-daemon-owned-log-"));
+    directories.push(home);
+    process.env.OPENTAG_SERVICE_MODE = "1";
+    const entries: Array<{ fields: ClientLogBindings; message: string }> = [];
+    const owner = await acquireDaemonOwner(home, "existing-instance");
+
+    try {
+      await expect(runDaemonService({ home, logger: recordingLogger(entries) })).rejects.toThrow("already running");
+    } finally {
+      await owner.release();
+    }
+
+    expect(clientMocks.configureClientLoggerForService).not.toHaveBeenCalled();
+    await expect(access(join(home, "logs", "client.log"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          category: "ownership",
+          instanceId: expect.any(String),
+        }),
+        message: "Daemon ownership prevented startup; inspect daemon status",
+      }),
+    );
+  });
+
   it("does not start after a signal arrives during startup", async () => {
     const signals = new EventEmitter();
     const run = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
@@ -115,7 +167,7 @@ describe("daemon service runtime", () => {
     });
     clientMocks.createCodexClientRuntime.mockResolvedValue({ run, stop });
 
-    await runDaemonService({ home, log: () => undefined, signals: signals as unknown as NodeJS.Process });
+    await runDaemonService({ home, logger: noopLogger(), signals: signals as unknown as NodeJS.Process });
 
     expect(clientMocks.createCodexClientRuntime).toHaveBeenCalledOnce();
     expect(clientMocks.createCodexClientRuntime.mock.calls[0]?.[1]).toMatchObject({ home, clientVersion: "0.0.1" });
@@ -123,4 +175,223 @@ describe("daemon service runtime", () => {
     expect(run).toHaveBeenCalledOnce();
     expect(stop).not.toHaveBeenCalled();
   });
+
+  it("logs ownership release failures safely and returns a failed service exit", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-daemon-release-"));
+    directories.push(home);
+    const signals = new EventEmitter();
+    const entries: Array<{ fields: ClientLogBindings; message: string }> = [];
+    const release = vi.fn(async () => {
+      throw new Error("sensitive release failure");
+    });
+    ownershipMocks.acquireDaemonOwner.mockResolvedValueOnce({ release });
+    clientMocks.readCredentials.mockResolvedValue({
+      accessToken: "access",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+      refreshToken: "refresh",
+      serverUrl: "http://127.0.0.1:3000",
+    });
+    clientMocks.getAccessTokenLease.mockResolvedValue({
+      accessToken: "access",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    clientMocks.me.mockResolvedValue({ user: { id: "user-1" }, memberships: [] });
+    clientMocks.resolveComputerIdentity.mockResolvedValue({
+      version: 1,
+      computerId: "00000000-0000-4000-8000-000000000001",
+      serverUrl: "http://127.0.0.1:3000",
+      userId: "user-1",
+    });
+    clientMocks.createCodexClientRuntime.mockResolvedValue({
+      run: vi.fn(async () => undefined),
+      stop: vi.fn(),
+    });
+
+    await expect(
+      runDaemonServiceEntry({
+        home,
+        logger: recordingLogger(entries),
+        signals: signals as unknown as NodeJS.Process,
+      }),
+    ).resolves.toBe(1);
+
+    expect(release).toHaveBeenCalledOnce();
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          category: "ownership_release",
+          computerId: "00000000-0000-4000-8000-000000000001",
+          instanceId: expect.any(String),
+        }),
+        message: "Daemon ownership release failed",
+      }),
+    );
+    expect(JSON.stringify(entries)).not.toContain("sensitive release failure");
+  });
+
+  it("preserves the runtime failure when ownership release also fails", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-daemon-double-failure-"));
+    directories.push(home);
+    const entries: Array<{ fields: ClientLogBindings; message: string }> = [];
+    ownershipMocks.acquireDaemonOwner.mockResolvedValueOnce({
+      release: vi.fn(async () => {
+        throw new Error("sensitive release failure");
+      }),
+    });
+    clientMocks.readCredentials.mockResolvedValue(undefined);
+
+    await expect(runDaemonService({ home, logger: recordingLogger(entries) })).rejects.toThrow("not logged in");
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({ fields: expect.objectContaining({ category: "configuration" }) }),
+    );
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        fields: expect.objectContaining({ category: "ownership_release", instanceId: expect.any(String) }),
+        message: "Daemon ownership release failed",
+      }),
+    );
+    expect(JSON.stringify(entries)).not.toContain("sensitive release failure");
+  });
+
+  it("does not write daemon logs after ownership is released", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-daemon-release-order-"));
+    directories.push(home);
+    const signals = new EventEmitter();
+    const entries: Array<{ fields: ClientLogBindings; message: string }> = [];
+    let entriesAtRelease = -1;
+    ownershipMocks.acquireDaemonOwner.mockResolvedValueOnce({
+      release: vi.fn(async () => {
+        entriesAtRelease = entries.length;
+      }),
+    });
+    clientMocks.readCredentials.mockResolvedValue(undefined);
+
+    await expect(
+      runDaemonService({
+        home,
+        logger: recordingLogger(entries),
+        signals: signals as unknown as NodeJS.Process,
+      }),
+    ).rejects.toThrow("not logged in");
+
+    expect(entriesAtRelease).toBeGreaterThan(0);
+    expect(entries).toHaveLength(entriesAtRelease);
+    expect(entries.at(-1)?.message).toBe("Daemon runtime stopped");
+  });
+
+  it("suppresses delayed runtime child logs after ownership is released", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-daemon-delayed-log-"));
+    directories.push(home);
+    const signals = new EventEmitter();
+    const entries: Array<{ fields: ClientLogBindings; message: string }> = [];
+    let delayedLogger: ClientLogger | undefined;
+    clientMocks.readCredentials.mockResolvedValue({
+      accessToken: "access",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+      refreshToken: "refresh",
+      serverUrl: "http://127.0.0.1:3000",
+    });
+    clientMocks.getAccessTokenLease.mockResolvedValue({
+      accessToken: "access",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    clientMocks.me.mockResolvedValue({ user: { id: "user-1" }, memberships: [] });
+    clientMocks.resolveComputerIdentity.mockResolvedValue({
+      version: 1,
+      computerId: "00000000-0000-4000-8000-000000000001",
+      serverUrl: "http://127.0.0.1:3000",
+      userId: "user-1",
+    });
+    clientMocks.createCodexClientRuntime.mockImplementation(async (_connection, options) => {
+      delayedLogger = options.logger.child({ module: "report-recovery" });
+      return { run: vi.fn(async () => undefined), stop: vi.fn() };
+    });
+
+    await runDaemonService({
+      home,
+      logger: recordingLogger(entries),
+      signals: signals as unknown as NodeJS.Process,
+    });
+    const entriesAfterRelease = entries.length;
+    delayedLogger?.warn({ agentId: "agent-1", sessionId: "session-1" }, "Delayed recovery log");
+
+    expect(entries).toHaveLength(entriesAfterRelease);
+    expect(entries).not.toContainEqual(expect.objectContaining({ message: "Delayed recovery log" }));
+  });
+
+  it("keeps instance and Computer identity on a terminal runtime failure", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-daemon-terminal-"));
+    directories.push(home);
+    const signals = new EventEmitter();
+    const entries: Array<{ fields: ClientLogBindings; message: string }> = [];
+    clientMocks.readCredentials.mockResolvedValue({
+      accessToken: "access",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+      refreshToken: "refresh",
+      serverUrl: "http://127.0.0.1:3000",
+    });
+    clientMocks.getAccessTokenLease.mockResolvedValue({
+      accessToken: "access",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    clientMocks.me.mockResolvedValue({ user: { id: "user-1" }, memberships: [] });
+    clientMocks.resolveComputerIdentity.mockResolvedValue({
+      version: 1,
+      computerId: "00000000-0000-4000-8000-000000000001",
+      serverUrl: "http://127.0.0.1:3000",
+      userId: "user-1",
+    });
+    clientMocks.createCodexClientRuntime.mockResolvedValue({
+      run: vi.fn(async () => {
+        throw new Error("sensitive provider failure");
+      }),
+      stop: vi.fn(),
+    });
+
+    await expect(
+      runDaemonService({
+        home,
+        logger: recordingLogger(entries),
+        signals: signals as unknown as NodeJS.Process,
+      }),
+    ).rejects.toThrow("sensitive provider failure");
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          category: "unexpected",
+          computerId: "00000000-0000-4000-8000-000000000001",
+          instanceId: expect.any(String),
+        }),
+        message: "Daemon stopped because of an unexpected internal failure",
+      }),
+    );
+    expect(JSON.stringify(entries)).not.toContain("sensitive provider failure");
+  });
 });
+
+function noopLogger(): ClientLogger {
+  return {
+    child: () => noopLogger(),
+    debug: (_fields: ClientLogBindings, _message: string) => undefined,
+    error: (_fields: ClientLogBindings, _message: string) => undefined,
+    info: (_fields: ClientLogBindings, _message: string) => undefined,
+    warn: (_fields: ClientLogBindings, _message: string) => undefined,
+  };
+}
+
+function recordingLogger(
+  entries: Array<{ fields: ClientLogBindings; message: string }>,
+  bindings: ClientLogBindings = {},
+): ClientLogger {
+  const record = (fields: ClientLogBindings, message: string) =>
+    entries.push({ fields: { ...bindings, ...fields }, message });
+  return {
+    child: (childBindings) => recordingLogger(entries, { ...bindings, ...childBindings }),
+    debug: record,
+    error: record,
+    info: record,
+    warn: record,
+  };
+}

--- a/apps/cli/src/__tests__/daemon-service-runtime.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-runtime.test.ts
@@ -84,7 +84,7 @@ describe("daemon service runtime", () => {
           category: "ownership",
           instanceId: expect.any(String),
         }),
-        message: "Daemon ownership prevented startup; inspect daemon status",
+        message: "Daemon is already running; inspect daemon status",
       }),
     );
   });

--- a/apps/cli/src/core/daemon/environment.ts
+++ b/apps/cli/src/core/daemon/environment.ts
@@ -6,6 +6,7 @@ export interface DaemonEnvironmentResult {
   appliedKeys: string[];
   diagnostics: string[];
   env: NodeJS.ProcessEnv;
+  malformedLineNumbers: number[];
 }
 
 export async function loadDaemonEnvironment(
@@ -25,7 +26,7 @@ export async function loadDaemonEnvironment(
     content = await readFile(path, "utf8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { appliedKeys: [], diagnostics: [], env: { ...baseEnvironment } };
+      return { appliedKeys: [], diagnostics: [], env: { ...baseEnvironment }, malformedLineNumbers: [] };
     }
     throw error;
   }
@@ -33,6 +34,7 @@ export async function loadDaemonEnvironment(
   const env = { ...baseEnvironment };
   const appliedKeys: string[] = [];
   const diagnostics: string[] = [];
+  const malformedLineNumbers: number[] = [];
   const lines = content.split(/\r?\n/u);
   for (const [index, line] of lines.entries()) {
     const trimmed = line.trim();
@@ -40,36 +42,36 @@ export async function loadDaemonEnvironment(
     const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/u);
     if (!match) {
       diagnostics.push(`Ignored malformed daemon.env line ${index + 1}`);
+      malformedLineNumbers.push(index + 1);
       continue;
     }
     const key = match[1];
     if (!key) {
       diagnostics.push(`Ignored malformed daemon.env line ${index + 1}`);
+      malformedLineNumbers.push(index + 1);
       continue;
     }
     const parsed = parseEnvironmentValue(match[2] ?? "");
     if (parsed === undefined) {
-      diagnostics.push(`Ignored malformed daemon.env value for ${key} on line ${index + 1}`);
+      diagnostics.push(`Ignored malformed daemon.env line ${index + 1}`);
+      malformedLineNumbers.push(index + 1);
       continue;
     }
     if (env[key]) continue;
     env[key] = parsed;
     appliedKeys.push(key);
   }
-  return { appliedKeys, diagnostics, env };
+  return { appliedKeys, diagnostics, env, malformedLineNumbers };
 }
 
 export async function applyDaemonEnvironment(
   home: string,
   environment: NodeJS.ProcessEnv = process.env,
-  log: (message: string) => void = console.log,
 ): Promise<DaemonEnvironmentResult> {
   const result = await loadDaemonEnvironment(home, environment);
   for (const [key, value] of Object.entries(result.env)) {
     if (value !== undefined) environment[key] = value;
   }
-  for (const diagnostic of result.diagnostics) log(diagnostic);
-  if (result.appliedKeys.length > 0) log(`Applied daemon.env keys: ${result.appliedKeys.sort().join(", ")}`);
   return result;
 }
 

--- a/apps/cli/src/core/daemon/runtime.ts
+++ b/apps/cli/src/core/daemon/runtime.ts
@@ -229,7 +229,11 @@ function daemonOperatorMessage(error: unknown): string {
   if (error instanceof DaemonRuntimeConfigurationError) {
     return "Daemon configuration is invalid; run login or inspect daemon status";
   }
-  if (error instanceof DaemonOwnerStartupError) return "Daemon ownership prevented startup; inspect daemon status";
+  if (error instanceof DaemonOwnerStartupError) {
+    return error.code === "BUSY"
+      ? "Daemon is already running; inspect daemon status"
+      : "Daemon ownership prevented startup; inspect daemon status";
+  }
   if (error instanceof RuntimeConnectionError) return "Daemon connection was rejected; run login again";
   return "Daemon service configuration prevented startup; inspect daemon status";
 }

--- a/apps/cli/src/core/daemon/runtime.ts
+++ b/apps/cli/src/core/daemon/runtime.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { arch, hostname, platform } from "node:os";
+import { join } from "node:path";
 import {
   AccessTokenProvider,
+  type ClientLogger,
+  configureClientLoggerForService,
   createCodexClientRuntime,
+  createLogger,
   OpenTagApi,
   OpenTagApiError,
   RuntimeConnection,
@@ -18,7 +22,7 @@ import { DaemonServiceError } from "./service/types.js";
 
 export interface DaemonRuntimeOptions {
   home?: string;
-  log?: (message: string) => void;
+  logger?: ClientLogger;
   signals?: NodeJS.Process;
 }
 
@@ -30,6 +34,11 @@ interface DaemonRuntime {
 interface DaemonSignals {
   off(event: "SIGINT" | "SIGTERM", listener: () => void): unknown;
   once(event: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+}
+
+interface ClientLoggerGate {
+  disable(): void;
+  logger: ClientLogger;
 }
 
 export async function runDaemonLifecycle(
@@ -67,18 +76,50 @@ export class DaemonRuntimeConfigurationError extends Error {
 
 export async function runDaemonService(options: DaemonRuntimeOptions = {}): Promise<void> {
   const home = options.home ?? resolveOpenTagHome();
-  const log = options.log ?? console.log;
   const signals = options.signals ?? process;
-  await applyDaemonEnvironment(home, process.env, log);
   const instanceId = randomUUID();
-  const ownership = await acquireDaemonOwner(home, instanceId);
+  const currentPlatform = platform();
+  const baseBindings = {
+    clientVersion: CLI_VERSION,
+    instanceId,
+    platform: currentPlatform,
+  };
+  let ownership: Awaited<ReturnType<typeof acquireDaemonOwner>>;
   try {
+    ownership = await acquireDaemonOwner(home, instanceId);
+  } catch (error) {
+    const logger = (options.logger ?? createLogger("daemon", { destination: "stderr" })).child(baseBindings);
+    logTerminalFailure(logger, error);
+    throw error;
+  }
+
+  let lifecycleLogger: ClientLogger | undefined;
+  let terminalLogger: ClientLogger | undefined;
+  let runtimeLoggerGate: ClientLoggerGate | undefined;
+  let failure: unknown;
+  let failed = false;
+  try {
+    const environmentResult = await applyDaemonEnvironment(home, process.env);
+    if (process.env.OPENTAG_SERVICE_MODE === "1") configureClientLoggerForService(join(home, "logs"));
+    const logger = (options.logger ?? createLogger("daemon")).child(baseBindings);
+    lifecycleLogger = logger;
+    terminalLogger = logger;
+    const gatedRuntimeLogger = createClientLoggerGate(logger);
+    runtimeLoggerGate = gatedRuntimeLogger;
+    const environmentLogger = logger.child({ module: "environment" });
+    environmentLogger.debug({ appliedCount: environmentResult.appliedKeys.length }, "Daemon environment loaded");
+    for (const lineNumber of environmentResult.malformedLineNumbers) {
+      environmentLogger.warn({ lineNumber }, "Malformed daemon environment line ignored");
+    }
+    logger.info({}, "Daemon startup started");
     await runDaemonLifecycle(async (signal) => {
       let credentials: Awaited<ReturnType<typeof readCredentials>>;
       try {
         credentials = await readCredentials(home);
       } catch (error) {
-        throw new DaemonRuntimeConfigurationError("OpenTag credentials are invalid; run login again", { cause: error });
+        throw new DaemonRuntimeConfigurationError("OpenTag credentials are invalid; run login again", {
+          cause: error,
+        });
       }
       signal.throwIfAborted();
       if (!credentials) throw new DaemonRuntimeConfigurationError("OpenTag is not logged in; run login first");
@@ -114,43 +155,122 @@ export async function runDaemonService(options: DaemonRuntimeOptions = {}): Prom
         throw new DaemonRuntimeConfigurationError("The local Computer identity is invalid", { cause: error });
       }
       signal.throwIfAborted();
-      const currentPlatform = platform();
       if (currentPlatform !== "darwin" && currentPlatform !== "linux") {
         throw new DaemonRuntimeConfigurationError(`Unsupported daemon service platform: ${currentPlatform}`);
       }
+      terminalLogger = logger.child({ computerId: identity.computerId });
+      const runtimeLogger = gatedRuntimeLogger.logger.child({ computerId: identity.computerId });
       const connection = new RuntimeConnection({
         arch: arch(),
         clientVersion: CLI_VERSION,
         computer: identity,
         displayName: hostname(),
         instanceId,
-        log,
+        logger: runtimeLogger.child({ module: "connection" }),
         platform: currentPlatform,
         tokenProvider,
       });
-      return createCodexClientRuntime(connection, { home, clientVersion: CLI_VERSION, log, signal });
+      const runtime = await createCodexClientRuntime(connection, {
+        home,
+        clientVersion: CLI_VERSION,
+        logger: runtimeLogger,
+        signal,
+      });
+      void connection.whenRegistered(signal).then(
+        () => runtimeLogger.info({}, "Daemon is ready"),
+        () => undefined,
+      );
+      return runtime;
     }, signals);
-  } finally {
-    await ownership.release();
+  } catch (error) {
+    const logger =
+      terminalLogger ?? (options.logger ?? createLogger("daemon", { destination: "stderr" })).child(baseBindings);
+    logTerminalFailure(logger, error);
+    failure = error;
+    failed = true;
   }
+
+  lifecycleLogger?.info({}, "Daemon stopping");
+  lifecycleLogger?.info({}, "Daemon runtime stopped");
+  runtimeLoggerGate?.disable();
+  try {
+    await ownership.release();
+  } catch (error) {
+    const logger =
+      terminalLogger ?? (options.logger ?? createLogger("daemon", { destination: "stderr" })).child(baseBindings);
+    logger.error({ category: "ownership_release" }, "Daemon ownership release failed");
+    if (!failed) {
+      failure = error;
+      failed = true;
+    }
+  }
+  if (failed) throw failure;
 }
 
 export async function runDaemonServiceEntry(options: DaemonRuntimeOptions = {}): Promise<0 | 1> {
-  const log = options.log ?? console.error;
   try {
     await runDaemonService(options);
     return 0;
   } catch (error) {
-    if (
-      error instanceof DaemonRuntimeConfigurationError ||
-      error instanceof DaemonOwnerStartupError ||
-      (error instanceof RuntimeConnectionError && error.fatal) ||
-      (error instanceof DaemonServiceError && ["CONFIGURATION", "UNSUPPORTED_PLATFORM"].includes(error.code))
-    ) {
-      log(error.message);
-      return 0;
-    }
-    log("The OpenTag daemon stopped because of an unexpected internal failure");
-    return 1;
+    return isExpectedDaemonStop(error) ? 0 : 1;
   }
+}
+
+function isExpectedDaemonStop(error: unknown): boolean {
+  return (
+    error instanceof DaemonRuntimeConfigurationError ||
+    error instanceof DaemonOwnerStartupError ||
+    (error instanceof RuntimeConnectionError && error.fatal) ||
+    (error instanceof DaemonServiceError && ["CONFIGURATION", "UNSUPPORTED_PLATFORM"].includes(error.code))
+  );
+}
+
+function daemonOperatorMessage(error: unknown): string {
+  if (error instanceof DaemonRuntimeConfigurationError) {
+    return "Daemon configuration is invalid; run login or inspect daemon status";
+  }
+  if (error instanceof DaemonOwnerStartupError) return "Daemon ownership prevented startup; inspect daemon status";
+  if (error instanceof RuntimeConnectionError) return "Daemon connection was rejected; run login again";
+  return "Daemon service configuration prevented startup; inspect daemon status";
+}
+
+function daemonFailureCategory(error: unknown): string {
+  if (error instanceof DaemonRuntimeConfigurationError) return "configuration";
+  if (error instanceof DaemonOwnerStartupError) return "ownership";
+  if (error instanceof RuntimeConnectionError) return error.fatal ? "connection_fatal" : "connection";
+  if (error instanceof DaemonServiceError) return error.code.toLowerCase();
+  return "unexpected";
+}
+
+function logTerminalFailure(logger: ClientLogger, error: unknown): void {
+  if (isExpectedDaemonStop(error)) {
+    logger.warn({ category: daemonFailureCategory(error) }, daemonOperatorMessage(error));
+    return;
+  }
+  logger.error({ category: daemonFailureCategory(error) }, "Daemon stopped because of an unexpected internal failure");
+}
+
+function createClientLoggerGate(logger: ClientLogger): ClientLoggerGate {
+  const state = { enabled: true };
+  const wrap = (target: ClientLogger): ClientLogger => ({
+    child: (bindings) => wrap(target.child(bindings)),
+    debug: (fields, message) => {
+      if (state.enabled) target.debug(fields, message);
+    },
+    error: (fields, message) => {
+      if (state.enabled) target.error(fields, message);
+    },
+    info: (fields, message) => {
+      if (state.enabled) target.info(fields, message);
+    },
+    warn: (fields, message) => {
+      if (state.enabled) target.warn(fields, message);
+    },
+  });
+  return {
+    disable: () => {
+      state.enabled = false;
+    },
+    logger: wrap(logger),
+  };
 }

--- a/apps/cli/src/core/daemon/service/launchd.ts
+++ b/apps/cli/src/core/daemon/service/launchd.ts
@@ -288,7 +288,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
     return {
       currentHome: options.home,
       definitionPath: plistPath,
-      logHint: `${stdoutPath} / ${stderrPath}`,
+      logHint: `${join(options.home, "logs", "client.log")} (fallback: ${stdoutPath} / ${stderrPath})`,
       platform: "launchd",
       serviceId: options.serviceId,
       state,

--- a/apps/cli/src/core/daemon/service/systemd.ts
+++ b/apps/cli/src/core/daemon/service/systemd.ts
@@ -280,7 +280,7 @@ export function createSystemdBackend(options: SystemdBackendOptions): DaemonServ
     return {
       currentHome: options.home,
       definitionPath: unitPath,
-      logHint: `journalctl --user -u ${identity.systemdUnitName} -f`,
+      logHint: `${join(options.home, "logs", "client.log")} (fallback: journalctl --user -u ${identity.systemdUnitName} -f)`,
       platform: "systemd",
       serviceId: options.serviceId,
       state,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@opentag/shared": "workspace:*",
+    "pino": "^10.3.1",
     "ws": "^8.21.3"
   },
   "devDependencies": {

--- a/packages/client/src/__tests__/client-runtime-domain.test.ts
+++ b/packages/client/src/__tests__/client-runtime-domain.test.ts
@@ -7,6 +7,7 @@ import { WebSocketServer } from "ws";
 import type { AccessTokenProvider } from "../auth/token-provider.js";
 import { ClientRuntime } from "../runtime/client-runtime.js";
 import { RuntimeConnection } from "../runtime/runtime-connection.js";
+import { type RecordedLog, recordingLogger } from "./recording-logger.js";
 
 const cleanup: Array<() => Promise<void>> = [];
 afterEach(async () => Promise.all(cleanup.splice(0).map((close) => close())));
@@ -102,7 +103,9 @@ describe("ClientRuntime domain dispatch", () => {
     const sendError = new Error("socket unavailable");
     const connection = new FailingResultConnection(computerId, request, sendError);
     const onReconcileResultSendFailed = vi.fn();
+    const logs: RecordedLog[] = [];
     const runtime = new ClientRuntime(connection as unknown as RuntimeConnection, {
+      logger: recordingLogger(logs, { computerId, instanceId: "instance-1" }),
       onReconcileResultSendFailed,
       prepareReconcileResult: (_request, result) => result,
     });
@@ -117,6 +120,19 @@ describe("ClientRuntime domain dispatch", () => {
       }),
       sendError,
     );
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        fields: expect.objectContaining({
+          agentId: "agent-1",
+          instanceId: "instance-1",
+          requestId: request.requestId,
+          sessionId: "session-1",
+        }),
+        level: "warn",
+        message: "Session reconcile result send failed",
+      }),
+    );
+    expect(JSON.stringify(logs)).not.toContain(sendError.message);
   });
 });
 

--- a/packages/client/src/__tests__/client-turn.integration.test.ts
+++ b/packages/client/src/__tests__/client-turn.integration.test.ts
@@ -18,6 +18,7 @@ import { SessionBindingStore } from "../runtime/session-binding-store.js";
 import { SessionReconciler } from "../runtime/session-reconciler.js";
 import { TurnCustodyOwner } from "../runtime/turn-custody-owner.js";
 import { TurnReportOwner } from "../runtime/turn-report-owner.js";
+import { type RecordedLog, recordingLogger } from "./recording-logger.js";
 
 const directories: string[] = [];
 
@@ -32,7 +33,24 @@ describe("Codex Client Turn vertical", () => {
     await first.onAcceptedSent?.();
     const firstReport = await fixture.waitForReport(0);
 
-    expect(fixture.logs).toEqual([]);
+    expect(fixture.logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fields: expect.objectContaining({
+            agentId: "agent-1",
+            computerId: expect.any(String),
+            instanceId: "instance-1",
+            sessionId: "session-1",
+            turnId: expect.any(String),
+          }),
+          level: "info",
+          message: "Turn started",
+        }),
+        expect.objectContaining({ level: "info", message: "Turn completed" }),
+      ]),
+    );
+    const started = fixture.logs.find((entry) => entry.message === "Turn started");
+    expect(started?.fields.instanceId).not.toBe(started?.fields.agentId);
     expect(firstReport.errorReason).toBeUndefined();
     expect(firstReport).toMatchObject({
       deliveryId: "delivery-1",
@@ -109,7 +127,7 @@ async function runtimeFixture(terminalGate: Promise<void> = Promise.resolve()) {
   const connection = new FakeConnection();
   const reportOwner = new TurnReportOwner({ connection });
   const clients: ScriptedTurnClient[] = [];
-  const logs: string[] = [];
+  const logs: RecordedLog[] = [];
   const adapter = new CodexAdapter({
     clientVersion: "0.0.1",
     createClient: (cwd) => {
@@ -138,7 +156,7 @@ async function runtimeFixture(terminalGate: Promise<void> = Promise.resolve()) {
     custody,
     reportOwner,
     workspace,
-    log: (message) => logs.push(message),
+    logger: recordingLogger(logs, { computerId, instanceId: "instance-1" }),
   });
   const reconcile: SessionReconcileRequest = {
     type: "session:reconcile",

--- a/packages/client/src/__tests__/mvp-turn-report-recovery.test.ts
+++ b/packages/client/src/__tests__/mvp-turn-report-recovery.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@opentag/shared";
 import { describe, expect, it, vi } from "vitest";
 import { MvpTurnReportRecovery, type MvpTurnReportRecoveryOptions } from "../runtime/mvp-turn-report-recovery.js";
+import { type RecordedLog, recordingLogger } from "./recording-logger.js";
 
 describe("MvpTurnReportRecovery", () => {
   it("bounds active replay work and lazily reloads full reports from durable bindings", async () => {
@@ -25,8 +26,10 @@ describe("MvpTurnReportRecovery", () => {
     const submit = vi.fn((report: TurnReportRequest) =>
       report.sessionId === first.sessionId ? firstPending : Promise.resolve(),
     );
+    const logs: RecordedLog[] = [];
     const recovery = new MvpTurnReportRecovery({
       bindingStore: { read, recordResult } as unknown as MvpTurnReportRecoveryOptions["bindingStore"],
+      logger: recordingLogger(logs),
       maxActiveReplays: 1,
       reconciler: {
         clearRecovery: vi.fn(),
@@ -55,6 +58,17 @@ describe("MvpTurnReportRecovery", () => {
     expect(submit).toHaveBeenLastCalledWith(reloadedSecond, expect.any(Function), {
       onTerminal: expect.any(Function),
     });
+    await vi.waitFor(() =>
+      expect(logs.filter((entry) => entry.message === "Turn Report replay completed")).toHaveLength(2),
+    );
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fields: expect.objectContaining({ agentId: "agent-1", sessionId: "session-1" }),
+          message: "Turn Report replay started",
+        }),
+      ]),
+    );
   });
 
   it("releases an active replay slot when the Server returns a terminal Report status", async () => {
@@ -90,7 +104,6 @@ describe("MvpTurnReportRecovery", () => {
 
     await vi.waitFor(() => expect(submit).toHaveBeenCalledTimes(2));
     expect(submit.mock.calls[1]?.[0]).toEqual(second);
-
     rearmTerminal.mockClear();
     const retryRequest = reconcileRequest(first.agentId, first.sessionId);
     const retryResult = await recovery.prepare(retryRequest, recoveryRequired(retryRequest, first));

--- a/packages/client/src/__tests__/recording-logger.ts
+++ b/packages/client/src/__tests__/recording-logger.ts
@@ -1,0 +1,20 @@
+import type { ClientLogBindings, ClientLogger } from "../observability/logger.js";
+
+export interface RecordedLog {
+  fields: ClientLogBindings;
+  level: "debug" | "error" | "info" | "warn";
+  message: string;
+}
+
+export function recordingLogger(entries: RecordedLog[], bindings: ClientLogBindings = {}): ClientLogger {
+  const record = (level: RecordedLog["level"], fields: ClientLogBindings, message: string) => {
+    entries.push({ fields: { ...bindings, ...fields }, level, message });
+  };
+  return {
+    child: (childBindings) => recordingLogger(entries, { ...bindings, ...childBindings }),
+    debug: (fields, message) => record("debug", fields, message),
+    error: (fields, message) => record("error", fields, message),
+    info: (fields, message) => record("info", fields, message),
+    warn: (fields, message) => record("warn", fields, message),
+  };
+}

--- a/packages/client/src/__tests__/runtime.test.ts
+++ b/packages/client/src/__tests__/runtime.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import WebSocket, { WebSocketServer } from "ws";
 import type { AccessTokenProvider } from "../auth/token-provider.js";
 import { RuntimeConnection } from "../runtime/runtime-connection.js";
+import { type RecordedLog, recordingLogger } from "./recording-logger.js";
 
 const cleanup: Array<() => Promise<void>> = [];
 afterEach(async () => Promise.all(cleanup.splice(0).map((close) => close())));
@@ -393,7 +394,7 @@ describe("RuntimeConnection", () => {
         } else if (frame.type === "test:result") receiveBusinessResult?.(frame);
       });
     });
-    const logs: string[] = [];
+    const logs: RecordedLog[] = [];
     const received: Record<string, unknown>[] = [];
     const states: string[] = [];
     const connection = new RuntimeConnection({
@@ -402,7 +403,7 @@ describe("RuntimeConnection", () => {
       computer: { version: 1, computerId: randomUUID(), serverUrl: server.url, userId: randomUUID() },
       displayName: "workstation",
       instanceId: randomUUID(),
-      log: (message) => logs.push(message),
+      logger: recordingLogger(logs),
       parseBusinessFrame: (value) => {
         if (!value || typeof value !== "object" || (value as Record<string, unknown>).type !== "test:event") {
           return undefined;
@@ -426,7 +427,11 @@ describe("RuntimeConnection", () => {
     await vi.waitFor(() => expect(received).toEqual([{ type: "test:event", value: 1 }]));
     await connection.send({ type: "test:result", ok: true }, { priority: "result" });
     await expect(businessResult).resolves.toMatchObject({ type: "test:result", ok: true });
-    await vi.waitFor(() => expect(logs).toContain("A runtime business frame listener failed"));
+    await vi.waitFor(() =>
+      expect(logs).toContainEqual(
+        expect.objectContaining({ level: "warn", message: "Runtime business frame listener failed" }),
+      ),
+    );
     connection.stop();
     await running;
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -16,6 +16,12 @@ export {
   ServerHealthResponseError,
 } from "./health.js";
 export {
+  type ClientLogBindings,
+  type ClientLogger,
+  configureClientLoggerForService,
+  createLogger,
+} from "./observability/logger.js";
+export {
   buildOpenTagRuntimeContext,
   CODEX_V0_APP_SERVER_ARGS,
   CODEX_V0_ITEM_LIMIT,

--- a/packages/client/src/observability/__tests__/logger.test.ts
+++ b/packages/client/src/observability/__tests__/logger.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureClientLoggerForService, createLogger, resetClientLoggerForTests } from "../logger.js";
+
+const directories: string[] = [];
+const originalLevel = process.env.OPENTAG_LOG_LEVEL;
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  resetClientLoggerForTests();
+  if (originalLevel === undefined) delete process.env.OPENTAG_LOG_LEVEL;
+  else process.env.OPENTAG_LOG_LEVEL = originalLevel;
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("Client logger", () => {
+  it("writes NDJSON child bindings and redacts sensitive structured fields", async () => {
+    const directory = await temporaryDirectory();
+    process.env.OPENTAG_LOG_LEVEL = "info";
+    configureClientLoggerForService(directory);
+    createLogger("daemon")
+      .child({ computerId: "computer-1", instanceId: "instance-1", module: "turn" })
+      .child({ agentId: "agent-1", computerId: "computer-1", instanceId: "instance-1" })
+      .info(
+        {
+          accessToken: "access-secret",
+          auth: { refreshToken: "refresh-secret" },
+          headers: { authorization: "Bearer secret", cookie: "session=secret" },
+          sessionId: "session-1",
+        },
+        "Turn started",
+      );
+
+    const raw = (await readFile(join(directory, "client.log"), "utf8")).trim();
+    const record = JSON.parse(raw);
+    expect(record).toMatchObject({ agentId: "agent-1", level: 30, message: "Turn started", module: "turn" });
+    expect(record.time).toEqual(expect.any(String));
+    expect(JSON.stringify(record)).not.toContain("access-secret");
+    expect(JSON.stringify(record)).not.toContain("refresh-secret");
+    expect(JSON.stringify(record)).not.toContain("Bearer secret");
+    expect(JSON.stringify(record)).not.toContain("session=secret");
+    for (const key of ["module", "computerId", "instanceId"]) {
+      expect(raw.match(new RegExp(`"${key}":`, "gu"))).toHaveLength(1);
+    }
+  });
+
+  it("treats repeated configuration as a no-op and rejects another directory", async () => {
+    const first = await temporaryDirectory();
+    const second = await temporaryDirectory();
+    configureClientLoggerForService(first);
+    expect(() => configureClientLoggerForService(first)).not.toThrow();
+    expect(() => configureClientLoggerForService(second)).toThrow("different log directory");
+  });
+
+  it("falls back to info and emits a safe warning for an invalid configured level", async () => {
+    const directory = await temporaryDirectory();
+    process.env.OPENTAG_LOG_LEVEL = "credential-value";
+    configureClientLoggerForService(directory);
+    createLogger("daemon").info({}, "Daemon startup started");
+    const content = await readFile(join(directory, "client.log"), "utf8");
+    expect(content).toContain("Invalid OPENTAG_LOG_LEVEL; using info");
+    expect(content).toContain("Daemon startup started");
+    expect(content).not.toContain("credential-value");
+  });
+
+  it("is silent in tests unless an explicit level is configured", async () => {
+    delete process.env.OPENTAG_LOG_LEVEL;
+    const silentDirectory = await temporaryDirectory();
+    configureClientLoggerForService(silentDirectory);
+    createLogger("test").warn({}, "Hidden test diagnostic");
+    expect(await readFile(join(silentDirectory, "client.log"), "utf8")).toBe("");
+
+    resetClientLoggerForTests();
+    process.env.OPENTAG_LOG_LEVEL = "debug";
+    const visibleDirectory = await temporaryDirectory();
+    configureClientLoggerForService(visibleDirectory);
+    createLogger("test").debug({}, "Visible configured diagnostic");
+    expect(await readFile(join(visibleDirectory, "client.log"), "utf8")).toContain("Visible configured diagnostic");
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "opentag-logger-"));
+  directories.push(directory);
+  return directory;
+}

--- a/packages/client/src/observability/__tests__/rotating-file-stream.test.ts
+++ b/packages/client/src/observability/__tests__/rotating-file-stream.test.ts
@@ -1,5 +1,5 @@
 import { writeSync } from "node:fs";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -38,6 +38,67 @@ describe("RotatingFileStream", () => {
       fallbackWrite: (chunk) => fallback.push(chunk),
     });
     expect(() => stream.write("safe\n")).not.toThrow();
+    expect(fallback).toEqual(["safe\n"]);
+  });
+
+  it("normalizes permissions on a pre-existing directory and log file", async () => {
+    const root = await temporaryDirectory();
+    const directory = join(root, "logs");
+    const path = join(directory, "client.log");
+    await mkdir(directory, { mode: 0o777 });
+    await writeFile(path, "existing\n", { mode: 0o666 });
+    await chmod(directory, 0o777);
+    await chmod(path, 0o666);
+
+    const stream = new RotatingFileStream(directory);
+    stream.write("new\n");
+    stream.close();
+
+    expect((await stat(directory)).mode & 0o777).toBe(0o700);
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    expect(await readFile(path, "utf8")).toBe("existing\nnew\n");
+  });
+
+  it("rejects a symlinked log directory without touching its target", async () => {
+    const root = await temporaryDirectory();
+    const target = join(root, "target");
+    const directory = join(root, "logs");
+    await mkdir(target);
+    await symlink(target, directory, "dir");
+    const fallback: string[] = [];
+
+    const stream = new RotatingFileStream(directory, { fallbackWrite: (chunk) => fallback.push(chunk) });
+    stream.write("safe\n");
+
+    expect(fallback).toEqual(["safe\n"]);
+    await expect(readFile(join(target, "client.log"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a symlinked log file without touching its target", async () => {
+    const root = await temporaryDirectory();
+    const directory = join(root, "logs");
+    const target = join(root, "target.log");
+    await mkdir(directory);
+    await writeFile(target, "unchanged\n");
+    await symlink(target, join(directory, "client.log"));
+    const fallback: string[] = [];
+
+    const stream = new RotatingFileStream(directory, { fallbackWrite: (chunk) => fallback.push(chunk) });
+    stream.write("safe\n");
+
+    expect(fallback).toEqual(["safe\n"]);
+    expect(await readFile(target, "utf8")).toBe("unchanged\n");
+  });
+
+  it("rejects a non-regular log path", async () => {
+    const root = await temporaryDirectory();
+    const directory = join(root, "logs");
+    await mkdir(join(directory, "client.log"), { recursive: true });
+    const fallback: string[] = [];
+
+    const stream = new RotatingFileStream(directory, { fallbackWrite: (chunk) => fallback.push(chunk) });
+    stream.write("safe\n");
+
     expect(fallback).toEqual(["safe\n"]);
   });
 

--- a/packages/client/src/observability/__tests__/rotating-file-stream.test.ts
+++ b/packages/client/src/observability/__tests__/rotating-file-stream.test.ts
@@ -1,0 +1,91 @@
+import { writeSync } from "node:fs";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { RotatingFileStream } from "../rotating-file-stream.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("RotatingFileStream", () => {
+  it("creates private paths and rotates oldest-first within the backup limit", async () => {
+    const root = await temporaryDirectory();
+    const directory = join(root, "logs");
+    const stream = new RotatingFileStream(directory, { maxBackups: 2, maxBytes: 5 });
+    stream.write("one\n");
+    stream.write("two\n");
+    stream.write("three\n");
+    stream.write("four\n");
+    stream.close();
+
+    expect((await stat(directory)).mode & 0o777).toBe(0o700);
+    expect((await stat(join(directory, "client.log"))).mode & 0o777).toBe(0o600);
+    expect(await readFile(join(directory, "client.log"), "utf8")).toBe("four\n");
+    expect(await readFile(join(directory, "client.log.1"), "utf8")).toBe("three\n");
+    expect(await readFile(join(directory, "client.log.2"), "utf8")).toBe("two\n");
+  });
+
+  it("switches permanently to stderr fallback when the file sink cannot open", async () => {
+    const root = await temporaryDirectory();
+    const blocked = join(root, "not-a-directory");
+    await writeFile(blocked, "file");
+    const fallback: string[] = [];
+    const stream = new RotatingFileStream(blocked, {
+      fallbackWrite: (chunk) => fallback.push(chunk),
+    });
+    expect(() => stream.write("safe\n")).not.toThrow();
+    expect(fallback).toEqual(["safe\n"]);
+  });
+
+  it("falls back without throwing when rotation fails", async () => {
+    const directory = await temporaryDirectory();
+    const fallback: string[] = [];
+    const stream = new RotatingFileStream(directory, {
+      fallbackWrite: (chunk) => fallback.push(chunk),
+      maxBytes: 4,
+      operations: {
+        rename: () => {
+          throw Object.assign(new Error("rename failed"), { code: "EACCES" });
+        },
+      },
+    });
+    stream.write("one\n");
+    expect(() => stream.write("two\n")).not.toThrow();
+    expect(fallback).toEqual(["two\n"]);
+  });
+
+  it("loops until a short synchronous write completes the NDJSON line", async () => {
+    const directory = await temporaryDirectory();
+    const stream = new RotatingFileStream(directory, {
+      operations: {
+        write: (fileDescriptor, buffer, offset, length) =>
+          writeSync(fileDescriptor, buffer, offset, Math.min(1, length)),
+      },
+    });
+    stream.write('{"message":"complete"}\n');
+    stream.close();
+    expect(await readFile(join(directory, "client.log"), "utf8")).toBe('{"message":"complete"}\n');
+  });
+
+  it("swallows a second failure in the synchronous fallback", async () => {
+    const root = await temporaryDirectory();
+    const blocked = join(root, "not-a-directory");
+    await writeFile(blocked, "file");
+    const stream = new RotatingFileStream(blocked, {
+      fallbackWrite: () => {
+        throw new Error("stderr unavailable");
+      },
+    });
+    expect(() => stream.write("safe\n")).not.toThrow();
+  });
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "opentag-rotation-"));
+  directories.push(directory);
+  return directory;
+}

--- a/packages/client/src/observability/logger.ts
+++ b/packages/client/src/observability/logger.ts
@@ -1,0 +1,125 @@
+import { resolve } from "node:path";
+import pino, { type DestinationStream, type Logger as PinoLogger } from "pino";
+import { RotatingFileStream, writeStringToFileDescriptor } from "./rotating-file-stream.js";
+
+export type ClientLogBindings = Readonly<Record<string, unknown>>;
+
+export interface ClientLogger {
+  child(bindings: ClientLogBindings): ClientLogger;
+  debug(fields: ClientLogBindings, message: string): void;
+  error(fields: ClientLogBindings, message: string): void;
+  info(fields: ClientLogBindings, message: string): void;
+  warn(fields: ClientLogBindings, message: string): void;
+}
+
+interface CreateLoggerOptions {
+  destination?: "configured" | "stderr";
+}
+
+const LOG_LEVELS = new Set(["trace", "debug", "info", "warn", "error", "fatal"]);
+const SENSITIVE_KEYS = [
+  "password",
+  "token",
+  "accessToken",
+  "refreshToken",
+  "jwt",
+  "secret",
+  "apiKey",
+  "api_key",
+  "credentials",
+  "authorization",
+] as const;
+const REDACT_PATHS = [
+  ...SENSITIVE_KEYS,
+  ...SENSITIVE_KEYS.map((key) => `*.${key}`),
+  "headers.authorization",
+  "headers.cookie",
+  "*.headers.authorization",
+  "*.headers.cookie",
+];
+
+let serviceDirectory: string | undefined;
+let serviceStream: RotatingFileStream | undefined;
+let rootLogger: PinoLogger | undefined;
+
+export function configureClientLoggerForService(logDirectory: string): void {
+  const canonicalDirectory = resolve(logDirectory);
+  if (serviceDirectory && serviceDirectory !== canonicalDirectory) {
+    throw new Error("The Client logger is already configured for a different log directory");
+  }
+  if (serviceDirectory) return;
+  serviceDirectory = canonicalDirectory;
+  serviceStream = new RotatingFileStream(canonicalDirectory);
+  rootLogger = undefined;
+}
+
+export function createLogger(module: string, options: CreateLoggerOptions = {}): ClientLogger {
+  return adapt(options.destination === "stderr" ? buildRoot(stderrDestination(), false) : root(), { module });
+}
+
+export function resetClientLoggerForTests(): void {
+  serviceStream?.close();
+  serviceDirectory = undefined;
+  serviceStream = undefined;
+  rootLogger = undefined;
+}
+
+function root(): PinoLogger {
+  if (rootLogger) return rootLogger;
+  rootLogger = buildRoot(serviceStream ?? stderrDestination(), serviceDirectory !== undefined);
+  return rootLogger;
+}
+
+function buildRoot(destination: DestinationStream, serviceMode: boolean): PinoLogger {
+  const configured = process.env.OPENTAG_LOG_LEVEL;
+  const validConfigured = configured && LOG_LEVELS.has(configured) ? configured : undefined;
+  const level =
+    validConfigured ??
+    (configured ? "info" : process.env.NODE_ENV === "test" ? "silent" : serviceMode ? "info" : "warn");
+  const logger = pino(
+    {
+      base: null,
+      level,
+      messageKey: "message",
+      redact: { paths: REDACT_PATHS, censor: "[REDACTED]" },
+      timestamp: pino.stdTimeFunctions.isoTime,
+    },
+    destination,
+  );
+  if (configured && !validConfigured) {
+    logger.warn({ module: "logger" }, "Invalid OPENTAG_LOG_LEVEL; using info");
+  }
+  return logger;
+}
+
+function stderrDestination(): DestinationStream {
+  return {
+    write(chunk: string) {
+      try {
+        writeStringToFileDescriptor(2, chunk);
+      } catch {
+        // Logging failures never escape into runtime behavior.
+      }
+    },
+  };
+}
+
+function adapt(logger: PinoLogger, bindings: ClientLogBindings): ClientLogger {
+  const write = (method: "debug" | "error" | "info" | "warn", fields: ClientLogBindings, message: string) =>
+    safeWrite(() => logger[method]({ ...bindings, ...fields }, message));
+  return {
+    child: (childBindings) => adapt(logger, { ...bindings, ...childBindings }),
+    debug: (fields, message) => write("debug", fields, message),
+    error: (fields, message) => write("error", fields, message),
+    info: (fields, message) => write("info", fields, message),
+    warn: (fields, message) => write("warn", fields, message),
+  };
+}
+
+function safeWrite(write: () => void): void {
+  try {
+    write();
+  } catch {
+    // Observability is deliberately isolated from business behavior.
+  }
+}

--- a/packages/client/src/observability/rotating-file-stream.ts
+++ b/packages/client/src/observability/rotating-file-stream.ts
@@ -1,8 +1,10 @@
+import type { Stats } from "node:fs";
 import {
-  chmodSync,
   closeSync,
-  existsSync,
+  constants,
+  fchmodSync,
   fstatSync,
+  lstatSync,
   mkdirSync,
   openSync,
   renameSync,
@@ -23,22 +25,22 @@ export interface RotatingFileStreamOptions {
 }
 
 export interface RotatingFileOperations {
-  chmod(path: string, mode: number): void;
   close(fileDescriptor: number): void;
-  exists(path: string): boolean;
-  fileSize(fileDescriptor: number): number;
+  fileStatus(fileDescriptor: number): Stats;
+  fchmod(fileDescriptor: number, mode: number): void;
+  lstat(path: string): Stats;
   makeDirectory(path: string, mode: number): void;
-  open(path: string, flags: string, mode: number): number;
+  open(path: string, flags: number, mode: number): number;
   rename(from: string, to: string): void;
   unlink(path: string): void;
   write(fileDescriptor: number, buffer: Buffer, offset: number, length: number): number;
 }
 
 const defaultOperations: RotatingFileOperations = {
-  chmod: chmodSync,
   close: closeSync,
-  exists: existsSync,
-  fileSize: (fileDescriptor) => fstatSync(fileDescriptor).size,
+  fileStatus: fstatSync,
+  fchmod: fchmodSync,
+  lstat: lstatSync,
   makeDirectory: (path, mode) => mkdirSync(path, { recursive: true, mode }),
   open: openSync,
   rename: renameSync,
@@ -100,13 +102,8 @@ export class RotatingFileStream {
 
   #open(): void {
     try {
-      const directoryExisted = this.#operations.exists(this.directory);
-      this.#operations.makeDirectory(this.directory, 0o700);
-      if (!directoryExisted) this.#operations.chmod(this.directory, 0o700);
-      const fileExisted = this.#operations.exists(this.path);
-      this.#fileDescriptor = this.#operations.open(this.path, "a", 0o600);
-      if (!fileExisted) this.#operations.chmod(this.path, 0o600);
-      this.#bytes = this.#operations.fileSize(this.#fileDescriptor);
+      this.#ensurePrivateDirectory();
+      this.#openLogFile();
     } catch {
       this.#failover();
     }
@@ -119,9 +116,54 @@ export class RotatingFileStream {
       this.#renameIfPresent(`${this.path}.${index}`, `${this.path}.${index + 1}`);
     }
     this.#renameIfPresent(this.path, `${this.path}.1`);
-    this.#fileDescriptor = this.#operations.open(this.path, "a", 0o600);
-    this.#operations.chmod(this.path, 0o600);
-    this.#bytes = 0;
+    this.#openLogFile();
+  }
+
+  #ensurePrivateDirectory(): void {
+    this.#operations.makeDirectory(this.directory, 0o700);
+    const pathStatus = this.#operations.lstat(this.directory);
+    if (!pathStatus.isDirectory() || pathStatus.isSymbolicLink()) {
+      throw new Error("Client log directory must be a real directory");
+    }
+    const fileDescriptor = this.#operations.open(
+      this.directory,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+      0o700,
+    );
+    try {
+      const openedStatus = this.#operations.fileStatus(fileDescriptor);
+      if (!openedStatus.isDirectory()) throw new Error("Client log directory changed during open");
+      this.#operations.fchmod(fileDescriptor, 0o700);
+    } finally {
+      this.#operations.close(fileDescriptor);
+    }
+  }
+
+  #openLogFile(): void {
+    try {
+      const pathStatus = this.#operations.lstat(this.path);
+      if (!pathStatus.isFile() || pathStatus.isSymbolicLink()) {
+        throw new Error("Client log path must be a regular file");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+
+    const fileDescriptor = this.#operations.open(
+      this.path,
+      constants.O_APPEND | constants.O_CREAT | constants.O_WRONLY | constants.O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      const openedStatus = this.#operations.fileStatus(fileDescriptor);
+      if (!openedStatus.isFile()) throw new Error("Client log path changed during open");
+      this.#operations.fchmod(fileDescriptor, 0o600);
+      this.#fileDescriptor = fileDescriptor;
+      this.#bytes = openedStatus.size;
+    } catch (error) {
+      this.#operations.close(fileDescriptor);
+      throw error;
+    }
   }
 
   #renameIfPresent(from: string, to: string): void {

--- a/packages/client/src/observability/rotating-file-stream.ts
+++ b/packages/client/src/observability/rotating-file-stream.ts
@@ -1,0 +1,179 @@
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+export const CLIENT_LOG_FILE_NAME = "client.log";
+export const CLIENT_LOG_MAX_BYTES = 10 * 1024 * 1024;
+export const CLIENT_LOG_BACKUPS = 7;
+
+export interface RotatingFileStreamOptions {
+  fallbackWrite?: (chunk: string) => void;
+  operations?: Partial<RotatingFileOperations>;
+  maxBackups?: number;
+  maxBytes?: number;
+}
+
+export interface RotatingFileOperations {
+  chmod(path: string, mode: number): void;
+  close(fileDescriptor: number): void;
+  exists(path: string): boolean;
+  fileSize(fileDescriptor: number): number;
+  makeDirectory(path: string, mode: number): void;
+  open(path: string, flags: string, mode: number): number;
+  rename(from: string, to: string): void;
+  unlink(path: string): void;
+  write(fileDescriptor: number, buffer: Buffer, offset: number, length: number): number;
+}
+
+const defaultOperations: RotatingFileOperations = {
+  chmod: chmodSync,
+  close: closeSync,
+  exists: existsSync,
+  fileSize: (fileDescriptor) => fstatSync(fileDescriptor).size,
+  makeDirectory: (path, mode) => mkdirSync(path, { recursive: true, mode }),
+  open: openSync,
+  rename: renameSync,
+  unlink: unlinkSync,
+  write: (fileDescriptor, buffer, offset, length) => writeSync(fileDescriptor, buffer, offset, length),
+};
+
+export class RotatingFileStream {
+  readonly directory: string;
+  readonly path: string;
+  readonly #fallbackWrite: (chunk: string) => void;
+  readonly #maxBackups: number;
+  readonly #maxBytes: number;
+  readonly #operations: RotatingFileOperations;
+  #bytes = 0;
+  #failed = false;
+  #fileDescriptor?: number;
+
+  constructor(directory: string, options: RotatingFileStreamOptions = {}) {
+    this.directory = resolve(directory);
+    this.path = join(this.directory, CLIENT_LOG_FILE_NAME);
+    this.#fallbackWrite = options.fallbackWrite ?? ((chunk) => writeStringToFileDescriptor(2, chunk));
+    this.#operations = { ...defaultOperations, ...options.operations };
+    this.#maxBackups = options.maxBackups ?? CLIENT_LOG_BACKUPS;
+    this.#maxBytes = options.maxBytes ?? CLIENT_LOG_MAX_BYTES;
+    if (!Number.isSafeInteger(this.#maxBackups) || this.#maxBackups < 1) {
+      throw new Error("Client log backup count must be a positive safe integer");
+    }
+    if (!Number.isSafeInteger(this.#maxBytes) || this.#maxBytes < 1) {
+      throw new Error("Client log size limit must be a positive safe integer");
+    }
+    this.#open();
+  }
+
+  write(chunk: string): boolean {
+    if (this.#failed) return this.#writeFallback(chunk);
+    try {
+      const bytes = Buffer.from(chunk, "utf8");
+      if (this.#bytes > 0 && this.#bytes + bytes.byteLength > this.#maxBytes) this.#rotate();
+      if (this.#fileDescriptor === undefined) throw new Error("Client log file is unavailable");
+      this.#writeFully(this.#fileDescriptor, bytes);
+      this.#bytes += bytes.byteLength;
+    } catch {
+      this.#failover();
+      this.#writeFallback(chunk);
+    }
+    return true;
+  }
+
+  close(): void {
+    if (this.#fileDescriptor === undefined) return;
+    try {
+      this.#operations.close(this.#fileDescriptor);
+    } catch {
+      // Logging cleanup must never affect runtime shutdown.
+    }
+    this.#fileDescriptor = undefined;
+  }
+
+  #open(): void {
+    try {
+      const directoryExisted = this.#operations.exists(this.directory);
+      this.#operations.makeDirectory(this.directory, 0o700);
+      if (!directoryExisted) this.#operations.chmod(this.directory, 0o700);
+      const fileExisted = this.#operations.exists(this.path);
+      this.#fileDescriptor = this.#operations.open(this.path, "a", 0o600);
+      if (!fileExisted) this.#operations.chmod(this.path, 0o600);
+      this.#bytes = this.#operations.fileSize(this.#fileDescriptor);
+    } catch {
+      this.#failover();
+    }
+  }
+
+  #rotate(): void {
+    this.close();
+    this.#removeIfPresent(`${this.path}.${this.#maxBackups}`);
+    for (let index = this.#maxBackups - 1; index >= 1; index -= 1) {
+      this.#renameIfPresent(`${this.path}.${index}`, `${this.path}.${index + 1}`);
+    }
+    this.#renameIfPresent(this.path, `${this.path}.1`);
+    this.#fileDescriptor = this.#operations.open(this.path, "a", 0o600);
+    this.#operations.chmod(this.path, 0o600);
+    this.#bytes = 0;
+  }
+
+  #renameIfPresent(from: string, to: string): void {
+    try {
+      this.#operations.rename(from, to);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+
+  #removeIfPresent(path: string): void {
+    try {
+      this.#operations.unlink(path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+
+  #failover(): void {
+    this.close();
+    this.#failed = true;
+  }
+
+  #writeFallback(chunk: string): boolean {
+    try {
+      this.#fallbackWrite(chunk);
+    } catch {
+      // A broken diagnostic destination must remain isolated from the runtime.
+    }
+    return true;
+  }
+
+  #writeFully(fileDescriptor: number, buffer: Buffer): void {
+    let offset = 0;
+    while (offset < buffer.byteLength) {
+      const written = this.#operations.write(fileDescriptor, buffer, offset, buffer.byteLength - offset);
+      if (!Number.isSafeInteger(written) || written <= 0 || written > buffer.byteLength - offset) {
+        throw new Error("Client log write returned an invalid byte count");
+      }
+      offset += written;
+    }
+  }
+}
+
+export function writeStringToFileDescriptor(fileDescriptor: number, chunk: string): void {
+  const buffer = Buffer.from(chunk, "utf8");
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    const written = writeSync(fileDescriptor, buffer, offset, buffer.byteLength - offset);
+    if (!Number.isSafeInteger(written) || written <= 0 || written > buffer.byteLength - offset) {
+      throw new Error("Diagnostic write returned an invalid byte count");
+    }
+    offset += written;
+  }
+}

--- a/packages/client/src/runtime/client-runtime.ts
+++ b/packages/client/src/runtime/client-runtime.ts
@@ -8,6 +8,7 @@ import {
   SessionReconcileResultSchema,
   type TurnReportResult,
 } from "@opentag/shared";
+import { type ClientLogger, createLogger } from "../observability/logger.js";
 import type { RuntimeConnection } from "./runtime-connection.js";
 import { SessionReconciler } from "./session-reconciler.js";
 
@@ -17,6 +18,7 @@ export interface DeliveryDecision {
 }
 
 export interface ClientRuntimeOptions {
+  logger?: ClientLogger;
   handleDelivery?(request: DirectImMessageDeliveryRequest): Promise<DeliveryDecision> | DeliveryDecision;
   handleTurnReportResult?(result: TurnReportResult): Promise<void> | void;
   onReconcileResultSendFailed?(
@@ -36,12 +38,14 @@ export class ClientRuntime {
   readonly reconciler: SessionReconciler;
   readonly #connection: RuntimeConnection;
   readonly #options: ClientRuntimeOptions;
+  readonly #logger: ClientLogger;
   readonly #abort = new AbortController();
   #unsubscribe?: () => void;
 
   constructor(connection: RuntimeConnection, options: ClientRuntimeOptions = {}) {
     this.#connection = connection;
     this.#options = options;
+    this.#logger = options.logger ?? createLogger("client-runtime");
     this.reconciler = options.reconciler ?? new SessionReconciler({ computerId: connection.computerId });
   }
 
@@ -65,6 +69,13 @@ export class ClientRuntime {
     if (!parsed.success || this.#abort.signal.aborted) return;
     const frame = parsed.data;
     if (frame.type === "session:reconcile") {
+      const fields = {
+        agentId: frame.agentId,
+        placementGeneration: frame.placementGeneration,
+        requestId: frame.requestId,
+        sessionId: frame.sessionId,
+      };
+      this.#logger.debug(fields, "Session reconcile received");
       const reconciled = await this.reconciler.reconcile(frame);
       const result = SessionReconcileResultSchema.parse(
         (await this.#options.prepareReconcileResult?.(frame, reconciled)) ?? reconciled,
@@ -72,13 +83,23 @@ export class ClientRuntime {
       try {
         await this.#connection.send(result, { priority: "result", signal: this.#abort.signal });
       } catch (error) {
+        this.#logger.warn({ ...fields, status: result.status }, "Session reconcile result send failed");
         await this.#options.onReconcileResultSendFailed?.(frame, result, error);
         throw error;
       }
+      this.#logger.debug({ ...fields, reason: result.reason, status: result.status }, "Session reconcile completed");
       await this.#options.onReconciled?.(frame, result);
       return;
     }
     if (frame.type === "im:deliver") {
+      const fields = {
+        agentId: frame.agentId,
+        deliveryId: frame.deliveryId,
+        placementGeneration: frame.placementGeneration,
+        requestId: frame.requestId,
+        sessionId: frame.sessionId,
+      };
+      this.#logger.debug(fields, "IM delivery received");
       const reason = this.reconciler.checkDelivery(frame);
       const decision = reason
         ? { result: rejectedDelivery(frame, reason) }
@@ -87,6 +108,9 @@ export class ClientRuntime {
           });
       const result = ImMessageDeliveryResultSchema.parse(decision.result);
       await this.#connection.send(result, { priority: "result", signal: this.#abort.signal });
+      const resultFields = { ...fields, reason: result.reason, status: result.status };
+      if (result.status === "accepted") this.#logger.debug(resultFields, "IM delivery accepted");
+      else this.#logger.warn(resultFields, "IM delivery rejected");
       if (result.status === "accepted") await decision.onAcceptedSent?.();
       return;
     }

--- a/packages/client/src/runtime/codex-client-runtime.ts
+++ b/packages/client/src/runtime/codex-client-runtime.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { delimiter, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { computeRuntimeSnapshotHashes, type InputRejectReason } from "@opentag/shared";
+import { type ClientLogger, createLogger } from "../observability/logger.js";
 import { CodexAdapter, CodexLocalPolicy, codexProviderEnvironment } from "../providers/codex/adapter.js";
 import { RuntimeStorageError } from "../storage/durable-file.js";
 import { AgentWorkspaceManager } from "./agent-workspace.js";
@@ -27,7 +28,7 @@ export interface CreateCodexClientRuntimeOptions {
   codexHome?: string;
   environment?: NodeJS.ProcessEnv;
   home: string;
-  log?: (message: string) => void;
+  logger?: ClientLogger;
   probe?: (command: string, environment: NodeJS.ProcessEnv, signal?: AbortSignal) => Promise<void>;
   signal?: AbortSignal;
 }
@@ -81,6 +82,7 @@ export async function createCodexClientRuntime(
   connection: RuntimeConnection,
   options: CreateCodexClientRuntimeOptions,
 ): Promise<CodexClientRuntime> {
+  const moduleLogger = (module: string) => options.logger?.child({ module }) ?? createLogger(module);
   const sourceEnvironment = options.environment ?? process.env;
   options.signal?.throwIfAborted();
   const defaultHome = sourceEnvironment.HOME ?? homedir();
@@ -115,7 +117,7 @@ export async function createCodexClientRuntime(
   const reportOwner = new TurnReportOwner({ connection });
   const mvpReportRecovery = new MvpTurnReportRecovery({
     bindingStore,
-    log: options.log,
+    logger: moduleLogger("report-recovery"),
     reconciler,
     reportOwner,
   });
@@ -150,11 +152,12 @@ export async function createCodexClientRuntime(
     bindingStore,
     connection,
     custody,
-    log: options.log,
+    logger: moduleLogger("turn"),
     reportOwner,
     workspace,
   });
   const runtime = new ClientRuntime(connection, {
+    logger: moduleLogger("client-runtime"),
     reconciler,
     handleDelivery: (request) => custody.accept(request),
     handleTurnReportResult: async (result) => {

--- a/packages/client/src/runtime/codex-turn-runner.ts
+++ b/packages/client/src/runtime/codex-turn-runner.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { TurnFailureReason, TurnReportHashInput, TurnReportRequest } from "@opentag/shared";
+import { type ClientLogger, createLogger } from "../observability/logger.js";
 import { type CodexAdapter, CodexTurnError, type CodexTurnOutcome } from "../providers/codex/adapter.js";
 import { CodexAppServerError } from "../providers/codex/app-server-wire.js";
 import type { AgentWorkspaceManager } from "./agent-workspace.js";
@@ -14,7 +15,7 @@ export interface CodexTurnRunnerOptions {
   bindingStore: SessionBindingStore;
   connection: Pick<RuntimeConnection, "send">;
   custody: Pick<TurnCustodyOwner, "markReporting" | "recordResult">;
-  log?: (message: string) => void;
+  logger?: ClientLogger;
   now?: () => number;
   reportOwner: TurnReportOwner;
   workspace: AgentWorkspaceManager;
@@ -38,7 +39,7 @@ export class CodexTurnRunner {
   readonly #bindingStore: SessionBindingStore;
   readonly #connection: Pick<RuntimeConnection, "send">;
   readonly #custody: Pick<TurnCustodyOwner, "markReporting" | "recordResult">;
-  readonly #log?: (message: string) => void;
+  readonly #logger: ClientLogger;
   readonly #now: () => number;
   readonly #reportOwner: TurnReportOwner;
   readonly #workspace: AgentWorkspaceManager;
@@ -50,7 +51,7 @@ export class CodexTurnRunner {
     this.#bindingStore = options.bindingStore;
     this.#connection = options.connection;
     this.#custody = options.custody;
-    this.#log = options.log;
+    this.#logger = options.logger ?? createLogger("turn");
     this.#now = options.now ?? Date.now;
     this.#reportOwner = options.reportOwner;
     this.#workspace = options.workspace;
@@ -82,6 +83,14 @@ export class CodexTurnRunner {
   }
 
   async #run(owner: LiveTurnOwner, shutdownSignal: AbortSignal): Promise<void> {
+    const startedAt = this.#now();
+    const fields = {
+      agentId: owner.request.agentId,
+      deliveryId: owner.request.deliveryId,
+      sessionId: owner.request.sessionId,
+      turnId: owner.turnId,
+    };
+    this.#logger.info(fields, "Turn started");
     const timeout = new AbortController();
     const timeoutMs = turnTimeoutMs(owner, this.#now());
     const timer = setTimeout(() => timeout.abort("turn_timeout"), timeoutMs);
@@ -146,16 +155,33 @@ export class CodexTurnRunner {
               ...(result.usage ? { usage: result.usage } : {}),
             };
     } catch (error) {
-      if (error instanceof CodexTurnError && error.cause instanceof CodexAppServerError) {
-        this.#log?.(`Turn ${owner.turnId} failed at the Codex boundary (${error.cause.code})`);
-      }
       completion = completionForError(error, signal.reason);
+      const failureFields = {
+        ...fields,
+        durationMs: Math.max(0, this.#now() - startedAt),
+        errorReason: completion.errorReason,
+        outcome: completion.outcome,
+        ...(error instanceof CodexTurnError && error.cause instanceof CodexAppServerError
+          ? { providerCode: error.cause.code }
+          : {}),
+      };
+      if (error instanceof CodexTurnError || signal.aborted) {
+        this.#logger.warn(failureFields, "Turn failed");
+      } else {
+        this.#logger.error(failureFields, "Turn failed unexpectedly");
+      }
       trace.turnCompleted(completion.outcome);
     } finally {
       clearTimeout(timer);
     }
 
     const traceSummary = await trace.finish();
+    if (completion.outcome === "completed") {
+      this.#logger.info(
+        { ...fields, durationMs: Math.max(0, this.#now() - startedAt), outcome: completion.outcome },
+        "Turn completed",
+      );
+    }
     const reportInput: TurnReportHashInput = {
       deliveryId: owner.request.deliveryId,
       turnId: owner.turnId,
@@ -174,7 +200,7 @@ export class CodexTurnRunner {
       report = this.#reportOwner.create(reportInput);
       await this.#custody.markReporting(owner.turnId, report);
     } catch {
-      this.#log?.(`Turn ${owner.turnId} could not enter the reporting phase`);
+      this.#logger.warn(fields, "Turn could not enter the reporting phase");
       return;
     }
     void this.#reportOwner

--- a/packages/client/src/runtime/mvp-turn-report-recovery.ts
+++ b/packages/client/src/runtime/mvp-turn-report-recovery.ts
@@ -4,13 +4,14 @@ import {
   type SessionReconcileResult,
   type TurnReportRequest,
 } from "@opentag/shared";
+import { type ClientLogger, createLogger } from "../observability/logger.js";
 import type { SessionBindingStore } from "./session-binding-store.js";
 import type { SessionReconciler } from "./session-reconciler.js";
 import type { TurnReportOwner } from "./turn-report-owner.js";
 
 export interface MvpTurnReportRecoveryOptions {
   bindingStore: Pick<SessionBindingStore, "read" | "recordResult">;
-  log?: (message: string) => void;
+  logger?: ClientLogger;
   maxActiveReplays?: number;
   maxPreparedBatches?: number;
   reconciler: Pick<SessionReconciler, "clearRecovery" | "withAgentLock">;
@@ -38,7 +39,7 @@ interface ReplayQueue {
 // Turn storage replaces this reconcile manifest and replay queue after MVP.
 export class MvpTurnReportRecovery {
   readonly #bindingStore: MvpTurnReportRecoveryOptions["bindingStore"];
-  readonly #log?: (message: string) => void;
+  readonly #logger: ClientLogger;
   readonly #maxActiveReplays: number;
   readonly #maxPreparedBatches: number;
   readonly #reconciler: MvpTurnReportRecoveryOptions["reconciler"];
@@ -49,7 +50,7 @@ export class MvpTurnReportRecovery {
 
   constructor(options: MvpTurnReportRecoveryOptions) {
     this.#bindingStore = options.bindingStore;
-    this.#log = options.log;
+    this.#logger = options.logger ?? createLogger("report-recovery");
     this.#maxActiveReplays = options.maxActiveReplays ?? 10;
     this.#maxPreparedBatches = options.maxPreparedBatches ?? 256;
     this.#reconciler = options.reconciler;
@@ -104,7 +105,10 @@ export class MvpTurnReportRecovery {
       running: false,
     };
     if (queue.agentId !== batch.agentId) {
-      this.#log?.(`MVP Turn Report replay for Session ${batch.sessionId} has a conflicting Agent owner`);
+      this.#logger.warn(
+        { agentId: batch.agentId, sessionId: batch.sessionId },
+        "Turn Report replay has a conflicting Agent owner",
+      );
       return;
     }
     if (!this.#queues.has(batch.sessionId)) this.#queues.set(batch.sessionId, queue);
@@ -151,6 +155,7 @@ export class MvpTurnReportRecovery {
   }
 
   async #runQueue(sessionId: string, queue: ReplayQueue): Promise<boolean> {
+    this.#logger.info({ agentId: queue.agentId, sessionId }, "Turn Report replay started");
     try {
       while (queue.references.length > 0) {
         const reference = queue.references[0];
@@ -179,15 +184,19 @@ export class MvpTurnReportRecovery {
           )
           .then(() => "recorded" as const);
         if ((await Promise.race([submitted, terminal])) === "terminal") {
-          this.#log?.(`MVP Turn Report replay for Session ${sessionId} reached a terminal Server status`);
+          this.#logger.warn(
+            { agentId: queue.agentId, sessionId, turnId: report.turnId },
+            "Turn Report replay reached a terminal Server status",
+          );
           return false;
         }
         queue.references.shift();
         queue.keys.delete(reportKey(reference));
       }
+      this.#logger.info({ agentId: queue.agentId, sessionId }, "Turn Report replay completed");
       return true;
     } catch {
-      this.#log?.(`MVP Turn Report replay for Session ${sessionId} remains pending`);
+      this.#logger.warn({ agentId: queue.agentId, sessionId }, "Turn Report replay remains pending");
       return false;
     }
   }

--- a/packages/client/src/runtime/runtime-connection.ts
+++ b/packages/client/src/runtime/runtime-connection.ts
@@ -12,6 +12,7 @@ import {
 import WebSocket, { type RawData } from "ws";
 import { OpenTagApiError } from "../api.js";
 import type { AccessTokenProvider } from "../auth/token-provider.js";
+import { type ClientLogger, createLogger } from "../observability/logger.js";
 import type { ComputerIdentity } from "./computer-identity.js";
 
 const SERVER_CONTROL_FRAME_TYPES = new Set([
@@ -84,7 +85,7 @@ export interface RuntimeConnectionOptions {
   handshakeTimeoutMs?: number;
   instanceId: string;
   jitter?: () => number;
-  log?: (message: string) => void;
+  logger?: ClientLogger;
   now?: () => number;
   parseBusinessFrame?: (value: unknown) => RuntimeBusinessFrame | undefined;
   platform: "darwin" | "linux" | "win32";
@@ -128,6 +129,7 @@ const defaultQueueLimits: RuntimeQueueLimits = {
 
 export class RuntimeConnection {
   readonly #options: RuntimeConnectionOptions;
+  readonly #logger: ClientLogger;
   readonly #scheduler: RuntimeScheduler;
   readonly #now: () => number;
   readonly #queueLimits: RuntimeQueueLimits;
@@ -146,6 +148,10 @@ export class RuntimeConnection {
 
   constructor(options: RuntimeConnectionOptions) {
     this.#options = options;
+    this.#logger = (options.logger ?? createLogger("connection")).child({
+      computerId: options.computer.computerId,
+      instanceId: options.instanceId,
+    });
     this.#scheduler = options.scheduler ?? defaultScheduler;
     this.#now = options.now ?? Date.now;
     this.#queueLimits = { ...defaultQueueLimits, ...options.queueLimits };
@@ -221,23 +227,41 @@ export class RuntimeConnection {
       while (!this.#stopped) {
         try {
           this.#setState("connecting");
+          this.#logger.debug({ attempt: attempt + 1, state: "connecting" }, "Runtime connection attempt started");
           await this.#connectOnce(() => {
             attempt = 0;
           });
         } catch (error) {
           if (this.#stopped || isAbortError(error)) break;
-          if (error instanceof RuntimeConnectionError && error.fatal) throw error;
+          if (error instanceof RuntimeConnectionError && error.fatal) {
+            this.#logger.error(
+              { attempt: attempt + 1, category: "protocol", state: this.#state },
+              "Runtime connection was rejected",
+            );
+            throw error;
+          }
           if (error instanceof OpenTagApiError && !["transient", "rate_limit"].includes(error.category)) {
+            this.#logger.error(
+              { attempt: attempt + 1, category: error.category, state: this.#state },
+              "Runtime authentication failed",
+            );
             throw new RuntimeConnectionError(`${error.message}; run login again`, true);
           }
           if (error instanceof Error && error.message.includes("not logged in")) {
+            this.#logger.error(
+              { attempt: attempt + 1, category: "credential", state: this.#state },
+              "Runtime authentication failed",
+            );
             throw new RuntimeConnectionError(`${error.message}; run login first`, true);
           }
           attempt += 1;
           const maximum = Math.min(30_000, 1_000 * 2 ** Math.min(attempt - 1, 5));
           const jitter = Math.min(1, Math.max(0, this.#options.jitter?.() ?? Math.random()));
           const delay = Math.floor(maximum * jitter);
-          this.#options.log?.(`Runtime connection lost; retrying in ${delay}ms`);
+          this.#logger.warn(
+            { attempt, category: connectionErrorCategory(error), delayMs: delay, state: this.#state },
+            "Runtime connection lost; retry scheduled",
+          );
           try {
             await this.#waitForRetry(delay);
           } catch (retryError) {
@@ -477,7 +501,7 @@ export class RuntimeConnection {
           this.#setState("registered");
           this.#resolveRegisteredWaiters();
           onRegistered();
-          this.#options.log?.(`Computer ${this.#options.computer.computerId} connected`);
+          this.#logger.info({ state: "registered" }, "Runtime connection registered");
           armSilence();
           scheduleHeartbeat();
           const remaining = Date.parse(serverTokenExpiresAt ?? lease.expiresAt) - this.#now();
@@ -688,13 +712,14 @@ export class RuntimeConnection {
     for (const listener of this.#businessListeners) {
       Promise.resolve()
         .then(() => listener(frame))
-        .catch(() => this.#options.log?.("A runtime business frame listener failed"));
+        .catch(() => this.#logger.warn({ category: "listener" }, "Runtime business frame listener failed"));
     }
   }
 
   #setState(state: RuntimeConnectionState): void {
     if (this.#state === state) return;
     this.#state = state;
+    this.#logger.debug({ state }, "Runtime connection state changed");
     for (const listener of this.#stateListeners) this.#notifyStateListener(listener, state);
   }
 
@@ -702,7 +727,7 @@ export class RuntimeConnection {
     try {
       listener(state);
     } catch {
-      this.#options.log?.("A runtime connection state listener failed");
+      this.#logger.warn({ category: "listener", state }, "Runtime connection state listener failed");
     }
   }
 
@@ -737,6 +762,13 @@ export class RuntimeConnection {
       signal.addEventListener("abort", onAbort, { once: true });
     });
   }
+}
+
+function connectionErrorCategory(error: unknown): string {
+  if (error instanceof OpenTagApiError) return error.category;
+  if (error instanceof RuntimeConnectionError) return error.fatal ? "protocol" : "transport";
+  if (error instanceof RuntimeSendError) return error.code;
+  return "unexpected";
 }
 
 function rawDataBuffer(data: RawData): Buffer {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@opentag/shared':
         specifier: workspace:*
         version: link:../shared
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       ws:
         specifier: ^8.21.3
         version: 8.21.3

--- a/scripts/__tests__/release-scripts.test.mjs
+++ b/scripts/__tests__/release-scripts.test.mjs
@@ -205,11 +205,24 @@ test("classifies npm registry lookups without treating errors as absence", () =>
 test("generates complete notices for bundled CLI dependencies", async () => {
   const notices = await generateThirdPartyNotices();
 
-  assert.match(notices, /^## commander@\d+\.\d+\.\d+$/m);
-  assert.match(notices, /^## ws@\d+\.\d+\.\d+$/m);
-  assert.match(notices, /^## zod@\d+\.\d+\.\d+$/m);
+  for (const packageName of [
+    "@pinojs/redact",
+    "atomic-sleep",
+    "commander",
+    "on-exit-leak-free",
+    "pino",
+    "pino-std-serializers",
+    "quick-format-unescaped",
+    "safe-stable-stringify",
+    "sonic-boom",
+    "thread-stream",
+    "ws",
+    "zod",
+  ]) {
+    assert.match(notices, new RegExp(`^## ${packageName.replace("/", "\\/")}@\\d+\\.\\d+\\.\\d+$`, "m"));
+  }
   assert.match(notices, /Copyright \(c\) 2011 TJ Holowaychuk/);
   assert.match(notices, /Copyright \(c\) 2011 Einar Otto Stangvik/);
   assert.match(notices, /Copyright \(c\) 2025 Colin McDonnell/);
-  assert.equal((notices.match(/Permission is hereby granted/g) ?? []).length, 3);
+  assert.equal((notices.match(/Permission is hereby granted/g) ?? []).length, 12);
 });

--- a/scripts/third-party-notices.mjs
+++ b/scripts/third-party-notices.mjs
@@ -9,6 +9,20 @@ const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const noticePath = resolve(projectRoot, "apps/cli/THIRD_PARTY_NOTICES");
 const bundledPackages = [
   { name: "commander", consumerManifest: "apps/cli/package.json" },
+  {
+    name: "pino",
+    consumerManifest: "packages/client/package.json",
+    bundledDependencies: [
+      "@pinojs/redact",
+      "atomic-sleep",
+      "on-exit-leak-free",
+      "pino-std-serializers",
+      "quick-format-unescaped",
+      "safe-stable-stringify",
+      "sonic-boom",
+      "thread-stream",
+    ],
+  },
   { name: "ws", consumerManifest: "apps/cli/package.json" },
   { name: "zod", consumerManifest: "packages/shared/package.json" },
 ];
@@ -58,14 +72,22 @@ export async function generateThirdPartyNotices() {
   for (const bundledPackage of bundledPackages) {
     const consumerPath = resolve(projectRoot, bundledPackage.consumerManifest);
     const packageRequire = createRequire(pathToFileURL(consumerPath));
-    const { manifest, manifestPath } = await findPackageManifest(packageRequire, bundledPackage.name);
-    const license = await readLicense(dirname(manifestPath));
-    sections.push(
-      `## ${manifest.name}@${manifest.version}\n\nSource: ${repositoryUrl(manifest.repository)}\nLicense: ${manifest.license}\n\n${license}`,
-    );
+    const rootPackage = await findPackageManifest(packageRequire, bundledPackage.name);
+    await appendNotice(sections, rootPackage);
+    const dependencyRequire = createRequire(pathToFileURL(rootPackage.manifestPath));
+    for (const dependency of bundledPackage.bundledDependencies ?? []) {
+      await appendNotice(sections, await findPackageManifest(dependencyRequire, dependency));
+    }
   }
 
   return `OpenTag Third-Party Notices\n\nThis distribution includes source code from the following packages.\n\n${sections.join("\n\n---\n\n")}\n`;
+}
+
+async function appendNotice(sections, { manifest, manifestPath }) {
+  const license = await readLicense(dirname(manifestPath));
+  sections.push(
+    `## ${manifest.name}@${manifest.version}\n\nSource: ${repositoryUrl(manifest.repository)}\nLicense: ${manifest.license}\n\n${license}`,
+  );
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

- add a Pino-based `ClientLogger` with structured fields, credential redaction, configurable levels, and a private rotating NDJSON sink at `$OPENTAG_HOME/logs/client.log`
- migrate daemon, connection, client runtime, Turn, and report-recovery diagnostics from string callbacks to structured logger children with minimal correlation IDs
- make logging failures observational only through synchronous stderr fallback, short-write handling, rotation failure isolation, and daemon ownership-scoped logger gating
- update launchd/systemd status output to identify `client.log` as the primary service log while retaining supervisor output as a startup-crash fallback

## Identity and safety boundaries

- `instanceId` remains the per-daemon connection instance and is not treated as `agentId`
- events add only the IDs available at their layer (`computerId`, `agentId`, `sessionId`, `turnId`, `requestId`, `deliveryId`, and `placementGeneration` as applicable)
- no message payloads, prompts, raw frames, provider stderr, credentials, external IM identifiers, database changes, or protocol/trace schema changes are included
- only the daemon holding the canonical-home ownership lease can configure or write the service sink; the entire runtime logger tree is disabled before lease release

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
  - scripts: 12 tests
  - shared: 42 tests
  - client: 103 tests
  - server: 79 tests
  - web: 13 tests
  - CLI: 99 tests
- `git diff --check`
