### PR TITLE
fix: stabilize Agent runtime snapshots and add CLI settings

### DIFF
--- a/apps/cli/src/__tests__/agent.test.ts
+++ b/apps/cli/src/__tests__/agent.test.ts
@@ -1,5 +1,9 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
 import type { Agent } from "@opentag/shared";
 import { describe, expect, it, vi } from "vitest";
+import { createProgram } from "../cli/program.js";
 import { formatAgent, formatAgentCreated, formatAgentList } from "../core/agent/formatting.js";
 import { runAgentCreate, runAgentDelete, runAgentUpdate, selectComputer } from "../core/agent/mutations.js";
 import { runAgentList, runAgentShow } from "../core/agent/queries.js";
@@ -109,6 +113,42 @@ describe("Agent CLI core", () => {
     expect(formatAgentCreated(result)).toContain(agentId);
   });
 
+  it("creates runtime settings and preserves UTF-8 instruction file contents", async () => {
+    const home = await mkdtemp(resolve(tmpdir(), "opentag-agent-cli-"));
+    try {
+      const instructionsFile = resolve(home, "instructions.txt");
+      await writeFile(instructionsFile, "请逐行检查。\n\n", "utf8");
+      const client = api();
+      await runAgentCreate({
+        accessToken: "access",
+        api: client,
+        name: "code-reviewer",
+        displayName: "Code Reviewer",
+        runtimeProvider: "codex",
+        model: "gpt-5",
+        reasoningEffort: "high",
+        instructionsFile,
+        allowedTools: ["opentag_message_send", "opentag_message_reply"],
+        maxDurationMs: "30000",
+      });
+      expect(client.createAgent).toHaveBeenCalledWith("access", teamId, {
+        computerId,
+        displayName: "Code Reviewer",
+        name: "code-reviewer",
+        runtimeProvider: "codex",
+        runtimeConfig: {
+          model: "gpt-5",
+          reasoningEffort: "high",
+          instructions: "请逐行检查。\n\n",
+          allowedTools: ["opentag_message_reply", "opentag_message_send"],
+          maxDurationMs: 30_000,
+        },
+      });
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("lists and formats deterministic Agent projections", async () => {
     const client = api();
     const response = await runAgentList({ accessToken: "access", api: client });
@@ -136,6 +176,125 @@ describe("Agent CLI core", () => {
       "revision conflict",
     );
     expect(client.updateAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates runtime settings and maps explicit clears onto the existing CAS writer", async () => {
+    const client = api();
+    await runAgentUpdate(agentId, {
+      accessToken: "access",
+      api: client,
+      instructions: "",
+      clearModel: true,
+      clearReasoningEffort: true,
+      clearAllowedTools: true,
+      clearMaxDuration: true,
+    });
+    expect(client.updateAgent).toHaveBeenCalledWith("access", agentId, {
+      expectedRevision: 1,
+      runtimeConfig: {
+        model: null,
+        reasoningEffort: null,
+        instructions: "",
+        allowedTools: [],
+        maxDurationMs: null,
+      },
+    });
+  });
+
+  it("rejects conflicting, duplicate, invalid, and empty runtime mutations before API access", async () => {
+    const createConflict = api();
+    await expect(
+      runAgentCreate({
+        accessToken: "access",
+        api: createConflict,
+        name: "code-reviewer",
+        displayName: "Code Reviewer",
+        runtimeProvider: "codex",
+        instructions: "inline",
+        instructionsFile: "/tmp/unused",
+      }),
+    ).rejects.toThrow("cannot be used together");
+    expect(createConflict.me).not.toHaveBeenCalled();
+
+    for (const options of [
+      { model: "gpt-5", clearModel: true },
+      { reasoningEffort: "high", clearReasoningEffort: true },
+      { allowedTools: ["opentag_message_send"], clearAllowedTools: true },
+      { maxDurationMs: "100", clearMaxDuration: true },
+      { instructions: "inline", instructionsFile: "/tmp/unused" },
+    ]) {
+      const client = api();
+      await expect(runAgentUpdate(agentId, { accessToken: "access", api: client, ...options })).rejects.toThrow(
+        "cannot be used together",
+      );
+      expect(client.getAgent).not.toHaveBeenCalled();
+    }
+
+    const invalidDuration = api();
+    await expect(
+      runAgentUpdate(agentId, { accessToken: "access", api: invalidDuration, maxDurationMs: "1.5" }),
+    ).rejects.toThrow("positive base-10 safe integer");
+    expect(invalidDuration.getAgent).not.toHaveBeenCalled();
+
+    const excessiveDuration = api();
+    await expect(
+      runAgentUpdate(agentId, { accessToken: "access", api: excessiveDuration, maxDurationMs: "86400001" }),
+    ).rejects.toThrow();
+    expect(excessiveDuration.getAgent).not.toHaveBeenCalled();
+
+    const unknownTool = api();
+    await expect(
+      runAgentUpdate(agentId, { accessToken: "access", api: unknownTool, allowedTools: ["unknown_tool"] }),
+    ).rejects.toThrow();
+    expect(unknownTool.getAgent).not.toHaveBeenCalled();
+
+    const duplicateTools = api();
+    await expect(
+      runAgentUpdate(agentId, {
+        accessToken: "access",
+        api: duplicateTools,
+        allowedTools: ["opentag_message_send", "opentag_message_send"],
+      }),
+    ).rejects.toThrow("Agent tool IDs must be unique");
+    expect(duplicateTools.getAgent).not.toHaveBeenCalled();
+
+    const empty = api();
+    await expect(runAgentUpdate(agentId, { accessToken: "access", api: empty })).rejects.toThrow(
+      "No Agent changes were provided",
+    );
+    expect(empty.getAgent).not.toHaveBeenCalled();
+  });
+
+  it("registers every runtime setting option and keeps update display name optional", () => {
+    const program = createProgram();
+    const agentCommand = program.commands.find((command) => command.name() === "agent");
+    const create = agentCommand?.commands.find((command) => command.name() === "create");
+    const update = agentCommand?.commands.find((command) => command.name() === "update");
+    expect(create?.options.map((option) => option.long)).toEqual(
+      expect.arrayContaining([
+        "--model",
+        "--reasoning-effort",
+        "--instructions",
+        "--instructions-file",
+        "--allowed-tool",
+        "--max-duration-ms",
+      ]),
+    );
+    expect(update?.options.map((option) => option.long)).toEqual(
+      expect.arrayContaining([
+        "--model",
+        "--clear-model",
+        "--reasoning-effort",
+        "--clear-reasoning-effort",
+        "--instructions",
+        "--instructions-file",
+        "--allowed-tool",
+        "--clear-allowed-tools",
+        "--max-duration-ms",
+        "--clear-max-duration",
+      ]),
+    );
+    expect(update?.options.find((option) => option.long === "--display-name")?.mandatory).toBe(false);
   });
 
   it("deletes the explicit Agent without an interactive prompt", async () => {

--- a/apps/cli/src/commands/agent/create.ts
+++ b/apps/cli/src/commands/agent/create.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { type Command, Option } from "commander";
 import { formatAgentCreated } from "../../core/agent/formatting.js";
 import { runAgentCreate } from "../../core/agent/mutations.js";
 
@@ -10,6 +10,14 @@ export function registerAgentCreateCommand(agent: Command): void {
     .requiredOption("--provider <provider>", "runtime provider: codex or claude-code")
     .option("--computer <uuid>", "Computer owned by the current user")
     .option("--team <name>", "Team canonical name")
+    .option("--model <model>", "default runtime model")
+    .option("--reasoning-effort <effort>", "default runtime reasoning effort")
+    .addOption(new Option("--instructions <text>", "Agent runtime instructions").conflicts("instructionsFile"))
+    .addOption(
+      new Option("--instructions-file <path>", "read Agent instructions from a UTF-8 file").conflicts("instructions"),
+    )
+    .option("--allowed-tool <tool-id>", "allow an OpenTag runtime tool (repeatable)", collectValue)
+    .option("--max-duration-ms <integer>", "maximum runtime duration in milliseconds")
     .action(async (options) => {
       const result = await runAgentCreate({
         name: options.name,
@@ -17,8 +25,18 @@ export function registerAgentCreateCommand(agent: Command): void {
         runtimeProvider: options.provider,
         computerId: options.computer,
         teamName: options.team,
+        model: options.model,
+        reasoningEffort: options.reasoningEffort,
+        instructions: options.instructions,
+        instructionsFile: options.instructionsFile,
+        allowedTools: options.allowedTool,
+        maxDurationMs: options.maxDurationMs,
       });
       if (result.warning) process.stderr.write(`${result.warning}\n`);
       process.stdout.write(`${formatAgentCreated(result)}\n`);
     });
+}
+
+function collectValue(value: string, previous: string[] | undefined): string[] {
+  return [...(previous ?? []), value];
 }

--- a/apps/cli/src/commands/agent/update.ts
+++ b/apps/cli/src/commands/agent/update.ts
@@ -1,12 +1,56 @@
-import type { Command } from "commander";
+import { type Command, Option } from "commander";
 import { formatAgent } from "../../core/agent/formatting.js";
 import { runAgentUpdate } from "../../core/agent/mutations.js";
 
 export function registerAgentUpdateCommand(agent: Command): void {
   agent
     .command("update <agent-id>")
-    .requiredOption("--display-name <display-name>", "new human-facing Agent name")
+    .option("--display-name <display-name>", "new human-facing Agent name")
+    .addOption(new Option("--model <model>", "default runtime model").conflicts("clearModel"))
+    .addOption(new Option("--clear-model", "clear the default runtime model").conflicts("model"))
+    .addOption(
+      new Option("--reasoning-effort <effort>", "default runtime reasoning effort").conflicts("clearReasoningEffort"),
+    )
+    .addOption(
+      new Option("--clear-reasoning-effort", "clear the default runtime reasoning effort").conflicts("reasoningEffort"),
+    )
+    .addOption(new Option("--instructions <text>", "Agent runtime instructions").conflicts("instructionsFile"))
+    .addOption(
+      new Option("--instructions-file <path>", "read Agent instructions from a UTF-8 file").conflicts("instructions"),
+    )
+    .addOption(
+      new Option("--allowed-tool <tool-id>", "allow an OpenTag runtime tool (repeatable)")
+        .argParser(collectValue)
+        .conflicts("clearAllowedTools"),
+    )
+    .addOption(new Option("--clear-allowed-tools", "clear the runtime tool allowlist").conflicts("allowedTool"))
+    .addOption(
+      new Option("--max-duration-ms <integer>", "maximum runtime duration in milliseconds").conflicts(
+        "clearMaxDuration",
+      ),
+    )
+    .addOption(new Option("--clear-max-duration", "clear the maximum runtime duration").conflicts("maxDurationMs"))
     .action(async (agentId, options) => {
-      process.stdout.write(`${formatAgent(await runAgentUpdate(agentId, { displayName: options.displayName }))}\n`);
+      process.stdout.write(
+        `${formatAgent(
+          await runAgentUpdate(agentId, {
+            displayName: options.displayName,
+            model: options.model,
+            clearModel: options.clearModel,
+            reasoningEffort: options.reasoningEffort,
+            clearReasoningEffort: options.clearReasoningEffort,
+            instructions: options.instructions,
+            instructionsFile: options.instructionsFile,
+            allowedTools: options.allowedTool,
+            clearAllowedTools: options.clearAllowedTools,
+            maxDurationMs: options.maxDurationMs,
+            clearMaxDuration: options.clearMaxDuration,
+          }),
+        )}\n`,
+      );
     });
+}
+
+function collectValue(value: string, previous: string[] | undefined): string[] {
+  return [...(previous ?? []), value];
 }

--- a/apps/cli/src/core/agent/mutations.ts
+++ b/apps/cli/src/core/agent/mutations.ts
@@ -1,12 +1,25 @@
+import { readFile } from "node:fs/promises";
 import type { Agent, Computer, ListComputersResponse } from "@opentag/shared";
-import { CreateAgentRequestSchema } from "@opentag/shared";
+import {
+  CreateAgentRequestSchema,
+  CreateAgentRuntimeConfigSchema,
+  type UpdateAgentRequest,
+  UpdateAgentRequestSchema,
+  UpdateAgentRuntimeConfigSchema,
+} from "@opentag/shared";
 import { selectTeam } from "../selection/team.js";
 import { type AgentCommandDependencies, resolveAgentCommandContext } from "./context.js";
 
 export interface AgentCreateOptions extends AgentCommandDependencies {
+  allowedTools?: string[];
   computerId?: string;
   displayName: string;
+  instructions?: string;
+  instructionsFile?: string;
+  maxDurationMs?: number | string;
+  model?: string;
   name: string;
+  reasoningEffort?: string;
   runtimeProvider: string;
   teamName?: string;
 }
@@ -17,7 +30,17 @@ export interface AgentCreateResult {
 }
 
 export interface AgentUpdateOptions extends AgentCommandDependencies {
-  displayName: string;
+  allowedTools?: string[];
+  clearAllowedTools?: boolean;
+  clearMaxDuration?: boolean;
+  clearModel?: boolean;
+  clearReasoningEffort?: boolean;
+  displayName?: string;
+  instructions?: string;
+  instructionsFile?: string;
+  maxDurationMs?: number | string;
+  model?: string;
+  reasoningEffort?: string;
 }
 
 export function selectComputer(response: ListComputersResponse, requestedComputerId?: string): Computer {
@@ -36,6 +59,7 @@ export function selectComputer(response: ListComputersResponse, requestedCompute
 }
 
 export async function runAgentCreate(options: AgentCreateOptions): Promise<AgentCreateResult> {
+  const runtimeConfig = await createRuntimeConfig(options);
   const { api, accessToken } = await resolveAgentCommandContext(options);
   const [me, computers] = await Promise.all([api.me(accessToken), api.listComputers(accessToken)]);
   const team = selectTeam(me, options.teamName);
@@ -45,6 +69,7 @@ export async function runAgentCreate(options: AgentCreateOptions): Promise<Agent
     displayName: options.displayName,
     runtimeProvider: options.runtimeProvider,
     computerId: computer.id,
+    ...(runtimeConfig ? { runtimeConfig } : {}),
   });
   const agent = await api.createAgent(accessToken, team.teamId, input);
   return {
@@ -56,16 +81,99 @@ export async function runAgentCreate(options: AgentCreateOptions): Promise<Agent
 }
 
 export async function runAgentUpdate(agentId: string, options: AgentUpdateOptions): Promise<Agent> {
+  const mutation = await updateMutation(options);
   const { api, accessToken } = await resolveAgentCommandContext(options);
   const current = await api.getAgent(accessToken, agentId);
-  return api.updateAgent(accessToken, agentId, {
-    displayName: options.displayName,
+  const input = UpdateAgentRequestSchema.parse({
+    ...mutation,
     expectedRevision: current.revision,
   });
+  return api.updateAgent(accessToken, agentId, input);
 }
 
 export async function runAgentDelete(agentId: string, options: AgentCommandDependencies = {}): Promise<string> {
   const { api, accessToken } = await resolveAgentCommandContext(options);
   await api.deleteAgent(accessToken, agentId);
   return `Deleted Agent ${agentId}`;
+}
+
+async function createRuntimeConfig(options: AgentCreateOptions) {
+  assertInstructionsSource(options);
+  const runtimeConfig = {
+    ...(options.model !== undefined ? { model: options.model } : {}),
+    ...(options.reasoningEffort !== undefined ? { reasoningEffort: options.reasoningEffort } : {}),
+    ...(options.instructions !== undefined || options.instructionsFile !== undefined
+      ? { instructions: await readInstructions(options) }
+      : {}),
+    ...(options.allowedTools !== undefined ? { allowedTools: options.allowedTools } : {}),
+    ...(options.maxDurationMs !== undefined ? { maxDurationMs: parseMaxDuration(options.maxDurationMs) } : {}),
+  };
+  return Object.keys(runtimeConfig).length > 0 ? CreateAgentRuntimeConfigSchema.parse(runtimeConfig) : undefined;
+}
+
+async function updateMutation(options: AgentUpdateOptions): Promise<Omit<UpdateAgentRequest, "expectedRevision">> {
+  assertInstructionsSource(options);
+  assertExclusive(options.model, options.clearModel, "--model", "--clear-model");
+  assertExclusive(
+    options.reasoningEffort,
+    options.clearReasoningEffort,
+    "--reasoning-effort",
+    "--clear-reasoning-effort",
+  );
+  assertExclusive(options.allowedTools, options.clearAllowedTools, "--allowed-tool", "--clear-allowed-tools");
+  assertExclusive(options.maxDurationMs, options.clearMaxDuration, "--max-duration-ms", "--clear-max-duration");
+
+  const runtimeConfigInput = {
+    ...(options.model !== undefined || options.clearModel ? { model: options.clearModel ? null : options.model } : {}),
+    ...(options.reasoningEffort !== undefined || options.clearReasoningEffort
+      ? { reasoningEffort: options.clearReasoningEffort ? null : options.reasoningEffort }
+      : {}),
+    ...(options.instructions !== undefined || options.instructionsFile !== undefined
+      ? { instructions: await readInstructions(options) }
+      : {}),
+    ...(options.allowedTools !== undefined || options.clearAllowedTools
+      ? { allowedTools: options.clearAllowedTools ? [] : options.allowedTools }
+      : {}),
+    ...(options.maxDurationMs !== undefined || options.clearMaxDuration
+      ? { maxDurationMs: options.clearMaxDuration ? null : parseMaxDuration(options.maxDurationMs) }
+      : {}),
+  };
+  const runtimeConfig =
+    Object.keys(runtimeConfigInput).length > 0 ? UpdateAgentRuntimeConfigSchema.parse(runtimeConfigInput) : undefined;
+  if (options.displayName === undefined && runtimeConfig === undefined) {
+    throw new Error("No Agent changes were provided; specify a profile or runtime setting option");
+  }
+  const preflight = UpdateAgentRequestSchema.parse({
+    expectedRevision: 1,
+    ...(options.displayName !== undefined ? { displayName: options.displayName } : {}),
+    ...(runtimeConfig ? { runtimeConfig } : {}),
+  });
+  const { expectedRevision: _expectedRevision, ...mutation } = preflight;
+  return mutation;
+}
+
+function assertInstructionsSource(options: { instructions?: string; instructionsFile?: string }): void {
+  if (options.instructions !== undefined && options.instructionsFile !== undefined) {
+    throw new Error("--instructions and --instructions-file cannot be used together");
+  }
+}
+
+function assertExclusive(value: unknown, clear: boolean | undefined, valueFlag: string, clearFlag: string): void {
+  if (value !== undefined && clear) throw new Error(`${valueFlag} and ${clearFlag} cannot be used together`);
+}
+
+async function readInstructions(options: { instructions?: string; instructionsFile?: string }): Promise<string> {
+  if (options.instructionsFile !== undefined) return readFile(options.instructionsFile, "utf8");
+  return options.instructions ?? "";
+}
+
+function parseMaxDuration(value: number | string | undefined): number {
+  if (value === undefined) throw new Error("--max-duration-ms requires a value");
+  if (typeof value === "number") {
+    if (Number.isSafeInteger(value) && value > 0) return value;
+  } else if (/^[1-9][0-9]*$/.test(value)) {
+    const parsed = Number(value);
+    if (Number.isSafeInteger(parsed)) return parsed;
+  }
+  throw new Error("--max-duration-ms must be a positive base-10 safe integer");
 }

--- a/packages/server/src/__tests__/effective-runtime-snapshot-assembler.test.ts
+++ b/packages/server/src/__tests__/effective-runtime-snapshot-assembler.test.ts
@@ -1,0 +1,131 @@
+import { OPENTAG_PLATFORM_INSTRUCTIONS } from "@opentag/shared";
+import { describe, expect, it } from "vitest";
+import type { DatabaseClient } from "../db/client.js";
+import {
+  DEFAULT_AGENT_RUNTIME_CONFIG,
+  EffectiveRuntimeSnapshotAssembler,
+  EffectiveRuntimeSnapshotAssemblerError,
+} from "../services/runtime-config/index.js";
+
+const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
+const sessionId = "b077f77b-ad35-4031-8628-aee73f9a7ca8";
+
+function authority(overrides: Record<string, unknown> = {}) {
+  return {
+    agentDeletedAt: null,
+    agentId,
+    integrationStatus: "active",
+    runtimeConfig: {
+      revision: 7,
+      model: "gpt-5",
+      reasoningEffort: "high",
+      instructions: "Review the change.",
+      allowedTools: ["opentag_message_reply", "opentag_message_send"],
+      maxDurationMs: 30_000,
+    },
+    runtimeProvider: "codex",
+    sessionEndedAt: null,
+    sessionId,
+    ...overrides,
+  };
+}
+
+function assembler(loadAuthority: (value: string) => Promise<ReturnType<typeof authority> | undefined>) {
+  return new EffectiveRuntimeSnapshotAssembler({} as DatabaseClient, { loadAuthority });
+}
+
+describe("EffectiveRuntimeSnapshotAssembler", () => {
+  it("compiles one deterministic effective snapshot from Server authority", async () => {
+    const first = await assembler(async (value) => {
+      expect(value).toBe(sessionId);
+      return authority();
+    }).assembleForSession(sessionId);
+    const second = await assembler(async () => authority()).assembleForSession(sessionId);
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      agentId,
+      provider: "codex",
+      model: "gpt-5",
+      reasoningEffort: "high",
+      instructions: { platform: OPENTAG_PLATFORM_INSTRUCTIONS, agent: "Review the change." },
+      allowedTools: ["opentag_message_reply", "opentag_message_send"],
+      budget: { maxDurationMs: 30_000 },
+      revision: {
+        agent: { sequence: 7, id: expect.stringMatching(/^[a-f0-9]{64}$/) },
+        session: { sequence: 7, id: expect.stringMatching(/^[a-f0-9]{64}$/) },
+      },
+      workspace: { workspaceId: agentId, mode: "empty_on_create", sharing: "agent" },
+    });
+  });
+
+  it("uses versioned layer hashes and the config revision for both effective sequences", async () => {
+    const original = await assembler(async () => authority()).assembleForSession(sessionId);
+    const instructionsChanged = await assembler(async () =>
+      authority({
+        runtimeConfig: {
+          ...(authority().runtimeConfig as Record<string, unknown>),
+          revision: 8,
+          instructions: "Changed",
+        },
+      }),
+    ).assembleForSession(sessionId);
+    const modelChanged = await assembler(async () =>
+      authority({
+        runtimeConfig: { ...(authority().runtimeConfig as Record<string, unknown>), revision: 9, model: "gpt-5.1" },
+      }),
+    ).assembleForSession(sessionId);
+
+    expect(instructionsChanged.revision.agent.id).not.toBe(original.revision.agent.id);
+    expect(instructionsChanged.revision.session.id).toBe(original.revision.session.id);
+    expect(instructionsChanged.revision.agent.sequence).toBe(8);
+    expect(instructionsChanged.revision.session.sequence).toBe(8);
+    expect(modelChanged.revision.agent.id).toBe(original.revision.agent.id);
+    expect(modelChanged.revision.session.id).not.toBe(original.revision.session.id);
+    expect(modelChanged.revision.agent.sequence).toBe(9);
+    expect(modelChanged.revision.session.sequence).toBe(9);
+  });
+
+  it("omits nullable runtime fields when compiling the stored default configuration", async () => {
+    const snapshot = await assembler(async () =>
+      authority({ runtimeConfig: { revision: 1, ...DEFAULT_AGENT_RUNTIME_CONFIG } }),
+    ).assembleForSession(sessionId);
+
+    expect(snapshot).not.toHaveProperty("model");
+    expect(snapshot).not.toHaveProperty("reasoningEffort");
+    expect(snapshot).not.toHaveProperty("budget");
+    expect(snapshot.instructions.agent).toBe(DEFAULT_AGENT_RUNTIME_CONFIG.instructions);
+    expect(snapshot.allowedTools).toEqual(DEFAULT_AGENT_RUNTIME_CONFIG.allowedTools);
+  });
+
+  it.each([
+    ["missing", async () => undefined, "SESSION_NOT_FOUND"],
+    ["ended Session", async () => authority({ sessionEndedAt: new Date() }), "AUTHORITY_INACTIVE"],
+    ["inactive Integration", async () => authority({ integrationStatus: "disabled" }), "AUTHORITY_INACTIVE"],
+    ["deleted Agent", async () => authority({ agentDeletedAt: new Date() }), "AUTHORITY_INACTIVE"],
+    ["missing config", async () => authority({ runtimeConfig: null }), "RUNTIME_CONFIG_MISSING"],
+    ["unsupported provider", async () => authority({ runtimeProvider: "claude-code" }), "UNSUPPORTED_PROVIDER"],
+    [
+      "invalid stored config",
+      async () =>
+        authority({ runtimeConfig: { ...(authority().runtimeConfig as Record<string, unknown>), revision: 0 } }),
+      "INVALID_STORED_CONFIG",
+    ],
+    ["invalid effective snapshot", async () => authority({ agentId: "not-an-opaque-id!" }), "SNAPSHOT_INVALID"],
+  ])("fails closed for %s authority", async (_label, loadAuthority, code) => {
+    await expect(assembler(loadAuthority).assembleForSession(sessionId)).rejects.toMatchObject({
+      name: "EffectiveRuntimeSnapshotAssemblerError",
+      code,
+    });
+  });
+
+  it("distinguishes database failures without including stored instructions", async () => {
+    const failure = new Error("database unavailable: secret instructions");
+    const result = assembler(async () => {
+      throw failure;
+    }).assembleForSession(sessionId);
+    await expect(result).rejects.toBeInstanceOf(EffectiveRuntimeSnapshotAssemblerError);
+    await expect(result).rejects.toMatchObject({ code: "DATABASE_FAILURE" });
+    await expect(result).rejects.not.toHaveProperty("message", expect.stringContaining("secret instructions"));
+  });
+});

--- a/packages/server/src/__tests__/im-delivery-worker.test.ts
+++ b/packages/server/src/__tests__/im-delivery-worker.test.ts
@@ -8,6 +8,7 @@ describe("ImDeliveryWorker diagnostics", () => {
       transaction: vi.fn().mockRejectedValue(new Error("secret provider response must not escape")),
     };
     const worker = new ImDeliveryWorker({
+      assembler: { assembleForSession: vi.fn() },
       database: database as never,
       domain: {} as never,
       registry: {} as never,

--- a/packages/server/src/__tests__/integration/im-integration.test.ts
+++ b/packages/server/src/__tests__/integration/im-integration.test.ts
@@ -9,7 +9,10 @@ import {
   computeTurnResultHash,
   type DirectImMessageDeliveryRequest,
   type NormalizedInboundImEvent,
+  type SessionReconcileRequest,
+  type SessionReconcileResult,
   type TurnReportRequest,
+  type UpdateAgentRequest,
 } from "@opentag/shared";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { eq } from "drizzle-orm";
@@ -48,6 +51,7 @@ import {
   IntegrationService,
   ProviderAdapterResolutionError,
 } from "../../services/integrations/index.js";
+import { EffectiveRuntimeSnapshotAssembler } from "../../services/runtime-config/index.js";
 import { SessionService } from "../../services/sessions/index.js";
 
 const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
@@ -185,6 +189,13 @@ async function unboundFixture() {
   return { ...client, agent, bootstrap, computer, cipher, integrationService };
 }
 
+function imDeliveryWorker(input: Omit<ConstructorParameters<typeof ImDeliveryWorker>[0], "assembler">) {
+  return new ImDeliveryWorker({
+    ...input,
+    assembler: new EffectiveRuntimeSnapshotAssembler(input.database),
+  });
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
@@ -250,6 +261,28 @@ async function createClientSessionBindingStore(home: string) {
   return new module.SessionBindingStore({ home, providerHomeIdentity: "a".repeat(64) });
 }
 
+async function createDurableClientReconciler(home: string, computerId: string) {
+  const bindingStore = await createClientSessionBindingStore(home);
+  const workspaceModuleUrl = new URL("../../../../client/src/runtime/agent-workspace.ts", import.meta.url).href;
+  const reconcilerModuleUrl = new URL("../../../../client/src/runtime/session-reconciler.ts", import.meta.url).href;
+  const workspaceModule = (await import(workspaceModuleUrl)) as {
+    AgentWorkspaceManager: new (options: { bindingStore: typeof bindingStore; home: string }) => object;
+  };
+  const reconcilerModule = (await import(reconcilerModuleUrl)) as {
+    SessionReconciler: new (options: {
+      computerId: string;
+      preparation: object;
+    }) => {
+      clearRecovery: (sessionId: string, turnId: string) => boolean;
+      getAgent: (agentId: string) => { revisionSequence: number } | undefined;
+      reconcile: (request: SessionReconcileRequest) => Promise<SessionReconcileResult>;
+    };
+  };
+  const workspace = new workspaceModule.AgentWorkspaceManager({ bindingStore, home });
+  const reconciler = new reconcilerModule.SessionReconciler({ computerId, preparation: workspace });
+  return { bindingStore, reconciler };
+}
+
 async function respondingRuntime(input: {
   acceptDeliveries?: boolean;
   database: ReturnType<typeof createDatabaseClient>["database"];
@@ -257,7 +290,7 @@ async function respondingRuntime(input: {
   deliveryGate?: Promise<void>;
   instanceId: string;
   requestTimeoutMs?: number;
-  reconcileResult?: (frame: Record<string, unknown>) => Record<string, unknown>;
+  reconcileResult?: (frame: Record<string, unknown>) => Promise<Record<string, unknown>> | Record<string, unknown>;
   userId: string;
 }) {
   const frames: unknown[] = [];
@@ -278,20 +311,20 @@ async function respondingRuntime(input: {
       frames.push(frame);
       callback();
       queueMicrotask(() => {
-        if (frame.type === "session:reconcile") {
-          void domain.handle(
-            (input.reconcileResult?.(frame) ?? {
-              type: "session:reconcile:result",
-              requestId: frame.requestId,
-              sessionId: frame.sessionId,
-              placementGeneration: frame.placementGeneration,
-              status: "ready",
-            }) as never,
-            context,
-          );
-        } else if (frame.type === "im:deliver") {
-          if (input.acceptDeliveries === false) return;
-          void (async () => {
+        void (async () => {
+          if (frame.type === "session:reconcile") {
+            const result = input.reconcileResult
+              ? await input.reconcileResult(frame)
+              : {
+                  type: "session:reconcile:result",
+                  requestId: frame.requestId,
+                  sessionId: frame.sessionId,
+                  placementGeneration: frame.placementGeneration,
+                  status: "ready",
+                };
+            await domain.handle(result as never, context);
+          } else if (frame.type === "im:deliver") {
+            if (input.acceptDeliveries === false) return;
             await input.deliveryGate;
             await domain.handle(
               {
@@ -305,8 +338,8 @@ async function respondingRuntime(input: {
               } as never,
               context,
             );
-          })();
-        }
+          }
+        })();
       });
     }),
   } as unknown as WebSocket;
@@ -604,7 +637,7 @@ describe("IM Integration persistence", () => {
         instanceId,
         userId: value.bootstrap.userId,
       });
-      const deliveryRun = new ImDeliveryWorker({
+      const deliveryRun = imDeliveryWorker({
         database: value.database,
         registry: runtime.registry,
         domain: runtime.domain,
@@ -683,7 +716,7 @@ describe("IM Integration persistence", () => {
         instanceId,
         userId: value.bootstrap.userId,
       });
-      const deliveryRun = new ImDeliveryWorker({
+      const deliveryRun = imDeliveryWorker({
         database: value.database,
         registry: runtime.registry,
         domain: runtime.domain,
@@ -695,7 +728,7 @@ describe("IM Integration persistence", () => {
         .update(imMessageDeliveries)
         .set({ expiresAt: new Date(0) })
         .where(eq(imMessageDeliveries.id, deliveryId));
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: runtime.registry,
         domain: runtime.domain,
@@ -763,7 +796,7 @@ describe("IM Integration persistence", () => {
         instanceId,
         userId: value.bootstrap.userId,
       });
-      const deliveryRun = new ImDeliveryWorker({
+      const deliveryRun = imDeliveryWorker({
         database: value.database,
         registry: runtime.registry,
         domain: runtime.domain,
@@ -1016,7 +1049,7 @@ describe("IM Integration persistence", () => {
         instanceId,
         userId: value.bootstrap.userId,
       });
-      const worker = new ImDeliveryWorker({
+      const worker = imDeliveryWorker({
         database: value.database,
         registry: runtime.registry,
         domain: runtime.domain,
@@ -1035,6 +1068,23 @@ describe("IM Integration persistence", () => {
       );
       await worker.runOnce();
       expect(directA.deliveryIds).toHaveLength(1);
+      const [acceptedA] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, directA.deliveryIds[0] as string));
+      if (!acceptedA?.turnId) throw new Error("Initial mention-only delivery was not accepted");
+      await expect(
+        runtime.domain.handle(
+          turnReportFor({
+            agentId: value.agent.id,
+            deliveryId: acceptedA.id,
+            placementGeneration: acceptedA.placementGeneration,
+            sessionId: acceptedA.sessionId,
+            turnId: acceptedA.turnId,
+          }),
+          runtime.context,
+        ),
+      ).resolves.toMatchObject({ status: "recorded" });
 
       const interveningEvent = revisionEvent({
         providerEventId: "mention-only-b",
@@ -1216,7 +1266,7 @@ describe("IM Integration persistence", () => {
         requestReconcile: vi.fn().mockRejectedValue(new Error("runtime unavailable")),
         requestDelivery: vi.fn(),
       };
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: registry as never,
         domain: failedDomain as never,
@@ -1230,7 +1280,7 @@ describe("IM Integration persistence", () => {
         instanceId,
         userId: value.bootstrap.userId,
       });
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: recovered.registry,
         domain: recovered.domain,
@@ -1252,6 +1302,713 @@ describe("IM Integration persistence", () => {
     }
   });
 
+  it("advances both effective revisions when an existing Session receives each Agent config update", async () => {
+    const value = await fixture();
+    const clientHome = await mkdtemp(resolve(tmpdir(), "opentag-im-config-update-"));
+    const owners: RuntimeDomainOwner[] = [];
+    try {
+      const instanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: instanceId })
+        .where(eq(computers.id, value.computer.id));
+      const runtime = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId,
+        userId: value.bootstrap.userId,
+      });
+      owners.push(runtime.domain);
+      const inbox = new ImMessageInbox(value.database);
+      const clientStore = await createClientSessionBindingStore(clientHome);
+      const service = new AgentService(value.database);
+      let currentAgent = value.agent;
+      let previousSequence = 0;
+
+      const deliverAndRecord = async (event: NormalizedInboundImEvent) => {
+        const before = runtime.frames.length;
+        await inbox.ingest(value.integrationId, 1, event);
+        await imDeliveryWorker({
+          database: value.database,
+          registry: runtime.registry,
+          domain: runtime.domain,
+        }).runOnce();
+        const request = runtime.frames
+          .slice(before)
+          .find(
+            (frame): frame is DirectImMessageDeliveryRequest =>
+              typeof frame === "object" && frame !== null && (frame as { type?: unknown }).type === "im:deliver",
+          );
+        if (!request) throw new Error("Updated Agent delivery was not dispatched");
+        await clientStore.prepare(
+          {
+            type: "session:reconcile",
+            requestId: crypto.randomUUID(),
+            computerId: value.computer.id,
+            sessionId: request.sessionId,
+            agentId: request.agentId,
+            placementGeneration: request.placementGeneration,
+            desired: "ready",
+            runtime: request.runtime,
+          },
+          computeRuntimeSnapshotHashes(request.runtime),
+        );
+        const turnId = `turn-${request.deliveryId}`;
+        await expect(
+          runtime.domain.handle(
+            turnReportFor({
+              agentId: request.agentId,
+              deliveryId: request.deliveryId,
+              placementGeneration: request.placementGeneration,
+              sessionId: request.sessionId,
+              turnId,
+            }),
+            runtime.context,
+          ),
+        ).resolves.toMatchObject({ status: "recorded" });
+        return request.runtime;
+      };
+
+      const initial = await deliverAndRecord(inbound("Ev-config-initial"));
+      previousSequence = initial.revision.session.sequence;
+      const changes: Array<{
+        expected: Record<string, unknown>;
+        runtimeConfig: NonNullable<UpdateAgentRequest["runtimeConfig"]>;
+      }> = [
+        { runtimeConfig: { model: "gpt-5" }, expected: { model: "gpt-5" } },
+        { runtimeConfig: { reasoningEffort: "high" }, expected: { reasoningEffort: "high" } },
+        { runtimeConfig: { instructions: "Updated instructions." }, expected: {} },
+        {
+          runtimeConfig: { allowedTools: ["opentag_message_send"] },
+          expected: { allowedTools: ["opentag_message_send"] },
+        },
+        { runtimeConfig: { maxDurationMs: 45_000 }, expected: { budget: { maxDurationMs: 45_000 } } },
+      ];
+      for (const [index, change] of changes.entries()) {
+        currentAgent = await service.updateById(value.bootstrap.userId, value.agent.id, {
+          expectedRevision: currentAgent.revision,
+          runtimeConfig: change.runtimeConfig,
+        });
+        const snapshot = await deliverAndRecord(
+          revisionEvent({
+            providerEventId: `Ev-config-${index}`,
+            externalMessageId: `config-message-${index}`,
+            operation: "created",
+            occurredAt: `2026-08-19T00:00:0${index + 2}.000Z`,
+            revisionKey: "1",
+          }),
+        );
+        expect(snapshot).toMatchObject(change.expected);
+        if ("instructions" in change.runtimeConfig) {
+          expect(snapshot.instructions.agent).toBe(change.runtimeConfig.instructions);
+        }
+        expect(snapshot.revision.agent.sequence).toBe(currentAgent.runtimeConfig.revision);
+        expect(snapshot.revision.session.sequence).toBe(currentAgent.runtimeConfig.revision);
+        expect(snapshot.revision.session.sequence).toBeGreaterThan(previousSequence);
+        previousSequence = snapshot.revision.session.sequence;
+      }
+    } finally {
+      for (const owner of owners) owner.close();
+      await rm(clientHome, { recursive: true, force: true });
+      await value.sql.end();
+    }
+  });
+
+  it("fences a higher Agent revision until pinned accepted custody recovers and reports", async () => {
+    const value = await fixture();
+    const clientHome = await mkdtemp(resolve(tmpdir(), "opentag-agent-custody-fence-"));
+    const owners: RuntimeDomainOwner[] = [];
+    try {
+      const firstInstanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: firstInstanceId })
+        .where(eq(computers.id, value.computer.id));
+      const firstClient = await createDurableClientReconciler(clientHome, value.computer.id);
+      const first = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId: firstInstanceId,
+        userId: value.bootstrap.userId,
+        reconcileResult: (frame) => firstClient.reconciler.reconcile(frame as unknown as SessionReconcileRequest),
+      });
+      owners.push(first.domain);
+      const inbox = new ImMessageInbox(value.database);
+      await inbox.ingest(value.integrationId, 1, inbound("Ev-agent-fence-accepted"));
+      await imDeliveryWorker({
+        database: value.database,
+        registry: first.registry,
+        domain: first.domain,
+      }).runOnce();
+      const firstRequest = first.frames.find(
+        (frame): frame is DirectImMessageDeliveryRequest =>
+          typeof frame === "object" && frame !== null && (frame as { type?: unknown }).type === "im:deliver",
+      );
+      if (!firstRequest) throw new Error("Initial Agent custody request was not dispatched");
+      const turnId = `turn-${firstRequest.deliveryId}`;
+      await firstClient.bindingStore.recordAccepted(firstRequest, computeDirectInputHash(firstRequest), turnId);
+      const report = turnReportFor({
+        agentId: firstRequest.agentId,
+        deliveryId: firstRequest.deliveryId,
+        placementGeneration: firstRequest.placementGeneration,
+        sessionId: firstRequest.sessionId,
+        turnId,
+      });
+      await firstClient.bindingStore.updateUnresolved(
+        firstRequest.agentId,
+        firstRequest.sessionId,
+        turnId,
+        "reporting",
+        {
+          report,
+          resultHash: report.resultHash,
+        },
+      );
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date(Date.now() + 60_000) })
+        .where(eq(imMessageDeliveries.id, firstRequest.deliveryId));
+
+      const updatedAgent = await new AgentService(value.database).updateById(value.bootstrap.userId, value.agent.id, {
+        expectedRevision: value.agent.revision,
+        runtimeConfig: { model: "gpt-5-after-custody" },
+      });
+      const pendingAdmission = await inbox.ingest(
+        value.integrationId,
+        1,
+        revisionEvent({
+          providerEventId: "Ev-agent-fence-pending",
+          externalMessageId: "agent-fence-pending",
+          operation: "created",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+          revisionKey: "1",
+        }),
+      );
+      const pendingId = pendingAdmission.deliveryIds[0];
+      if (!pendingId) throw new Error("Higher revision pending request was not admitted");
+      const [accepted] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, firstRequest.deliveryId));
+      if (!accepted?.dispatchRequestId || !accepted.dispatchInputHash || !accepted.inputHash || !accepted.turnId) {
+        throw new Error("Accepted Agent custody was not persisted");
+      }
+      first.domain.close();
+
+      const secondInstanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: secondInstanceId })
+        .where(eq(computers.id, value.computer.id));
+      const rebuiltClient = await createDurableClientReconciler(clientHome, value.computer.id);
+      const second = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId: secondInstanceId,
+        userId: value.bootstrap.userId,
+        reconcileResult: async (frame) => {
+          const result = await rebuiltClient.reconciler.reconcile(frame as unknown as SessionReconcileRequest);
+          return result.status === "recovery_required"
+            ? {
+                ...result,
+                retainedReports: [
+                  {
+                    dispatchRequestId: accepted.dispatchRequestId,
+                    deliveryId: accepted.id,
+                    inputHash: accepted.inputHash,
+                    turnId: accepted.turnId,
+                    placementGeneration: accepted.placementGeneration,
+                    resultHash: report.resultHash,
+                  },
+                ],
+              }
+            : result;
+        },
+      });
+      owners.push(second.domain);
+      const worker = imDeliveryWorker({
+        database: value.database,
+        registry: second.registry,
+        domain: second.domain,
+      });
+
+      await worker.runOnce();
+      expect(second.frames).toEqual([]);
+      expect(
+        (await value.database.select().from(imMessageDeliveries).where(eq(imMessageDeliveries.id, pendingId)))[0],
+      ).toMatchObject({ attemptCount: 0, state: "pending" });
+
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date(0) })
+        .where(eq(imMessageDeliveries.id, firstRequest.deliveryId));
+      await worker.runOnce();
+      const recovery = second.frames[0] as SessionReconcileRequest | undefined;
+      expect(recovery).toMatchObject({ type: "session:reconcile", runtime: firstRequest.runtime });
+      expect(rebuiltClient.reconciler.getAgent(value.agent.id)?.revisionSequence).toBe(
+        firstRequest.runtime.revision.agent.sequence,
+      );
+      await expect(second.domain.handle(report, second.context)).resolves.toMatchObject({ status: "recorded" });
+      await rebuiltClient.bindingStore.recordResult(value.agent.id, firstRequest.sessionId, turnId, report.resultHash);
+      expect(rebuiltClient.reconciler.clearRecovery(firstRequest.sessionId, turnId)).toBe(true);
+
+      const beforePending = second.frames.length;
+      await worker.runOnce();
+      const pendingFrames = second.frames.slice(beforePending);
+      expect(pendingFrames).toEqual([
+        expect.objectContaining({
+          type: "session:reconcile",
+          runtime: expect.objectContaining({
+            model: "gpt-5-after-custody",
+            revision: {
+              agent: expect.objectContaining({ sequence: updatedAgent.runtimeConfig.revision }),
+              session: expect.objectContaining({ sequence: updatedAgent.runtimeConfig.revision }),
+            },
+          }),
+        }),
+        expect.objectContaining({ type: "im:deliver", deliveryId: pendingId }),
+      ]);
+      expect(rebuiltClient.reconciler.getAgent(value.agent.id)?.revisionSequence).toBe(
+        updatedAgent.runtimeConfig.revision,
+      );
+    } finally {
+      for (const owner of owners) owner.close();
+      await rm(clientHome, { recursive: true, force: true });
+      await value.sql.end();
+    }
+  });
+
+  it("rechecks Agent custody after claim before a higher revision can reach runtime side effects", async () => {
+    const value = await fixture();
+    const clientHome = await mkdtemp(resolve(tmpdir(), "opentag-agent-custody-claim-race-"));
+    const owners: RuntimeDomainOwner[] = [];
+    try {
+      const firstInstanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: firstInstanceId })
+        .where(eq(computers.id, value.computer.id));
+      const inbox = new ImMessageInbox(value.database);
+      const firstAdmission = await inbox.ingest(value.integrationId, 1, inbound("Ev-agent-claim-race-accepted"));
+      const firstDeliveryId = firstAdmission.deliveryIds[0];
+      if (!firstDeliveryId || !firstAdmission.messageId) throw new Error("Race fixture was not admitted");
+      const [firstDelivery] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, firstDeliveryId));
+      if (!firstDelivery) throw new Error("Race delivery was not persisted");
+      const assembler = new EffectiveRuntimeSnapshotAssembler(value.database);
+      const pinnedRuntime = await assembler.assembleForSession(firstDelivery.sessionId);
+      const firstRequest: DirectImMessageDeliveryRequest = {
+        type: "im:deliver",
+        requestId: crypto.randomUUID(),
+        deliveryId: firstDelivery.id,
+        imMessageId: firstDelivery.messageId,
+        sessionId: firstDelivery.sessionId,
+        agentId: value.agent.id,
+        placementGeneration: firstDelivery.placementGeneration,
+        attention: firstDelivery.attention,
+        content: { kind: "text", text: "late accepted input" },
+        runtime: pinnedRuntime,
+        deadlineAt: firstDelivery.expiresAt.toISOString(),
+      };
+      const firstClient = await createDurableClientReconciler(clientHome, value.computer.id);
+      await expect(
+        firstClient.reconciler.reconcile({
+          type: "session:reconcile",
+          requestId: crypto.randomUUID(),
+          computerId: value.computer.id,
+          sessionId: firstRequest.sessionId,
+          agentId: firstRequest.agentId,
+          placementGeneration: firstRequest.placementGeneration,
+          desired: "ready",
+          runtime: firstRequest.runtime,
+        }),
+      ).resolves.toMatchObject({ status: "ready" });
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date(Date.now() + 60_000) })
+        .where(eq(imMessageDeliveries.id, firstDelivery.id));
+
+      const updatedAgent = await new AgentService(value.database).updateById(value.bootstrap.userId, value.agent.id, {
+        expectedRevision: value.agent.revision,
+        runtimeConfig: { model: "gpt-5-after-late-accept" },
+      });
+      const secondAdmission = await inbox.ingest(
+        value.integrationId,
+        1,
+        revisionEvent({
+          providerEventId: "Ev-agent-claim-race-pending",
+          externalMessageId: "agent-claim-race-pending",
+          operation: "created",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+          revisionKey: "1",
+        }),
+      );
+      const secondDeliveryId = secondAdmission.deliveryIds[0];
+      if (!secondDeliveryId) throw new Error("Higher revision race delivery was not admitted");
+
+      const assemblerEntered = deferred<void>();
+      const releaseAssembler = deferred<void>();
+      const guardedAssembler = {
+        assembleForSession: async (sessionId: string) => {
+          const runtime = await assembler.assembleForSession(sessionId);
+          assemblerEntered.resolve();
+          await releaseAssembler.promise;
+          return runtime;
+        },
+      };
+      const oldDomain = { requestReconcile: vi.fn(), requestDelivery: vi.fn() };
+      const oldRegistry = { currentInstanceId: () => firstInstanceId };
+      const racingRun = new ImDeliveryWorker({
+        assembler: guardedAssembler,
+        database: value.database,
+        domain: oldDomain as never,
+        registry: oldRegistry as never,
+      }).runOnce();
+      await assemblerEntered.promise;
+      expect(
+        (
+          await value.database.select().from(imMessageDeliveries).where(eq(imMessageDeliveries.id, secondDeliveryId))
+        )[0],
+      ).toMatchObject({ lastErrorCode: expect.stringMatching(/^IM_DELIVERY_CLAIM_[A-F0-9]{32}$/) });
+
+      const firstInputHash = computeDirectInputHash(firstRequest);
+      const custody = new PostgresRuntimeCustodyStore(value.database);
+      const firstContext = {
+        computerId: value.computer.id,
+        instanceId: firstInstanceId,
+        signal: new AbortController().signal,
+        userId: value.bootstrap.userId,
+      };
+      await expect(custody.beginDeliveryDispatch(firstRequest, firstInputHash, firstContext)).resolves.toBe(
+        "dispatched",
+      );
+      const turnId = `turn-${firstRequest.deliveryId}`;
+      await expect(custody.acceptDelivery(firstRequest, firstInputHash, turnId, firstContext)).resolves.toBe(
+        "accepted",
+      );
+      await firstClient.bindingStore.recordAccepted(firstRequest, firstInputHash, turnId);
+      const report = turnReportFor({
+        agentId: firstRequest.agentId,
+        deliveryId: firstRequest.deliveryId,
+        placementGeneration: firstRequest.placementGeneration,
+        sessionId: firstRequest.sessionId,
+        turnId,
+      });
+      await firstClient.bindingStore.updateUnresolved(
+        firstRequest.agentId,
+        firstRequest.sessionId,
+        turnId,
+        "reporting",
+        { report, resultHash: report.resultHash },
+      );
+      const [accepted] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, firstDelivery.id));
+      if (!accepted?.dispatchRequestId || !accepted.inputHash || !accepted.turnId) {
+        throw new Error("Late accepted custody was not persisted");
+      }
+
+      const secondInstanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: secondInstanceId })
+        .where(eq(computers.id, value.computer.id));
+      const rebuiltClient = await createDurableClientReconciler(clientHome, value.computer.id);
+      const recovered = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId: secondInstanceId,
+        userId: value.bootstrap.userId,
+        reconcileResult: async (frame) => {
+          const result = await rebuiltClient.reconciler.reconcile(frame as unknown as SessionReconcileRequest);
+          return result.status === "recovery_required"
+            ? {
+                ...result,
+                retainedReports: [
+                  {
+                    dispatchRequestId: accepted.dispatchRequestId,
+                    deliveryId: accepted.id,
+                    inputHash: accepted.inputHash,
+                    turnId: accepted.turnId,
+                    placementGeneration: accepted.placementGeneration,
+                    resultHash: report.resultHash,
+                  },
+                ],
+              }
+            : result;
+        },
+      });
+      owners.push(recovered.domain);
+      releaseAssembler.resolve();
+      await racingRun;
+      expect(oldDomain.requestReconcile).not.toHaveBeenCalled();
+      expect(oldDomain.requestDelivery).not.toHaveBeenCalled();
+      expect(
+        (
+          await value.database.select().from(imMessageDeliveries).where(eq(imMessageDeliveries.id, secondDeliveryId))
+        )[0],
+      ).toMatchObject({ lastErrorCode: "IM_DELIVERY_AGENT_CUSTODY_FENCED", state: "pending" });
+
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date(0) })
+        .where(eq(imMessageDeliveries.id, firstDelivery.id));
+      const recoveryWorker = imDeliveryWorker({
+        database: value.database,
+        registry: recovered.registry,
+        domain: recovered.domain,
+      });
+      await recoveryWorker.runOnce();
+      expect(recovered.frames[0]).toMatchObject({ type: "session:reconcile", runtime: pinnedRuntime });
+      await expect(recovered.domain.handle(report, recovered.context)).resolves.toMatchObject({ status: "recorded" });
+      await rebuiltClient.bindingStore.recordResult(value.agent.id, firstRequest.sessionId, turnId, report.resultHash);
+      expect(rebuiltClient.reconciler.clearRecovery(firstRequest.sessionId, turnId)).toBe(true);
+
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date(0) })
+        .where(eq(imMessageDeliveries.id, secondDeliveryId));
+      const beforePending = recovered.frames.length;
+      await recoveryWorker.runOnce();
+      expect(recovered.frames.slice(beforePending)).toEqual([
+        expect.objectContaining({
+          type: "session:reconcile",
+          runtime: expect.objectContaining({
+            model: "gpt-5-after-late-accept",
+            revision: {
+              agent: expect.objectContaining({ sequence: updatedAgent.runtimeConfig.revision }),
+              session: expect.objectContaining({ sequence: updatedAgent.runtimeConfig.revision }),
+            },
+          }),
+        }),
+        expect.objectContaining({ type: "im:deliver", deliveryId: secondDeliveryId }),
+      ]);
+    } finally {
+      for (const owner of owners) owner.close();
+      await rm(clientHome, { recursive: true, force: true });
+      await value.sql.end();
+    }
+  });
+
+  it("renews an active claim lease and fences same-Agent work across workers", async () => {
+    const value = await fixture();
+    try {
+      const instanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: instanceId })
+        .where(eq(computers.id, value.computer.id));
+      const inbox = new ImMessageInbox(value.database);
+      const firstAdmission = await inbox.ingest(value.integrationId, 1, inbound("Ev-owned-claim-first"));
+      const firstDeliveryId = firstAdmission.deliveryIds[0];
+      if (!firstDeliveryId) throw new Error("Owned claim fixture was not admitted");
+      const reconcileEntered = deferred<void>();
+      const releaseReconcile = deferred<void>();
+      const firstDomain = {
+        requestReconcile: vi.fn(async () => {
+          reconcileEntered.resolve();
+          await releaseReconcile.promise;
+          return { status: "ready" };
+        }),
+        requestDelivery: vi.fn().mockResolvedValue({
+          status: "rejected",
+          reason: "configuration_unsupported",
+        }),
+      };
+      const firstWorker = imDeliveryWorker({
+        database: value.database,
+        registry: { currentInstanceId: () => instanceId } as never,
+        domain: firstDomain as never,
+        claimLeaseMs: 300,
+        claimRenewMs: 50,
+      });
+      const firstRun = firstWorker.runOnce();
+      await reconcileEntered.promise;
+      const [claimed] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, firstDeliveryId));
+      expect(claimed?.lastErrorCode).toMatch(/^IM_DELIVERY_CLAIM_[A-F0-9]{32}$/);
+
+      await new AgentService(value.database).updateById(value.bootstrap.userId, value.agent.id, {
+        expectedRevision: value.agent.revision,
+        runtimeConfig: { model: "gpt-5-owned-claim" },
+      });
+      const secondAdmission = await inbox.ingest(
+        value.integrationId,
+        1,
+        revisionEvent({
+          providerEventId: "Ev-owned-claim-second",
+          externalMessageId: "owned-claim-second",
+          operation: "created",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+          revisionKey: "1",
+        }),
+      );
+      const secondDeliveryId = secondAdmission.deliveryIds[0];
+      if (!secondDeliveryId) throw new Error("Same-Agent fenced fixture was not admitted");
+
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 400));
+      const [renewedClaim] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, firstDeliveryId));
+      expect(renewedClaim?.nextAttemptAt.getTime()).toBeGreaterThan(claimed?.nextAttemptAt.getTime() ?? 0);
+      const secondDomain = { requestReconcile: vi.fn(), requestDelivery: vi.fn() };
+      const secondWorker = imDeliveryWorker({
+        database: value.database,
+        registry: { currentInstanceId: () => undefined } as never,
+        domain: secondDomain as never,
+      });
+      await secondWorker.runOnce();
+      expect(firstDomain.requestReconcile).toHaveBeenCalledTimes(1);
+      expect(secondDomain.requestReconcile).not.toHaveBeenCalled();
+      expect(secondDomain.requestDelivery).not.toHaveBeenCalled();
+      expect(
+        (await value.database.select().from(imMessageDeliveries).where(eq(imMessageDeliveries.id, firstDeliveryId)))[0]
+          ?.lastErrorCode,
+      ).toBe(claimed?.lastErrorCode);
+      expect(
+        (
+          await value.database.select().from(imMessageDeliveries).where(eq(imMessageDeliveries.id, secondDeliveryId))
+        )[0],
+      ).toMatchObject({ attemptCount: 0, state: "pending" });
+
+      releaseReconcile.resolve();
+      await firstRun;
+      expect(
+        (await value.database.select().from(imMessageDeliveries).where(eq(imMessageDeliveries.id, firstDeliveryId)))[0],
+      ).toMatchObject({ lastErrorCode: "IM_DELIVERY_TERMINAL", state: "terminal_rejected" });
+      await secondWorker.runOnce();
+      expect(
+        (
+          await value.database.select().from(imMessageDeliveries).where(eq(imMessageDeliveries.id, secondDeliveryId))
+        )[0],
+      ).toMatchObject({ attemptCount: 1, lastErrorCode: "IM_DELIVERY_RUNTIME_UNAVAILABLE", state: "pending" });
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("does not let a pending delivery for an ended Session fence another active Session of the Agent", async () => {
+    const value = await fixture();
+    try {
+      const instanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: instanceId })
+        .where(eq(computers.id, value.computer.id));
+      const inbox = new ImMessageInbox(value.database);
+      const endedAdmission = await inbox.ingest(value.integrationId, 1, inbound("Ev-ended-session-pending"));
+      const endedDeliveryId = endedAdmission.deliveryIds[0];
+      if (!endedDeliveryId) throw new Error("Ended Session fixture was not admitted");
+      const [endedDelivery] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, endedDeliveryId));
+      if (!endedDelivery) throw new Error("Ended Session delivery was not found");
+      await value.database
+        .update(sessions)
+        .set({ endedAt: new Date() })
+        .where(eq(sessions.id, endedDelivery.sessionId));
+
+      const activeAdmission = await inbox.ingest(
+        value.integrationId,
+        1,
+        revisionEvent({
+          providerEventId: "Ev-active-session-pending",
+          externalMessageId: "active-session-pending",
+          operation: "created",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+          revisionKey: "1",
+        }),
+      );
+      const activeDeliveryId = activeAdmission.deliveryIds[0];
+      if (!activeDeliveryId) throw new Error("Active Session fixture was not admitted");
+
+      const worker = imDeliveryWorker({
+        database: value.database,
+        registry: { currentInstanceId: () => instanceId } as never,
+        domain: {
+          requestReconcile: vi.fn().mockResolvedValue({ status: "ready" }),
+          requestDelivery: vi.fn().mockResolvedValue({
+            status: "rejected",
+            reason: "configuration_unsupported",
+          }),
+        } as never,
+      });
+      await worker.runOnce();
+
+      const [stillEnded] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, endedDeliveryId));
+      const [processedActive] = await value.database
+        .select()
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.id, activeDeliveryId));
+      expect(stillEnded).toMatchObject({ attemptCount: 0, lastErrorCode: null, state: "pending" });
+      expect(processedActive).toMatchObject({ attemptCount: 1, state: "terminal_rejected" });
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it.each(["pending", "accepted"] as const)(
+    "rejects a schema-valid %s payload mutation that no longer matches custody hashes",
+    async (state) => {
+      const value = await fixture();
+      try {
+        const instanceId = crypto.randomUUID();
+        await value.database
+          .update(computers)
+          .set({ currentInstanceId: instanceId })
+          .where(eq(computers.id, value.computer.id));
+        await new ImMessageInbox(value.database).ingest(value.integrationId, 1, inbound(`Ev-payload-hash-${state}`));
+        const runtime = await respondingRuntime({
+          acceptDeliveries: state === "accepted",
+          database: value.database,
+          computerId: value.computer.id,
+          instanceId,
+          requestTimeoutMs: 100,
+          userId: value.bootstrap.userId,
+        });
+        const worker = imDeliveryWorker({
+          database: value.database,
+          registry: runtime.registry,
+          domain: runtime.domain,
+        });
+        await worker.runOnce();
+        const [stored] = await value.database.select().from(imMessageDeliveries);
+        if (!stored?.dispatchPayload) throw new Error("Custody payload was not persisted");
+        await value.database
+          .update(imMessageDeliveries)
+          .set({
+            dispatchPayload: {
+              ...stored.dispatchPayload,
+              runtime: { ...stored.dispatchPayload.runtime, model: "schema-valid-tampering" },
+            },
+            nextAttemptAt: new Date(0),
+          })
+          .where(eq(imMessageDeliveries.id, stored.id));
+        const beforeRetry = runtime.frames.length;
+        await worker.runOnce();
+        expect(runtime.frames).toHaveLength(beforeRetry);
+        expect((await value.database.select().from(imMessageDeliveries))[0]).toMatchObject({
+          lastErrorCode:
+            state === "accepted" ? "IM_DELIVERY_RECOVERY_PAYLOAD_INVALID" : "IM_DELIVERY_DISPATCH_PAYLOAD_INVALID",
+          state,
+        });
+        runtime.domain.close();
+      } finally {
+        await value.sql.end();
+      }
+    },
+  );
+
   it("expires a never-dispatched delivery even after reconcile increased its attempt count", async () => {
     const value = await fixture();
     try {
@@ -1266,7 +2023,7 @@ describe("IM Integration persistence", () => {
         requestDelivery: vi.fn(),
       };
       const registry = { currentInstanceId: () => instanceId };
-      const worker = new ImDeliveryWorker({
+      const worker = imDeliveryWorker({
         database: value.database,
         registry: registry as never,
         domain: failedDomain as never,
@@ -1311,15 +2068,21 @@ describe("IM Integration persistence", () => {
         userId: value.bootstrap.userId,
       });
       owners.push(first.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: first.registry,
         domain: first.domain,
       }).runOnce();
       const [accepted] = await value.database.select().from(imMessageDeliveries);
-      if (!accepted?.turnId || !accepted.dispatchRequestId || !accepted.dispatchInputHash) {
+      if (
+        !accepted?.turnId ||
+        !accepted.dispatchRequestId ||
+        !accepted.dispatchInputHash ||
+        !accepted.dispatchPayload
+      ) {
         throw new Error("Accepted delivery fixture was not persisted");
       }
+      const pinnedRuntime = accepted.dispatchPayload.runtime;
       const report = turnReportFor({
         agentId: value.agent.id,
         deliveryId: accepted.id,
@@ -1327,6 +2090,11 @@ describe("IM Integration persistence", () => {
         sessionId: accepted.sessionId,
         turnId: accepted.turnId,
       });
+      const updatedAgent = await new AgentService(value.database).updateById(value.bootstrap.userId, value.agent.id, {
+        expectedRevision: value.agent.revision,
+        runtimeConfig: { model: "gpt-5-after-accept" },
+      });
+      expect(updatedAgent.runtimeConfig.revision).toBeGreaterThan(pinnedRuntime.revision.session.sequence);
       first.domain.close();
 
       const secondInstanceId = crypto.randomUUID();
@@ -1364,14 +2132,20 @@ describe("IM Integration persistence", () => {
         }),
       });
       owners.push(second.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: second.registry,
         domain: second.domain,
       }).runOnce();
+      const recoveryReconcile = second.frames.find(
+        (frame): frame is Record<string, unknown> & { runtime: DirectImMessageDeliveryRequest["runtime"] } =>
+          typeof frame === "object" && frame !== null && (frame as { type?: unknown }).type === "session:reconcile",
+      );
+      expect(recoveryReconcile?.runtime).toEqual(pinnedRuntime);
       expect(await second.domain.getDelivery(accepted.id)).toMatchObject({ instanceId: secondInstanceId });
       await expect(second.domain.handle(report, second.context)).resolves.toMatchObject({ status: "recorded" });
       expect(await second.domain.getTurn(report.turnId)).toMatchObject({ resultHash: report.resultHash });
+      expect((await value.database.select().from(imMessageDeliveries))[0]?.dispatchPayload).toBeNull();
       second.domain.close();
 
       const thirdInstanceId = crypto.randomUUID();
@@ -1395,6 +2169,68 @@ describe("IM Integration persistence", () => {
     }
   });
 
+  it("uses a diagnostic best-effort assembler fallback only for legacy accepted rows without payload", async () => {
+    const value = await fixture();
+    const owners: RuntimeDomainOwner[] = [];
+    try {
+      const firstInstanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: firstInstanceId })
+        .where(eq(computers.id, value.computer.id));
+      await new ImMessageInbox(value.database).ingest(value.integrationId, 1, inbound("Ev-legacy-recovery"));
+      const first = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId: firstInstanceId,
+        userId: value.bootstrap.userId,
+      });
+      owners.push(first.domain);
+      await imDeliveryWorker({
+        database: value.database,
+        registry: first.registry,
+        domain: first.domain,
+      }).runOnce();
+      const [accepted] = await value.database.select().from(imMessageDeliveries);
+      if (!accepted) throw new Error("Legacy accepted fixture was not persisted");
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ dispatchPayload: null, nextAttemptAt: new Date(0) })
+        .where(eq(imMessageDeliveries.id, accepted.id));
+      first.domain.close();
+
+      const secondInstanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: secondInstanceId })
+        .where(eq(computers.id, value.computer.id));
+      const second = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId: secondInstanceId,
+        userId: value.bootstrap.userId,
+      });
+      owners.push(second.domain);
+      const diagnostic = vi.fn();
+      await imDeliveryWorker({
+        database: value.database,
+        registry: second.registry,
+        domain: second.domain,
+        onDiagnostic: diagnostic,
+      }).runOnce();
+      expect(diagnostic).toHaveBeenCalledWith("IM_DELIVERY_RECOVERY_LEGACY_SNAPSHOT_FALLBACK");
+      expect(second.frames).toEqual([
+        expect.objectContaining({
+          type: "session:reconcile",
+          runtime: expect.objectContaining({ agentId: value.agent.id }),
+        }),
+      ]);
+    } finally {
+      for (const owner of owners) owner.close();
+      await value.sql.end();
+    }
+  });
+
   it.each(["pending", "expired"] as const)(
     "recovers a retained Client Turn from a %s dispatch after rebuilding the Server owner",
     async (durableState) => {
@@ -1412,11 +2248,11 @@ describe("IM Integration persistence", () => {
           database: value.database,
           computerId: value.computer.id,
           instanceId: firstInstanceId,
-          requestTimeoutMs: 10,
+          requestTimeoutMs: 100,
           userId: value.bootstrap.userId,
         });
         owners.push(first.domain);
-        await new ImDeliveryWorker({
+        await imDeliveryWorker({
           database: value.database,
           registry: first.registry,
           domain: first.domain,
@@ -1444,7 +2280,7 @@ describe("IM Integration persistence", () => {
             requestReconcile: vi.fn().mockResolvedValue({ status: "recovery_required" }),
             requestDelivery: vi.fn(),
           };
-          await new ImDeliveryWorker({
+          await imDeliveryWorker({
             database: value.database,
             registry: first.registry,
             domain: expiryDomain as never,
@@ -1492,19 +2328,21 @@ describe("IM Integration persistence", () => {
           }),
         });
         owners.push(second.domain);
-        await new ImDeliveryWorker({
+        await imDeliveryWorker({
           database: value.database,
           registry: second.registry,
           domain: second.domain,
         }).runOnce();
         expect(second.frames.filter((frame) => (frame as { type?: unknown }).type === "im:deliver")).toEqual([]);
         expect((await value.database.select().from(imMessageDeliveries))[0]).toMatchObject({
+          dispatchPayload: firstFrame,
           reportOwnerInstanceId: secondInstanceId,
           state: "accepted",
           turnId,
         });
         await expect(second.domain.handle(report, second.context)).resolves.toMatchObject({ status: "recorded" });
         expect((await value.database.select().from(imMessageDeliveries))[0]).toMatchObject({
+          dispatchPayload: null,
           reportedAt: expect.any(Date),
           state: "accepted",
           turnId,
@@ -1531,11 +2369,11 @@ describe("IM Integration persistence", () => {
         database: value.database,
         computerId: value.computer.id,
         instanceId: firstInstanceId,
-        requestTimeoutMs: 10,
+        requestTimeoutMs: 100,
         userId: value.bootstrap.userId,
       });
       owners.push(first.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: first.registry,
         domain: first.domain,
@@ -1571,7 +2409,7 @@ describe("IM Integration persistence", () => {
         userId: value.bootstrap.userId,
       });
       owners.push(second.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: second.registry,
         domain: second.domain,
@@ -1588,7 +2426,7 @@ describe("IM Integration persistence", () => {
         .update(imMessageDeliveries)
         .set({ nextAttemptAt: new Date(0) })
         .where(eq(imMessageDeliveries.id, firstFrame.deliveryId));
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: second.registry,
         domain: second.domain,
@@ -1636,7 +2474,7 @@ describe("IM Integration persistence", () => {
         instanceId,
         userId: value.bootstrap.userId,
       });
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: runtime.registry,
         domain: runtime.domain,
@@ -1674,7 +2512,7 @@ describe("IM Integration persistence", () => {
         instanceId,
         userId: value.bootstrap.userId,
       });
-      const run = new ImDeliveryWorker({
+      const run = imDeliveryWorker({
         database: value.database,
         registry: runtime.registry,
         domain: runtime.domain,
@@ -1723,11 +2561,11 @@ describe("IM Integration persistence", () => {
         database: value.database,
         computerId: value.computer.id,
         instanceId: firstInstanceId,
-        requestTimeoutMs: 10,
+        requestTimeoutMs: 100,
         userId: value.bootstrap.userId,
       });
       owners.push(first.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: first.registry,
         domain: first.domain,
@@ -1769,7 +2607,7 @@ describe("IM Integration persistence", () => {
         .update(imMessageDeliveries)
         .set({ nextAttemptAt: new Date(0) })
         .where(eq(imMessageDeliveries.id, oldRequest.deliveryId));
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: second.registry,
         domain: second.domain,
@@ -1825,7 +2663,7 @@ describe("IM Integration persistence", () => {
         .update(imMessageDeliveries)
         .set({ nextAttemptAt: new Date(0) })
         .where(eq(imMessageDeliveries.id, oldRequest.deliveryId));
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: third.registry,
         domain: third.domain,
@@ -1858,7 +2696,7 @@ describe("IM Integration persistence", () => {
         .update(imMessageDeliveries)
         .set({ nextAttemptAt: new Date(0) })
         .where(eq(imMessageDeliveries.id, oldRequest.deliveryId));
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: fourth.registry,
         domain: fourth.domain,
@@ -1877,7 +2715,7 @@ describe("IM Integration persistence", () => {
         .update(imMessageDeliveries)
         .set({ nextAttemptAt: new Date(0) })
         .where(eq(imMessageDeliveries.id, oldRequest.deliveryId));
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: fourth.registry,
         domain: fourth.domain,
@@ -1925,11 +2763,11 @@ describe("IM Integration persistence", () => {
         database: value.database,
         computerId: value.computer.id,
         instanceId: firstInstanceId,
-        requestTimeoutMs: 10,
+        requestTimeoutMs: 100,
         userId: value.bootstrap.userId,
       });
       owners.push(first.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: first.registry,
         domain: first.domain,
@@ -1943,7 +2781,7 @@ describe("IM Integration persistence", () => {
         .update(imMessageDeliveries)
         .set({ expiresAt: new Date(0), nextAttemptAt: new Date(0) })
         .where(eq(imMessageDeliveries.id, oldRequest.deliveryId));
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: first.registry,
         domain: {
@@ -1974,7 +2812,7 @@ describe("IM Integration persistence", () => {
         .update(imMessageDeliveries)
         .set({ nextAttemptAt: new Date(0) })
         .where(eq(imMessageDeliveries.id, oldRequest.deliveryId));
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: second.registry,
         domain: second.domain,
@@ -2020,14 +2858,14 @@ describe("IM Integration persistence", () => {
         userId: value.bootstrap.userId,
       });
       owners.push(runtime.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: runtime.registry,
         domain: runtime.domain,
       }).runOnce();
       const [accepted] = await value.database.select().from(imMessageDeliveries);
       if (!accepted?.turnId) throw new Error("Accepted custody was not persisted");
-      expect(accepted.dispatchPayload).toBeNull();
+      expect(accepted.dispatchPayload).not.toBeNull();
       const sessionsService = new SessionService(value.database);
       await expect(sessionsService.movePlacement(accepted.sessionId, value.computer.id)).rejects.toMatchObject({
         code: "SESSION_PLACEMENT_CUSTODY_PENDING",
@@ -2040,6 +2878,7 @@ describe("IM Integration persistence", () => {
         turnId: accepted.turnId,
       });
       await expect(runtime.domain.handle(report, runtime.context)).resolves.toMatchObject({ status: "recorded" });
+      expect((await value.database.select().from(imMessageDeliveries))[0]?.dispatchPayload).toBeNull();
       await expect(sessionsService.movePlacement(accepted.sessionId, value.computer.id)).resolves.toMatchObject({
         generation: 2,
       });
@@ -2065,11 +2904,11 @@ describe("IM Integration persistence", () => {
         database: value.database,
         computerId: value.computer.id,
         instanceId: firstInstanceId,
-        requestTimeoutMs: 10,
+        requestTimeoutMs: 100,
         userId: value.bootstrap.userId,
       });
       owners.push(first.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: first.registry,
         domain: first.domain,
@@ -2155,7 +2994,7 @@ describe("IM Integration persistence", () => {
         }),
       });
       owners.push(second.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: second.registry,
         domain: second.domain,
@@ -2191,11 +3030,11 @@ describe("IM Integration persistence", () => {
           database: value.database,
           computerId: value.computer.id,
           instanceId,
-          requestTimeoutMs: 10,
+          requestTimeoutMs: 100,
           userId: value.bootstrap.userId,
         });
         owners.push(runtime.domain);
-        await new ImDeliveryWorker({
+        await imDeliveryWorker({
           database: value.database,
           registry: runtime.registry,
           domain: runtime.domain,
@@ -2293,7 +3132,7 @@ describe("IM Integration persistence", () => {
         userId: value.bootstrap.userId,
       });
       owners.push(first.domain);
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: first.registry,
         domain: first.domain,
@@ -2325,7 +3164,7 @@ describe("IM Integration persistence", () => {
         .where(eq(imMessageDeliveries.id, pending.id));
 
       const before = first.frames.length;
-      await new ImDeliveryWorker({
+      await imDeliveryWorker({
         database: value.database,
         registry: first.registry,
         domain: first.domain,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,7 @@ import {
 import { createImProviderAdapterResolver, IntegrationService } from "./services/integrations/index.js";
 import { DefaultSlackApiClient, SlackAdapter } from "./services/integrations/slack/index.js";
 import { InvitationService } from "./services/invitations/index.js";
+import { EffectiveRuntimeSnapshotAssembler } from "./services/runtime-config/index.js";
 import { TeamMembershipService } from "./services/teams/index.js";
 
 export { bootstrapInitialAdmin } from "./admin/bootstrap.js";
@@ -176,7 +177,9 @@ export async function startServer(): Promise<void> {
     const resolveImAdapter = createImProviderAdapterResolver({ integrations: integrationService, slackApi });
     outboundMessageService = new OutboundMessageService(database, resolveImAdapter);
     const imResourceService = new ImResourceService(database, resolveImAdapter);
+    const runtimeSnapshotAssembler = new EffectiveRuntimeSnapshotAssembler(database);
     const imDeliveryWorker = new ImDeliveryWorker({
+      assembler: runtimeSnapshotAssembler,
       database,
       domain: domainOwner,
       registry,

--- a/packages/server/src/runtime/im-delivery-worker.ts
+++ b/packages/server/src/runtime/im-delivery-worker.ts
@@ -1,18 +1,18 @@
 import { randomUUID } from "node:crypto";
 import {
+  computeDirectInputHash,
   type DirectImMessageDeliveryRequest,
   DirectImMessageDeliveryRequestSchema,
   type EffectiveRuntimeSnapshot,
-  OPENTAG_PLATFORM_INSTRUCTIONS,
   RUNTIME_DIRECT_TEXT_MAX_BYTES,
   RUNTIME_IM_HISTORY_MAX_BYTES,
   RUNTIME_MAX_FRAME_BYTES,
   runtimeFrameByteLength,
 } from "@opentag/shared";
-import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm";
-import type { DatabaseClient } from "../db/client.js";
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, like, lt, lte, ne, notExists, or, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import type { DatabaseClient, DatabaseTransaction } from "../db/client.js";
 import {
-  agentRuntimeConfigs,
   agents,
   computers,
   imMessageDeliveries,
@@ -21,17 +21,33 @@ import {
   sessionPlacements,
   sessions,
 } from "../db/schema/index.js";
+import {
+  type EffectiveRuntimeSnapshotAssembler,
+  EffectiveRuntimeSnapshotAssemblerError,
+} from "../services/runtime-config/index.js";
 import type { ConnectionRegistry } from "./connection-registry.js";
 import type { RuntimeDomainOwner } from "./runtime-domain-owner.js";
 
 const DEFAULT_INTERVAL_MS = 500;
 const RETRY_DELAY_MS = 2_000;
+const CLAIM_LEASE_MS = 15_000;
+const CLAIM_RENEW_MS = 5_000;
+// This durable marker bridges the transaction-to-runtime gap. The advisory lock
+// serializes competing claims; the marker keeps later transactions fenced after commit.
+const DISPATCH_CLAIM_PREFIX = "IM_DELIVERY_CLAIM_";
+const acceptedDeliveries = alias(imMessageDeliveries, "agent_accepted_deliveries");
+const acceptedSessions = alias(sessions, "agent_accepted_sessions");
+const acceptedIntegrations = alias(integrations, "agent_accepted_integrations");
+const acceptedAgents = alias(agents, "agent_accepted_agents");
 
 export class ImDeliveryWorker {
   readonly #database: DatabaseClient;
   readonly #domain: RuntimeDomainOwner;
+  readonly #assembler: Pick<EffectiveRuntimeSnapshotAssembler, "assembleForSession">;
   readonly #registry: ConnectionRegistry;
   readonly #intervalMs: number;
+  readonly #claimLeaseMs: number;
+  readonly #claimRenewMs: number;
   readonly #onDiagnostic: (code: string) => void;
   #timer?: ReturnType<typeof setInterval>;
   #running = false;
@@ -39,14 +55,20 @@ export class ImDeliveryWorker {
   constructor(input: {
     database: DatabaseClient;
     domain: RuntimeDomainOwner;
+    assembler: Pick<EffectiveRuntimeSnapshotAssembler, "assembleForSession">;
     registry: ConnectionRegistry;
     intervalMs?: number;
+    claimLeaseMs?: number;
+    claimRenewMs?: number;
     onDiagnostic?: (code: string) => void;
   }) {
     this.#database = input.database;
     this.#domain = input.domain;
+    this.#assembler = input.assembler;
     this.#registry = input.registry;
     this.#intervalMs = input.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.#claimLeaseMs = input.claimLeaseMs ?? CLAIM_LEASE_MS;
+    this.#claimRenewMs = input.claimRenewMs ?? CLAIM_RENEW_MS;
     this.#onDiagnostic = input.onDiagnostic ?? (() => undefined);
   }
 
@@ -68,7 +90,7 @@ export class ImDeliveryWorker {
     try {
       const claimed = await this.#claim();
       if (claimed) {
-        if (claimed.kind === "pending") await this.#deliver(claimed.id);
+        if (claimed.kind === "pending") await this.#deliver(claimed.id, claimed.claimToken);
         else await this.#recover(claimed.id);
       }
     } finally {
@@ -80,7 +102,9 @@ export class ImDeliveryWorker {
     void this.runOnce().catch(() => this.#onDiagnostic("IM_DELIVERY_WORKER_SCHEDULING_FAILED"));
   }
 
-  async #claim(): Promise<{ id: string; kind: "pending" | "recovery" } | undefined> {
+  async #claim(): Promise<
+    { id: string; kind: "pending"; claimToken: string } | { id: string; kind: "recovery" } | undefined
+  > {
     return this.#database.transaction(async (transaction) => {
       const now = new Date();
       await transaction
@@ -99,28 +123,60 @@ export class ImDeliveryWorker {
           state: imMessageDeliveries.state,
           deliveryGeneration: imMessageDeliveries.placementGeneration,
           dispatchRequestId: imMessageDeliveries.dispatchRequestId,
+          dispatchInputHash: imMessageDeliveries.dispatchInputHash,
           dispatchPayload: imMessageDeliveries.dispatchPayload,
           generation: sessionPlacements.generation,
+          agentId: integrations.agentId,
         })
         .from(imMessageDeliveries)
         .innerJoin(sessionPlacements, eq(sessionPlacements.sessionId, imMessageDeliveries.sessionId))
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .innerJoin(integrations, eq(integrations.id, sessions.integrationId))
+        .innerJoin(agents, eq(agents.id, integrations.agentId))
         .where(
-          or(
-            and(
-              eq(imMessageDeliveries.state, "pending"),
-              isNull(imMessageDeliveries.reason),
-              lte(imMessageDeliveries.nextAttemptAt, now),
-              sql`${imMessageDeliveries.expiresAt} > now()`,
-            ),
-            and(
-              eq(imMessageDeliveries.state, "expired"),
-              isNotNull(imMessageDeliveries.dispatchRequestId),
-              lte(imMessageDeliveries.nextAttemptAt, now),
-            ),
-            and(
-              eq(imMessageDeliveries.state, "accepted"),
-              isNull(imMessageDeliveries.reportedAt),
-              lte(imMessageDeliveries.nextAttemptAt, now),
+          and(
+            isNull(sessions.endedAt),
+            eq(integrations.status, "active"),
+            isNull(agents.deletedAt),
+            or(
+              and(
+                or(
+                  and(
+                    eq(imMessageDeliveries.state, "pending"),
+                    isNull(imMessageDeliveries.reason),
+                    lte(imMessageDeliveries.nextAttemptAt, now),
+                    sql`${imMessageDeliveries.expiresAt} > now()`,
+                  ),
+                  and(
+                    eq(imMessageDeliveries.state, "expired"),
+                    isNotNull(imMessageDeliveries.dispatchRequestId),
+                    lte(imMessageDeliveries.nextAttemptAt, now),
+                  ),
+                ),
+                notExists(
+                  transaction
+                    .select({ id: acceptedDeliveries.id })
+                    .from(acceptedDeliveries)
+                    .innerJoin(acceptedSessions, eq(acceptedSessions.id, acceptedDeliveries.sessionId))
+                    .innerJoin(acceptedIntegrations, eq(acceptedIntegrations.id, acceptedSessions.integrationId))
+                    .innerJoin(acceptedAgents, eq(acceptedAgents.id, acceptedIntegrations.agentId))
+                    .where(
+                      and(
+                        eq(acceptedIntegrations.agentId, integrations.agentId),
+                        ne(acceptedDeliveries.id, imMessageDeliveries.id),
+                        isNull(acceptedSessions.endedAt),
+                        eq(acceptedIntegrations.status, "active"),
+                        isNull(acceptedAgents.deletedAt),
+                        uncertainAgentCustody(acceptedDeliveries),
+                      ),
+                    ),
+                ),
+              ),
+              and(
+                eq(imMessageDeliveries.state, "accepted"),
+                isNull(imMessageDeliveries.reportedAt),
+                lte(imMessageDeliveries.nextAttemptAt, now),
+              ),
             ),
           ),
         )
@@ -128,6 +184,12 @@ export class ImDeliveryWorker {
         .limit(1)
         .for("update", { of: imMessageDeliveries, skipLocked: true });
       if (!row) return undefined;
+      await transaction.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${`im-agent-custody:${row.agentId}`}, 0))`,
+      );
+      if (row.state !== "accepted" && (await hasOtherAgentCustody(transaction, row.agentId, row.id))) {
+        return undefined;
+      }
       if (row.state === "accepted") {
         await transaction
           .update(imMessageDeliveries)
@@ -145,8 +207,7 @@ export class ImDeliveryWorker {
       const staleCorrelation =
         row.dispatchRequestId !== null &&
         (row.deliveryGeneration !== row.generation ||
-          !persistedRequest?.success ||
-          persistedRequest.data.placementGeneration !== row.generation);
+          (persistedRequest?.success && persistedRequest.data.placementGeneration !== row.generation));
       if (staleCorrelation) {
         await transaction
           .update(imMessageDeliveries)
@@ -157,20 +218,30 @@ export class ImDeliveryWorker {
           .where(eq(imMessageDeliveries.id, row.id));
         return undefined;
       }
+      const claimToken = dispatchClaimToken();
       await transaction
         .update(imMessageDeliveries)
         .set({
           attemptCount: sql`${imMessageDeliveries.attemptCount} + 1`,
           ...(row.state === "pending" ? { placementGeneration: row.generation } : {}),
-          nextAttemptAt: new Date(now.getTime() + RETRY_DELAY_MS),
-          lastErrorCode: null,
+          nextAttemptAt: new Date(now.getTime() + this.#claimLeaseMs),
+          lastErrorCode: claimToken,
         })
         .where(eq(imMessageDeliveries.id, row.id));
-      return { id: row.id, kind: "pending" as const };
+      return { id: row.id, kind: "pending" as const, claimToken };
     });
   }
 
-  async #deliver(deliveryId: string): Promise<void> {
+  async #deliver(deliveryId: string, claimToken: string): Promise<void> {
+    const lease = this.#maintainClaimLease(deliveryId, claimToken);
+    try {
+      await this.#deliverClaimed(deliveryId, claimToken, lease);
+    } finally {
+      await lease.stop();
+    }
+  }
+
+  async #deliverClaimed(deliveryId: string, claimToken: string, lease: ClaimLease): Promise<void> {
     const [row] = await this.#database
       .select({
         delivery: imMessageDeliveries,
@@ -179,7 +250,6 @@ export class ImDeliveryWorker {
         placement: sessionPlacements,
         integration: integrations,
         agent: agents,
-        runtimeConfig: agentRuntimeConfigs,
         computer: computers,
       })
       .from(imMessageDeliveries)
@@ -188,7 +258,6 @@ export class ImDeliveryWorker {
       .innerJoin(sessionPlacements, eq(sessionPlacements.sessionId, sessions.id))
       .innerJoin(integrations, eq(integrations.id, sessions.integrationId))
       .innerJoin(agents, eq(agents.id, integrations.agentId))
-      .innerJoin(agentRuntimeConfigs, eq(agentRuntimeConfigs.agentId, agents.id))
       .innerJoin(computers, eq(computers.id, sessionPlacements.computerId))
       .where(
         and(
@@ -203,26 +272,47 @@ export class ImDeliveryWorker {
         ),
       )
       .limit(1);
-    if (!row) return;
+    if (!row) {
+      await this.#recordFailure(deliveryId, "IM_DELIVERY_RUNTIME_AUTHORITY_UNAVAILABLE", claimToken);
+      return;
+    }
     if (row.delivery.placementGeneration !== row.placement.generation) {
-      await this.#recordFailure(deliveryId, "IM_DELIVERY_PLACEMENT_STALE");
+      await this.#recordFailure(deliveryId, "IM_DELIVERY_PLACEMENT_STALE", claimToken);
       return;
     }
     const instanceId = this.#registry.currentInstanceId(row.placement.computerId);
     if (!instanceId || row.computer.currentInstanceId !== instanceId) {
-      await this.#recordFailure(deliveryId, "IM_DELIVERY_RUNTIME_UNAVAILABLE");
+      await this.#recordFailure(deliveryId, "IM_DELIVERY_RUNTIME_UNAVAILABLE", claimToken);
       return;
     }
-    if (row.agent.runtimeProvider !== "codex") {
-      await this.#reject(deliveryId, "configuration_unsupported");
-      return;
-    }
-    const persistedRequest = row.delivery.dispatchPayload
-      ? DirectImMessageDeliveryRequestSchema.parse(row.delivery.dispatchPayload)
+    const parsedPersistedRequest = row.delivery.dispatchPayload
+      ? DirectImMessageDeliveryRequestSchema.safeParse(row.delivery.dispatchPayload)
       : undefined;
+    if (
+      parsedPersistedRequest &&
+      (!parsedPersistedRequest.success ||
+        parsedPersistedRequest.data.deliveryId !== row.delivery.id ||
+        parsedPersistedRequest.data.imMessageId !== row.message.id ||
+        parsedPersistedRequest.data.sessionId !== row.session.id ||
+        parsedPersistedRequest.data.agentId !== row.agent.id ||
+        parsedPersistedRequest.data.placementGeneration !== row.placement.generation ||
+        parsedPersistedRequest.data.requestId !== row.delivery.dispatchRequestId ||
+        computeDirectInputHash(parsedPersistedRequest.data) !== row.delivery.dispatchInputHash)
+    ) {
+      await this.#recordFailure(deliveryId, "IM_DELIVERY_DISPATCH_PAYLOAD_INVALID", claimToken);
+      return;
+    }
+    const persistedRequest = parsedPersistedRequest?.data;
     const runtime =
-      persistedRequest?.runtime ??
-      runtimeSnapshot(row.agent.id, row.runtimeConfig, row.session.id, row.session.revision);
+      persistedRequest?.runtime ?? (await this.#assembleRuntime(deliveryId, row.session.id, "delivery", claimToken));
+    if (!runtime) return;
+    // A late acceptance may commit after this delivery was claimed. Recheck at
+    // the last boundary before any reconcile or delivery frame reaches runtime.
+    if (await hasOtherAgentCustody(this.#database, row.agent.id, deliveryId)) {
+      await this.#recordFailure(deliveryId, "IM_DELIVERY_AGENT_CUSTODY_FENCED", claimToken);
+      return;
+    }
+    if (!(await lease.assertOwned())) return;
     try {
       const reconcile = await this.#domain.requestReconcile(row.placement.computerId, instanceId, {
         type: "session:reconcile",
@@ -242,25 +332,32 @@ export class ImDeliveryWorker {
       if (!currentDelivery || currentDelivery.state === "accepted" || currentDelivery.state === "terminal_rejected") {
         return;
       }
+      if (!(await lease.assertOwned())) return;
       if (reconcile.status !== "ready") {
         await this.#recordFailure(
           deliveryId,
           reconcile.status === "rejected" ? "IM_DELIVERY_RECONCILE_REJECTED" : "IM_DELIVERY_RECONCILE_NOT_READY",
+          claimToken,
         );
         return;
       }
       if (reconcile.retainedReports?.some((claim) => claim.deliveryId === deliveryId)) {
-        await this.#recordFailure(deliveryId, "IM_DELIVERY_RETAINED_CUSTODY_CONFLICT");
+        await this.#recordFailure(deliveryId, "IM_DELIVERY_RETAINED_CUSTODY_CONFLICT", claimToken);
         return;
       }
       if (currentDelivery.state === "expired") {
         if (persistedRequest) {
-          await this.#releaseDispatch(deliveryId, persistedRequest.requestId, "IM_DELIVERY_EXPIRED");
+          await this.#releaseDispatch(deliveryId, persistedRequest.requestId, "IM_DELIVERY_EXPIRED", claimToken);
         }
         return;
       }
       if (persistedRequest) {
-        await this.#releaseDispatch(deliveryId, persistedRequest.requestId, "IM_DELIVERY_RECONCILED_NO_CUSTODY");
+        await this.#releaseDispatch(
+          deliveryId,
+          persistedRequest.requestId,
+          "IM_DELIVERY_RECONCILED_NO_CUSTODY",
+          claimToken,
+        );
         return;
       }
       const resources = row.message.content.resources ?? [];
@@ -302,17 +399,18 @@ export class ImDeliveryWorker {
         deadlineAt: row.delivery.expiresAt.toISOString(),
       };
       fitDeliveryFrame(request);
+      if (!(await lease.assertOwned())) return;
       const result = await this.#domain.requestDelivery(row.placement.computerId, instanceId, request);
       if (
         result.status === "rejected" &&
         ["configuration_unsupported", "invalid_input"].includes(result.reason ?? "")
       ) {
-        await this.#reject(deliveryId, result.reason ?? "terminal_rejected");
+        await this.#reject(deliveryId, result.reason ?? "terminal_rejected", claimToken);
       } else if (result.status === "rejected") {
-        await this.#releaseDispatch(deliveryId, request.requestId, "IM_DELIVERY_RUNTIME_REJECTED");
+        await this.#releaseDispatch(deliveryId, request.requestId, "IM_DELIVERY_RUNTIME_REJECTED", claimToken);
       }
     } catch {
-      await this.#recordFailure(deliveryId, "IM_DELIVERY_RUNTIME_FAILED");
+      await this.#recordFailure(deliveryId, "IM_DELIVERY_RUNTIME_FAILED", claimToken);
     }
   }
 
@@ -324,7 +422,6 @@ export class ImDeliveryWorker {
         placement: sessionPlacements,
         integration: integrations,
         agent: agents,
-        runtimeConfig: agentRuntimeConfigs,
         computer: computers,
       })
       .from(imMessageDeliveries)
@@ -332,7 +429,6 @@ export class ImDeliveryWorker {
       .innerJoin(sessionPlacements, eq(sessionPlacements.sessionId, sessions.id))
       .innerJoin(integrations, eq(integrations.id, sessions.integrationId))
       .innerJoin(agents, eq(agents.id, integrations.agentId))
-      .innerJoin(agentRuntimeConfigs, eq(agentRuntimeConfigs.agentId, agents.id))
       .innerJoin(computers, eq(computers.id, sessionPlacements.computerId))
       .where(
         and(
@@ -355,6 +451,30 @@ export class ImDeliveryWorker {
       await this.#recordFailure(deliveryId, "IM_DELIVERY_RUNTIME_UNAVAILABLE");
       return;
     }
+    let runtime: EffectiveRuntimeSnapshot | undefined;
+    if (row.delivery.dispatchPayload !== null) {
+      const pinned = DirectImMessageDeliveryRequestSchema.safeParse(row.delivery.dispatchPayload);
+      const pinnedInputHash = pinned.success ? computeDirectInputHash(pinned.data) : undefined;
+      if (
+        !pinned.success ||
+        pinned.data.deliveryId !== row.delivery.id ||
+        pinned.data.imMessageId !== row.delivery.messageId ||
+        pinned.data.sessionId !== row.session.id ||
+        pinned.data.agentId !== row.agent.id ||
+        pinned.data.placementGeneration !== row.placement.generation ||
+        pinned.data.requestId !== row.delivery.dispatchRequestId ||
+        pinnedInputHash !== row.delivery.dispatchInputHash ||
+        pinnedInputHash !== row.delivery.inputHash
+      ) {
+        await this.#recordFailure(deliveryId, "IM_DELIVERY_RECOVERY_PAYLOAD_INVALID");
+        return;
+      }
+      runtime = pinned.data.runtime;
+    } else {
+      this.#onDiagnostic("IM_DELIVERY_RECOVERY_LEGACY_SNAPSHOT_FALLBACK");
+      runtime = await this.#assembleRuntime(deliveryId, row.session.id, "recovery");
+    }
+    if (!runtime) return;
     try {
       await this.#domain.requestReconcile(row.placement.computerId, instanceId, {
         type: "session:reconcile",
@@ -364,43 +484,85 @@ export class ImDeliveryWorker {
         agentId: row.agent.id,
         placementGeneration: row.placement.generation,
         desired: "ready",
-        runtime: runtimeSnapshot(row.agent.id, row.runtimeConfig, row.session.id, row.session.revision),
+        runtime,
       });
     } catch {
       await this.#recordFailure(deliveryId, "IM_DELIVERY_RECOVERY_FAILED");
     }
   }
 
-  async #recordFailure(deliveryId: string, code: string): Promise<void> {
+  async #assembleRuntime(
+    deliveryId: string,
+    sessionId: string,
+    mode: "delivery" | "recovery",
+    claimToken?: string,
+  ): Promise<EffectiveRuntimeSnapshot | undefined> {
+    try {
+      return await this.#assembler.assembleForSession(sessionId);
+    } catch (error) {
+      const code = error instanceof EffectiveRuntimeSnapshotAssemblerError ? error.code : "DATABASE_FAILURE";
+      if (
+        mode === "delivery" &&
+        ["UNSUPPORTED_PROVIDER", "RUNTIME_CONFIG_MISSING", "INVALID_STORED_CONFIG", "SNAPSHOT_INVALID"].includes(code)
+      ) {
+        await this.#reject(
+          deliveryId,
+          code === "UNSUPPORTED_PROVIDER" ? "configuration_unsupported" : "invalid_input",
+          claimToken,
+        );
+        return undefined;
+      }
+      await this.#recordFailure(
+        deliveryId,
+        code === "DATABASE_FAILURE"
+          ? "IM_DELIVERY_RUNTIME_AUTHORITY_FAILED"
+          : "IM_DELIVERY_RUNTIME_AUTHORITY_UNAVAILABLE",
+        claimToken,
+      );
+      return undefined;
+    }
+  }
+
+  async #recordFailure(deliveryId: string, code: string, claimToken?: string): Promise<void> {
     const bounded = /^IM_DELIVERY_[A-Z0-9_]{1,100}$/.test(code) ? code : "IM_DELIVERY_FAILED";
-    await this.#database
+    const [updated] = await this.#database
       .update(imMessageDeliveries)
-      .set({ lastErrorCode: bounded })
+      .set({ lastErrorCode: bounded, ...(claimToken ? { nextAttemptAt: new Date(Date.now() + RETRY_DELAY_MS) } : {}) })
       .where(
         and(
           eq(imMessageDeliveries.id, deliveryId),
           sql`${imMessageDeliveries.state} in ('pending', 'accepted', 'expired')`,
+          ...(claimToken ? [eq(imMessageDeliveries.lastErrorCode, claimToken)] : []),
         ),
-      );
-    this.#onDiagnostic(bounded);
+      )
+      .returning({ id: imMessageDeliveries.id });
+    if (updated) this.#onDiagnostic(bounded);
   }
 
-  async #releaseDispatch(deliveryId: string, requestId: string, code: string): Promise<void> {
+  async #releaseDispatch(deliveryId: string, requestId: string, code: string, claimToken: string): Promise<void> {
     const bounded = /^IM_DELIVERY_[A-Z0-9_]{1,100}$/.test(code) ? code : "IM_DELIVERY_FAILED";
-    await this.#database
+    const [released] = await this.#database
       .update(imMessageDeliveries)
-      .set({ dispatchRequestId: null, dispatchInputHash: null, dispatchPayload: null, lastErrorCode: bounded })
+      .set({
+        dispatchRequestId: null,
+        dispatchInputHash: null,
+        dispatchPayload: null,
+        lastErrorCode: bounded,
+        nextAttemptAt: new Date(Date.now() + RETRY_DELAY_MS),
+      })
       .where(
         and(
           eq(imMessageDeliveries.id, deliveryId),
           inArray(imMessageDeliveries.state, ["pending", "expired"]),
           eq(imMessageDeliveries.dispatchRequestId, requestId),
+          eq(imMessageDeliveries.lastErrorCode, claimToken),
         ),
-      );
-    this.#onDiagnostic(bounded);
+      )
+      .returning({ id: imMessageDeliveries.id });
+    if (released) this.#onDiagnostic(bounded);
   }
 
-  async #reject(deliveryId: string, reason: string): Promise<void> {
+  async #reject(deliveryId: string, reason: string, claimToken?: string): Promise<void> {
     await this.#database
       .update(imMessageDeliveries)
       .set({
@@ -411,7 +573,70 @@ export class ImDeliveryWorker {
         reason: reason.slice(0, 120),
         lastErrorCode: "IM_DELIVERY_TERMINAL",
       })
-      .where(and(eq(imMessageDeliveries.id, deliveryId), eq(imMessageDeliveries.state, "pending")));
+      .where(
+        and(
+          eq(imMessageDeliveries.id, deliveryId),
+          eq(imMessageDeliveries.state, "pending"),
+          ...(claimToken ? [eq(imMessageDeliveries.lastErrorCode, claimToken)] : []),
+        ),
+      );
+  }
+
+  #maintainClaimLease(deliveryId: string, claimToken: string): ClaimLease {
+    let active = true;
+    let lost = false;
+    let renewal = Promise.resolve();
+    const renew = () => {
+      renewal = renewal
+        .then(async () => {
+          if (!active || lost) return;
+          lost = !(await this.#renewClaim(deliveryId, claimToken));
+        })
+        .catch(() => {
+          lost = true;
+        });
+    };
+    const timer = setInterval(renew, this.#claimRenewMs);
+    timer.unref();
+    return {
+      assertOwned: async () => {
+        await renewal;
+        if (lost) return false;
+        const [owned] = await this.#database
+          .select({ id: imMessageDeliveries.id })
+          .from(imMessageDeliveries)
+          .where(
+            and(
+              eq(imMessageDeliveries.id, deliveryId),
+              inArray(imMessageDeliveries.state, ["pending", "expired"]),
+              eq(imMessageDeliveries.lastErrorCode, claimToken),
+            ),
+          )
+          .limit(1);
+        if (!owned) lost = true;
+        return !lost;
+      },
+      stop: async () => {
+        active = false;
+        clearInterval(timer);
+        await renewal;
+      },
+    };
+  }
+
+  async #renewClaim(deliveryId: string, claimToken: string): Promise<boolean> {
+    const [renewed] = await this.#database
+      .update(imMessageDeliveries)
+      .set({ nextAttemptAt: new Date(Date.now() + this.#claimLeaseMs) })
+      .where(
+        and(
+          eq(imMessageDeliveries.id, deliveryId),
+          inArray(imMessageDeliveries.state, ["pending", "expired"]),
+          eq(imMessageDeliveries.lastErrorCode, claimToken),
+        ),
+      )
+      .returning({ id: imMessageDeliveries.id });
+    return renewed !== undefined;
   }
 
   async #history(
@@ -479,6 +704,46 @@ export class ImDeliveryWorker {
   }
 }
 
+type CustodyQuery = Pick<DatabaseClient | DatabaseTransaction, "select">;
+
+interface ClaimLease {
+  assertOwned(): Promise<boolean>;
+  stop(): Promise<void>;
+}
+
+async function hasOtherAgentCustody(database: CustodyQuery, agentId: string, deliveryId: string): Promise<boolean> {
+  const [row] = await database
+    .select({ id: imMessageDeliveries.id })
+    .from(imMessageDeliveries)
+    .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+    .innerJoin(integrations, eq(integrations.id, sessions.integrationId))
+    .innerJoin(agents, eq(agents.id, integrations.agentId))
+    .where(
+      and(
+        eq(integrations.agentId, agentId),
+        ne(imMessageDeliveries.id, deliveryId),
+        isNull(sessions.endedAt),
+        eq(integrations.status, "active"),
+        isNull(agents.deletedAt),
+        uncertainAgentCustody(imMessageDeliveries),
+      ),
+    )
+    .limit(1);
+  return row !== undefined;
+}
+
+function uncertainAgentCustody(delivery: typeof imMessageDeliveries | typeof acceptedDeliveries) {
+  return or(
+    and(eq(delivery.state, "accepted"), isNull(delivery.reportedAt)),
+    and(inArray(delivery.state, ["pending", "expired"]), isNotNull(delivery.dispatchRequestId)),
+    and(eq(delivery.state, "pending"), like(delivery.lastErrorCode, `${DISPATCH_CLAIM_PREFIX}%`)),
+  );
+}
+
+function dispatchClaimToken(): string {
+  return `${DISPATCH_CLAIM_PREFIX}${randomUUID().replaceAll("-", "").toUpperCase()}`;
+}
+
 function messageBefore(occurredAt: Date, providerRevisionKey: string, messageId: string) {
   return or(
     lt(imMessages.occurredAt, occurredAt),
@@ -503,32 +768,6 @@ function messageAfter(occurredAt: Date, providerRevisionKey: string, messageId: 
       ),
     ),
   );
-}
-
-function runtimeSnapshot(
-  agentId: string,
-  config: typeof agentRuntimeConfigs.$inferSelect,
-  sessionId: string,
-  sessionRevision: number,
-): EffectiveRuntimeSnapshot {
-  return {
-    revision: {
-      agent: { sequence: config.revision, id: agentId },
-      session: { sequence: sessionRevision, id: sessionId },
-    },
-    agentId,
-    provider: "codex",
-    ...(config.model ? { model: config.model } : {}),
-    ...(config.reasoningEffort ? { reasoningEffort: config.reasoningEffort } : {}),
-    instructions: {
-      platform: OPENTAG_PLATFORM_INSTRUCTIONS,
-      agent: config.instructions,
-    },
-    allowedTools: config.allowedTools,
-    execution: { approvalPolicy: "never", networkAccess: false },
-    ...(config.maxDurationMs ? { budget: { maxDurationMs: config.maxDurationMs } } : {}),
-    workspace: { workspaceId: agentId, mode: "empty_on_create", sharing: "agent" },
-  };
 }
 
 function truncateUtf8(value: string, maxBytes: number): string {

--- a/packages/server/src/runtime/runtime-custody-store.ts
+++ b/packages/server/src/runtime/runtime-custody-store.ts
@@ -139,7 +139,6 @@ export class PostgresRuntimeCustodyStore implements RuntimeCustodyStore {
         .update(imMessageDeliveries)
         .set({
           state: "accepted",
-          dispatchPayload: null,
           placementGeneration: request.placementGeneration,
           inputHash,
           turnId,
@@ -201,7 +200,6 @@ export class PostgresRuntimeCustodyStore implements RuntimeCustodyStore {
             .update(imMessageDeliveries)
             .set({
               state: "accepted",
-              dispatchPayload: null,
               inputHash: claim.inputHash,
               turnId: claim.turnId,
               reportOwnerInstanceId: context.instanceId,
@@ -301,7 +299,13 @@ export class PostgresRuntimeCustodyStore implements RuntimeCustodyStore {
       }
       await transaction
         .update(imMessageDeliveries)
-        .set({ resultHash: report.resultHash, turnReport: report, reportedAt: this.#now(), lastErrorCode: null })
+        .set({
+          dispatchPayload: null,
+          resultHash: report.resultHash,
+          turnReport: report,
+          reportedAt: this.#now(),
+          lastErrorCode: null,
+        })
         .where(eq(imMessageDeliveries.id, report.deliveryId));
       return "recorded";
     });

--- a/packages/server/src/services/runtime-config/effective-runtime-snapshot-assembler.ts
+++ b/packages/server/src/services/runtime-config/effective-runtime-snapshot-assembler.ts
@@ -1,0 +1,151 @@
+import {
+  AgentRuntimeConfigSchema,
+  type EffectiveRuntimeSnapshot,
+  EffectiveRuntimeSnapshotSchema,
+  hashTuple,
+  OPENTAG_PLATFORM_INSTRUCTIONS,
+} from "@opentag/shared";
+import { eq } from "drizzle-orm";
+import type { DatabaseClient } from "../../db/client.js";
+import { agentRuntimeConfigs, agents, integrations, sessions } from "../../db/schema/index.js";
+import { EffectiveRuntimeSnapshotAssemblerError } from "./errors.js";
+
+interface EffectiveRuntimeSnapshotAuthority {
+  agentDeletedAt: Date | null;
+  agentId: string;
+  integrationStatus: string;
+  runtimeConfig: unknown;
+  runtimeProvider: string;
+  sessionEndedAt: Date | null;
+  sessionId: string;
+}
+
+type AuthorityLoader = (sessionId: string) => Promise<EffectiveRuntimeSnapshotAuthority | undefined>;
+
+export class EffectiveRuntimeSnapshotAssembler {
+  readonly #loadAuthority: AuthorityLoader;
+
+  constructor(database: DatabaseClient, options: { loadAuthority?: AuthorityLoader } = {}) {
+    this.#loadAuthority = options.loadAuthority ?? ((sessionId) => loadAuthority(database, sessionId));
+  }
+
+  async assembleForSession(sessionId: string): Promise<EffectiveRuntimeSnapshot> {
+    let authority: EffectiveRuntimeSnapshotAuthority | undefined;
+    try {
+      authority = await this.#loadAuthority(sessionId);
+    } catch (error) {
+      throw new EffectiveRuntimeSnapshotAssemblerError("DATABASE_FAILURE", { cause: error });
+    }
+    if (!authority) throw new EffectiveRuntimeSnapshotAssemblerError("SESSION_NOT_FOUND");
+    if (
+      authority.sessionEndedAt !== null ||
+      authority.integrationStatus !== "active" ||
+      authority.agentDeletedAt !== null
+    ) {
+      throw new EffectiveRuntimeSnapshotAssemblerError("AUTHORITY_INACTIVE");
+    }
+    if (authority.runtimeProvider !== "codex") {
+      throw new EffectiveRuntimeSnapshotAssemblerError("UNSUPPORTED_PROVIDER");
+    }
+    if (authority.runtimeConfig === null) {
+      throw new EffectiveRuntimeSnapshotAssemblerError("RUNTIME_CONFIG_MISSING");
+    }
+    const parsedConfig = AgentRuntimeConfigSchema.safeParse(authority.runtimeConfig);
+    if (!parsedConfig.success) {
+      throw new EffectiveRuntimeSnapshotAssemblerError("INVALID_STORED_CONFIG", { cause: parsedConfig.error });
+    }
+    const config = parsedConfig.data;
+    const agentRevisionId = revisionId("agent", [
+      authority.agentId,
+      authority.runtimeProvider,
+      OPENTAG_PLATFORM_INSTRUCTIONS,
+      config.instructions,
+      authority.agentId,
+      "empty_on_create",
+      "agent",
+    ]);
+    const sessionRevisionId = revisionId("session", [
+      authority.sessionId,
+      config.model,
+      config.reasoningEffort,
+      null,
+      config.allowedTools,
+      "never",
+      false,
+      config.maxDurationMs,
+    ]);
+    const snapshot = EffectiveRuntimeSnapshotSchema.safeParse({
+      revision: {
+        agent: { sequence: config.revision, id: agentRevisionId },
+        session: { sequence: config.revision, id: sessionRevisionId },
+      },
+      agentId: authority.agentId,
+      provider: "codex",
+      ...(config.model !== null ? { model: config.model } : {}),
+      ...(config.reasoningEffort !== null ? { reasoningEffort: config.reasoningEffort } : {}),
+      instructions: {
+        platform: OPENTAG_PLATFORM_INSTRUCTIONS,
+        agent: config.instructions,
+      },
+      allowedTools: config.allowedTools,
+      execution: { approvalPolicy: "never", networkAccess: false },
+      workspace: { workspaceId: authority.agentId, mode: "empty_on_create", sharing: "agent" },
+      ...(config.maxDurationMs !== null ? { budget: { maxDurationMs: config.maxDurationMs } } : {}),
+    });
+    if (!snapshot.success) {
+      throw new EffectiveRuntimeSnapshotAssemblerError("SNAPSHOT_INVALID", { cause: snapshot.error });
+    }
+    return snapshot.data;
+  }
+}
+
+async function loadAuthority(
+  database: DatabaseClient,
+  sessionId: string,
+): Promise<EffectiveRuntimeSnapshotAuthority | undefined> {
+  const [row] = await database
+    .select({
+      sessionId: sessions.id,
+      sessionEndedAt: sessions.endedAt,
+      integrationStatus: integrations.status,
+      agentId: agents.id,
+      agentDeletedAt: agents.deletedAt,
+      runtimeProvider: agents.runtimeProvider,
+      configRevision: agentRuntimeConfigs.revision,
+      configModel: agentRuntimeConfigs.model,
+      configReasoningEffort: agentRuntimeConfigs.reasoningEffort,
+      configInstructions: agentRuntimeConfigs.instructions,
+      configAllowedTools: agentRuntimeConfigs.allowedTools,
+      configMaxDurationMs: agentRuntimeConfigs.maxDurationMs,
+    })
+    .from(sessions)
+    .innerJoin(integrations, eq(integrations.id, sessions.integrationId))
+    .innerJoin(agents, eq(agents.id, integrations.agentId))
+    .leftJoin(agentRuntimeConfigs, eq(agentRuntimeConfigs.agentId, agents.id))
+    .where(eq(sessions.id, sessionId))
+    .limit(1);
+  if (!row) return undefined;
+  return {
+    agentDeletedAt: row.agentDeletedAt,
+    agentId: row.agentId,
+    integrationStatus: row.integrationStatus,
+    runtimeConfig:
+      row.configRevision === null
+        ? null
+        : {
+            revision: row.configRevision,
+            model: row.configModel,
+            reasoningEffort: row.configReasoningEffort,
+            instructions: row.configInstructions,
+            allowedTools: row.configAllowedTools,
+            maxDurationMs: row.configMaxDurationMs,
+          },
+    runtimeProvider: row.runtimeProvider,
+    sessionEndedAt: row.sessionEndedAt,
+    sessionId: row.sessionId,
+  };
+}
+
+function revisionId(layer: "agent" | "session", values: readonly unknown[]): string {
+  return hashTuple(["opentag-runtime-revision", 1, layer, ...values]);
+}

--- a/packages/server/src/services/runtime-config/errors.ts
+++ b/packages/server/src/services/runtime-config/errors.ts
@@ -1,0 +1,28 @@
+export type EffectiveRuntimeSnapshotAssemblerErrorCode =
+  | "SESSION_NOT_FOUND"
+  | "AUTHORITY_INACTIVE"
+  | "RUNTIME_CONFIG_MISSING"
+  | "UNSUPPORTED_PROVIDER"
+  | "INVALID_STORED_CONFIG"
+  | "DATABASE_FAILURE"
+  | "SNAPSHOT_INVALID";
+
+const messages: Record<EffectiveRuntimeSnapshotAssemblerErrorCode, string> = {
+  SESSION_NOT_FOUND: "The Session runtime authority does not exist",
+  AUTHORITY_INACTIVE: "The Session runtime authority is inactive",
+  RUNTIME_CONFIG_MISSING: "The Agent runtime configuration is missing",
+  UNSUPPORTED_PROVIDER: "The Agent runtime provider is unsupported",
+  INVALID_STORED_CONFIG: "The stored Agent runtime configuration is invalid",
+  DATABASE_FAILURE: "The Session runtime authority could not be read",
+  SNAPSHOT_INVALID: "The effective runtime snapshot is invalid",
+};
+
+export class EffectiveRuntimeSnapshotAssemblerError extends Error {
+  readonly code: EffectiveRuntimeSnapshotAssemblerErrorCode;
+
+  constructor(code: EffectiveRuntimeSnapshotAssemblerErrorCode, options: { cause?: unknown } = {}) {
+    super(messages[code], options);
+    this.name = "EffectiveRuntimeSnapshotAssemblerError";
+    this.code = code;
+  }
+}

--- a/packages/server/src/services/runtime-config/index.ts
+++ b/packages/server/src/services/runtime-config/index.ts
@@ -1,3 +1,8 @@
+export { EffectiveRuntimeSnapshotAssembler } from "./effective-runtime-snapshot-assembler.js";
+export {
+  EffectiveRuntimeSnapshotAssemblerError,
+  type EffectiveRuntimeSnapshotAssemblerErrorCode,
+} from "./errors.js";
 export {
   DEFAULT_AGENT_INSTRUCTIONS,
   DEFAULT_AGENT_RUNTIME_CONFIG,


### PR DESCRIPTION
## Summary

- add the single server-side `EffectiveRuntimeSnapshotAssembler` with stable versioned revision hashes and effective Agent/Session revision sequencing
- pin accepted IM dispatch payloads for recovery, clean them up after atomic Turn reporting, and serialize same-Agent custody with renewable owner-token claims
- add Agent runtime settings to CLI create/update, including file-based instructions, repeatable tools, timeout, CAS, and clear semantics
- replace the IM worker's inline snapshot builder and validate persisted payload/hash correlation

## Correctness

- Agent configuration changes advance both effective revisions for existing Sessions without causing Client configuration conflicts
- accepted Turns recover with their original immutable snapshot before a newer Agent revision can be applied
- active claims are fenced across workers with conditional leases; inactive Session/Integration/Agent authority cannot leave a global routing fence
- unsupported providers and invalid stored configuration fail closed

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/server test:integration` (6 files, 96 tests)
- `git diff --check`

No database migration is included.
