### PR TITLE
refactor(client): harden Agent Runtime contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Enforce Agent Runtime coverage
+        run: pnpm --filter @opentag/client test:agent-runtime:coverage
+
       - name: Test PostgreSQL integration
         run: pnpm --filter @opentag/server test:integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,6 @@ jobs:
       - name: Test
         run: pnpm test
 
-      - name: Enforce Agent Runtime coverage
-        run: pnpm --filter @opentag/client test:agent-runtime:coverage
-
       - name: Test PostgreSQL integration
         run: pnpm --filter @opentag/server test:integration
 

--- a/docs/design/agent-runtime-contract.md
+++ b/docs/design/agent-runtime-contract.md
@@ -1,0 +1,98 @@
+# Agent Runtime Contract
+
+Status: normative
+
+Last updated: 2026-08-20
+
+## Purpose
+
+Agent Runtime is the lowest Client execution boundary. It lets the Client own
+admission, durable custody, ordered events, policy, and recovery without
+depending on a Provider SDK or leaking a Provider wire protocol into higher
+modules.
+
+The dependency direction is:
+
+```text
+Client Runtime -> AgentRuntime / AgentRuntimeFactory -> Provider adapter -> local Provider executable
+```
+
+The contract contains no Codex, Claude Code, or Pi types. A Provider adapter
+translates one local executable into the common contract and owns all
+Provider-specific configuration, binding, and protocol validation.
+
+## Runtime Ownership
+
+- A Runtime owns one durable Provider session binding.
+- `prompt` requires an idle Runtime. `followUp` owns a strict FIFO queue.
+- One Run is active at a time. Every mutation carries an expected Run identity.
+- The Base Runtime serializes and awaits event delivery before settling a Run.
+- Provider terminal ingress may be claimed before queued translation finishes;
+  public settlement still waits for the Provider execution to finish.
+- `close` is idempotent, cancels queued work, joins the active Run, closes the
+  Provider process, and emits `runtime_closed` when the event sink is healthy.
+
+## Provider Event Grammar
+
+Each Run has independent identifier namespaces for model turns, messages, and
+tool calls.
+
+- Model-turn events are optional because not every Provider exposes that
+  boundary. If emitted, each `model_turn_started(id)` has exactly one matching
+  `model_turn_completed(id)`.
+- A message is `message_started(id)`, followed by zero or more deltas, followed
+  by exactly one `message_completed(id)`. IDs cannot be reused within a Run.
+- A tool is `tool_started(id, name)`, followed by zero or more updates, followed
+  by exactly one `tool_completed(id, name, status)`. Parallel tools are allowed;
+  the name cannot change during a lifecycle and IDs cannot be reused.
+- Usage, warning, and Provider-extension events may occur anywhere within the
+  active Run and must contain bounded, validated data.
+- A successfully completed Run must close every started lifecycle. Failed and
+  aborted Runs terminate open lifecycles implicitly because a broken or
+  interrupted Provider stream cannot always emit closing frames.
+
+`BaseAgentRuntime` enforces this grammar. Adapters must normalize legal wire
+differences, such as a completion without an observable start, before emitting
+common events. Adapter-local state machines continue to reject crossed session,
+Run, and Provider-protocol identities.
+
+## Data and Cancellation Boundaries
+
+- Contract JSON accepts finite numbers, primitives, dense arrays, and plain or
+  null-prototype data objects with enumerable data properties only.
+- Dates, maps, sets, class instances, accessors, symbols, sparse arrays, custom
+  array properties, cycles, and non-finite numbers are rejected.
+- Runtime snapshots are immutable. Binding equality is structural and does not
+  depend on object insertion order.
+- Every readiness probe receives the caller `AbortSignal`. The factory must
+  propagate it to child processes and must still reject promptly if a custom
+  probe runner ignores the signal.
+- Probe cancellation is not reported as artifact absence.
+
+## Provider and Product Support
+
+Provider implementation and production product support are separate claims:
+
+| Provider | Contract adapter | Local live smoke | Shared/Server/Client production composition |
+| --- | --- | --- | --- |
+| Codex | supported | supported | supported |
+| Claude Code | supported | supported | not registered |
+| Pi | supported | supported | not registered |
+
+Claude Code and Pi remain intentionally outside production composition until
+the Shared snapshot schema, Server assembly, Provider-specific policy mapping,
+artifact identity, and readiness ownership are reviewed as one end-to-end
+security boundary.
+
+## Verification
+
+The required CI coverage command is:
+
+```bash
+pnpm --filter @opentag/client test:agent-runtime:coverage
+```
+
+It enforces 100% statements, branches, functions, and lines over the common
+contract, all Provider adapters and wires, shared process ownership, and the
+production Agent Runtime composition path. Live Provider tests remain explicit
+because they use installed user credentials and make real model requests.

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -241,8 +241,8 @@ is reported as a failure; it is never converted into a skipped success.
 
 ## Latest Local Execution
 
-On 2026-08-20 the contract-hardening Agent Runtime suite passed 250 tests with
-100% statements, branches, functions, and lines. All 369 Client tests passed.
+On 2026-08-20 the contract-hardening Agent Runtime suite passed 251 tests with
+100% statements, branches, functions, and lines. All 370 Client tests passed.
 Repository formatting, notice, build, and type-check gates passed, as did all
 104 Server integration tests.
 

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -11,6 +11,7 @@ Codex, Claude Code, and Pi Provider implementations are safe to use as the
 lowest Client execution layer. It covers these production boundaries:
 
 - `src/agent-runtime/base-agent-runtime.ts`
+- `src/agent-runtime/event-validator.ts`
 - `src/agent-runtime/errors.ts`
 - `src/agent-runtime/types.ts`
 - `src/agent-runtime/validation.ts`
@@ -20,6 +21,7 @@ lowest Client execution layer. It covers these production boundaries:
 - `src/providers/claude-code/process-wire.ts`
 - `src/providers/pi/agent-runtime.ts`
 - `src/providers/pi/rpc-wire.ts`
+- `src/providers/process-owner.ts`
 
 Production Client execution now uses this contract through:
 
@@ -28,9 +30,10 @@ Production Client execution now uses this contract through:
 - `src/runtime/agent-turn-runner.ts`
 - `src/runtime/client-runtime-composition.ts`
 
-The coverage gate requires 100% statements, branches, functions, and lines for
-the contract, Codex translation, hosted-tool host, Session Runtime manager, and
-Claude Code translation, Turn runner, and Session Runtime/hosted-tool integration.
+The required CI coverage gate enforces 100% statements, branches, functions,
+and lines for the contract, all three Provider translations and wire adapters,
+shared process ownership, hosted-tool host, Turn runner, Session Runtime
+manager, and production Client Runtime composition.
 Coverage is a floor, not the acceptance criterion by itself: production
 composition, crash recovery, protocol behavior, and live local Provider sessions
 are tested separately.
@@ -76,6 +79,8 @@ Required cases are:
 - strict FIFO follow-ups and independent typed results;
 - Run ID, input, configuration, binding, and JSON validation limits;
 - ordered, awaited event delivery before Promise settlement;
+- centrally enforced model-turn, message, and parallel-tool event lifecycles;
+- strict JSON shapes and insertion-order-independent binding equality;
 - steer, respond, abort, and interaction Run fences;
 - caller `AbortSignal` handling for active and queued Runs;
 - rejected interrupts before and after an authoritative Provider terminal claim;
@@ -97,6 +102,7 @@ A scripted interactive App Server client verifies:
 - approval, permissions, structured question, and MCP elicitation responses;
 - foreign Thread/Turn events, duplicate requests, malformed data, and process failure;
 - probe outcomes, credential discovery, process environment allow-listing, and cleanup.
+- readiness-probe cancellation, including custom probe runners that ignore signals.
 
 The same suite verifies the experimental hosted-tool protocol: initialization
 advertises experimental API support, `thread/start` receives the exact canonical
@@ -235,10 +241,10 @@ is reported as a failure; it is never converted into a skipped success.
 
 ## Latest Local Execution
 
-On 2026-08-20 the merged Agent Runtime, three-Provider, and production Client
-Runtime suite passed 207 tests with 100% statements, branches, functions, and
-lines. All 304 Client tests passed. Repository formatting, notice, build, and
-type-check gates passed, as did all 96 Server integration tests.
+On 2026-08-20 the contract-hardening Agent Runtime suite passed 250 tests with
+100% statements, branches, functions, and lines. All 369 Client tests passed.
+Repository formatting, notice, build, and type-check gates passed, as did all
+104 Server integration tests.
 
 The Pi live test passed against the user-installed `pi` 0.83.0 executable:
 both create and resumed Runs completed, the materialized opaque binding was

--- a/packages/client/src/__tests__/agent-runtime-event-validator.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-event-validator.test.ts
@@ -115,6 +115,22 @@ describe("AgentRunEventValidator", () => {
     ).toThrow();
   });
 
