### PR TITLE
fix: repair IM runtime bootstrap contracts

### DIFF
--- a/apps/cli/src/__tests__/daemon-service-renderers.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-renderers.test.ts
@@ -161,6 +161,45 @@ describe("systemd service backend", () => {
     );
     expect(unit).toContain(`ExecStart="${installedCli}" "daemon" "service-run"`);
     expect(unit).not.toContain(staleCli);
+    expect(unit).toContain(staleBin);
+    expect(unit.indexOf(installedBin)).toBeLessThan(unit.indexOf(staleBin));
+  });
+
+  it("detects and reconciles an active service whose PATH predates user-directory inheritance", async () => {
+    const userHome = await temporaryDirectory("opentag-systemd-path-drift-");
+    const home = await temporaryDirectory("opentag-systemd-home-");
+    const invocation = { args: [], program: "/opt/opentag/bin/opentag" };
+    const unitPath = join(userHome, ".config", "systemd", "user", "opentag.service");
+    await writeFileWithParents(
+      unitPath,
+      renderSystemdUnit({
+        home,
+        invocation,
+        path: buildServicePath(invocation, "linux"),
+        serviceId: "opentag",
+      }),
+    );
+    const runner = fakeRunner((program, args) => {
+      if (program === "loginctl" || args.includes("show-environment")) return result(0, "", "");
+      if (args.includes("is-active")) return result(0, "active", "");
+      if (args.includes("MainPID")) return result(0, "321", "");
+      return result(0, "", "");
+    });
+    const backend = createSystemdBackend({
+      home,
+      invocation,
+      runner,
+      serviceId: "opentag",
+      sourcePath: "/home/test/.local/bin:/usr/bin",
+      uid: 1000,
+      userHome,
+      username: "test",
+    });
+
+    await expect(backend.status()).resolves.toMatchObject({ drifted: true, state: "active" });
+    await expect(backend.installAndStart()).resolves.toMatchObject({ drifted: false, state: "active" });
+    expect(runner.run).toHaveBeenCalledWith("systemctl", ["--user", "restart", "opentag.service"], expect.any(Object));
+    await expect(readFile(unitPath, "utf8")).resolves.toContain("/home/test/.local/bin");
   });
 
   it.each([
@@ -496,6 +535,7 @@ describe("launchd service backend", () => {
       runner,
       serviceId: "opentag",
       sleep: async () => undefined,
+      sourcePath: "/Users/test/.local/bin:relative:/usr/bin",
       uid: 501,
       userHome,
     });
@@ -508,6 +548,9 @@ describe("launchd service backend", () => {
     const evictionPrints = calls.slice(0, bootstrapIndex).filter((value) => value === "print gui/501/opentag");
     expect(bootstrapIndex).toBeGreaterThan(0);
     expect(evictionPrints).toHaveLength(3);
+    const plist = await readFile(join(userHome, "Library", "LaunchAgents", "opentag.plist"), "utf8");
+    expect(plist).toContain("/Users/test/.local/bin");
+    expect(plist).not.toContain("relative");
   });
 
   it("reports a loaded waiting LaunchAgent without a PID as inactive", async () => {

--- a/apps/cli/src/__tests__/daemon-service-shared.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-shared.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { getChannelConfig } from "@opentag/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadDaemonEnvironment } from "../core/daemon/environment.js";
@@ -13,6 +13,7 @@ import {
 import {
   acquireServiceOperationLease,
   acquireServiceTargetLease,
+  buildServicePath,
   canonicalizeServiceHome,
   deriveServiceIdentity,
   escapeXml,
@@ -82,6 +83,23 @@ describe("daemon service primitives", () => {
         env: { PATH: `${installedBin}:${staleBin}` },
       }),
     ).resolves.toEqual({ args: [], program: currentDist });
+  });
+
+  it("builds a stable service PATH from trusted executable, user, and platform directories", () => {
+    const invocation = { args: [], program: "/opt/opentag/bin/opentag" };
+    const servicePath = buildServicePath(
+      invocation,
+      "linux",
+      "/home/test/.local/bin:relative:/opt/opentag/bin::/home/test/tools:/usr/bin",
+    ).split(":");
+
+    expect(servicePath[0]).toBe("/opt/opentag/bin");
+    expect(servicePath[1]).toBe(dirname(process.execPath));
+    expect(servicePath).toContain("/home/test/.local/bin");
+    expect(servicePath).toContain("/home/test/tools");
+    expect(servicePath).not.toContain("relative");
+    expect(servicePath.filter((entry) => entry === "/opt/opentag/bin")).toHaveLength(1);
+    expect(servicePath.filter((entry) => entry === "/usr/bin")).toHaveLength(1);
   });
 
   it("atomically replaces files and leaves no temporary files", async () => {

--- a/apps/cli/src/core/daemon/service/index.ts
+++ b/apps/cli/src/core/daemon/service/index.ts
@@ -51,8 +51,9 @@ type DaemonServiceMutation = "install" | "restart" | "start" | "stop" | "uninsta
 export async function createDaemonServiceManager(
   options: CreateDaemonServiceManagerOptions = {},
 ): Promise<DaemonServiceManager> {
+  const environment = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
-  const home = await canonicalizeServiceHome(resolve(options.home ?? resolveOpenTagHome(options.env ?? process.env)));
+  const home = await canonicalizeServiceHome(resolve(options.home ?? resolveOpenTagHome(environment)));
   const runner = options.runner ?? defaultServiceRunner;
   const userHome = await canonicalizeServiceHome(resolve(options.userHome ?? homedir()));
   const channelDefaultHome = await canonicalizeServiceHome(getChannelConfig(CHANNEL, userHome).defaultHome);
@@ -68,6 +69,7 @@ export async function createDaemonServiceManager(
     invocation,
     platform,
     runner,
+    sourcePath: environment.PATH,
     uid,
     userHome,
     username: options.username,
@@ -176,6 +178,7 @@ function createBackend(options: {
   invocation: ResolvedCliInvocation;
   platform: NodeJS.Platform;
   runner: ServiceRunner;
+  sourcePath?: string;
   uid: number;
   userHome: string;
   username?: string;
@@ -186,6 +189,7 @@ function createBackend(options: {
       invocation: options.invocation,
       runner: options.runner,
       serviceId: channelConfig.serviceId,
+      ...(options.sourcePath ? { sourcePath: options.sourcePath } : {}),
       uid: options.uid,
       userHome: options.userHome,
       ...(options.username ? { username: options.username } : {}),
@@ -198,6 +202,7 @@ function createBackend(options: {
       invocation: options.invocation,
       runner: options.runner,
       serviceId: channelConfig.serviceId,
+      ...(options.sourcePath ? { sourcePath: options.sourcePath } : {}),
       uid: options.uid,
       userHome: options.userHome,
     });

--- a/apps/cli/src/core/daemon/service/launchd.ts
+++ b/apps/cli/src/core/daemon/service/launchd.ts
@@ -28,6 +28,7 @@ export interface LaunchdBackendOptions {
   launchctl?: string;
   runner: ServiceRunner;
   serviceId: string;
+  sourcePath?: string;
   sleep?: (milliseconds: number) => Promise<void>;
   uid?: number;
   userHome?: string;
@@ -95,7 +96,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
   const logDirectory = paths.logs;
   const stdoutPath = paths.daemonStdoutLog;
   const stderrPath = paths.daemonStderrLog;
-  const servicePath = buildServicePath(options.invocation, "darwin");
+  const servicePath = buildServicePath(options.invocation, "darwin", options.sourcePath);
   const expectedWrapper = renderLaunchdWrapper(options.invocation);
   const expectedPlist = renderLaunchdPlist({
     home: options.home,

--- a/apps/cli/src/core/daemon/service/shared.ts
+++ b/apps/cli/src/core/daemon/service/shared.ts
@@ -101,12 +101,20 @@ export async function resolveCliInvocation(options: {
   };
 }
 
-export function buildServicePath(invocation: ResolvedCliInvocation, platform: "darwin" | "linux"): string {
+export function buildServicePath(
+  invocation: ResolvedCliInvocation,
+  platform: "darwin" | "linux",
+  sourcePath?: string,
+): string {
   const base =
     platform === "darwin"
       ? ["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin"]
       : ["/usr/local/bin", "/usr/bin", "/bin"];
-  return [...new Set([dirname(invocation.program), dirname(process.execPath), ...base])].join(":");
+  const inherited = (sourcePath ?? "")
+    .split(delimiter)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && isAbsolute(entry));
+  return [...new Set([dirname(invocation.program), dirname(process.execPath), ...inherited, ...base])].join(delimiter);
 }
 
 export function invocationArguments(invocation: ResolvedCliInvocation): string[] {

--- a/apps/cli/src/core/daemon/service/systemd.ts
+++ b/apps/cli/src/core/daemon/service/systemd.ts
@@ -22,6 +22,7 @@ export interface SystemdBackendOptions {
   invocation: ResolvedCliInvocation;
   runner: ServiceRunner;
   serviceId: string;
+  sourcePath?: string;
   systemctl?: string;
   uid?: number;
   userHome?: string;
@@ -75,7 +76,7 @@ export function createSystemdBackend(options: SystemdBackendOptions): DaemonServ
     identity.systemdUnitName,
   );
   const systemctl = options.systemctl ?? "systemctl";
-  const servicePath = buildServicePath(options.invocation, "linux");
+  const servicePath = buildServicePath(options.invocation, "linux", options.sourcePath);
   const expected = renderSystemdUnit({
     home: options.home,
     invocation: options.invocation,

--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -33,6 +33,9 @@ describe("AgentTurnRunner", () => {
     ]);
     expect(JSON.stringify(input)).not.toContain(request.runtime.instructions.platform);
     expect(JSON.stringify(input)).not.toContain(request.runtime.instructions.agent);
+    expect(input.items[0]?.text).toContain("For a new IM write, omit retryRequestId");
+    expect(input.items[0]?.text).toContain("Never automatically repeat an unknown IM write");
+    expect(input.items[0]?.text).not.toContain("same requestId");
     expect(
       buildAgentInput({ ...request, runtime: { ...request.runtime, instructions: { platform: "p", agent: "a" } } })
         .items[0]?.text,

--- a/packages/client/src/__tests__/agent-workspace.test.ts
+++ b/packages/client/src/__tests__/agent-workspace.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import {
@@ -37,7 +37,7 @@ describe("AgentWorkspaceManager", () => {
     await expect(fixture.reconciler.reconcile(first)).resolves.toMatchObject({ status: "ready" });
     const cwd = await fixture.workspace.cwd("agent-1");
     expect(await readFile(resolve(cwd, ".missing"), "utf8").catch(() => undefined)).toBeUndefined();
-    await expect(readdir(cwd)).resolves.toEqual([]);
+    await expect(readdir(cwd)).resolves.toEqual(["AGENTS.md"]);
     await writeFile(resolve(cwd, "shared.txt"), "from session A", "utf8");
 
     await expect(fixture.reconciler.reconcile(second)).resolves.toMatchObject({ status: "ready" });
@@ -62,6 +62,7 @@ describe("AgentWorkspaceManager", () => {
     expect(await readFile(resolve(cwdB, "only-a.txt"), "utf8").catch(() => undefined)).toBeUndefined();
 
     const agentsA = fixture.workspace.paths("agent-a").agentsFile;
+    expect(resolve(agentsA, "..")).toBe(cwdA);
     const managed = await readFile(agentsA, "utf8");
     expect(managed).toContain("platform instructions");
     expect(managed).toContain("agent instructions");
@@ -123,6 +124,92 @@ describe("AgentWorkspaceManager", () => {
     expect(await readFile(fixture.workspace.paths("agent-1").agentsFile, "utf8")).toContain(
       "upgraded agent instructions",
     );
+  });
+
+  it("migrates a v1 workspace to one managed AGENTS.md in the Codex cwd", async () => {
+    const fixture = await workspaceFixture();
+    const runtime = snapshot("agent-1", "workspace-1", "session");
+    const paths = await downgradeWorkspaceToV1(fixture.workspace, runtime);
+    await writeFile(resolve(paths.files, "user.txt"), "keep", "utf8");
+
+    await expect(
+      fixture.workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime)),
+    ).resolves.toBeUndefined();
+
+    expect(paths.agentsFile).toBe(resolve(await fixture.workspace.cwd("agent-1"), "AGENTS.md"));
+    await expect(readFile(paths.agentsFile, "utf8")).resolves.toContain("agent instructions");
+    await expect(stat(paths.legacyAgentsFile)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(resolve(paths.files, "user.txt"), "utf8")).resolves.toBe("keep");
+    expect(JSON.parse(await readFile(paths.workspaceState, "utf8"))).toMatchObject({ schemaVersion: 2 });
+  });
+
+  it.each(["new-written", "legacy-removed"] as const)(
+    "re-enters a v1 migration after the %s crash point",
+    async (crashPoint) => {
+      const fixture = await workspaceFixture();
+      const runtime = snapshot("agent-1", "workspace-1", "session");
+      const paths = await downgradeWorkspaceToV1(fixture.workspace, runtime);
+      const content = await readFile(paths.legacyAgentsFile, "utf8");
+      await writeFile(paths.agentsFile, content, { mode: 0o444 });
+      if (crashPoint === "legacy-removed") await rm(paths.legacyAgentsFile);
+
+      await expect(
+        fixture.workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime)),
+      ).resolves.toBeUndefined();
+      await expect(readFile(paths.agentsFile, "utf8")).resolves.toBe(content);
+      await expect(stat(paths.legacyAgentsFile)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(JSON.parse(await readFile(paths.workspaceState, "utf8"))).toMatchObject({ schemaVersion: 2 });
+    },
+  );
+
+  it.each(["legacy", "current"] as const)("fails closed when the %s migration file was modified", async (kind) => {
+    const fixture = await workspaceFixture();
+    const runtime = snapshot("agent-1", "workspace-1", "session");
+    const paths = await downgradeWorkspaceToV1(fixture.workspace, runtime);
+    const target = kind === "legacy" ? paths.legacyAgentsFile : paths.agentsFile;
+    if (kind === "current") await writeFile(target, "external current instructions\n", { mode: 0o444 });
+    else {
+      await chmod(target, 0o600);
+      await writeFile(target, "external legacy instructions\n", "utf8");
+    }
+
+    await expect(fixture.workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime))).rejects.toThrow(
+      /modified outside|conflicting AGENTS/i,
+    );
+    await expect(readFile(target, "utf8")).resolves.toContain("external");
+    expect(JSON.parse(await readFile(paths.workspaceState, "utf8"))).toMatchObject({ schemaVersion: 1 });
+  });
+
+  it.each(["modified", "legacy-reappeared"] as const)(
+    "fails closed when a v2 managed file is %s outside OpenTag",
+    async (change) => {
+      const fixture = await workspaceFixture();
+      const runtime = snapshot("agent-1", "workspace-1", "session");
+      await fixture.workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime));
+      const paths = fixture.workspace.paths("agent-1");
+      if (change === "modified") {
+        await chmod(paths.agentsFile, 0o600);
+        await writeFile(paths.agentsFile, "external\n", "utf8");
+      } else {
+        await writeFile(paths.legacyAgentsFile, "external\n", "utf8");
+      }
+
+      await expect(fixture.workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime))).rejects.toThrow(
+        /modified outside|legacy AGENTS/i,
+      );
+    },
+  );
+
+  it("recovers a v2 bootstrap whose state was persisted before the managed file", async () => {
+    const fixture = await workspaceFixture();
+    const runtime = snapshot("agent-1", "workspace-1", "session");
+    const hashes = computeRuntimeSnapshotHashes(runtime);
+    await fixture.workspace.prepareAgent(runtime, hashes);
+    const paths = fixture.workspace.paths("agent-1");
+    await rm(paths.agentsFile);
+
+    await expect(fixture.workspace.prepareAgent(runtime, hashes)).resolves.toBeUndefined();
+    await expect(readFile(paths.agentsFile, "utf8")).resolves.toContain("agent instructions");
   });
 
   it("C-13 fails closed on symlinked or unmanaged workspace state", async () => {
@@ -201,6 +288,17 @@ async function workspaceFixture() {
   const workspace = new AgentWorkspaceManager({ home, bindingStore });
   const reconciler = new SessionReconciler({ computerId, preparation: workspace });
   return { bindingStore, computerId, home, reconciler, workspace };
+}
+
+async function downgradeWorkspaceToV1(workspace: AgentWorkspaceManager, runtime: EffectiveRuntimeSnapshot) {
+  await workspace.prepareAgent(runtime, computeRuntimeSnapshotHashes(runtime));
+  const paths = workspace.paths(runtime.agentId);
+  await rename(paths.agentsFile, paths.legacyAgentsFile);
+  const state = JSON.parse(await readFile(paths.workspaceState, "utf8"));
+  await writeFile(paths.workspaceState, `${JSON.stringify({ ...state, schemaVersion: 1 }, undefined, 2)}\n`, {
+    mode: 0o600,
+  });
+  return paths;
 }
 
 async function temporaryHome(): Promise<string> {

--- a/packages/client/src/__tests__/client-turn.integration.test.ts
+++ b/packages/client/src/__tests__/client-turn.integration.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import type {
@@ -67,6 +67,10 @@ describe("Agent Runtime Client Turn vertical", () => {
       finalText: "answer-1",
     });
     expect(fixture.clients).toHaveLength(1);
+    expect(fixture.clients[0]?.cwd).toBe(resolve(fixture.workspace.paths("agent-1").agentsFile, ".."));
+    await expect(readFile(resolve(fixture.clients[0]?.cwd ?? "", "AGENTS.md"), "utf8")).resolves.toContain(
+      "# OpenTag managed instructions",
+    );
     expect(fixture.clients[0]?.methods).toContain("thread/start");
     expect(fixture.clients[0]?.methods).not.toContain("thread/resume");
     expect(await fixture.store.read("agent-1", "session-1")).toMatchObject({

--- a/packages/client/src/__tests__/fixtures/codex-app-server.mjs
+++ b/packages/client/src/__tests__/fixtures/codex-app-server.mjs
@@ -73,7 +73,7 @@ createInterface({ input: process.stdin }).on("line", (line) => {
               callId: "call-1",
               namespace: null,
               tool: "opentag_message_send",
-              arguments: { requestId: "11111111-1111-4111-8111-111111111111", text: "hello" },
+              arguments: { text: "hello" },
             },
           });
           if (scenario === "hosted-tool-duplicate-run") {
@@ -86,7 +86,7 @@ createInterface({ input: process.stdin }).on("line", (line) => {
                 callId: "call-2",
                 namespace: null,
                 tool: "opentag_message_send",
-                arguments: { requestId: "22222222-2222-4222-8222-222222222222", text: "duplicate" },
+                arguments: { text: "duplicate" },
               },
             });
           }
@@ -145,7 +145,7 @@ createInterface({ input: process.stdin }).on("line", (line) => {
         callId: "call-1",
         namespace: message.method === "fixture/hosted-tool" ? null : 42,
         tool: "opentag_message_send",
-        arguments: { requestId: "11111111-1111-4111-8111-111111111111", text: "hello" },
+        arguments: { text: "hello" },
       },
     });
     return;

--- a/packages/client/src/__tests__/home-layout.test.ts
+++ b/packages/client/src/__tests__/home-layout.test.ts
@@ -51,6 +51,8 @@ describe("OpenTag Home layout", () => {
     expect(paths.workspaceRoot).toMatch(
       new RegExp(`^${escapeRegExp(join(home, "data", "workspaces"))}/a-[a-f0-9]{40}$`, "u"),
     );
+    expect(paths.agentsFile).toBe(join(paths.files, "AGENTS.md"));
+    expect(paths.legacyAgentsFile).toBe(join(paths.workspaceRoot, "AGENTS.md"));
     expect(sessionBindingPath(home, "agent-1", "session-1")).toMatch(
       /\/data\/runtime\/session-bindings\/a-[a-f0-9]{40}\/s-[a-f0-9]{40}\.json$/u,
     );

--- a/packages/client/src/__tests__/runtime-tool-host.test.ts
+++ b/packages/client/src/__tests__/runtime-tool-host.test.ts
@@ -1,16 +1,25 @@
 import { randomUUID } from "node:crypto";
-import type { DirectImMessageDeliveryRequest } from "@opentag/shared";
+import { type DirectImMessageDeliveryRequest, RUNTIME_DIRECT_TEXT_MAX_BYTES } from "@opentag/shared";
 import { describe, expect, it, vi } from "vitest";
 import type { RuntimeBusinessFrame } from "../runtime/runtime-connection.js";
 import { openTagHostedToolDefinitions, RuntimeToolHost } from "../runtime/runtime-tool-host.js";
 
 describe("RuntimeToolHost", () => {
-  it("settles a missing Server result as a deterministic hosted-tool timeout", async () => {
+  it("returns an unknown identity after timeout and reuses it only for an explicit retry", async () => {
     vi.useFakeTimers();
     try {
+      let listener: ((frame: RuntimeBusinessFrame) => void | Promise<void>) | undefined;
+      const sent: Array<{ requestId: string }> = [];
       const host = new RuntimeToolHost({
-        send: vi.fn(async () => undefined),
-        subscribeBusinessFrames: () => () => undefined,
+        send: vi.fn(async (frame: unknown) => {
+          sent.push(frame as { requestId: string });
+        }),
+        subscribeBusinessFrames: (next) => {
+          listener = next;
+          return () => {
+            listener = undefined;
+          };
+        },
       });
       const delivery = request();
       const release = host.activateRun("turn-timeout", delivery, ["opentag_message_send"]);
@@ -18,14 +27,35 @@ describe("RuntimeToolHost", () => {
         runId: "turn-timeout",
         toolCallId: "call-timeout",
         name: "opentag_message_send",
-        input: { requestId: randomUUID(), text: "timeout" },
+        input: { text: "timeout" },
         signal: new AbortController().signal,
       });
       await vi.advanceTimersByTimeAsync(60_000);
-      await expect(result).resolves.toMatchObject({
+      const timedOut = await result;
+      expect(timedOut).toMatchObject({
         success: false,
-        error: { code: "tool_call_failed", message: expect.stringContaining("timed out") },
+        error: { code: "tool_result_timeout", message: expect.stringContaining("timed out") },
       });
+      const timeoutBody = JSON.parse((timedOut.content[0] as { text: string }).text) as {
+        requestId: string;
+        state: string;
+        code: string;
+      };
+      expect(timeoutBody).toMatchObject({ state: "unknown", code: "tool_result_timeout" });
+      expect(timeoutBody.requestId).toBe(sent[0]?.requestId);
+
+      const retry = host.execute({
+        runId: "turn-timeout",
+        toolCallId: "call-timeout-retry",
+        name: "opentag_message_send",
+        input: { retryRequestId: timeoutBody.requestId, text: "timeout" },
+        signal: new AbortController().signal,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sent).toHaveLength(2);
+      expect(sent[1]?.requestId).toBe(timeoutBody.requestId);
+      await listener?.({ type: "im:tool:result", requestId: timeoutBody.requestId, state: "succeeded" });
+      await expect(retry).resolves.toMatchObject({ success: true });
       release();
       host.close();
     } finally {
@@ -35,8 +65,10 @@ describe("RuntimeToolHost", () => {
 
   it("binds model arguments to the current delivery scope and correlates the Server result", async () => {
     let listener: ((frame: RuntimeBusinessFrame) => void | Promise<void>) | undefined;
+    let sentRequestId: string | undefined;
     const send = vi.fn(async (frame: unknown) => {
       const request = frame as { requestId: string };
+      sentRequestId = request.requestId;
       queueMicrotask(() =>
         listener?.({
           type: "im:tool:result",
@@ -56,7 +88,6 @@ describe("RuntimeToolHost", () => {
       },
     });
     const delivery = request();
-    const requestId = randomUUID();
     const signal = new AbortController().signal;
     const release = host.activateRun("turn-1", delivery, ["opentag_message_reply"]);
     await expect(
@@ -65,22 +96,24 @@ describe("RuntimeToolHost", () => {
         toolCallId: "call-1",
         name: "opentag_message_reply",
         input: {
-          requestId,
           text: "reply",
           replyToImMessageId: delivery.imMessageId,
-          sessionId: randomUUID(),
-          placementGeneration: 999,
         },
         signal,
       }),
     ).resolves.toEqual({
       success: true,
-      content: [{ type: "text", text: JSON.stringify({ state: "succeeded", providerMessageId: "provider-1" }) }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ requestId: sentRequestId, state: "succeeded", providerMessageId: "provider-1" }),
+        },
+      ],
     });
     expect(send).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "im:tool",
-        requestId,
+        requestId: expect.stringMatching(/^[0-9a-f-]{36}$/u),
         sessionId: delivery.sessionId,
         agentId: delivery.agentId,
         placementGeneration: delivery.placementGeneration,
@@ -93,9 +126,68 @@ describe("RuntimeToolHost", () => {
     host.close();
   });
 
-  it("shares one pending owner for the same request intent and rejects conflicting reuse before send", async () => {
+  it("enforces the shared outbound byte limit before dispatch for send and reply", async () => {
     let listener: ((frame: RuntimeBusinessFrame) => void | Promise<void>) | undefined;
-    const send = vi.fn(async () => undefined);
+    const sent: Array<{ requestId: string }> = [];
+    const host = new RuntimeToolHost({
+      send: async (frame: unknown) => {
+        sent.push(frame as { requestId: string });
+      },
+      subscribeBusinessFrames: (next) => {
+        listener = next;
+        return () => {
+          listener = undefined;
+        };
+      },
+    });
+    const delivery = request();
+    const release = host.activateRun("turn-byte-limit", delivery, ["opentag_message_send", "opentag_message_reply"]);
+    const signal = new AbortController().signal;
+    const boundaryText = "x".repeat(RUNTIME_DIRECT_TEXT_MAX_BYTES);
+    const multibyteOverLimit = `${"x".repeat(RUNTIME_DIRECT_TEXT_MAX_BYTES - 2)}你`;
+    expect(Buffer.byteLength(multibyteOverLimit, "utf8")).toBe(RUNTIME_DIRECT_TEXT_MAX_BYTES + 1);
+
+    const cases = [
+      { name: "opentag_message_send", input: (text: string) => ({ text }) },
+      {
+        name: "opentag_message_reply",
+        input: (text: string) => ({ replyToImMessageId: delivery.imMessageId, text }),
+      },
+    ] as const;
+    for (const [index, entry] of cases.entries()) {
+      const boundary = host.execute({
+        runId: "turn-byte-limit",
+        toolCallId: `boundary-${index}`,
+        name: entry.name,
+        input: entry.input(boundaryText),
+        signal,
+      });
+      await vi.waitFor(() => expect(sent).toHaveLength(index + 1));
+      await listener?.({
+        type: "im:tool:result",
+        requestId: sent[index]?.requestId as string,
+        state: "succeeded",
+      });
+      await expect(boundary).resolves.toMatchObject({ success: true });
+
+      await expect(
+        host.execute({
+          runId: "turn-byte-limit",
+          toolCallId: `over-limit-${index}`,
+          name: entry.name,
+          input: entry.input(multibyteOverLimit),
+          signal,
+        }),
+      ).resolves.toMatchObject({ success: false, error: { code: "tool_call_failed" } });
+      expect(sent).toHaveLength(index + 1);
+    }
+    release();
+    host.close();
+  });
+
+  it("reuses an explicit retry identity and rejects conflicting reuse before send", async () => {
+    let listener: ((frame: RuntimeBusinessFrame) => void | Promise<void>) | undefined;
+    const send = vi.fn(async (_frame: unknown) => undefined);
     const host = new RuntimeToolHost({
       send,
       subscribeBusinessFrames: (next) => {
@@ -113,7 +205,7 @@ describe("RuntimeToolHost", () => {
       runId: "turn-1",
       toolCallId: callId,
       name: "opentag_message_send",
-      input: { requestId, text },
+      input: { retryRequestId: requestId, text },
       signal,
     });
     const first = host.execute(call("hello", "call-1"));
@@ -122,19 +214,26 @@ describe("RuntimeToolHost", () => {
     await listener?.({ type: "im:tool:result", requestId, state: "unknown", code: "provider_unknown" });
     await expect(first).resolves.toMatchObject({ success: false });
     await expect(same).resolves.toEqual(await first);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    const explicitRetry = host.execute(call("hello", "call-retry"));
+    await expect.poll(() => send.mock.calls.length).toBe(2);
+    expect(send.mock.calls[1]?.[0]).toMatchObject({ requestId, text: "hello" });
+    await listener?.({ type: "im:tool:result", requestId, state: "succeeded" });
+    await expect(explicitRetry).resolves.toMatchObject({ success: true });
 
     const conflictingId = randomUUID();
     const pending = host.execute({
       ...call("one", "call-3"),
-      input: { requestId: conflictingId, text: "one" },
+      input: { retryRequestId: conflictingId, text: "one" },
     });
     await expect(
       host.execute({
         ...call("two", "call-4"),
-        input: { requestId: conflictingId, text: "two" },
+        input: { retryRequestId: conflictingId, text: "two" },
       }),
-    ).resolves.toMatchObject({ success: false, error: { code: "tool_call_failed" } });
-    expect(send).toHaveBeenCalledTimes(2);
+    ).resolves.toMatchObject({ success: false, error: { code: "request_id_conflict" } });
+    expect(send).toHaveBeenCalledTimes(3);
     await listener?.({ type: "im:tool:result", requestId: conflictingId, state: "succeeded" });
     await expect(pending).resolves.toMatchObject({ success: true });
     release();
@@ -155,12 +254,24 @@ describe("RuntimeToolHost", () => {
     expect(definitions.every((definition) => (definition.inputSchema as { type?: string }).type === "object")).toBe(
       true,
     );
+    for (const definition of definitions) {
+      const schema = definition.inputSchema as {
+        properties?: Record<string, unknown>;
+        required?: readonly string[];
+      };
+      expect(schema.properties).toHaveProperty("retryRequestId");
+      expect(schema.properties).not.toHaveProperty("requestId");
+      expect(schema.required).not.toContain("retryRequestId");
+    }
     expect(() => openTagHostedToolDefinitions(["unknown"])).toThrow("allow-list");
     expect(() => openTagHostedToolDefinitions(["opentag_message_send", "opentag_message_send"])).toThrow("allow-list");
 
     let listener: ((frame: RuntimeBusinessFrame) => void | Promise<void>) | undefined;
+    let sentRequestId: string | undefined;
     const host = new RuntimeToolHost({
-      send: vi.fn(async () => undefined),
+      send: vi.fn(async (frame: unknown) => {
+        sentRequestId = (frame as { requestId: string }).requestId;
+      }),
       subscribeBusinessFrames: (next) => {
         listener = next;
         return () => {
@@ -180,12 +291,11 @@ describe("RuntimeToolHost", () => {
     await expect(
       host.execute({ runId: "missing", toolCallId: "one", name: "opentag_message_send", input: {}, signal }),
     ).resolves.toMatchObject({ success: false, error: { code: "tool_not_authorized" } });
-    const requestId = randomUUID();
     const first = host.execute({
       runId: "turn-1",
       toolCallId: "same-call",
       name: "opentag_message_send",
-      input: { requestId, text: "one" },
+      input: { text: "one" },
       signal,
     });
     await expect(
@@ -193,7 +303,7 @@ describe("RuntimeToolHost", () => {
         runId: "turn-1",
         toolCallId: "same-call",
         name: "opentag_message_send",
-        input: { requestId, text: "two" },
+        input: { text: "two" },
         signal,
       }),
     ).resolves.toMatchObject({ success: false, error: { code: "tool_call_conflict" } });
@@ -201,12 +311,14 @@ describe("RuntimeToolHost", () => {
       runId: "turn-1",
       toolCallId: "same-call",
       name: "opentag_message_send",
-      input: { requestId, text: "one" },
+      input: { text: "one" },
       signal,
     });
-    await listener?.({ type: "im:tool:result", requestId, state: "succeeded" });
+    await vi.waitFor(() => expect(sentRequestId).toMatch(/^[0-9a-f-]{36}$/u));
+    await listener?.({ type: "im:tool:result", requestId: sentRequestId as string, state: "succeeded" });
     await expect(first).resolves.toMatchObject({ success: true });
     await expect(same).resolves.toEqual(await first);
+    expect(sentRequestId).toBeDefined();
     release();
     release();
     host.close();
@@ -247,17 +359,17 @@ describe("RuntimeToolHost", () => {
     const cases = [
       {
         name: "opentag_message_send",
-        input: { requestId: randomUUID(), text: "send" },
+        input: { text: "send" },
         operation: "send",
       },
       {
         name: "opentag_message_reply",
-        input: { requestId: randomUUID(), text: "reply", replyToImMessageId: delivery.imMessageId },
+        input: { text: "reply", replyToImMessageId: delivery.imMessageId },
         operation: "reply",
       },
       {
         name: "opentag_message_react",
-        input: { requestId: randomUUID(), targetImMessageId: delivery.imMessageId, emoji: "👍" },
+        input: { targetImMessageId: delivery.imMessageId, emoji: "👍" },
         operation: "react",
       },
     ] as const;
@@ -270,10 +382,12 @@ describe("RuntimeToolHost", () => {
         signal,
       });
       await vi.waitFor(() => expect(sent).toHaveLength(index + 1));
-      expect(sent.at(-1)).toMatchObject({ operation: entry.operation });
+      const requestId = (sent.at(-1) as { requestId: string }).requestId;
+      expect(requestId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu);
+      expect(sent.at(-1)).toMatchObject({ operation: entry.operation, requestId });
       await listener?.({
         type: "im:tool:result",
-        requestId: entry.input.requestId,
+        requestId,
         state: index === 0 ? "deterministic_failed" : "succeeded",
         ...(index === 0 ? { code: "provider_failed", retryAfterSeconds: 3 } : {}),
       });
@@ -282,13 +396,19 @@ describe("RuntimeToolHost", () => {
           ? { success: false, error: { code: "provider_failed" }, content: [expect.objectContaining({ type: "text" })] }
           : { success: true },
       );
+      const resultText = ((await pending).content[0] as { text: string }).text;
+      expect(JSON.parse(resultText)).toMatchObject({
+        requestId,
+        state: index === 0 ? "deterministic_failed" : "succeeded",
+      });
     }
 
     const invalidInputs: unknown[] = [
       [],
-      { requestId: "not-uuid", text: "text" },
-      { requestId: randomUUID(), text: " " },
-      { requestId: randomUUID(), text: "x".repeat(24 * 1024 + 1) },
+      { retryRequestId: "not-uuid", text: "text" },
+      { requestId: randomUUID(), text: "text" },
+      { text: " " },
+      { text: "x".repeat(RUNTIME_DIRECT_TEXT_MAX_BYTES + 1) },
     ];
     for (const [index, input] of invalidInputs.entries()) {
       await expect(
@@ -306,44 +426,56 @@ describe("RuntimeToolHost", () => {
     await expect(
       host.execute({
         runId: "turn-1",
+        toolCallId: "aborted-invalid",
+        name: "opentag_message_send",
+        input: null,
+        signal: aborted.signal,
+      }),
+    ).resolves.toMatchObject({ success: false, error: { code: "tool_call_cancelled" } });
+    await expect(
+      host.execute({
+        runId: "turn-1",
         toolCallId: "aborted",
         name: "opentag_message_send",
-        input: { requestId: randomUUID(), text: "cancel" },
+        input: { text: "cancel" },
         signal: aborted.signal,
       }),
     ).resolves.toMatchObject({ success: false, error: { code: "tool_call_cancelled" } });
 
     for (const [index, failure] of [new Error("send failed"), "non-error"].entries()) {
       sendFailure = failure;
-      await expect(
-        host.execute({
-          runId: "turn-1",
-          toolCallId: `send-failure-${index}`,
-          name: "opentag_message_send",
-          input: { requestId: randomUUID(), text: "fail" },
-          signal,
-        }),
-      ).resolves.toMatchObject({ success: false, error: { code: "tool_call_failed" } });
+      const sendFailureResult = await host.execute({
+        runId: "turn-1",
+        toolCallId: `send-failure-${index}`,
+        name: "opentag_message_send",
+        input: { text: "fail" },
+        signal,
+      });
+      expect(sendFailureResult).toMatchObject({ success: false, error: { code: "runtime_send_failed" } });
+      expect(JSON.parse((sendFailureResult.content[0] as { text: string }).text)).toMatchObject({
+        requestId: (sent.at(-1) as { requestId: string }).requestId,
+        state: "unknown",
+        code: "runtime_send_failed",
+      });
     }
 
     let requestIdReads = 0;
     const nonErrorInput = {
-      get requestId() {
+      get retryRequestId() {
         requestIdReads += 1;
         if (requestIdReads > 1) throw "non-error arguments failure";
         return randomUUID();
       },
       text: "fail",
     };
-    await expect(
-      host.execute({
-        runId: "turn-1",
-        toolCallId: "non-error-arguments",
-        name: "opentag_message_send",
-        input: nonErrorInput,
-        signal,
-      }),
-    ).resolves.toMatchObject({ success: false, error: { code: "tool_call_failed" } });
+    const nonErrorFailure = await host.execute({
+      runId: "turn-1",
+      toolCallId: "non-error-arguments",
+      name: "opentag_message_send",
+      input: nonErrorInput,
+      signal,
+    });
+    expect(nonErrorFailure).toMatchObject({ success: false, error: { code: "tool_call_failed" } });
 
     sendFailure = undefined;
     const noCodeRequestId = randomUUID();
@@ -351,7 +483,7 @@ describe("RuntimeToolHost", () => {
       runId: "turn-1",
       toolCallId: "failed-without-code",
       name: "opentag_message_send",
-      input: { requestId: noCodeRequestId, text: "fail" },
+      input: { retryRequestId: noCodeRequestId, text: "fail" },
       signal,
     });
     await listener?.({ type: "im:tool:result", requestId: noCodeRequestId, state: "deterministic_failed" });
@@ -364,7 +496,7 @@ describe("RuntimeToolHost", () => {
       runId: "turn-1",
       toolCallId: "shared-owner",
       name: "opentag_message_send",
-      input: { requestId: sharedRequestId, text: "shared" },
+      input: { retryRequestId: sharedRequestId, text: "shared" },
       signal,
     });
     const cancelledCaller = new AbortController();
@@ -374,7 +506,7 @@ describe("RuntimeToolHost", () => {
         runId: "turn-1",
         toolCallId: "shared-cancelled-caller",
         name: "opentag_message_send",
-        input: { requestId: sharedRequestId, text: "shared" },
+        input: { retryRequestId: sharedRequestId, text: "shared" },
         signal: cancelledCaller.signal,
       }),
     ).resolves.toMatchObject({ success: false, error: { code: "tool_call_cancelled" } });
@@ -387,23 +519,36 @@ describe("RuntimeToolHost", () => {
       runId: "turn-1",
       toolCallId: "abort-during-request",
       name: "opentag_message_send",
-      input: { requestId: abortRequestId, text: "cancel" },
+      input: { retryRequestId: abortRequestId, text: "cancel" },
       signal: abortDuringRequest.signal,
     });
     abortDuringRequest.abort();
-    await expect(abortPending).resolves.toMatchObject({ success: false, error: { code: "tool_call_cancelled" } });
+    const abortedAfterDispatch = await abortPending;
+    expect(abortedAfterDispatch).toMatchObject({ success: false, error: { code: "tool_call_cancelled" } });
+    expect(JSON.parse((abortedAfterDispatch.content[0] as { text: string }).text)).toMatchObject({
+      requestId: abortRequestId,
+      state: "unknown",
+      code: "tool_call_cancelled",
+    });
     await listener?.({ type: "im:tool:result", requestId: abortRequestId, state: "succeeded" });
 
     const pendingAtClose = host.execute({
       runId: "turn-1",
       toolCallId: "pending-at-close",
       name: "opentag_message_send",
-      input: { requestId: randomUUID(), text: "pending" },
+      input: { text: "pending" },
       signal,
     });
+    const closeRequestId = (sent.at(-1) as { requestId: string }).requestId;
     release();
     host.close();
-    await expect(pendingAtClose).resolves.toMatchObject({ success: false, error: { code: "tool_call_failed" } });
+    const closed = await pendingAtClose;
+    expect(closed).toMatchObject({ success: false, error: { code: "tool_host_closed" } });
+    expect(JSON.parse((closed.content[0] as { text: string }).text)).toEqual({
+      requestId: closeRequestId,
+      state: "unknown",
+      code: "tool_host_closed",
+    });
   });
 });
 

--- a/packages/client/src/__tests__/runtime-tool-host.test.ts
+++ b/packages/client/src/__tests__/runtime-tool-host.test.ts
@@ -44,6 +44,17 @@ describe("RuntimeToolHost", () => {
       expect(timeoutBody).toMatchObject({ state: "unknown", code: "tool_result_timeout" });
       expect(timeoutBody.requestId).toBe(sent[0]?.requestId);
 
+      await expect(
+        host.execute({
+          runId: "turn-timeout",
+          toolCallId: "call-timeout-changed-retry",
+          name: "opentag_message_send",
+          input: { retryRequestId: timeoutBody.requestId, text: "changed" },
+          signal: new AbortController().signal,
+        }),
+      ).resolves.toMatchObject({ success: false, error: { code: "request_id_conflict" } });
+      expect(sent).toHaveLength(1);
+
       const retry = host.execute({
         runId: "turn-timeout",
         toolCallId: "call-timeout-retry",
@@ -185,9 +196,12 @@ describe("RuntimeToolHost", () => {
     host.close();
   });
 
-  it("reuses an explicit retry identity and rejects conflicting reuse before send", async () => {
+  it("permits only exact retries of identities returned as unknown in the active Run", async () => {
     let listener: ((frame: RuntimeBusinessFrame) => void | Promise<void>) | undefined;
-    const send = vi.fn(async (_frame: unknown) => undefined);
+    const sent: Array<{ requestId: string; text: string }> = [];
+    const send = vi.fn(async (frame: unknown) => {
+      sent.push(frame as { requestId: string; text: string });
+    });
     const host = new RuntimeToolHost({
       send,
       subscribeBusinessFrames: (next) => {
@@ -198,44 +212,191 @@ describe("RuntimeToolHost", () => {
       },
     });
     const delivery = request();
-    const requestId = randomUUID();
     const release = host.activateRun("turn-1", delivery, ["opentag_message_send"]);
     const signal = new AbortController().signal;
-    const call = (text: string, callId: string) => ({
-      runId: "turn-1",
-      toolCallId: callId,
-      name: "opentag_message_send",
-      input: { retryRequestId: requestId, text },
-      signal,
-    });
-    const first = host.execute(call("hello", "call-1"));
-    const same = host.execute(call("hello", "call-2"));
-    await expect.poll(() => send.mock.calls.length).toBe(1);
-    await listener?.({ type: "im:tool:result", requestId, state: "unknown", code: "provider_unknown" });
-    await expect(first).resolves.toMatchObject({ success: false });
-    await expect(same).resolves.toEqual(await first);
-    expect(send).toHaveBeenCalledTimes(1);
-
-    const explicitRetry = host.execute(call("hello", "call-retry"));
-    await expect.poll(() => send.mock.calls.length).toBe(2);
-    expect(send.mock.calls[1]?.[0]).toMatchObject({ requestId, text: "hello" });
-    await listener?.({ type: "im:tool:result", requestId, state: "succeeded" });
-    await expect(explicitRetry).resolves.toMatchObject({ success: true });
-
-    const conflictingId = randomUUID();
-    const pending = host.execute({
-      ...call("one", "call-3"),
-      input: { retryRequestId: conflictingId, text: "one" },
-    });
+    const arbitraryRequestId = randomUUID();
     await expect(
       host.execute({
-        ...call("two", "call-4"),
-        input: { retryRequestId: conflictingId, text: "two" },
+        runId: "turn-1",
+        toolCallId: "call-arbitrary-retry",
+        name: "opentag_message_send",
+        input: { retryRequestId: arbitraryRequestId, text: "hello" },
+        signal,
+      }),
+    ).resolves.toMatchObject({ success: false, error: { code: "retry_request_not_unknown" } });
+    expect(send).not.toHaveBeenCalled();
+
+    const first = host.execute({
+      runId: "turn-1",
+      toolCallId: "call-first",
+      name: "opentag_message_send",
+      input: { text: "hello" },
+      signal,
+    });
+    await expect.poll(() => send.mock.calls.length).toBe(1);
+    const requestId = sent[0]?.requestId as string;
+    await listener?.({ type: "im:tool:result", requestId, state: "unknown", code: "provider_unknown" });
+    const unknown = await first;
+    expect(unknown).toMatchObject({ success: false, error: { code: "provider_unknown" } });
+    expect(JSON.parse((unknown.content[0] as { text: string }).text)).toMatchObject({ requestId, state: "unknown" });
+    expect(send).toHaveBeenCalledTimes(1);
+
+    await expect(
+      host.execute({
+        runId: "turn-1",
+        toolCallId: "call-changed-retry",
+        name: "opentag_message_send",
+        input: { retryRequestId: requestId, text: "changed" },
+        signal,
       }),
     ).resolves.toMatchObject({ success: false, error: { code: "request_id_conflict" } });
-    expect(send).toHaveBeenCalledTimes(3);
-    await listener?.({ type: "im:tool:result", requestId: conflictingId, state: "succeeded" });
-    await expect(pending).resolves.toMatchObject({ success: true });
+    expect(send).toHaveBeenCalledTimes(1);
+
+    const retryCall = (toolCallId: string, retrySignal = signal) =>
+      host.execute({
+        runId: "turn-1",
+        toolCallId,
+        name: "opentag_message_send",
+        input: { retryRequestId: requestId, text: "hello" },
+        signal: retrySignal,
+      });
+    const explicitRetry = retryCall("call-retry");
+    const concurrentController = new AbortController();
+    const concurrentRetry = retryCall("call-concurrent-retry", concurrentController.signal);
+    const definiteController = new AbortController();
+    const definiteConcurrentRetry = retryCall("call-definite-concurrent-retry", definiteController.signal);
+    await expect.poll(() => send.mock.calls.length).toBe(2);
+    expect(sent[1]).toMatchObject({ requestId, text: "hello" });
+    concurrentController.abort();
+    await expect(concurrentRetry).resolves.toMatchObject({
+      success: false,
+      error: { code: "tool_call_cancelled" },
+    });
+    await listener?.({ type: "im:tool:result", requestId, state: "succeeded" });
+    definiteController.abort();
+    await expect(explicitRetry).resolves.toMatchObject({ success: true });
+    await expect(definiteConcurrentRetry).resolves.toMatchObject({ success: true });
+
+    await expect(
+      host.execute({
+        runId: "turn-1",
+        toolCallId: "call-retry-after-success",
+        name: "opentag_message_send",
+        input: { retryRequestId: requestId, text: "hello" },
+        signal,
+      }),
+    ).resolves.toMatchObject({ success: false, error: { code: "retry_request_not_unknown" } });
+    expect(send).toHaveBeenCalledTimes(2);
+    release();
+    host.close();
+  });
+
+  it("lets a definite Server result win a same-tick caller abort and keeps its identity non-retryable", async () => {
+    for (const state of ["succeeded", "deterministic_failed"] as const) {
+      let listener: ((frame: RuntimeBusinessFrame) => void | Promise<void>) | undefined;
+      const sent: Array<{ requestId: string }> = [];
+      const host = new RuntimeToolHost({
+        send: async (frame: unknown) => {
+          sent.push(frame as { requestId: string });
+        },
+        subscribeBusinessFrames: (next) => {
+          listener = next;
+          return () => {
+            listener = undefined;
+          };
+        },
+      });
+      const runId = `turn-definite-abort-${state}`;
+      const release = host.activateRun(runId, request(), ["opentag_message_send"]);
+      const controller = new AbortController();
+      const pending = host.execute({
+        runId,
+        toolCallId: "call-first",
+        name: "opentag_message_send",
+        input: { text: "hello" },
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(sent).toHaveLength(1));
+      const requestId = sent[0]?.requestId as string;
+
+      void listener?.({ type: "im:tool:result", requestId, state, code: "provider_result" });
+      controller.abort();
+
+      await expect(pending).resolves.toMatchObject(
+        state === "succeeded" ? { success: true } : { success: false, error: { code: "provider_result" } },
+      );
+      await expect(
+        host.execute({
+          runId,
+          toolCallId: "call-retry",
+          name: "opentag_message_send",
+          input: { retryRequestId: requestId, text: "hello" },
+          signal: new AbortController().signal,
+        }),
+      ).resolves.toMatchObject({ success: false, error: { code: "retry_request_not_unknown" } });
+      expect(sent).toHaveLength(1);
+      release();
+      host.close();
+    }
+  });
+
+  it("bounds retryable unknown identities to the most recent 64 entries in a Run", async () => {
+    let listener: ((frame: RuntimeBusinessFrame) => void | Promise<void>) | undefined;
+    const sent: Array<{ requestId: string; text: string }> = [];
+    const host = new RuntimeToolHost({
+      send: async (frame: unknown) => {
+        sent.push(frame as { requestId: string; text: string });
+      },
+      subscribeBusinessFrames: (next) => {
+        listener = next;
+        return () => {
+          listener = undefined;
+        };
+      },
+    });
+    const delivery = request();
+    const release = host.activateRun("turn-bounded-retries", delivery, ["opentag_message_send"]);
+    const signal = new AbortController().signal;
+    const unknownIds: string[] = [];
+
+    for (let index = 0; index < 65; index += 1) {
+      const pending = host.execute({
+        runId: "turn-bounded-retries",
+        toolCallId: `call-${index}`,
+        name: "opentag_message_send",
+        input: { text: `message-${index}` },
+        signal,
+      });
+      await vi.waitFor(() => expect(sent).toHaveLength(index + 1));
+      const requestId = sent[index]?.requestId as string;
+      unknownIds.push(requestId);
+      await listener?.({ type: "im:tool:result", requestId, state: "unknown" });
+      await expect(pending).resolves.toMatchObject({ success: false });
+    }
+
+    await expect(
+      host.execute({
+        runId: "turn-bounded-retries",
+        toolCallId: "retry-evicted",
+        name: "opentag_message_send",
+        input: { retryRequestId: unknownIds[0] as string, text: "message-0" },
+        signal,
+      }),
+    ).resolves.toMatchObject({ success: false, error: { code: "retry_request_not_unknown" } });
+    expect(sent).toHaveLength(65);
+
+    const latestRequestId = unknownIds[64] as string;
+    const latestRetry = host.execute({
+      runId: "turn-bounded-retries",
+      toolCallId: "retry-latest",
+      name: "opentag_message_send",
+      input: { retryRequestId: latestRequestId, text: "message-64" },
+      signal,
+    });
+    await vi.waitFor(() => expect(sent).toHaveLength(66));
+    expect(sent[65]).toMatchObject({ requestId: latestRequestId, text: "message-64" });
+    await listener?.({ type: "im:tool:result", requestId: latestRequestId, state: "succeeded" });
+    await expect(latestRetry).resolves.toMatchObject({ success: true });
     release();
     host.close();
   });
@@ -478,27 +639,30 @@ describe("RuntimeToolHost", () => {
     expect(nonErrorFailure).toMatchObject({ success: false, error: { code: "tool_call_failed" } });
 
     sendFailure = undefined;
-    const noCodeRequestId = randomUUID();
     const noCode = host.execute({
       runId: "turn-1",
       toolCallId: "failed-without-code",
       name: "opentag_message_send",
-      input: { retryRequestId: noCodeRequestId, text: "fail" },
+      input: { text: "fail" },
       signal,
     });
+    const noCodeRequestId = (sent.at(-1) as { requestId: string }).requestId;
     await listener?.({ type: "im:tool:result", requestId: noCodeRequestId, state: "deterministic_failed" });
     await expect(noCode).resolves.toMatchObject({ success: false, error: { code: "deterministic_failed" } });
 
     await listener?.({ type: "not-a-tool-result" } as never);
 
-    const sharedRequestId = randomUUID();
+    const sharedOwnerAbort = new AbortController();
     const shared = host.execute({
       runId: "turn-1",
       toolCallId: "shared-owner",
       name: "opentag_message_send",
-      input: { retryRequestId: sharedRequestId, text: "shared" },
-      signal,
+      input: { text: "shared" },
+      signal: sharedOwnerAbort.signal,
     });
+    const sharedRequestId = (sent.at(-1) as { requestId: string }).requestId;
+    sharedOwnerAbort.abort();
+    await expect(shared).resolves.toMatchObject({ success: false, error: { code: "tool_call_cancelled" } });
     const cancelledCaller = new AbortController();
     cancelledCaller.abort();
     await expect(
@@ -511,17 +675,16 @@ describe("RuntimeToolHost", () => {
       }),
     ).resolves.toMatchObject({ success: false, error: { code: "tool_call_cancelled" } });
     await listener?.({ type: "im:tool:result", requestId: sharedRequestId, state: "succeeded" });
-    await shared;
 
     const abortDuringRequest = new AbortController();
-    const abortRequestId = randomUUID();
     const abortPending = host.execute({
       runId: "turn-1",
       toolCallId: "abort-during-request",
       name: "opentag_message_send",
-      input: { retryRequestId: abortRequestId, text: "cancel" },
+      input: { text: "cancel" },
       signal: abortDuringRequest.signal,
     });
+    const abortRequestId = (sent.at(-1) as { requestId: string }).requestId;
     abortDuringRequest.abort();
     const abortedAfterDispatch = await abortPending;
     expect(abortedAfterDispatch).toMatchObject({ success: false, error: { code: "tool_call_cancelled" } });

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -214,7 +214,8 @@ export function buildAgentInput(request: DirectImMessageDeliveryRequest, supplem
     `Agent revision: ${request.runtime.revision.agent.sequence}/${request.runtime.revision.agent.id}`,
     `Session revision: ${request.runtime.revision.session.sequence}/${request.runtime.revision.session.id}`,
     "Reload and obey the managed AGENTS.md before acting.",
-    "For the same logical IM write retry, reuse the exact same requestId; never mint a new ID after an unknown result.",
+    "For a new IM write, omit retryRequestId; OpenTag assigns the request identity.",
+    "Never automatically repeat an unknown IM write. Only when explicitly retrying the exact same payload, reuse the returned requestId as retryRequestId.",
     "Session instructions:",
     sessionInstructions,
   ].join("\n");

--- a/packages/client/src/runtime/agent-workspace.ts
+++ b/packages/client/src/runtime/agent-workspace.ts
@@ -13,6 +13,7 @@ import {
   RuntimeStorageError,
   readDurableJson,
   readSecureFile,
+  removeDurableFile,
   writeDurableFile,
   writeDurableJson,
 } from "../storage/durable-file.js";
@@ -20,8 +21,7 @@ import { agentRuntimePaths } from "./runtime-paths.js";
 import type { SessionBindingStore, SessionPreparationResult } from "./session-binding-store.js";
 import type { RuntimePreparation } from "./session-reconciler.js";
 
-export interface LocalAgentWorkspaceState {
-  schemaVersion: 1;
+interface AgentWorkspaceStateFields {
   agentId: string;
   workspaceId: string;
   provider: "codex";
@@ -30,6 +30,16 @@ export interface LocalAgentWorkspaceState {
   agentConfigHash: string;
   managedInstructionsHash: string;
 }
+
+interface LegacyAgentWorkspaceState extends AgentWorkspaceStateFields {
+  schemaVersion: 1;
+}
+
+export interface LocalAgentWorkspaceState extends AgentWorkspaceStateFields {
+  schemaVersion: 2;
+}
+
+type ParsedAgentWorkspaceState = LegacyAgentWorkspaceState | LocalAgentWorkspaceState;
 
 export interface AgentWorkspaceManagerOptions {
   bindingStore: SessionBindingStore;
@@ -56,7 +66,7 @@ export class AgentWorkspaceManager implements RuntimePreparation {
     const content = renderManagedInstructions(snapshot);
     const managedInstructionsHash = sha256(content);
     const next: LocalAgentWorkspaceState = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       agentId: snapshot.agentId,
       workspaceId: snapshot.workspace.workspaceId,
       provider: snapshot.provider,
@@ -69,36 +79,14 @@ export class AgentWorkspaceManager implements RuntimePreparation {
     await ensurePrivateDirectory(this.#home, paths.workspaceRoot);
     await ensurePrivateDirectory(this.#home, paths.files);
 
-    if (state) {
-      validateWorkspaceIdentity(state, snapshot);
-      if (snapshot.revision.agent.sequence < state.appliedAgentRevisionSequence) {
-        throw new RuntimeStorageError("conflict", "The Agent runtime revision is stale");
-      }
-      if (
-        snapshot.revision.agent.sequence === state.appliedAgentRevisionSequence &&
-        (snapshot.revision.agent.id !== state.appliedAgentRevisionId ||
-          hashes.agentConfigHash !== state.agentConfigHash)
-      ) {
-        throw new RuntimeStorageError("conflict", "The Agent runtime revision conflicts with the workspace");
-      }
-      if (snapshot.revision.agent.sequence === state.appliedAgentRevisionSequence) {
-        const existing = await readSecureFile(paths.agentsFile);
-        if (existing === undefined && state.managedInstructionsHash === managedInstructionsHash) {
-          await writeDurableFile(paths.agentsFile, content, 0o444);
-          return;
-        }
-        if (existing === undefined || sha256(existing) !== state.managedInstructionsHash || existing !== content) {
-          throw new RuntimeStorageError("conflict", "The managed AGENTS.md file was modified outside OpenTag");
-        }
-        await chmod(paths.agentsFile, 0o444);
-        return;
-      }
-    } else if ((await readSecureFile(paths.agentsFile)) !== undefined) {
-      throw new RuntimeStorageError("conflict", "OpenTag will not replace an unmanaged AGENTS.md file");
+    const current = state ?? next;
+    validateWorkspaceIdentity(current, snapshot);
+    validateWorkspaceRevision(current, snapshot, hashes);
+    if (current.schemaVersion === 1) {
+      await migrateLegacyWorkspace(current, next, paths, content);
+      return;
     }
-
-    await writeDurableFile(paths.agentsFile, content, 0o444);
-    if (state) await writeDurableJson(paths.workspaceState, next);
+    await prepareCurrentWorkspace(current, next, paths, content, managedInstructionsHash);
   }
 
   async prepareSession(
@@ -145,7 +133,7 @@ export function renderManagedInstructions(snapshot: EffectiveRuntimeSnapshot): s
   ].join("\n");
 }
 
-function parseAgentWorkspaceState(value: unknown): LocalAgentWorkspaceState {
+function parseAgentWorkspaceState(value: unknown): ParsedAgentWorkspaceState {
   if (
     typeof value !== "object" ||
     value === null ||
@@ -168,7 +156,7 @@ function parseAgentWorkspaceState(value: unknown): LocalAgentWorkspaceState {
   }
   const state = value as Record<string, unknown>;
   if (
-    state.schemaVersion !== 1 ||
+    (state.schemaVersion !== 1 && state.schemaVersion !== 2) ||
     typeof state.agentId !== "string" ||
     typeof state.workspaceId !== "string" ||
     state.provider !== "codex" ||
@@ -181,10 +169,10 @@ function parseAgentWorkspaceState(value: unknown): LocalAgentWorkspaceState {
   ) {
     throw new RuntimeStorageError("invalid", "Agent workspace state values are invalid");
   }
-  return state as unknown as LocalAgentWorkspaceState;
+  return state as unknown as ParsedAgentWorkspaceState;
 }
 
-function validateWorkspaceIdentity(state: LocalAgentWorkspaceState, snapshot: EffectiveRuntimeSnapshot): void {
+function validateWorkspaceIdentity(state: ParsedAgentWorkspaceState, snapshot: EffectiveRuntimeSnapshot): void {
   if (
     state.agentId !== snapshot.agentId ||
     state.workspaceId !== snapshot.workspace.workspaceId ||
@@ -192,6 +180,78 @@ function validateWorkspaceIdentity(state: LocalAgentWorkspaceState, snapshot: Ef
   ) {
     throw new RuntimeStorageError("conflict", "Agent workspace identity cannot be changed");
   }
+}
+
+function validateWorkspaceRevision(
+  state: ParsedAgentWorkspaceState,
+  snapshot: EffectiveRuntimeSnapshot,
+  hashes: RuntimeSnapshotHashes,
+): void {
+  if (snapshot.revision.agent.sequence < state.appliedAgentRevisionSequence) {
+    throw new RuntimeStorageError("conflict", "The Agent runtime revision is stale");
+  }
+  if (
+    snapshot.revision.agent.sequence === state.appliedAgentRevisionSequence &&
+    (snapshot.revision.agent.id !== state.appliedAgentRevisionId || hashes.agentConfigHash !== state.agentConfigHash)
+  ) {
+    throw new RuntimeStorageError("conflict", "The Agent runtime revision conflicts with the workspace");
+  }
+}
+
+async function migrateLegacyWorkspace(
+  state: LegacyAgentWorkspaceState,
+  next: LocalAgentWorkspaceState,
+  paths: ReturnType<typeof agentRuntimePaths>,
+  content: string,
+): Promise<void> {
+  const legacy = await readSecureFile(paths.legacyAgentsFile);
+  if (legacy !== undefined && sha256(legacy) !== state.managedInstructionsHash) {
+    throw new RuntimeStorageError("conflict", "The legacy managed AGENTS.md file was modified outside OpenTag");
+  }
+  const current = await readSecureFile(paths.agentsFile);
+  if (current !== undefined && current !== content) {
+    throw new RuntimeStorageError("conflict", "OpenTag will not replace a conflicting AGENTS.md file in the Agent cwd");
+  }
+  if (current === undefined) await writeDurableFile(paths.agentsFile, content, 0o444);
+  else await chmod(paths.agentsFile, 0o444);
+  if (legacy !== undefined) await removeDurableFile(paths.legacyAgentsFile);
+  await writeDurableJson(paths.workspaceState, next);
+}
+
+async function prepareCurrentWorkspace(
+  state: LocalAgentWorkspaceState,
+  next: LocalAgentWorkspaceState,
+  paths: ReturnType<typeof agentRuntimePaths>,
+  content: string,
+  managedInstructionsHash: string,
+): Promise<void> {
+  if ((await readSecureFile(paths.legacyAgentsFile)) !== undefined) {
+    throw new RuntimeStorageError("conflict", "A legacy AGENTS.md file conflicts with the current Agent workspace");
+  }
+  const existing = await readSecureFile(paths.agentsFile);
+  const sameRevision = next.appliedAgentRevisionSequence === state.appliedAgentRevisionSequence;
+  if (existing === undefined) {
+    if (!sameRevision || state.managedInstructionsHash !== managedInstructionsHash) {
+      throw new RuntimeStorageError("conflict", "The managed AGENTS.md file was removed outside OpenTag");
+    }
+    await writeDurableFile(paths.agentsFile, content, 0o444);
+    return;
+  }
+  if (sha256(existing) !== state.managedInstructionsHash) {
+    throw new RuntimeStorageError("conflict", "The managed AGENTS.md file was modified outside OpenTag");
+  }
+  if (sameRevision) {
+    if (existing !== content) {
+      throw new RuntimeStorageError(
+        "conflict",
+        "The managed AGENTS.md file conflicts with the current runtime snapshot",
+      );
+    }
+    await chmod(paths.agentsFile, 0o444);
+    return;
+  }
+  await writeDurableFile(paths.agentsFile, content, 0o444);
+  await writeDurableJson(paths.workspaceState, next);
 }
 
 async function realDirectoryExists(path: string): Promise<boolean> {

--- a/packages/client/src/runtime/runtime-paths.ts
+++ b/packages/client/src/runtime/runtime-paths.ts
@@ -11,6 +11,7 @@ export interface AgentRuntimePaths {
   agentsFile: string;
   effectiveSnapshotsRoot: string;
   files: string;
+  legacyAgentsFile: string;
   runtimeRoot: string;
   sessionBindingsRoot: string;
   sessions: string;
@@ -25,9 +26,10 @@ export function agentRuntimePaths(home: string, agentId: string): AgentRuntimePa
   const key = deriveRuntimeKey("agent", agentId);
   const workspaceRoot = resolve(layout.workspaces, key);
   return {
-    agentsFile: resolve(workspaceRoot, "AGENTS.md"),
+    agentsFile: resolve(workspaceRoot, "files", "AGENTS.md"),
     effectiveSnapshotsRoot: layout.runtimeEffectiveSnapshots,
     files: resolve(workspaceRoot, "files"),
+    legacyAgentsFile: resolve(workspaceRoot, "AGENTS.md"),
     runtimeRoot: layout.runtime,
     sessionBindingsRoot: layout.runtimeSessionBindings,
     sessions: resolve(layout.runtimeSessionBindings, key),

--- a/packages/client/src/runtime/runtime-tool-host.ts
+++ b/packages/client/src/runtime/runtime-tool-host.ts
@@ -1,7 +1,8 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   type DirectImMessageDeliveryRequest,
   OPENTAG_MESSAGE_TOOLS,
+  RUNTIME_DIRECT_TEXT_MAX_BYTES,
   type RuntimeImToolRequest,
   type RuntimeImToolResult,
   RuntimeImToolResultSchema,
@@ -15,7 +16,6 @@ import type {
 import type { RuntimeConnection } from "./runtime-connection.js";
 
 const TOOL_TIMEOUT_MS = 60_000;
-const TOOL_TEXT_MAX_BYTES = 24 * 1024;
 const OPENTAG_TOOL_SET: ReadonlySet<string> = new Set(OPENTAG_MESSAGE_TOOLS);
 
 interface PendingTool {
@@ -30,6 +30,17 @@ interface ActiveRun {
   readonly allowedTools: ReadonlySet<string>;
   readonly calls: Map<string, { readonly hash: string; readonly promise: Promise<AgentHostedToolResult> }>;
   readonly delivery: DirectImMessageDeliveryRequest;
+}
+
+class RuntimeToolRequestError extends Error {
+  constructor(
+    readonly state: "deterministic_failed" | "unknown",
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RuntimeToolRequestError";
+  }
 }
 
 export class RuntimeToolHost {
@@ -84,7 +95,11 @@ export class RuntimeToolHost {
   close(): void {
     this.#unsubscribe();
     this.#activeRuns.clear();
-    const error = new Error("OpenTag runtime tool host stopped");
+    const error = new RuntimeToolRequestError(
+      "unknown",
+      "tool_host_closed",
+      "OpenTag runtime tool host stopped before the Server result arrived",
+    );
     for (const pending of [...this.#pending.values()]) pending.reject(error);
     this.#pending.clear();
   }
@@ -93,10 +108,12 @@ export class RuntimeToolHost {
     delivery: DirectImMessageDeliveryRequest,
     call: AgentHostedToolCall,
   ): Promise<AgentHostedToolResult> {
+    let request: RuntimeImToolRequest | undefined;
     try {
-      const request = buildToolRequest(delivery, call);
+      request = buildToolRequest(delivery, call);
       const result = await this.#request(request, call.signal);
       const text = JSON.stringify({
+        requestId: result.requestId,
         state: result.state,
         ...(result.code ? { code: result.code } : {}),
         ...(result.providerMessageId ? { providerMessageId: result.providerMessageId } : {}),
@@ -110,6 +127,9 @@ export class RuntimeToolHost {
             error: { code: result.code ?? result.state, message: "OpenTag message operation did not succeed." },
           };
     } catch (error) {
+      if (request && error instanceof RuntimeToolRequestError) {
+        return failedRequestResult(request.requestId, error.state, error.code, error.message);
+      }
       return failedToolResult(
         call.signal.aborted ? "tool_call_cancelled" : "tool_call_failed",
         error instanceof Error ? error.message : "OpenTag runtime tool call failed.",
@@ -118,11 +138,23 @@ export class RuntimeToolHost {
   }
 
   async #request(request: RuntimeImToolRequest, signal: AbortSignal): Promise<RuntimeImToolResult> {
-    if (signal.aborted) throw new Error("OpenTag runtime tool call was aborted");
+    if (signal.aborted) {
+      throw new RuntimeToolRequestError(
+        "deterministic_failed",
+        "tool_call_cancelled",
+        "OpenTag runtime tool call was aborted before dispatch",
+      );
+    }
     const hash = requestHash(request);
     const existing = this.#pending.get(request.requestId);
     if (existing) {
-      if (existing.hash !== hash) throw new Error("OpenTag runtime tool request ID conflicts with another intent");
+      if (existing.hash !== hash) {
+        throw new RuntimeToolRequestError(
+          "deterministic_failed",
+          "request_id_conflict",
+          "OpenTag runtime tool request ID conflicts with another intent",
+        );
+      }
       return withCallerAbort(existing.promise, signal);
     }
     let resolveResult!: (result: RuntimeImToolResult) => void;
@@ -131,7 +163,17 @@ export class RuntimeToolHost {
       resolveResult = resolve;
       rejectResult = reject;
     });
-    const timer = setTimeout(() => rejectResult(new Error("OpenTag runtime tool call timed out")), TOOL_TIMEOUT_MS);
+    const timer = setTimeout(
+      () =>
+        rejectResult(
+          new RuntimeToolRequestError(
+            "unknown",
+            "tool_result_timeout",
+            "OpenTag runtime tool result timed out after dispatch",
+          ),
+        ),
+      TOOL_TIMEOUT_MS,
+    );
     timer.unref();
     const pending: PendingTool = {
       hash,
@@ -148,7 +190,8 @@ export class RuntimeToolHost {
     };
     void promise.then(cleanup, cleanup);
     void (async () => this.#connection.send(request, { priority: "result" }))().catch((error: unknown) => {
-      pending.reject(error instanceof Error ? error : new Error("Runtime send failed"));
+      const detail = error instanceof Error ? error.message : "Runtime send failed";
+      pending.reject(new RuntimeToolRequestError("unknown", "runtime_send_failed", detail));
     });
     return withCallerAbort(promise, signal);
   }
@@ -169,10 +212,10 @@ export function openTagHostedToolDefinitions(allowedTools: readonly string[]): r
 }
 
 function toolDefinition(name: (typeof OPENTAG_MESSAGE_TOOLS)[number]): AgentHostedToolDefinition {
-  const requestId = {
+  const retryRequestId = {
     type: "string",
     format: "uuid",
-    description: "Stable operation ID. Reuse it when retrying the same logical write.",
+    description: "Only reuse the requestId returned by an unknown result when explicitly retrying the same payload.",
   } as const;
   if (name === "opentag_message_react") {
     return {
@@ -182,11 +225,11 @@ function toolDefinition(name: (typeof OPENTAG_MESSAGE_TOOLS)[number]): AgentHost
         type: "object",
         additionalProperties: false,
         properties: {
-          requestId,
+          retryRequestId,
           targetImMessageId: { type: "string", format: "uuid" },
           emoji: { type: "string" },
         },
-        required: ["requestId", "targetImMessageId", "emoji"],
+        required: ["targetImMessageId", "emoji"],
       },
     };
   }
@@ -198,11 +241,11 @@ function toolDefinition(name: (typeof OPENTAG_MESSAGE_TOOLS)[number]): AgentHost
         type: "object",
         additionalProperties: false,
         properties: {
-          requestId,
+          retryRequestId,
           replyToImMessageId: { type: "string", format: "uuid" },
           text: { type: "string" },
         },
-        required: ["requestId", "replyToImMessageId", "text"],
+        required: ["replyToImMessageId", "text"],
       },
     };
   }
@@ -212,8 +255,8 @@ function toolDefinition(name: (typeof OPENTAG_MESSAGE_TOOLS)[number]): AgentHost
     inputSchema: {
       type: "object",
       additionalProperties: false,
-      properties: { requestId, text: { type: "string" } },
-      required: ["requestId", "text"],
+      properties: { retryRequestId, text: { type: "string" } },
+      required: ["text"],
     },
   };
 }
@@ -222,13 +265,33 @@ function failedToolResult(code: string, message: string): AgentHostedToolResult 
   return { success: false, content: [{ type: "text", text: message }], error: { code, message } };
 }
 
+function failedRequestResult(
+  requestId: string,
+  state: "deterministic_failed" | "unknown",
+  code: string,
+  message: string,
+): AgentHostedToolResult {
+  return {
+    success: false,
+    content: [{ type: "text", text: JSON.stringify({ requestId, state, code }) }],
+    error: { code, message },
+  };
+}
+
 function requestHash(request: unknown): string {
   return createHash("sha256").update(JSON.stringify(request)).digest("hex");
 }
 
 function withCallerAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(new Error("OpenTag runtime tool call was aborted"));
+    const onAbort = () =>
+      reject(
+        new RuntimeToolRequestError(
+          "unknown",
+          "tool_call_cancelled",
+          "OpenTag runtime tool call was aborted after dispatch",
+        ),
+      );
     signal.addEventListener("abort", onAbort, { once: true });
     void promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
   });
@@ -236,30 +299,41 @@ function withCallerAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T
 
 function buildToolRequest(delivery: DirectImMessageDeliveryRequest, call: AgentHostedToolCall): RuntimeImToolRequest {
   const input = requireRecord(call.input);
-  const base = {
+  if (call.name === "opentag_message_send") {
+    requireOnlyKeys(input, ["retryRequestId", "text"]);
+    const text = requireText(input.text);
+    return { ...toolRequestBase(delivery, input.retryRequestId), operation: "send", text };
+  }
+  if (call.name === "opentag_message_reply") {
+    requireOnlyKeys(input, ["replyToImMessageId", "retryRequestId", "text"]);
+    const text = requireText(input.text);
+    const replyToImMessageId = requireUuid(input.replyToImMessageId);
+    return {
+      ...toolRequestBase(delivery, input.retryRequestId),
+      operation: "reply",
+      text,
+      replyToImMessageId,
+    };
+  }
+  requireOnlyKeys(input, ["emoji", "retryRequestId", "targetImMessageId"]);
+  const targetImMessageId = requireUuid(input.targetImMessageId);
+  const emoji = requireString(input.emoji, 128);
+  return {
+    ...toolRequestBase(delivery, input.retryRequestId),
+    operation: "react",
+    targetImMessageId,
+    emoji,
+  };
+}
+
+function toolRequestBase(delivery: DirectImMessageDeliveryRequest, retryRequestId: unknown) {
+  return {
     type: "im:tool" as const,
-    requestId: requireUuid(input.requestId),
+    requestId: retryRequestId === undefined ? randomUUID() : requireUuid(retryRequestId),
     sessionId: delivery.sessionId,
     agentId: delivery.agentId,
     placementGeneration: delivery.placementGeneration,
     expectedLatestImMessageId: delivery.imMessageId,
-  };
-  if (call.name === "opentag_message_send") {
-    return { ...base, operation: "send", text: requireText(input.text) };
-  }
-  if (call.name === "opentag_message_reply") {
-    return {
-      ...base,
-      operation: "reply",
-      text: requireText(input.text),
-      replyToImMessageId: requireUuid(input.replyToImMessageId),
-    };
-  }
-  return {
-    ...base,
-    operation: "react",
-    targetImMessageId: requireUuid(input.targetImMessageId),
-    emoji: requireString(input.emoji, 128),
   };
 }
 
@@ -271,9 +345,16 @@ function requireRecord(value: unknown): Record<string, unknown> {
 }
 
 function requireText(value: unknown): string {
-  const text = requireString(value, TOOL_TEXT_MAX_BYTES);
+  const text = requireString(value, RUNTIME_DIRECT_TEXT_MAX_BYTES);
   if (text.trim().length === 0) throw new Error("OpenTag message text cannot be empty");
   return text;
+}
+
+function requireOnlyKeys(input: Record<string, unknown>, allowedKeys: readonly string[]): void {
+  const allowed = new Set(allowedKeys);
+  if (Object.keys(input).some((key) => !allowed.has(key))) {
+    throw new Error("OpenTag runtime tool arguments contain an unsupported field");
+  }
 }
 
 function requireString(value: unknown, maxBytes: number): string {

--- a/packages/client/src/runtime/runtime-tool-host.ts
+++ b/packages/client/src/runtime/runtime-tool-host.ts
@@ -16,9 +16,11 @@ import type {
 import type { RuntimeConnection } from "./runtime-connection.js";
 
 const TOOL_TIMEOUT_MS = 60_000;
+const RETRYABLE_UNKNOWN_LIMIT = 64;
 const OPENTAG_TOOL_SET: ReadonlySet<string> = new Set(OPENTAG_MESSAGE_TOOLS);
 
 interface PendingTool {
+  definiteResult: boolean;
   hash: string;
   promise: Promise<RuntimeImToolResult>;
   reject(error: Error): void;
@@ -30,6 +32,12 @@ interface ActiveRun {
   readonly allowedTools: ReadonlySet<string>;
   readonly calls: Map<string, { readonly hash: string; readonly promise: Promise<AgentHostedToolResult> }>;
   readonly delivery: DirectImMessageDeliveryRequest;
+  readonly retryableUnknown: Map<string, string>;
+}
+
+interface BuiltToolRequest {
+  readonly request: RuntimeImToolRequest;
+  readonly retryRequested: boolean;
 }
 
 class RuntimeToolRequestError extends Error {
@@ -67,7 +75,7 @@ export class RuntimeToolHost {
     if (allowed.size !== allowedTools.length || [...allowed].some((name) => !OPENTAG_TOOL_SET.has(name))) {
       throw new Error("OpenTag runtime tool allow-list is invalid");
     }
-    const active: ActiveRun = { allowedTools: allowed, calls: new Map(), delivery };
+    const active: ActiveRun = { allowedTools: allowed, calls: new Map(), delivery, retryableUnknown: new Map() };
     this.#activeRuns.set(runId, active);
     return () => {
       if (this.#activeRuns.get(runId) === active) this.#activeRuns.delete(runId);
@@ -87,7 +95,7 @@ export class RuntimeToolHost {
       }
       return existing.promise;
     }
-    const promise = this.#executeActive(active.delivery, call);
+    const promise = this.#executeActive(active, call);
     active.calls.set(call.toolCallId, { hash, promise });
     return promise;
   }
@@ -104,14 +112,14 @@ export class RuntimeToolHost {
     this.#pending.clear();
   }
 
-  async #executeActive(
-    delivery: DirectImMessageDeliveryRequest,
-    call: AgentHostedToolCall,
-  ): Promise<AgentHostedToolResult> {
-    let request: RuntimeImToolRequest | undefined;
+  async #executeActive(active: ActiveRun, call: AgentHostedToolCall): Promise<AgentHostedToolResult> {
+    let built: BuiltToolRequest | undefined;
+    let intentHash: string | undefined;
     try {
-      request = buildToolRequest(delivery, call);
-      const result = await this.#request(request, call.signal);
+      built = buildToolRequest(active.delivery, call);
+      intentHash = requestHash(built.request);
+      if (built.retryRequested) assertRetryableUnknown(active, built.request.requestId, intentHash);
+      const result = await this.#request(active, built.request, intentHash, call.signal);
       const text = JSON.stringify({
         requestId: result.requestId,
         state: result.state,
@@ -127,8 +135,8 @@ export class RuntimeToolHost {
             error: { code: result.code ?? result.state, message: "OpenTag message operation did not succeed." },
           };
     } catch (error) {
-      if (request && error instanceof RuntimeToolRequestError) {
-        return failedRequestResult(request.requestId, error.state, error.code, error.message);
+      if (built && error instanceof RuntimeToolRequestError) {
+        return failedRequestResult(built.request.requestId, error.state, error.code, error.message);
       }
       return failedToolResult(
         call.signal.aborted ? "tool_call_cancelled" : "tool_call_failed",
@@ -137,7 +145,12 @@ export class RuntimeToolHost {
     }
   }
 
-  async #request(request: RuntimeImToolRequest, signal: AbortSignal): Promise<RuntimeImToolResult> {
+  async #request(
+    active: ActiveRun,
+    request: RuntimeImToolRequest,
+    hash: string,
+    signal: AbortSignal,
+  ): Promise<RuntimeImToolResult> {
     if (signal.aborted) {
       throw new RuntimeToolRequestError(
         "deterministic_failed",
@@ -145,9 +158,9 @@ export class RuntimeToolHost {
         "OpenTag runtime tool call was aborted before dispatch",
       );
     }
-    const hash = requestHash(request);
     const existing = this.#pending.get(request.requestId);
     if (existing) {
+      /* v8 ignore next 7 -- supplied retry IDs are hash-checked against the Run ledger before this method; only an unforgeable randomUUID collision can reach this defense. */
       if (existing.hash !== hash) {
         throw new RuntimeToolRequestError(
           "deterministic_failed",
@@ -155,7 +168,11 @@ export class RuntimeToolHost {
           "OpenTag runtime tool request ID conflicts with another intent",
         );
       }
-      return withCallerAbort(existing.promise, signal);
+      return withCallerAbort(existing.promise, signal, () => {
+        if (existing.definiteResult) return false;
+        rememberRetryableUnknown(active, request.requestId, hash);
+        return true;
+      });
     }
     let resolveResult!: (result: RuntimeImToolResult) => void;
     let rejectResult!: (error: Error) => void;
@@ -163,9 +180,10 @@ export class RuntimeToolHost {
       resolveResult = resolve;
       rejectResult = reject;
     });
+    let pending!: PendingTool;
     const timer = setTimeout(
       () =>
-        rejectResult(
+        pending.reject(
           new RuntimeToolRequestError(
             "unknown",
             "tool_result_timeout",
@@ -175,12 +193,26 @@ export class RuntimeToolHost {
       TOOL_TIMEOUT_MS,
     );
     timer.unref();
-    const pending: PendingTool = {
+    pending = {
+      definiteResult: false,
       hash,
       promise,
       timer,
-      resolve: resolveResult,
-      reject: rejectResult,
+      resolve: (result) => {
+        if (result.state === "unknown") {
+          if (!pending.definiteResult) rememberRetryableUnknown(active, request.requestId, hash);
+        } else {
+          pending.definiteResult = true;
+          active.retryableUnknown.delete(request.requestId);
+        }
+        resolveResult(result);
+      },
+      reject: (error) => {
+        if (error instanceof RuntimeToolRequestError && error.state === "unknown") {
+          if (!pending.definiteResult) rememberRetryableUnknown(active, request.requestId, hash);
+        }
+        rejectResult(error);
+      },
     };
     this.#pending.set(request.requestId, pending);
     const cleanup = () => {
@@ -193,7 +225,11 @@ export class RuntimeToolHost {
       const detail = error instanceof Error ? error.message : "Runtime send failed";
       pending.reject(new RuntimeToolRequestError("unknown", "runtime_send_failed", detail));
     });
-    return withCallerAbort(promise, signal);
+    return withCallerAbort(promise, signal, () => {
+      if (pending.definiteResult) return false;
+      rememberRetryableUnknown(active, request.requestId, hash);
+      return true;
+    });
   }
 
   #handleResult(input: unknown): void {
@@ -282,9 +318,36 @@ function requestHash(request: unknown): string {
   return createHash("sha256").update(JSON.stringify(request)).digest("hex");
 }
 
-function withCallerAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+function assertRetryableUnknown(active: ActiveRun, requestId: string, intentHash: string): void {
+  const retryableHash = active.retryableUnknown.get(requestId);
+  if (!retryableHash) {
+    throw new RuntimeToolRequestError(
+      "deterministic_failed",
+      "retry_request_not_unknown",
+      "OpenTag rejected a retry request ID that is not retryable in the active Run",
+    );
+  }
+  if (retryableHash !== intentHash) {
+    throw new RuntimeToolRequestError(
+      "deterministic_failed",
+      "request_id_conflict",
+      "OpenTag runtime tool request ID conflicts with the original unknown intent",
+    );
+  }
+}
+
+function rememberRetryableUnknown(active: ActiveRun, requestId: string, intentHash: string): void {
+  active.retryableUnknown.delete(requestId);
+  active.retryableUnknown.set(requestId, intentHash);
+  if (active.retryableUnknown.size <= RETRYABLE_UNKNOWN_LIMIT) return;
+  const oldestRequestId = active.retryableUnknown.keys().next().value as string;
+  active.retryableUnknown.delete(oldestRequestId);
+}
+
+function withCallerAbort<T>(promise: Promise<T>, signal: AbortSignal, shouldAbort: () => boolean): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () =>
+    const onAbort = () => {
+      if (!shouldAbort()) return;
       reject(
         new RuntimeToolRequestError(
           "unknown",
@@ -292,37 +355,50 @@ function withCallerAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T
           "OpenTag runtime tool call was aborted after dispatch",
         ),
       );
+    };
     signal.addEventListener("abort", onAbort, { once: true });
     void promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
   });
 }
 
-function buildToolRequest(delivery: DirectImMessageDeliveryRequest, call: AgentHostedToolCall): RuntimeImToolRequest {
+function buildToolRequest(delivery: DirectImMessageDeliveryRequest, call: AgentHostedToolCall): BuiltToolRequest {
   const input = requireRecord(call.input);
   if (call.name === "opentag_message_send") {
     requireOnlyKeys(input, ["retryRequestId", "text"]);
     const text = requireText(input.text);
-    return { ...toolRequestBase(delivery, input.retryRequestId), operation: "send", text };
+    const retryRequestId = input.retryRequestId;
+    return {
+      request: { ...toolRequestBase(delivery, retryRequestId), operation: "send", text },
+      retryRequested: retryRequestId !== undefined,
+    };
   }
   if (call.name === "opentag_message_reply") {
     requireOnlyKeys(input, ["replyToImMessageId", "retryRequestId", "text"]);
     const text = requireText(input.text);
     const replyToImMessageId = requireUuid(input.replyToImMessageId);
+    const retryRequestId = input.retryRequestId;
     return {
-      ...toolRequestBase(delivery, input.retryRequestId),
-      operation: "reply",
-      text,
-      replyToImMessageId,
+      request: {
+        ...toolRequestBase(delivery, retryRequestId),
+        operation: "reply",
+        text,
+        replyToImMessageId,
+      },
+      retryRequested: retryRequestId !== undefined,
     };
   }
   requireOnlyKeys(input, ["emoji", "retryRequestId", "targetImMessageId"]);
   const targetImMessageId = requireUuid(input.targetImMessageId);
   const emoji = requireString(input.emoji, 128);
+  const retryRequestId = input.retryRequestId;
   return {
-    ...toolRequestBase(delivery, input.retryRequestId),
-    operation: "react",
-    targetImMessageId,
-    emoji,
+    request: {
+      ...toolRequestBase(delivery, retryRequestId),
+      operation: "react",
+      targetImMessageId,
+      emoji,
+    },
+    retryRequested: retryRequestId !== undefined,
   };
 }
 

--- a/packages/client/src/storage/durable-file.ts
+++ b/packages/client/src/storage/durable-file.ts
@@ -109,6 +109,12 @@ export async function writeDurableJson(path: string, value: unknown): Promise<vo
   await writeDurableFile(path, `${JSON.stringify(value, undefined, 2)}\n`, 0o600);
 }
 
+export async function removeDurableFile(path: string): Promise<void> {
+  await assertReplaceableFile(path);
+  await rm(path);
+  await syncDirectory(dirname(path));
+}
+
 export async function assertRealDirectory(path: string): Promise<void> {
   const status = await lstat(path);
   if (!status.isDirectory() || status.isSymbolicLink()) {


### PR DESCRIPTION
## Summary

- preserve the manager's absolute user `PATH` entries in systemd and launchd service definitions while keeping the resolved OpenTag and Node entry points first; existing service definitions are reconciled and restarted when they drift
- move managed `AGENTS.md` instructions into the actual Codex working directory and migrate workspace state from v1 to v2 with hash validation, crash-safe re-entry, trusted legacy cleanup, and fail-closed conflict handling
- make the Client Runtime own outbound message request UUIDs, expose only `retryRequestId` for explicit retries of `unknown` results, and preserve request identity across timeout and transport uncertainty
- reuse the shared 16 KiB outbound text limit so invalid tool input is rejected before dispatch

## Compatibility and boundaries

- Client-to-Server wire schemas, Server APIs, database schemas, provider adapters, Feishu setup, and Web binding behavior are unchanged.
- Existing workspace state migrates automatically from v1 to v2. A user-modified or conflicting managed instruction file fails closed instead of being overwritten.
- Model-facing `opentag_message_send`, `opentag_message_reply`, and `opentag_message_react` calls no longer accept `requestId`; new request identities are generated by the Runtime. `retryRequestId` is optional and reserved for an explicit retry of the same payload after an `unknown` result.

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (100% statements, branches, functions, and lines)

## Post-release verification

The staging incident currently has a local systemd PATH drop-in and a temporary managed instruction compatibility file. They must remain until this change is released to staging. After release, remove both workarounds and run one real Feishu inbound/outbound acceptance check.
