### PR TITLE
test(server): cover startup and IM boundaries

### DIFF
--- a/packages/server/src/__tests__/im-resource-api.test.ts
+++ b/packages/server/src/__tests__/im-resource-api.test.ts
@@ -1,0 +1,107 @@
+import { Readable } from "node:stream";
+import { runtimeImResourcePath } from "@opentag/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../app.js";
+import type { UserAuthService } from "../services/auth/index.js";
+
+const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
+const sessionId = "07a9192e-cb82-477a-a931-2c694e937012";
+const computerId = "e9f6f9f3-84e2-4448-bbe4-f933cbd5b68f";
+const instanceId = "fef187cf-0e5b-4c12-826a-c012e3a2b4cd";
+const imMessageId = "f7ca351d-337f-4c64-8aca-1ad5ab6fa7f2";
+const authorization = { authorization: "Bearer access" };
+const apps: ReturnType<typeof createApp>[] = [];
+
+afterEach(async () => Promise.all(apps.splice(0).map((app) => app.close())));
+
+function authService(): UserAuthService {
+  return {
+    exchangeConnectCode: vi.fn(),
+    refresh: vi.fn(),
+    getActiveUserById: vi.fn(),
+    getAuthenticatedUser: vi.fn().mockResolvedValue({
+      tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
+      me: {
+        user: { id: userId, email: "admin@example.com", displayName: "Admin" },
+        memberships: [],
+      },
+    }),
+  };
+}
+
+function resourceUrl(overrides: Partial<Parameters<typeof runtimeImResourcePath>[2]> = {}, ordinal = 2) {
+  return runtimeImResourcePath(imMessageId, ordinal, {
+    sessionId,
+    computerId,
+    instanceId,
+    placementGeneration: 7,
+    ...overrides,
+  });
+}
+
+function createResourceApp(resource: Record<string, unknown>) {
+  const resources = { open: vi.fn().mockResolvedValue(resource) };
+  const app = createApp({ authService: authService(), imResourceService: resources as never });
+  apps.push(app);
+  return { app, resources };
+}
+
+describe("IM resource HTTP API", () => {
+  it("passes the authenticated placement scope and returns safe resource metadata", async () => {
+    const { app, resources } = createResourceApp({
+      stream: Readable.from([Buffer.from("image")]),
+      kind: "image",
+      mediaType: "image/png",
+      sizeBytes: 5,
+      filename: "报告 图.png",
+    });
+
+    const response = await app.inject({ method: "GET", url: resourceUrl(), headers: authorization });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe("image");
+    expect(response.headers["content-type"]).toBe("image/png");
+    expect(response.headers["content-length"]).toBe("5");
+    expect(response.headers["content-disposition"]).toBe(
+      "attachment; filename*=UTF-8''%E6%8A%A5%E5%91%8A%20%E5%9B%BE.png",
+    );
+    expect(resources.open).toHaveBeenCalledWith(
+      userId,
+      { sessionId, computerId, instanceId, placementGeneration: 7 },
+      imMessageId,
+      2,
+    );
+  });
+
+  it("falls back to a safe media type and omits absent optional metadata", async () => {
+    const { app } = createResourceApp({
+      stream: Readable.from([Buffer.from("data")]),
+      kind: "file",
+      mediaType: "text/plain\r\nx-secret: leaked",
+    });
+
+    const response = await app.inject({ method: "GET", url: resourceUrl(), headers: authorization });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-type"]).toBe("application/octet-stream");
+    expect(response.headers["content-disposition"]).toBeUndefined();
+    expect(response.headers["content-length"]).toBeUndefined();
+  });
+
+  it.each([
+    ["invalid message id", resourceUrl().replace(imMessageId, "not-a-uuid")],
+    ["out-of-range ordinal", resourceUrl({}, 16)],
+    ["invalid placement generation", resourceUrl({ placementGeneration: 0 })],
+  ])("rejects %s before calling the resource service", async (_label, url) => {
+    const { app, resources } = createResourceApp({
+      stream: Readable.from([]),
+      kind: "file",
+    });
+
+    const response = await app.inject({ method: "GET", url, headers: authorization });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({ error: { code: "VALIDATION_ERROR", category: "validation" } });
+    expect(resources.open).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/__tests__/provider-adapter-resolver.test.ts
+++ b/packages/server/src/__tests__/provider-adapter-resolver.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImProviderAdapterResolver,
+  ProviderAdapterResolutionError,
+} from "../services/im-bindings/provider-adapter-resolver.js";
+
+const imBindingId = "6d93de68-ec32-4ac9-a41e-e96ed2d7dac0";
+
+function bindings() {
+  return {
+    getSlackConnectionMaterial: vi.fn(),
+    getFeishuConnectionMaterial: vi.fn(),
+  };
+}
+
+describe("IM provider adapter resolver", () => {
+  it("prefers matching Slack material without reading Feishu credentials", async () => {
+    const imBindings = bindings();
+    const postMessage = vi.fn().mockResolvedValue({ ok: true, ts: "1.2" });
+    imBindings.getSlackConnectionMaterial.mockResolvedValue({
+      imBindingId,
+      generation: 3,
+      appId: "A1",
+      teamId: "T1",
+      botUserId: "U1",
+      botAccessToken: "xoxb-current",
+      signingSecret: "signing-secret",
+      grantedScopes: ["chat:write"],
+    });
+    const resolve = createImProviderAdapterResolver({
+      imBindings: imBindings as never,
+      slackApi: { postMessage } as never,
+    });
+
+    const adapter = await resolve(imBindingId, 3);
+    await adapter.send({ conversationExternalId: "C1", fallbackText: "hello" });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      token: "xoxb-current",
+      channel: "C1",
+      text: "hello",
+      threadTs: undefined,
+    });
+    expect(imBindings.getFeishuConnectionMaterial).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a stale Slack generation without constructing another adapter", async () => {
+    const imBindings = bindings();
+    imBindings.getSlackConnectionMaterial.mockResolvedValue({
+      imBindingId,
+      generation: 4,
+      appId: "A1",
+      teamId: "T1",
+      botUserId: "U1",
+      botAccessToken: "xoxb-sensitive",
+      signingSecret: "signing-sensitive",
+      grantedScopes: [],
+    });
+    const createFeishuAdapter = vi.fn();
+    const resolve = createImProviderAdapterResolver({
+      imBindings: imBindings as never,
+      slackApi: {} as never,
+      createFeishuAdapter,
+    });
+
+    const failure = await resolve(imBindingId, 3).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(ProviderAdapterResolutionError);
+    expect(failure).toMatchObject({ name: "ProviderAdapterResolutionError", code: "IM_BINDING_GENERATION_STALE" });
+    expect(String(failure)).not.toContain("sensitive");
+    expect(createFeishuAdapter).not.toHaveBeenCalled();
+    expect(imBindings.getFeishuConnectionMaterial).not.toHaveBeenCalled();
+  });
+
+  it("falls back to matching Feishu material and passes only that binding's material", async () => {
+    const imBindings = bindings();
+    imBindings.getSlackConnectionMaterial.mockResolvedValue(undefined);
+    imBindings.getFeishuConnectionMaterial.mockResolvedValue({
+      imBindingId,
+      generation: 7,
+      appId: "cli_a1",
+      appSecret: "feishu-sensitive",
+      teamId: "tenant-1",
+      botOpenId: "ou_1",
+      teamBrand: "feishu",
+      grantedScopes: ["im:message"],
+    });
+    const adapter = { send: vi.fn() };
+    const createFeishuAdapter = vi.fn(() => adapter as never);
+    const resolve = createImProviderAdapterResolver({
+      imBindings: imBindings as never,
+      slackApi: {} as never,
+      createFeishuAdapter,
+    });
+
+    await expect(resolve(imBindingId, 7)).resolves.toBe(adapter);
+    expect(createFeishuAdapter).toHaveBeenCalledWith({
+      appId: "cli_a1",
+      appSecret: "feishu-sensitive",
+      teamId: "tenant-1",
+      teamBrand: "feishu",
+    });
+  });
+
+  it("fails closed for stale or unavailable Feishu material without exposing credentials", async () => {
+    const imBindings = bindings();
+    imBindings.getSlackConnectionMaterial.mockResolvedValue(undefined);
+    imBindings.getFeishuConnectionMaterial.mockResolvedValue({
+      imBindingId,
+      generation: 9,
+      appId: "cli_a1",
+      appSecret: "feishu-sensitive",
+      teamId: null,
+      botOpenId: "ou_1",
+      teamBrand: null,
+      grantedScopes: [],
+    });
+    const createFeishuAdapter = vi.fn();
+    const resolve = createImProviderAdapterResolver({
+      imBindings: imBindings as never,
+      slackApi: {} as never,
+      createFeishuAdapter,
+    });
+
+    const stale = await resolve(imBindingId, 8).catch((error: unknown) => error);
+    expect(stale).toMatchObject({
+      name: "ProviderAdapterResolutionError",
+      code: "IM_BINDING_GENERATION_STALE",
+    });
+    expect(String(stale)).not.toContain("feishu-sensitive");
+    expect(createFeishuAdapter).not.toHaveBeenCalled();
+
+    imBindings.getFeishuConnectionMaterial.mockResolvedValue(undefined);
+    const unavailable = await resolve(imBindingId, 8).catch((error: unknown) => error);
+    expect(unavailable).toMatchObject({
+      name: "ProviderAdapterResolutionError",
+      code: "IM_BINDING_ADAPTER_UNAVAILABLE",
+    });
+  });
+});

--- a/packages/server/src/__tests__/server-startup.test.ts
+++ b/packages/server/src/__tests__/server-startup.test.ts
@@ -1,0 +1,481 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  events: [] as string[],
+  config: {} as Record<string, unknown>,
+  app: undefined as unknown,
+  appOptions: undefined as unknown,
+  onClose: undefined as (() => Promise<void>) | undefined,
+  database: undefined as unknown,
+  selectedAgents: [] as Array<{ computerId: string }>,
+  sql: { end: vi.fn() },
+  parseServerConfig: vi.fn(),
+  migrateDatabase: vi.fn(),
+  verifyDatabaseMigrations: vi.fn(),
+  createDatabaseClient: vi.fn(),
+  createApp: vi.fn(),
+  registryCurrentInstanceId: vi.fn(),
+  registrySupports: vi.fn(),
+  imBindingOptions: undefined as unknown,
+  imBindingGetAgentComputerId: vi.fn(),
+  feishuConnectionOptions: undefined as unknown,
+  feishuConnectionStart: vi.fn(),
+  feishuConnectionStop: vi.fn(),
+  feishuSetupOptions: undefined as unknown,
+  feishuSetupStart: vi.fn(),
+  feishuSetupStop: vi.fn(),
+  workerOptions: undefined as unknown,
+  workerStart: vi.fn(),
+  workerStop: vi.fn(),
+  domainOptions: undefined as unknown,
+  outboundExecute: vi.fn(),
+  googleOptions: undefined as unknown,
+  devAuthArgs: undefined as unknown,
+  slackAdapterOptions: undefined as unknown,
+}));
+
+vi.mock("../app.js", () => ({ createApp: state.createApp }));
+vi.mock("../admin/bootstrap.js", () => ({ bootstrapInitialAdmin: vi.fn() }));
+vi.mock("../bootstrap-readiness.js", () => ({
+  BootstrapReadiness: class {
+    complete(stage: string) {
+      state.events.push(`ready:${stage}`);
+    }
+  },
+}));
+vi.mock("../config.js", () => ({
+  parseServerConfig: state.parseServerConfig,
+  isHostedEnvironment: vi.fn(() => true),
+  serverEnvironmentSummary: vi.fn(() => ({ environment: "prod" })),
+}));
+vi.mock("../db/client.js", () => ({ createDatabaseClient: state.createDatabaseClient }));
+vi.mock("../db/migrate.js", () => ({
+  MigrationVerificationError: class extends Error {},
+  migrateDatabase: state.migrateDatabase,
+  verifyDatabaseMigrations: state.verifyDatabaseMigrations,
+  withMigrationLock: vi.fn(),
+}));
+vi.mock("../runtime/connection-registry.js", () => ({
+  ConnectionRegistry: class {
+    currentInstanceId(computerId: string) {
+      return state.registryCurrentInstanceId(computerId);
+    }
+    supports(computerId: string, instanceId: string, capability: string) {
+      return state.registrySupports(computerId, instanceId, capability);
+    }
+  },
+  RuntimeRegistrySendError: class extends Error {},
+}));
+vi.mock("../runtime/im-delivery-worker.js", () => ({
+  ImDeliveryWorker: class {
+    constructor(options: unknown) {
+      state.workerOptions = options;
+    }
+    start() {
+      state.events.push("worker:start");
+      state.workerStart();
+    }
+    stop() {
+      state.events.push("worker:stop");
+      state.workerStop();
+    }
+  },
+}));
+vi.mock("../runtime/runtime-custody-store.js", () => ({ PostgresRuntimeCustodyStore: class {} }));
+vi.mock("../runtime/runtime-domain-owner.js", () => ({
+  RuntimeDomainConflictError: class extends Error {},
+  RuntimeDomainOwner: class {
+    constructor(_registry: unknown, _store: unknown, options: unknown) {
+      state.domainOptions = options;
+    }
+  },
+  RuntimeDomainRequestError: class extends Error {},
+}));
+vi.mock("../services/agents/index.js", () => ({ AgentService: class {}, AgentServiceError: class extends Error {} }));
+vi.mock("../services/auth/index.js", () => ({
+  AuthIdentityService: class {},
+  AuthService: class {},
+  AuthServiceError: class extends Error {},
+  AuthTokenService: class {},
+  ConnectCodeService: class {},
+  DefaultGoogleIdentityClient: class {},
+  DevBrowserAuthService: class {
+    constructor(...args: unknown[]) {
+      state.devAuthArgs = args;
+    }
+  },
+  formatStartupError: (error: unknown, knownSecrets: string[]) => {
+    let detail = error instanceof Error ? error.message : String(error);
+    for (const secret of knownSecrets) if (secret) detail = detail.replaceAll(secret, "[REDACTED]");
+    return detail;
+  },
+  GoogleBrowserAuthService: class {
+    constructor(options: unknown) {
+      state.googleOptions = options;
+    }
+  },
+  OAuthFlowService: class {},
+  PostAuthenticationService: class {},
+}));
+vi.mock("../services/computers/index.js", () => ({ ComputerService: class {} }));
+vi.mock("../services/crypto.js", () => ({ ApplicationCipher: class {} }));
+vi.mock("../services/im/index.js", () => ({
+  ImMessageInbox: class {},
+  ImResourceService: class {},
+  OutboundMessageService: class {
+    execute(input: unknown) {
+      return state.outboundExecute(input);
+    }
+  },
+}));
+vi.mock("../services/im-bindings/feishu/index.js", () => ({
+  DefaultFeishuRegistrationGateway: class {},
+  FeishuConnectionManager: class {
+    constructor(options: unknown) {
+      state.feishuConnectionOptions = options;
+    }
+    start() {
+      state.events.push("feishu-connections:start");
+      state.feishuConnectionStart();
+    }
+    async stop() {
+      state.events.push("feishu-connections:stop");
+      await state.feishuConnectionStop();
+    }
+  },
+  FeishuSetupService: class {
+    constructor(options: unknown) {
+      state.feishuSetupOptions = options;
+    }
+    start() {
+      state.events.push("feishu-setup:start");
+      state.feishuSetupStart();
+    }
+    async stop() {
+      state.events.push("feishu-setup:stop");
+      await state.feishuSetupStop();
+    }
+  },
+}));
+vi.mock("../services/im-bindings/index.js", () => ({
+  createImProviderAdapterResolver: vi.fn(() => vi.fn()),
+  ImBindingService: class {
+    constructor(_database: unknown, _cipher: unknown, options: unknown) {
+      state.imBindingOptions = options;
+    }
+    getAgentComputerId(agentId: string) {
+      return state.imBindingGetAgentComputerId(agentId);
+    }
+  },
+}));
+vi.mock("../services/im-bindings/slack/index.js", () => ({
+  DefaultSlackApiClient: class {},
+  SlackAdapter: class {
+    constructor(options: unknown) {
+      state.slackAdapterOptions = options;
+    }
+  },
+}));
+vi.mock("../services/invitations/index.js", () => ({ InvitationService: class {} }));
+vi.mock("../services/runtime-config/index.js", () => ({ EffectiveRuntimeSnapshotAssembler: class {} }));
+vi.mock("../services/teams/index.js", () => ({ TeamMembershipService: class {} }));
+vi.mock("../web-app.js", () => ({ defaultWebAppRoot: "/mock-web" }));
+
+import { startServer } from "../index.js";
+
+const originalSecrets = {
+  database: process.env.OPENTAG_DATABASE_URL,
+  jwt: process.env.OPENTAG_JWT_SECRET,
+  google: process.env.OPENTAG_GOOGLE_CLIENT_SECRET,
+  encryption: process.env.OPENTAG_ENCRYPTION_KEY,
+};
+const originalExitCode = process.exitCode;
+
+function defaultConfig() {
+  return {
+    accessTokenTtlSeconds: 900,
+    autoMigrate: true,
+    databaseUrl: "postgres://db-user:db-password@localhost/opentag",
+    encryptionKey: new Uint8Array(32),
+    channel: {
+      binName: "opentag",
+      channel: "prod",
+      defaultHome: "/tmp/opentag",
+      displayName: "OpenTag",
+      packageName: "@opentag/cli",
+      serviceId: "opentag",
+    },
+    environment: "prod",
+    devAuth: { email: "dev@example.com" },
+    google: { clientId: "google-client", clientSecret: "google-secret" },
+    host: "127.0.0.1",
+    jwtSecret: "jwt-secret",
+    migrationsDirectory: "/mock/migrations",
+    port: 8000,
+    publicUrl: "https://opentag.example.com",
+    refreshTokenTtlSeconds: 2_592_000,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.events.length = 0;
+  state.config = defaultConfig();
+  state.appOptions = undefined;
+  state.onClose = undefined;
+  state.selectedAgents = [{ computerId: "computer-1" }];
+  state.imBindingOptions = undefined;
+  state.feishuConnectionOptions = undefined;
+  state.feishuSetupOptions = undefined;
+  state.workerOptions = undefined;
+  state.domainOptions = undefined;
+  state.googleOptions = undefined;
+  state.devAuthArgs = undefined;
+  state.slackAdapterOptions = undefined;
+  state.sql = { end: vi.fn(async () => state.events.push("sql:end")) };
+  state.database = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => state.selectedAgents),
+        })),
+      })),
+    })),
+  };
+  state.parseServerConfig.mockImplementation(() => state.config);
+  state.migrateDatabase.mockImplementation(async () => state.events.push("migration:run"));
+  state.verifyDatabaseMigrations.mockImplementation(async () => state.events.push("migration:verify"));
+  state.createDatabaseClient.mockImplementation(() => ({ database: state.database, sql: state.sql }));
+  state.registryCurrentInstanceId.mockReturnValue("instance-1");
+  state.registrySupports.mockReturnValue(true);
+  state.imBindingGetAgentComputerId.mockResolvedValue("computer-1");
+  state.outboundExecute.mockResolvedValue({ status: "succeeded" });
+  const log = { info: vi.fn(), error: vi.fn() };
+  state.app = {
+    addHook: vi.fn((_name: string, hook: () => Promise<void>) => {
+      state.onClose = hook;
+    }),
+    listen: vi.fn(async () => state.events.push("listen")),
+    close: vi.fn(async () => {
+      state.events.push("app:close");
+      await state.onClose?.();
+    }),
+    log,
+  };
+  state.createApp.mockImplementation((options: unknown) => {
+    state.appOptions = options;
+    return state.app;
+  });
+  process.env.OPENTAG_DATABASE_URL = "postgres://db-user:db-password@localhost/opentag";
+  process.env.OPENTAG_JWT_SECRET = "jwt-secret";
+  process.env.OPENTAG_GOOGLE_CLIENT_SECRET = "google-secret";
+  process.env.OPENTAG_ENCRYPTION_KEY = "encryption-secret";
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  const restore = (key: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+  restore("OPENTAG_DATABASE_URL", originalSecrets.database);
+  restore("OPENTAG_JWT_SECRET", originalSecrets.jwt);
+  restore("OPENTAG_GOOGLE_CLIENT_SECRET", originalSecrets.google);
+  restore("OPENTAG_ENCRYPTION_KEY", originalSecrets.encryption);
+  process.exitCode = originalExitCode;
+});
+
+describe("Server startup", () => {
+  it("migrates before listen, wires runtime/auth/provider services, and cleans up in reverse ownership order", async () => {
+    await startServer();
+
+    expect(state.migrateDatabase).toHaveBeenCalledWith(state.config.databaseUrl, state.config.migrationsDirectory);
+    expect(state.verifyDatabaseMigrations).not.toHaveBeenCalled();
+    expect(state.events).toEqual([
+      "ready:configuration",
+      "migration:run",
+      "ready:migration",
+      "feishu-setup:start",
+      "feishu-connections:start",
+      "worker:start",
+      "ready:application",
+      "listen",
+      "ready:listen",
+    ]);
+
+    const appOptions = state.appOptions as {
+      browserAuth: { dev: unknown; google: unknown; secureCookies: boolean };
+      slackEvents: { createAdapter(binding: unknown): unknown };
+    };
+    expect(appOptions.browserAuth).toMatchObject({ secureCookies: true });
+    expect(appOptions.browserAuth.dev).toBeDefined();
+    expect(appOptions.browserAuth.google).toBeDefined();
+    expect(state.devAuthArgs).toEqual(expect.arrayContaining(["dev@example.com"]));
+    expect(state.googleOptions).toMatchObject({ publicUrl: state.config.publicUrl });
+
+    const slackBinding = {
+      botAccessToken: "xoxb-current",
+      appId: "A1",
+      teamId: "T1",
+      botUserId: "U1",
+    };
+    appOptions.slackEvents.createAdapter(slackBinding);
+    expect(state.slackAdapterOptions).toMatchObject({
+      appId: "A1",
+      teamId: "T1",
+      botUserId: "U1",
+      token: "xoxb-current",
+    });
+
+    const runtimeReady = (state.imBindingOptions as { runtimeReady(agentId: string): Promise<boolean> }).runtimeReady;
+    await expect(runtimeReady("agent-1")).resolves.toBe(true);
+    expect(state.registrySupports).toHaveBeenCalledWith("computer-1", "instance-1", "imMessageTool");
+    state.registrySupports.mockReturnValue(false);
+    await expect(runtimeReady("agent-1")).resolves.toBe(false);
+    state.registrySupports.mockReturnValue(true);
+    state.registryCurrentInstanceId.mockReturnValue(undefined);
+    await expect(runtimeReady("agent-1")).resolves.toBe(false);
+
+    const feishuRuntimeReady = (state.feishuConnectionOptions as { runtimeReady(agentId: string): Promise<boolean> })
+      .runtimeReady;
+    state.registryCurrentInstanceId.mockReturnValue("instance-1");
+    await expect(feishuRuntimeReady("agent-1")).resolves.toBe(true);
+    state.imBindingGetAgentComputerId.mockResolvedValue(undefined);
+    await expect(feishuRuntimeReady("agent-1")).resolves.toBe(false);
+
+    const onImToolRequest = (
+      state.domainOptions as {
+        onImToolRequest(request: Record<string, unknown>, context: Record<string, unknown>): Promise<unknown>;
+      }
+    ).onImToolRequest;
+    await expect(
+      onImToolRequest(
+        {
+          requestId: "request-1",
+          sessionId: "session-1",
+          agentId: "agent-1",
+          placementGeneration: 3,
+          expectedLatestImMessageId: "message-1",
+          operation: "send",
+          text: "hello",
+          replyToImMessageId: "reply-1",
+          targetImMessageId: "target-1",
+          emoji: "eyes",
+        },
+        { computerId: "computer-1", instanceId: "instance-1" },
+      ),
+    ).resolves.toMatchObject({ type: "im:tool:result", requestId: "request-1", status: "succeeded" });
+    expect(state.outboundExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        computerId: "computer-1",
+        computerInstanceId: "instance-1",
+        content: expect.objectContaining({ fallbackText: "hello" }),
+        replyToImMessageId: "reply-1",
+        targetImMessageId: "target-1",
+        emoji: "eyes",
+      }),
+    );
+
+    (state.workerOptions as { onDiagnostic(code: string): void }).onDiagnostic("IM_DELIVERY_FAILED");
+    expect((state.app as { log: { error: ReturnType<typeof vi.fn> } }).log.error).toHaveBeenCalledWith(
+      { code: "IM_DELIVERY_FAILED" },
+      "IM delivery worker diagnostic",
+    );
+
+    const app = state.app as { addHook: ReturnType<typeof vi.fn>; close(): Promise<void> };
+    expect(app.addHook).toHaveBeenCalledWith("onClose", expect.any(Function));
+    await app.close();
+    expect(state.events.slice(-5)).toEqual([
+      "app:close",
+      "worker:stop",
+      "feishu-setup:stop",
+      "feishu-connections:stop",
+      "sql:end",
+    ]);
+  });
+
+  it("verifies checked-in migrations before listening when auto-migrate is disabled", async () => {
+    state.config = { ...defaultConfig(), autoMigrate: false, google: undefined, devAuth: undefined };
+
+    await startServer();
+
+    expect(state.migrateDatabase).not.toHaveBeenCalled();
+    expect(state.verifyDatabaseMigrations).toHaveBeenCalledWith(
+      state.config.databaseUrl,
+      state.config.migrationsDirectory,
+    );
+    expect(state.events.indexOf("migration:verify")).toBeLessThan(state.events.indexOf("listen"));
+    const browserAuth = (state.appOptions as { browserAuth: { google?: unknown; dev?: unknown } }).browserAuth;
+    expect(browserAuth.google).toBeUndefined();
+    expect(browserAuth.dev).toBeUndefined();
+  });
+
+  it.each([
+    ["configuration", []],
+    ["migration", ["ready:configuration"]],
+  ])(
+    "fails during %s without announcing later readiness or exposing known secrets",
+    async (failureStage, expectedEvents) => {
+      const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      const failure = new Error(
+        "postgres://db-user:db-password@localhost/opentag jwt-secret google-secret encryption-secret",
+      );
+      if (failureStage === "configuration")
+        state.parseServerConfig.mockImplementation(() => {
+          throw failure;
+        });
+      else state.migrateDatabase.mockRejectedValue(failure);
+
+      await startServer();
+
+      expect(state.createApp).not.toHaveBeenCalled();
+      expect(state.events).toEqual(expectedEvents);
+      expect(process.exitCode).toBe(1);
+      const output = stderr.mock.calls.flat().join(" ");
+      expect(output).toContain("Failed to start OpenTag server");
+      for (const secret of [
+        "postgres://db-user:db-password@localhost/opentag",
+        "jwt-secret",
+        "google-secret",
+        "encryption-secret",
+      ]) {
+        expect(output).not.toContain(secret);
+      }
+      stderr.mockRestore();
+    },
+  );
+
+  it("logs a redacted post-creation failure and closes every started resource", async () => {
+    const app = state.app as {
+      listen: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
+      log: { error: ReturnType<typeof vi.fn> };
+    };
+    app.listen.mockRejectedValue(
+      new Error("postgres://db-user:db-password@localhost/opentag jwt-secret google-secret encryption-secret"),
+    );
+
+    await startServer();
+
+    expect(process.exitCode).toBe(1);
+    expect(app.close).toHaveBeenCalledTimes(1);
+    expect(state.events).not.toContain("ready:listen");
+    expect(state.events.slice(-5)).toEqual([
+      "app:close",
+      "worker:stop",
+      "feishu-setup:stop",
+      "feishu-connections:stop",
+      "sql:end",
+    ]);
+    const logged = JSON.stringify(app.log.error.mock.calls);
+    expect(logged).toContain("Failed to start OpenTag server");
+    for (const secret of [
+      "postgres://db-user:db-password@localhost/opentag",
+      "jwt-secret",
+      "google-secret",
+      "encryption-secret",
+    ]) {
+      expect(logged).not.toContain(secret);
+    }
+  });
+});