+  it("rejects an invalid tool completion status without consuming the active lifecycle", () => {
+    const validator = new AgentRunEventValidator();
+    validator.accept({ type: "tool_started", toolCallId: "tool", name: "read" });
+    expect(() =>
+      validator.accept({
+        type: "tool_completed",
+        toolCallId: "tool",
+        name: "read",
+        status: "unknown" as never,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "provider_protocol_error" }));
+    expect(() =>
+      validator.accept({ type: "tool_completed", toolCallId: "tool", name: "read", status: "failed" }),
+    ).not.toThrow();
+  });
+
   it("normalizes non-Error validation failures into protocol errors", () => {
     const event = new Proxy<AgentProviderRunEvent>(
       { type: "message_started", messageId: "message" },

--- a/packages/client/src/__tests__/agent-runtime-event-validator.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-event-validator.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { AgentRunEventValidator } from "../agent-runtime/event-validator.js";
+import { AGENT_RUNTIME_TEXT_MAX_BYTES, type AgentProviderRunEvent } from "../agent-runtime/types.js";
+
+describe("AgentRunEventValidator", () => {
+  it("accepts the complete provider-neutral grammar with optional model turns and parallel tools", () => {
+    const validator = new AgentRunEventValidator();
+    for (const event of [
+      { type: "model_turn_started", modelTurnId: "turn-1" },
+      { type: "message_started", messageId: "message-1" },
+      { type: "message_delta", messageId: "message-1", delta: "" },
+      { type: "message_completed", messageId: "message-1", text: "answer" },
+      { type: "tool_started", toolCallId: "tool-1", name: "read", input: { path: "one" } },
+      { type: "tool_started", toolCallId: "tool-2", name: "write" },
+      { type: "tool_updated", toolCallId: "tool-2", update: { progress: 1 } },
+      { type: "tool_completed", toolCallId: "tool-2", name: "write", status: "completed", output: null },
+      { type: "tool_completed", toolCallId: "tool-1", name: "read", status: "completed" },
+      { type: "usage_updated", usage: { inputTokens: 0, cachedInputTokens: 1, outputTokens: 2 } },
+      { type: "usage_updated", usage: {} },
+      { type: "provider_warning", code: "notice", message: "warning" },
+      { type: "provider_event", providerId: "test", schemaVersion: 1, payload: { value: true } },
+      { type: "model_turn_completed", modelTurnId: "turn-1" },
+    ] satisfies AgentProviderRunEvent[]) {
+      expect(() => validator.accept(event)).not.toThrow();
+    }
+    expect(() => validator.assertSettled({ status: "completed" })).not.toThrow();
+
+    const withoutTurns = new AgentRunEventValidator();
+    withoutTurns.accept({ type: "message_started", messageId: "message" });
+    withoutTurns.accept({ type: "message_completed", messageId: "message", text: "done" });
+    expect(() => withoutTurns.assertSettled({ status: "completed" })).not.toThrow();
+  });
+
+  it.each([
+    [{ type: "model_turn_completed", modelTurnId: "missing" }],
+    [
+      { type: "model_turn_started", modelTurnId: "duplicate" },
+      { type: "model_turn_started", modelTurnId: "duplicate" },
+    ],
+    [{ type: "message_delta", messageId: "missing", delta: "x" }],
+    [{ type: "message_completed", messageId: "missing", text: "x" }],
+    [
+      { type: "message_started", messageId: "duplicate" },
+      { type: "message_completed", messageId: "duplicate", text: "x" },
+      { type: "message_started", messageId: "duplicate" },
+    ],
+    [{ type: "tool_updated", toolCallId: "missing", update: null }],
+    [{ type: "tool_completed", toolCallId: "missing", name: "read", status: "completed" }],
+    [
+      { type: "tool_started", toolCallId: "duplicate", name: "read" },
+      { type: "tool_completed", toolCallId: "duplicate", name: "read", status: "completed" },
+      { type: "tool_started", toolCallId: "duplicate", name: "read" },
+    ],
+    [
+      { type: "tool_started", toolCallId: "renamed", name: "read" },
+      { type: "tool_completed", toolCallId: "renamed", name: "write", status: "completed" },
+    ],
+  ] as AgentProviderRunEvent[][])("rejects invalid lifecycle sequence %#", (...events: AgentProviderRunEvent[]) => {
+    const validator = new AgentRunEventValidator();
+    expect(() => {
+      for (const event of events) validator.accept(event);
+    }).toThrowError(expect.objectContaining({ code: "provider_protocol_error" }));
+  });
+
+  it.each([
+    null,
+    { type: "unknown" },
+    { type: "model_turn_started", modelTurnId: "" },
+    { type: "message_started", messageId: "" },
+    { type: "tool_started", toolCallId: "tool", name: "", input: null },
+    { type: "tool_started", toolCallId: "tool", name: "read", input: new Date() },
+    { type: "usage_updated", usage: null },
+    { type: "usage_updated", usage: { inputTokens: -1 } },
+    { type: "usage_updated", usage: { outputTokens: 1.5 } },
+    { type: "provider_warning", code: "", message: "warning" },
+    { type: "provider_warning", code: "warning", message: "x".repeat(AGENT_RUNTIME_TEXT_MAX_BYTES + 1) },
+    { type: "provider_event", providerId: "", schemaVersion: 1, payload: null },
+    { type: "provider_event", providerId: "test", schemaVersion: 0, payload: null },
+    { type: "provider_event", providerId: "test", schemaVersion: 1.5, payload: null },
+    { type: "provider_event", providerId: "test", schemaVersion: 1, payload: new Map() },
+  ])("rejects malformed event %#", (event) => {
+    const validator = new AgentRunEventValidator();
+    expect(() => validator.accept(event as AgentProviderRunEvent)).toThrowError(
+      expect.objectContaining({ code: "provider_protocol_error" }),
+    );
+  });
+
+  it("rejects oversized message content", () => {
+    const validator = new AgentRunEventValidator();
+    validator.accept({ type: "message_started", messageId: "message" });
+    expect(() =>
+      validator.accept({
+        type: "message_delta",
+        messageId: "message",
+        delta: "x".repeat(AGENT_RUNTIME_TEXT_MAX_BYTES + 1),
+      }),
+    ).toThrowError(expect.objectContaining({ code: "provider_protocol_error" }));
+  });
+
+  it("rejects invalid tool update and output payloads", () => {
+    const update = new AgentRunEventValidator();
+    update.accept({ type: "tool_started", toolCallId: "tool", name: "read" });
+    expect(() => update.accept({ type: "tool_updated", toolCallId: "tool", update: new Date() as never })).toThrow();
+
+    const output = new AgentRunEventValidator();
+    output.accept({ type: "tool_started", toolCallId: "tool", name: "read" });
+    expect(() =>
+      output.accept({
+        type: "tool_completed",
+        toolCallId: "tool",
+        name: "read",
+        status: "completed",
+        output: new Date() as never,
+      }),
+    ).toThrow();
+  });
+
+  it("normalizes non-Error validation failures into protocol errors", () => {
+    const event = new Proxy<AgentProviderRunEvent>(
+      { type: "message_started", messageId: "message" },
+      {
+        get() {
+          throw "invalid provider object";
+        },
+      },
+    );
+    expect(() => new AgentRunEventValidator().accept(event)).toThrowError(
+      expect.objectContaining({ code: "provider_protocol_error", message: "provider emitted an invalid event" }),
+    );
+  });
+
+  it("requires successful runs to close every lifecycle and lets failed or aborted runs truncate them", () => {
+    for (const event of [
+      { type: "model_turn_started", modelTurnId: "turn" },
+      { type: "message_started", messageId: "message" },
+      { type: "tool_started", toolCallId: "tool", name: "read" },
+    ] satisfies AgentProviderRunEvent[]) {
+      const validator = new AgentRunEventValidator();
+      validator.accept(event);
+      expect(() => validator.assertSettled({ status: "completed" })).toThrowError(
+        expect.objectContaining({ code: "provider_protocol_error" }),
+      );
+      expect(() => validator.assertSettled({ status: "failed" })).not.toThrow();
+      expect(() => validator.assertSettled({ status: "aborted" })).not.toThrow();
+    }
+  });
+});

--- a/packages/client/src/__tests__/agent-runtime-validation.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   AGENT_RUNTIME_BINDING_MAX_BYTES,
   AGENT_RUNTIME_ID_MAX_BYTES,
@@ -13,6 +13,7 @@ import {
   assertIdentifier,
   assertJsonValue,
   assertPromptRequest,
+  runWithAbortSignal,
   sameBinding,
 } from "../agent-runtime/validation.js";
 
@@ -278,8 +279,35 @@ describe("Agent Runtime validation", () => {
     }
     const shared = { value: true };
     expect(() => assertJsonValue({ left: shared, right: shared }, "value")).not.toThrow();
+    const nullPrototype = Object.assign(Object.create(null) as Record<string, unknown>, { value: true });
+    expect(() => assertJsonValue(nullPrototype, "value")).not.toThrow();
 
-    for (const value of [Number.NaN, Number.POSITIVE_INFINITY, undefined, 1n, () => undefined]) {
+    class CustomJsonObject {
+      value = true;
+    }
+    const withGetter = Object.defineProperty({}, "value", { enumerable: true, get: () => true });
+    const withHidden = Object.defineProperty({}, "value", { enumerable: false, value: true });
+    const withSymbol = { [Symbol("value")]: true };
+    const sparse: unknown[] = [];
+    sparse.length = 2;
+    sparse[1] = true;
+    const customArray = [true] as unknown[] & { extra?: boolean };
+    customArray.extra = true;
+    for (const value of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      undefined,
+      1n,
+      () => undefined,
+      new Date(),
+      new Map(),
+      new CustomJsonObject(),
+      withGetter,
+      withHidden,
+      withSymbol,
+      sparse,
+      customArray,
+    ]) {
       expect(() => assertJsonValue(value, "value")).toThrowError(expect.objectContaining({ code: "invalid_request" }));
     }
     const cycle: { self?: unknown } = {};
@@ -293,6 +321,37 @@ describe("Agent Runtime validation", () => {
     const binding: AgentRuntimeBinding = { providerId: "test", schemaVersion: 1, payload: { id: "one" } };
     expect(sameBinding(undefined, binding)).toBe(false);
     expect(sameBinding(binding, { ...binding, payload: { id: "one" } })).toBe(true);
+    expect(
+      sameBinding(
+        { providerId: "test", schemaVersion: 1, payload: { first: 1, second: [true, null] } },
+        { schemaVersion: 1, providerId: "test", payload: { second: [true, null], first: 1 } },
+      ),
+    ).toBe(true);
     expect(sameBinding(binding, { ...binding, payload: { id: "two" } })).toBe(false);
+    expect(sameBinding(binding, { ...binding, payload: { id: "one", extra: true } })).toBe(false);
+    expect(
+      sameBinding({ ...binding, payload: [0, { value: true }] }, { ...binding, payload: [0, { value: false }] }),
+    ).toBe(false);
+    expect(sameBinding({ ...binding, payload: [0] }, { ...binding, payload: [0, 1] })).toBe(false);
+    expect(sameBinding({ ...binding, payload: 0 }, { ...binding, payload: -0 })).toBe(true);
+    expect(sameBinding({ ...binding, payload: null }, { ...binding, payload: {} })).toBe(false);
+  });
+
+  it("runs probes with cooperative and enforced AbortSignal cancellation", async () => {
+    await expect(runWithAbortSignal(async () => "without-signal")).resolves.toBe("without-signal");
+
+    const completed = new AbortController();
+    const operation = vi.fn(async (signal?: AbortSignal) => signal);
+    await expect(runWithAbortSignal(operation, completed.signal)).resolves.toBe(completed.signal);
+    expect(operation).toHaveBeenCalledWith(completed.signal);
+
+    const preAborted = new AbortController();
+    preAborted.abort(new Error("already stopped"));
+    await expect(runWithAbortSignal(async () => "unreachable", preAborted.signal)).rejects.toThrow("already stopped");
+
+    const inFlight = new AbortController();
+    const hanging = runWithAbortSignal(() => new Promise<never>(() => undefined), inFlight.signal);
+    inFlight.abort(new Error("stop now"));
+    await expect(hanging).rejects.toThrow("stop now");
   });
 });

--- a/packages/client/src/__tests__/agent-runtime-validation.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-validation.test.ts
@@ -286,6 +286,14 @@ describe("Agent Runtime validation", () => {
       value = true;
     }
     const withGetter = Object.defineProperty({}, "value", { enumerable: true, get: () => true });
+    let arrayGetterReads = 0;
+    const arrayWithGetter = Object.defineProperty([true], "0", {
+      enumerable: true,
+      get: () => {
+        arrayGetterReads += 1;
+        return true;
+      },
+    });
     const withHidden = Object.defineProperty({}, "value", { enumerable: false, value: true });
     const withSymbol = { [Symbol("value")]: true };
     const sparse: unknown[] = [];
@@ -303,6 +311,7 @@ describe("Agent Runtime validation", () => {
       new Map(),
       new CustomJsonObject(),
       withGetter,
+      arrayWithGetter,
       withHidden,
       withSymbol,
       sparse,
@@ -310,6 +319,7 @@ describe("Agent Runtime validation", () => {
     ]) {
       expect(() => assertJsonValue(value, "value")).toThrowError(expect.objectContaining({ code: "invalid_request" }));
     }
+    expect(arrayGetterReads).toBe(0);
     const cycle: { self?: unknown } = {};
     cycle.self = cycle;
     expect(() => assertJsonValue(cycle, "value", "binding_incompatible")).toThrowError(

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -566,6 +566,22 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
         {},
       ),
     ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+
+    const authStarted = join(directory, "auth-started");
+    const hangingAuthCommand = join(directory, "claude-hanging-auth");
+    await writeFile(
+      hangingAuthCommand,
+      `#!/bin/sh\nif [ "$1" = "--version" ]; then echo "2.1.210 (Claude Code)"; exit 0; fi\nif [ "$1" = "--help" ]; then echo "stream-json --session-id --resume"; exit 0; fi\nprintf started > '${authStarted}'\nexec '${process.execPath}' -e 'setInterval(() => undefined, 1000)'\n`,
+      "utf8",
+    );
+    await chmod(hangingAuthCommand, 0o755);
+    const authAbort = new AbortController();
+    const authProbe = new ClaudeCodeAgentRuntimeFactory({
+      process: { command: hangingAuthCommand, env: { PATH: process.env.PATH } },
+    }).probe({ signal: authAbort.signal });
+    await vi.waitFor(async () => expect(await readFile(authStarted, "utf8")).toBe("started"));
+    authAbort.abort(new Error("stop"));
+    await expect(authProbe).rejects.toBeDefined();
     expect(claudeCodeAgentRuntimeEnvironment()).toEqual(expect.any(Object));
   });
 

--- a/packages/client/src/__tests__/claude-code-agent-runtime.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime.test.ts
@@ -151,6 +151,13 @@ describe("ClaudeCodeAgentRuntime", () => {
       ready: false,
       issues: [{ code: "version_incompatible" }, { code: "credential_missing" }],
     });
+
+    const controller = new AbortController();
+    const hanging = new ClaudeCodeAgentRuntimeFactory({
+      probeRunner: async () => new Promise<never>(() => undefined),
+    }).probe({ signal: controller.signal });
+    controller.abort(new Error("stop Claude probe"));
+    await expect(hanging).rejects.toThrow("stop Claude probe");
   });
 
   it("passes only system and Claude provider environment variables", () => {

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -1,17 +1,32 @@
 import { randomUUID } from "node:crypto";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { delimiter, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { EffectiveRuntimeSnapshot, SessionReconcileRequest } from "@opentag/shared";
+import type {
+  DirectImMessageDeliveryRequest,
+  EffectiveRuntimeSnapshot,
+  SessionReconcileRequest,
+} from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import type { AgentRuntime, AgentRuntimeFactory } from "../agent-runtime/types.js";
+import { createLogger } from "../observability/logger.js";
 import { CODEX_AGENT_RUNTIME_APP_SERVER_ARGS } from "../providers/codex/agent-runtime.js";
-import { createClientRuntime, resolveCodexHome } from "../runtime/client-runtime-composition.js";
+import {
+  ComposedClientRuntime,
+  createClientRuntime,
+  createClientRuntimeHandlers,
+  createClientRuntimePreflight,
+  resolveCodexHome,
+  resolvedCodexFactory,
+  resolveExecutable,
+  serializeReadiness,
+} from "../runtime/client-runtime-composition.js";
 import { RuntimeConnection } from "../runtime/runtime-connection.js";
+import { RuntimeStorageError } from "../storage/durable-file.js";
 
 const fixture = fileURLToPath(new URL("./fixtures/codex-app-server.mjs", import.meta.url));
 const directories: string[] = [];
@@ -83,6 +98,248 @@ describe("createClientRuntime production composition", () => {
 
   it("uses HOME when CODEX_HOME is absent", () => {
     expect(resolveCodexHome({ HOME: "/provider-home" })).toBe(resolve("/provider-home/.codex"));
+    expect(resolveCodexHome({ CODEX_HOME: "/explicit-provider-home", HOME: "/ignored" })).toBe(
+      resolve("/explicit-provider-home"),
+    );
+    expect(resolveCodexHome()).toEqual(expect.any(String));
+    expect(resolveCodexHome({})).toBe(resolve(homedir(), ".codex"));
+  });
+
+  it("fails closed for unregistered providers and caller cancellation during initial readiness", async () => {
+    const home = await temporaryDirectory("opentag-client-composition-fences-");
+    await expect(
+      createClientRuntime(runtimeConnection(), {
+        clientVersion: "0.0.1",
+        codexHome: resolve(home, "wrong-provider-home"),
+        environment: {},
+        factory: readyFactory("claude-code"),
+        home,
+      }),
+    ).rejects.toThrow("only registers the reviewed Codex provider");
+
+    const controller = new AbortController();
+    const error = new Error("cancel readiness");
+    const cancelling = readyFactory("codex", async () => {
+      controller.abort(error);
+      throw error;
+    });
+    await expect(
+      createClientRuntime(runtimeConnection(), {
+        clientVersion: "0.0.1",
+        codexHome: resolve(home, "cancelled-home"),
+        environment: {},
+        factory: cancelling,
+        home,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("cancel readiness");
+  });
+
+  it("detects Provider Home replacement after readiness and supports default environment/logger composition", async () => {
+    const home = await temporaryDirectory("opentag-client-composition-identity-");
+    const codexHome = resolve(home, "codex-home");
+    const replacement = resolve(home, "replacement");
+    await mkdir(codexHome);
+    await mkdir(replacement);
+    const replacing = readyFactory("codex", async () => {
+      await rm(codexHome, { recursive: true });
+      await symlink(replacement, codexHome);
+      return { ready: true, issues: [] };
+    });
+    const replaced = await createClientRuntime(runtimeConnection(), {
+      capabilityRefreshIntervalMs: 1,
+      clientVersion: "0.0.1",
+      codexHome,
+      environment: {},
+      factory: replacing,
+      home,
+      logger: { child: () => createLogger("composition-child") } as never,
+      signal: new AbortController().signal,
+    });
+    expect(replaced.messageToolAvailable).toBe(false);
+    replaced.stop();
+    replaced.stop();
+
+    const defaultEnvironment = await createClientRuntime(runtimeConnection(), {
+      clientVersion: "0.0.1",
+      codexHome: resolve(home, "default-environment-home"),
+      factory: readyFactory(),
+      home,
+    });
+    defaultEnvironment.stop();
+  });
+
+  it("tests executable resolution and the resolved factory readiness fence without a shell", async () => {
+    const home = await temporaryDirectory("opentag-client-executable-");
+    const empty = resolve(home, "empty");
+    const bin = resolve(home, "bin");
+    await mkdir(empty);
+    await mkdir(bin);
+    const command = resolve(bin, "codex-fixture");
+    await writeFile(command, "#!/bin/sh\nexit 0\n", "utf8");
+    await chmod(command, 0o755);
+    const canonicalCommand = await realpath(command);
+    await expect(resolveExecutable(command, {})).resolves.toBe(canonicalCommand);
+    await expect(resolveExecutable("codex-fixture", { PATH: `${delimiter}${empty}${delimiter}${bin}` })).resolves.toBe(
+      canonicalCommand,
+    );
+    await expect(resolveExecutable("missing", {})).rejects.toThrow("PATH is unavailable");
+    await expect(resolveExecutable("missing", { PATH: empty })).rejects.toThrow("compatible Codex executable");
+
+    const factory = resolvedCodexFactory({
+      clientVersion: "0.0.1",
+      codexHome: home,
+      command: resolve(home, "missing-absolute"),
+      environment: {},
+      sourceEnvironment: {},
+    });
+    expect(() => factory.create({} as never)).toThrow("readiness has not been established");
+    expect(() => factory.resume({} as never)).toThrow("readiness has not been established");
+    await expect(factory.probe({})).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    const aborted = new AbortController();
+    aborted.abort(new Error("stop resolution"));
+    await expect(factory.probe({ signal: aborted.signal })).rejects.toThrow("stop resolution");
+  });
+
+  it("unit-tests composition delegates and every preflight outcome", async () => {
+    const accepted = { result: { status: "accepted" } };
+    const custody = { accept: vi.fn(async () => accepted) };
+    const reportOwner = { handleResult: vi.fn(async () => "handled") };
+    const recovery = {
+      afterReconciled: vi.fn(async () => undefined),
+      cancel: vi.fn(async () => undefined),
+      prepare: vi.fn(async (_request, result) => result),
+    };
+    const handlers = createClientRuntimeHandlers(custody as never, reportOwner as never, recovery as never);
+    await expect(handlers.handleDelivery({} as never)).resolves.toBe(accepted);
+    await expect(handlers.handleTurnReportResult({} as never)).resolves.toBeUndefined();
+    await expect(handlers.prepareReconcileResult({} as never, { status: "ready" } as never)).resolves.toEqual({
+      status: "ready",
+    });
+    await expect(
+      handlers.onReconcileResultSendFailed({} as never, {} as never, new Error("send")),
+    ).resolves.toBeUndefined();
+    await expect(handlers.onReconciled({} as never, {} as never)).resolves.toBeUndefined();
+
+    const request = delivery(snapshot());
+    const ensureProviderReady = vi.fn(async () => undefined);
+    const runtime = vi.fn(() => ({ state: { phase: "idle" } }));
+    const verifyAgent = vi.fn(async () => undefined);
+    const validate = vi.fn(() => undefined as "configuration_unsupported" | undefined);
+    const preflight = createClientRuntimePreflight({
+      ensureProviderReady,
+      isProviderReady: () => false,
+      runtimeManager: { runtime, validate } as never,
+      workspace: { verifyAgent } as never,
+    });
+    await expect(preflight(request)).resolves.toBeUndefined();
+    expect(ensureProviderReady).toHaveBeenCalledOnce();
+    expect(verifyAgent).toHaveBeenCalledOnce();
+    expect(runtime).toHaveBeenCalledWith("session-1");
+
+    validate.mockReturnValue("configuration_unsupported");
+    await expect(preflight(request)).resolves.toBe("configuration_unsupported");
+
+    validate.mockReturnValue(undefined);
+    verifyAgent.mockRejectedValueOnce(new RuntimeStorageError("conflict", "binding conflict"));
+    await expect(preflight(request)).resolves.toBe("session_binding_conflict");
+    verifyAgent.mockRejectedValueOnce(new Error("provider failed"));
+    await expect(preflight(request)).resolves.toBe("provider_unavailable");
+
+    const alreadyReady = createClientRuntimePreflight({
+      ensureProviderReady,
+      isProviderReady: () => true,
+      runtimeManager: { runtime, validate } as never,
+      workspace: { verifyAgent: vi.fn(async () => undefined) } as never,
+    });
+    await expect(alreadyReady(request)).resolves.toBeUndefined();
+  });
+
+  it("deduplicates concurrent readiness work and permits a fresh probe after settlement", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      release = resolveGate;
+    });
+    const operation = vi.fn(() => gate);
+    const readiness = serializeReadiness(operation);
+    const first = readiness();
+    const second = readiness();
+    expect(second).toBe(first);
+    expect(operation).toHaveBeenCalledOnce();
+    release();
+    await first;
+    await readiness();
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("covers ComposedClientRuntime monitor guards with deterministic component doubles", async () => {
+    const runtime = { run: vi.fn(async () => undefined), stop: vi.fn() };
+    const components = {
+      bindingStore: {},
+      custody: {},
+      messageToolAvailable: true,
+      reconciler: {},
+      reportOwner: { stop: vi.fn() },
+      runner: { settled: vi.fn(async () => undefined), stop: vi.fn() },
+      runtimeManager: { close: vi.fn(async () => undefined) },
+      toolHost: { close: vi.fn() },
+      workspace: {},
+      refreshCapability: vi.fn(async () => undefined),
+      capabilityRefreshIntervalMs: 10,
+      capabilityAbort: new AbortController(),
+    };
+    const stopped = new ComposedClientRuntime(runtime as never, components as never);
+    stopped.stop();
+    stopped.stop();
+    await expect(stopped.run()).resolves.toBeUndefined();
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      release = resolveGate;
+    });
+    const concurrentRuntime = { run: vi.fn(() => gate), stop: vi.fn() };
+    const concurrent = new ComposedClientRuntime(
+      concurrentRuntime as never,
+      {
+        ...components,
+        capabilityAbort: new AbortController(),
+      } as never,
+    );
+    const first = concurrent.run();
+    const second = concurrent.run();
+    release();
+    await Promise.all([first, second]);
+
+    let finishRuntime!: () => void;
+    const runtimeGate = new Promise<void>((resolveRuntime) => {
+      finishRuntime = resolveRuntime;
+    });
+    let startRefresh!: () => void;
+    const refreshStarted = new Promise<void>((resolveStarted) => {
+      startRefresh = resolveStarted;
+    });
+    let finishRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolveRefresh) => {
+      finishRefresh = resolveRefresh;
+    });
+    const refreshing = new ComposedClientRuntime(
+      { run: () => runtimeGate, stop: vi.fn() } as never,
+      {
+        ...components,
+        capabilityAbort: new AbortController(),
+        refreshCapability: () => {
+          startRefresh();
+          return refreshGate;
+        },
+      } as never,
+    );
+    const running = refreshing.run();
+    await refreshStarted;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 25));
+    finishRuntime();
+    await Promise.resolve();
+    finishRefresh();
+    await running;
   });
 
   it("revokes and restores the advertised message-tool capability after fresh Provider probes", async () => {
@@ -447,5 +704,36 @@ function snapshot(): EffectiveRuntimeSnapshot {
     allowedTools: [],
     execution: { approvalPolicy: "never", networkAccess: false },
     workspace: { workspaceId: "workspace-1", mode: "empty_on_create", sharing: "agent" },
+  };
+}
+
+function delivery(runtime: EffectiveRuntimeSnapshot): DirectImMessageDeliveryRequest {
+  return {
+    type: "im:deliver",
+    requestId: randomUUID(),
+    deliveryId: "delivery-1",
+    imMessageId: "message-1",
+    sessionId: "session-1",
+    agentId: "agent-1",
+    placementGeneration: 1,
+    attention: "direct",
+    content: { kind: "text", text: "hello" },
+    runtime,
+  };
+}
+
+function readyFactory(
+  providerId = "codex",
+  probe: AgentRuntimeFactory["probe"] = async () => ({ ready: true, issues: [] }),
+): AgentRuntimeFactory {
+  return {
+    manifest: { providerId, displayName: providerId, contractVersion: 1, bindingSchemaVersion: 1 },
+    probe,
+    create: async () => {
+      throw new Error("not used");
+    },
+    resume: async () => {
+      throw new Error("not used");
+    },
   };
 }

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -308,7 +308,8 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
       ],
     });
 
