### PR TITLE
fix: handle leading-hyphen connect codes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
           }
           trap cleanup_runtime EXIT
           OPENTAG_HOME="$runtime_home" node apps/cli/dist/cli/index.mjs \
-            login "$connect_code" --server http://127.0.0.1:18000 --no-start
+            login --server http://127.0.0.1:18000 --no-start -- "$connect_code"
           test -f "$runtime_home/config/credentials.json"
           test ! -e "$runtime_home/config/computer.json"
           test ! -e "$runtime_home/data/computer.json"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -105,7 +105,7 @@ export OPENTAG_BOOTSTRAP_TEAM_DISPLAY_NAME=Example
 pnpm --filter @opentag/server bootstrap:admin
 ./scripts/dev-install.sh
 export PATH="$HOME/.local/bin${PATH:+:$PATH}"
-opentag-dev login <connect-code> --server http://127.0.0.1:8000
+opentag-dev login --server http://127.0.0.1:8000 -- <connect-code>
 ```
 
 The source checkout is the `dev` channel. `scripts/dev-install.sh` builds the complete workspace, links the configured

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -104,7 +104,7 @@ export OPENTAG_BOOTSTRAP_TEAM_DISPLAY_NAME=Example
 pnpm --filter @opentag/server bootstrap:admin
 ./scripts/dev-install.sh
 export PATH="$HOME/.local/bin${PATH:+:$PATH}"
-opentag-dev login <connect-code> --server http://127.0.0.1:8000
+opentag-dev login --server http://127.0.0.1:8000 -- <connect-code>
 ```
 
 源码 checkout 属于 `dev` channel。`scripts/dev-install.sh` 会构建完整 workspace，将 channel config 指定的 dev

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ export OPENTAG_BOOTSTRAP_TEAM_DISPLAY_NAME=Example
 pnpm --filter @opentag/server bootstrap:admin
 ./scripts/dev-install.sh
 export PATH="$HOME/.local/bin${PATH:+:$PATH}"
-opentag-dev login <connect-code> --server http://127.0.0.1:8000
+opentag-dev login --server http://127.0.0.1:8000 -- <connect-code>
 opentag-dev daemon status
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,7 +46,7 @@ export OPENTAG_BOOTSTRAP_TEAM_DISPLAY_NAME=Example
 pnpm --filter @opentag/server bootstrap:admin
 ./scripts/dev-install.sh
 export PATH="$HOME/.local/bin${PATH:+:$PATH}"