--- a/packages/server/src/__tests__/slack-events.test.ts
+++ b/packages/server/src/__tests__/slack-events.test.ts
@@ -1,0 +1,222 @@
+import { createHmac } from "node:crypto";
+import { Writable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../app.js";
+
+const now = new Date("2026-08-20T00:00:00.000Z");
+const timestamp = String(Math.floor(now.getTime() / 1000));
+const apps: ReturnType<typeof createApp>[] = [];
+
+afterEach(async () => Promise.all(apps.splice(0).map((app) => app.close())));
+
+function binding() {
+  return {
+    imBindingId: "6d93de68-ec32-4ac9-a41e-e96ed2d7dac0",
+    generation: 5,
+    appId: "A1",
+    teamId: "T1",
+    botUserId: "U_BOT",
+    botAccessToken: "xoxb-sensitive",
+    signingSecret: "signing-sensitive",
+  };
+}
+
+function signedRequest(envelope: Record<string, unknown>, signingSecret = binding().signingSecret) {
+  const payload = JSON.stringify(envelope);
+  const signature = `v0=${createHmac("sha256", signingSecret).update(`v0:${timestamp}:${payload}`).digest("hex")}`;
+  return {
+    method: "POST" as const,
+    url: "/api/v1/im-bindings/slack/events",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-slack-request-timestamp": timestamp,
+      "x-slack-signature": signature,
+    },
+  };
+}
+
+function createServices(overrides: Record<string, unknown> = {}, loggerStream?: Writable) {
+  const current = binding();
+  const imBindings = {
+    findSlackIngressBinding: vi.fn().mockResolvedValue(current),
+    disableFromProvider: vi.fn().mockResolvedValue(undefined),
+    requireReauthorization: vi.fn().mockResolvedValue(undefined),
+  };
+  const inbox = { ingest: vi.fn().mockResolvedValue(undefined) };
+  const adapter = { normalizeInbound: vi.fn().mockReturnValue([]) };
+  const createAdapter = vi.fn(() => adapter);
+  const app = createApp({
+    loggerStream,
+    slackEvents: {
+      now: () => now,
+      imBindings: imBindings as never,
+      inbox: inbox as never,
+      createAdapter: createAdapter as never,
+      ...overrides,
+    },
+  });
+  apps.push(app);
+  return { app, imBindings, inbox, adapter, createAdapter, current };
+}
+
+describe("Slack Events API ingress", () => {
+  it("rejects non-buffer and unroutable bodies before credential lookup", async () => {
+    const { app, imBindings } = createServices();
+    const nonBuffer = await app.inject({
+      method: "POST",
+      url: "/api/v1/im-bindings/slack/events",
+      headers: { "content-type": "text/plain" },
+      payload: "not-json",
+    });
+    expect(nonBuffer.statusCode).toBe(400);
+    expect(nonBuffer.json()).toEqual({ error: "invalid_body" });
+
+    const unroutable = await app.inject({
+      method: "POST",
+      url: "/api/v1/im-bindings/slack/events",
+      headers: { "content-type": "application/json" },
+      payload: JSON.stringify({ type: "event_callback" }),
+    });
+    expect(unroutable.statusCode).toBe(400);
+    expect(unroutable.json()).toEqual({ error: "invalid_route" });
+    expect(imBindings.findSlackIngressBinding).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing bindings, invalid signatures, and mismatched verified identities", async () => {
+    const missing = createServices();
+    missing.imBindings.findSlackIngressBinding.mockResolvedValue(undefined);
+    const envelope = { type: "url_verification", api_app_id: "A1", team_id: "T1", challenge: "ok" };
+    const missingResponse = await missing.app.inject(signedRequest(envelope));
+    expect(missingResponse.statusCode).toBe(404);
+
+    const invalid = createServices();
+    const invalidResponse = await invalid.app.inject(signedRequest(envelope, "wrong-secret"));
+    expect(invalidResponse.statusCode).toBe(401);
+    expect(invalidResponse.json()).toEqual({ error: "invalid_signature" });
+
+    const mismatched = createServices();
+    mismatched.imBindings.findSlackIngressBinding.mockResolvedValue({ ...binding(), appId: "A2" });
+    const mismatchResponse = await mismatched.app.inject(signedRequest(envelope));
+    expect(mismatchResponse.statusCode).toBe(401);
+    expect(mismatchResponse.json()).toEqual({ error: "binding_mismatch" });
+  });
+
+  it("validates URL verification and event callback envelope fields", async () => {
+    const { app } = createServices();
+    const invalidChallenge = await app.inject(
+      signedRequest({ type: "url_verification", api_app_id: "A1", team_id: "T1" }),
+    );
+    expect(invalidChallenge.statusCode).toBe(400);
+    expect(invalidChallenge.json()).toEqual({ error: "invalid_challenge" });
+
+    const unsupported = await app.inject(
+      signedRequest({ type: "event_callback", api_app_id: "A1", team_id: "T1", event_id: "Ev1" }),
+    );
+    expect(unsupported.statusCode).toBe(400);
+    expect(unsupported.json()).toEqual({ error: "unsupported_envelope" });
+  });
+
+  it("disables an uninstalled binding and fences Slack token revocation", async () => {
+    const { app, imBindings, current } = createServices();
+    const base = { type: "event_callback", api_app_id: "A1", team_id: "T1", event_id: "Ev1" };
+
+    await expect(app.inject(signedRequest({ ...base, event: { type: "app_uninstalled" } }))).resolves.toMatchObject({
+      statusCode: 200,
+    });
+    expect(imBindings.disableFromProvider).toHaveBeenCalledWith(current.imBindingId);
+
+    await app.inject(
+      signedRequest({ ...base, event_id: "Ev2", event: { type: "tokens_revoked", tokens: { bot: ["OTHER"] } } }),
+    );
+    expect(imBindings.requireReauthorization).not.toHaveBeenCalled();
+
+    await app.inject(
+      signedRequest({
+        ...base,
+        event_id: "Ev3",
+        event: { type: "tokens_revoked", tokens: { oauth: ["U_OTHER"], bot: [current.botUserId] } },
+      }),
+    );
+    expect(imBindings.requireReauthorization).toHaveBeenCalledWith(current.imBindingId, "SLACK_TOKEN_REVOKED");
+  });
+
+  it("ingests every normalized event with the verified binding generation", async () => {
+    const { app, adapter, inbox, createAdapter, current } = createServices();
+    const events = [{ providerEventId: "Ev1:1" }, { providerEventId: "Ev1:2" }];
+    adapter.normalizeInbound.mockReturnValue(events);
+    const envelope = {
+      type: "event_callback",
+      api_app_id: "A1",
+      team_id: "T1",
+      event_id: "Ev1",
+      event_time: 1_724_025_600,
+      event: { type: "app_mention", channel: "C1", text: "hello" },
+    };
+
+    const response = await app.inject(signedRequest(envelope));
+
+    expect(response.statusCode).toBe(200);
+    expect(createAdapter).toHaveBeenCalledWith(current);
+    expect(adapter.normalizeInbound).toHaveBeenCalledWith({
+      eventId: "Ev1",
+      appId: current.appId,
+      teamId: current.teamId,
+      botUserId: current.botUserId,
+      event: envelope.event,
+      eventTime: envelope.event_time,
+    });
+    expect(inbox.ingest.mock.calls).toEqual([
+      [current.imBindingId, current.generation, events[0]],
+      [current.imBindingId, current.generation, events[1]],
+    ]);
+  });
+
+  it.each(["adapter factory", "normalization", "inbox ingestion"])(
+    "does not expose credentials or raw provider failures from %s",
+    async (failurePoint) => {
+      let logs = "";
+      const loggerStream = new Writable({
+        write(chunk, _encoding, callback) {
+          logs += chunk.toString();
+          callback();
+        },
+      });
+      const { app, adapter, createAdapter, inbox } = createServices({}, loggerStream);
+      const failure = new Error("raw-provider-error xoxb-sensitive signing-sensitive");
+      if (failurePoint === "adapter factory")
+        createAdapter.mockImplementation(() => {
+          throw failure;
+        });
+      if (failurePoint === "normalization")
+        adapter.normalizeInbound.mockImplementation(() => {
+          throw failure;
+        });
+      if (failurePoint === "inbox ingestion") {
+        adapter.normalizeInbound.mockReturnValue([{ providerEventId: "Ev1" }]);
+        inbox.ingest.mockRejectedValue(failure);
+      }
+      const response = await app.inject(
+        signedRequest({
+          type: "event_callback",
+          api_app_id: "A1",
+          team_id: "T1",
+          event_id: "Ev1",
+          event: { type: "app_mention", text: "raw-request-body-detail" },
+        }),
+      );
+
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).toMatchObject({ error: { code: "INTERNAL_ERROR", category: "transient" } });
+      expect(response.body).not.toContain("raw-provider-error");
+      expect(response.body).not.toContain("xoxb-sensitive");
+      expect(response.body).not.toContain("signing-sensitive");
+      expect(response.body).not.toContain("raw-request-body-detail");
+      expect(logs).toContain("SLACK_EVENT_PROCESSING_FAILED");
+      expect(logs).not.toContain("raw-provider-error");
+      expect(logs).not.toContain("xoxb-sensitive");
+      expect(logs).not.toContain("signing-sensitive");
+      expect(logs).not.toContain("raw-request-body-detail");
+    },
+  );
+});