-    await expect(run).resolves.toMatchObject({
+    const runResult = await run;
+    expect(runResult, JSON.stringify(runResult)).toMatchObject({
       status: "completed",
       output: [{ text: "terminal answer" }],
       usage: { inputTokens: 8, cachedInputTokens: 2, outputTokens: 4 },
@@ -334,7 +335,12 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
 
   it("maps completed fallback, interrupted, and failed Turn terminal forms", async () => {
     const client = new ManualCodexClient();
-    const runtime = await factory(client).create(createRequest(() => undefined));
+    const events: AgentRuntimeEvent[] = [];
+    const runtime = await factory(client).create(
+      createRequest((event) => {
+        events.push(event);
+      }),
+    );
 
     const fallback = runtime.prompt({ runId: "fallback", input: input("one") });
     await client.called("turn/start");
@@ -374,6 +380,49 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
     await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(4));
     client.complete({ id: "turn-4", status: "failed", error: {}, items: [] });
     await expect(failedDefault).resolves.toMatchObject({ status: "failed", error: { message: "Codex turn failed" } });
+
+    const openMessage = runtime.prompt({ runId: "open-message", input: input("five") });
+    await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(5));
+    client.emit({
+      method: "item/agentMessage/delta",
+      params: { threadId: "thread-1", turnId: "turn-5", itemId: "open", delta: "partial" },
+    });
+    client.complete({
+      id: "turn-5",
+      items: [{ id: "open", type: "agentMessage", phase: "final_answer", text: "terminal text" }],
+    });
+    await expect(openMessage).resolves.toMatchObject({ status: "completed", output: [{ text: "terminal text" }] });
+
+    const openDelta = runtime.prompt({ runId: "open-delta", input: input("six") });
+    await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(6));
+    client.emit({
+      method: "item/agentMessage/delta",
+      params: { threadId: "thread-1", turnId: "turn-6", itemId: "delta-only", delta: "partial" },
+    });
+    client.complete({ id: "turn-6", items: [] });
+    await expect(openDelta).resolves.toMatchObject({ status: "completed" });
+
+    for (const [index, terminalStatus, itemStatus] of [
+      [7, "completed", "declined"],
+      [8, "completed", "failed"],
+      [9, "failed", "completed"],
+      [10, "interrupted", "completed"],
+    ] as const) {
+      const toolRun = runtime.prompt({ runId: `open-tool-${index}`, input: input("tool") });
+      await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(index));
+      client.emitItem("item/started", { id: `tool-${index}`, type: "commandExecution" });
+      client.complete({
+        id: `turn-${index}`,
+        status: terminalStatus,
+        items: [{ id: `tool-${index}`, type: "commandExecution", status: itemStatus }],
+      });
+      await expect(toolRun).resolves.toMatchObject({
+        status: terminalStatus === "completed" ? "completed" : terminalStatus === "failed" ? "failed" : "aborted",
+      });
+    }
+    expect(events.find((event) => event.type === "tool_completed" && event.toolCallId === "tool-10")).toMatchObject({
+      status: "failed",
+    });
     await runtime.close();
   });
 
