### PR TITLE
refactor(web): extract Computer setup lifecycle

### DIFF
--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -195,6 +195,39 @@ describe("ComputerSetup", () => {
     expect(vi.getTimerCount()).toBe(2);
   });
 
+  it("clears an old-cycle error when replacement issuance succeeds", async () => {
+    const replacementIssue = deferred<{ bootstrapCommand: string; expiresIn: number; issuedAt: string }>();
+    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [] });
+    vi.spyOn(browserApi, "issueConnectCode")
+      .mockResolvedValueOnce({ bootstrapCommand: "first command", expiresIn: 2, issuedAt: connectedAt })
+      .mockImplementationOnce(() => replacementIssue.promise);
+
+    render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+    await clickGenerate();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(screen.getByRole("alert").textContent).toBe(
+      "This Computer connection command expired. Generate a new one to continue.",
+    );
+
+    await act(async () => {
+      replacementIssue.resolve({
+        bootstrapCommand: "replacement command",
+        expiresIn: 5,
+        issuedAt: "2026-08-20T00:00:02.000Z",
+      });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("replacement command")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(vi.getTimerCount()).toBe(2);
+  });
+
   it("ignores an old in-flight poll after replacement issuance succeeds", async () => {
     const oldPoll = deferred<{ computers: Computer[] }>();
     const replacementIssue = deferred<{ bootstrapCommand: string; expiresIn: number; issuedAt: string }>();

--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -25,6 +25,14 @@ const newComputer: Computer = {
   platform: "linux",
 };
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 async function clickGenerate(): Promise<void> {
   await act(async () => {
     fireEvent.click(screen.getByRole("button", { name: "Generate connection command" }));
@@ -185,6 +193,70 @@ describe("ComputerSetup", () => {
     expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
     expect(screen.queryByRole("alert")).toBeNull();
     expect(vi.getTimerCount()).toBe(2);
+  });
+
+  it("ignores an old in-flight poll after replacement issuance succeeds", async () => {
+    const oldPoll = deferred<{ computers: Computer[] }>();
+    const replacementIssue = deferred<{ bootstrapCommand: string; expiresIn: number; issuedAt: string }>();
+    const onConnected = vi.fn();
+    let ownComputersCall = 0;
+    vi.spyOn(browserApi, "ownComputers").mockImplementation(() => {
+      ownComputersCall += 1;
+      return ownComputersCall === 2 ? oldPoll.promise : Promise.resolve({ computers: [] });
+    });
+    vi.spyOn(browserApi, "issueConnectCode")
+      .mockResolvedValueOnce({ bootstrapCommand: "first command", expiresIn: 900, issuedAt: connectedAt })
+      .mockImplementationOnce(() => replacementIssue.promise);
+
+    render(<ComputerSetup teamId={teamId} onConnected={onConnected} />);
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+    await clickGenerate();
+
+    await act(async () => {
+      replacementIssue.resolve({
+        bootstrapCommand: "replacement command",
+        expiresIn: 900,
+        issuedAt: "2026-08-20T00:00:01.500Z",
+      });
+      await Promise.resolve();
+      oldPoll.resolve({ computers: [newComputer] });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("replacement command")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(onConnected).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(2);
+  });
+
+  it("keeps the current polling cycle when replacement issuance fails", async () => {
+    const onConnected = vi.fn();
+    vi.spyOn(browserApi, "ownComputers")
+      .mockResolvedValueOnce({ computers: [] })
+      .mockResolvedValueOnce({ computers: [] })
+      .mockResolvedValue({ computers: [newComputer] });
+    vi.spyOn(browserApi, "issueConnectCode")
+      .mockResolvedValueOnce({ bootstrapCommand: "first command", expiresIn: 900, issuedAt: connectedAt })
+      .mockRejectedValueOnce(new Error("Replacement command failed"));
+
+    render(<ComputerSetup teamId={teamId} onConnected={onConnected} />);
+    await clickGenerate();
+    await clickGenerate();
+
+    expect(screen.getByRole("alert").textContent).toBe("Replacement command failed");
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(vi.getTimerCount()).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+
+    expect(screen.getByRole("status").textContent).toBe("Computer connected.");
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("normalizes connect-code issuance errors", async () => {

--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -34,6 +34,7 @@ async function clickGenerate(): Promise<void> {
 describe("ComputerSetup", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.setSystemTime(connectedAt);
   });
 
   afterEach(() => {
@@ -62,7 +63,7 @@ describe("ComputerSetup", () => {
 
   it.each([
     ["new", [existingComputer, newComputer]],
-    ["refreshed", [{ ...existingComputer, lastSeenAt: "2026-08-20T00:00:02.000Z" }]],
+    ["refreshed", [{ ...existingComputer, connectedAt: "2026-08-20T00:00:02.000Z" }]],
   ])("detects a %s Computer and cleans up polling on completion", async (_kind, polledComputers) => {
     const onConnected = vi.fn();
     vi.spyOn(browserApi, "ownComputers")
@@ -76,7 +77,7 @@ describe("ComputerSetup", () => {
 
     render(<ComputerSetup teamId={teamId} onConnected={onConnected} />);
     await clickGenerate();
-    expect(vi.getTimerCount()).toBe(1);
+    expect(vi.getTimerCount()).toBe(2);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1_500);
@@ -87,9 +88,13 @@ describe("ComputerSetup", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("does not report an unchanged Computer as connected", async () => {
+  it("does not report an existing Computer heartbeat as connected", async () => {
     const onConnected = vi.fn();
-    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [existingComputer] });
+    vi.spyOn(browserApi, "ownComputers")
+      .mockResolvedValueOnce({ computers: [existingComputer] })
+      .mockResolvedValue({
+        computers: [{ ...existingComputer, lastSeenAt: "2026-08-20T00:00:10.000Z" }],
+      });
     vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
       bootstrapCommand,
       expiresIn: 900,
@@ -104,7 +109,7 @@ describe("ComputerSetup", () => {
 
     expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
     expect(onConnected).not.toHaveBeenCalled();
-    expect(vi.getTimerCount()).toBe(1);
+    expect(vi.getTimerCount()).toBe(2);
   });
 
   it("cleans up polling when unmounted", async () => {
@@ -117,10 +122,35 @@ describe("ComputerSetup", () => {
 
     const view = render(<ComputerSetup teamId={teamId} />);
     await clickGenerate();
-    expect(vi.getTimerCount()).toBe(1);
+    expect(vi.getTimerCount()).toBe(2);
 
     view.unmount();
 
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stops polling when the connect code expires", async () => {
+    const onConnected = vi.fn();
+    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [] });
+    vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 2,
+      issuedAt: connectedAt,
+    });
+
+    render(<ComputerSetup teamId={teamId} onConnected={onConnected} />);
+    await clickGenerate();
+    expect(vi.getTimerCount()).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(screen.getByRole("alert").textContent).toBe(
+      "This Computer connection command expired. Generate a new one to continue.",
+    );
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(onConnected).not.toHaveBeenCalled();
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -155,6 +185,6 @@ describe("ComputerSetup", () => {
 
     expect(screen.getByRole("alert").textContent).toBe("Unable to refresh Computers");
     expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
-    expect(vi.getTimerCount()).toBe(1);
+    expect(vi.getTimerCount()).toBe(2);
   });
 });

--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -154,6 +154,39 @@ describe("ComputerSetup", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("restarts expiry and polling when a replacement command is generated", async () => {
+    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [] });
+    vi.spyOn(browserApi, "issueConnectCode")
+      .mockResolvedValueOnce({
+        bootstrapCommand: "first command",
+        expiresIn: 2,
+        issuedAt: connectedAt,
+      })
+      .mockResolvedValueOnce({
+        bootstrapCommand: "replacement command",
+        expiresIn: 5,
+        issuedAt: "2026-08-20T00:00:01.000Z",
+      });
+
+    render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    await clickGenerate();
+
+    expect(screen.getByText("replacement command")).toBeTruthy();
+    expect(vi.getTimerCount()).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_001);
+    });
+
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(vi.getTimerCount()).toBe(2);
+  });
+
   it("normalizes connect-code issuance errors", async () => {
     vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [] });
     vi.spyOn(browserApi, "issueConnectCode").mockRejectedValue("unavailable");

--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -1,0 +1,160 @@
+import type { Computer } from "@opentag/shared/browser";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { browserApi } from "./api.js";
+import { ComputerSetup } from "./computer-setup.js";
+
+const teamId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
+const bootstrapCommand = "opentag login --server https://opentag.example.com -- connect-code";
+const connectedAt = "2026-08-20T00:00:00.000Z";
+const existingComputer: Computer = {
+  id: "85fe9af3-d1c6-472b-b78c-8a7ccf512750",
+  ownerUserId: "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e",
+  displayName: "Ada's Mac",
+  platform: "darwin",
+  arch: "arm64",
+  clientVersion: "0.0.1",
+  connectionStatus: "online",
+  connectedAt,
+  lastSeenAt: "2026-08-20T00:00:01.000Z",
+};
+const newComputer: Computer = {
+  ...existingComputer,
+  id: "95fe9af3-d1c6-472b-b78c-8a7ccf512750",
+  displayName: "Ada's Linux Computer",
+  platform: "linux",
+};
+
+async function clickGenerate(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Generate connection command" }));
+  });
+}
+
+describe("ComputerSetup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("captures the owned-Computer baseline before issuing a connect code", async () => {
+    const calls: string[] = [];
+    vi.spyOn(browserApi, "ownComputers").mockImplementation(async () => {
+      calls.push("baseline");
+      return { computers: [existingComputer] };
+    });
+    vi.spyOn(browserApi, "issueConnectCode").mockImplementation(async () => {
+      calls.push("issue");
+      return { bootstrapCommand, expiresIn: 900, issuedAt: connectedAt };
+    });
+
+    render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+
+    expect(calls).toEqual(["baseline", "issue"]);
+    expect(screen.getByText(bootstrapCommand)).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+  });
+
+  it.each([
+    ["new", [existingComputer, newComputer]],
+    ["refreshed", [{ ...existingComputer, lastSeenAt: "2026-08-20T00:00:02.000Z" }]],
+  ])("detects a %s Computer and cleans up polling on completion", async (_kind, polledComputers) => {
+    const onConnected = vi.fn();
+    vi.spyOn(browserApi, "ownComputers")
+      .mockResolvedValueOnce({ computers: [existingComputer] })
+      .mockResolvedValue({ computers: polledComputers });
+    vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(<ComputerSetup teamId={teamId} onConnected={onConnected} />);
+    await clickGenerate();
+    expect(vi.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+
+    expect(screen.getByRole("status").textContent).toBe("Computer connected.");
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not report an unchanged Computer as connected", async () => {
+    const onConnected = vi.fn();
+    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [existingComputer] });
+    vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(<ComputerSetup teamId={teamId} onConnected={onConnected} />);
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(onConnected).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it("cleans up polling when unmounted", async () => {
+    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [existingComputer] });
+    vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    const view = render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+    expect(vi.getTimerCount()).toBe(1);
+
+    view.unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("normalizes connect-code issuance errors", async () => {
+    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [] });
+    vi.spyOn(browserApi, "issueConnectCode").mockRejectedValue("unavailable");
+
+    render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+
+    expect(screen.getByRole("alert").textContent).toBe("Unable to create a Computer connection command");
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("normalizes polling errors and keeps waiting", async () => {
+    vi.spyOn(browserApi, "ownComputers")
+      .mockResolvedValueOnce({ computers: [] })
+      .mockRejectedValueOnce("offline")
+      .mockResolvedValue({ computers: [] });
+    vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+
+    expect(screen.getByRole("alert").textContent).toBe("Unable to refresh Computers");
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(vi.getTimerCount()).toBe(1);
+  });
+});

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -27,6 +27,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
   const baselineConnections = useRef<Map<string, string | null>>(new Map());
   const connectCodeExpiresAt = useRef(0);
   const connectAttempt = useRef(0);
+  const activePollCycle = useRef(0);
   const mounted = useRef(false);
   const onConnectedRef = useRef(onConnected);
   onConnectedRef.current = onConnected;
@@ -36,6 +37,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
     return () => {
       mounted.current = false;
       connectAttempt.current += 1;
+      activePollCycle.current += 1;
     };
   }, []);
 
@@ -50,11 +52,13 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
       if (!mounted.current || connectAttempt.current !== attempt) return;
       const issued = await browserApi.issueConnectCode(teamId);
       if (!mounted.current || connectAttempt.current !== attempt) return;
+      const cycle = activePollCycle.current + 1;
+      activePollCycle.current = cycle;
       baselineConnections.current = baseline;
       connectCodeExpiresAt.current = Date.parse(issued.issuedAt) + issued.expiresIn * 1_000;
       setBootstrapCommand(issued.bootstrapCommand);
       setComputerConnected(false);
-      setPollCycle(attempt);
+      setPollCycle(cycle);
       setWaitingForComputer(true);
     } catch (cause) {
       if (!mounted.current || connectAttempt.current !== attempt) return;
@@ -71,7 +75,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
     let pollTimer = 0;
     const expiryTimer = window.setTimeout(
       () => {
-        if (!active || completed) return;
+        if (!active || completed || activePollCycle.current !== pollCycle) return;
         completed = true;
         window.clearInterval(pollTimer);
         setWaitingForComputer(false);
@@ -83,7 +87,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
     pollTimer = window.setInterval(() => {
       void browserApi.ownComputers().then(
         (value) => {
-          if (!active || completed) return;
+          if (!active || completed || activePollCycle.current !== pollCycle) return;
           const connected = value.computers.some(
             (computer: Computer) =>
               computer.connectionStatus === "online" &&
@@ -101,7 +105,9 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
           onConnectedRef.current?.();
         },
         (cause: unknown) => {
-          if (active && !completed) setError(errorMessage(cause, "Unable to refresh Computers"));
+          if (active && !completed && activePollCycle.current === pollCycle) {
+            setError(errorMessage(cause, "Unable to refresh Computers"));
+          }
         },
       );
     }, COMPUTER_POLL_INTERVAL_MS);

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { browserApi } from "./api.js";
 
 const COMPUTER_POLL_INTERVAL_MS = 1_500;
+const CONNECT_CODE_EXPIRED_MESSAGE = "This Computer connection command expired. Generate a new one to continue.";
 
 export interface ComputerSetupProps {
   teamId: string;
@@ -21,7 +22,9 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
   const [bootstrapCommand, setBootstrapCommand] = useState<string>();
   const [error, setError] = useState<string>();
   const [waitingForComputer, setWaitingForComputer] = useState(false);
-  const baselineComputers = useRef<Map<string, string>>(new Map());
+  const [computerConnected, setComputerConnected] = useState(false);
+  const baselineConnections = useRef<Map<string, string | null>>(new Map());
+  const connectCodeExpiresAt = useRef(0);
   const connectAttempt = useRef(0);
   const mounted = useRef(false);
   const onConnectedRef = useRef(onConnected);
@@ -41,13 +44,15 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
     setError(undefined);
     try {
       const baseline = new Map(
-        (await browserApi.ownComputers()).computers.map((computer: Computer) => [computer.id, computer.lastSeenAt]),
+        (await browserApi.ownComputers()).computers.map((computer: Computer) => [computer.id, computer.connectedAt]),
       );
       if (!mounted.current || connectAttempt.current !== attempt) return;
-      baselineComputers.current = baseline;
       const issued = await browserApi.issueConnectCode(teamId);
       if (!mounted.current || connectAttempt.current !== attempt) return;
+      baselineConnections.current = baseline;
+      connectCodeExpiresAt.current = Date.parse(issued.issuedAt) + issued.expiresIn * 1_000;
       setBootstrapCommand(issued.bootstrapCommand);
+      setComputerConnected(false);
       setWaitingForComputer(true);
     } catch (cause) {
       if (!mounted.current || connectAttempt.current !== attempt) return;
@@ -59,17 +64,36 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
     if (!waitingForComputer) return;
     let active = true;
     let completed = false;
-    const timer = window.setInterval(() => {
+    let pollTimer = 0;
+    const expiryTimer = window.setTimeout(
+      () => {
+        if (!active || completed) return;
+        completed = true;
+        window.clearInterval(pollTimer);
+        setWaitingForComputer(false);
+        setComputerConnected(false);
+        setError(CONNECT_CODE_EXPIRED_MESSAGE);
+      },
+      Math.max(0, connectCodeExpiresAt.current - Date.now()),
+    );
+    pollTimer = window.setInterval(() => {
       void browserApi.ownComputers().then(
         (value) => {
           if (!active || completed) return;
           const connected = value.computers.some(
-            (computer: Computer) => baselineComputers.current.get(computer.id) !== computer.lastSeenAt,
+            (computer: Computer) =>
+              computer.connectionStatus === "online" &&
+              ((!baselineConnections.current.has(computer.id) && computer.connectedAt !== null) ||
+                (baselineConnections.current.has(computer.id) &&
+                  computer.connectedAt !== null &&
+                  baselineConnections.current.get(computer.id) !== computer.connectedAt)),
           );
           if (!connected) return;
           completed = true;
-          window.clearInterval(timer);
+          window.clearInterval(pollTimer);
+          window.clearTimeout(expiryTimer);
           setWaitingForComputer(false);
+          setComputerConnected(true);
           onConnectedRef.current?.();
         },
         (cause: unknown) => {
@@ -79,7 +103,8 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
     }, COMPUTER_POLL_INTERVAL_MS);
     return () => {
       active = false;
-      window.clearInterval(timer);
+      window.clearInterval(pollTimer);
+      window.clearTimeout(expiryTimer);
     };
   }, [waitingForComputer]);
 
@@ -95,7 +120,9 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
           <pre>
             <code>{bootstrapCommand}</code>
           </pre>
-          <p role="status">{waitingForComputer ? "Waiting for the Computer to connect…" : "Computer connected."}</p>
+          {waitingForComputer || computerConnected ? (
+            <p role="status">{waitingForComputer ? "Waiting for the Computer to connect…" : "Computer connected."}</p>
+          ) : null}
         </>
       ) : null}
       {error ? (

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -56,6 +56,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
       activePollCycle.current = cycle;
       baselineConnections.current = baseline;
       connectCodeExpiresAt.current = Date.parse(issued.issuedAt) + issued.expiresIn * 1_000;
+      setError(undefined);
       setBootstrapCommand(issued.bootstrapCommand);
       setComputerConnected(false);
       setPollCycle(cycle);

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -1,0 +1,108 @@
+import type { Computer } from "@opentag/shared/browser";
+import { useEffect, useRef, useState } from "react";
+import { browserApi } from "./api.js";
+
+const COMPUTER_POLL_INTERVAL_MS = 1_500;
+
+export interface ComputerSetupProps {
+  teamId: string;
+  onConnected?: () => void;
+}
+
+function errorMessage(cause: unknown, fallback: string): string {
+  return cause instanceof Error && cause.message ? cause.message : fallback;
+}
+
+export function ComputerSetup({ teamId, onConnected }: ComputerSetupProps) {
+  return <ComputerSetupLifecycle key={teamId} teamId={teamId} onConnected={onConnected} />;
+}
+
+function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
+  const [bootstrapCommand, setBootstrapCommand] = useState<string>();
+  const [error, setError] = useState<string>();
+  const [waitingForComputer, setWaitingForComputer] = useState(false);
+  const baselineComputers = useRef<Map<string, string>>(new Map());
+  const connectAttempt = useRef(0);
+  const mounted = useRef(false);
+  const onConnectedRef = useRef(onConnected);
+  onConnectedRef.current = onConnected;
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      connectAttempt.current += 1;
+    };
+  }, []);
+
+  async function connectComputer() {
+    const attempt = connectAttempt.current + 1;
+    connectAttempt.current = attempt;
+    setError(undefined);
+    try {
+      const baseline = new Map(
+        (await browserApi.ownComputers()).computers.map((computer: Computer) => [computer.id, computer.lastSeenAt]),
+      );
+      if (!mounted.current || connectAttempt.current !== attempt) return;
+      baselineComputers.current = baseline;
+      const issued = await browserApi.issueConnectCode(teamId);
+      if (!mounted.current || connectAttempt.current !== attempt) return;
+      setBootstrapCommand(issued.bootstrapCommand);
+      setWaitingForComputer(true);
+    } catch (cause) {
+      if (!mounted.current || connectAttempt.current !== attempt) return;
+      setError(errorMessage(cause, "Unable to create a Computer connection command"));
+    }
+  }
+
+  useEffect(() => {
+    if (!waitingForComputer) return;
+    let active = true;
+    let completed = false;
+    const timer = window.setInterval(() => {
+      void browserApi.ownComputers().then(
+        (value) => {
+          if (!active || completed) return;
+          const connected = value.computers.some(
+            (computer: Computer) => baselineComputers.current.get(computer.id) !== computer.lastSeenAt,
+          );
+          if (!connected) return;
+          completed = true;
+          window.clearInterval(timer);
+          setWaitingForComputer(false);
+          onConnectedRef.current?.();
+        },
+        (cause: unknown) => {
+          if (active && !completed) setError(errorMessage(cause, "Unable to refresh Computers"));
+        },
+      );
+    }, COMPUTER_POLL_INTERVAL_MS);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [waitingForComputer]);
+
+  return (
+    <section className="panel">
+      <h2>Connect a Local Computer</h2>
+      <p>Generate a short-lived command, then run it in a terminal on the Computer.</p>
+      <button className="button" type="button" onClick={() => void connectComputer()}>
+        Generate connection command
+      </button>
+      {bootstrapCommand ? (
+        <>
+          <pre>
+            <code>{bootstrapCommand}</code>
+          </pre>
+          <p role="status">{waitingForComputer ? "Waiting for the Computer to connect…" : "Computer connected."}</p>
+        </>
+      ) : null}
+      {error ? (
+        <div className="notice error" role="alert">
+          {error}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -23,6 +23,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
   const [error, setError] = useState<string>();
   const [waitingForComputer, setWaitingForComputer] = useState(false);
   const [computerConnected, setComputerConnected] = useState(false);
+  const [pollCycle, setPollCycle] = useState(0);
   const baselineConnections = useRef<Map<string, string | null>>(new Map());
   const connectCodeExpiresAt = useRef(0);
   const connectAttempt = useRef(0);
@@ -53,6 +54,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
       connectCodeExpiresAt.current = Date.parse(issued.issuedAt) + issued.expiresIn * 1_000;
       setBootstrapCommand(issued.bootstrapCommand);
       setComputerConnected(false);
+      setPollCycle(attempt);
       setWaitingForComputer(true);
     } catch (cause) {
       if (!mounted.current || connectAttempt.current !== attempt) return;
@@ -61,7 +63,9 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
   }
 
   useEffect(() => {
-    if (!waitingForComputer) return;
+    if (!waitingForComputer || pollCycle === 0) return;
+    const baseline = baselineConnections.current;
+    const expiresAt = connectCodeExpiresAt.current;
     let active = true;
     let completed = false;
     let pollTimer = 0;
@@ -74,7 +78,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
         setComputerConnected(false);
         setError(CONNECT_CODE_EXPIRED_MESSAGE);
       },
-      Math.max(0, connectCodeExpiresAt.current - Date.now()),
+      Math.max(0, expiresAt - Date.now()),
     );
     pollTimer = window.setInterval(() => {
       void browserApi.ownComputers().then(
@@ -83,10 +87,10 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
           const connected = value.computers.some(
             (computer: Computer) =>
               computer.connectionStatus === "online" &&
-              ((!baselineConnections.current.has(computer.id) && computer.connectedAt !== null) ||
-                (baselineConnections.current.has(computer.id) &&
+              ((!baseline.has(computer.id) && computer.connectedAt !== null) ||
+                (baseline.has(computer.id) &&
                   computer.connectedAt !== null &&
-                  baselineConnections.current.get(computer.id) !== computer.connectedAt)),
+                  baseline.get(computer.id) !== computer.connectedAt)),
           );
           if (!connected) return;
           completed = true;
@@ -106,7 +110,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
       window.clearInterval(pollTimer);
       window.clearTimeout(expiryTimer);
     };
-  }, [waitingForComputer]);
+  }, [pollCycle, waitingForComputer]);
 
   return (
     <section className="panel">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -26,6 +26,7 @@ import {
 } from "react";
 import { Link, Navigate, NavLink, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import { ApiError, browserApi } from "./api.js";
+import { ComputerSetup } from "./computer-setup.js";
 import { CreateTeamForm } from "./create-team-form.js";
 
 type LoadState<T> = { kind: "loading" } | { kind: "error"; error: Error } | { kind: "ready"; value: T };
@@ -1541,66 +1542,9 @@ function InvitationSettings({ teamId }: { teamId: string }) {
 function ComputersSettings({ canManage, teamId }: { canManage: boolean; teamId: string }) {
   const [reload, setReload] = useState(0);
   const state = useResource(() => browserApi.computers(teamId), `${teamId}:${reload}`);
-  const [bootstrapCommand, setBootstrapCommand] = useState<string>();
-  const [error, setError] = useState<string>();
-  const [waitingForComputer, setWaitingForComputer] = useState(false);
-  const baselineComputers = useRef<Map<string, string>>(new Map());
-  async function connectComputer() {
-    try {
-      setError(undefined);
-      baselineComputers.current = new Map(
-        (await browserApi.ownComputers()).computers.map((computer: Computer) => [computer.id, computer.lastSeenAt]),
-      );
-      const issued = await browserApi.issueConnectCode(teamId);
-      setBootstrapCommand(issued.bootstrapCommand);
-      setWaitingForComputer(true);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Unable to create a Computer connection command");
-    }
-  }
-  useEffect(() => {
-    if (!waitingForComputer) return;
-    const timer = window.setInterval(() => {
-      void browserApi.ownComputers().then(
-        (value) => {
-          if (
-            value.computers.some(
-              (computer: Computer) => baselineComputers.current.get(computer.id) !== computer.lastSeenAt,
-            )
-          ) {
-            setWaitingForComputer(false);
-            setReload((current) => current + 1);
-          }
-        },
-        (cause: unknown) => setError(cause instanceof Error ? cause.message : "Unable to refresh Computers"),
-      );
-    }, 1_500);
-    return () => window.clearInterval(timer);
-  }, [waitingForComputer]);
   return (
     <>
-      {canManage ? (
-        <section className="panel">
-          <h2>Connect a Local Computer</h2>
-          <p>Generate a short-lived command, then run it in a terminal on the Computer.</p>
-          <button className="button" type="button" onClick={() => void connectComputer()}>
-            Generate connection command
-          </button>
-          {bootstrapCommand ? (
-            <>
-              <pre>
-                <code>{bootstrapCommand}</code>
-              </pre>
-              <p role="status">{waitingForComputer ? "Waiting for the Computer to connect…" : "Computer connected."}</p>
-            </>
-          ) : null}
-          {error ? (
-            <div className="notice error" role="alert">
-              {error}
-            </div>
-          ) : null}
-        </section>
-      ) : null}
+      {canManage ? <ComputerSetup teamId={teamId} onConnected={() => setReload((current) => current + 1)} /> : null}
       <AsyncState state={state}>
         {(value) => (
           <div className="list">


### PR DESCRIPTION
## Summary

- Extract the Local Computer command and polling lifecycle into a reusable ComputerSetup Web component with a teamId prop and optional onConnected callback.
- Keep the Team Computer list and its reload trigger in ComputersSettings, preserving the existing settings UI and behavior.
- Cover baseline-before-issuance ordering, new and refreshed Computer detection, unchanged-entry rejection, completion and unmount cleanup, and normalized errors.
- Future /onboarding work should render this same ComputerSetup module rather than duplicate baseline capture, connect-code issuance, or polling logic.

No Server, Shared, API, or Client runtime behavior changes are included.

## Testing

Passed:

- pnpm check
- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/web test (79 tests)

Attempted repository-wide validation:

- pnpm test: all Web, Shared, and Server suites passed; two unchanged CLI tests failed locally because macOS canonicalized /tmp paths to /private/tmp.
- pnpm --filter @opentag/client test:agent-runtime:coverage: 257/259 tests passed; one unchanged path-canonicalization assertion failed and one 5-second process test timed out on this run.
- pnpm test:coverage: 791/796 tests passed, including all Web tests and 100% statement/function/line coverage for computer-setup.tsx; the five failures were unchanged CLI/Client /var paths versus canonical /private/var paths on macOS.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and PR documentation cover the changed behavior.
- [ ] pnpm check, pnpm build, pnpm typecheck, and pnpm test pass. (The first three pass; pnpm test has the unrelated macOS path failures documented above.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable. (No mirrored docs changed.)