### PR TITLE
feat: complete Team invitation flow

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -251,7 +251,8 @@ Open `/` for the shared Team App Shell. Active members use the same navigation w
 Admins receive the management controls. On **Settings → Computers**, **Generate connection command** mints a 15-minute, single-use code and copies the
 server-authored install/login command. The page polls the current user's Computer list until the new daemon handshake
 arrives. The Web never selects the npm package, binary, or Server URL itself. Use the CLI for membership and invitation
-mutations:
+mutations. Team Admins can also create, copy, and rotate the current bearer invitation from **Settings → Members**;
+successful redemption selects the joined Team in the Web:
 
 ```bash
 pnpm --filter open-tag start team member list --team example

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -243,7 +243,8 @@ export OPENTAG_DEV_AUTH_EMAIL=admin@example.com
 打开 `/` 可使用 Team 共享 App Shell。active member 使用同一套导航和 member-safe 只读投影，Team Admin 额外获得管理控件。
 在 **Settings → Computers** 中点击 **Generate connection command** 会签发一个 15 分钟、仅可使用
 一次的 code，并复制由 Server 生成的安装/login 命令。页面会轮询当前用户的 Computer 列表，直到新的 daemon
-握手到达；Web 本身不会选择 npm package、binary 或 Server URL。membership 与邀请变更使用 CLI：
+握手到达；Web 本身不会选择 npm package、binary 或 Server URL。membership 与邀请变更可使用 CLI；Team Admin
+也可在 **Settings → Members** 创建、复制和轮换当前 bearer 邀请，成功兑换后 Web 会选中刚加入的 Team：
 
 ```bash
 pnpm --filter open-tag start team member list --team example

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ This records the Agent identity and Computer binding only; it does not start a C
 Configure `OPENTAG_GOOGLE_CLIENT_ID` and `OPENTAG_GOOGLE_CLIENT_SECRET` to enable Google sign-in, then open
 `http://127.0.0.1:8000/`. Active Team members share the same App Shell and member-safe views; Team Admins additionally
 manage Agents, runtime configuration, IM bindings, and Local Computer setup. The Computers page lists timestamped Team
-Computer observations, and Admins can generate a short-lived install/login command. Membership and invitation changes
-remain explicit CLI operations:
+Computer observations, and Admins can generate a short-lived install/login command. **Settings → Members** lets Team
+Admins create, copy, and rotate the bearer invitation link. Invitees can preview the link before signing in; after
+redemption, the Web selects the joined Team. Membership role and lifecycle changes remain explicit CLI operations:
 
 For loopback development without Google credentials, set `OPENTAG_DEV_AUTH_BYPASS_ENABLED=true` and
 `OPENTAG_DEV_AUTH_EMAIL` to the unique email of an existing bootstrap user. This bypass is rejected outside the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 # OpenTag
 
 > Canonical source: [README.md](./README.md)
-> Last synced with: 2026-08-19
+> Last synced with: 2026-08-20
 
 OpenTag 是一个全新的独立开源产品，用于连接团队即时通信与 AI 编码 Agent。项目目前处于 **pre-alpha**
 阶段：产品工作流仍在开发中，尚不适合生产使用。
@@ -72,7 +72,9 @@ pnpm --filter open-tag start agent list
 配置 `OPENTAG_GOOGLE_CLIENT_ID` 和 `OPENTAG_GOOGLE_CLIENT_SECRET` 后即可启用 Google 登录，然后打开
 `http://127.0.0.1:8000/`。active Team member 使用同一套 App Shell 和 member-safe 视图；Team Admin 额外管理
 Agent、runtime 配置、IM binding 与 Local Computer setup。Computers 页面列出带时间戳的 Team Computer 观测，
-Admin 还可以生成短期有效的安装/login 命令。membership 与邀请变更仍通过显式 CLI 操作完成：
+Admin 还可以生成短期有效的安装/login 命令。Team Admin 可在 **Settings → Members** 创建、复制和轮换 bearer
+邀请链接；受邀者可在登录前预览邀请，兑换后 Web 会选中刚加入的 Team。membership role 与 lifecycle 变更仍通过
+显式 CLI 操作完成：
 
 若 loopback 开发环境没有 Google 凭据，可设置 `OPENTAG_DEV_AUTH_BYPASS_ENABLED=true`，并将
 `OPENTAG_DEV_AUTH_EMAIL` 设为已有 bootstrap 用户的唯一 email。该 bypass 在 `dev` 以外的环境会被拒绝，