-opentag-dev login <connect-code> --server http://127.0.0.1:8000
+opentag-dev login --server http://127.0.0.1:8000 -- <connect-code>
 opentag-dev daemon status
 ```
 

--- a/apps/cli/src/__tests__/login.test.ts
+++ b/apps/cli/src/__tests__/login.test.ts
@@ -2,8 +2,9 @@ import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { credentialsPath, readCredentials, resolveComputerIdentity } from "@opentag/client";
+import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { executeLoginCommand } from "../commands/login.js";
+import { executeLoginCommand, registerLoginCommand } from "../commands/login.js";
 import { runLogin } from "../core/auth/login.js";
 import { LoginServiceInstallError, runLoginWithService } from "../core/auth/login-service.js";
 import type { DaemonServiceManager } from "../core/daemon/service/index.js";
@@ -15,6 +16,31 @@ afterEach(async () => {
 });
 
 describe("runLogin", () => {
+  it("parses a leading-hyphen connect code after the option terminator", async () => {
+    const login = vi.fn().mockResolvedValue({ credentialsPath: "/private/credentials.json", message: "Logged in" });
+    const program = new Command().name("opentag").exitOverride();
+    registerLoginCommand(program, { login, writeOutput: vi.fn() });
+
+    await program.parseAsync([
+      "node",
+      "opentag",
+      "login",
+      "--server",
+      "https://opentag.example",
+      "--no-start",
+      "--",
+      "-R5hUHv2GVEjyiKiBLCyzgi-yef7_tQ5",
+    ]);
+
+    expect(login).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "-R5hUHv2GVEjyiKiBLCyzgi-yef7_tQ5",
+        noStart: true,
+        serverUrl: "https://opentag.example",
+      }),
+    );
+  });
+
   it("stores credentials without returning or printing secrets", async () => {
     const home = await mkdtemp(join(tmpdir(), "opentag-login-"));
     temporaryDirectories.push(home);

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -48,7 +48,7 @@ export async function executeLoginCommand(
   }
 }
 
-export function registerLoginCommand(program: Command): void {
+export function registerLoginCommand(program: Command, dependencies: LoginCommandDependencies = {}): void {
   program
     .command("login")
     .description("Exchange a one-time connect code and store private credentials")
@@ -57,6 +57,6 @@ export function registerLoginCommand(program: Command): void {
     .option("--home <path>", "OpenTag home directory")
     .option("--no-start", "store credentials without installing the daemon service")
     .action(async (code: string, options: LoginCommandOptions) => {
-      process.exitCode = await executeLoginCommand(code, options);
+      process.exitCode = await executeLoginCommand(code, options, dependencies);
     });
 }

--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -186,7 +186,7 @@ describe("BrowserApi", () => {
       expect(init?.body).toBe(JSON.stringify({ teamId }));
       return new Response(
         JSON.stringify({
-          bootstrapCommand: `./scripts/dev-install.sh && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag-dev" login code --server http://127.0.0.1:8000`,
+          bootstrapCommand: `./scripts/dev-install.sh && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag-dev" login --server http://127.0.0.1:8000 -- code`,
           expiresIn: 900,
           issuedAt: "2030-01-01T00:00:00.000Z",
         }),

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -123,7 +123,7 @@ function installApi(
     if (path === "/api/v1/me/connect-codes" && init?.method === "POST") {
       return json(
         {
-          bootstrapCommand: "npm i -g @opentag/cli && opentag login --code example",
+          bootstrapCommand: "npm i -g @opentag/cli && opentag login --server https://opentag.example.com -- example",
           expiresIn: 900,
           issuedAt: "2026-08-20T00:00:00.000Z",
         },
@@ -382,7 +382,7 @@ describe("OpenTag Web App Shell", () => {
     const button = await screen.findByRole("button", { name: "Generate connection command" });
     expect(vi.mocked(fetch).mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
     fireEvent.click(button);
-    expect(await screen.findByText(/opentag login --code example/)).toBeTruthy();
+    expect(await screen.findByText(/opentag login --server https:\/\/opentag\.example\.com -- example/)).toBeTruthy();
   });
 
   it("guides Agent creation to Computer setup when none is connected", async () => {

--- a/packages/server/src/__tests__/auth-api.test.ts
+++ b/packages/server/src/__tests__/auth-api.test.ts
@@ -152,7 +152,7 @@ describe("auth HTTP API", () => {
     expect(response.headers["cache-control"]).toBe("no-store");
     expect(response.json()).toEqual({
       bootstrapCommand:
-        "npm i -g open-tag-staging && opentag-staging login short_lived_code --server https://dev.example.com",
+        "npm i -g open-tag-staging && opentag-staging login --server https://dev.example.com -- short_lived_code",
       expiresIn: 900,
       issuedAt: "2030-01-01T00:00:00.000Z",
     });

--- a/packages/server/src/__tests__/connect-code-command.test.ts
+++ b/packages/server/src/__tests__/connect-code-command.test.ts
@@ -5,10 +5,10 @@ describe("buildConnectBootstrapCommand", () => {
   it.each([
     [
       "dev",
-      `./scripts/dev-install.sh && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag-dev" login code_123 --server http://127.0.0.1:8000`,
+      `./scripts/dev-install.sh && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag-dev" login --server http://127.0.0.1:8000 -- code_123`,
     ],
-    ["staging", "npm i -g open-tag-staging && opentag-staging login code_123 --server https://dev.example.com"],
-    ["prod", "npm i -g open-tag && opentag login code_123 --server https://opentag.example.com"],
+    ["staging", "npm i -g open-tag-staging && opentag-staging login --server https://dev.example.com -- code_123"],
+    ["prod", "npm i -g open-tag && opentag login --server https://opentag.example.com -- code_123"],
   ] as const)("builds the %s command from the shared channel config", (environment, expected) => {
     expect(
       buildConnectBootstrapCommand({
@@ -32,7 +32,7 @@ describe("buildConnectBootstrapCommand", () => {
       publicUrl: "https://dev.example.com",
     });
     expect(command).toBe(
-      "npm i -g open-tag-staging && opentag-staging login 'code'\\''; echo injected' --server https://dev.example.com",
+      "npm i -g open-tag-staging && opentag-staging login --server https://dev.example.com -- 'code'\\''; echo injected'",
     );
     expect(command.slice(0, command.indexOf("&&"))).not.toContain("code");
   });
@@ -44,7 +44,7 @@ describe("buildConnectBootstrapCommand", () => {
       publicUrl: "http://127.0.0.1:8000",
     });
     expect(command).toBe(
-      `./scripts/dev-install.sh && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag-dev" login 'code'\\''; echo injected' --server http://127.0.0.1:8000`,
+      `./scripts/dev-install.sh && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag-dev" login --server http://127.0.0.1:8000 -- 'code'\\''; echo injected'`,
     );
     expect(command.slice(0, command.indexOf("login"))).not.toContain("code");
   });

--- a/packages/server/src/services/auth/connect-code-service.ts
+++ b/packages/server/src/services/auth/connect-code-service.ts
@@ -34,7 +34,7 @@ export function buildConnectBootstrapCommand(options: {
   publicUrl: string;
 }): string {
   const channel = getChannelConfig(options.environment);
-  const loginArgs = `login ${shellArg(options.code)} --server ${shellArg(options.publicUrl)}`;
+  const loginArgs = `login --server ${shellArg(options.publicUrl)} -- ${shellArg(options.code)}`;
   if (options.environment === "dev") {
     if (!SAFE_SHELL_ARG_PATTERN.test(channel.binName)) throw new TypeError("Invalid channel binary name");
     return `./scripts/dev-install.sh && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/${channel.binName}" ${loginArgs}`;

--- a/packages/shared/src/__tests__/auth.test.ts
+++ b/packages/shared/src/__tests__/auth.test.ts
@@ -32,7 +32,7 @@ describe("auth contracts", () => {
 
   it("accepts only the server-authored connect command contract", () => {
     const response = {
-      bootstrapCommand: "npm i -g open-tag && opentag login code --server https://opentag.example.com",
+      bootstrapCommand: "npm i -g open-tag && opentag login --server https://opentag.example.com -- code",
       expiresIn: 900,
       issuedAt: "2030-01-01T00:00:00.000Z",
     };


### PR DESCRIPTION
## Summary

- place login options before Commander's option terminator so one-time connect codes beginning with `-` remain positional arguments
- update server-generated bootstrap commands, Container Smoke, and user-facing command examples
- add parser-level regression coverage and align existing command fixtures with the supported CLI contract

## Testing

- `pnpm build`
- `pnpm check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm --filter @opentag/client test:agent-runtime:coverage`
- targeted CLI, server, shared, and Web tests
- `git diff --check`

Browser E2E was intentionally skipped per the task owner's instruction.
