### PR TITLE
test: add unit coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,23 @@ jobs:
       - name: Test PostgreSQL integration
         run: pnpm --filter @opentag/server test:integration
 
+      - name: Enforce Agent Runtime coverage
+        run: pnpm --filter @opentag/client test:agent-runtime:coverage
+
+      - name: Measure unit coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unit-coverage-reports-${{ github.sha }}
+          path: |
+            packages/client/coverage/**
+            coverage/unit/**
+          if-no-files-found: warn
+          retention-days: 14
+
   node-compatibility:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ pnpm check
 pnpm build
 pnpm typecheck
 pnpm test
+pnpm --filter @opentag/client test:agent-runtime:coverage
+pnpm test:coverage
 ```
 
 Run directly affected tests during development and all commands above before opening a pull request. Unit tests must not

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,10 +24,20 @@ pnpm check
 pnpm build
 pnpm typecheck
 pnpm test
+pnpm --filter @opentag/client test:agent-runtime:coverage
+pnpm test:coverage
 pnpm --filter @opentag/server test:integration
 ```
 
 Use `pnpm lint` for lint-only feedback. Use `pnpm format` to apply Biome formatting.
+
+`pnpm test:coverage` builds the workspaces and measures the offline unit tests for CLI, Web, Shared, Client, and Server.
+It includes production source files that tests do not import, but excludes root `scripts/`, Server PostgreSQL integration
+tests, and Provider end-to-end tests. The unified report is a measurement baseline for finding and prioritizing gaps; it
+does not yet enforce repository-wide or per-workspace coverage thresholds. Add regression thresholds only after the
+measurement is stable across repeated runs. Agent Runtime keeps its separate 100% gate in
+`packages/client/vitest.agent-runtime.config.ts`, enforced by
+`pnpm --filter @opentag/client test:agent-runtime:coverage`.
 
 The required pull request check is the stable `CI` fan-in job. It covers the commands above, source and staging CLI
 tarball installation, a production-container health smoke, and the supported Node.js lines. Full validation and releases

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -25,10 +25,19 @@ pnpm check
 pnpm build
 pnpm typecheck
 pnpm test
+pnpm --filter @opentag/client test:agent-runtime:coverage
+pnpm test:coverage
 pnpm --filter @opentag/server test:integration
 ```
 
 仅检查 lint 可运行 `pnpm lint`；应用 Biome 格式化可运行 `pnpm format`。
+
+`pnpm test:coverage` 会先构建 workspace，再统计 CLI、Web、Shared、Client 和 Server 的离线单测覆盖率。它会纳入
+未被测试 import 的生产源码，但排除根目录 `scripts/`、Server PostgreSQL integration tests 和 Provider E2E。
+统一报告目前用于测量基线、定位缺口和安排优先级，暂不设置全仓或分 workspace 覆盖率阈值。只有在重复运行的
+统计结果稳定后，才应增加回退阈值。Agent Runtime 继续使用 `packages/client/vitest.agent-runtime.config.ts` 中
+独立的 100% 门槛，并由
+`pnpm --filter @opentag/client test:agent-runtime:coverage` 执行。
 
 Pull Request 的必过检查是稳定的 `CI` fan-in job。它会覆盖上述命令、source/staging CLI tarball 安装、生产容器
 健康检查和受支持的 Node.js 版本。完整验证与发布使用 Node.js 24；兼容 job 会在精确下限 Node.js 22.13.0 和

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    name: "web",
+    sequence: { groupOrder: 2 },
     setupFiles: ["./src/__tests__/setup.ts"],
   },
 });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck",
     "test": "node --test --test-concurrency=1 scripts/__tests__/*.test.mjs && turbo run test --concurrency=2",
+    "test:coverage": "pnpm build && vitest run --config vitest.coverage.config.ts --maxWorkers=1",
     "check:node-compat": "pnpm build && pnpm test && node scripts/node-compat-smoke.mjs",
     "notices:write": "node scripts/third-party-notices.mjs --write"
   },

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -570,8 +570,11 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
   });
 
   it("keeps the package boundary free of Claude SDK, CLI, and bundled binary dependencies", async () => {
-    for (const path of [join(process.cwd(), "../..", "package.json"), join(process.cwd(), "package.json")]) {
-      const manifest = JSON.parse(await readFile(path, "utf8")) as Record<string, Record<string, string>>;
+    for (const url of [
+      new URL("../../../../package.json", import.meta.url),
+      new URL("../../package.json", import.meta.url),
+    ]) {
+      const manifest = JSON.parse(await readFile(url, "utf8")) as Record<string, Record<string, string>>;
       const dependencies = {
         ...manifest.dependencies,
         ...manifest.devDependencies,

--- a/vitest.coverage.config.ts
+++ b/vitest.coverage.config.ts
@@ -1,0 +1,55 @@
+import { configDefaults, coverageConfigDefaults, defineConfig, defineProject } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    maxWorkers: 1,
+    projects: [
+      defineProject({
+        test: {
+          name: "cli",
+          root: "apps/cli",
+          sequence: { groupOrder: 1 },
+        },
+      }),
+      "apps/web/vite.config.ts",
+      defineProject({
+        test: {
+          name: "shared",
+          root: "packages/shared",
+          sequence: { groupOrder: 3 },
+        },
+      }),
+      defineProject({
+        test: {
+          name: "client",
+          root: "packages/client",
+          sequence: { groupOrder: 4 },
+        },
+      }),
+      defineProject({
+        test: {
+          exclude: [...configDefaults.exclude, "src/__tests__/integration/**"],
+          name: "server",
+          root: "packages/server",
+          sequence: { groupOrder: 5 },
+        },
+      }),
+    ],
+    coverage: {
+      all: true,
+      enabled: true,
+      exclude: [...coverageConfigDefaults.exclude, "**/src/__tests__/**", "**/src/smoke/**"],
+      include: [
+        "apps/cli/src/**/*.{ts,tsx}",
+        "apps/web/src/**/*.{ts,tsx}",
+        "packages/shared/src/**/*.{ts,tsx}",
+        "packages/client/src/**/*.{ts,tsx}",
+        "packages/server/src/**/*.{ts,tsx}",
+      ],
+      provider: "v8",
+      reporter: ["text", "json-summary", "html"],
+      reportOnFailure: true,
+      reportsDirectory: "coverage/unit",
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- enforce the existing Agent Runtime 100% V8 coverage gate in the primary Node.js 24 `Checks` job
- add one root Vitest projects runner for CLI, Web, Shared, Client, and Server, including unimported production files
- upload Agent Runtime and unified JSON summary/HTML reports, and document the commands and baseline maintenance rules in English and Chinese