@@ -584,6 +633,35 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
       await expect(run, entry.name).resolves.toMatchObject({ status: "failed" });
       await vi.waitFor(() => expect(runtime.state.phase).toBe("closed"));
     }
+  });
+
+  it("rejects wire lifecycles that reuse messages or rename active tools", async () => {
+    const duplicateClient = new ManualCodexClient();
+    const duplicate = await factory(duplicateClient).create(createRequest(() => undefined));
+    const duplicateRun = duplicate.prompt({ runId: "duplicate-message", input: input("fail") });
+    await duplicateClient.called("turn/start");
+    duplicateClient.emitItem("item/completed", { id: "message", type: "agentMessage", text: "done" });
+    duplicateClient.emitItem("item/started", { id: "message", type: "agentMessage" });
+    await expect(duplicateRun).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "provider_protocol_error", message: "Codex reused a completed agent message ID" },
+    });
+    await vi.waitFor(() => expect(duplicate.state.phase).toBe("closed"));
+
+    const renamedClient = new ManualCodexClient();
+    const renamed = await factory(renamedClient).create(createRequest(() => undefined));
+    const renamedRun = renamed.prompt({ runId: "renamed-tool", input: input("fail") });
+    await renamedClient.called("turn/start");
+    renamedClient.emit({
+      method: "item/commandExecution/outputDelta",
+      params: { threadId: "thread-1", turnId: "turn-1", itemId: "tool", delta: "output" },
+    });
+    renamedClient.emitItem("item/started", { id: "tool", type: "mcpToolCall", server: "server", tool: "read" });
+    await expect(renamedRun).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "provider_protocol_error", message: "Codex changed a tool name during its lifecycle" },
+    });
+    await vi.waitFor(() => expect(renamed.state.phase).toBe("closed"));
   });
 
   it("fails when a trailing notification breaks after Codex emits terminal", async () => {
@@ -1157,7 +1235,9 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
     });
     const controller = new AbortController();
     const probing = runtimeFactory.probe({ signal: controller.signal });
-    await vi.waitFor(async () => expect(Number(await readFile(pidFile, "utf8"))).toBeGreaterThan(0));
+    await vi.waitFor(async () => expect(Number(await readFile(pidFile, "utf8"))).toBeGreaterThan(0), {
+      timeout: 5_000,
+    });
     const pid = Number(await readFile(pidFile, "utf8"));
 
     controller.abort(new Error("stop"));

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -407,6 +407,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
       [8, "completed", "failed"],
       [9, "failed", "completed"],
       [10, "interrupted", "completed"],
+      [11, "completed", "completed"],
     ] as const) {
       const toolRun = runtime.prompt({ runId: `open-tool-${index}`, input: input("tool") });
       await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(index));
@@ -421,6 +422,15 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
       });
     }
     expect(events.find((event) => event.type === "tool_completed" && event.toolCallId === "tool-10")).toMatchObject({
+      status: "failed",
+    });
+
+    const missingTool = runtime.prompt({ runId: "open-tool-12", input: input("tool") });
+    await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(12));
+    client.emitItem("item/started", { id: "tool-12", type: "commandExecution" });
+    client.complete({ id: "turn-12", status: "completed", items: [] });
+    await expect(missingTool).resolves.toMatchObject({ status: "completed" });
+    expect(events.find((event) => event.type === "tool_completed" && event.toolCallId === "tool-12")).toMatchObject({
       status: "failed",
     });
     await runtime.close();

