### PR TITLE
fix(server): accept Google OAuth callback fields

### DIFF
--- a/packages/server/src/__tests__/browser-auth.test.ts
+++ b/packages/server/src/__tests__/browser-auth.test.ts
@@ -36,10 +36,25 @@ function google() {
     start: vi
       .fn()
       .mockResolvedValue({ authorizationUrl: "https://accounts.google.com/auth", context: "signed-context" }),
-    callback: vi.fn().mockResolvedValue({
-      next: "/admin",
-      tokens: { accessToken: "access-secret", refreshToken: "refresh-secret", tokenType: "Bearer", expiresIn: 900 },
+    callback: vi.fn().mockImplementation(async (_input: unknown, _context: string, options: { onVerified(): void }) => {
+      options.onVerified();
+      return {
+        next: "/admin",
+        tokens: {
+          accessToken: "access-secret",
+          refreshToken: "refresh-secret",
+          tokenType: "Bearer" as const,
+          expiresIn: 900,
+        },
+      };
     }),
+  };
+}
+
+function failAfterVerification(error: Error) {
+  return async (_input: unknown, _context: string, options: { onVerified(): void }) => {
+    options.onVerified();
+    throw error;
   };
 }
 
@@ -162,7 +177,7 @@ describe("browser authentication routes", () => {
     expect(googleService?.callback).toHaveBeenCalledWith(
       { code: "code", state: "state" },
       "signed-context",
-      expect.any(Object),
+      expect.objectContaining({ audit: expect.any(Object), onVerified: expect.any(Function) }),
     );
   });
 
@@ -179,7 +194,7 @@ describe("browser authentication routes", () => {
     expect(googleService?.callback).toHaveBeenCalledWith(
       { code: "code", state: "state" },
       "signed-context",
-      expect.any(Object),
+      expect.objectContaining({ audit: expect.any(Object), onVerified: expect.any(Function) }),
     );
   });
 
@@ -203,8 +218,10 @@ describe("browser authentication routes", () => {
 
   it("returns a stable cancellation error and clears the OAuth context without reflecting provider text", async () => {
     const googleService = google();
-    googleService.callback.mockRejectedValueOnce(
-      new AuthServiceError("AUTH_OAUTH_FAILED", "credential", "Google sign-in was cancelled", 401),
+    googleService.callback.mockImplementationOnce(
+      failAfterVerification(
+        new AuthServiceError("AUTH_OAUTH_FAILED", "credential", "Google sign-in was cancelled", 401),
+      ),
     );
     const { app } = createBrowserApp({ googleService });
     const response = await app.inject({
@@ -224,14 +241,16 @@ describe("browser authentication routes", () => {
     expect(googleService.callback).toHaveBeenCalledWith(
       { error: "access_denied", state: "state" },
       "signed-context",
-      expect.any(Object),
+      expect.objectContaining({ audit: expect.any(Object), onVerified: expect.any(Function) }),
     );
   });
 
   it("clears the OAuth context when Google code exchange fails", async () => {
     const googleService = google();
-    googleService.callback.mockRejectedValueOnce(
-      new AuthServiceError("AUTH_OAUTH_FAILED", "credential", "Google sign-in could not be verified", 401),
+    googleService.callback.mockImplementationOnce(
+      failAfterVerification(
+        new AuthServiceError("AUTH_OAUTH_FAILED", "credential", "Google sign-in could not be verified", 401),
+      ),
     );
     const { app } = createBrowserApp({ googleService });
     const response = await app.inject({
@@ -245,6 +264,29 @@ describe("browser authentication routes", () => {
     const cookies = String(response.headers["set-cookie"]);
     expect(cookies).toContain("opentag_oauth_context=; Path=/api/v1/auth/google/callback");
     expect(cookies).toContain("Max-Age=0");
+  });
+
+  it("does not clear the OAuth context when state verification fails", async () => {
+    const googleService = google();
+    googleService.callback.mockRejectedValueOnce(
+      new AuthServiceError("AUTH_OAUTH_FAILED", "credential", "The browser sign-in flow is invalid or expired", 401),
+    );
+    const { app } = createBrowserApp({ googleService });
+    const response = await app.inject({
+      method: "GET",
+      url: `${HTTP_PATHS.authGoogleCallback}?code=fake-code&state=mismatched-state`,
+      headers: { cookie: "opentag_oauth_context=signed-context" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toMatchObject({
+      error: {
+        code: "AUTH_OAUTH_FAILED",
+        category: "credential",
+        message: "The browser sign-in flow is invalid or expired",
+      },
+    });
+    expect(response.headers["set-cookie"]).toBeUndefined();
   });
 
   it("requires same-origin double-submit CSRF for refresh while bearer API auth remains unaffected", async () => {

--- a/packages/server/src/__tests__/browser-auth.test.ts
+++ b/packages/server/src/__tests__/browser-auth.test.ts
@@ -1,7 +1,12 @@
 import { HTTP_PATHS } from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
-import type { DevBrowserAuthService, GoogleBrowserAuthService, UserAuthService } from "../services/auth/index.js";
+import {
+  AuthServiceError,
+  type DevBrowserAuthService,
+  type GoogleBrowserAuthService,
+  type UserAuthService,
+} from "../services/auth/index.js";
 
 const apps: ReturnType<typeof createApp>[] = [];
 afterEach(async () => Promise.all(apps.splice(0).map((app) => app.close())));
@@ -150,9 +155,96 @@ describe("browser authentication routes", () => {
     const cookies = String(response.headers["set-cookie"]);
     expect(cookies).toContain("opentag_access=access-secret");
     expect(cookies).toContain("opentag_refresh=refresh-secret");
+    expect(cookies).toContain("opentag_oauth_context=; Path=/api/v1/auth/google/callback");
+    expect(cookies).toContain("Max-Age=0");
     expect(cookies).toContain("HttpOnly");
     expect(response.body).not.toContain("access-secret");
-    expect(googleService?.callback).toHaveBeenCalledWith("code", "state", "signed-context", expect.any(Object));
+    expect(googleService?.callback).toHaveBeenCalledWith(
+      { code: "code", state: "state" },
+      "signed-context",
+      expect.any(Object),
+    );
+  });
+
+  it("accepts provider-owned callback fields but passes only supported values to the Google service", async () => {
+    const { app, googleService } = createBrowserApp();
+    const response = await app.inject({
+      method: "GET",
+      url: `${HTTP_PATHS.authGoogleCallback}?code=code&state=state&scope=openid%20email&authuser=0&prompt=consent`,
+      headers: { cookie: "opentag_oauth_context=signed-context" },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/admin");
+    expect(googleService?.callback).toHaveBeenCalledWith(
+      { code: "code", state: "state" },
+      "signed-context",
+      expect.any(Object),
+    );
+  });
+
+  it("rejects callbacks without exactly one provider result before invoking the Google service", async () => {
+    const { app, googleService } = createBrowserApp();
+
+    for (const query of ["state=state", "code=code", "code=code&error=access_denied&state=state"]) {
+      const response = await app.inject({
+        method: "GET",
+        url: `${HTTP_PATHS.authGoogleCallback}?${query}`,
+        headers: { cookie: "opentag_oauth_context=signed-context" },
+      });
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({
+        error: { code: "VALIDATION_ERROR", category: "validation", message: "The request payload is invalid" },
+      });
+    }
+
+    expect(googleService?.callback).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable cancellation error and clears the OAuth context without reflecting provider text", async () => {
+    const googleService = google();
+    googleService.callback.mockRejectedValueOnce(
+      new AuthServiceError("AUTH_OAUTH_FAILED", "credential", "Google sign-in was cancelled", 401),
+    );
+    const { app } = createBrowserApp({ googleService });
+    const response = await app.inject({
+      method: "GET",
+      url: `${HTTP_PATHS.authGoogleCallback}?error=access_denied&error_description=private-provider-text&state=state`,
+      headers: { cookie: "opentag_oauth_context=signed-context" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toMatchObject({
+      error: { code: "AUTH_OAUTH_FAILED", category: "credential", message: "Google sign-in was cancelled" },
+    });
+    expect(response.body).not.toContain("private-provider-text");
+    const cookies = String(response.headers["set-cookie"]);
+    expect(cookies).toContain("opentag_oauth_context=; Path=/api/v1/auth/google/callback");
+    expect(cookies).toContain("Max-Age=0");
+    expect(googleService.callback).toHaveBeenCalledWith(
+      { error: "access_denied", state: "state" },
+      "signed-context",
+      expect.any(Object),
+    );
+  });
+
+  it("clears the OAuth context when Google code exchange fails", async () => {
+    const googleService = google();
+    googleService.callback.mockRejectedValueOnce(
+      new AuthServiceError("AUTH_OAUTH_FAILED", "credential", "Google sign-in could not be verified", 401),
+    );
+    const { app } = createBrowserApp({ googleService });
+    const response = await app.inject({
+      method: "GET",
+      url: `${HTTP_PATHS.authGoogleCallback}?code=code&state=state`,
+      headers: { cookie: "opentag_oauth_context=signed-context" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toMatchObject({ error: { code: "AUTH_OAUTH_FAILED" } });
+    const cookies = String(response.headers["set-cookie"]);
+    expect(cookies).toContain("opentag_oauth_context=; Path=/api/v1/auth/google/callback");
+    expect(cookies).toContain("Max-Age=0");
   });
 
   it("requires same-origin double-submit CSRF for refresh while bearer API auth remains unaffected", async () => {

--- a/packages/server/src/__tests__/google-auth.test.ts
+++ b/packages/server/src/__tests__/google-auth.test.ts
@@ -83,15 +83,32 @@ describe("GoogleBrowserAuthService", () => {
     ["temporarily_unavailable", "Google sign-in failed"],
   ])("verifies state before mapping provider error %s", async (error, message) => {
     const { exchangeCode, service, verify } = createService();
+    const onVerified = vi.fn();
 
-    await expect(service.callback({ error, state: "state" }, "signed-context")).rejects.toMatchObject({
+    await expect(service.callback({ error, state: "state" }, "signed-context", { onVerified })).rejects.toMatchObject({
       code: "AUTH_OAUTH_FAILED",
       category: "credential",
       message,
       statusCode: 401,
     });
     expect(verify).toHaveBeenCalledWith("state", "signed-context");
+    expect(onVerified).toHaveBeenCalledOnce();
     expect(exchangeCode).not.toHaveBeenCalled();
+  });
+
+  it("runs the verified lifecycle before exchanging an authorization code", async () => {
+    const { exchangeCode, service } = createService();
+    const onVerified = vi.fn();
+    const exchangeFailure = new Error("provider exchange failed");
+    exchangeCode.mockImplementationOnce(async () => {
+      expect(onVerified).toHaveBeenCalledOnce();
+      throw exchangeFailure;
+    });
+
+    await expect(service.callback({ code: "code", state: "state" }, "signed-context", { onVerified })).rejects.toBe(
+      exchangeFailure,
+    );
+    expect(exchangeCode).toHaveBeenCalledOnce();
   });
 
   it("preserves invalid or expired flow errors before interpreting the provider result", async () => {
@@ -102,10 +119,12 @@ describe("GoogleBrowserAuthService", () => {
       401,
     );
     const { exchangeCode, service } = createService(vi.fn().mockRejectedValue(flowError));
+    const onVerified = vi.fn();
 
-    await expect(service.callback({ error: "access_denied", state: "invalid-state" }, "expired-context")).rejects.toBe(
-      flowError,
-    );
+    await expect(
+      service.callback({ error: "access_denied", state: "invalid-state" }, "expired-context", { onVerified }),
+    ).rejects.toBe(flowError);
+    expect(onVerified).not.toHaveBeenCalled();
     expect(exchangeCode).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/__tests__/google-auth.test.ts
+++ b/packages/server/src/__tests__/google-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { DefaultGoogleIdentityClient } from "../services/auth/index.js";
+import { AuthServiceError, DefaultGoogleIdentityClient, GoogleBrowserAuthService } from "../services/auth/index.js";
 
 describe("DefaultGoogleIdentityClient", () => {
   it("builds an OIDC request and verifies provider results through injected network boundaries", async () => {
@@ -60,5 +60,52 @@ describe("DefaultGoogleIdentityClient", () => {
         redirectUri: "https://example.com/callback",
       }),
     ).rejects.toMatchObject({ code: "AUTH_OAUTH_FAILED", message: "Google sign-in could not be verified" });
+  });
+});
+
+describe("GoogleBrowserAuthService", () => {
+  function createService(verify = vi.fn().mockResolvedValue({ next: "/admin", oidcNonce: "oidc-nonce" })) {
+    const exchangeCode = vi.fn();
+    const service = new GoogleBrowserAuthService({
+      database: {} as never,
+      flow: { verify } as never,
+      google: { exchangeCode } as never,
+      identities: {} as never,
+      postAuthentication: {} as never,
+      publicUrl: "https://opentag.example.com",
+      tokenIssuer: {} as never,
+    });
+    return { exchangeCode, service, verify };
+  }
+
+  it.each([
+    ["access_denied", "Google sign-in was cancelled"],
+    ["temporarily_unavailable", "Google sign-in failed"],
+  ])("verifies state before mapping provider error %s", async (error, message) => {
+    const { exchangeCode, service, verify } = createService();
+
+    await expect(service.callback({ error, state: "state" }, "signed-context")).rejects.toMatchObject({
+      code: "AUTH_OAUTH_FAILED",
+      category: "credential",
+      message,
+      statusCode: 401,
+    });
+    expect(verify).toHaveBeenCalledWith("state", "signed-context");
+    expect(exchangeCode).not.toHaveBeenCalled();
+  });
+
+  it("preserves invalid or expired flow errors before interpreting the provider result", async () => {
+    const flowError = new AuthServiceError(
+      "AUTH_OAUTH_FAILED",
+      "credential",
+      "The browser sign-in flow is invalid or expired",
+      401,
+    );
+    const { exchangeCode, service } = createService(vi.fn().mockRejectedValue(flowError));
+
+    await expect(service.callback({ error: "access_denied", state: "invalid-state" }, "expired-context")).rejects.toBe(
+      flowError,
+    );
+    expect(exchangeCode).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/api/browser-auth.ts
+++ b/packages/server/src/api/browser-auth.ts
@@ -155,7 +155,6 @@ export function registerBrowserAuthRoutes(
         401,
       );
     }
-    clearOAuthContextCookie(reply, options.secureCookies);
     const result = await options.google.callback(
       {
         ...(callback.code !== undefined ? { code: callback.code } : {}),
@@ -163,7 +162,10 @@ export function registerBrowserAuthRoutes(
         state: callback.state,
       },
       context,
-      audit(request),
+      {
+        audit: audit(request),
+        onVerified: () => clearOAuthContextCookie(reply, options.secureCookies),
+      },
     );
     setBrowserSessionCookies(reply, result.tokens, {
       refreshTtlSeconds: options.refreshTokenTtlSeconds,

--- a/packages/server/src/api/browser-auth.ts
+++ b/packages/server/src/api/browser-auth.ts
@@ -19,8 +19,21 @@ import { parseRequest } from "./request-validation.js";
 
 const StartQuerySchema = z.object({ next: z.string().max(1024).optional() }).strict();
 const CallbackQuerySchema = z
-  .object({ code: z.string().min(1).max(4096), state: z.string().min(1).max(4096) })
-  .strict();
+  .object({
+    code: z.string().min(1).max(4096).optional(),
+    error: z.string().min(1).max(256).optional(),
+    error_description: z.string().max(1024).optional(),
+    state: z.string().min(1).max(4096),
+  })
+  .superRefine((value, context) => {
+    if ((value.code === undefined) === (value.error === undefined)) {
+      context.addIssue({
+        code: "custom",
+        message: "Exactly one of code or error is required",
+        path: ["code"],
+      });
+    }
+  });
 
 export interface BrowserAuthRoutesOptions {
   dev?: DevBrowserAuthService;
@@ -132,7 +145,7 @@ export function registerBrowserAuthRoutes(
     if (!options.google) {
       throw new AuthServiceError("AUTH_PROVIDER_DISABLED", "deterministic", "Google sign-in is not configured", 404);
     }
-    const { code, state } = parseRequest(CallbackQuerySchema, request.query);
+    const callback = parseRequest(CallbackQuerySchema, request.query);
     const context = parseCookies(request.headers.cookie)[BROWSER_COOKIE_NAMES.oauthContext];
     if (!context) {
       throw new AuthServiceError(
@@ -142,8 +155,16 @@ export function registerBrowserAuthRoutes(
         401,
       );
     }
-    const result = await options.google.callback(code, state, context, audit(request));
     clearOAuthContextCookie(reply, options.secureCookies);
+    const result = await options.google.callback(
+      {
+        ...(callback.code !== undefined ? { code: callback.code } : {}),
+        ...(callback.error !== undefined ? { error: callback.error } : {}),
+        state: callback.state,
+      },
+      context,
+      audit(request),
+    );
     setBrowserSessionCookies(reply, result.tokens, {
       refreshTtlSeconds: options.refreshTokenTtlSeconds,
       secure: options.secureCookies,

--- a/packages/server/src/services/auth/google-browser-auth.ts
+++ b/packages/server/src/services/auth/google-browser-auth.ts
@@ -2,6 +2,7 @@ import type { RefreshTokenResponse } from "@opentag/shared";
 import type { DatabaseClient } from "../../db/client.js";
 import type { InvitationAuditContext } from "../invitations/index.js";
 import type { ResolvedUserTokenIssuer } from "./auth-service.js";
+import { AuthServiceError } from "./errors.js";
 import type { AuthIdentityService } from "./identity-service.js";
 import type { GoogleIdentityClient } from "./oauth/google.js";
 import { invitationTokenFromNext, type OAuthFlowService } from "./oauth/state.js";
@@ -15,6 +16,12 @@ export interface GoogleAuthStartResult {
 export interface GoogleAuthCallbackResult {
   next: string;
   tokens: RefreshTokenResponse;
+}
+
+export interface GoogleAuthCallbackInput {
+  code?: string;
+  error?: string;
+  state: string;
 }
 
 export class GoogleBrowserAuthService {
@@ -57,13 +64,27 @@ export class GoogleBrowserAuthService {
   }
 
   async callback(
-    code: string,
-    state: string,
+    input: GoogleAuthCallbackInput,
     context: string,
     audit: InvitationAuditContext = {},
   ): Promise<GoogleAuthCallbackResult> {
-    const flow = await this.#flow.verify(state, context);
-    const identity = await this.#google.exchangeCode({ code, nonce: flow.oidcNonce, redirectUri: this.#redirectUri });
+    const flow = await this.#flow.verify(input.state, context);
+    if (input.error) {
+      throw new AuthServiceError(
+        "AUTH_OAUTH_FAILED",
+        "credential",
+        input.error === "access_denied" ? "Google sign-in was cancelled" : "Google sign-in failed",
+        401,
+      );
+    }
+    if (!input.code) {
+      throw new AuthServiceError("AUTH_OAUTH_FAILED", "credential", "Google sign-in failed", 401);
+    }
+    const identity = await this.#google.exchangeCode({
+      code: input.code,
+      nonce: flow.oidcNonce,
+      redirectUri: this.#redirectUri,
+    });
     const userId = await this.#database.transaction(async (transaction) => {
       const resolvedUserId = await this.#identities.resolveOrCreateInTransaction(transaction, identity);
       await this.#postAuthentication.completeInTransaction(

--- a/packages/server/src/services/auth/google-browser-auth.ts
+++ b/packages/server/src/services/auth/google-browser-auth.ts
@@ -24,6 +24,11 @@ export interface GoogleAuthCallbackInput {
   state: string;
 }
 
+export interface GoogleAuthCallbackOptions {
+  audit?: InvitationAuditContext;
+  onVerified(): void;
+}
+
 export class GoogleBrowserAuthService {
   readonly #database: DatabaseClient;
   readonly #flow: OAuthFlowService;
@@ -66,9 +71,10 @@ export class GoogleBrowserAuthService {
   async callback(
     input: GoogleAuthCallbackInput,
     context: string,
-    audit: InvitationAuditContext = {},
+    options: GoogleAuthCallbackOptions,
   ): Promise<GoogleAuthCallbackResult> {
     const flow = await this.#flow.verify(input.state, context);
+    options.onVerified();
     if (input.error) {
       throw new AuthServiceError(
         "AUTH_OAUTH_FAILED",
@@ -91,7 +97,7 @@ export class GoogleBrowserAuthService {
         transaction,
         resolvedUserId,
         invitationTokenFromNext(flow.next),
-        audit,
+        options.audit ?? {},
       );
       return resolvedUserId;
     });

--- a/packages/server/src/services/auth/index.ts
+++ b/packages/server/src/services/auth/index.ts
@@ -16,6 +16,7 @@ export {
 export { DevBrowserAuthService, type DevBrowserTokenIssuer } from "./dev-browser-auth.js";
 export { AuthServiceError } from "./errors.js";
 export {
+  type GoogleAuthCallbackInput,
   type GoogleAuthCallbackResult,
   type GoogleAuthStartResult,
   GoogleBrowserAuthService,

--- a/packages/server/src/services/auth/index.ts
+++ b/packages/server/src/services/auth/index.ts
@@ -17,6 +17,7 @@ export { DevBrowserAuthService, type DevBrowserTokenIssuer } from "./dev-browser
 export { AuthServiceError } from "./errors.js";
 export {
   type GoogleAuthCallbackInput,
+  type GoogleAuthCallbackOptions,
   type GoogleAuthCallbackResult,
   type GoogleAuthStartResult,
   GoogleBrowserAuthService,


### PR DESCRIPTION
## Summary

- accept provider-owned query fields on the Google OAuth callback while preserving validation for `state` and exactly one of `code` or `error`
- verify OAuth state before mapping provider errors, returning stable `AUTH_OAUTH_FAILED` responses for cancellations and other failures without reflecting provider text
- clear the one-time OAuth context cookie before code exchange or provider error handling so terminal callbacks cannot reuse the flow context
- add route and service regression coverage for real Google callback fields, invalid callback shapes, provider errors, invalid flows, and cookie cleanup

The root cause was a strict callback query schema that rejected valid Google-owned fields such as `scope`, `authuser`, and `prompt` before OAuth state verification or code exchange.

## Testing

- `pnpm --filter @opentag/server exec vitest run --maxWorkers=1 src/__tests__/browser-auth.test.ts src/__tests__/google-auth.test.ts`
- `pnpm --filter @opentag/server typecheck`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
