### PR TITLE
feat(web): manage Team member roles

### DIFF
--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ApiError, BrowserApi } from "../api.js";
 
 const teamId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
+const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 
 function setDocumentCookie(value: string): void {
   const setter = Object.getOwnPropertyDescriptor(Document.prototype, "cookie")?.set;
@@ -10,6 +11,36 @@ function setDocumentCookie(value: string): void {
 }
 
 describe("BrowserApi", () => {
+  it("updates a Team member role with the browser mutation contract", async () => {
+    setDocumentCookie("opentag_csrf=member-csrf; Path=/");
+    const updatedMember = {
+      teamId,
+      userId,
+      email: "ada@example.com",
+      displayName: "Ada",
+      role: "member" as const,
+      status: "active" as const,
+      createdAt: "2030-01-01T00:00:00.000Z",
+      updatedAt: "2030-01-01T00:01:00.000Z",
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      expect(String(input)).toBe(`/api/v1/teams/${teamId}/members/${userId}`);
+      expect(init?.method).toBe("PATCH");
+      expect(init?.body).toBe(JSON.stringify({ role: "member" }));
+      expect(new Headers(init?.headers).get("content-type")).toBe("application/json");
+      expect(new Headers(init?.headers).get("X-OpenTag-CSRF")).toBe("member-csrf");
+      return new Response(JSON.stringify(updatedMember), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    await expect(new BrowserApi(fetchImpl).updateTeamMember(teamId, userId, { role: "member" })).resolves.toEqual(
+      updatedMember,
+    );
+    setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
+  });
+
   it("updates Team profile fields with the browser mutation contract", async () => {
     setDocumentCookie("opentag_csrf=team-csrf; Path=/");
     const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -5,6 +5,8 @@ import { App } from "../app.js";
 const teamId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
 const invitedTeamId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
+const memberUserId = "63e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
+const otherMemberUserId = "73e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const computerId = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const invitationToken = "A".repeat(43);
@@ -34,11 +36,16 @@ function installApi(
     invitationExists?: boolean;
     provider?: "feishu" | "slack";
     redeemFails?: boolean;
+    roleUpdate?: (targetUserId: string, role: "admin" | "member") => Promise<Response> | Response;
+    roleUpdateFails?: boolean;
     scopeReauth?: boolean;
     unauthenticated?: boolean;
   } = {},
 ) {
   const teamProfile = { name: "example", displayName: "Example" };
+  let currentRole = role;
+  let memberRole: "admin" | "member" = "member";
+  let otherMemberRole: "admin" | "member" = "member";
   let invitationExists = options.invitationExists ?? false;
   let invitationVersion: "A" | "B" = "A";
   let joinedInvitation = options.alreadyJoinedInvitation ?? false;
@@ -58,7 +65,7 @@ function installApi(
       return json({
         user: { id: userId, email: "ada@example.com", displayName: "Ada" },
         memberships: [
-          { teamId, teamName: teamProfile.name, teamDisplayName: teamProfile.displayName, role },
+          { teamId, teamName: teamProfile.name, teamDisplayName: teamProfile.displayName, role: currentRole },
           ...(joinedInvitation
             ? [
                 {
@@ -89,7 +96,41 @@ function installApi(
       });
     }
     if (path === `/api/v1/teams/${teamId}/members`) {
-      return json({ members: [{ userId, displayName: "Ada", role }] });
+      return json({
+        members: [
+          { userId, displayName: "Ada", role: currentRole },
+          { userId: memberUserId, displayName: "Grace", role: memberRole },
+          { userId: otherMemberUserId, displayName: "Lin", role: otherMemberRole },
+        ],
+      });
+    }
+    if (path.startsWith(`/api/v1/teams/${teamId}/members/`) && init?.method === "PATCH") {
+      const targetUserId = path.slice(path.lastIndexOf("/") + 1);
+      const body = JSON.parse(String(init.body)) as { role: "admin" | "member" };
+      const response = options.roleUpdate
+        ? await options.roleUpdate(targetUserId, body.role)
+        : options.roleUpdateFails
+          ? json({ error: { message: "The last active Team admin cannot be demoted" } }, 409)
+          : json({
+              teamId,
+              userId: targetUserId,
+              email:
+                targetUserId === userId
+                  ? "ada@example.com"
+                  : targetUserId === memberUserId
+                    ? "grace@example.com"
+                    : "lin@example.com",
+              displayName: targetUserId === userId ? "Ada" : targetUserId === memberUserId ? "Grace" : "Lin",
+              role: body.role,
+              status: "active",
+              createdAt: "2026-08-20T00:00:00.000Z",
+              updatedAt: "2026-08-20T00:01:00.000Z",
+            });
+      if (!response.ok) return response;
+      if (targetUserId === userId) currentRole = body.role;
+      if (targetUserId === memberUserId) memberRole = body.role;
+      if (targetUserId === otherMemberUserId) otherMemberRole = body.role;
+      return response;
     }
     if (path === `/api/v1/teams/${teamId}/invitation` && init?.method === undefined) {
       return invitationExists ? json(invitation()) : new Response(null, { status: 204 });
@@ -143,7 +184,7 @@ function installApi(
           409,
         );
       }
-      return json({ ...agentSummary, viewerCapabilities: { canManage: role === "admin" } });
+      return json({ ...agentSummary, viewerCapabilities: { canManage: currentRole === "admin" } });
     }
     if (path === `/api/v1/agents/${agentId}/config`) {
       return json({
@@ -332,6 +373,109 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Invite people" })).toBeNull();
+    expect(screen.queryByLabelText("Role for Ada")).toBeNull();
+    expect(await screen.findAllByText("member")).toHaveLength(3);
+  });
+
+  it("lets Team admins update another member role from the member list", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+    const role = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
+    fireEvent.change(role, { target: { value: "admin" } });
+    await waitFor(() => expect((screen.getByLabelText("Role for Grace") as HTMLSelectElement).value).toBe("admin"));
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      `/api/v1/teams/${teamId}/members/${memberUserId}`,
+      expect.objectContaining({ method: "PATCH", body: JSON.stringify({ role: "admin" }) }),
+    );
+  });
+
+  it("tracks overlapping role updates per member and prevents duplicate submissions", async () => {
+    let resolveGrace: (response: Response) => void = () => undefined;
+    let resolveLin: (response: Response) => void = () => undefined;
+    const graceUpdate = new Promise<Response>((resolve) => {
+      resolveGrace = resolve;
+    });
+    const linUpdate = new Promise<Response>((resolve) => {
+      resolveLin = resolve;
+    });
+    installApi("admin", {
+      roleUpdate: (targetUserId) => (targetUserId === memberUserId ? graceUpdate : linUpdate),
+    });
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+    const graceRole = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
+    const linRole = screen.getByLabelText("Role for Lin") as HTMLSelectElement;
+
+    fireEvent.change(graceRole, { target: { value: "admin" } });
+    fireEvent.change(linRole, { target: { value: "admin" } });
+    fireEvent.change(graceRole, { target: { value: "admin" } });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Role for Grace") as HTMLSelectElement).disabled).toBe(true);
+      expect((screen.getByLabelText("Role for Lin") as HTMLSelectElement).disabled).toBe(true);
+    });
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.filter(
+          ([input, init]) => String(input).endsWith(`/members/${memberUserId}`) && init?.method === "PATCH",
+        ),
+    ).toHaveLength(1);
+
+    resolveGrace(
+      json({
+        teamId,
+        userId: memberUserId,
+        email: "grace@example.com",
+        displayName: "Grace",
+        role: "admin",
+        status: "active",
+        createdAt: "2026-08-20T00:00:00.000Z",
+        updatedAt: "2026-08-20T00:01:00.000Z",
+      }),
+    );
+    await waitFor(() => {
+      expect((screen.getByLabelText("Role for Grace") as HTMLSelectElement).disabled).toBe(false);
+      expect((screen.getByLabelText("Role for Lin") as HTMLSelectElement).disabled).toBe(true);
+    });
+
+    resolveLin(
+      json({
+        teamId,
+        userId: otherMemberUserId,
+        email: "lin@example.com",
+        displayName: "Lin",
+        role: "admin",
+        status: "active",
+        createdAt: "2026-08-20T00:00:00.000Z",
+        updatedAt: "2026-08-20T00:01:00.000Z",
+      }),
+    );
+    await waitFor(() => expect((screen.getByLabelText("Role for Lin") as HTMLSelectElement).disabled).toBe(false));
+  });
+
+  it("refreshes current membership authority after an admin demotes themself", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+    fireEvent.change(await screen.findByLabelText("Role for Ada"), { target: { value: "member" } });
+    await waitFor(() =>
+      expect(vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/v1/me")).toHaveLength(2),
+    );
+    expect(await screen.findByText("Member · read only")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Invite people" })).toBeNull();
+    expect(screen.queryByLabelText("Role for Ada")).toBeNull();
+  });
+
+  it("keeps the confirmed role and displays the server error when an update is rejected", async () => {
+    installApi("admin", { roleUpdateFails: true });
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+    const role = (await screen.findByLabelText("Role for Ada")) as HTMLSelectElement;
+    fireEvent.change(role, { target: { value: "member" } });
+    expect((await screen.findByRole("alert")).textContent).toBe("The last active Team admin cannot be demoted");
+    expect(role.value).toBe("admin");
   });
 
   it("does not create an IM setup attempt while rendering Agent detail", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -43,6 +43,8 @@ import {
   MeResponseSchema,
   type TeamInvitation,
   TeamInvitationSchema,
+  type TeamMemberAdminConfig,
+  TeamMemberAdminConfigSchema,
   type TeamProfile,
   TeamProfileSchema,
   teamAgentsPath,
@@ -50,8 +52,10 @@ import {
   teamComputersPath,
   teamInvitationPath,
   teamInvitationRotatePath,
+  teamMemberPath,
   teamMembersPath,
   type UpdateAgentRequest,
+  type UpdateTeamMemberRequest,
   type UpdateTeamProfileRequest,
 } from "@opentag/shared/browser";
 
@@ -84,6 +88,14 @@ export class BrowserApi {
 
   members(teamId: string): Promise<ListTeamMembersResponse> {
     return this.request(teamMembersPath(teamId), ListTeamMembersResponseSchema);
+  }
+
+  updateTeamMember(teamId: string, userId: string, input: UpdateTeamMemberRequest): Promise<TeamMemberAdminConfig> {
+    return this.request(teamMemberPath(teamId, userId), TeamMemberAdminConfigSchema, {
+      method: "PATCH",
+      body: JSON.stringify(input),
+      headers: { "content-type": "application/json", ...this.csrfHeaders() },
+    });
   }
 
   updateTeam(teamId: string, input: UpdateTeamProfileRequest): Promise<TeamProfile> {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -11,6 +11,7 @@ import type {
   TeamMemberSummary,
   UpdateAgentRuntimeConfig,
 } from "@opentag/shared/browser";
+import { MembershipRoleSchema } from "@opentag/shared/browser";
 import { toString as qrToString } from "qrcode";
 import {
   createContext,
@@ -804,7 +805,7 @@ function AccessTab({ agent }: { agent: AgentDetail }) {
 
 function SettingsPage() {
   const { section = "team" } = useParams();
-  const { membership, refreshMe } = useTeam();
+  const { me, membership, refreshMe } = useTeam();
   const allowed = ["team", "computers", "resources", "members", "security"];
   if (!allowed.includes(section)) return <NotFoundPage />;
   return (
@@ -818,7 +819,12 @@ function SettingsPage() {
       </nav>
       {section === "team" ? <TeamSettings membership={membership} refreshMe={refreshMe} /> : null}
       {section === "members" ? (
-        <MembersSettings canManage={membership.role === "admin"} teamId={membership.teamId} />
+        <MembersSettings
+          canManage={membership.role === "admin"}
+          currentUserId={me.user.id}
+          refreshMe={refreshMe}
+          teamId={membership.teamId}
+        />
       ) : null}
       {section === "computers" ? (
         <ComputersSettings canManage={membership.role === "admin"} teamId={membership.teamId} />
@@ -881,8 +887,41 @@ function TeamSettings({ membership, refreshMe }: { membership: MeMembership; ref
   );
 }
 
-function MembersSettings({ canManage, teamId }: { canManage: boolean; teamId: string }) {
-  const state = useResource(() => browserApi.members(teamId), teamId);
+function MembersSettings({
+  canManage,
+  currentUserId,
+  refreshMe,
+  teamId,
+}: {
+  canManage: boolean;
+  currentUserId: string;
+  refreshMe: () => void;
+  teamId: string;
+}) {
+  const [revision, setRevision] = useState(0);
+  const state = useResource(() => browserApi.members(teamId), `${teamId}:${revision}`);
+  const pendingUserIdsRef = useRef(new Set<string>());
+  const [pendingUserIds, setPendingUserIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [error, setError] = useState<string>();
+
+  async function changeRole(member: TeamMemberSummary, value: string) {
+    if (value === member.role || pendingUserIdsRef.current.has(member.userId)) return;
+    pendingUserIdsRef.current.add(member.userId);
+    setPendingUserIds(new Set(pendingUserIdsRef.current));
+    setError(undefined);
+    try {
+      const role = MembershipRoleSchema.parse(value);
+      await browserApi.updateTeamMember(teamId, member.userId, { role });
+      setRevision((current) => current + 1);
+      if (member.userId === currentUserId) refreshMe();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Unable to update the member role");
+    } finally {
+      pendingUserIdsRef.current.delete(member.userId);
+      setPendingUserIds(new Set(pendingUserIdsRef.current));
+    }
+  }
+
   return (
     <>
       {canManage ? <InvitationSettings teamId={teamId} /> : null}
@@ -894,12 +933,32 @@ function MembersSettings({ canManage, teamId }: { canManage: boolean; teamId: st
               {value.members.map((member: TeamMemberSummary) => (
                 <div className="row" key={member.userId}>
                   <strong>{member.displayName}</strong>
-                  <span>{member.role}</span>
+                  {canManage ? (
+                    <select
+                      aria-label={`Role for ${member.displayName}`}
+                      disabled={pendingUserIds.has(member.userId)}
+                      value={member.role}
+                      onChange={(event) => void changeRole(member, event.currentTarget.value)}
+                    >
+                      {MembershipRoleSchema.options.map((role) => (
+                        <option value={role} key={role}>
+                          {role}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <span>{member.role}</span>
+                  )}
                 </div>
               ))}
             </div>
           )}
         </AsyncState>
+        {error ? (
+          <p className="notice error" role="alert">
+            {error}
+          </p>
+        ) : null}
       </section>
     </>
   );


### PR DESCRIPTION
## Summary

- add the CSRF-protected browser API adapter for the existing Team member role update endpoint
- show `admin` / `member` roles in Settings → Members, with editable controls for Team admins and read-only roles for members
- reload server-confirmed member roles, refresh `/me` after self-role changes, and preserve the confirmed role when the server rejects an update

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage`
- `pnpm test:coverage`

Context Tree: https://github.com/first-tree-ai/first-tree-context/pull/965