--- a/packages/server/src/api/slack-events.ts
+++ b/packages/server/src/api/slack-events.ts
@@ -15,6 +15,15 @@ interface SlackEnvelopeBase {
   event?: { type?: string; tokens?: { oauth?: string[]; bot?: string[] } } & Record<string, unknown>;
 }
 
+class SlackEventProcessingError extends Error {
+  readonly code = "SLACK_EVENT_PROCESSING_FAILED";
+
+  constructor() {
+    super("SLACK_EVENT_PROCESSING_FAILED");
+    this.name = "SlackEventProcessingError";
+  }
+}
+
 export interface SlackEventsRouteOptions {
   imBindings: ImBindingService;
   inbox: ImMessageInbox;
@@ -80,16 +89,20 @@ export function registerSlackEventsRoute(app: FastifyInstance, options: SlackEve
       return reply.code(200).send({ ok: true });
     }
 
-    const adapter = options.createAdapter(binding);
-    const events = adapter.normalizeInbound({
-      eventId: envelope.event_id,
-      appId: binding.appId,
-      teamId: binding.teamId,
-      botUserId: binding.botUserId,
-      event: envelope.event,
-      eventTime: envelope.event_time,
-    });
-    for (const event of events) await options.inbox.ingest(binding.imBindingId, binding.generation, event);
+    try {
+      const adapter = options.createAdapter(binding);
+      const events = adapter.normalizeInbound({
+        eventId: envelope.event_id,
+        appId: binding.appId,
+        teamId: binding.teamId,
+        botUserId: binding.botUserId,
+        event: envelope.event,
+        eventTime: envelope.event_time,
+      });
+      for (const event of events) await options.inbox.ingest(binding.imBindingId, binding.generation, event);
+    } catch {
+      throw new SlackEventProcessingError();
+    }
     return reply.code(200).send({ ok: true });
   });
 }


