### PR TITLE
refactor!: clarify OpenTag Home recovery data layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,10 @@ jobs:
           OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs \
             login "$connect_code" --server http://127.0.0.1:18000 --no-start
           test -f "$runtime_home/config/credentials.json"
+          test ! -e "$runtime_home/config/computer.json"
+          test ! -e "$runtime_home/data/computer.json"
           test ! -e "$runtime_home/credentials.json"
+          test ! -e "$runtime_home/computer.json"
           OPENTAG_HOME="$runtime_home" OPENTAG_SERVICE_MODE=1 node apps/cli/dist/cli/index.mjs daemon service-run \
             >"$daemon_log" 2>&1 &
           daemon_pid=$!
@@ -315,7 +318,8 @@ jobs:
           grep -q "already running" "$runtime_home/second.log"
           OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs computer list | grep -q $'\tonline\t'
           computer_id=$(node -p "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8')).computerId" \
-            "$runtime_home/data/computer.json")
+            "$runtime_home/config/computer.json")
+          test ! -e "$runtime_home/data/computer.json"
           test ! -e "$runtime_home/computer.json"
 
           agent_create=$(OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs agent create \

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,18 +113,23 @@ opentag-dev daemon status
 opentag-dev computer list
 ```
 
-The daemon reuses the stable Computer ID stored at `${OPENTAG_HOME}/data/computer.json`, creates a new process instance
+The daemon reuses the stable Computer ID stored at `${OPENTAG_HOME}/config/computer.json`, creates a new process instance
 on every service start, and connects to `/api/v1/computer/ws`. OpenTag Home is organized by lifecycle:
 
 ```text
 ${OPENTAG_HOME}/
 ├── config/
 │   ├── credentials.json
+│   ├── computer.json
 │   └── daemon.env
 ├── data/
-│   ├── computer.json
-│   ├── runtime/agents/<agent-key>/
+│   ├── runtime/
+│   │   ├── workspace-states/<agent-key>.json
+│   │   ├── session-bindings/<agent-key>/<session-key>.json
+│   │   └── effective-snapshots/<agent-key>/<snapshot-key>.json
 │   └── workspaces/<agent-key>/
+│       ├── AGENTS.md
+│       └── files/
 ├── state/
 │   ├── daemon/owner.json
 │   └── service/
@@ -139,8 +144,28 @@ files (`0600`). Directories and files are created only when their owner needs th
 creates only `config/credentials.json`; runtime recovery records and workspaces appear on the first relevant reconcile.
 
 This layout is a clean break: OpenTag does not read, migrate, delete, or fall back to root-level `credentials.json`,
-`computer.json`, `daemon-owner.json`, `runtime/`, `service/`, or `~/.opentag-service-targets`. Use a fresh Home, or move
-the old Home aside and log in again. Existing legacy files otherwise remain unused on disk.
+`computer.json`, `daemon-owner.json`, `runtime/`, `service/`, `data/computer.json`, `data/runtime/agents`, or
+`~/.opentag-service-targets`. Use a fresh Home, or move the old Home aside and log in again. Existing legacy files
+otherwise remain unused on disk.
+
+### Local data loss and recovery
+
+Re-login restores connectivity, not the prior local execution continuity. The Server can reissue credentials and
+rebuild effective snapshots, managed `AGENTS.md`, and snapshot-derived workspace-state fields. Reissued credentials are
+new values. If `config/computer.json` is lost, the current Client creates a new Computer identity; although the Server
+retains the old Computer and placement records, the Client does not automatically reclaim that identity or repair old
+bindings.
+
+Provider bindings, evidence for Turns not yet reported successfully, Workspace files, and local `daemon.env` values are
+local-only. Losing a Session binding can reset exact Provider resume continuity and can leave accepted-but-unreported
+work requiring explicit repair. Losing workspace state while its Workspace is non-empty fails closed instead of
+silently adopting those files. Workspace files require Git, external storage, or a local backup; the OpenTag Server
+cannot restore them. Effective snapshots are reproducible and are not a primary backup target.
+
+Daemon/service owner and lease state plus logs are locally reproducible only while the daemon is stopped and no service
+mutation is running. Deleting owner or lease evidence while operations are live can break single-daemon and service
+mutual exclusion. Backups should prioritize `config/computer.json`, local `config/daemon.env`,
+`data/runtime/session-bindings`, and `data/runtime/workspace-states` together with `data/workspaces`.
 
 Manage the daemon with `daemon install/start/stop/restart/status/uninstall`. `uninstall` preserves `config/` and `data/`.
 Windows services are not supported in v0.1. Linux logs are available through

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -113,18 +113,23 @@ opentag-dev daemon status
 opentag-dev computer list
 ```
 
-daemon 会复用 `${OPENTAG_HOME}/data/computer.json` 中的稳定 Computer ID，每次服务启动创建新的进程
+daemon 会复用 `${OPENTAG_HOME}/config/computer.json` 中的稳定 Computer ID，每次服务启动创建新的进程
 instance，并连接 `/api/v1/computer/ws`。OpenTag Home 按生命周期组织：
 
 ```text
 ${OPENTAG_HOME}/
 ├── config/
 │   ├── credentials.json
+│   ├── computer.json
 │   └── daemon.env
 ├── data/
-│   ├── computer.json
-│   ├── runtime/agents/<agent-key>/
+│   ├── runtime/
+│   │   ├── workspace-states/<agent-key>.json
+│   │   ├── session-bindings/<agent-key>/<session-key>.json
+│   │   └── effective-snapshots/<agent-key>/<snapshot-key>.json
 │   └── workspaces/<agent-key>/
+│       ├── AGENTS.md
+│       └── files/
 ├── state/
 │   ├── daemon/owner.json
 │   └── service/
@@ -139,8 +144,26 @@ ${OPENTAG_HOME}/
 `config/credentials.json`；runtime recovery record 和 Workspace 在首次相关 reconcile 时才出现。
 
 此布局采用 clean break：OpenTag 不会读取、迁移、删除或回退到根目录的 `credentials.json`、
-`computer.json`、`daemon-owner.json`、`runtime/`、`service/` 或 `~/.opentag-service-targets`。请使用全新
-Home，或先移走旧 Home 再重新登录；否则旧文件会原样保留，但新版不会使用它们。
+`computer.json`、`daemon-owner.json`、`runtime/`、`service/`，也不会读取 `data/computer.json`、
+`data/runtime/agents` 或 `~/.opentag-service-targets`。请使用全新 Home，或先移走旧 Home 再重新登录；
+否则旧文件会原样保留，但新版不会使用它们。
+
+### 本地数据丢失与恢复
+
+重新登录只能恢复连接，不能恢复原有的本地执行连续性。Server 可以重新签发 credentials，并重建 effective
+snapshot、托管 `AGENTS.md` 以及可由 snapshot 推导的 workspace-state 字段；重新签发的 credentials 不是原值。
+如果 `config/computer.json` 丢失，当前 Client 会创建新的 Computer identity。Server 虽保留旧 Computer 与
+placement 记录，但 Client 不会自动认领旧 identity 或修复旧 binding。
+
+Provider binding、尚未成功上报的 Turn 证据、Workspace 文件和本机 `daemon.env` 值仅存在于本地。Session
+binding 丢失会破坏 Provider 精确续接，并可能使已 accepted 但尚未上报的工作需要显式修复。Workspace 非空
+但 workspace state 丢失时，Client 会 fail closed，不会在无提示的情况下认领这些文件。Workspace 文件只能依赖
+Git、外部存储或本机备份，OpenTag Server 无法恢复。Effective snapshot 可重新生成，不属于主要备份目标。
+
+daemon/service owner、lease state 与日志只有在 daemon 已停止且没有 service mutation 时才可视为本机可重新
+生成数据；操作仍在运行时删除 owner 或 lease 证据，会破坏单 daemon 和 service 互斥。备份应重点保护
+`config/computer.json`、本机 `config/daemon.env`、`data/runtime/session-bindings`，以及成对保存的
+`data/runtime/workspace-states` 与 `data/workspaces`。
 
 使用 `daemon install/start/stop/restart/status/uninstall` 管理服务；`uninstall` 会保留 `config/` 与
 `data/`。v0.1 不支持 Windows daemon 服务。Linux 日志通过

--- a/packages/client/src/__tests__/agent-workspace.test.ts
+++ b/packages/client/src/__tests__/agent-workspace.test.ts
@@ -2,7 +2,11 @@ import { randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import type { EffectiveRuntimeSnapshot, SessionReconcileRequest } from "@opentag/shared";
+import {
+  computeRuntimeSnapshotHashes,
+  type EffectiveRuntimeSnapshot,
+  type SessionReconcileRequest,
+} from "@opentag/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { AgentWorkspaceManager } from "../runtime/agent-workspace.js";
 import { agentRuntimePaths, deriveRuntimeKey } from "../runtime/runtime-paths.js";
@@ -88,6 +92,18 @@ describe("AgentWorkspaceManager", () => {
     await expect(readdir(fixture.workspace.paths("agent-1").sessions)).resolves.toHaveLength(10);
   });
 
+  it("keeps workspace-state ownership separate from Session binding and snapshot directories", async () => {
+    const fixture = await workspaceFixture();
+    const runtime = snapshot("agent-1", "workspace-1", "session");
+    const paths = fixture.workspace.paths("agent-1");
+
+    await fixture.workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime));
+
+    await expect(stat(paths.workspaceState)).resolves.toBeDefined();
+    await expect(stat(paths.sessions)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(paths.snapshots)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("C-11 atomically upgrades Agent instructions without deleting live files", async () => {
     const fixture = await workspaceFixture();
     const initialRuntime = snapshot("agent-1", "workspace-1", "session");
@@ -122,6 +138,59 @@ describe("AgentWorkspaceManager", () => {
     const request = reconcileRequest(computerId, "session-1", snapshot("agent-1", "workspace-1", "s"));
 
     await expect(reconciler.reconcile(request)).rejects.toThrow(/real director|workspace/i);
+  });
+
+  it.each(["symlink", "file"] as const)("fails closed on a %s workspace-states root", async (kind) => {
+    const home = await temporaryHome();
+    const external = await temporaryHome();
+    const runtimeRoot = resolve(home, "data", "runtime");
+    const workspaceStatesRoot = resolve(runtimeRoot, "workspace-states");
+    await mkdir(runtimeRoot, { recursive: true, mode: 0o700 });
+    if (kind === "symlink") await symlink(external, workspaceStatesRoot, "dir");
+    else await writeFile(workspaceStatesRoot, "not-a-directory", "utf8");
+    const bindingStore = new SessionBindingStore({ home, providerHomeIdentity: "a".repeat(64) });
+    const workspace = new AgentWorkspaceManager({ home, bindingStore });
+    const runtime = snapshot("agent-1", "workspace-1", "session");
+
+    await expect(workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime))).rejects.toThrow(
+      /real director|directories/i,
+    );
+    expect(await readdir(external)).toEqual([]);
+  });
+
+  it("ignores the legacy runtime/agents workspace state without migrating or deleting it", async () => {
+    const home = await temporaryHome();
+    const legacyPath = resolve(
+      home,
+      "data",
+      "runtime",
+      "agents",
+      deriveRuntimeKey("agent", "agent-1"),
+      "workspace.json",
+    );
+    await mkdir(resolve(legacyPath, ".."), { recursive: true, mode: 0o700 });
+    await writeFile(legacyPath, '{"legacy":true}\n', { mode: 0o600 });
+    const bindingStore = new SessionBindingStore({ home, providerHomeIdentity: "a".repeat(64) });
+    const workspace = new AgentWorkspaceManager({ home, bindingStore });
+    const runtime = snapshot("agent-1", "workspace-1", "session");
+
+    await expect(workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime))).resolves.toBeUndefined();
+    expect(await readFile(legacyPath, "utf8")).toBe('{"legacy":true}\n');
+    expect(JSON.parse(await readFile(workspace.paths("agent-1").workspaceState, "utf8"))).toMatchObject({
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+    });
+  });
+
+  it("fails closed when workspace state is lost while the managed Workspace remains non-empty", async () => {
+    const fixture = await workspaceFixture();
+    const runtime = snapshot("agent-1", "workspace-1", "session");
+    const hashes = computeRuntimeSnapshotHashes(runtime);
+    await fixture.workspace.prepareAgent(runtime, hashes);
+    const paths = fixture.workspace.paths("agent-1");
+    await rm(paths.workspaceState);
+
+    await expect(fixture.workspace.prepareAgent(runtime, hashes)).rejects.toThrow(/non-empty.*no valid runtime state/i);
   });
 });
 