## Unit coverage baseline

Percentages and uncovered counts below come from the final local run. This is a measurement baseline, not a new coverage gate: repeated Web and Client runs currently vary slightly, so repository-wide or per-workspace regression thresholds are deferred until the measurement is stable.

| Workspace | Statements | Branches | Functions | Lines |
| --- | ---: | ---: | ---: | ---: |
| CLI | 77.28% (616) | 71.74% (204) | 81.95% (35) | 77.28% (616) |
| Web | 63.51% (390) | 80.64% (42) | 68.81% (29) | 63.51% (390) |
| Shared | 89.95% (155) | 72.52% (25) | 35.13% (24) | 89.95% (155) |
| Client | 93.73% (578) | 92.18% (300) | 95.14% (34) | 93.73% (578) |
| Server | 37.09% (6065) | 72.92% (261) | 51.23% (198) | 37.09% (6065) |

Agent Runtime remains independently gated at 100% statements, branches, functions, and lines.

## Follow-up priorities

1. Web is the highest-value UI target: `router.tsx` is 60.56% statements with 338 uncovered. Cover invitation errors, Agent creation failures, revision conflicts, IM setup polling/failure/disable, Team switching, and loading/error states.
2. Server is 37.09% statements in the unit-only report. Some low service numbers reflect the deliberate PostgreSQL-integration exclusion, but `index.ts` is still 0% with 268 uncovered statements; unit-test migration/verification branches, partial-start cleanup, listen failure, and service ordering.
3. Shared has 35.13% function coverage, led by `http-paths.ts` at 8.33% functions and `browser.ts` at 0%. Add direct schema/path boundary tests, especially UTF-8 byte limits, union/enum failures, resource limits, and provider write-error variants.
4. CLI and Client are stronger overall; target CLI `core/agent/im.ts` (5.26% statements) and Client `runtime-connection.ts` (79.72%) after the higher-risk Web and Server gaps.
5. Stabilize Web/Client V8 remapping results across repeated runs before introducing per-workspace regression thresholds.

## Validation

- `pnpm install --frozen-lockfile --config.engine-strict=true`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (674 passed)
- `pnpm --filter @opentag/server test:integration` (104 passed)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (207 passed; all four metrics 100%)
- `pnpm test:coverage` (636 passed; JSON summary and HTML reports generated)