### PR DESCRIPTION
## Summary

- add offline unit coverage for Server startup ordering, readiness, service wiring, cleanup, and secret redaction
- cover IM provider generation fencing, Slack ingress lifecycle events and failures, and IM resource placement/header validation
- collapse unknown Slack adapter/normalization/ingestion failures into a stable credential-safe diagnostic without changing the HTTP error contract

## Coverage

No coverage thresholds are added in this PR.

| Scope | Statements | Branches | Functions | Lines |
| --- | ---: | ---: | ---: | ---: |
| Server aggregate (before, `main` artifact) | 37.27% (3,598 / 9,654) | 73.09% | 51.35% | 37.27% |
| Server aggregate (after) | 40.59% (3,923 / 9,665) | 75.50% | 53.86% | 40.59% |
| `index.ts` | 98.66% | 70.58% | 100% | 98.66% |
| `provider-adapter-resolver.ts` | 100% | 91.66% | 100% | 100% |
| `slack-events.ts` | 97.53% | 92.50% | 100% | 97.53% |
| `im-resources.ts` | 100% | 91.66% | 100% | 100% |

The four new files add 22 deterministic unit tests. PostgreSQL-backed service behavior remains covered by the existing integration suite rather than duplicated with database mocks.

## Validation

- `pnpm install --frozen-lockfile --config.engine-strict=true`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/server test:integration` (104 tests)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (207 tests; statements, branches, functions, and lines all 100%)
- `pnpm test:coverage`

All commands passed locally. After the final assertion-only tightening, the Slack ingress file (8 tests), the Server startup file (5 tests), and `pnpm check` were rerun successfully.
