### PR TITLE
feat(web): derive onboarding state from facts

### DIFF
--- a/apps/web/src/onboarding/flow.test.ts
+++ b/apps/web/src/onboarding/flow.test.ts
@@ -75,8 +75,29 @@ describe("deriveOnboardingState", () => {
     });
   });
 
-  it("asks only when multiple Computers are eligible", () => {
+  it("automatically uses the only Computer with a runnable Provider", () => {
     expect(deriveOnboardingState(facts({ computers: [computerA, computerB] })).currentState).toEqual({
+      kind: "agent",
+      computer: computerA,
+      provider: codex,
+    });
+  });
+
+  it("asks among multiple eligible Computers without listing ineligible ones", () => {
+    const computerC = { ...computerB, id: "computer-c", displayName: "Computer C" };
+    const codexOnB = { ...codex, computerId: computerB.id };
+    expect(
+      deriveOnboardingState(facts({ computers: [computerA, computerB, computerC], providers: [codex, codexOnB] }))
+        .currentState,
+    ).toEqual({
+      kind: "computer",
+      availability: "choice",
+      computers: [computerA, computerB],
+    });
+  });
+
+  it("asks which online Computer to prepare when none has a runnable Provider", () => {
+    expect(deriveOnboardingState(facts({ computers: [computerA, computerB], providers: [] })).currentState).toEqual({
       kind: "computer",
       availability: "choice",
       computers: [computerA, computerB],

--- a/apps/web/src/onboarding/flow.test.ts
+++ b/apps/web/src/onboarding/flow.test.ts
@@ -70,7 +70,7 @@ describe("deriveOnboardingState", () => {
   it("automatically uses the single online Computer and ignores offline alternatives", () => {
     const offline = { ...computerB, connectionStatus: "offline" as const };
     expect(deriveOnboardingState(facts({ computers: [offline, computerA] }))).toMatchObject({
-      currentState: { kind: "agent", computer: computerA, provider: codex },
+      currentState: { kind: "agent", computer: computerA, provider: codex, alternatives: [] },
       runtimeReady: true,
     });
   });
@@ -80,6 +80,7 @@ describe("deriveOnboardingState", () => {
       kind: "agent",
       computer: computerA,
       provider: codex,
+      alternatives: [],
     });
   });
 
@@ -115,22 +116,64 @@ describe("deriveOnboardingState", () => {
 
   it("automatically uses one runnable Provider", () => {
     expect(deriveOnboardingState(facts())).toMatchObject({
-      currentState: { kind: "agent", computer: computerA, provider: codex },
+      currentState: { kind: "agent", computer: computerA, provider: codex, alternatives: [] },
       runtimeReady: true,
     });
   });
 
-  it("asks only when multiple Providers are runnable", () => {
+  it("selects Codex by default regardless of Provider input order", () => {
     const claude = { ...codex, provider: "claude-code" as const };
-    expect(deriveOnboardingState(facts({ providers: [codex, claude] }))).toMatchObject({
+    expect(deriveOnboardingState(facts({ providers: [claude, codex] }))).toMatchObject({
       currentState: {
-        kind: "provider",
-        availability: "choice",
+        kind: "agent",
         computer: computerA,
-        providers: [codex, claude],
+        provider: codex,
       },
-      runtimeReady: false,
+      runtimeReady: true,
     });
+  });
+
+  it("preserves an explicit Claude Code selection while it remains runnable", () => {
+    const claude = { ...codex, provider: "claude-code" as const };
+    expect(
+      deriveOnboardingState(
+        facts({
+          providers: [codex, claude],
+          providerSelection: { computerId: computerA.id, provider: "claude-code" },
+        }),
+      ).currentState,
+    ).toMatchObject({ kind: "agent", provider: claude });
+  });
+
+  it("falls back to Codex when an explicit selection is stale", () => {
+    const claude = { ...codex, provider: "claude-code" as const };
+    const unavailableClaude = { ...codex, provider: "claude-code" as const, runtimeReady: false };
+    const unavailable = deriveOnboardingState(
+      facts({
+        providers: [unavailableClaude, codex],
+        providerSelection: { computerId: computerA.id, provider: "claude-code" },
+      }),
+    ).currentState;
+    const wrongComputer = deriveOnboardingState(
+      facts({
+        providers: [claude, codex],
+        providerSelection: { computerId: computerB.id, provider: "claude-code" },
+      }),
+    ).currentState;
+    expect(unavailable).toMatchObject({ kind: "agent", provider: codex });
+    expect(wrongComputer).toMatchObject({ kind: "agent", provider: codex });
+  });
+
+  it("returns only the remaining runnable Providers as alternatives", () => {
+    const claude = { ...codex, provider: "claude-code" as const };
+    expect(
+      deriveOnboardingState(
+        facts({
+          providers: [codex, claude],
+          providerSelection: { computerId: computerA.id, provider: "claude-code" },
+        }),
+      ).currentState,
+    ).toEqual({ kind: "agent", computer: computerA, provider: claude, alternatives: [codex] });
   });
 
   it("does not move an existing Agent back when its Computer goes offline", () => {

--- a/apps/web/src/onboarding/flow.test.ts
+++ b/apps/web/src/onboarding/flow.test.ts
@@ -145,6 +145,20 @@ describe("deriveOnboardingState", () => {
     ).toMatchObject({ kind: "agent", provider: claude });
   });
 
+  it("applies an explicit runnable route before eligible Computer ambiguity", () => {
+    const codexOnB = { ...codex, computerId: computerB.id };
+    const claudeOnB = { ...codexOnB, provider: "claude-code" as const };
+    expect(
+      deriveOnboardingState(
+        facts({
+          computers: [computerA, computerB],
+          providers: [codex, claudeOnB, codexOnB],
+          providerSelection: { computerId: computerB.id, provider: "claude-code" },
+        }),
+      ).currentState,
+    ).toEqual({ kind: "agent", computer: computerB, provider: claudeOnB, alternatives: [codexOnB] });
+  });
+
   it("falls back to Codex when an explicit selection is stale", () => {
     const claude = { ...codex, provider: "claude-code" as const };
     const unavailableClaude = { ...codex, provider: "claude-code" as const, runtimeReady: false };

--- a/apps/web/src/onboarding/flow.test.ts
+++ b/apps/web/src/onboarding/flow.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveOnboardingState,
+  type OnboardingAgent,
+  type OnboardingComputer,
+  type OnboardingFacts,
+  type OnboardingHandoff,
+  type OnboardingProvider,
+} from "./flow.js";
+
+const computerA: OnboardingComputer = {
+  id: "computer-a",
+  displayName: "Computer A",
+  connectionStatus: "online",
+};
+
+const computerB: OnboardingComputer = {
+  id: "computer-b",
+  displayName: "Computer B",
+  connectionStatus: "online",
+};
+
+const codex: OnboardingProvider = {
+  computerId: computerA.id,
+  provider: "codex",
+  runtimeReady: true,
+};
+
+const agent: OnboardingAgent = {
+  id: "agent-a",
+  computerId: computerA.id,
+  runtimeProvider: "codex",
+};
+
+function facts(overrides: Partial<OnboardingFacts> = {}): OnboardingFacts {
+  return {
+    team: { role: "admin" },
+    computers: [computerA],
+    providers: [codex],
+    agent: undefined,
+    handoff: undefined,
+    ...overrides,
+  };
+}
+
+describe("deriveOnboardingState", () => {
+  it("starts with Team creation when no Team exists", () => {
+    expect(deriveOnboardingState(facts({ team: undefined }))).toEqual({
+      currentState: { kind: "team" },
+      runtimeReady: false,
+      handoffReady: false,
+      canManage: true,
+    });
+  });
+
+  it("distinguishes no Computers from only offline Computers", () => {
+    expect(deriveOnboardingState(facts({ computers: [] })).currentState).toEqual({
+      kind: "computer",
+      availability: "none",
+    });
+
+    const offline = { ...computerA, connectionStatus: "offline" as const };
+    expect(deriveOnboardingState(facts({ computers: [offline] })).currentState).toEqual({
+      kind: "computer",
+      availability: "offline",
+      computers: [offline],
+    });
+  });
+
+  it("automatically uses the single online Computer and ignores offline alternatives", () => {
+    const offline = { ...computerB, connectionStatus: "offline" as const };
+    expect(deriveOnboardingState(facts({ computers: [offline, computerA] }))).toMatchObject({
+      currentState: { kind: "agent", computer: computerA, provider: codex },
+      runtimeReady: true,
+    });
+  });
+
+  it("asks only when multiple Computers are eligible", () => {
+    expect(deriveOnboardingState(facts({ computers: [computerA, computerB] })).currentState).toEqual({
+      kind: "computer",
+      availability: "choice",
+      computers: [computerA, computerB],
+    });
+  });
+
+  it("reports no runnable Provider for the selected Computer", () => {
+    const unavailable = { ...codex, runtimeReady: false };
+    const readyElsewhere = { ...codex, computerId: computerB.id };
+    expect(deriveOnboardingState(facts({ providers: [unavailable, readyElsewhere] }))).toMatchObject({
+      currentState: { kind: "provider", availability: "none", computer: computerA },
+      runtimeReady: false,
+    });
+  });
+
+  it("automatically uses one runnable Provider", () => {
+    expect(deriveOnboardingState(facts())).toMatchObject({
+      currentState: { kind: "agent", computer: computerA, provider: codex },
+      runtimeReady: true,
+    });
+  });
+
+  it("asks only when multiple Providers are runnable", () => {
+    const claude = { ...codex, provider: "claude-code" as const };
+    expect(deriveOnboardingState(facts({ providers: [codex, claude] }))).toMatchObject({
+      currentState: {
+        kind: "provider",
+        availability: "choice",
+        computer: computerA,
+        providers: [codex, claude],
+      },
+      runtimeReady: false,
+    });
+  });
+
+  it("does not move an existing Agent back when its Computer goes offline", () => {
+    const offline = { ...computerA, connectionStatus: "offline" as const };
+    const unavailable = { ...codex, runtimeReady: false };
+    expect(deriveOnboardingState(facts({ computers: [offline], providers: [unavailable], agent }))).toMatchObject({
+      currentState: { kind: "agent-runtime", agent },
+      runtimeReady: false,
+      handoffReady: false,
+    });
+  });
+
+  it("does not announce Ready when handoff readiness outlives runtime readiness", () => {
+    const offline = { ...computerA, connectionStatus: "offline" as const };
+    const unavailable = { ...codex, runtimeReady: false };
+    const handoff: OnboardingHandoff = { bindingState: "active", handoffReady: true };
+    expect(
+      deriveOnboardingState(facts({ computers: [offline], providers: [unavailable], agent, handoff })),
+    ).toMatchObject({
+      currentState: { kind: "agent-runtime", agent },
+      runtimeReady: false,
+      handoffReady: true,
+    });
+  });
+
+  it("continues to handoff after an existing Agent runtime becomes ready again", () => {
+    const blocked = deriveOnboardingState(facts({ providers: [{ ...codex, runtimeReady: false }], agent }));
+    const recovered = deriveOnboardingState(facts({ agent }));
+    expect(blocked.currentState).toEqual({ kind: "agent-runtime", agent });
+    expect(recovered.currentState).toEqual({ kind: "handoff", agent, progress: { kind: "none" } });
+  });
+
+  it.each([
+    [undefined, { kind: "none" }],
+    [{ bindingState: "provisioning" as const, handoffReady: false as const }, { kind: "provisioning" }],
+    [{ bindingState: "active" as const, handoffReady: false as const }, { kind: "active-not-ready" }],
+    [
+      { bindingState: "reauthorization_required" as const, handoffReady: false as const },
+      { kind: "attention", bindingState: "reauthorization_required" },
+    ],
+  ])("keeps a non-ready IM handoff in progress", (handoff, progress) => {
+    expect(deriveOnboardingState(facts({ agent, handoff })).currentState).toEqual({
+      kind: "handoff",
+      agent,
+      progress,
+    });
+  });
+
+  it("enters Ready only from authoritative handoff readiness", () => {
+    const handoff: OnboardingHandoff = { bindingState: "active", handoffReady: true };
+    const blocked = deriveOnboardingState(facts({ providers: [{ ...codex, runtimeReady: false }], agent, handoff }));
+    const ready = deriveOnboardingState(facts({ agent, handoff }));
+    expect(blocked.currentState).toEqual({ kind: "agent-runtime", agent });
+    expect(ready).toMatchObject({
+      currentState: { kind: "ready", agent, handoff },
+      runtimeReady: true,
+      handoffReady: true,
+    });
+  });
+
+  it("derives identical progress with read-only controls for members", () => {
+    const admin = deriveOnboardingState(facts({ agent }));
+    const member = deriveOnboardingState(facts({ team: { role: "member" }, agent }));
+    expect(member.currentState).toEqual(admin.currentState);
+    expect(member.canManage).toBe(false);
+    expect(admin.canManage).toBe(true);
+  });
+});

--- a/apps/web/src/onboarding/flow.ts
+++ b/apps/web/src/onboarding/flow.ts
@@ -147,11 +147,11 @@ export function deriveOnboardingState(facts: OnboardingFacts): OnboardingState {
   }
 
   const onlineComputers = facts.computers.filter((computer) => computer.connectionStatus === "online");
-  const [computer, ...otherOnlineComputers] = onlineComputers;
+  const [onlineComputer, ...otherOnlineComputers] = onlineComputers;
   if (facts.computers.length === 0) {
     return { currentState: { kind: "computer", availability: "none" }, runtimeReady: false, handoffReady, canManage };
   }
-  if (!computer) {
+  if (!onlineComputer) {
     return {
       currentState: { kind: "computer", availability: "offline", computers: facts.computers },
       runtimeReady: false,
@@ -159,13 +159,32 @@ export function deriveOnboardingState(facts: OnboardingFacts): OnboardingState {
       canManage,
     };
   }
-  if (otherOnlineComputers.length > 0) {
+
+  const runnableComputerIds = new Set(
+    facts.providers.filter((provider) => provider.runtimeReady).map((provider) => provider.computerId),
+  );
+  const eligibleComputers = onlineComputers.filter((computer) => runnableComputerIds.has(computer.id));
+  const [eligibleComputer, ...otherEligibleComputers] = eligibleComputers;
+  if (otherEligibleComputers.length > 0) {
     return {
-      currentState: { kind: "computer", availability: "choice", computers: onlineComputers },
+      currentState: { kind: "computer", availability: "choice", computers: eligibleComputers },
       runtimeReady: false,
       handoffReady,
       canManage,
     };
+  }
+
+  let computer = eligibleComputer;
+  if (!computer) {
+    if (otherOnlineComputers.length > 0) {
+      return {
+        currentState: { kind: "computer", availability: "choice", computers: onlineComputers },
+        runtimeReady: false,
+        handoffReady,
+        canManage,
+      };
+    }
+    computer = onlineComputer;
   }
 
   const runnableProviders = facts.providers.filter(

--- a/apps/web/src/onboarding/flow.ts
+++ b/apps/web/src/onboarding/flow.ts
@@ -43,6 +43,8 @@ export interface OnboardingFacts {
   readonly team: OnboardingTeam | undefined;
   readonly computers: readonly OnboardingComputer[];
   readonly providers: readonly OnboardingProvider[];
+  /** An explicit current choice; ignored unless it still names a runnable route. */
+  readonly providerSelection?: Pick<OnboardingProvider, "computerId" | "provider">;
   /** The Agent belonging to this onboarding intent, if it already exists. */
   readonly agent: OnboardingAgent | undefined;
   readonly handoff: OnboardingHandoff | undefined;
@@ -76,15 +78,11 @@ export type OnboardingCurrentState =
       readonly computer: OnboardingComputer;
     }
   | {
-      readonly kind: "provider";
-      readonly availability: "choice";
-      readonly computer: OnboardingComputer;
-      readonly providers: readonly OnboardingProvider[];
-    }
-  | {
       readonly kind: "agent";
       readonly computer: OnboardingComputer;
       readonly provider: OnboardingProvider;
+      /** Remaining runnable Providers for a non-blocking Change control. */
+      readonly alternatives: readonly OnboardingProvider[];
     }
   | { readonly kind: "agent-runtime"; readonly agent: OnboardingAgent }
   | {
@@ -190,8 +188,9 @@ export function deriveOnboardingState(facts: OnboardingFacts): OnboardingState {
   const runnableProviders = facts.providers.filter(
     (provider) => provider.computerId === computer.id && provider.runtimeReady,
   );
-  const [provider, ...otherRunnableProviders] = runnableProviders;
-  if (!provider) {
+  const orderedProviders = [...runnableProviders].sort(compareProviders);
+  const [defaultProvider] = orderedProviders;
+  if (!defaultProvider) {
     return {
       currentState: { kind: "provider", availability: "none", computer },
       runtimeReady: false,
@@ -199,21 +198,33 @@ export function deriveOnboardingState(facts: OnboardingFacts): OnboardingState {
       canManage,
     };
   }
-  if (otherRunnableProviders.length > 0) {
-    return {
-      currentState: { kind: "provider", availability: "choice", computer, providers: runnableProviders },
-      runtimeReady: false,
-      handoffReady,
-      canManage,
-    };
-  }
+
+  const selection = facts.providerSelection;
+  const provider =
+    orderedProviders.find(
+      (candidate) =>
+        selection !== undefined &&
+        candidate.computerId === selection.computerId &&
+        candidate.provider === selection.provider,
+    ) ?? defaultProvider;
+  const alternatives = orderedProviders.filter(
+    (candidate) => candidate.computerId !== provider.computerId || candidate.provider !== provider.provider,
+  );
 
   return {
-    currentState: { kind: "agent", computer, provider },
+    currentState: { kind: "agent", computer, provider, alternatives },
     runtimeReady: true,
     handoffReady,
     canManage,
   };
+}
+
+function compareProviders(left: OnboardingProvider, right: OnboardingProvider): number {
+  return providerRank(left.provider) - providerRank(right.provider);
+}
+
+function providerRank(provider: AgentRuntimeProvider): number {
+  return provider === "codex" ? 0 : 1;
 }
 
 function agentRuntimeIsReady(agent: OnboardingAgent, providers: readonly OnboardingProvider[]): boolean {

--- a/apps/web/src/onboarding/flow.ts
+++ b/apps/web/src/onboarding/flow.ts
@@ -1,0 +1,212 @@
+import type {
+  AgentRuntimeProvider,
+  ComputerConnectionStatus,
+  ImBindingState,
+  MembershipRole,
+} from "@opentag/shared/browser";
+
+export interface OnboardingTeam {
+  readonly role: MembershipRole;
+}
+
+export interface OnboardingComputer {
+  readonly id: string;
+  readonly displayName: string;
+  readonly connectionStatus: ComputerConnectionStatus;
+}
+
+export interface OnboardingProvider {
+  readonly computerId: string;
+  readonly provider: AgentRuntimeProvider;
+  /** Whether this provider can run an Agent on this Computer now. */
+  readonly runtimeReady: boolean;
+}
+
+export interface OnboardingAgent {
+  readonly id: string;
+  readonly computerId: string;
+  readonly runtimeProvider: AgentRuntimeProvider;
+}
+
+type UnusableImBindingState = Exclude<ImBindingState, "active">;
+
+/**
+ * `handoffReady` is the authoritative combined IM readiness fact. In
+ * particular, an active binding is not necessarily a usable handoff.
+ */
+export type OnboardingHandoff =
+  | { readonly bindingState: "active"; readonly handoffReady: true }
+  | { readonly bindingState: "active"; readonly handoffReady: false }
+  | { readonly bindingState: UnusableImBindingState; readonly handoffReady: false };
+
+export interface OnboardingFacts {
+  readonly team: OnboardingTeam | undefined;
+  readonly computers: readonly OnboardingComputer[];
+  readonly providers: readonly OnboardingProvider[];
+  /** The Agent belonging to this onboarding intent, if it already exists. */
+  readonly agent: OnboardingAgent | undefined;
+  readonly handoff: OnboardingHandoff | undefined;
+}
+
+export type HandoffProgress =
+  | { readonly kind: "none" }
+  | { readonly kind: "provisioning" }
+  | { readonly kind: "active-not-ready" }
+  | {
+      readonly kind: "attention";
+      readonly bindingState: Exclude<UnusableImBindingState, "provisioning">;
+    };
+
+export type OnboardingCurrentState =
+  | { readonly kind: "team" }
+  | { readonly kind: "computer"; readonly availability: "none" }
+  | {
+      readonly kind: "computer";
+      readonly availability: "offline";
+      readonly computers: readonly OnboardingComputer[];
+    }
+  | {
+      readonly kind: "computer";
+      readonly availability: "choice";
+      readonly computers: readonly OnboardingComputer[];
+    }
+  | {
+      readonly kind: "provider";
+      readonly availability: "none";
+      readonly computer: OnboardingComputer;
+    }
+  | {
+      readonly kind: "provider";
+      readonly availability: "choice";
+      readonly computer: OnboardingComputer;
+      readonly providers: readonly OnboardingProvider[];
+    }
+  | {
+      readonly kind: "agent";
+      readonly computer: OnboardingComputer;
+      readonly provider: OnboardingProvider;
+    }
+  | { readonly kind: "agent-runtime"; readonly agent: OnboardingAgent }
+  | {
+      readonly kind: "handoff";
+      readonly agent: OnboardingAgent;
+      readonly progress: HandoffProgress;
+    }
+  | {
+      readonly kind: "ready";
+      readonly agent: OnboardingAgent;
+      readonly handoff: OnboardingHandoff & { readonly bindingState: "active"; readonly handoffReady: true };
+    };
+
+export interface OnboardingState {
+  readonly currentState: OnboardingCurrentState;
+  /** Whether the selected or Agent-bound runtime path is currently runnable. */
+  readonly runtimeReady: boolean;
+  /** Whether the Server says the Agent's IM handoff is currently usable. */
+  readonly handoffReady: boolean;
+  /** Members observe the same state without receiving mutation controls. */
+  readonly canManage: boolean;
+}
+
+/**
+ * Derives the current page state from facts; no step cursor or browser state is
+ * retained. Once an Agent exists, earlier prerequisites never pull the flow back.
+ */
+export function deriveOnboardingState(facts: OnboardingFacts): OnboardingState {
+  const canManage = facts.team === undefined || facts.team.role === "admin";
+  const handoffReady = facts.handoff?.handoffReady === true;
+
+  if (!facts.team) {
+    return { currentState: { kind: "team" }, runtimeReady: false, handoffReady, canManage };
+  }
+
+  if (facts.agent) {
+    const runtimeReady = agentRuntimeIsReady(facts.agent, facts.providers);
+    if (!runtimeReady) {
+      return {
+        currentState: { kind: "agent-runtime", agent: facts.agent },
+        runtimeReady,
+        handoffReady,
+        canManage,
+      };
+    }
+    if (facts.handoff?.bindingState === "active" && facts.handoff.handoffReady) {
+      return {
+        currentState: { kind: "ready", agent: facts.agent, handoff: facts.handoff },
+        runtimeReady,
+        handoffReady,
+        canManage,
+      };
+    }
+    return {
+      currentState: { kind: "handoff", agent: facts.agent, progress: handoffProgress(facts.handoff) },
+      runtimeReady,
+      handoffReady,
+      canManage,
+    };
+  }
+
+  const onlineComputers = facts.computers.filter((computer) => computer.connectionStatus === "online");
+  const [computer, ...otherOnlineComputers] = onlineComputers;
+  if (facts.computers.length === 0) {
+    return { currentState: { kind: "computer", availability: "none" }, runtimeReady: false, handoffReady, canManage };
+  }
+  if (!computer) {
+    return {
+      currentState: { kind: "computer", availability: "offline", computers: facts.computers },
+      runtimeReady: false,
+      handoffReady,
+      canManage,
+    };
+  }
+  if (otherOnlineComputers.length > 0) {
+    return {
+      currentState: { kind: "computer", availability: "choice", computers: onlineComputers },
+      runtimeReady: false,
+      handoffReady,
+      canManage,
+    };
+  }
+
+  const runnableProviders = facts.providers.filter(
+    (provider) => provider.computerId === computer.id && provider.runtimeReady,
+  );
+  const [provider, ...otherRunnableProviders] = runnableProviders;
+  if (!provider) {
+    return {
+      currentState: { kind: "provider", availability: "none", computer },
+      runtimeReady: false,
+      handoffReady,
+      canManage,
+    };
+  }
+  if (otherRunnableProviders.length > 0) {
+    return {
+      currentState: { kind: "provider", availability: "choice", computer, providers: runnableProviders },
+      runtimeReady: false,
+      handoffReady,
+      canManage,
+    };
+  }
+
+  return {
+    currentState: { kind: "agent", computer, provider },
+    runtimeReady: true,
+    handoffReady,
+    canManage,
+  };
+}
+
+function agentRuntimeIsReady(agent: OnboardingAgent, providers: readonly OnboardingProvider[]): boolean {
+  return providers.some(
+    (provider) =>
+      provider.computerId === agent.computerId && provider.provider === agent.runtimeProvider && provider.runtimeReady,
+  );
+}
+
+function handoffProgress(handoff: OnboardingHandoff | undefined): HandoffProgress {
+  if (!handoff) return { kind: "none" };
+  if (handoff.bindingState === "provisioning") return { kind: "provisioning" };
+  if (handoff.bindingState === "active") return { kind: "active-not-ready" };
+  return { kind: "attention", bindingState: handoff.bindingState };
+}

--- a/apps/web/src/onboarding/flow.ts
+++ b/apps/web/src/onboarding/flow.ts
@@ -162,8 +162,19 @@ export function deriveOnboardingState(facts: OnboardingFacts): OnboardingState {
     facts.providers.filter((provider) => provider.runtimeReady).map((provider) => provider.computerId),
   );
   const eligibleComputers = onlineComputers.filter((computer) => runnableComputerIds.has(computer.id));
+  const selection = facts.providerSelection;
+  const selectedRoute = facts.providers.find(
+    (provider) =>
+      selection !== undefined &&
+      provider.runtimeReady &&
+      provider.computerId === selection.computerId &&
+      provider.provider === selection.provider,
+  );
+  const selectedComputer = selectedRoute
+    ? onlineComputers.find((computer) => computer.id === selectedRoute.computerId)
+    : undefined;
   const [eligibleComputer, ...otherEligibleComputers] = eligibleComputers;
-  if (otherEligibleComputers.length > 0) {
+  if (!selectedComputer && otherEligibleComputers.length > 0) {
     return {
       currentState: { kind: "computer", availability: "choice", computers: eligibleComputers },
       runtimeReady: false,
@@ -172,7 +183,7 @@ export function deriveOnboardingState(facts: OnboardingFacts): OnboardingState {
     };
   }
 
-  let computer = eligibleComputer;
+  let computer = selectedComputer ?? eligibleComputer;
   if (!computer) {
     if (otherOnlineComputers.length > 0) {
       return {
@@ -199,7 +210,6 @@ export function deriveOnboardingState(facts: OnboardingFacts): OnboardingState {
     };
   }
 
-  const selection = facts.providerSelection;
   const provider =
     orderedProviders.find(
       (candidate) =>


### PR DESCRIPTION
## Summary

- add one pure `deriveOnboardingState` module that derives the current onboarding page state from normalized facts
- preserve a valid explicit Computer+Provider route before classifying Computer ambiguity
- otherwise auto-select the only online Computer with a runnable Provider and apply a stable Codex-before-Claude-Code default without blocking Agent creation
- return remaining ready Providers from the selected Computer as quiet Change alternatives
- preserve an existing Agent when its Computer/runtime later becomes unavailable, without claiming IM handoff or Ready
- gate Ready on both the Agent-bound runtime and the authoritative IM handoff readiness fact
- expose the same progress to members with `canManage: false`

## State model

| Facts | Current state |
| --- | --- |
| no Team | `team` |
| no Computers / all offline | `computer: none / offline` |
| valid explicit online+runnable Computer+Provider route | adopt that Computer and Provider |
| exactly one online Computer with a runnable Provider | auto-select that Computer |
| multiple online Computers with runnable Providers and no valid explicit route | `computer: choice`, listing only those eligible Computers |
| no runnable Provider on any online Computer | one Computer goes to `provider: none`; multiple Computers go to `computer: choice` |
| one or more runnable Providers on the selected Computer | `agent`; preserve a valid explicit selection, otherwise prefer Codex then Claude Code |
| existing Agent with unavailable runtime | `agent-runtime` |
| existing Agent with ready runtime but no usable IM handoff | `handoff` |
| existing Agent with ready runtime and authoritative usable IM handoff | `ready` |

The `agent` state carries the selected Provider plus the remaining runnable alternatives from that Computer for a non-blocking Change control. The result reports `runtimeReady`, `handoffReady`, and `currentState` separately. `bindingState: "active"` alone never means Ready.

## Interface

`deriveOnboardingState({ team, computers, providers, providerSelection?, agent, handoff })` accepts only normalized data. Provider facts and the optional explicit selection are keyed by Computer. The exact route is applied before Computer ambiguity only while its Computer is online and that Provider remains runnable; otherwise the module retains normal ambiguity and stable-default behavior. The Web adapter can map authoritative Provider readiness into `runtimeReady` without coupling this module to its transport DTO. The Agent input is the Agent already associated with this onboarding intent, so this module does not recover or guess identity.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @opentag/web test` (67 tests)
- `git diff --check`

## Non-goals

- no React, routing, CSS, network requests, browser storage, recovery, or mutation logic
- no persisted step index, fixed stepper, name-based Agent selection, blocking Provider choice, or binding-state readiness inference
- no generic Provider capability-order framework, shared contract changes, or Provider readiness implementation changes