--- a/packages/client/src/__tests__/auth.test.ts
+++ b/packages/client/src/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -158,24 +158,57 @@ describe("Computer identity", () => {
     const home = await temporaryHome();
     const first = await resolveComputerIdentity(home, "https://opentag.example", crypto.randomUUID());
     expect(await resolveComputerIdentity(home, first.serverUrl, first.userId)).toEqual(first);
+    expect(computerIdentityPath(home)).toBe(join(home, "config", "computer.json"));
     expect((await stat(computerIdentityPath(home))).mode & 0o777).toBe(0o600);
     await expect(resolveComputerIdentity(home, "https://other.example", first.userId)).rejects.toThrow(
       "bound to another server or user",
     );
   });
 
-  it("does not read a legacy root Computer identity", async () => {
+  it("does not read, migrate, or delete legacy Computer identities", async () => {
     const home = await temporaryHome();
-    const legacy = {
+    const rootLegacy = {
       version: 1,
       computerId: crypto.randomUUID(),
-      serverUrl: "https://legacy.example",
+      serverUrl: "https://root-legacy.example",
       userId: crypto.randomUUID(),
     };
-    await writeFile(join(home, "computer.json"), `${JSON.stringify(legacy)}\n`, { mode: 0o600 });
+    const dataLegacy = {
+      version: 1,
+      computerId: crypto.randomUUID(),
+      serverUrl: "https://data-legacy.example",
+      userId: crypto.randomUUID(),
+    };
+    const rootLegacyPath = join(home, "computer.json");
+    const dataLegacyPath = join(home, "data", "computer.json");
+    await mkdir(join(home, "data"), { mode: 0o700 });
+    await writeFile(rootLegacyPath, `${JSON.stringify(rootLegacy)}\n`, { mode: 0o600 });
+    await writeFile(dataLegacyPath, `${JSON.stringify(dataLegacy)}\n`, { mode: 0o600 });
 
     const current = await resolveComputerIdentity(home, "https://opentag.example", crypto.randomUUID());
-    expect(current.computerId).not.toBe(legacy.computerId);
-    expect(computerIdentityPath(home)).toBe(join(home, "data", "computer.json"));
+    expect(current.computerId).not.toBe(rootLegacy.computerId);
+    expect(current.computerId).not.toBe(dataLegacy.computerId);
+    expect(await readFile(rootLegacyPath, "utf8")).toBe(`${JSON.stringify(rootLegacy)}\n`);
+    expect(await readFile(dataLegacyPath, "utf8")).toBe(`${JSON.stringify(dataLegacy)}\n`);
+  });
+
+  it("rejects a symlinked nested config directory", async () => {
+    const home = await temporaryHome();
+    const external = await temporaryHome();
+    await symlink(external, join(home, "config"), "dir");
+
+    await expect(resolveComputerIdentity(home, "https://opentag.example", crypto.randomUUID())).rejects.toThrow(
+      /real director/i,
+    );
+    expect(await readdir(external)).toEqual([]);
+  });
+
+  it("rejects a non-directory nested config path", async () => {
+    const home = await temporaryHome();
+    await writeFile(join(home, "config"), "not-a-directory", "utf8");
+
+    await expect(resolveComputerIdentity(home, "https://opentag.example", crypto.randomUUID())).rejects.toThrow(
+      /real director/i,
+    );
   });
 });

--- a/packages/client/src/__tests__/home-layout.test.ts
+++ b/packages/client/src/__tests__/home-layout.test.ts
@@ -24,7 +24,10 @@ describe("OpenTag Home layout", () => {
       data: join(root, "data"),
       home: root,
       logs: join(root, "logs"),
-      runtimeAgents: join(root, "data", "runtime", "agents"),
+      runtime: join(root, "data", "runtime"),
+      runtimeEffectiveSnapshots: join(root, "data", "runtime", "effective-snapshots"),
+      runtimeSessionBindings: join(root, "data", "runtime", "session-bindings"),
+      runtimeWorkspaceStates: join(root, "data", "runtime", "workspace-states"),
       serviceState: join(root, "state", "service"),
       state: join(root, "state"),
       workspaces: join(root, "data", "workspaces"),
@@ -36,13 +39,24 @@ describe("OpenTag Home layout", () => {
     directories.push(home);
     const paths = agentRuntimePaths(home, "agent-1");
 
-    expect(paths.controlRoot).toBe(join(home, "data", "runtime", "agents"));
-    expect(paths.agentControl).toMatch(new RegExp(`^${escapeRegExp(paths.controlRoot)}/a-[a-f0-9]{40}$`, "u"));
+    expect(paths.runtimeRoot).toBe(join(home, "data", "runtime"));
+    expect(paths.workspaceStatesRoot).toBe(join(home, "data", "runtime", "workspace-states"));
+    expect(paths.sessionBindingsRoot).toBe(join(home, "data", "runtime", "session-bindings"));
+    expect(paths.effectiveSnapshotsRoot).toBe(join(home, "data", "runtime", "effective-snapshots"));
+    expect(paths.workspaceState).toMatch(
+      new RegExp(`^${escapeRegExp(paths.workspaceStatesRoot)}/a-[a-f0-9]{40}\\.json$`, "u"),
+    );
+    expect(paths.sessions).toMatch(new RegExp(`^${escapeRegExp(paths.sessionBindingsRoot)}/a-[a-f0-9]{40}$`, "u"));
+    expect(paths.snapshots).toMatch(new RegExp(`^${escapeRegExp(paths.effectiveSnapshotsRoot)}/a-[a-f0-9]{40}$`, "u"));
     expect(paths.workspaceRoot).toMatch(
       new RegExp(`^${escapeRegExp(join(home, "data", "workspaces"))}/a-[a-f0-9]{40}$`, "u"),
     );
-    expect(sessionBindingPath(home, "agent-1", "session-1")).toContain("/data/runtime/agents/");
-    expect(snapshotPath(home, "agent-1", "snapshot-1")).toContain("/data/runtime/agents/");
+    expect(sessionBindingPath(home, "agent-1", "session-1")).toMatch(
+      /\/data\/runtime\/session-bindings\/a-[a-f0-9]{40}\/s-[a-f0-9]{40}\.json$/u,
+    );
+    expect(snapshotPath(home, "agent-1", "snapshot-1")).toMatch(
+      /\/data\/runtime\/effective-snapshots\/a-[a-f0-9]{40}\/s-[a-f0-9]{40}\.json$/u,
+    );
   });
 });
 

--- a/packages/client/src/__tests__/session-binding-store.test.ts
+++ b/packages/client/src/__tests__/session-binding-store.test.ts
@@ -1,9 +1,10 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import {
   computeDirectInputHash,
+  computeRuntimeSnapshotHashes,
   computeTurnResultHash,
   type DirectImMessageDeliveryRequest,
   type EffectiveRuntimeSnapshot,
@@ -12,7 +13,7 @@ import {
 } from "@opentag/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { AgentWorkspaceManager } from "../runtime/agent-workspace.js";
-import { sessionBindingPath } from "../runtime/runtime-paths.js";
+import { agentRuntimePaths, deriveRuntimeKey, sessionBindingPath, snapshotPath } from "../runtime/runtime-paths.js";
 import { SessionBindingStore } from "../runtime/session-binding-store.js";
 import { SessionReconciler } from "../runtime/session-reconciler.js";
 
@@ -41,6 +42,38 @@ describe("SessionBindingStore", () => {
     await expect(mismatched.reconcile({ ...fixture.reconcile, requestId: randomUUID() })).rejects.toThrow(
       /identity|binding/i,
     );
+  });
+
+  it("stores each Session in an independent private file and isolates Agents", async () => {
+    const fixture = await bindingFixture();
+    const secondSession = { ...fixture.reconcile, requestId: randomUUID(), sessionId: "session-2" };
+    const secondAgentRuntime = {
+      ...snapshot(),
+      agentId: "agent-2",
+      workspace: { ...snapshot().workspace, workspaceId: "workspace-2" },
+    };
+    const secondAgent = {
+      ...fixture.reconcile,
+      requestId: randomUUID(),
+      sessionId: "session-3",
+      agentId: "agent-2",
+      runtime: secondAgentRuntime,
+    };
+
+    await expect(
+      Promise.all([fixture.reconciler.reconcile(secondSession), fixture.reconciler.reconcile(secondAgent)]),
+    ).resolves.toEqual([expect.objectContaining({ status: "ready" }), expect.objectContaining({ status: "ready" })]);
+
+    const firstPath = sessionBindingPath(fixture.home, "agent-1", "session-1");
+    const secondPath = sessionBindingPath(fixture.home, "agent-1", "session-2");
+    const otherAgentPath = sessionBindingPath(fixture.home, "agent-2", "session-3");
+    expect(new Set([firstPath, secondPath, otherAgentPath]).size).toBe(3);
+    await expect(readdir(agentRuntimePaths(fixture.home, "agent-1").sessions)).resolves.toHaveLength(2);
+    await expect(readdir(agentRuntimePaths(fixture.home, "agent-2").sessions)).resolves.toHaveLength(1);
+    if (process.platform !== "win32") {
+      expect((await stat(firstPath)).mode & 0o777).toBe(0o600);
+      expect((await stat(agentRuntimePaths(fixture.home, "agent-1").sessions)).mode & 0o777).toBe(0o700);
+    }
   });
 
   it("C-18 retains only the most recent 64 recorded input tombstones", async () => {
@@ -85,6 +118,21 @@ describe("SessionBindingStore", () => {
       status: "recovery_required",
       turn: { deliveryId: "delivery-1", turnId: "turn-1" },
     });
+  });
+
+  it("recreates a missing effective snapshot from the next Server reconcile", async () => {
+    const fixture = await bindingFixture();
+    const hashes = computeRuntimeSnapshotHashes(fixture.runtime);
+    const path = snapshotPath(fixture.home, "agent-1", hashes.effectiveSnapshotHash);
+    await rm(path);
+
+    const reopenedStore = new SessionBindingStore({ home: fixture.home, providerHomeIdentity: fixture.homeIdentity });
+    const reopenedWorkspace = new AgentWorkspaceManager({ home: fixture.home, bindingStore: reopenedStore });
+    const reopened = new SessionReconciler({ computerId: fixture.computerId, preparation: reopenedWorkspace });
+    await expect(reopened.reconcile({ ...fixture.reconcile, requestId: randomUUID() })).resolves.toMatchObject({
+      status: "ready",
+    });
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual(fixture.runtime);
   });
 
   it("keeps the immutable full Turn Report durable before and after acknowledgement", async () => {
@@ -147,9 +195,144 @@ describe("SessionBindingStore", () => {
     });
     expect(rewritten).not.toHaveProperty("providerThreadId");
   });
+
+  it("ignores the legacy runtime/agents binding without migrating or deleting it", async () => {
+    const fixture = await unpreparedBindingFixture();
+    const legacyPath = resolve(
+      fixture.home,
+      "data",
+      "runtime",
+      "agents",
+      deriveRuntimeKey("agent", "agent-1"),
+      "sessions",
+      `${deriveRuntimeKey("session", "session-1")}.json`,
+    );
+    await mkdir(resolve(legacyPath, ".."), { recursive: true, mode: 0o700 });
+    await writeFile(legacyPath, '{"legacy":true}\n', { mode: 0o600 });
+
+    await expect(fixture.reconciler.reconcile(fixture.reconcile)).resolves.toMatchObject({ status: "ready" });
+    expect(await readFile(legacyPath, "utf8")).toBe('{"legacy":true}\n');
+    await expect(fixture.store.read("agent-1", "session-1")).resolves.toMatchObject({ schemaVersion: 2 });
+  });
+
+  it.each(["type root", "Agent directory"] as const)(
+    "fails closed when a direct binding read crosses a symlinked %s",
+    async (linkLevel) => {
+      const source = await bindingFixture();
+      const fixture = await unpreparedBindingFixture();
+      const external = await mkdtemp(resolve(tmpdir(), "opentag-binding-read-external-"));
+      homes.push(external);
+      const raw = await readFile(sessionBindingPath(source.home, "agent-1", "session-1"), "utf8");
+      const agentKey = deriveRuntimeKey("agent", "agent-1");
+      const sessionFile = `${deriveRuntimeKey("session", "session-1")}.json`;
+      const paths = agentRuntimePaths(fixture.home, "agent-1");
+      const externalBinding =
+        linkLevel === "type root" ? resolve(external, agentKey, sessionFile) : resolve(external, sessionFile);
+
+      if (linkLevel === "type root") {
+        await mkdir(resolve(fixture.home, "data", "runtime"), { recursive: true, mode: 0o700 });
+        await mkdir(resolve(external, agentKey), { recursive: true, mode: 0o700 });
+        await symlink(external, resolve(fixture.home, "data", "runtime", "session-bindings"), "dir");
+      } else {
+        await mkdir(resolve(paths.sessions, ".."), { recursive: true, mode: 0o700 });
+        await symlink(external, paths.sessions, "dir");
+      }
+      await writeFile(externalBinding, raw, { mode: 0o600 });
+
+      await expect(fixture.store.read("agent-1", "session-1")).rejects.toThrow(/real director|directories/i);
+      expect(await readFile(externalBinding, "utf8")).toBe(raw);
+    },
+  );
+
+  it("does not mutate an external binding through a symlinked type root", async () => {
+    const source = await bindingFixture();
+    const fixture = await unpreparedBindingFixture();
+    const external = await mkdtemp(resolve(tmpdir(), "opentag-binding-mutation-external-"));
+    homes.push(external);
+    const raw = await readFile(sessionBindingPath(source.home, "agent-1", "session-1"), "utf8");
+    const agentKey = deriveRuntimeKey("agent", "agent-1");
+    const sessionFile = `${deriveRuntimeKey("session", "session-1")}.json`;
+    const externalAgent = resolve(external, agentKey);
+    const externalBinding = resolve(externalAgent, sessionFile);
+    const runtimeRoot = resolve(fixture.home, "data", "runtime");
+    await mkdir(runtimeRoot, { recursive: true, mode: 0o700 });
+    await mkdir(externalAgent, { recursive: true, mode: 0o700 });
+    await writeFile(externalBinding, raw, { mode: 0o600 });
+    await symlink(external, resolve(runtimeRoot, "session-bindings"), "dir");
+    const request = delivery(fixture.runtime, 77);
+
+    await expect(
+      fixture.store.recordAccepted(request, computeDirectInputHash(request), "turn-external"),
+    ).rejects.toThrow(/real director|directories/i);
+    expect(await readFile(externalBinding, "utf8")).toBe(raw);
+  });
+
+  it.each(["session-bindings", "effective-snapshots"] as const)(
+    "fails closed on a symlinked %s type root",
+    async (typeRoot) => {
+      const fixture = await unpreparedBindingFixture();
+      const external = await mkdtemp(resolve(tmpdir(), "opentag-binding-external-"));
+      homes.push(external);
+      const runtimeRoot = resolve(fixture.home, "data", "runtime");
+      await mkdir(runtimeRoot, { recursive: true, mode: 0o700 });
+      await symlink(external, resolve(runtimeRoot, typeRoot), "dir");
+
+      await expect(
+        fixture.store.prepare(fixture.reconcile, computeRuntimeSnapshotHashes(fixture.runtime)),
+      ).rejects.toThrow(/real director|directories/i);
+      expect(await readdir(external)).toEqual([]);
+    },
+  );
+
+  it.each(["session-bindings", "effective-snapshots"] as const)(
+    "fails closed on a non-directory %s type root",
+    async (typeRoot) => {
+      const fixture = await unpreparedBindingFixture();
+      const runtimeRoot = resolve(fixture.home, "data", "runtime");
+      await mkdir(runtimeRoot, { recursive: true, mode: 0o700 });
+      await writeFile(resolve(runtimeRoot, typeRoot), "not-a-directory", "utf8");
+
+      await expect(
+        fixture.store.prepare(fixture.reconcile, computeRuntimeSnapshotHashes(fixture.runtime)),
+      ).rejects.toThrow(/real director|directories/i);
+    },
+  );
+
+  it.each(["sessions", "snapshots"] as const)("fails closed on a symlinked Agent %s directory", async (pathKey) => {
+    const fixture = await unpreparedBindingFixture();
+    const external = await mkdtemp(resolve(tmpdir(), "opentag-binding-agent-external-"));
+    homes.push(external);
+    const paths = agentRuntimePaths(fixture.home, "agent-1");
+    const target = paths[pathKey];
+    await mkdir(resolve(target, ".."), { recursive: true, mode: 0o700 });
+    await symlink(external, target, "dir");
+
+    await expect(
+      fixture.store.prepare(fixture.reconcile, computeRuntimeSnapshotHashes(fixture.runtime)),
+    ).rejects.toThrow(/real director|directories/i);
+    expect(await readdir(external)).toEqual([]);
+  });
+
+  it.each(["sessions", "snapshots"] as const)("fails closed on a non-directory Agent %s path", async (pathKey) => {
+    const fixture = await unpreparedBindingFixture();
+    const paths = agentRuntimePaths(fixture.home, "agent-1");
+    const target = paths[pathKey];
+    await mkdir(resolve(target, ".."), { recursive: true, mode: 0o700 });
+    await writeFile(target, "not-a-directory", "utf8");
+
+    await expect(
+      fixture.store.prepare(fixture.reconcile, computeRuntimeSnapshotHashes(fixture.runtime)),
+    ).rejects.toThrow(/real director|directories/i);
+  });
 });
 
 async function bindingFixture() {
+  const fixture = await unpreparedBindingFixture();
+  await fixture.reconciler.reconcile(fixture.reconcile);
+  return fixture;
+}
+
+async function unpreparedBindingFixture() {
   const home = await mkdtemp(resolve(tmpdir(), "opentag-binding-test-"));
   homes.push(home);
   const computerId = randomUUID();
@@ -168,7 +351,6 @@ async function bindingFixture() {
     desired: "ready",
     runtime,
   };
-  await reconciler.reconcile(reconcile);
   return { computerId, home, homeIdentity, reconcile, reconciler, runtime, store, workspace };
 }
 