--- a/packages/client/src/__tests__/pi-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/pi-agent-runtime-exhaustive.test.ts
@@ -663,6 +663,36 @@ printf 'provider model\\nfixture configured\\n'
         },
       }).probe({}),
     ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+
+    const directory = await temporaryDirectory("opentag-pi-probe-abort-");
+    const helpStarted = join(directory, "help-started");
+    const hangingHelp = await probeCli(`
+if [ "$1" = "--version" ]; then echo "0.80.6"; exit 0; fi
+if [ "$1" = "--help" ]; then printf started > '${helpStarted}'; exec '${process.execPath}' -e 'setInterval(() => undefined, 1000)'; fi
+exit 1
+`);
+    const helpAbort = new AbortController();
+    const helpProbe = new PiAgentRuntimeFactory({ process: { command: hangingHelp, env: {} } }).probe({
+      signal: helpAbort.signal,
+    });
+    await vi.waitFor(async () => expect(await readFile(helpStarted, "utf8")).toBe("started"));
+    helpAbort.abort(new Error("stop"));
+    await expect(helpProbe).rejects.toBeDefined();
+
+    const modelsStarted = join(directory, "models-started");
+    const hangingModels = await probeCli(`
+if [ "$1" = "--version" ]; then echo "0.80.6"; exit 0; fi
+if [ "$1" = "--help" ]; then echo "--mode rpc --session-id --session-dir --offline --no-extensions --no-skills --no-prompt-templates --no-themes --no-context-files --no-approve --tools --model --thinking --append-system-prompt --name"; exit 0; fi
+printf started > '${modelsStarted}'
+exec '${process.execPath}' -e 'setInterval(() => undefined, 1000)'
+`);
+    const modelsAbort = new AbortController();
+    const modelsProbe = new PiAgentRuntimeFactory({ process: { command: hangingModels, env: {} } }).probe({
+      signal: modelsAbort.signal,
+    });
+    await vi.waitFor(async () => expect(await readFile(modelsStarted, "utf8")).toBe("started"));
+    modelsAbort.abort(new Error("stop"));
+    await expect(modelsProbe).rejects.toBeDefined();
   });
 
   it("uses the default local Pi process boundary without adding a package dependency", async () => {

--- a/packages/client/src/__tests__/pi-agent-runtime.test.ts
+++ b/packages/client/src/__tests__/pi-agent-runtime.test.ts
@@ -197,6 +197,12 @@ describe("PiAgentRuntime", () => {
       ready: false,
       issues: [{ code: "version_incompatible" }, { code: "credential_missing" }],
     });
+    const controller = new AbortController();
+    const hanging = new PiAgentRuntimeFactory({
+      probeRunner: async () => new Promise<never>(() => undefined),
+    }).probe({ signal: controller.signal });
+    controller.abort(new Error("stop Pi probe"));
+    await expect(hanging).rejects.toThrow("stop Pi probe");
     expect(
       piAgentRuntimeEnvironment({
         HOME: "/home/provider",

--- a/packages/client/src/agent-runtime/base-agent-runtime.ts
+++ b/packages/client/src/agent-runtime/base-agent-runtime.ts
@@ -1,4 +1,5 @@
 import { AgentProviderError, AgentRuntimeError } from "./errors.js";
+import { AgentRunEventValidator } from "./event-validator.js";
 import type {
   AgentAbortRequest,
   AgentInteractionRequest,
@@ -37,6 +38,7 @@ interface RunRecord {
   readonly request: AgentPromptRequest;
   readonly controller: AbortController;
   readonly executionFailure: Promise<never>;
+  readonly eventValidator: AgentRunEventValidator;
   readonly failExecution: (error: Error) => void;
   readonly promise: Promise<AgentRunResult>;
   readonly resolve: (result: AgentRunResult) => void;
@@ -234,6 +236,7 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
       request: snapshot,
       controller: new AbortController(),
       executionFailure,
+      eventValidator: new AgentRunEventValidator(),
       failExecution,
       promise,
       resolve: resolveResult,
@@ -261,6 +264,7 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
       await this.#dispatch({ type: "run_started", runId: record.request.runId });
       const providerExecution = Promise.resolve().then(() => this.executeRun(record.request, this.#context(record)));
       const providerResult = await Promise.race([providerExecution, record.executionFailure]);
+      record.eventValidator.assertSettled(providerResult);
       result = this.#providerResult(record.request.runId, providerResult);
     } catch (error) {
       result = this.#resultForThrownError(record, error);
@@ -295,6 +299,7 @@ export abstract class BaseAgentRuntime implements AgentRuntime {
       },
       emit: async (event: AgentProviderRunEvent) => {
         assertCurrent();
+        record.eventValidator.accept(event);
         await this.#dispatch({ ...event, runId: record.request.runId } as AgentRuntimeEvent);
       },
       updateBinding: async (binding: AgentRuntimeBinding) => {

--- a/packages/client/src/agent-runtime/event-validator.ts
+++ b/packages/client/src/agent-runtime/event-validator.ts
@@ -1,0 +1,142 @@
+import { AgentProviderError } from "./errors.js";
+import type { AgentProviderRunEvent, AgentProviderRunResult, AgentUsage } from "./types.js";
+import { AGENT_RUNTIME_TEXT_MAX_BYTES } from "./types.js";
+import { assertIdentifier, assertJsonValue } from "./validation.js";
+
+interface ToolLifecycle {
+  readonly name: string;
+}
+
+/**
+ * Validates the provider-neutral event grammar for one Run. Provider adapters
+ * remain responsible only for translating their wire protocol into this grammar.
+ * Model turns are optional because some providers do not expose that boundary.
+ */
+export class AgentRunEventValidator {
+  readonly #activeMessages = new Set<string>();
+  readonly #activeModelTurns = new Set<string>();
+  readonly #activeTools = new Map<string, ToolLifecycle>();
+  readonly #seenMessages = new Set<string>();
+  readonly #seenModelTurns = new Set<string>();
+  readonly #seenTools = new Set<string>();
+
+  accept(event: AgentProviderRunEvent): void {
+    try {
+      this.#accept(event);
+    } catch (error) {
+      if (error instanceof AgentProviderError) throw error;
+      throw protocolError(error instanceof Error ? error.message : "provider emitted an invalid event");
+    }
+  }
+
+  assertSettled(result: AgentProviderRunResult): void {
+    if (result.status !== "completed") return;
+    if (this.#activeModelTurns.size > 0 || this.#activeMessages.size > 0 || this.#activeTools.size > 0) {
+      throw protocolError("provider completed a run with unfinished event lifecycles");
+    }
+  }
+
+  #accept(event: AgentProviderRunEvent): void {
+    if (!event || typeof event !== "object" || typeof event.type !== "string") {
+      throw protocolError("provider emitted an invalid event");
+    }
+    switch (event.type) {
+      case "model_turn_started":
+        this.#start(event.modelTurnId, "modelTurnId", this.#seenModelTurns, this.#activeModelTurns);
+        return;
+      case "model_turn_completed":
+        this.#complete(event.modelTurnId, "modelTurnId", this.#activeModelTurns);
+        return;
+      case "message_started":
+        this.#start(event.messageId, "messageId", this.#seenMessages, this.#activeMessages);
+        return;
+      case "message_delta":
+        this.#requireActive(event.messageId, "messageId", this.#activeMessages);
+        assertText(event.delta, "message delta");
+        return;
+      case "message_completed":
+        this.#complete(event.messageId, "messageId", this.#activeMessages);
+        assertText(event.text, "message text");
+        return;
+      case "tool_started":
+        assertIdentifier(event.toolCallId, "toolCallId");
+        assertIdentifier(event.name, "tool name");
+        if (this.#seenTools.has(event.toolCallId)) throw protocolError("provider reused a toolCallId");
+        if (event.input !== undefined) assertJsonValue(event.input, "tool input");
+        this.#seenTools.add(event.toolCallId);
+        this.#activeTools.set(event.toolCallId, { name: event.name });
+        return;
+      case "tool_updated":
+        this.#requireTool(event.toolCallId);
+        assertJsonValue(event.update, "tool update");
+        return;
+      case "tool_completed": {
+        const tool = this.#requireTool(event.toolCallId);
+        assertIdentifier(event.name, "tool name");
+        if (tool.name !== event.name) throw protocolError("provider changed a tool name during its lifecycle");
+        if (event.output !== undefined) assertJsonValue(event.output, "tool output");
+        this.#activeTools.delete(event.toolCallId);
+        return;
+      }
+      case "usage_updated":
+        assertUsage(event.usage);
+        return;
+      case "provider_warning":
+        assertIdentifier(event.code, "provider warning code");
+        assertText(event.message, "provider warning message");
+        return;
+      case "provider_event":
+        assertIdentifier(event.providerId, "provider event providerId");
+        if (!Number.isSafeInteger(event.schemaVersion) || event.schemaVersion < 1) {
+          throw protocolError("provider event schemaVersion must be a positive safe integer");
+        }
+        assertJsonValue(event.payload, "provider event payload");
+        return;
+      default:
+        throw protocolError("provider emitted an unknown event type");
+    }
+  }
+
+  #start(id: string, field: string, seen: Set<string>, active: Set<string>): void {
+    assertIdentifier(id, field);
+    if (seen.has(id)) throw protocolError(`provider reused a ${field}`);
+    seen.add(id);
+    active.add(id);
+  }
+
+  #complete(id: string, field: string, active: Set<string>): void {
+    this.#requireActive(id, field, active);
+    active.delete(id);
+  }
+
+  #requireActive(id: string, field: string, active: Set<string>): void {
+    assertIdentifier(id, field);
+    if (!active.has(id)) throw protocolError(`provider referenced an inactive ${field}`);
+  }
+
+  #requireTool(toolCallId: string): ToolLifecycle {
+    assertIdentifier(toolCallId, "toolCallId");
+    const tool = this.#activeTools.get(toolCallId);
+    if (!tool) throw protocolError("provider referenced an inactive toolCallId");
+    return tool;
+  }
+}
+
+function assertText(value: unknown, field: string): asserts value is string {
+  if (typeof value !== "string" || Buffer.byteLength(value, "utf8") > AGENT_RUNTIME_TEXT_MAX_BYTES) {
+    throw protocolError(`${field} must be bounded text`);
+  }
+}
+
+function assertUsage(usage: AgentUsage): void {
+  if (!usage || typeof usage !== "object") throw protocolError("provider usage must be an object");
+  for (const value of [usage.inputTokens, usage.cachedInputTokens, usage.outputTokens]) {
+    if (value !== undefined && (!Number.isSafeInteger(value) || value < 0)) {
+      throw protocolError("provider usage must contain non-negative safe integers");
+    }
+  }
+}
+
+function protocolError(message: string): AgentProviderError {
+  return new AgentProviderError("provider_protocol_error", message);
+}

--- a/packages/client/src/agent-runtime/event-validator.ts
+++ b/packages/client/src/agent-runtime/event-validator.ts
@@ -7,6 +7,8 @@ interface ToolLifecycle {
   readonly name: string;
 }
 
+const TOOL_COMPLETION_STATUSES: ReadonlySet<unknown> = new Set(["completed", "failed", "declined"]);
+
 /**
  * Validates the provider-neutral event grammar for one Run. Provider adapters
  * remain responsible only for translating their wire protocol into this grammar.
@@ -74,6 +76,9 @@ export class AgentRunEventValidator {
         const tool = this.#requireTool(event.toolCallId);
         assertIdentifier(event.name, "tool name");
         if (tool.name !== event.name) throw protocolError("provider changed a tool name during its lifecycle");
+        if (!TOOL_COMPLETION_STATUSES.has(event.status)) {
+          throw protocolError("provider emitted an invalid tool completion status");
+        }
         if (event.output !== undefined) assertJsonValue(event.output, "tool output");
         this.#activeTools.delete(event.toolCallId);
         return;

--- a/packages/client/src/agent-runtime/types.ts
+++ b/packages/client/src/agent-runtime/types.ts
@@ -220,6 +220,8 @@ export interface AgentInteractionRequest {
 }
 
 export type AgentProviderRunEvent =
+  // Model-turn events are optional: providers that cannot observe this boundary
+  // emit message/tool lifecycles directly within the Run.
   | { readonly type: "model_turn_started"; readonly modelTurnId: string }
   | { readonly type: "model_turn_completed"; readonly modelTurnId: string }
   | { readonly type: "message_started"; readonly messageId: string }

--- a/packages/client/src/agent-runtime/validation.ts
+++ b/packages/client/src/agent-runtime/validation.ts
@@ -129,9 +129,33 @@ export function assertJsonValue(
     if (seen.has(candidate)) throw new AgentRuntimeError(code, `${field} must not contain cycles`);
     seen.add(candidate);
     if (Array.isArray(candidate)) {
+      const keys = Reflect.ownKeys(candidate);
+      if (
+        keys.some(
+          (key) =>
+            key !== "length" &&
+            (typeof key !== "string" || !/^(0|[1-9]\d*)$/.test(key) || Number(key) >= candidate.length),
+        ) ||
+        candidate.length !== Object.keys(candidate).length
+      ) {
+        throw new AgentRuntimeError(code, `${field} must contain dense JSON arrays without custom properties`);
+      }
       for (const item of candidate) visit(item);
     } else {
-      for (const item of Object.values(candidate)) visit(item);
+      const prototype = Object.getPrototypeOf(candidate);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new AgentRuntimeError(code, `${field} must contain only plain JSON objects`);
+      }
+      for (const key of Reflect.ownKeys(candidate)) {
+        if (typeof key !== "string") {
+          throw new AgentRuntimeError(code, `${field} must not contain symbol properties`);
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
+        if (!descriptor?.enumerable || !("value" in descriptor)) {
+          throw new AgentRuntimeError(code, `${field} must contain enumerable data properties`);
+        }
+        visit(descriptor.value);
+      }
     }
     seen.delete(candidate);
   };
@@ -139,7 +163,56 @@ export function assertJsonValue(
 }
 
 export function sameBinding(left: AgentRuntimeBinding | undefined, right: AgentRuntimeBinding): boolean {
-  return left !== undefined && JSON.stringify(left) === JSON.stringify(right);
+  return left !== undefined && sameJsonValue(left as unknown as JsonComparable, right as unknown as JsonComparable);
+}
+
+export async function runWithAbortSignal<T>(
+  operation: (signal?: AbortSignal) => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) return operation();
+  signal.throwIfAborted();
+  let rejectAborted!: (reason: unknown) => void;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAborted = reject;
+  });
+  const onAbort = () => rejectAborted(signal.reason);
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    return await Promise.race([operation(signal), aborted]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+}
+
+type JsonComparable = boolean | number | string | null | readonly JsonComparable[] | JsonComparableObject;
+interface JsonComparableObject {
+  readonly [key: string]: JsonComparable;
+}
+
+function sameJsonValue(left: JsonComparable, right: JsonComparable): boolean {
+  if (left === right) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => sameJsonValue(value, right[index] as JsonComparable))
+    );
+  }
+  if (left === null || right === null || typeof left !== "object" || typeof right !== "object") return false;
+  const leftObject = left as JsonComparableObject;
+  const rightObject = right as JsonComparableObject;
+  const leftKeys = Object.keys(leftObject);
+  const rightKeys = Object.keys(rightObject);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        Object.hasOwn(rightObject, key) &&
+        sameJsonValue(leftObject[key] as JsonComparable, rightObject[key] as JsonComparable),
+    )
+  );
 }
 
 const TOOL_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;

--- a/packages/client/src/agent-runtime/validation.ts
+++ b/packages/client/src/agent-runtime/validation.ts
@@ -140,7 +140,13 @@ export function assertJsonValue(
       ) {
         throw new AgentRuntimeError(code, `${field} must contain dense JSON arrays without custom properties`);
       }
-      for (const item of candidate) visit(item);
+      for (let index = 0; index < candidate.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, String(index));
+        if (!descriptor?.enumerable || !("value" in descriptor)) {
+          throw new AgentRuntimeError(code, `${field} must contain enumerable data properties`);
+        }
+        visit(descriptor.value);
+      }
     } else {
       const prototype = Object.getPrototypeOf(candidate);
       if (prototype !== Object.prototype && prototype !== null) {

--- a/packages/client/src/providers/claude-code/agent-runtime.ts
+++ b/packages/client/src/providers/claude-code/agent-runtime.ts
@@ -21,7 +21,7 @@ import {
   type JsonValue,
   type ResumeAgentRuntimeRequest,
 } from "../../agent-runtime/types.js";
-import { assertBinding, assertJsonValue } from "../../agent-runtime/validation.js";
+import { assertBinding, assertJsonValue, runWithAbortSignal } from "../../agent-runtime/validation.js";
 import {
   ClaudeCodeProcess,
   type ClaudeCodeProcessClient,
@@ -70,7 +70,7 @@ export interface ClaudeCodeAgentRuntimeFactoryOptions {
   };
   readonly createProcess?: (cwd: string, args: readonly string[]) => ClaudeCodeProcessClient;
   readonly createSessionId?: () => string;
-  readonly probeRunner?: () => Promise<{
+  readonly probeRunner?: (signal?: AbortSignal) => Promise<{
     readonly credential: boolean;
     readonly streamJson: boolean;
     readonly version: string;
@@ -529,7 +529,7 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
   readonly manifest = CLAUDE_CODE_AGENT_RUNTIME_MANIFEST;
   readonly #createSessionId: () => string;
   readonly #createProcess: (cwd: string, args: readonly string[]) => ClaudeCodeProcessClient;
-  readonly #probeRunner: () => Promise<{
+  readonly #probeRunner: (signal?: AbortSignal) => Promise<{
     readonly credential: boolean;
     readonly streamJson: boolean;
     readonly version: string;
@@ -552,7 +552,7 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
           maxStderrBytes: options.process?.maxStderrBytes,
           spawnProcess: options.process?.spawnProcess,
         }));
-    this.#probeRunner = options.probeRunner ?? (() => probeClaudeCode(command, environment));
+    this.#probeRunner = options.probeRunner ?? ((signal) => probeClaudeCode(command, environment, signal));
   }
 
   async probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult> {
@@ -564,7 +564,7 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
     }
     let version: string | undefined;
     try {
-      const result = await this.#probeRunner();
+      const result = await runWithAbortSignal(this.#probeRunner, request.signal);
       version = result.version;
       if (!result.streamJson) {
         issues.push({ code: "version_incompatible", message: "Claude Code stream-json mode is unavailable" });
@@ -572,7 +572,8 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
       if (!result.credential) {
         issues.push({ code: "credential_missing", message: "Claude Code credentials were not found" });
       }
-    } catch {
+    } catch (error) {
+      if (request.signal?.aborted) throw error;
       issues.push({ code: "artifact_missing", message: "Claude Code CLI could not be executed" });
     }
     return { ready: issues.length === 0, ...(version ? { version } : {}), issues };
@@ -661,8 +662,9 @@ export function claudeCodeAgentRuntimeEnvironment(source: NodeJS.ProcessEnv = pr
 async function probeClaudeCode(
   command: string,
   environment: NodeJS.ProcessEnv,
+  signal?: AbortSignal,
 ): Promise<{ readonly credential: boolean; readonly streamJson: boolean; readonly version: string }> {
-  const execution = { encoding: "utf8" as const, env: environment, timeout: 5_000, windowsHide: true };
+  const execution = { encoding: "utf8" as const, env: environment, signal, timeout: 5_000, windowsHide: true };
   const [versionResult, helpResult] = await Promise.all([
     execFileAsync(command, ["--version"], execution),
     execFileAsync(command, ["--help"], execution),
@@ -673,7 +675,8 @@ async function probeClaudeCode(
     helpResult.stdout.includes("stream-json") &&
     helpResult.stdout.includes("--session-id") &&
     helpResult.stdout.includes("--resume");
-  const credential = hasCredentialEnvironment(environment) || (await probeClaudeCodeCredential(command, execution));
+  const credential =
+    hasCredentialEnvironment(environment) || (await probeClaudeCodeCredential(command, execution, signal));
   return { credential, streamJson, version };
 }
 
@@ -682,14 +685,17 @@ async function probeClaudeCodeCredential(
   execution: {
     readonly encoding: "utf8";
     readonly env: NodeJS.ProcessEnv;
+    readonly signal?: AbortSignal;
     readonly timeout: number;
     readonly windowsHide: boolean;
   },
+  signal?: AbortSignal,
 ): Promise<boolean> {
   let output: string;
   try {
     output = (await execFileAsync(command, ["auth", "status", "--json"], execution)).stdout;
   } catch (error) {
+    if (signal?.aborted) throw error;
     output = (error as Error & { readonly stdout: string }).stdout;
   }
   if (!output) return false;

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -170,6 +170,8 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
   readonly #unsubscribeRequests: () => void;
   readonly #wireInteractions = new Map<string, CodexAppServerRequest>();
   readonly #completedMessages = new Map<string, { readonly phase?: string; readonly text: string }>();
+  readonly #activeMessages = new Map<string, string>();
+  readonly #activeTools = new Map<string, string>();
   readonly #hostedToolCalls = new Map<
     string,
     { readonly hash: string; readonly result: Promise<CodexDynamicToolResult> }
@@ -215,6 +217,8 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
     this.#providerFailure = undefined;
     this.#latestUsage = undefined;
     this.#completedMessages.clear();
+    this.#activeMessages.clear();
+    this.#activeTools.clear();
     this.#wireInteractions.clear();
     this.#buffered = [];
     this.#buffering = true;
@@ -237,6 +241,7 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
       const terminal = await this.#terminal.promise;
       await this.#eventTail;
       if (this.#providerFailure) throw this.#providerFailure;
+      await this.#completeOpenLifecycles(terminal);
       return this.#runResult(terminal);
     } catch (error) {
       const failure = error instanceof Error ? error : new Error("Codex run failed");
@@ -416,18 +421,24 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
     }
     if (method === "item/agentMessage/delta") {
       this.#assertNotificationTurn(params);
+      const messageId = requireString(params?.itemId, "agent message delta has no itemId");
+      const delta = requireString(params?.delta, "agent message delta has no text", true);
+      await this.#ensureMessageStarted(messageId);
+      this.#activeMessages.set(messageId, `${this.#activeMessages.get(messageId) as string}${delta}`);
       await context.emit({
         type: "message_delta",
-        messageId: requireString(params?.itemId, "agent message delta has no itemId"),
-        delta: requireString(params?.delta, "agent message delta has no text", true),
+        messageId,
+        delta,
       });
       return;
     }
     if (method === "item/commandExecution/outputDelta") {
       this.#assertNotificationTurn(params);
+      const toolCallId = requireString(params?.itemId, "command output delta has no itemId");
+      await this.#ensureToolStarted(toolCallId, "commandExecution", { id: toolCallId, type: "commandExecution" });
       await context.emit({
         type: "tool_updated",
-        toolCallId: requireString(params?.itemId, "command output delta has no itemId"),
+        toolCallId,
         update: { delta: requireString(params?.delta, "command output delta has no text", true) },
       });
       return;
@@ -463,21 +474,25 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
     const type = requireString(item.type, `${method} item has no type`);
     if (type === "agentMessage") {
       if (method === "item/started") {
-        await context.emit({ type: "message_started", messageId: id });
+        await this.#ensureMessageStarted(id);
         return;
       }
       const text = requireString(item.text, "completed agent message has no text", true);
       const phase = typeof item.phase === "string" ? item.phase : undefined;
+      await this.#ensureMessageStarted(id);
       this.#completedMessages.set(id, { text, ...(phase ? { phase } : {}) });
       await context.emit({ type: "message_completed", messageId: id, text });
+      this.#activeMessages.delete(id);
       return;
     }
     if (!TOOL_ITEM_TYPES.has(type)) return;
-    const name = toolName(item, type);
+    const name =
+      method === "item/completed" ? (this.#activeTools.get(id) ?? toolName(item, type)) : toolName(item, type);
     if (method === "item/started") {
-      await context.emit({ type: "tool_started", toolCallId: id, name, input: toJsonValue(item) });
+      await this.#ensureToolStarted(id, name, item);
       return;
     }
+    await this.#ensureToolStarted(id, name, item);
     const status = item.status === "declined" ? "declined" : item.status === "failed" ? "failed" : "completed";
     await context.emit({
       type: "tool_completed",
@@ -486,6 +501,54 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
       status,
       output: toJsonValue(item),
     });
+    this.#activeTools.delete(id);
+  }
+
+  async #ensureMessageStarted(messageId: string): Promise<void> {
+    if (this.#activeMessages.has(messageId)) return;
+    if (this.#completedMessages.has(messageId)) throw protocolError("Codex reused a completed agent message ID");
+    this.#activeMessages.set(messageId, "");
+    await this.#requireContext().emit({ type: "message_started", messageId });
+  }
+
+  async #ensureToolStarted(toolCallId: string, name: string, input: Record<string, unknown>): Promise<void> {
+    const activeName = this.#activeTools.get(toolCallId);
+    if (activeName) {
+      if (activeName !== name) throw protocolError("Codex changed a tool name during its lifecycle");
+      return;
+    }
+    this.#activeTools.set(toolCallId, name);
+    await this.#requireContext().emit({ type: "tool_started", toolCallId, name, input: toJsonValue(input) });
+  }
+
+  async #completeOpenLifecycles(turn: ParsedTurn): Promise<void> {
+    const context = this.#requireContext();
+    const terminalItems = new Map(
+      turn.items.filter((item) => typeof item.id === "string").map((item) => [item.id as string, item] as const),
+    );
+    for (const [messageId, deltaText] of this.#activeMessages) {
+      const item = terminalItems.get(messageId);
+      const text = typeof item?.text === "string" ? item.text : deltaText;
+      await context.emit({ type: "message_completed", messageId, text });
+      this.#activeMessages.delete(messageId);
+    }
+    for (const [toolCallId, name] of this.#activeTools) {
+      const item = terminalItems.get(toolCallId);
+      const status =
+        item?.status === "declined"
+          ? "declined"
+          : item?.status === "failed" || turn.status !== "completed"
+            ? "failed"
+            : "completed";
+      await context.emit({
+        type: "tool_completed",
+        toolCallId,
+        name,
+        status,
+        ...(item ? { output: toJsonValue(item) } : {}),
+      });
+      this.#activeTools.delete(toolCallId);
+    }
   }
 
   async #handleServerRequest(request: CodexAppServerRequest): Promise<void> {

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -537,7 +537,7 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
       const status =
         item?.status === "declined"
           ? "declined"
-          : item?.status === "failed" || turn.status !== "completed"
+          : !item || item.status === "failed" || turn.status !== "completed"
             ? "failed"
             : "completed";
       await context.emit({

--- a/packages/client/src/providers/pi/agent-runtime.ts
+++ b/packages/client/src/providers/pi/agent-runtime.ts
@@ -25,7 +25,7 @@ import {
   type JsonValue,
   type ResumeAgentRuntimeRequest,
 } from "../../agent-runtime/types.js";
-import { assertBinding, assertJsonValue } from "../../agent-runtime/validation.js";
+import { assertBinding, assertJsonValue, runWithAbortSignal } from "../../agent-runtime/validation.js";
 import { type PiRpcClient, PiRpcError, PiRpcProcess, type PiRpcProcessSpawnOptions } from "./rpc-wire.js";
 
 const execFileAsync = promisify(execFile);
@@ -84,7 +84,7 @@ export interface PiAgentRuntimeFactoryOptions {
   };
   readonly createClient?: (cwd: string, args: readonly string[]) => PiRpcClient;
   readonly createSessionId?: () => string;
-  readonly probeRunner?: () => Promise<{
+  readonly probeRunner?: (signal?: AbortSignal) => Promise<{
     readonly credential: boolean;
     readonly rpc: boolean;
     readonly version: string;
@@ -603,7 +603,7 @@ export class PiAgentRuntimeFactory implements AgentRuntimeFactory {
   readonly manifest = PI_AGENT_RUNTIME_MANIFEST;
   readonly #createSessionId: () => string;
   readonly #createClient: (cwd: string, args: readonly string[]) => PiRpcClient;
-  readonly #probeRunner: () => Promise<{
+  readonly #probeRunner: (signal?: AbortSignal) => Promise<{
     readonly credential: boolean;
     readonly rpc: boolean;
     readonly version: string;
@@ -633,7 +633,7 @@ export class PiAgentRuntimeFactory implements AgentRuntimeFactory {
           requestTimeoutMs: options.process?.requestTimeoutMs,
           spawnProcess: options.process?.spawnProcess,
         }));
-    this.#probeRunner = options.probeRunner ?? (() => probePi(command, environment));
+    this.#probeRunner = options.probeRunner ?? ((signal) => probePi(command, environment, signal));
   }
 
   async probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult> {
@@ -645,12 +645,13 @@ export class PiAgentRuntimeFactory implements AgentRuntimeFactory {
     }
     let version: string | undefined;
     try {
-      const result = await this.#probeRunner();
+      const result = await runWithAbortSignal(this.#probeRunner, request.signal);
       version = result.version;
       if (!result.rpc) issues.push({ code: "version_incompatible", message: "Pi RPC mode is unavailable" });
       if (!result.credential)
         issues.push({ code: "credential_missing", message: "Pi has no configured model credential" });
-    } catch {
+    } catch (error) {
+      if (request.signal?.aborted) throw error;
       issues.push({ code: "artifact_missing", message: "Pi CLI could not be executed" });
     }
     return { ready: issues.length === 0, ...(version ? { version } : {}), issues };
@@ -778,14 +779,16 @@ export function piAgentRuntimeEnvironment(source: NodeJS.ProcessEnv = process.en
 async function probePi(
   command: string,
   environment: NodeJS.ProcessEnv,
+  signal?: AbortSignal,
 ): Promise<{ readonly credential: boolean; readonly rpc: boolean; readonly version: string }> {
-  const execution = { encoding: "utf8" as const, env: environment, timeout: 5_000, windowsHide: true };
+  const execution = { encoding: "utf8" as const, env: environment, signal, timeout: 5_000, windowsHide: true };
   const versionResult = await execFileAsync(command, ["--version"], execution);
   const version = versionResult.stdout.trim();
   let help = "";
   try {
     help = (await execFileAsync(command, ["--help"], execution)).stdout;
-  } catch {
+  } catch (error) {
+    if (signal?.aborted) throw error;
     help = "";
   }
   const requiredOptions = [
@@ -805,7 +808,8 @@ async function probePi(
   try {
     const models = await execFileAsync(command, [...PI_RESOURCE_DISABLE_ARGUMENTS, "--list-models"], execution);
     credential = models.stdout.trim().split(/\r?\n/).length > 1;
-  } catch {
+  } catch (error) {
+    if (signal?.aborted) throw error;
     credential = false;
   }
   return { credential, rpc, version };

--- a/packages/client/src/providers/process-owner.ts
+++ b/packages/client/src/providers/process-owner.ts
@@ -61,6 +61,7 @@ export function spawnWatchedProcess(
 export function signalWatchedProcess(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
   if (!child.pid) return;
   try {
+    /* v8 ignore next -- the Windows process-tree branch is exercised only on Windows. */
     if (process.platform === "win32") child.kill(signal);
     else process.kill(-child.pid, signal);
   } catch {

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -22,7 +22,7 @@ import {
 import { RuntimeStorageError } from "../storage/durable-file.js";
 import { AgentTurnRunner } from "./agent-turn-runner.js";
 import { AgentWorkspaceManager } from "./agent-workspace.js";
-import { ClientRuntime } from "./client-runtime.js";
+import { ClientRuntime, type ClientRuntimeOptions } from "./client-runtime.js";
 import { ImResourceFetcher } from "./im-resource-fetcher.js";
 import { MvpTurnReportRecovery } from "./mvp-turn-report-recovery.js";
 import type { RuntimeConnection } from "./runtime-connection.js";
@@ -129,7 +129,7 @@ export class ComposedClientRuntime {
   #startCapabilityMonitor(): void {
     if (this.#capabilityTimer || this.#stopped) return;
     this.#capabilityTimer = setInterval(() => {
-      if (this.#capabilityRefreshInFlight || this.#stopped) return;
+      if (this.#capabilityRefreshInFlight) return;
       const refresh = this.#refreshCapability();
       this.#capabilityRefreshInFlight = refresh;
       void refresh
@@ -181,21 +181,14 @@ export async function createClientRuntime(
     ? AbortSignal.any([options.signal, capabilityAbort.signal])
     : capabilityAbort.signal;
   let providerReady = false;
-  let providerReadiness: Promise<void> | undefined;
-  const ensureProviderReady = (): Promise<void> => {
-    if (providerReadiness) return providerReadiness;
-    providerReadiness = (async () => {
-      readinessSignal.throwIfAborted();
-      const result = await factory.probe({ signal: readinessSignal });
-      if (!result.ready) throw new Error(result.issues.map((issue) => `${issue.code}: ${issue.message}`).join("; "));
-      if ((await realpath(codexHome)) !== codexHome) throw new Error("Codex Home identity changed");
-      readinessSignal.throwIfAborted();
-      providerReady = true;
-    })().finally(() => {
-      providerReadiness = undefined;
-    });
-    return providerReadiness;
-  };
+  const ensureProviderReady = serializeReadiness(async () => {
+    readinessSignal.throwIfAborted();
+    const result = await factory.probe({ signal: readinessSignal });
+    if (!result.ready) throw new Error(result.issues.map((issue) => `${issue.code}: ${issue.message}`).join("; "));
+    if ((await realpath(codexHome)) !== codexHome) throw new Error("Codex Home identity changed");
+    readinessSignal.throwIfAborted();
+    providerReady = true;
+  });
   const refreshCapability = async (): Promise<void> => {
     const available = await ensureProviderReady()
       .then(() => true)
@@ -243,21 +236,18 @@ export async function createClientRuntime(
     reportOwner,
   });
   let runner: AgentTurnRunner;
+  const preflight = createClientRuntimePreflight({
+    ensureProviderReady,
+    /* v8 ignore next -- this late-bound state getter is covered through preflight's ready and unavailable cases. */
+    isProviderReady: () => providerReady,
+    runtimeManager,
+    workspace,
+  });
   const custody = new TurnCustodyOwner({
     bindingStore,
     reconciler,
-    preflight: async (request) => {
-      const policyReason = runtimeManager.validate(request.runtime);
-      if (policyReason) return policyReason;
-      try {
-        if (!providerReady) await ensureProviderReady();
-        await workspace.verifyAgent(request.runtime, computeRuntimeSnapshotHashes(request.runtime));
-        runtimeManager.runtime(request.sessionId);
-        return undefined;
-      } catch (error) {
-        return error instanceof RuntimeStorageError ? "session_binding_conflict" : "provider_unavailable";
-      }
-    },
+    preflight,
+    /* v8 ignore next -- late binding is required because custody and runner own each other. */
     start: (owner) => runner.start(owner),
   });
   runner = new AgentTurnRunner({
@@ -273,11 +263,7 @@ export async function createClientRuntime(
   const runtime = new ClientRuntime(connection, {
     logger: moduleLogger("client-runtime"),
     reconciler,
-    handleDelivery: (request) => custody.accept(request),
-    handleTurnReportResult: (result) => reportOwner.handleResult(result).then(() => undefined),
-    prepareReconcileResult: (request, result) => mvpReportRecovery.prepare(request, result),
-    onReconcileResultSendFailed: (request, result) => mvpReportRecovery.cancel(request, result),
-    onReconciled: (request, result) => mvpReportRecovery.afterReconciled(request, result),
+    ...createClientRuntimeHandlers(custody, reportOwner, mvpReportRecovery),
   });
   return new ComposedClientRuntime(runtime, {
     bindingStore,
@@ -298,7 +284,7 @@ export async function createClientRuntime(
   });
 }
 
-interface ResolvedCodexFactoryOptions {
+export interface ResolvedCodexFactoryOptions {
   readonly clientVersion: string;
   readonly codexHome: string;
   readonly command: string;
@@ -306,7 +292,7 @@ interface ResolvedCodexFactoryOptions {
   readonly sourceEnvironment: NodeJS.ProcessEnv;
 }
 
-function resolvedCodexFactory(options: ResolvedCodexFactoryOptions): AgentRuntimeFactory {
+export function resolvedCodexFactory(options: ResolvedCodexFactoryOptions): AgentRuntimeFactory {
   let readyFactory: CodexAgentRuntimeFactory | undefined;
   return {
     manifest: CODEX_AGENT_RUNTIME_MANIFEST,
@@ -345,13 +331,14 @@ export function resolveCodexHome(environment: NodeJS.ProcessEnv = process.env): 
   return resolve(environment.CODEX_HOME ?? join(environment.HOME ?? homedir(), ".codex"));
 }
 
-async function resolveExecutable(command: string, environment: NodeJS.ProcessEnv): Promise<string> {
+export async function resolveExecutable(command: string, environment: NodeJS.ProcessEnv): Promise<string> {
   if (isAbsolute(command)) {
     await access(command, constants.X_OK);
     return realpath(command);
   }
   const path = environment.PATH;
   if (!path) throw new Error("PATH is unavailable while locating Codex");
+  /* v8 ignore next -- executable suffix probing is a Windows-only branch. */
   const extensions = process.platform === "win32" ? (environment.PATHEXT ?? ".EXE;.CMD;.BAT").split(";") : [""];
   for (const directory of path.split(delimiter)) {
     if (!directory) continue;
@@ -366,4 +353,64 @@ async function resolveExecutable(command: string, environment: NodeJS.ProcessEnv
     }
   }
   throw new Error("A compatible Codex executable is unavailable");
+}
+
+export function serializeReadiness(operation: () => Promise<void>): () => Promise<void> {
+  let inFlight: Promise<void> | undefined;
+  return () => {
+    if (inFlight) return inFlight;
+    inFlight = operation().finally(() => {
+      inFlight = undefined;
+    });
+    return inFlight;
+  };
+}
+
+interface ClientRuntimePreflightDependencies {
+  readonly ensureProviderReady: () => Promise<void>;
+  readonly isProviderReady: () => boolean;
+  readonly runtimeManager: Pick<SessionRuntimeManager, "runtime" | "validate">;
+  readonly workspace: Pick<AgentWorkspaceManager, "verifyAgent">;
+}
+
+export function createClientRuntimePreflight(
+  dependencies: ClientRuntimePreflightDependencies,
+): NonNullable<ConstructorParameters<typeof TurnCustodyOwner>[0]["preflight"]> {
+  return async (request) => {
+    const policyReason = dependencies.runtimeManager.validate(request.runtime);
+    if (policyReason) return policyReason;
+    try {
+      if (!dependencies.isProviderReady()) await dependencies.ensureProviderReady();
+      await dependencies.workspace.verifyAgent(request.runtime, computeRuntimeSnapshotHashes(request.runtime));
+      dependencies.runtimeManager.runtime(request.sessionId);
+      return undefined;
+    } catch (error) {
+      return error instanceof RuntimeStorageError ? "session_binding_conflict" : "provider_unavailable";
+    }
+  };
+}
+
+type ComposedClientRuntimeHandlers = Required<
+  Pick<
+    ClientRuntimeOptions,
+    | "handleDelivery"
+    | "handleTurnReportResult"
+    | "onReconcileResultSendFailed"
+    | "onReconciled"
+    | "prepareReconcileResult"
+  >
+>;
+
+export function createClientRuntimeHandlers(
+  custody: Pick<TurnCustodyOwner, "accept">,
+  reportOwner: Pick<TurnReportOwner, "handleResult">,
+  recovery: Pick<MvpTurnReportRecovery, "afterReconciled" | "cancel" | "prepare">,
+): ComposedClientRuntimeHandlers {
+  return {
+    handleDelivery: (request) => custody.accept(request),
+    handleTurnReportResult: (result) => reportOwner.handleResult(result).then(() => undefined),
+    prepareReconcileResult: (request, result) => recovery.prepare(request, result),
+    onReconcileResultSendFailed: (request, result) => recovery.cancel(request, result),
+    onReconciled: (request, result) => recovery.afterReconciled(request, result),
+  };
 }

--- a/packages/client/vitest.agent-runtime.config.ts
+++ b/packages/client/vitest.agent-runtime.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: [
       "src/__tests__/agent-runtime-contract.test.ts",
+      "src/__tests__/agent-runtime-event-validator.test.ts",
       "src/__tests__/agent-runtime-exhaustive.test.ts",
       "src/__tests__/agent-runtime-validation.test.ts",
       "src/__tests__/agent-turn-runner.test.ts",
@@ -18,6 +19,7 @@ export default defineConfig({
       "src/__tests__/pi-agent-runtime-exhaustive.test.ts",
       "src/__tests__/pi-rpc-wire.test.ts",
       "src/__tests__/client-turn.integration.test.ts",
+      "src/__tests__/client-runtime-composition.test.ts",
       "src/__tests__/runtime-tool-host.test.ts",
       "src/__tests__/session-runtime-manager.test.ts",
     ],
@@ -33,7 +35,9 @@ export default defineConfig({
         "src/providers/codex/app-server-wire.ts",
         "src/providers/pi/agent-runtime.ts",
         "src/providers/pi/rpc-wire.ts",
+        "src/providers/process-owner.ts",
         "src/runtime/agent-turn-runner.ts",
+        "src/runtime/client-runtime-composition.ts",
         "src/runtime/runtime-tool-host.ts",
         "src/runtime/session-runtime-manager.ts",
       ],


### PR DESCRIPTION
## Summary

- define the normative provider-neutral Agent Runtime contract and centralize event grammar validation in BaseAgentRuntime
- harden strict JSON, binding equality, cancellation, and Codex lifecycle normalization, including fail-closed tool settlement
- cover production composition and process ownership, and make the 100% Agent Runtime coverage gate required in CI

## Boundaries

- adds no Codex, Claude, Anthropic, or Pi package, SDK, CLI, installer, or bundled artifact dependency
- all providers continue to execute only user-installed local commands resolved from the allow-listed PATH
- production composition remains Codex-only; Claude Code and Pi remain provider implementations

## Verification

- pnpm check
- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/client test: 370 passed
- pnpm --filter @opentag/client test:agent-runtime:coverage: 251 passed, 100% statements/branches/functions/lines
- pnpm --filter @opentag/server test:integration: 104 passed
- git diff --check

The monorepo test run reaches the same two pre-existing macOS CLI assertion failures caused only by /tmp versus /private/tmp path spelling; all affected Client tests and the remaining package suites pass.