### PR TITLE
ci: deploy main to CapRover staging from the GHCR commit image

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,182 @@
+name: Deploy Staging
+
+on:
+  # CI, not Docker: staging must only ever run a revision whose checks passed, and `main` CI is the
+  # gate that proves that. The image the revision needs is published by the Docker workflow running
+  # alongside CI, so this workflow waits for that coordinate instead of building anything itself.
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - main
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: "Commit in main history to deploy; defaults to the current main tip"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  PRIMARY_NODE_VERSION: "24"
+  IMAGE: ghcr.io/${{ github.repository }}
+
+concurrency:
+  # Staging is one mutable target where only the newest revision is worth shipping, so a superseded
+  # pending run should be dropped rather than deployed after the run that replaced it. This is the
+  # opposite of the image workflow, whose coordinates are immutable and must never be dropped.
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  staging:
+    name: Deploy Staging
+    if: >-
+      github.repository == 'first-tree-ai/opentag' &&
+      ((github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.head_branch == 'main') ||
+       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: staging
+    steps:
+      - name: Check out main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so main membership of the target revision can be proven locally.
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+
+      - name: Resolve the deployment revision
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_REVISION: ${{ github.event.workflow_run.head_sha }}
+          REQUESTED_REVISION: ${{ inputs.revision }}
+        run: |
+          set -euo pipefail
+          git fetch origin main:refs/remotes/origin/main
+
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            REVISION="$RUN_REVISION"
+          elif [ -n "$REQUESTED_REVISION" ]; then
+            REVISION=$(git rev-parse --verify "${REQUESTED_REVISION}^{commit}")
+          else
+            REVISION=$(git rev-parse --verify refs/remotes/origin/main)
+          fi
+
+          if ! printf '%s' "$REVISION" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "Could not resolve a full commit SHA to deploy (got \"$REVISION\")" >&2
+            exit 1
+          fi
+
+          # A revision outside main history has no reviewed provenance, and the image workflow only
+          # guarantees a commit coordinate for branch pushes it built.
+          if ! git merge-base --is-ancestor "$REVISION" refs/remotes/origin/main; then
+            echo "Revision $REVISION is not contained in main history" >&2
+            exit 1
+          fi
+
+          echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
+          echo "Deployment target is $REVISION"
+
+      - name: Wait for the commit image
+        id: image
+        # Bounded so a revision whose image never lands fails instead of holding the deploy slot for
+        # the full job timeout.
+        timeout-minutes: 20
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVISION: ${{ steps.target.outputs.revision }}
+        run: |
+          # CI and the image build run in parallel, so the commit coordinate is normally already
+          # published by the time CI concludes; waiting covers the case where it is not.
+          node scripts/registry-coordinate.mjs --image "$IMAGE" --reference "$REVISION" --wait
+
+      - name: Confirm the revision is still current
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REVISION: ${{ steps.target.outputs.revision }}
+        run: |
+          set -euo pipefail
+          git fetch origin main:refs/remotes/origin/main
+          MAIN_TIP=$(git rev-parse refs/remotes/origin/main)
+
+          # A manual deploy is an explicit decision, including a deliberate rollback to an older
+          # revision, so it is never treated as stale.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # An automatic deploy must never move staging backwards. Runs for consecutive commits can
+          # overlap, so a run whose revision is no longer the tip of main skips rather than
+          # overwriting the newer revision that has already shipped or is about to.
+          if [ "$REVISION" != "$MAIN_TIP" ]; then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: $REVISION is no longer the tip of main ($MAIN_TIP)"
+            exit 0
+          fi
+
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the CapRover secrets are configured
+        if: steps.gate.outputs.deploy == 'true'
+        env:
+          CAPROVER_SERVER: ${{ secrets.CAPROVER_STAGING_SERVER }}
+          CAPROVER_APP: ${{ secrets.CAPROVER_STAGING_APP }}
+          CAPROVER_APP_TOKEN: ${{ secrets.CAPROVER_STAGING_APP_TOKEN }}
+        run: |
+          # The deploy action reports a missing secret as an opaque CLI failure, so name the gap here.
+          MISSING=""
+          [ -n "$CAPROVER_SERVER" ] || MISSING="$MISSING CAPROVER_STAGING_SERVER"
+          [ -n "$CAPROVER_APP" ] || MISSING="$MISSING CAPROVER_STAGING_APP"
+          [ -n "$CAPROVER_APP_TOKEN" ] || MISSING="$MISSING CAPROVER_STAGING_APP_TOKEN"
+          if [ -n "$MISSING" ]; then
+            echo "Missing repository secrets:$MISSING" >&2
+            exit 1
+          fi
+
+      - name: Deploy the commit image to CapRover
+        if: steps.gate.outputs.deploy == 'true'
+        uses: caprover/deploy-from-github@c221bd9d1c3a55de4c2b66c0dc4a3972d04c027c # v1.2.0
+        with:
+          server: ${{ secrets.CAPROVER_STAGING_SERVER }}
+          app: ${{ secrets.CAPROVER_STAGING_APP }}
+          token: ${{ secrets.CAPROVER_STAGING_APP_TOKEN }}
+          # The immutable per-commit coordinate, never `edge`: a moving tag would leave CapRover with
+          # an unchanged image reference and nothing to roll forward to.
+          image: ${{ env.IMAGE }}:${{ steps.target.outputs.revision }}
+
+      - name: Summarise the deployment
+        if: always() && steps.target.outputs.revision != ''
+        env:
+          DEPLOYED: ${{ steps.gate.outputs.deploy }}
+          DIGEST: ${{ steps.image.outputs.digest }}
+          REVISION: ${{ steps.target.outputs.revision }}
+        run: |
+          {
+            echo "### Staging deployment"
+            echo
+            printf -- "- Revision: \`%s\`\n" "$REVISION"
+            printf -- "- Image: \`%s:%s\`\n" "$IMAGE" "$REVISION"
+            if [ -n "$DIGEST" ]; then
+              printf -- "- Digest: \`%s\`\n" "$DIGEST"
+            fi
+            if [ "$DEPLOYED" != "true" ]; then
+              echo "- Skipped: this revision is no longer the tip of main."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ future vertical slices.
 - [Development guide](./DEVELOPMENT.md)
 - [Contributing guide](./CONTRIBUTING.md)
 - [Release guide](./docs/releasing.md)
+- [Deployment guide](./docs/deploying.md)
 - [Security policy](./SECURITY.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,6 +99,7 @@ Admin Web；Agent 执行与即时通信仍属于后续纵向切片。
 - [开发指南](./DEVELOPMENT.zh-CN.md)
 - [贡献指南](./CONTRIBUTING.zh-CN.md)
 - [发布指南](./docs/zh-CN/releasing.md)
+- [部署指南](./docs/zh-CN/deploying.md)
 - [安全政策](./SECURITY.zh-CN.md)
 - [行为准则](./CODE_OF_CONDUCT.zh-CN.md)
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,101 @@
+# OpenTag deployment guide
+
+[简体中文](./zh-CN/deploying.md)
+
+OpenTag runs its Staging environment on [CapRover](https://caprover.com/). Every revision that lands on `main` and
+passes CI is deployed automatically from the container image the `Docker` workflow already published to GHCR. Nothing is
+built on the CapRover host and no source tarball is uploaded; the deployment is a pointer change to an immutable image.
+
+| Environment | Trigger | Image | Workflow |
+| --- | --- | --- | --- |
+| Staging | Successful `CI` on `main`, or an intentional manual run | `ghcr.io/first-tree-ai/opentag:<commit-sha>` | `deploy-staging.yml` |
+
+Production is not deployed by this repository. See [releasing.md](./releasing.md) for the published production
+artifacts.
+
+## How a push reaches Staging
+
+1. A revision lands on `main`. `CI` and `Docker` start in parallel.
+2. `Docker` builds and pushes the immutable commit coordinate `ghcr.io/first-tree-ai/opentag:<commit-sha>`.
+3. `CI` succeeds, which starts `Deploy Staging`.
+4. `Deploy Staging` proves the revision belongs to `main` history, waits for the commit coordinate to be published, and
+   confirms the revision is still the tip of `main`.
+5. The CapRover App is pointed at that exact image tag and CapRover pulls and rolls it out.
+
+The deployment always uses the per-commit tag, never `edge` or `latest`. A moving tag would leave CapRover with an
+unchanged image reference and nothing to roll forward to, and it would make the running revision unidentifiable.
+
+Two properties are worth knowing before debugging a missing deployment:
+
+- **Staging never moves backwards.** Runs for consecutive commits can overlap, so an automatic run whose revision is no
+  longer the tip of `main` skips instead of overwriting a newer revision. The run succeeds and records the skip in its
+  job summary.
+- **A broken tip parks Staging.** If commit `A` passes CI and commit `B` lands and fails, the run for `A` skips because
+  `A` is no longer the tip, and `B` never deploys. Staging stays on the last revision that shipped. Use a manual run to
+  deploy `A` on purpose.
+
+## Repository secrets
+
+Configure these as repository secrets under **Settings → Secrets and variables → Actions**. The workflow fails with the
+missing names listed before it calls CapRover, so an unconfigured deployment is reported rather than half-attempted.
+
+| Secret | Value | Where to find it |
+| --- | --- | --- |
+| `CAPROVER_STAGING_SERVER` | CapRover dashboard URL, for example `https://captain.apps.example.com` | Your CapRover installation |
+| `CAPROVER_STAGING_APP` | The CapRover App name that serves Staging | CapRover dashboard → Apps |
+| `CAPROVER_STAGING_APP_TOKEN` | App-scoped deployment token | CapRover dashboard → App → Deployment → App Token |
+
+Use the App Token rather than the CapRover account password. The token authorises deployments to that one App, so a leak
+cannot reconfigure the rest of the server, and it can be rotated from the App's Deployment tab without touching any
+other App.
+
+The workflow declares a `staging` GitHub Environment so deployments appear in the repository's Deployments view and can
+later be given protection rules. Repository secrets remain readable from that job; moving the three secrets into the
+Environment instead also works and scopes them to Staging.
+
+## CapRover App prerequisites
+
+The workflow only changes which image the App runs. Everything below is CapRover-side configuration that has to exist
+before the first deployment.
+
+- **Container HTTP port** `8000`, matching the port the image exposes.
+- **PostgreSQL**, either a CapRover one-click Postgres App or an external instance reachable from the host.
+- **Persistent storage** is not required by the server image itself, but the database App needs it.
+- **Environment variables** on the App:
+
+| Variable | Staging value |
+| --- | --- |
+| `OPENTAG_ENV` | `staging` |
+| `OPENTAG_HOST` | `0.0.0.0` |
+| `OPENTAG_PORT` | `8000` |
+| `OPENTAG_PUBLIC_URL` | The App's HTTPS URL; hosted environments reject plain HTTP |
+| `OPENTAG_DATABASE_URL` | `postgresql://…` for the Staging database |
+| `OPENTAG_JWT_SECRET` | At least 32 random characters, unique to Staging |
+| `OPENTAG_ENCRYPTION_KEY` | Base64 32-byte key, unique to Staging |
+| `OPENTAG_AUTO_MIGRATE` | `true` so each rollout applies pending migrations |
+
+Enable HTTPS and force HTTPS on the App before setting `OPENTAG_PUBLIC_URL`; the server refuses to start in a hosted
+environment whose public URL is not HTTPS. Staging secrets must not be shared with any other environment.
+
+The GHCR package is public, so CapRover pulls the image anonymously. If the package is ever made private, add a
+registry credential in **CapRover → Cluster → Docker Registries** using a GitHub token with `read:packages`, otherwise
+every deployment fails at the pull step.
+
+## Manual deployment and rollback
+
+Run the **Deploy Staging** workflow from the Actions tab on `main`. Leaving the `revision` input empty deploys the
+current tip; supplying a commit SHA deploys that revision instead, which is how a rollback is performed. A manual run is
+treated as an explicit decision and is never skipped as stale, but the revision must still belong to `main` history and
+must already have a published image.
+
+Rolling back only reverts application code. It does not revert database migrations that a later revision applied, so a
+rollback across a destructive migration needs a deliberate database plan.
+
+## Verifying a deployment
+
+The job summary records the deployed revision, the image tag, and the image digest. Confirm the rollout from the
+CapRover side afterwards:
+
+- The App's Deployment tab shows the new image reference and a successful build log.
+- `https://<app>/healthz` returns success.
+- The App logs show the migration and listen lines for the expected revision.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,6 +9,9 @@ OpenTag publishes one self-contained CLI artifact in two isolated npm package id
 | Staging | `open-tag-staging` | `opentag-staging` | Successful `CI` on `main`, or an intentional manual rerun on `main` |
 | Production | `open-tag` | `opentag` | A protected stable `vX.Y.Z` tag |
 
+This guide covers published artifacts only. The Staging server is deployed from the same `main` revision by a separate
+workflow described in [deploying.md](./deploying.md).
+
 The internal `@opentag/client`, `@opentag/shared`, and `@opentag/server` workspaces remain private. Client and Shared
 code is bundled into the CLI tarball, and the packed manifest must not expose an `@opentag/*` runtime dependency.
 `THIRD_PARTY_NOTICES` is generated from the exact third-party packages bundled into the CLI and contains their complete

--- a/docs/zh-CN/deploying.md
+++ b/docs/zh-CN/deploying.md
@@ -1,0 +1,94 @@
+# OpenTag 部署指南
+
+> Canonical source: [../deploying.md](../deploying.md)
+> Last synced with: 2026-08-20
+
+OpenTag 的 Staging 环境运行在 [CapRover](https://caprover.com/) 上。每个合入 `main` 且通过 CI 的 revision，都会用
+`Docker` workflow 已经发布到 GHCR 的容器镜像自动部署。CapRover 主机上不构建任何内容，也不上传源码 tarball；一次部署
+只是把指针切到一个不可变镜像。
+
+| Environment | 触发条件 | 镜像 | Workflow |
+| --- | --- | --- | --- |
+| Staging | `main` 的 `CI` 成功，或有意的手动运行 | `ghcr.io/first-tree-ai/opentag:<commit-sha>` | `deploy-staging.yml` |
+
+本仓库不部署 Production。Production 发布的 artifact 见 [releasing.md](./releasing.md)。
+
+## 一次推送如何到达 Staging
+
+1. 一个 revision 合入 `main`，`CI` 与 `Docker` 并行启动。
+2. `Docker` 构建并推送不可变的 commit coordinate `ghcr.io/first-tree-ai/opentag:<commit-sha>`。
+3. `CI` 成功，触发 `Deploy Staging`。
+4. `Deploy Staging` 先证明该 revision 属于 `main` 历史，等待 commit coordinate 发布完成，再确认该 revision 仍是 `main`
+   的 tip。
+5. CapRover App 被指向这个精确的镜像 tag，由 CapRover 拉取并完成上线。
+
+部署始终使用按 commit 的 tag，绝不使用 `edge` 或 `latest`。移动的 tag 会让 CapRover 面对一个没有变化的镜像引用，从而
+无法向前推进，也会让线上运行的 revision 无法识别。
+
+排查"部署没发生"之前，有两个特性需要先知道：
+
+- **Staging 绝不回退。** 连续 commit 的运行可能重叠，因此自动运行如果发现自己的 revision 已不是 `main` 的 tip，就会
+  跳过，而不是覆盖更新的 revision。该运行仍然成功，并在 job summary 中记录这次跳过。
+- **tip 损坏会让 Staging 停在原地。** 如果 commit `A` 通过 CI，随后 commit `B` 合入并失败，那么 `A` 的运行会因为 `A`
+  不再是 tip 而跳过，`B` 也不会部署，Staging 保持在上一次成功上线的 revision。此时用手动运行有意部署 `A`。
+
+## 仓库 Secrets
+
+在 **Settings → Secrets and variables → Actions** 中配置以下 repository secrets。Workflow 会在调用 CapRover 之前列出
+缺失的名称并失败，因此未配置的部署会被明确报告，而不是执行到一半。
+
+| Secret | 值 | 获取位置 |
+| --- | --- | --- |
+| `CAPROVER_STAGING_SERVER` | CapRover dashboard URL，例如 `https://captain.apps.example.com` | 你的 CapRover 实例 |
+| `CAPROVER_STAGING_APP` | 承载 Staging 的 CapRover App 名称 | CapRover dashboard → Apps |
+| `CAPROVER_STAGING_APP_TOKEN` | App 级别的部署 token | CapRover dashboard → App → Deployment → App Token |
+
+请使用 App Token 而不是 CapRover 账号密码。该 token 只授权对这一个 App 的部署，泄露后无法重配置服务器其余部分，并且
+可以在该 App 的 Deployment 页单独轮换，不影响其他 App。
+
+Workflow 声明了 `staging` 这个 GitHub Environment，使部署出现在仓库的 Deployments 视图中，之后也可以为它加上保护规则。
+Repository secrets 在该 job 中依然可读；把这三个 secret 改放到该 Environment 下同样可行，并能把它们限定在 Staging。
+
+## CapRover App 前置条件
+
+Workflow 只改变 App 运行哪个镜像。以下都是首次部署前必须在 CapRover 侧完成的配置。
+
+- **Container HTTP port** 为 `8000`，与镜像暴露的端口一致。
+- **PostgreSQL**：CapRover 的一键 Postgres App，或主机可达的外部实例。
+- **持久化存储**：server 镜像本身不需要，但数据库 App 需要。
+- App 上的**环境变量**：
+
+| 变量 | Staging 取值 |
+| --- | --- |
+| `OPENTAG_ENV` | `staging` |
+| `OPENTAG_HOST` | `0.0.0.0` |
+| `OPENTAG_PORT` | `8000` |
+| `OPENTAG_PUBLIC_URL` | App 的 HTTPS URL；hosted environment 拒绝纯 HTTP |
+| `OPENTAG_DATABASE_URL` | Staging 数据库的 `postgresql://…` |
+| `OPENTAG_JWT_SECRET` | 至少 32 个随机字符，Staging 专用 |
+| `OPENTAG_ENCRYPTION_KEY` | Base64 编码的 32 字节 key，Staging 专用 |
+| `OPENTAG_AUTO_MIGRATE` | `true`，使每次上线都应用待执行的 migration |
+
+设置 `OPENTAG_PUBLIC_URL` 之前，先在 App 上启用 HTTPS 并强制 HTTPS；在 hosted environment 中，public URL 不是 HTTPS
+时 server 会拒绝启动。Staging 的 secret 不得与任何其他环境共用。
+
+GHCR package 是公开的，因此 CapRover 匿名拉取镜像即可。如果该 package 之后被改为私有，需要在
+**CapRover → Cluster → Docker Registries** 中用带 `read:packages` 的 GitHub token 添加 registry 凭据，否则每次部署都会
+在拉取阶段失败。
+
+## 手动部署与回滚
+
+在 Actions 页面基于 `main` 运行 **Deploy Staging** workflow。`revision` 输入留空表示部署当前 tip；填入 commit SHA 则
+部署该 revision，这也是执行回滚的方式。手动运行被视为显式决策，永远不会因为"过期"被跳过，但该 revision 仍必须属于
+`main` 历史，并且已经有发布好的镜像。
+
+回滚只回退应用代码，不会回退更新的 revision 已经执行过的数据库 migration，因此跨越破坏性 migration 的回滚需要一份
+有意为之的数据库方案。
+
+## 验证一次部署
+
+Job summary 会记录部署的 revision、镜像 tag 和镜像 digest。之后再从 CapRover 侧确认上线结果：
+
+- App 的 Deployment 页显示新的镜像引用和成功的构建日志。
+- `https://<app>/healthz` 返回成功。
+- App 日志中出现预期 revision 的 migration 与监听日志。

--- a/docs/zh-CN/releasing.md
+++ b/docs/zh-CN/releasing.md
@@ -1,7 +1,7 @@
 # OpenTag 发布指南
 
 > Canonical source: [../releasing.md](../releasing.md)
-> Last synced with: 2026-08-19
+> Last synced with: 2026-08-20
 
 OpenTag 以两个相互隔离的 npm package identity 发布一个自包含 CLI artifact：
 
@@ -9,6 +9,9 @@ OpenTag 以两个相互隔离的 npm package identity 发布一个自包含 CLI 
 | --- | --- | --- | --- |
 | Staging | `open-tag-staging` | `opentag-staging` | `main` 的 `CI` 成功，或在 `main` 上有意手动重跑 |
 | Production | `open-tag` | `opentag` | 受保护的稳定 `vX.Y.Z` tag |
+
+本指南只覆盖已发布的 artifact。Staging server 由另一个 workflow 从同一个 `main` revision 部署，说明见
+[deploying.md](./deploying.md)。
 
 内部 `@opentag/client`、`@opentag/shared` 和 `@opentag/server` workspace 永久保持 private。Client 与 Shared
 代码会 bundle 进 CLI tarball，pack 后的 manifest 不得暴露任何 `@opentag/*` runtime dependency。


### PR DESCRIPTION
## Summary

Staging now follows `main` automatically, deployed to CapRover from the container image the `Docker` workflow already
publishes to GHCR. Nothing is built on the deployment path and no source tarball is uploaded; a deployment is a pointer
change to an immutable image.

`.github/workflows/deploy-staging.yml`:

- **Triggers on successful `main` CI**, not on the `Docker` workflow. CI is the gate that proves a revision passed its
  checks; the image it needs is produced by the `Docker` workflow running alongside it, so this workflow waits for that
  coordinate via the existing `scripts/registry-coordinate.mjs --wait` instead of building anything.
- **Deploys the immutable per-commit coordinate** `ghcr.io/first-tree-ai/opentag:<commit-sha>`, never `edge` or
  `latest`. A moving tag would leave CapRover with an unchanged image reference and nothing to roll forward to, and it
  would make the running revision unidentifiable.
- **Never moves staging backwards.** Runs for consecutive commits can overlap, so an automatic run whose revision is no
  longer the tip of `main` skips and records that in its job summary rather than overwriting a newer revision. Every
  revision must also be proven to belong to `main` history.
- **`workflow_dispatch` with an optional `revision` input** is the manual path, including rollback. A manual run is an
  explicit decision and is never skipped as stale.
- Missing secrets are reported by name before CapRover is called, so an unconfigured deployment fails legibly instead of
  as an opaque CLI error.
- `caprover/deploy-from-github` is pinned to the `v1.2.0` commit, matching how every other action in this repository is
  pinned, and covered by the existing Dependabot `github-actions` ecosystem.
- Declares a `staging` GitHub Environment so deployments appear in the repository's Deployments view and can later be
  given protection rules.

Docs: `docs/deploying.md` with the Chinese mirror `docs/zh-CN/deploying.md`, cross-linked from both READMEs and the
release guide.

## Follow-up required before this works

This PR adds no credentials. A maintainer must configure three repository secrets — `CAPROVER_STAGING_SERVER`,
`CAPROVER_STAGING_APP`, `CAPROVER_STAGING_APP_TOKEN` — and the CapRover App prerequisites listed in
`docs/deploying.md` (container HTTP port `8000`, HTTPS, and the `OPENTAG_*` environment variables). `workflow_run` and
`workflow_dispatch` only take effect once the workflow file is on the default branch, so the first automatic deployment
happens on the first successful `main` CI after merge.

The GHCR package is currently public, so CapRover pulls the image anonymously and no Docker registry credential is
needed. `docs/deploying.md` records what to add if that ever changes.

## Testing

- `actionlint .github/workflows/deploy-staging.yml` — clean, no findings.
- `pnpm check` — passes.
- `pnpm build` — passes.
- `pnpm typecheck` — passes.
- `pnpm test` — 2 pre-existing failures in `apps/cli` daemon service tests, both caused by macOS resolving
  `/var/folders/...` to `/private/var/folders/...`; unrelated to this change, which touches only YAML and Markdown.
  All 38 `scripts/__tests__` tests pass.
- `node scripts/registry-coordinate.mjs --image ghcr.io/first-tree-ai/opentag --reference <main-sha>` resolves a real
  published commit coordinate without a token, confirming both the wait step and anonymous pullability.

## Breaking changes

None. No existing workflow, package, or runtime behavior is modified.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass, except the pre-existing macOS-only `apps/cli`
      path failures noted above.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.