--- a/packages/client/src/runtime/agent-workspace.ts
+++ b/packages/client/src/runtime/agent-workspace.ts
@@ -47,7 +47,7 @@ export class AgentWorkspaceManager implements RuntimePreparation {
 
   async prepareAgent(snapshot: EffectiveRuntimeSnapshot, hashes: RuntimeSnapshotHashes): Promise<void> {
     const paths = agentRuntimePaths(this.#home, snapshot.agentId);
-    await ensurePrivateDirectory(this.#home, paths.agentControl);
+    await ensurePrivateDirectory(this.#home, paths.workspaceStatesRoot);
     const state = await readDurableJson(paths.workspaceState, parseAgentWorkspaceState);
     const workspaceExists = await realDirectoryExists(paths.workspaceRoot);
     if (!state && workspaceExists && (await readdir(paths.workspaceRoot)).length > 0) {
@@ -68,8 +68,6 @@ export class AgentWorkspaceManager implements RuntimePreparation {
     if (!state) await writeDurableJson(paths.workspaceState, next);
     await ensurePrivateDirectory(this.#home, paths.workspaceRoot);
     await ensurePrivateDirectory(this.#home, paths.files);
-    await ensurePrivateDirectory(this.#home, paths.sessions);
-    await ensurePrivateDirectory(this.#home, paths.snapshots);
 
     if (state) {
       validateWorkspaceIdentity(state, snapshot);

--- a/packages/client/src/runtime/computer-identity.ts
+++ b/packages/client/src/runtime/computer-identity.ts
@@ -13,7 +13,7 @@ export interface ComputerIdentity {
 export const COMPUTER_IDENTITY_FILE_NAME = "computer.json";
 
 export function computerIdentityPath(home: string): string {
-  return join(resolveOpenTagHomeLayout(home).data, COMPUTER_IDENTITY_FILE_NAME);
+  return join(resolveOpenTagHomeLayout(home).config, COMPUTER_IDENTITY_FILE_NAME);
 }
 
 export function readComputerIdentity(home: string): Promise<ComputerIdentity | undefined> {

--- a/packages/client/src/runtime/runtime-paths.ts
+++ b/packages/client/src/runtime/runtime-paths.ts
@@ -8,31 +8,33 @@ export function deriveRuntimeKey(kind: "agent" | "session" | "snapshot", id: str
 }
 
 export interface AgentRuntimePaths {
-  agentControl: string;
   agentsFile: string;
-  controlRoot: string;
+  effectiveSnapshotsRoot: string;
   files: string;
+  runtimeRoot: string;
+  sessionBindingsRoot: string;
   sessions: string;
   snapshots: string;
   workspaceRoot: string;
   workspaceState: string;
+  workspaceStatesRoot: string;
 }
 
 export function agentRuntimePaths(home: string, agentId: string): AgentRuntimePaths {
   const layout = resolveOpenTagHomeLayout(home);
-  const controlRoot = layout.runtimeAgents;
   const key = deriveRuntimeKey("agent", agentId);
-  const agentControl = resolve(controlRoot, key);
   const workspaceRoot = resolve(layout.workspaces, key);
   return {
-    agentControl,
     agentsFile: resolve(workspaceRoot, "AGENTS.md"),
-    controlRoot,
+    effectiveSnapshotsRoot: layout.runtimeEffectiveSnapshots,
     files: resolve(workspaceRoot, "files"),
-    sessions: resolve(agentControl, "sessions"),
-    snapshots: resolve(agentControl, "snapshots"),
+    runtimeRoot: layout.runtime,
+    sessionBindingsRoot: layout.runtimeSessionBindings,
+    sessions: resolve(layout.runtimeSessionBindings, key),
+    snapshots: resolve(layout.runtimeEffectiveSnapshots, key),
     workspaceRoot,
-    workspaceState: resolve(agentControl, "workspace.json"),
+    workspaceState: resolve(layout.runtimeWorkspaceStates, `${key}.json`),
+    workspaceStatesRoot: layout.runtimeWorkspaceStates,
   };
 }
 

--- a/packages/client/src/runtime/session-binding-store.ts
+++ b/packages/client/src/runtime/session-binding-store.ts
@@ -1,3 +1,4 @@
+import { dirname } from "node:path";
 import {
   computeRuntimeSnapshotHashes,
   type DirectImMessageDeliveryRequest,
@@ -15,6 +16,7 @@ import {
   ensurePrivateDirectory,
   RuntimeStorageError,
   readDurableJson,
+  validatePrivateDirectory,
   writeDurableJson,
 } from "../storage/durable-file.js";
 import { agentRuntimePaths, sessionBindingPath, snapshotPath } from "./runtime-paths.js";
@@ -103,7 +105,7 @@ export class SessionBindingStore {
   }
 
   read(agentId: string, sessionId: string): Promise<LocalSessionBinding | undefined> {
-    return readDurableJson(sessionBindingPath(this.#home, agentId, sessionId), parseLocalSessionBinding);
+    return this.#readBinding(sessionBindingPath(this.#home, agentId, sessionId));
   }
 
   prepare(request: SessionReconcileRequest, hashes: RuntimeSnapshotHashes): Promise<SessionPreparationResult> {
@@ -114,7 +116,7 @@ export class SessionBindingStore {
       await ensurePrivateDirectory(this.#home, paths.sessions);
       await ensurePrivateDirectory(this.#home, paths.snapshots);
       const bindingPath = sessionBindingPath(this.#home, request.agentId, request.sessionId);
-      const current = await readDurableJson(bindingPath, parseLocalSessionBinding);
+      const current = await this.#readBinding(bindingPath);
       if (current) this.#validateIdentity(current, request);
       if (current?.unresolvedTurn) {
         if (
@@ -173,7 +175,7 @@ export class SessionBindingStore {
         lastEffectiveSnapshotHash: hashes.effectiveSnapshotHash,
         recentRecordedInputs: current?.recentRecordedInputs ?? [],
       };
-      await writeDurableJson(bindingPath, binding);
+      await this.#writeBinding(bindingPath, binding);
       return { binding };
     });
   }
@@ -209,7 +211,7 @@ export class SessionBindingStore {
         phase: "accepted",
       };
       const updated = { ...binding, unresolvedTurn };
-      await writeDurableJson(path, updated);
+      await this.#writeBinding(path, updated);
       return { status: "committed", binding: updated, unresolvedTurn };
     });
   }
@@ -256,7 +258,7 @@ export class SessionBindingStore {
           ...(fields.resultHash ? { resultHash: fields.resultHash } : {}),
         },
       };
-      await writeDurableJson(path, updated);
+      await this.#writeBinding(path, updated);
       return updated;
     });
   }
@@ -279,7 +281,7 @@ export class SessionBindingStore {
         throw new SessionBindingConflictError("conflict", "The Agent Runtime binding does not match the Session");
       }
       const updated = { ...binding, runtimeBinding };
-      await writeDurableJson(path, updated);
+      await this.#writeBinding(path, updated);
       return updated;
     });
   }
@@ -315,7 +317,7 @@ export class SessionBindingStore {
       ].slice(-this.#recordedInputLimit);
       const updated = { ...binding, recentRecordedInputs };
       delete updated.unresolvedTurn;
-      await writeDurableJson(path, updated);
+      await this.#writeBinding(path, updated);
       return updated;
     });
   }
@@ -324,6 +326,18 @@ export class SessionBindingStore {
     const binding = await this.read(agentId, sessionId);
     if (!binding) throw new SessionBindingConflictError("conflict", "The Session binding does not exist");
     return binding;
+  }
+
+  async #readBinding(path: string): Promise<LocalSessionBinding | undefined> {
+    if (!(await validatePrivateDirectory(this.#home, dirname(path)))) return undefined;
+    return readDurableJson(path, parseLocalSessionBinding);
+  }
+
+  async #writeBinding(path: string, binding: LocalSessionBinding): Promise<void> {
+    if (!(await validatePrivateDirectory(this.#home, dirname(path)))) {
+      throw new RuntimeStorageError("unsafe", "The Session binding directory does not exist");
+    }
+    await writeDurableJson(path, binding);
   }
 
   #validateIdentity(binding: LocalSessionBinding, request: SessionReconcileRequest): void {

--- a/packages/client/src/storage/home-layout.ts
+++ b/packages/client/src/storage/home-layout.ts
@@ -7,7 +7,10 @@ export interface OpenTagHomeLayout {
   data: string;
   home: string;
   logs: string;
-  runtimeAgents: string;
+  runtime: string;
+  runtimeEffectiveSnapshots: string;
+  runtimeSessionBindings: string;
+  runtimeWorkspaceStates: string;
   serviceState: string;
   state: string;
   workspaces: string;
@@ -21,6 +24,7 @@ export function resolveOpenTagHomeLayout(home = resolveOpenTagHome()): OpenTagHo
   const resolvedHome = resolve(home);
   const config = join(resolvedHome, "config");
   const data = join(resolvedHome, "data");
+  const runtime = join(data, "runtime");
   const state = join(resolvedHome, "state");
   return {
     config,
@@ -28,7 +32,10 @@ export function resolveOpenTagHomeLayout(home = resolveOpenTagHome()): OpenTagHo
     data,
     home: resolvedHome,
     logs: join(resolvedHome, "logs"),
-    runtimeAgents: join(data, "runtime", "agents"),
+    runtime,
+    runtimeEffectiveSnapshots: join(runtime, "effective-snapshots"),
+    runtimeSessionBindings: join(runtime, "session-bindings"),
+    runtimeWorkspaceStates: join(runtime, "workspace-states"),
     serviceState: join(state, "service"),
     state,
     workspaces: join(data, "workspaces"),


### PR DESCRIPTION
## Summary

- move the stable Computer bootstrap identity from `data/computer.json` to `config/computer.json`
- replace the Agent-first runtime tree with type-first `workspace-states`, `session-bindings`, and `effective-snapshots` partitions while keeping one durable file per Session
- enforce full Home-relative parent containment for every Session binding read and mutation
- extend fresh-login CI coverage, clean-break tests, path-safety tests, and the English/Chinese data-loss and recovery documentation

## Breaking behavior

This is a clean break from the paths introduced in #38. OpenTag does not read, migrate, double-write, delete, or fall back to `data/computer.json` or `data/runtime/agents`. Use a fresh Home or move the old Home aside and log in again.

This PR does not add a recovery protocol or command. It documents which data the Server can rebuild and which local recovery evidence requires backup or explicit repair.

## Verification

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`
- independent code review completed with no blocking findings