--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -98,8 +98,35 @@ describe("BrowserApi", () => {
       );
     });
 
-    await expect(new BrowserApi(fetchImpl).redeemInvitation("A".repeat(32))).resolves.toBeUndefined();
+    await expect(new BrowserApi(fetchImpl).redeemInvitation("A".repeat(32))).resolves.toMatchObject({
+      membership: { teamId },
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(3);
+    setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
+  });
+
+  it("creates and rotates Team invitation links through explicit CSRF-protected mutations", async () => {
+    setDocumentCookie("opentag_csrf=invite-csrf; Path=/");
+    const invitation = {
+      token: "A".repeat(43),
+      inviteUrl: `https://opentag.example.com/invites/${"A".repeat(43)}`,
+      role: "member" as const,
+      expiresAt: "2030-01-01T00:00:00.000Z",
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      expect(init?.method).toBe("POST");
+      expect(new Headers(init?.headers).get("X-OpenTag-CSRF")).toBe("invite-csrf");
+      const path = String(input);
+      expect([`/api/v1/teams/${teamId}/invitation`, `/api/v1/teams/${teamId}/invitation/rotate`]).toContain(path);
+      return new Response(JSON.stringify(invitation), {
+        status: path.endsWith("/rotate") ? 200 : 201,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const api = new BrowserApi(fetchImpl);
+    await expect(api.createInvitation(teamId)).resolves.toEqual(invitation);
+    await expect(api.rotateInvitation(teamId)).resolves.toEqual(invitation);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
     setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
   });
 

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app.js";
 
 const teamId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
+const invitedTeamId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const computerId = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
+const invitationToken = "A".repeat(43);
 
 const agentSummary = {
   id: agentId,
@@ -26,9 +28,26 @@ function json(value: unknown, status = 200) {
 
 function installApi(
   role: "admin" | "member",
-  options: { bound?: boolean; provider?: "feishu" | "slack"; scopeReauth?: boolean; unauthenticated?: boolean } = {},
+  options: {
+    alreadyJoinedInvitation?: boolean;
+    bound?: boolean;
+    invitationExists?: boolean;
+    provider?: "feishu" | "slack";
+    redeemFails?: boolean;
+    scopeReauth?: boolean;
+    unauthenticated?: boolean;
+  } = {},
 ) {
   const teamProfile = { name: "example", displayName: "Example" };
+  let invitationExists = options.invitationExists ?? false;
+  let invitationVersion: "A" | "B" = "A";
+  let joinedInvitation = options.alreadyJoinedInvitation ?? false;
+  const invitation = () => ({
+    token: invitationVersion.repeat(43),
+    inviteUrl: `https://opentag.example.com/invites/${invitationVersion.repeat(43)}`,
+    role: "member" as const,
+    expiresAt: "2026-08-27T00:00:00.000Z",
+  });
   vi.mocked(fetch).mockImplementation(async (input, init) => {
     const path = String(input);
     if (path === "/api/v1/auth/providers") {
@@ -38,7 +57,19 @@ function installApi(
       if (options.unauthenticated) return json({ error: { message: "Sign in required" } }, 401);
       return json({
         user: { id: userId, email: "ada@example.com", displayName: "Ada" },
-        memberships: [{ teamId, teamName: teamProfile.name, teamDisplayName: teamProfile.displayName, role }],
+        memberships: [
+          { teamId, teamName: teamProfile.name, teamDisplayName: teamProfile.displayName, role },
+          ...(joinedInvitation
+            ? [
+                {
+                  teamId: invitedTeamId,
+                  teamName: "invited-team",
+                  teamDisplayName: "Invited Team",
+                  role: "member" as const,
+                },
+              ]
+            : []),
+        ],
       });
     }
     if (path === `/api/v1/teams/${teamId}` && init?.method === "PATCH") {
@@ -52,7 +83,41 @@ function installApi(
         updatedAt: "2026-08-20T00:01:00.000Z",
       });
     }
-    if (path === `/api/v1/teams/${teamId}/agents`) return json({ agents: [agentSummary] });
+    if (path === `/api/v1/teams/${teamId}/agents` || path === `/api/v1/teams/${invitedTeamId}/agents`) {
+      return json({
+        agents: [path.includes(invitedTeamId) ? { ...agentSummary, teamId: invitedTeamId } : agentSummary],
+      });
+    }
+    if (path === `/api/v1/teams/${teamId}/members`) {
+      return json({ members: [{ userId, displayName: "Ada", role }] });
+    }
+    if (path === `/api/v1/teams/${teamId}/invitation` && init?.method === undefined) {
+      return invitationExists ? json(invitation()) : new Response(null, { status: 204 });
+    }
+    if (path === `/api/v1/teams/${teamId}/invitation` && init?.method === "POST") {
+      invitationExists = true;
+      return json(invitation(), 201);
+    }
+    if (path === `/api/v1/teams/${teamId}/invitation/rotate` && init?.method === "POST") {
+      invitationVersion = "B";
+      return json(invitation());
+    }
+    if (path === `/api/v1/invitations/${invitationToken}/preview`) {
+      return json({ teamDisplayName: "Invited Team", role: "member", expiresAt: "2026-08-27T00:00:00.000Z" });
+    }
+    if (path === `/api/v1/invitations/${invitationToken}/redeem` && init?.method === "POST") {
+      if (options.unauthenticated) return json({ error: { message: "Sign in required" } }, 401);
+      if (options.redeemFails) return json({ error: { message: "The invitation is invalid or expired" } }, 404);
+      joinedInvitation = true;
+      return json({
+        membership: {
+          teamId: invitedTeamId,
+          teamName: "invited-team",
+          teamDisplayName: "Invited Team",
+          role: "member",
+        },
+      });
+    }
     if (path === `/api/v1/teams/${teamId}/computers`) return json({ computers: [] });
     if (path === "/api/v1/me/computers") return json({ computers: [] });
     if (path === "/api/v1/me/connect-codes" && init?.method === "POST") {
@@ -140,6 +205,7 @@ function installApi(
 describe("OpenTag Web App Shell", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    window.sessionStorage.clear();
     window.history.replaceState({}, "", "/agents");
   });
 
@@ -197,6 +263,75 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Display name").parentElement?.querySelector("dd")?.textContent).toBe("Example");
     expect(screen.queryByRole("button", { name: "Save Team profile" })).toBeNull();
     expect(screen.queryByLabelText("Canonical name")).toBeNull();
+  });
+
+  it("accepts an invitation and selects the newly joined Team", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", `/invites/${invitationToken}`);
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Join Team" }));
+    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(invitedTeamId);
+    expect(window.sessionStorage.getItem("opentag.pendingInvitationToken")).toBeNull();
+    expect((screen.getByRole("combobox", { name: "Team" }) as HTMLSelectElement).value).toBe(invitedTeamId);
+  });
+
+  it("resumes a pending invitation after sign-in without requiring a second click", async () => {
+    installApi("admin");
+    window.sessionStorage.setItem("opentag.pendingInvitationToken", invitationToken);
+    window.history.replaceState({}, "", `/invites/${invitationToken}`);
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(invitedTeamId);
+  });
+
+  it("uses a server-selected Team after OAuth without replaying an invalidated invitation", async () => {
+    installApi("admin", { alreadyJoinedInvitation: true, redeemFails: true });
+    window.sessionStorage.setItem("opentag.pendingInvitationToken", invitationToken);
+    window.history.replaceState({}, "", `/invites/${invitationToken}?joinedTeamId=${invitedTeamId}`);
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(invitedTeamId);
+    expect(vi.mocked(fetch)).not.toHaveBeenCalledWith(
+      `/api/v1/invitations/${invitationToken}/redeem`,
+      expect.anything(),
+    );
+  });
+
+  it("preserves the pending invitation while redirecting an unauthenticated join to sign-in", async () => {
+    installApi("member", { unauthenticated: true });
+    window.history.replaceState({}, "", `/invites/${invitationToken}`);
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Join Team" }));
+    expect(await screen.findByRole("heading", { name: "Sign in" })).toBeTruthy();
+    expect(window.location.search).toBe(`?next=${encodeURIComponent(`/invites/${invitationToken}`)}`);
+    expect(window.sessionStorage.getItem("opentag.pendingInvitationToken")).toBe(invitationToken);
+  });
+
+  it("lets Team admins create, copy, and rotate the invitation link", async () => {
+    installApi("admin");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "clipboard", { configurable: true, value: { writeText } });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Create invitation link" }));
+    const link = (await screen.findByLabelText("Invitation link")) as HTMLInputElement;
+    expect(link.value).toBe(`https://opentag.example.com/invites/${"A".repeat(43)}`);
+    fireEvent.click(screen.getByRole("button", { name: "Copy invitation link" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith((link as HTMLInputElement).value));
+    fireEvent.click(screen.getByRole("button", { name: "Rotate invitation link" }));
+    await waitFor(() => expect(link.value).toBe(`https://opentag.example.com/invites/${"B".repeat(43)}`));
+    expect(confirm).toHaveBeenCalledOnce();
+    confirm.mockRestore();
+  });
+
+  it("keeps invitation-link management hidden from regular members", async () => {
+    installApi("member");
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Invite people" })).toBeNull();
   });
 
   it("does not create an IM setup attempt while rendering Agent detail", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -25,6 +25,7 @@ import {
   ImBindingSummarySchema,
   type InvitationPreview,
   InvitationPreviewSchema,
+  type InvitationRedemptionResponse,
   InvitationRedemptionResponseSchema,
   imBindingDiagnosticsPath,
   imBindingDisablePath,
@@ -48,6 +49,7 @@ import {
   teamByIdPath,
   teamComputersPath,
   teamInvitationPath,
+  teamInvitationRotatePath,
   teamMembersPath,
   type UpdateAgentRequest,
   type UpdateTeamProfileRequest,
@@ -181,12 +183,19 @@ export class BrowserApi {
     });
   }
 
+  rotateInvitation(teamId: string): Promise<TeamInvitation> {
+    return this.request(teamInvitationRotatePath(teamId), TeamInvitationSchema, {
+      method: "POST",
+      headers: this.csrfHeaders(),
+    });
+  }
+
   invitationPreview(token: string): Promise<InvitationPreview> {
     return this.request(invitationPreviewPath(token), InvitationPreviewSchema, undefined, false);
   }
 
-  async redeemInvitation(token: string): Promise<void> {
-    await this.request(invitationRedeemPath(token), InvitationRedemptionResponseSchema, {
+  redeemInvitation(token: string): Promise<InvitationRedemptionResponse> {
+    return this.request(invitationRedeemPath(token), InvitationRedemptionResponseSchema, {
       method: "POST",
       headers: this.csrfHeaders(),
     });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -133,18 +133,58 @@ function LoginPage() {
 
 function InvitePage() {
   const { token = "" } = useParams();
+  const location = useLocation();
   const navigate = useNavigate();
+  const selectedTeamHint = new URLSearchParams(location.search).get("joinedTeamId") ?? undefined;
   const preview = useResource(() => browserApi.invitationPreview(token), token);
   const [error, setError] = useState<string>();
-  async function join() {
-    try {
-      await browserApi.redeemInvitation(token);
-      navigate("/agents");
-    } catch (cause) {
-      if (cause instanceof ApiError && cause.status === 401) {
-        navigate(`/login?next=${encodeURIComponent(`/invites/${token}`)}`);
-      } else setError(cause instanceof Error ? cause.message : "The invitation could not be redeemed");
-    }
+  const [joining, setJoining] = useState(false);
+  const joinInFlight = useRef(false);
+  const completeJoin = useCallback(
+    async (serverSelectedTeamId?: string) => {
+      if (joinInFlight.current) return;
+      joinInFlight.current = true;
+      setJoining(true);
+      try {
+        if (serverSelectedTeamId) {
+          const me = await browserApi.me();
+          if (me.memberships.some((membership) => membership.teamId === serverSelectedTeamId)) {
+            clearPendingInvitation(token);
+            window.localStorage.setItem(SELECTED_TEAM_STORAGE_KEY, serverSelectedTeamId);
+            navigate("/agents", { replace: true });
+            return;
+          }
+        }
+        const redemption = await browserApi.redeemInvitation(token);
+        const me = await browserApi.me();
+        if (!me.memberships.some((membership) => membership.teamId === redemption.membership.teamId)) {
+          throw new Error("The invited Team is not available to the signed-in account");
+        }
+        clearPendingInvitation(token);
+        window.localStorage.setItem(SELECTED_TEAM_STORAGE_KEY, redemption.membership.teamId);
+        navigate("/agents", { replace: true });
+      } catch (cause) {
+        if (cause instanceof ApiError && cause.status === 401) {
+          rememberPendingInvitation(token);
+          navigate(`/login?next=${encodeURIComponent(`/invites/${token}`)}`);
+        } else {
+          if (!serverSelectedTeamId) clearPendingInvitation(token);
+          setError(cause instanceof Error ? cause.message : "The invitation could not be redeemed");
+        }
+      } finally {
+        joinInFlight.current = false;
+        setJoining(false);
+      }
+    },
+    [navigate, token],
+  );
+  useEffect(() => {
+    if (readPendingInvitation() === token) void completeJoin(selectedTeamHint);
+  }, [completeJoin, selectedTeamHint, token]);
+  function join() {
+    setError(undefined);
+    rememberPendingInvitation(token);
+    void completeJoin(selectedTeamHint);
   }
   return (
     <main className="center-card">
@@ -156,8 +196,8 @@ function InvitePage() {
             <p>
               This invitation grants the {value.role} role and expires {formatDate(value.expiresAt)}.
             </p>
-            <button className="button" type="button" onClick={join}>
-              Join Team
+            <button className="button" disabled={joining} type="button" onClick={join}>
+              {joining ? "Joining…" : "Join Team"}
             </button>
           </>
         )}
@@ -169,6 +209,35 @@ function InvitePage() {
       ) : null}
     </main>
   );
+}
+
+const SELECTED_TEAM_STORAGE_KEY = "opentag.selectedTeamId";
+const PENDING_INVITATION_STORAGE_KEY = "opentag.pendingInvitationToken";
+
+function readPendingInvitation(): string | undefined {
+  try {
+    return window.sessionStorage.getItem(PENDING_INVITATION_STORAGE_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rememberPendingInvitation(token: string): void {
+  try {
+    window.sessionStorage.setItem(PENDING_INVITATION_STORAGE_KEY, token);
+  } catch {
+    // The explicit Join action can still continue when browser storage is unavailable.
+  }
+}
+
+function clearPendingInvitation(token: string): void {
+  try {
+    if (window.sessionStorage.getItem(PENDING_INVITATION_STORAGE_KEY) === token) {
+      window.sessionStorage.removeItem(PENDING_INVITATION_STORAGE_KEY);
+    }
+  } catch {
+    // There is no pending browser state to clean up when storage is unavailable.
+  }
 }
 
 function AuthenticatedTeamGate() {
@@ -188,7 +257,7 @@ function AuthenticatedTeamGate() {
         if (!membership) return <UnavailablePage title="No active Team" />;
         const selectTeam = (teamId: string) => {
           if (!me.memberships.some((item: MeMembership) => item.teamId === teamId)) return;
-          window.localStorage.setItem("opentag.selectedTeamId", teamId);
+          window.localStorage.setItem(SELECTED_TEAM_STORAGE_KEY, teamId);
           navigate(location.pathname, { replace: true });
           window.location.reload();
         };
@@ -203,7 +272,7 @@ function AuthenticatedTeamGate() {
 }
 
 function readTeamPreference(): string | undefined {
-  const value = window.localStorage.getItem("opentag.selectedTeamId");
+  const value = window.localStorage.getItem(SELECTED_TEAM_STORAGE_KEY);
   return value && value.length <= 64 ? value : undefined;
 }
 
@@ -748,7 +817,9 @@ function SettingsPage() {
         ))}
       </nav>
       {section === "team" ? <TeamSettings membership={membership} refreshMe={refreshMe} /> : null}
-      {section === "members" ? <MembersSettings teamId={membership.teamId} /> : null}
+      {section === "members" ? (
+        <MembersSettings canManage={membership.role === "admin"} teamId={membership.teamId} />
+      ) : null}
       {section === "computers" ? (
         <ComputersSettings canManage={membership.role === "admin"} teamId={membership.teamId} />
       ) : null}
@@ -810,21 +881,109 @@ function TeamSettings({ membership, refreshMe }: { membership: MeMembership; ref
   );
 }
 
-function MembersSettings({ teamId }: { teamId: string }) {
+function MembersSettings({ canManage, teamId }: { canManage: boolean; teamId: string }) {
   const state = useResource(() => browserApi.members(teamId), teamId);
   return (
-    <AsyncState state={state}>
-      {(value) => (
-        <div className="list">
-          {value.members.map((member: TeamMemberSummary) => (
-            <div className="row" key={member.userId}>
-              <strong>{member.displayName}</strong>
-              <span>{member.role}</span>
+    <>
+      {canManage ? <InvitationSettings teamId={teamId} /> : null}
+      <section className="panel">
+        <h2>Team members</h2>
+        <AsyncState state={state}>
+          {(value) => (
+            <div className="list">
+              {value.members.map((member: TeamMemberSummary) => (
+                <div className="row" key={member.userId}>
+                  <strong>{member.displayName}</strong>
+                  <span>{member.role}</span>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      )}
-    </AsyncState>
+          )}
+        </AsyncState>
+      </section>
+    </>
+  );
+}
+
+function InvitationSettings({ teamId }: { teamId: string }) {
+  const state = useResource(() => browserApi.invitation(teamId), teamId);
+  const [current, setCurrent] = useState<Awaited<ReturnType<typeof browserApi.invitation>>>();
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string>();
+  const [error, setError] = useState<string>();
+
+  async function createInvitation() {
+    await mutateInvitation(() => browserApi.createInvitation(teamId), "Invitation link created.");
+  }
+
+  async function rotateInvitation() {
+    if (!window.confirm("Rotate this invitation link? The current link will stop working immediately.")) return;
+    await mutateInvitation(() => browserApi.rotateInvitation(teamId), "Invitation link rotated.");
+  }
+
+  async function mutateInvitation(action: () => Promise<NonNullable<typeof current>>, successMessage: string) {
+    setBusy(true);
+    setError(undefined);
+    setMessage(undefined);
+    try {
+      setCurrent(await action());
+      setMessage(successMessage);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Unable to update the invitation link");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copyInvitation(inviteUrl: string) {
+    setError(undefined);
+    setMessage(undefined);
+    try {
+      if (!window.navigator.clipboard) throw new Error("Clipboard access is unavailable in this browser");
+      await window.navigator.clipboard.writeText(inviteUrl);
+      setMessage("Invitation link copied.");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Unable to copy the invitation link");
+    }
+  }
+
+  return (
+    <section className="panel">
+      <h2>Invite people</h2>
+      <p>Anyone with the active link can join this Team as a member until the link expires.</p>
+      <AsyncState state={state}>
+        {(loaded) => {
+          const invitation = current ?? loaded;
+          return invitation ? (
+            <>
+              <label className="invite-link">
+                Invitation link
+                <input aria-label="Invitation link" readOnly type="url" value={invitation.inviteUrl} />
+              </label>
+              <p className="muted">Expires {formatDate(invitation.expiresAt)}.</p>
+              <div className="actions">
+                <button type="button" onClick={() => void copyInvitation(invitation.inviteUrl)}>
+                  Copy invitation link
+                </button>
+                <button className="secondary" disabled={busy} type="button" onClick={() => void rotateInvitation()}>
+                  {busy ? "Rotating…" : "Rotate invitation link"}
+                </button>
+              </div>
+            </>
+          ) : (
+            <button className="button" disabled={busy} type="button" onClick={() => void createInvitation()}>
+              {busy ? "Creating…" : "Create invitation link"}
+            </button>
+          );
+        }}
+      </AsyncState>
+      {message ? <p className="notice success">{message}</p> : null}
+      {error ? (
+        <p className="notice error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </section>
   );
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -229,6 +229,11 @@ dd {
   gap: 0.45rem;
   font-weight: 700;
 }
+.invite-link {
+  display: grid;
+  gap: 0.45rem;
+  font-weight: 700;
+}
 input,
 select {
   max-width: 100%;

--- a/packages/server/src/__tests__/browser-auth.test.ts
+++ b/packages/server/src/__tests__/browser-auth.test.ts
@@ -31,7 +31,7 @@ function authService(): UserAuthService {
   };
 }
 
-function google() {
+function google(result: { next?: string; selectedTeamId?: string } = {}) {
   return {
     start: vi
       .fn()
@@ -39,7 +39,8 @@ function google() {
     callback: vi.fn().mockImplementation(async (_input: unknown, _context: string, options: { onVerified(): void }) => {
       options.onVerified();
       return {
-        next: "/agents",
+        next: result.next ?? "/agents",
+        ...(result.selectedTeamId ? { selectedTeamId: result.selectedTeamId } : {}),
         tokens: {
           accessToken: "access-secret",
           refreshToken: "refresh-secret",
@@ -179,6 +180,21 @@ describe("browser authentication routes", () => {
       "signed-context",
       expect.objectContaining({ audit: expect.any(Object), onVerified: expect.any(Function) }),
     );
+  });
+
+  it("hands the Team selected during invitation sign-in back as a navigation hint", async () => {
+    const selectedTeamId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
+    const token = "A".repeat(43);
+    const googleService = google({ next: `/invites/${token}`, selectedTeamId });
+    const { app } = createBrowserApp({ googleService });
+    const response = await app.inject({
+      method: "GET",
+      url: `${HTTP_PATHS.authGoogleCallback}?code=code&state=state`,
+      headers: { cookie: "opentag_oauth_context=signed-context" },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe(`/invites/${token}?joinedTeamId=${selectedTeamId}`);
   });
 
   it("accepts provider-owned callback fields but passes only supported values to the Google service", async () => {

--- a/packages/server/src/__tests__/google-auth.test.ts
+++ b/packages/server/src/__tests__/google-auth.test.ts
@@ -111,6 +111,34 @@ describe("GoogleBrowserAuthService", () => {
     expect(exchangeCode).toHaveBeenCalledOnce();
   });
 
+  it("returns the Team selected while redeeming an invitation in the callback transaction", async () => {
+    const token = "A".repeat(43);
+    const selectedTeamId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
+    const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
+    const completeInTransaction = vi.fn().mockResolvedValue({ selectedTeamId, userId });
+    const issueTokensForUser = vi.fn().mockResolvedValue({
+      accessToken: "access-secret",
+      refreshToken: "refresh-secret",
+      tokenType: "Bearer",
+      expiresIn: 900,
+    });
+    const service = new GoogleBrowserAuthService({
+      database: { transaction: (callback: (transaction: object) => unknown) => callback({}) } as never,
+      flow: { verify: vi.fn().mockResolvedValue({ next: `/invites/${token}`, oidcNonce: "oidc-nonce" }) } as never,
+      google: { exchangeCode: vi.fn().mockResolvedValue({ provider: "google" }) } as never,
+      identities: { resolveOrCreateInTransaction: vi.fn().mockResolvedValue(userId) } as never,
+      postAuthentication: { completeInTransaction } as never,
+      publicUrl: "https://opentag.example.com",
+      tokenIssuer: { issueTokensForUser } as never,
+    });
+
+    await expect(
+      service.callback({ code: "code", state: "state" }, "signed-context", { onVerified: vi.fn() }),
+    ).resolves.toMatchObject({ next: `/invites/${token}`, selectedTeamId });
+    expect(completeInTransaction).toHaveBeenCalledWith(expect.anything(), userId, token, {});
+    expect(issueTokensForUser).toHaveBeenCalledWith(userId);
+  });
+
   it("preserves invalid or expired flow errors before interpreting the provider result", async () => {
     const flowError = new AuthServiceError(
       "AUTH_OAUTH_FAILED",

--- a/packages/server/src/__tests__/integration/account-team-foundation.test.ts
+++ b/packages/server/src/__tests__/integration/account-team-foundation.test.ts
@@ -11,6 +11,7 @@ import {
   agents,
   authIdentities,
   computers,
+  invitationRedemptions,
   invitations,
   memberships,
   teams,
@@ -284,6 +285,10 @@ describe("account identity and Team foundation persistence", () => {
         .from(memberships)
         .where(and(eq(memberships.userId, userId), eq(memberships.teamId, value.bootstrap.teamId)));
       expect(membership).toMatchObject({ role: "member", status: "active" });
+      await expect(value.invitations.redeem(userId, nextInvite.token, { ip: "127.0.0.2" })).resolves.toMatchObject({
+        membership: { teamId: value.bootstrap.teamId, role: "member" },
+      });
+      expect(await value.database.select().from(invitationRedemptions)).toHaveLength(1);
     } finally {
       await value.sql.end();
     }

--- a/packages/server/src/api/browser-auth.ts
+++ b/packages/server/src/api/browser-auth.ts
@@ -82,6 +82,13 @@ function audit(request: FastifyRequest) {
   return { ip: request.ip.slice(0, 255), ...(userAgent ? { userAgent: userAgent.slice(0, 1024) } : {}) };
 }
 
+function withSelectedTeamHint(next: string, selectedTeamId: string | undefined, publicOrigin: string): string {
+  if (!selectedTeamId) return next;
+  const destination = new URL(next, publicOrigin);
+  destination.searchParams.set("joinedTeamId", selectedTeamId);
+  return `${destination.pathname}${destination.search}${destination.hash}`;
+}
+
 export function registerBrowserAuthRoutes(
   app: FastifyInstance,
   authService: UserAuthService,
@@ -171,7 +178,7 @@ export function registerBrowserAuthRoutes(
       refreshTtlSeconds: options.refreshTokenTtlSeconds,
       secure: options.secureCookies,
     });
-    return reply.redirect(result.next, 302);
+    return reply.redirect(withSelectedTeamHint(result.next, result.selectedTeamId, options.publicOrigin), 302);
   });
 
   app.post(HTTP_PATHS.authBrowserRefresh, async (request, reply) => {

--- a/packages/server/src/services/auth/google-browser-auth.ts
+++ b/packages/server/src/services/auth/google-browser-auth.ts
@@ -15,6 +15,7 @@ export interface GoogleAuthStartResult {
 
 export interface GoogleAuthCallbackResult {
   next: string;
+  selectedTeamId?: string;
   tokens: RefreshTokenResponse;
 }
 
@@ -91,16 +92,21 @@ export class GoogleBrowserAuthService {
       nonce: flow.oidcNonce,
       redirectUri: this.#redirectUri,
     });
-    const userId = await this.#database.transaction(async (transaction) => {
+    const invitationToken = invitationTokenFromNext(flow.next);
+    const completion = await this.#database.transaction(async (transaction) => {
       const resolvedUserId = await this.#identities.resolveOrCreateInTransaction(transaction, identity);
-      await this.#postAuthentication.completeInTransaction(
+      const result = await this.#postAuthentication.completeInTransaction(
         transaction,
         resolvedUserId,
-        invitationTokenFromNext(flow.next),
+        invitationToken,
         options.audit ?? {},
       );
-      return resolvedUserId;
+      return { selectedTeamId: result.selectedTeamId, userId: resolvedUserId };
     });
-    return { next: flow.next, tokens: await this.#tokenIssuer.issueTokensForUser(userId) };
+    return {
+      next: flow.next,
+      ...(invitationToken && completion.selectedTeamId ? { selectedTeamId: completion.selectedTeamId } : {}),
+      tokens: await this.#tokenIssuer.issueTokensForUser(completion.userId),
+    };
   }
 }

--- a/packages/server/src/services/invitations/invitation-service.ts
+++ b/packages/server/src/services/invitations/invitation-service.ts
@@ -130,20 +130,22 @@ export class InvitationService {
     const now = this.#now();
     if (!invitation || invitation.revokedAt || invitation.expiresAt <= now) throw this.#invalid();
 
-    const membership = await this.#membershipService.joinWithInvitationInTransaction(
+    const { membership, transitioned } = await this.#membershipService.joinWithInvitationInTransaction(
       transaction,
       userId,
       invitation.teamId,
       invitation.role,
     );
 
-    await transaction.insert(invitationRedemptions).values({
-      invitationId: invitation.id,
-      userId,
-      redeemedAt: now,
-      ip: audit.ip,
-      userAgent: audit.userAgent,
-    });
+    if (transitioned) {
+      await transaction.insert(invitationRedemptions).values({
+        invitationId: invitation.id,
+        userId,
+        redeemedAt: now,
+        ip: audit.ip,
+        userAgent: audit.userAgent,
+      });
+    }
     const [team] = await transaction.select().from(teams).where(eq(teams.id, invitation.teamId)).limit(1);
     if (!team) throw this.#invalid();
     return {

--- a/packages/server/src/services/teams/team-membership-service.ts
+++ b/packages/server/src/services/teams/team-membership-service.ts
@@ -108,7 +108,7 @@ export class TeamMembershipService {
     userId: string,
     teamId: string,
     role: MembershipRole,
-  ): Promise<typeof memberships.$inferSelect> {
+  ): Promise<{ membership: typeof memberships.$inferSelect; transitioned: boolean }> {
     await this.lockTeamForMutation(transaction, teamId);
     const [user] = await transaction.select().from(users).where(eq(users.id, userId)).limit(1);
     if (!user || user.suspendedAt) {
@@ -128,7 +128,7 @@ export class TeamMembershipService {
         403,
       );
     }
-    if (existing?.status === "active") return existing;
+    if (existing?.status === "active") return { membership: existing, transitioned: false };
     const now = this.#now();
     const [membership] = existing
       ? await transaction
@@ -141,7 +141,7 @@ export class TeamMembershipService {
           .values({ teamId, userId, role, status: "active", createdAt: now, updatedAt: now })
           .returning();
     if (!membership) throw new Error("Invitation redemption did not return a membership");
-    return membership;
+    return { membership, transitioned: true };
   }
 
   async bootstrapAdminInTransaction(transaction: DatabaseTransaction, userId: string, teamId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- add admin-facing invitation link creation, copying, and rotation to Settings → Members
- resume pending invitation joins after sign-in, select the joined Team only after fresh membership verification, and hand off the Team selected during Google OAuth without replaying the bearer token
- make repeated invitation redemption audit-safe by reporting membership lifecycle transitions from the owning service
- document the completed Web invitation workflow in the canonical English docs and Chinese mirrors

## Testing

- `pnpm check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @opentag/server exec vitest run src/__tests__/integration/account-team-foundation.test.ts --maxWorkers=1`
- Browser E2E was intentionally skipped at the requester's direction.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
