### PR TITLE
refactor!: organize OpenTag Home by lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,10 @@ jobs:
           trap cleanup_runtime EXIT
           OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs \
             login "$connect_code" --server http://127.0.0.1:18000 --no-start
-          OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs daemon service-run >"$daemon_log" 2>&1 &
+          test -f "$runtime_home/config/credentials.json"
+          test ! -e "$runtime_home/credentials.json"
+          OPENTAG_HOME="$runtime_home" OPENTAG_SERVICE_MODE=1 node apps/cli/dist/cli/index.mjs daemon service-run \
+            >"$daemon_log" 2>&1 &
           daemon_pid=$!
 
           for attempt in $(seq 1 30); do
@@ -305,12 +308,15 @@ jobs:
             fi
             sleep 1
           done
+          test -f "$runtime_home/state/daemon/owner.json"
+          test -f "$runtime_home/logs/client.log"
           OPENTAG_HOME="$runtime_home" timeout 5s node apps/cli/dist/cli/index.mjs daemon service-run \
             >"$runtime_home/second.log" 2>&1
           grep -q "already running" "$runtime_home/second.log"
           OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs computer list | grep -q $'\tonline\t'
           computer_id=$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8')).computerId" \
-            "$runtime_home/computer.json")
+            "$runtime_home/data/computer.json")
+          test ! -e "$runtime_home/computer.json"
 
           agent_create=$(OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs agent create \
             --team example \
@@ -331,9 +337,11 @@ jobs:
           kill -INT "$daemon_pid"
           wait "$daemon_pid"
           unset daemon_pid
+          test ! -e "$runtime_home/state/daemon/owner.json"
           OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs computer list | grep -q $'\toffline\t'
 
-          OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs daemon service-run >"$daemon_log" 2>&1 &
+          OPENTAG_HOME="$runtime_home" OPENTAG_SERVICE_MODE=1 node apps/cli/dist/cli/index.mjs daemon service-run \
+            >"$daemon_log" 2>&1 &
           daemon_pid=$!
           for attempt in $(seq 1 30); do
             if list=$(OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs computer list) && \

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,19 +113,54 @@ opentag-dev daemon status
 opentag-dev computer list
 ```
 
-The daemon reuses the stable Computer ID stored in its home, creates a new process instance on every service start, and
-connects to `/api/v1/computer/ws`. Manage it with `daemon install/start/stop/restart/status/uninstall`. `uninstall`
-preserves credentials and Computer identity. Use `login --no-start` for credential-only setup; Windows services are not
-supported in v0.1. Linux logs are available through `journalctl --user -u opentag-dev.service`; macOS logs are under the
-channel home's `logs` directory. Optional `${OPENTAG_HOME}/daemon.env` must be a private regular file (mode `0600`) and
-can provide service-only environment values without overriding pinned service settings. The CLI uses `/api/v1/auth/...`
-and `/api/v1/me/...`; `/healthz` and `/readyz` remain unversioned deployment probes.
+The daemon reuses the stable Computer ID stored at `${OPENTAG_HOME}/data/computer.json`, creates a new process instance
+on every service start, and connects to `/api/v1/computer/ws`. OpenTag Home is organized by lifecycle:
+
+```text
+${OPENTAG_HOME}/
+├── config/
+│   ├── credentials.json
+│   └── daemon.env
+├── data/
+│   ├── computer.json
+│   ├── runtime/agents/<agent-key>/
+│   └── workspaces/<agent-key>/
+├── state/
+│   ├── daemon/owner.json
+│   └── service/
+│       ├── operation.json
+│       ├── target-operation.json  # default channel Home only
+│       └── <serviceId>
+└── logs/
+```
+
+Directories are private (`0700`); credentials, identity, runtime recovery records, and lease files are private regular
+files (`0600`). Directories and files are created only when their owner needs them. In particular, `login --no-start`
+creates only `config/credentials.json`; runtime recovery records and workspaces appear on the first relevant reconcile.
+
+This layout is a clean break: OpenTag does not read, migrate, delete, or fall back to root-level `credentials.json`,
+`computer.json`, `daemon-owner.json`, `runtime/`, `service/`, or `~/.opentag-service-targets`. Use a fresh Home, or move
+the old Home aside and log in again. Existing legacy files otherwise remain unused on disk.
+
+Manage the daemon with `daemon install/start/stop/restart/status/uninstall`. `uninstall` preserves `config/` and `data/`.
+Windows services are not supported in v0.1. Linux logs are available through
+`journalctl --user -u opentag-dev.service`; macOS logs are under `${OPENTAG_HOME}/logs`. Optional
+`${OPENTAG_HOME}/config/daemon.env` must be a private regular file (mode `0600`) and can provide service-only environment
+values without overriding pinned service settings. The CLI uses `/api/v1/auth/...` and `/api/v1/me/...`; `/healthz` and
+`/readyz` remain unversioned deployment probes.
 
 The dev service definition is `~/.config/systemd/user/opentag-dev.service` on Linux or
-`~/Library/LaunchAgents/opentag-dev.plist` on macOS; the macOS wrapper is `${OPENTAG_HOME}/service/opentag-dev`.
+`~/Library/LaunchAgents/opentag-dev.plist` on macOS; the macOS wrapper is
+`${OPENTAG_HOME}/state/service/opentag-dev`.
 Staging and production replace the suffix with their channel `serviceId` (`opentag-staging` or `opentag`). If login saves
 credentials but service installation fails, fix the reported manager issue and run
 `opentag-dev daemon install`; do not request another connect code.
+
+Service mutation has two independent leases. `${OPENTAG_HOME}/state/service/operation.json` serializes operations for
+the current Home. The target lease is fixed at the current user's default Home for the binary's channel — for example,
+`~/.opentag-dev/state/service/target-operation.json` — so multiple custom `OPENTAG_HOME` values cannot concurrently
+modify the same `opentag-dev.service`. Dev, staging, and production use different default Homes and service targets, so
+their target leases do not contend.
 
 ## Manage Agent configurations
 
@@ -228,7 +263,7 @@ processes.
 | `OPENTAG_AUTO_MIGRATE` | `true` | Run checked-in migrations before listening |
 | `OPENTAG_ACCESS_TOKEN_TTL_SECONDS` | `900` | Access-token lifetime |
 | `OPENTAG_REFRESH_TOKEN_TTL_SECONDS` | `2592000` | Refresh-JWT lifetime |
-| `OPENTAG_HOME` | channel-specific | CLI credentials, Computer identity, and daemon ownership directory (`~/.opentag-dev` in source) |
+| `OPENTAG_HOME` | channel-specific | Root for lifecycle-separated `config/`, `data/`, `state/`, and `logs/` (`~/.opentag-dev` in source) |
 
 If `doctor` fails, its error category distinguishes configuration, network, HTTP, and invalid-response failures. Confirm
 the server is running and that the configured URL points to its base address.

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -1,7 +1,7 @@
 # OpenTag 开发指南
 
 > Canonical source: [DEVELOPMENT.md](./DEVELOPMENT.md)
-> Last synced with: 2026-08-19
+> Last synced with: 2026-08-20
 
 ## 前置要求
 
@@ -113,19 +113,53 @@ opentag-dev daemon status
 opentag-dev computer list
 ```
 
-daemon 会复用 home 中的稳定 Computer ID，每次服务启动创建新的进程 instance，并连接
-`/api/v1/computer/ws`。使用 `daemon install/start/stop/restart/status/uninstall` 管理服务；`uninstall` 会保留
-凭据和 Computer identity。只需写入凭据时使用 `login --no-start`；v0.1 不支持 Windows daemon 服务。
-Linux 日志通过 `journalctl --user -u opentag-dev.service` 查看，macOS 日志位于 channel home 的 `logs`
-目录。可选的 `${OPENTAG_HOME}/daemon.env` 必须是私有普通文件（权限 `0600`），用于补充服务环境且不会
-覆盖固定的服务配置。CLI 使用 `/api/v1/auth/...` 与 `/api/v1/me/...`；`/healthz` 和 `/readyz` 继续作为
-无版本部署探针。
+daemon 会复用 `${OPENTAG_HOME}/data/computer.json` 中的稳定 Computer ID，每次服务启动创建新的进程
+instance，并连接 `/api/v1/computer/ws`。OpenTag Home 按生命周期组织：
+
+```text
+${OPENTAG_HOME}/
+├── config/
+│   ├── credentials.json
+│   └── daemon.env
+├── data/
+│   ├── computer.json
+│   ├── runtime/agents/<agent-key>/
+│   └── workspaces/<agent-key>/
+├── state/
+│   ├── daemon/owner.json
+│   └── service/
+│       ├── operation.json
+│       ├── target-operation.json  # 仅默认 channel Home
+│       └── <serviceId>
+└── logs/
+```
+
+目录权限为私有 `0700`；credentials、identity、runtime recovery record 与 lease 文件均为私有普通文件
+（`0600`）。各目录和文件只在对应 owner 需要时创建。特别地，`login --no-start` 只创建
+`config/credentials.json`；runtime recovery record 和 Workspace 在首次相关 reconcile 时才出现。
+
+此布局采用 clean break：OpenTag 不会读取、迁移、删除或回退到根目录的 `credentials.json`、
+`computer.json`、`daemon-owner.json`、`runtime/`、`service/` 或 `~/.opentag-service-targets`。请使用全新
+Home，或先移走旧 Home 再重新登录；否则旧文件会原样保留，但新版不会使用它们。
+
+使用 `daemon install/start/stop/restart/status/uninstall` 管理服务；`uninstall` 会保留 `config/` 与
+`data/`。v0.1 不支持 Windows daemon 服务。Linux 日志通过
+`journalctl --user -u opentag-dev.service` 查看，macOS 日志位于 `${OPENTAG_HOME}/logs`。可选的
+`${OPENTAG_HOME}/config/daemon.env` 必须是私有普通文件（权限 `0600`），用于补充服务环境且不会覆盖固定
+的服务配置。CLI 使用 `/api/v1/auth/...` 与 `/api/v1/me/...`；`/healthz` 和 `/readyz` 继续作为无版本部署探针。
 
 dev 服务定义在 Linux 上位于 `~/.config/systemd/user/opentag-dev.service`，在 macOS 上位于
-`~/Library/LaunchAgents/opentag-dev.plist`；macOS wrapper 位于 `${OPENTAG_HOME}/service/opentag-dev`。
+`~/Library/LaunchAgents/opentag-dev.plist`；macOS wrapper 位于
+`${OPENTAG_HOME}/state/service/opentag-dev`。
 staging 与 production 使用各自的 channel `serviceId`（`opentag-staging` 或 `opentag`）替换后缀。如果登录已
 保存凭据但服务安装失败，修复提示的 manager 问题后运行
 `opentag-dev daemon install`，不需要申请新的 connect code。
+
+Service mutation 使用两个独立 lease。`${OPENTAG_HOME}/state/service/operation.json` 只序列化当前 Home 的
+操作；target lease 固定放在当前用户对应 binary channel 的默认 Home，例如
+`~/.opentag-dev/state/service/target-operation.json`。因此多个自定义 `OPENTAG_HOME` 无法并发修改同一个
+`opentag-dev.service`。dev、staging、production 各自使用不同默认 Home 和 service target，target lease 之间
+不会竞争。
 
 ## 管理 Agent 配置
 
@@ -222,7 +256,7 @@ fail-closed 原则拒绝读取。
 | `OPENTAG_AUTO_MIGRATE` | `true` | 监听前执行已入库的 migration |
 | `OPENTAG_ACCESS_TOKEN_TTL_SECONDS` | `900` | access token 有效期 |
 | `OPENTAG_REFRESH_TOKEN_TTL_SECONDS` | `2592000` | refresh JWT 有效期 |
-| `OPENTAG_HOME` | 随 channel 而定 | CLI credentials、Computer identity 与 daemon ownership 目录（源码默认为 `~/.opentag-dev`） |
+| `OPENTAG_HOME` | 随 channel 而定 | 按生命周期分层的 `config/`、`data/`、`state/`、`logs/` 根目录（源码默认为 `~/.opentag-dev`） |
 
 如果 `doctor` 失败，其错误类别会区分配置、网络、HTTP 和无效响应。请确认 Server 已启动，且配置的 URL 指向其基础地址。
 

--- a/apps/cli/src/__tests__/daemon-owner.test.ts
+++ b/apps/cli/src/__tests__/daemon-owner.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { acquireDaemonOwner, inspectDaemonOwner } from "../core/daemon/ownership.js";
+import { resolveDaemonPaths } from "../core/daemon/paths.js";
 
 const directories: string[] = [];
 afterEach(async () => {
@@ -29,8 +30,10 @@ describe("daemon owner inspection", () => {
 
   it("quarantines a stale owner when acquiring the next lease", async () => {
     const home = await temporaryDirectory();
+    const paths = resolveDaemonPaths(home);
+    await mkdir(paths.daemonState, { mode: 0o700, recursive: true });
     await writeFile(
-      join(home, "daemon-owner.json"),
+      paths.daemonOwner,
       `${JSON.stringify({
         home,
         instanceId: "stale-instance",
@@ -49,8 +52,19 @@ describe("daemon owner inspection", () => {
 
   it("fails closed on malformed owner records", async () => {
     const home = await temporaryDirectory();
-    await writeFile(join(home, "daemon-owner.json"), "{}\n", { mode: 0o600 });
+    const paths = resolveDaemonPaths(home);
+    await mkdir(paths.daemonState, { mode: 0o700, recursive: true });
+    await writeFile(paths.daemonOwner, "{}\n", { mode: 0o600 });
     await expect(inspectDaemonOwner(home)).rejects.toThrow("malformed");
+  });
+
+  it("rejects a symlinked nested daemon state directory", async () => {
+    const home = await temporaryDirectory();
+    const external = await temporaryDirectory();
+    await symlink(external, join(home, "state"), "dir");
+
+    await expect(acquireDaemonOwner(home, "instance")).rejects.toThrow(/real director/i);
+    expect(await readdir(external)).toEqual([]);
   });
 
   it.each([
@@ -58,8 +72,10 @@ describe("daemon owner inspection", () => {
     ["an empty process start identity", { pid: process.pid, processStartId: "" }],
   ])("rejects %s in an owner record", async (_label, invalid) => {
     const home = await temporaryDirectory();
+    const paths = resolveDaemonPaths(home);
+    await mkdir(paths.daemonState, { mode: 0o700, recursive: true });
     await writeFile(
-      join(home, "daemon-owner.json"),
+      paths.daemonOwner,
       `${JSON.stringify({
         home,
         instanceId: "instance",

--- a/apps/cli/src/__tests__/daemon-service-commands.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-commands.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ClientLogBindings, ClientLogger } from "@opentag/client";
@@ -8,6 +8,7 @@ import { registerDaemonCommand } from "../commands/daemon/index.js";
 import { executeDaemonServiceCommand } from "../commands/daemon/shared.js";
 import { channelConfig } from "../core/channel/config.js";
 import { acquireDaemonOwner } from "../core/daemon/ownership.js";
+import { resolveDaemonPaths } from "../core/daemon/paths.js";
 import { runDaemonServiceEntry } from "../core/daemon/runtime.js";
 import { createDaemonServiceManager, type DaemonServiceManager } from "../core/daemon/service/index.js";
 import type { ServiceRunner } from "../core/daemon/service/types.js";
@@ -90,7 +91,9 @@ describe("daemon service commands", () => {
     const messages: Array<{ fields: ClientLogBindings; message: string }> = [];
     const home = await mkdtemp(join(tmpdir(), "opentag-service-owner-malformed-"));
     try {
-      await writeFile(join(home, "daemon-owner.json"), "{}\n", { mode: 0o600 });
+      const paths = resolveDaemonPaths(home);
+      await mkdir(paths.daemonState, { mode: 0o700, recursive: true });
+      await writeFile(paths.daemonOwner, "{}\n", { mode: 0o600 });
       await expect(
         runDaemonServiceEntry({
           home,

--- a/apps/cli/src/__tests__/daemon-service-renderers.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-renderers.test.ts
@@ -2,9 +2,11 @@ import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promi
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeCredentialsAtomically } from "@opentag/client";
+import { getChannelConfig } from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { channelConfig } from "../core/channel/config.js";
 import { acquireDaemonOwner } from "../core/daemon/ownership.js";
+import { resolveDaemonPaths } from "../core/daemon/paths.js";
 import { createDaemonServiceManager } from "../core/daemon/service/index.js";
 import { createLaunchdBackend, renderLaunchdPlist, renderLaunchdWrapper } from "../core/daemon/service/launchd.js";
 import { buildServicePath } from "../core/daemon/service/shared.js";
@@ -381,7 +383,15 @@ describe("systemd service backend", () => {
 
     const winner = first.installAndStart();
     await reloadReached;
+    const targetHome = getChannelConfig(channelConfig.channel, userHome).defaultHome;
+    await expect(readFile(resolveDaemonPaths(targetHome).serviceTargetOperation, "utf8")).resolves.toContain(
+      "operationId",
+    );
+    await expect(readFile(resolveDaemonPaths(firstHome).serviceOperation, "utf8")).resolves.toContain("operationId");
     await expect(second.installAndStart()).rejects.toThrow("service-target operation is already running");
+    await expect(readFile(resolveDaemonPaths(secondHome).serviceOperation, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     releaseReload?.();
     await expect(winner).resolves.toMatchObject({ configuredHome: canonicalFirstHome, state: "active" });
 
@@ -439,10 +449,10 @@ describe("launchd service backend", () => {
       path: "/usr/bin:/bin",
       stderrPath: "/Users/test/.opentag/logs/daemon.stderr.log",
       stdoutPath: "/Users/test/.opentag/logs/daemon.stdout.log",
-      wrapperPath: "/Users/test/.opentag/service/opentag",
+      wrapperPath: "/Users/test/.opentag/state/service/opentag",
     });
     expect(plist).toContain("<string>opentag</string>");
-    expect(plist).toContain("<string>/Users/test/.opentag/service/opentag</string>");
+    expect(plist).toContain("<string>/Users/test/.opentag/state/service/opentag</string>");
     expect(plist).not.toContain("node");
     expect(plist).not.toContain("index.mjs");
     expect(wrapper).toContain("'/usr/bin/node' '/app/index.mjs' 'daemon' 'service-run'");
@@ -670,7 +680,7 @@ async function writeLaunchdDefinitions(options: {
   invocation: { args: string[]; program: string };
   userHome: string;
 }): Promise<void> {
-  const wrapperPath = join(options.home, "service", "opentag");
+  const wrapperPath = join(options.home, "state", "service", "opentag");
   await writeFileWithParents(wrapperPath, renderLaunchdWrapper(options.invocation));
   await writeFileWithParents(
     join(options.userHome, "Library", "LaunchAgents", "opentag.plist"),

--- a/apps/cli/src/__tests__/daemon-service-runtime.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-runtime.test.ts
@@ -41,6 +41,7 @@ vi.mock("../core/daemon/ownership.js", async (importOriginal) => {
 });
 
 import { acquireDaemonOwner } from "../core/daemon/ownership.js";
+import { resolveDaemonPaths } from "../core/daemon/paths.js";
 import { runDaemonLifecycle, runDaemonService, runDaemonServiceEntry } from "../core/daemon/runtime.js";
 
 const directories: string[] = [];
@@ -139,7 +140,7 @@ describe("daemon service runtime", () => {
     await daemon;
 
     expect(clientMocks.me).not.toHaveBeenCalled();
-    await expect(access(join(home, "daemon-owner.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(resolveDaemonPaths(home).daemonOwner)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("composes the Codex Client Runtime after authenticated daemon startup", async () => {

--- a/apps/cli/src/__tests__/daemon-service-shared.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-shared.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { getChannelConfig } from "@opentag/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadDaemonEnvironment } from "../core/daemon/environment.js";
+import { resolveDaemonPaths } from "../core/daemon/paths.js";
 import {
   acquireProcessFileLease,
   inspectDarwinProcessIdentity,
@@ -11,6 +12,7 @@ import {
 } from "../core/daemon/process-lease.js";
 import {
   acquireServiceOperationLease,
+  acquireServiceTargetLease,
   canonicalizeServiceHome,
   deriveServiceIdentity,
   escapeXml,
@@ -100,11 +102,36 @@ describe("daemon service primitives", () => {
 
   it("serializes service mutations per home", async () => {
     const home = await temporaryDirectory("opentag-operation-");
+    const paths = resolveDaemonPaths(home);
     const first = await acquireServiceOperationLease(home);
+    await expect(readFile(paths.serviceOperation, "utf8")).resolves.toContain("operationId");
     await expect(acquireServiceOperationLease(home)).rejects.toThrow("already running");
     await first.release();
     const second = await acquireServiceOperationLease(home);
     await second.release();
+  });
+
+  it("stores a channel target lease in that channel's default Home", async () => {
+    const userHome = await temporaryDirectory("opentag-target-operation-");
+    const config = getChannelConfig("dev", userHome);
+    const paths = resolveDaemonPaths(config.defaultHome);
+
+    const lease = await acquireServiceTargetLease(config.defaultHome, config.serviceId);
+    await expect(readFile(paths.serviceTargetOperation, "utf8")).resolves.toContain("operationId");
+    await lease.release();
+  });
+
+  it("does not make different channels contend for one target lease", async () => {
+    const userHome = await temporaryDirectory("opentag-channel-operations-");
+    const dev = getChannelConfig("dev", userHome);
+    const production = getChannelConfig("prod", userHome);
+
+    const devLease = await acquireServiceTargetLease(dev.defaultHome, dev.serviceId);
+    const productionLease = await acquireServiceTargetLease(production.defaultHome, production.serviceId);
+    expect(resolveDaemonPaths(dev.defaultHome).serviceTargetOperation).not.toBe(
+      resolveDaemonPaths(production.defaultHome).serviceTargetOperation,
+    );
+    await Promise.all([devLease.release(), productionLease.release()]);
   });
 
   it("serializes stale lease takeover before publishing a successor", async () => {
@@ -309,8 +336,10 @@ describe("daemon service primitives", () => {
 describe("daemon.env", () => {
   it("fills missing keys without overriding pinned values or logging values", async () => {
     const home = await temporaryDirectory("opentag-env-");
+    const paths = resolveDaemonPaths(home);
+    await mkdir(paths.config, { mode: 0o700, recursive: true });
     await writeFile(
-      join(home, "daemon.env"),
+      paths.daemonEnvironment,
       ["# service env", "export HTTPS_PROXY='http://secret-proxy'", "OPENTAG_HOME=/wrong", "BROKEN", ""].join("\n"),
       { mode: 0o600 },
     );
@@ -324,14 +353,26 @@ describe("daemon.env", () => {
 
   it("rejects broad permissions and symlinks", async () => {
     const home = await temporaryDirectory("opentag-env-");
-    const target = join(home, "target.env");
+    const paths = resolveDaemonPaths(home);
+    await mkdir(paths.config, { mode: 0o700, recursive: true });
+    const target = join(paths.config, "target.env");
     await writeFile(target, "KEY=value\n", { mode: 0o600 });
-    await symlink(target, join(home, "daemon.env"));
+    await symlink(target, paths.daemonEnvironment);
     await expect(loadDaemonEnvironment(home, {})).rejects.toThrow("regular file");
-    await rm(join(home, "daemon.env"));
-    await writeFile(join(home, "daemon.env"), "KEY=value\n", { mode: 0o600 });
-    await chmod(join(home, "daemon.env"), 0o644);
+    await rm(paths.daemonEnvironment);
+    await writeFile(paths.daemonEnvironment, "KEY=value\n", { mode: 0o600 });
+    await chmod(paths.daemonEnvironment, 0o644);
     await expect(loadDaemonEnvironment(home, {})).rejects.toThrow("permissions");
+  });
+
+  it("rejects a symlinked config directory", async () => {
+    const home = await temporaryDirectory("opentag-env-home-");
+    const external = await temporaryDirectory("opentag-env-external-");
+    const paths = resolveDaemonPaths(home);
+    await writeFile(join(external, "daemon.env"), "KEY=value\n", { mode: 0o600 });
+    await symlink(external, paths.config, "dir");
+
+    await expect(loadDaemonEnvironment(home, {})).rejects.toThrow(/real director/i);
   });
 });
 

--- a/apps/cli/src/__tests__/login.test.ts
+++ b/apps/cli/src/__tests__/login.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { credentialsPath, readCredentials, resolveComputerIdentity } from "@opentag/client";
@@ -42,6 +42,7 @@ describe("runLogin", () => {
       accessTokenExpiresAt: "2026-08-18T00:15:00.000Z",
       refreshToken: "refresh-secret",
     });
+    expect(await readdir(home)).toEqual(["config"]);
   });
 
   it("rejects another server before consuming a connect code for a bound home", async () => {

--- a/apps/cli/src/core/daemon/environment.ts
+++ b/apps/cli/src/core/daemon/environment.ts
@@ -1,5 +1,6 @@
 import { lstat, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { validatePrivateDirectory } from "@opentag/client";
+import { resolveDaemonPaths } from "./paths.js";
 import { DaemonServiceError } from "./service/types.js";
 
 export interface DaemonEnvironmentResult {
@@ -13,7 +14,11 @@ export async function loadDaemonEnvironment(
   home: string,
   baseEnvironment: NodeJS.ProcessEnv = process.env,
 ): Promise<DaemonEnvironmentResult> {
-  const path = join(home, "daemon.env");
+  const paths = resolveDaemonPaths(home);
+  if (!(await validatePrivateDirectory(paths.home, paths.config))) {
+    return { appliedKeys: [], diagnostics: [], env: { ...baseEnvironment }, malformedLineNumbers: [] };
+  }
+  const path = paths.daemonEnvironment;
   let content: string;
   try {
     const status = await lstat(path);

--- a/apps/cli/src/core/daemon/ownership.ts
+++ b/apps/cli/src/core/daemon/ownership.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { basename } from "node:path";
+import { resolveDaemonPaths } from "./paths.js";
 import {
   acquireProcessFileLease,
   inspectProcessFileLease,
@@ -35,12 +37,11 @@ export class DaemonOwnerStartupError extends Error {
   }
 }
 
-const OWNER_FILE_NAME = "daemon-owner.json";
-
 export async function acquireDaemonOwner(home: string, instanceId: string): Promise<DaemonOwnerLease> {
+  const paths = resolveDaemonPaths(home);
   let lease: ProcessFileLease<DaemonOwner>;
   try {
-    lease = await acquireProcessFileLease(home, {
+    lease = await acquireProcessFileLease(paths.daemonState, {
       createRecord: (processStartId) => ({
         home,
         instanceId,
@@ -49,9 +50,10 @@ export async function acquireDaemonOwner(home: string, instanceId: string): Prom
         processStartId,
         startedAt: new Date().toISOString(),
       }),
-      fileName: OWNER_FILE_NAME,
+      fileName: basename(paths.daemonOwner),
       getId: (owner) => owner.ownerId,
       parseRecord: parseOwner,
+      rootDirectory: paths.home,
     });
   } catch (error) {
     if (error instanceof ProcessLeaseBusyError) {
@@ -73,11 +75,13 @@ export async function acquireDaemonOwner(home: string, instanceId: string): Prom
 }
 
 export async function inspectDaemonOwner(home: string): Promise<ProcessLeaseInspection<DaemonOwner>> {
+  const paths = resolveDaemonPaths(home);
   try {
-    return await inspectProcessFileLease(home, {
-      fileName: OWNER_FILE_NAME,
+    return await inspectProcessFileLease(paths.daemonState, {
+      fileName: basename(paths.daemonOwner),
       getId: (owner) => owner.ownerId,
       parseRecord: parseOwner,
+      rootDirectory: paths.home,
     });
   } catch (error) {
     throw normalizeOwnerError(error);

--- a/apps/cli/src/core/daemon/paths.ts
+++ b/apps/cli/src/core/daemon/paths.ts
@@ -1,0 +1,37 @@
+import { join } from "node:path";
+import { resolveOpenTagHomeLayout } from "@opentag/client";
+
+export interface DaemonPaths {
+  clientLog: string;
+  config: string;
+  daemonEnvironment: string;
+  daemonOwner: string;
+  daemonState: string;
+  daemonStderrLog: string;
+  daemonStdoutLog: string;
+  home: string;
+  logs: string;
+  serviceOperation: string;
+  serviceState: string;
+  serviceTargetOperation: string;
+  serviceWrapper(serviceId: string): string;
+}
+
+export function resolveDaemonPaths(home: string): DaemonPaths {
+  const layout = resolveOpenTagHomeLayout(home);
+  return {
+    clientLog: join(layout.logs, "client.log"),
+    config: layout.config,
+    daemonEnvironment: join(layout.config, "daemon.env"),
+    daemonOwner: join(layout.daemonState, "owner.json"),
+    daemonState: layout.daemonState,
+    daemonStderrLog: join(layout.logs, "daemon.stderr.log"),
+    daemonStdoutLog: join(layout.logs, "daemon.stdout.log"),
+    home: layout.home,
+    logs: layout.logs,
+    serviceOperation: join(layout.serviceState, "operation.json"),
+    serviceState: layout.serviceState,
+    serviceTargetOperation: join(layout.serviceState, "target-operation.json"),
+    serviceWrapper: (serviceId) => join(layout.serviceState, serviceId),
+  };
+}

--- a/apps/cli/src/core/daemon/process-lease.ts
+++ b/apps/cli/src/core/daemon/process-lease.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { lstat, open, readFile, rename, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { ensurePrivateDirectory, validatePrivateDirectory } from "@opentag/client";
 
 export interface ProcessLeaseRecord {
   pid: number;
@@ -25,6 +26,7 @@ export interface ProcessLeaseOptions<T extends ProcessLeaseRecord> {
   getProcessIdentity?: (pid: number) => Promise<ProcessIdentityInspection>;
   getId(record: T): string;
   parseRecord(value: unknown): T;
+  rootDirectory?: string;
 }
 
 export type ProcessIdentityInspection = { id: string; state: "identified" } | { state: "gone" | "unverifiable" };
@@ -49,7 +51,7 @@ export async function acquireProcessFileLease<T extends ProcessLeaseRecord>(
   home: string,
   options: ProcessLeaseOptions<T>,
 ): Promise<ProcessFileLease<T>> {
-  await ensurePrivateDirectory(home);
+  await ensurePrivateDirectory(options.rootDirectory ?? home, home);
   const path = join(home, options.fileName);
   const getProcessIdentity = options.getProcessIdentity ?? inspectProcessIdentity;
   const currentIdentity = await getProcessIdentity(process.pid);
@@ -90,6 +92,7 @@ export async function inspectProcessFileLease<T extends ProcessLeaseRecord>(
   home: string,
   options: Omit<ProcessLeaseOptions<T>, "createRecord">,
 ): Promise<ProcessLeaseInspection<T>> {
+  if (!(await validatePrivateDirectory(options.rootDirectory ?? home, home))) return { state: "missing" };
   const path = join(home, options.fileName);
   let record: T;
   try {
@@ -181,14 +184,6 @@ function leaseFor<T extends ProcessLeaseRecord>(
       await rm(path);
     },
   };
-}
-
-async function ensurePrivateDirectory(path: string): Promise<void> {
-  await mkdir(path, { recursive: true, mode: 0o700 });
-  const status = await lstat(path);
-  if (!status.isDirectory() || status.isSymbolicLink()) {
-    throw new Error("The OpenTag home must be a real directory");
-  }
 }
 
 async function readProcessLease<T extends ProcessLeaseRecord>(

--- a/apps/cli/src/core/daemon/runtime.ts
+++ b/apps/cli/src/core/daemon/runtime.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { arch, hostname, platform } from "node:os";
-import { join } from "node:path";
 import {
   AccessTokenProvider,
   type ClientLogger,
@@ -18,6 +17,7 @@ import {
 import { CLI_VERSION } from "../../build-info.js";
 import { applyDaemonEnvironment } from "./environment.js";
 import { acquireDaemonOwner, DaemonOwnerStartupError } from "./ownership.js";
+import { resolveDaemonPaths } from "./paths.js";
 import { DaemonServiceError } from "./service/types.js";
 
 export interface DaemonRuntimeOptions {
@@ -76,6 +76,7 @@ export class DaemonRuntimeConfigurationError extends Error {
 
 export async function runDaemonService(options: DaemonRuntimeOptions = {}): Promise<void> {
   const home = options.home ?? resolveOpenTagHome();
+  const paths = resolveDaemonPaths(home);
   const signals = options.signals ?? process;
   const instanceId = randomUUID();
   const currentPlatform = platform();
@@ -100,7 +101,7 @@ export async function runDaemonService(options: DaemonRuntimeOptions = {}): Prom
   let failed = false;
   try {
     const environmentResult = await applyDaemonEnvironment(home, process.env);
-    if (process.env.OPENTAG_SERVICE_MODE === "1") configureClientLoggerForService(join(home, "logs"));
+    if (process.env.OPENTAG_SERVICE_MODE === "1") configureClientLoggerForService(paths.logs);
     const logger = (options.logger ?? createLogger("daemon")).child(baseBindings);
     lifecycleLogger = logger;
     terminalLogger = logger;

--- a/apps/cli/src/core/daemon/service/index.ts
+++ b/apps/cli/src/core/daemon/service/index.ts
@@ -1,6 +1,8 @@
 import { homedir, userInfo } from "node:os";
 import { resolve } from "node:path";
 import { readCredentials, resolveOpenTagHome } from "@opentag/client";
+import { getChannelConfig } from "@opentag/shared";
+import { CHANNEL } from "../../../build-info.js";
 import { channelConfig } from "../../channel/config.js";
 import { inspectDaemonOwner } from "../ownership.js";
 import { createLaunchdBackend } from "./launchd.js";
@@ -53,6 +55,7 @@ export async function createDaemonServiceManager(
   const home = await canonicalizeServiceHome(resolve(options.home ?? resolveOpenTagHome(options.env ?? process.env)));
   const runner = options.runner ?? defaultServiceRunner;
   const userHome = await canonicalizeServiceHome(resolve(options.userHome ?? homedir()));
+  const channelDefaultHome = await canonicalizeServiceHome(getChannelConfig(CHANNEL, userHome).defaultHome);
   const invocation =
     options.invocation ??
     (platform === "darwin" || platform === "linux"
@@ -79,7 +82,7 @@ export async function createDaemonServiceManager(
     mutation: DaemonServiceMutation,
     operation: () => Promise<DaemonServiceInfo>,
   ): Promise<DaemonServiceInfo> => {
-    const targetLease = await acquireServiceTargetLease(userHome, channelConfig.serviceId);
+    const targetLease = await acquireServiceTargetLease(channelDefaultHome, channelConfig.serviceId);
     let lease: Awaited<ReturnType<typeof acquireServiceOperationLease>> | undefined;
     try {
       lease = await acquireServiceOperationLease(home);

--- a/apps/cli/src/core/daemon/service/launchd.ts
+++ b/apps/cli/src/core/daemon/service/launchd.ts
@@ -1,6 +1,8 @@
-import { mkdir, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { homedir, userInfo } from "node:os";
 import { join } from "node:path";
+import { ensurePrivateDirectory } from "@opentag/client";
+import { resolveDaemonPaths } from "../paths.js";
 import {
   buildServicePath,
   deriveServiceIdentity,
@@ -88,10 +90,11 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
   const target = `${domain}/${identity.launchdLabel}`;
   const launchctl = options.launchctl ?? "launchctl";
   const plistPath = join(userHome, "Library", "LaunchAgents", identity.launchdPlistName);
-  const wrapperPath = join(options.home, "service", identity.launchdWrapperName);
-  const logDirectory = join(options.home, "logs");
-  const stdoutPath = join(logDirectory, "daemon.stdout.log");
-  const stderrPath = join(logDirectory, "daemon.stderr.log");
+  const paths = resolveDaemonPaths(options.home);
+  const wrapperPath = paths.serviceWrapper(identity.launchdWrapperName);
+  const logDirectory = paths.logs;
+  const stdoutPath = paths.daemonStdoutLog;
+  const stderrPath = paths.daemonStderrLog;
   const servicePath = buildServicePath(options.invocation, "darwin");
   const expectedWrapper = renderLaunchdWrapper(options.invocation);
   const expectedPlist = renderLaunchdPlist({
@@ -213,8 +216,8 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
     preflight,
     async installAndStart() {
       await preflight();
-      await mkdir(logDirectory, { recursive: true, mode: 0o700 });
-      await writeFileAtomically(wrapperPath, expectedWrapper, 0o700);
+      await ensurePrivateDirectory(paths.home, logDirectory);
+      await writeFileAtomically(wrapperPath, expectedWrapper, 0o700, 0o700, paths.home);
       await writeFileAtomically(plistPath, expectedPlist, 0o644, 0o700);
       await bootout();
       await waitForEviction();
@@ -288,7 +291,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
     return {
       currentHome: options.home,
       definitionPath: plistPath,
-      logHint: `${join(options.home, "logs", "client.log")} (fallback: ${stdoutPath} / ${stderrPath})`,
+      logHint: `${paths.clientLog} (fallback: ${stdoutPath} / ${stderrPath})`,
       platform: "launchd",
       serviceId: options.serviceId,
       state,

--- a/apps/cli/src/core/daemon/service/shared.ts
+++ b/apps/cli/src/core/daemon/service/shared.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { access, chmod, lstat, mkdir, open, readFile, realpath, rename, rm } from "node:fs/promises";
 import { basename, delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { ensurePrivateDirectory } from "@opentag/client";
+import { resolveDaemonPaths } from "../paths.js";
 import {
   acquireProcessFileLease,
   ProcessLeaseBusyError,
@@ -18,8 +20,6 @@ import {
 } from "./types.js";
 
 const COMMAND_TIMEOUT_MS = 15_000;
-const SERVICE_OPERATION_FILE = "service-operation.json";
-const SERVICE_TARGET_DIRECTORY = ".opentag-service-targets";
 
 interface ServiceOperationRecord {
   operationId: string;
@@ -145,9 +145,14 @@ export async function writeFileAtomically(
   content: string,
   mode: number,
   directoryMode = 0o700,
+  containmentRoot?: string,
 ): Promise<void> {
   const parent = dirname(path);
-  await mkdir(parent, { recursive: true, mode: directoryMode });
+  if (containmentRoot) {
+    await ensurePrivateDirectory(containmentRoot, parent);
+  } else {
+    await mkdir(parent, { recursive: true, mode: directoryMode });
+  }
   const temporaryPath = join(parent, `.${randomUUID()}.tmp`);
   try {
     const handle = await open(temporaryPath, "wx", mode);
@@ -194,21 +199,33 @@ export async function runRequired(
 }
 
 export async function acquireServiceOperationLease(home: string): Promise<ServiceOperationLease> {
-  return acquireMappedOperationLease(home, SERVICE_OPERATION_FILE, "Another daemon service operation");
+  const paths = resolveDaemonPaths(home);
+  return acquireMappedOperationLease(
+    paths.home,
+    paths.serviceState,
+    basename(paths.serviceOperation),
+    "Another daemon service operation",
+  );
 }
 
-export async function acquireServiceTargetLease(userHome: string, serviceId: string): Promise<ServiceOperationLease> {
+export async function acquireServiceTargetLease(
+  channelDefaultHome: string,
+  serviceId: string,
+): Promise<ServiceOperationLease> {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(serviceId)) {
     throw new DaemonServiceError("CONFIGURATION", "The daemon service ID is invalid");
   }
+  const paths = resolveDaemonPaths(channelDefaultHome);
   return acquireMappedOperationLease(
-    join(userHome, SERVICE_TARGET_DIRECTORY),
-    `${serviceId}.json`,
+    paths.home,
+    paths.serviceState,
+    basename(paths.serviceTargetOperation),
     `Another ${serviceId} service-target operation`,
   );
 }
 
 async function acquireMappedOperationLease(
+  root: string,
   directory: string,
   fileName: string,
   busyLabel: string,
@@ -224,6 +241,7 @@ async function acquireMappedOperationLease(
       fileName,
       getId: (record) => record.operationId,
       parseRecord: parseServiceOperation,
+      rootDirectory: root,
     });
     return { release: lease.release };
   } catch (error) {

--- a/apps/cli/src/core/daemon/service/systemd.ts
+++ b/apps/cli/src/core/daemon/service/systemd.ts
@@ -1,6 +1,7 @@
 import { rm } from "node:fs/promises";
 import { homedir, userInfo } from "node:os";
 import { join } from "node:path";
+import { resolveDaemonPaths } from "../paths.js";
 import {
   buildServicePath,
   deriveServiceIdentity,
@@ -63,6 +64,7 @@ WantedBy=default.target
 
 export function createSystemdBackend(options: SystemdBackendOptions): DaemonServiceBackend {
   const identity = deriveServiceIdentity(options.serviceId);
+  const paths = resolveDaemonPaths(options.home);
   const userHome = options.userHome ?? homedir();
   const uid = options.uid ?? userInfo().uid;
   const username = options.username ?? userInfo().username;
@@ -280,7 +282,7 @@ export function createSystemdBackend(options: SystemdBackendOptions): DaemonServ
     return {
       currentHome: options.home,
       definitionPath: unitPath,
-      logHint: `${join(options.home, "logs", "client.log")} (fallback: journalctl --user -u ${identity.systemdUnitName} -f)`,
+      logHint: `${paths.clientLog} (fallback: journalctl --user -u ${identity.systemdUnitName} -f)`,
       platform: "systemd",
       serviceId: options.serviceId,
       state,

--- a/packages/client/src/__tests__/agent-workspace.test.ts
+++ b/packages/client/src/__tests__/agent-workspace.test.ts
@@ -113,7 +113,7 @@ describe("AgentWorkspaceManager", () => {
     const home = await temporaryHome();
     const external = await temporaryHome();
     const paths = agentRuntimePaths(home, "agent-1");
-    await mkdir(resolve(home, "runtime", "workspaces"), { recursive: true, mode: 0o700 });
+    await mkdir(resolve(home, "data", "workspaces"), { recursive: true, mode: 0o700 });
     await symlink(external, paths.workspaceRoot);
     const bindingStore = new SessionBindingStore({ home, providerHomeIdentity: "a".repeat(64) });
     const workspace = new AgentWorkspaceManager({ home, bindingStore });

--- a/packages/client/src/__tests__/auth.test.ts
+++ b/packages/client/src/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, stat, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -40,8 +40,10 @@ describe("credential storage", () => {
 
     expect(await readCredentials(home)).toEqual({ ...credentials, accessToken: "next" });
     expect((await stat(home)).mode & 0o777).toBe(0o700);
+    expect((await stat(join(home, "config"))).mode & 0o777).toBe(0o700);
     expect((await stat(credentialsPath(home))).mode & 0o777).toBe(0o600);
-    expect(await readdir(home)).toEqual(["credentials.json"]);
+    expect(await readdir(home)).toEqual(["config"]);
+    expect(await readdir(join(home, "config"))).toEqual(["credentials.json"]);
   });
 
   it("rejects a symlinked canonical home", async () => {
@@ -51,10 +53,24 @@ describe("credential storage", () => {
     await mkdir(target);
     await symlink(target, linkedHome, "dir");
 
-    await expect(writeCredentialsAtomically(credentials, linkedHome)).rejects.toThrow(
-      "The OpenTag home must be a real directory",
-    );
+    await expect(writeCredentialsAtomically(credentials, linkedHome)).rejects.toThrow(/real director/i);
     expect(await readdir(target)).toEqual([]);
+  });
+
+  it("rejects a symlinked nested config directory", async () => {
+    const home = await temporaryHome();
+    const external = await temporaryHome();
+    await symlink(external, join(home, "config"), "dir");
+
+    await expect(writeCredentialsAtomically(credentials, home)).rejects.toThrow(/real director/i);
+    expect(await readdir(external)).toEqual([]);
+  });
+
+  it("does not read legacy root credentials", async () => {
+    const home = await temporaryHome();
+    await writeFile(join(home, "credentials.json"), `${JSON.stringify(credentials)}\n`, { mode: 0o600 });
+
+    await expect(readCredentials(home)).resolves.toBeUndefined();
   });
 });
 
@@ -146,5 +162,20 @@ describe("Computer identity", () => {
     await expect(resolveComputerIdentity(home, "https://other.example", first.userId)).rejects.toThrow(
       "bound to another server or user",
     );
+  });
+
+  it("does not read a legacy root Computer identity", async () => {
+    const home = await temporaryHome();
+    const legacy = {
+      version: 1,
+      computerId: crypto.randomUUID(),
+      serverUrl: "https://legacy.example",
+      userId: crypto.randomUUID(),
+    };
+    await writeFile(join(home, "computer.json"), `${JSON.stringify(legacy)}\n`, { mode: 0o600 });
+
+    const current = await resolveComputerIdentity(home, "https://opentag.example", crypto.randomUUID());
+    expect(current.computerId).not.toBe(legacy.computerId);
+    expect(computerIdentityPath(home)).toBe(join(home, "data", "computer.json"));
   });
 });

--- a/packages/client/src/__tests__/home-layout.test.ts
+++ b/packages/client/src/__tests__/home-layout.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { agentRuntimePaths, sessionBindingPath, snapshotPath } from "../runtime/runtime-paths.js";
+import { resolveOpenTagHome, resolveOpenTagHomeLayout } from "../storage/home-layout.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((path) => rm(path, { force: true, recursive: true })));
+});
+
+describe("OpenTag Home layout", () => {
+  it("resolves the lifecycle roots from one canonical Home", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opentag-layout-"));
+    directories.push(root);
+    const home = join(root, "custom", "..");
+
+    expect(resolveOpenTagHome({ OPENTAG_HOME: home })).toBe(root);
+    expect(resolveOpenTagHomeLayout(home)).toEqual({
+      config: join(root, "config"),
+      daemonState: join(root, "state", "daemon"),
+      data: join(root, "data"),
+      home: root,
+      logs: join(root, "logs"),
+      runtimeAgents: join(root, "data", "runtime", "agents"),
+      serviceState: join(root, "state", "service"),
+      state: join(root, "state"),
+      workspaces: join(root, "data", "workspaces"),
+    });
+  });
+
+  it("keeps runtime recovery state and workspaces in separate data roots", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-layout-runtime-"));
+    directories.push(home);
+    const paths = agentRuntimePaths(home, "agent-1");
+
+    expect(paths.controlRoot).toBe(join(home, "data", "runtime", "agents"));
+    expect(paths.agentControl).toMatch(new RegExp(`^${escapeRegExp(paths.controlRoot)}/a-[a-f0-9]{40}$`, "u"));
+    expect(paths.workspaceRoot).toMatch(
+      new RegExp(`^${escapeRegExp(join(home, "data", "workspaces"))}/a-[a-f0-9]{40}$`, "u"),
+    );
+    expect(sessionBindingPath(home, "agent-1", "session-1")).toContain("/data/runtime/agents/");
+    expect(snapshotPath(home, "agent-1", "snapshot-1")).toContain("/data/runtime/agents/");
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}

--- a/packages/client/src/auth/credentials.ts
+++ b/packages/client/src/auth/credentials.ts
@@ -1,6 +1,8 @@
-import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import { resolveOpenTagHome, resolveOpenTagHomeLayout } from "../storage/home-layout.js";
 import { readPrivateJson, writePrivateJson } from "../storage/private-json-file.js";
+
+export { resolveOpenTagHome } from "../storage/home-layout.js";
 
 export interface StoredCredentials {
   accessToken: string;
@@ -11,21 +13,17 @@ export interface StoredCredentials {
 
 export const CREDENTIALS_FILE_NAME = "credentials.json";
 
-export function resolveOpenTagHome(environment: NodeJS.ProcessEnv = process.env): string {
-  return environment.OPENTAG_HOME ? resolve(environment.OPENTAG_HOME) : join(homedir(), ".opentag");
-}
-
 export function credentialsPath(home = resolveOpenTagHome()): string {
-  return join(home, CREDENTIALS_FILE_NAME);
+  return join(resolveOpenTagHomeLayout(home).config, CREDENTIALS_FILE_NAME);
 }
 
 export function readCredentials(home = resolveOpenTagHome()): Promise<StoredCredentials | undefined> {
-  return readPrivateJson(home, CREDENTIALS_FILE_NAME, validateCredentials);
+  return readPrivateJson(home, credentialsPath(home), validateCredentials);
 }
 
 export function writeCredentialsAtomically(credentials: StoredCredentials, home = resolveOpenTagHome()): Promise<void> {
   validateCredentials(credentials);
-  return writePrivateJson(home, CREDENTIALS_FILE_NAME, credentials);
+  return writePrivateJson(home, credentialsPath(home), credentials);
 }
 
 function validateCredentials(value: unknown): StoredCredentials {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -57,7 +57,6 @@ export {
   CREDENTIALS_FILE_NAME,
   credentialsPath,
   readCredentials,
-  resolveOpenTagHome,
   type StoredCredentials,
   writeCredentialsAtomically,
 } from "./auth/credentials.js";
@@ -237,7 +236,13 @@ export {
   RuntimeStorageError,
   readDurableJson,
   readSecureFile,
+  validatePrivateDirectory,
   writeDurableFile,
   writeDurableJson,
 } from "./storage/durable-file.js";
+export {
+  type OpenTagHomeLayout,
+  resolveOpenTagHome,
+  resolveOpenTagHomeLayout,
+} from "./storage/home-layout.js";
 export { readPrivateJson, writePrivateJson } from "./storage/private-json-file.js";

--- a/packages/client/src/runtime/computer-identity.ts
+++ b/packages/client/src/runtime/computer-identity.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
+import { resolveOpenTagHomeLayout } from "../storage/home-layout.js";
 import { readPrivateJson, writePrivateJson } from "../storage/private-json-file.js";
 
 export interface ComputerIdentity {
@@ -12,11 +13,11 @@ export interface ComputerIdentity {
 export const COMPUTER_IDENTITY_FILE_NAME = "computer.json";
 
 export function computerIdentityPath(home: string): string {
-  return join(home, COMPUTER_IDENTITY_FILE_NAME);
+  return join(resolveOpenTagHomeLayout(home).data, COMPUTER_IDENTITY_FILE_NAME);
 }
 
 export function readComputerIdentity(home: string): Promise<ComputerIdentity | undefined> {
-  return readPrivateJson(home, COMPUTER_IDENTITY_FILE_NAME, validateIdentity);
+  return readPrivateJson(home, computerIdentityPath(home), validateIdentity);
 }
 
 export async function resolveComputerIdentity(
@@ -32,7 +33,7 @@ export async function resolveComputerIdentity(
     return existing;
   }
   const identity: ComputerIdentity = { version: 1, computerId: randomUUID(), serverUrl, userId };
-  await writePrivateJson(home, COMPUTER_IDENTITY_FILE_NAME, identity);
+  await writePrivateJson(home, computerIdentityPath(home), identity);
   return identity;
 }
 

--- a/packages/client/src/runtime/runtime-paths.ts
+++ b/packages/client/src/runtime/runtime-paths.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { resolve } from "node:path";
+import { resolveOpenTagHomeLayout } from "../storage/home-layout.js";
 
 export function deriveRuntimeKey(kind: "agent" | "session" | "snapshot", id: string): string {
   const digest = createHash("sha256").update(`${kind}\0${id}`, "utf8").digest("hex");
@@ -18,11 +19,11 @@ export interface AgentRuntimePaths {
 }
 
 export function agentRuntimePaths(home: string, agentId: string): AgentRuntimePaths {
-  const runtimeRoot = resolve(home, "runtime");
-  const controlRoot = resolve(runtimeRoot, "control");
+  const layout = resolveOpenTagHomeLayout(home);
+  const controlRoot = layout.runtimeAgents;
   const key = deriveRuntimeKey("agent", agentId);
-  const agentControl = resolve(controlRoot, "agents", key);
-  const workspaceRoot = resolve(runtimeRoot, "workspaces", key);
+  const agentControl = resolve(controlRoot, key);
+  const workspaceRoot = resolve(layout.workspaces, key);
   return {
     agentControl,
     agentsFile: resolve(workspaceRoot, "AGENTS.md"),

--- a/packages/client/src/storage/durable-file.ts
+++ b/packages/client/src/storage/durable-file.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { chmod, lstat, mkdir, open, realpath, rename, rm } from "node:fs/promises";
-import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 export class RuntimeStorageError extends Error {
   constructor(
@@ -17,7 +17,7 @@ export async function ensurePrivateDirectory(root: string, target: string): Prom
   const rootPath = resolve(root);
   const targetPath = resolve(target);
   assertWithin(rootPath, targetPath);
-  await ensureOneDirectory(rootPath);
+  await ensureRootDirectory(rootPath);
   const suffix = relative(rootPath, targetPath);
   let current = rootPath;
   if (suffix) {
@@ -30,6 +30,27 @@ export async function ensurePrivateDirectory(root: string, target: string): Prom
   const canonicalTarget = await realpath(targetPath);
   assertWithin(canonicalRoot, canonicalTarget);
   return canonicalTarget;
+}
+
+export async function validatePrivateDirectory(root: string, target: string): Promise<boolean> {
+  const rootPath = resolve(root);
+  const targetPath = resolve(target);
+  assertWithin(rootPath, targetPath);
+  const suffix = relative(rootPath, targetPath);
+  let current = rootPath;
+  for (const segment of suffix ? ["", ...suffix.split(sep)] : [""]) {
+    if (segment) current = resolve(current, segment);
+    try {
+      await assertRealDirectory(current);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw error;
+    }
+  }
+  const canonicalRoot = await realpath(rootPath);
+  const canonicalTarget = await realpath(targetPath);
+  assertWithin(canonicalRoot, canonicalTarget);
+  return true;
 }
 
 export async function readSecureFile(path: string): Promise<string | undefined> {
@@ -111,6 +132,29 @@ async function ensureOneDirectory(path: string): Promise<void> {
   }
   await assertRealDirectory(path);
   await chmod(path, 0o700);
+}
+
+async function ensureRootDirectory(root: string): Promise<void> {
+  const missingSegments: string[] = [];
+  let existing = root;
+  for (;;) {
+    try {
+      await assertRealDirectory(existing);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = dirname(existing);
+      if (parent === existing) throw error;
+      missingSegments.unshift(basename(existing));
+      existing = parent;
+    }
+  }
+  let current = existing;
+  for (const segment of missingSegments) {
+    current = resolve(current, segment);
+    await ensureOneDirectory(current);
+  }
+  await ensureOneDirectory(root);
 }
 
 async function assertReplaceableFile(path: string): Promise<void> {

--- a/packages/client/src/storage/home-layout.ts
+++ b/packages/client/src/storage/home-layout.ts
@@ -1,0 +1,36 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export interface OpenTagHomeLayout {
+  config: string;
+  daemonState: string;
+  data: string;
+  home: string;
+  logs: string;
+  runtimeAgents: string;
+  serviceState: string;
+  state: string;
+  workspaces: string;
+}
+
+export function resolveOpenTagHome(environment: NodeJS.ProcessEnv = process.env): string {
+  return environment.OPENTAG_HOME ? resolve(environment.OPENTAG_HOME) : join(homedir(), ".opentag");
+}
+
+export function resolveOpenTagHomeLayout(home = resolveOpenTagHome()): OpenTagHomeLayout {
+  const resolvedHome = resolve(home);
+  const config = join(resolvedHome, "config");
+  const data = join(resolvedHome, "data");
+  const state = join(resolvedHome, "state");
+  return {
+    config,
+    daemonState: join(state, "daemon"),
+    data,
+    home: resolvedHome,
+    logs: join(resolvedHome, "logs"),
+    runtimeAgents: join(data, "runtime", "agents"),
+    serviceState: join(state, "service"),
+    state,
+    workspaces: join(data, "workspaces"),
+  };
+}

--- a/packages/client/src/storage/private-json-file.ts
+++ b/packages/client/src/storage/private-json-file.ts
@@ -1,73 +1,29 @@
-import { randomUUID } from "node:crypto";
-import { chmod, lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
-import { dirname, join } from "node:path";
-
-async function ensurePrivateHome(home: string): Promise<void> {
-  await mkdir(home, { mode: 0o700, recursive: true });
-  const status = await lstat(home);
-  if (!status.isDirectory() || status.isSymbolicLink()) {
-    throw new Error("The OpenTag home must be a real directory");
-  }
-  await chmod(home, 0o700);
-}
+import { dirname, isAbsolute, resolve } from "node:path";
+import {
+  assertWithin,
+  ensurePrivateDirectory,
+  readSecureFile,
+  validatePrivateDirectory,
+  writeDurableJson,
+} from "./durable-file.js";
 
 export async function readPrivateJson<T>(
   home: string,
-  fileName: string,
+  filePath: string,
   validate: (value: unknown) => T,
 ): Promise<T | undefined> {
-  const path = join(home, fileName);
-  try {
-    const homeStatus = await lstat(home);
-    if (!homeStatus.isDirectory() || homeStatus.isSymbolicLink()) {
-      throw new Error("The OpenTag home must be a real directory");
-    }
-    const fileStatus = await lstat(path);
-    if (!fileStatus.isFile() || fileStatus.isSymbolicLink()) {
-      throw new Error(`The OpenTag ${fileName} file must be a regular file`);
-    }
-    return validate(JSON.parse(await readFile(path, "utf8")));
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
-  }
+  const root = resolve(home);
+  const path = isAbsolute(filePath) ? resolve(filePath) : resolve(root, filePath);
+  assertWithin(root, path);
+  if (!(await validatePrivateDirectory(root, dirname(path)))) return undefined;
+  const content = await readSecureFile(path);
+  return content === undefined ? undefined : validate(JSON.parse(content));
 }
 
-export async function writePrivateJson(home: string, fileName: string, value: unknown): Promise<void> {
-  await ensurePrivateHome(home);
-  const destination = join(home, fileName);
-  try {
-    const status = await lstat(destination);
-    if (status.isSymbolicLink() || !status.isFile()) {
-      throw new Error(`The OpenTag ${fileName} file must be a regular file`);
-    }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  const temporary = join(dirname(destination), `.${fileName}.${process.pid}.${randomUUID()}.tmp`);
-  let handle: Awaited<ReturnType<typeof open>> | undefined;
-  try {
-    handle = await open(temporary, "wx", 0o600);
-    await handle.writeFile(`${JSON.stringify(value, undefined, 2)}\n`, "utf8");
-    await handle.sync();
-    await handle.close();
-    handle = undefined;
-    await rename(temporary, destination);
-    await chmod(destination, 0o600);
-    const directory = await open(home, "r");
-    try {
-      await directory.sync();
-    } finally {
-      await directory.close();
-    }
-  } catch (error) {
-    await handle?.close();
-    await rm(temporary, { force: true });
-    throw error;
-  }
+export async function writePrivateJson(home: string, filePath: string, value: unknown): Promise<void> {
+  const root = resolve(home);
+  const destination = isAbsolute(filePath) ? resolve(filePath) : resolve(root, filePath);
+  assertWithin(root, destination);
+  await ensurePrivateDirectory(root, dirname(destination));
+  await writeDurableJson(destination, value);
 }


### PR DESCRIPTION
## Summary

- add one Client Home layout resolver for lifecycle-separated `config/`, `data/`, `state/`, and `logs/` roots
- move credentials, Computer identity, runtime recovery, Workspaces, daemon ownership, service leases, and the launchd wrapper to their new owner-specific paths
- preserve nested-path containment, symlink rejection, private permissions, atomic replacement, and process-lease fail-closed behavior
- keep the channel service-target lease in the user's default Home for that channel while retaining an independent per-Home operation lease
- update the fresh-login CI smoke and synchronized English/Chinese contributor documentation

## Testing

- targeted Client tests: 4 files, 26 tests passed
- targeted CLI tests: 6 files, 76 tests passed
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`
- production path scan for legacy Home reader/writer literals

## Breaking changes

This is an intentional clean break for local OpenTag Home data. The new version does not read, migrate, copy, delete, or fall back to root-level `credentials.json`, `computer.json`, `daemon-owner.json`, `runtime/`, `service/`, or `~/.opentag-service-targets`.

Use a fresh Home, or move the old Home aside and run `login` again. `login --no-start` creates only `config/credentials.json`; daemon and runtime-owned directories remain on-demand. Existing legacy files are left untouched and unused.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
