### PR TITLE
fix(web): simplify team creation

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -47,6 +47,7 @@ function installApi(
     unauthenticated?: boolean;
     teamless?: boolean;
     teamNameConflict?: boolean;
+    teamNameConflicts?: number;
   } = {},
 ) {
   const teamProfile = { name: "example", displayName: "Example" };
@@ -81,7 +82,7 @@ function installApi(
   let invitationExists = options.invitationExists ?? false;
   let invitationVersion: "A" | "B" = "A";
   let joinedInvitation = options.alreadyJoinedInvitation ?? false;
-  let teamNameConflict = options.teamNameConflict ?? false;
+  let teamNameConflicts = options.teamNameConflicts ?? (options.teamNameConflict ? 1 : 0);
   const invitation = () => ({
     token: invitationVersion.repeat(43),
     inviteUrl: `https://opentag.example.com/invites/${invitationVersion.repeat(43)}`,
@@ -117,8 +118,8 @@ function installApi(
       });
     }
     if (path === "/api/v1/teams" && init?.method === "POST") {
-      if (teamNameConflict) {
-        teamNameConflict = false;
+      if (teamNameConflicts > 0) {
+        teamNameConflicts -= 1;
         return json(
           {
             error: {
@@ -752,20 +753,23 @@ describe("OpenTag Web App Shell", () => {
     });
   });
 
-  it("creates a safe internal handle for a Team name written without ASCII characters", async () => {
-    installApi("admin", { teamless: true });
+  it("uses a fresh internal handle for every collision on a Team name without ASCII characters", async () => {
+    installApi("admin", { teamless: true, teamNameConflicts: 2 });
     window.history.replaceState({}, "", "/teams/new");
     render(<App />);
     fireEvent.change(await screen.findByLabelText("Team name"), { target: { value: "示例团队" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
     await screen.findByRole("heading", { name: "Agents" });
-    const request = vi
+    const requests = vi
       .mocked(fetch)
-      .mock.calls.find(([path, init]) => path === "/api/v1/teams" && init?.method === "POST");
-    expect(JSON.parse(String(request?.[1]?.body))).toMatchObject({
-      displayName: "示例团队",
-      name: expect.stringMatching(/^team-[a-f0-9]{8}$/),
-    });
+      .mock.calls.filter(([path, init]) => path === "/api/v1/teams" && init?.method === "POST");
+    expect(requests).toHaveLength(3);
+    const bodies = requests.map(
+      (request) => JSON.parse(String(request[1]?.body)) as { displayName: string; name: string },
+    );
+    expect(bodies.every((body) => body.displayName === "示例团队")).toBe(true);
+    expect(bodies.every((body) => /^team-[a-f0-9]{8}$/.test(body.name))).toBe(true);
+    expect(new Set(bodies.map((body) => body.name))).toHaveProperty("size", 3);
   });
 
   it("lets an existing member create a second Team and offers both in the picker", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -81,6 +81,7 @@ function installApi(
   let invitationExists = options.invitationExists ?? false;
   let invitationVersion: "A" | "B" = "A";
   let joinedInvitation = options.alreadyJoinedInvitation ?? false;
+  let teamNameConflict = options.teamNameConflict ?? false;
   const invitation = () => ({
     token: invitationVersion.repeat(43),
     inviteUrl: `https://opentag.example.com/invites/${invitationVersion.repeat(43)}`,
@@ -116,7 +117,8 @@ function installApi(
       });
     }
     if (path === "/api/v1/teams" && init?.method === "POST") {
-      if (options.teamNameConflict) {
+      if (teamNameConflict) {
+        teamNameConflict = false;
         return json(
           {
             error: {
@@ -721,68 +723,49 @@ describe("OpenTag Web App Shell", () => {
   it("sends a Team-less session to Team creation and lands it on Agents", async () => {
     installApi("admin", { teamless: true });
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Create Team" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Create your team" })).toBeTruthy();
     expect(window.location.pathname).toBe("/teams/new");
-    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "First Tree AI" } });
-    expect((screen.getByLabelText("Canonical name") as HTMLInputElement).value).toBe("first-tree-ai");
+    expect(screen.getAllByRole("textbox")).toHaveLength(1);
+    expect(screen.queryByText(/canonical name/i)).toBeNull();
+    fireEvent.change(screen.getByLabelText("Team name"), { target: { value: "First Tree AI" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     expect(window.location.pathname).toBe("/agents");
     expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(createdTeamId);
   });
 
-  it("keeps a canonical name collision on the form with a readable message", async () => {
+  it("resolves an internal Team handle collision without asking the user for another name", async () => {
     installApi("admin", { teamless: true, teamNameConflict: true });
     window.history.replaceState({}, "", "/teams/new");
     render(<App />);
-    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "Example" } });
+    fireEvent.change(await screen.findByLabelText("Team name"), { target: { value: "Example" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
-    expect(await screen.findByText("Another Team already uses this canonical name")).toBeTruthy();
-    expect(window.location.pathname).toBe("/teams/new");
-    expect((screen.getByLabelText("Display name") as HTMLInputElement).value).toBe("Example");
-    expect(window.localStorage.getItem("opentag.selectedTeamId")).toBeNull();
+    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    const createRequests = vi
+      .mocked(fetch)
+      .mock.calls.filter(([path, init]) => path === "/api/v1/teams" && init?.method === "POST");
+    expect(createRequests).toHaveLength(2);
+    expect(JSON.parse(String(createRequests[0]?.[1]?.body))).toEqual({ name: "example", displayName: "Example" });
+    expect(JSON.parse(String(createRequests[1]?.[1]?.body))).toMatchObject({
+      displayName: "Example",
+      name: expect.stringMatching(/^example-[a-f0-9]{8}$/),
+    });
   });
 
-  it("stops deriving the canonical name once the user writes their own", async () => {
+  it("creates a safe internal handle for a Team name written without ASCII characters", async () => {
     installApi("admin", { teamless: true });
     window.history.replaceState({}, "", "/teams/new");
     render(<App />);
-    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "First Tree" } });
-    fireEvent.change(screen.getByLabelText("Canonical name"), { target: { value: "ft" } });
-    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "First Tree AI" } });
-    expect((screen.getByLabelText("Canonical name") as HTMLInputElement).value).toBe("ft");
-  });
-
-  it("resumes deriving the canonical name after the user empties the field", async () => {
-    installApi("admin", { teamless: true });
-    window.history.replaceState({}, "", "/teams/new");
-    render(<App />);
-    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "First Tree" } });
-    fireEvent.change(screen.getByLabelText("Canonical name"), { target: { value: "ft" } });
-    fireEvent.change(screen.getByLabelText("Canonical name"), { target: { value: "" } });
-    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "First Tree AI" } });
-    expect((screen.getByLabelText("Canonical name") as HTMLInputElement).value).toBe("first-tree-ai");
-  });
-
-  it.each([
-    ["示例团队", ""],
-    ["OpenTag 中文团队", "opentag"],
-  ])("says which characters the canonical name drops for %s", async (displayName, derived) => {
-    installApi("admin", { teamless: true });
-    window.history.replaceState({}, "", "/teams/new");
-    render(<App />);
-    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: displayName } });
-    expect((screen.getByLabelText("Canonical name") as HTMLInputElement).value).toBe(derived);
-    expect(await screen.findByText(new RegExp(`leaves out the rest of “${displayName}”`))).toBeTruthy();
-  });
-
-  it("keeps quiet when the display name maps cleanly onto a canonical name", async () => {
-    installApi("admin", { teamless: true });
-    window.history.replaceState({}, "", "/teams/new");
-    render(<App />);
-    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "Café Ops" } });
-    expect((screen.getByLabelText("Canonical name") as HTMLInputElement).value).toBe("cafe-ops");
-    expect(screen.queryByText(/leaves out the rest of/)).toBeNull();
+    fireEvent.change(await screen.findByLabelText("Team name"), { target: { value: "示例团队" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
+    await screen.findByRole("heading", { name: "Agents" });
+    const request = vi
+      .mocked(fetch)
+      .mock.calls.find(([path, init]) => path === "/api/v1/teams" && init?.method === "POST");
+    expect(JSON.parse(String(request?.[1]?.body))).toMatchObject({
+      displayName: "示例团队",
+      name: expect.stringMatching(/^team-[a-f0-9]{8}$/),
+    });
   });
 
   it("lets an existing member create a second Team and offers both in the picker", async () => {
@@ -790,7 +773,7 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Example" }));
     fireEvent.click(screen.getByRole("link", { name: "Create Team" }));
-    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "Second Team" } });
+    fireEvent.change(await screen.findByLabelText("Team name"), { target: { value: "Second Team" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Second Team" }));

--- a/apps/web/src/create-team-form.tsx
+++ b/apps/web/src/create-team-form.tsx
@@ -2,7 +2,7 @@ import type { CreateTeamResponse } from "@opentag/shared/browser";
 import { type FormEvent, useState } from "react";
 import { ApiError, browserApi } from "./api.js";
 
-/** Derives the canonical Team handle a display name suggests; the user stays free to replace it. */
+/** Derives the internal Team handle suggested by a user-facing name. */
 export function toTeamHandle(displayName: string): string {
   return displayName
     .normalize("NFKD")
@@ -12,13 +12,9 @@ export function toTeamHandle(displayName: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-/**
- * Canonical names are ASCII, so derivation drops anything else. Latin accents survive as their base letter,
- * but other scripts leave nothing behind: the suggestion silently empties or keeps only an ASCII fragment,
- * which the user has to be told rather than left to notice.
- */
-function dropsCharactersFromHandle(displayName: string): boolean {
-  return /[^\p{ASCII}]/u.test(displayName.normalize("NFKD").replace(/\p{M}/gu, ""));
+function handleWithSuffix(handle: string, suffix: string): string {
+  const base = (handle || "team").slice(0, 64 - suffix.length - 1).replace(/-+$/g, "") || "team";
+  return `${base}-${suffix}`;
 }
 
 /**
@@ -36,8 +32,7 @@ export function CreateTeamForm({
   submitLabel?: string;
 }) {
   const [displayName, setDisplayName] = useState("");
-  const [name, setName] = useState("");
-  const [nameEdited, setNameEdited] = useState(false);
+  const [handleSuffix] = useState(() => crypto.randomUUID().replaceAll("-", "").slice(0, 8));
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string>();
 
@@ -46,13 +41,26 @@ export function CreateTeamForm({
     setSubmitting(true);
     try {
       setError(undefined);
-      onCreated(await browserApi.createTeam({ name, displayName }));
+      const suggestedHandle = toTeamHandle(displayName);
+      const initialHandle = suggestedHandle || handleWithSuffix(suggestedHandle, handleSuffix);
+      try {
+        onCreated(await browserApi.createTeam({ name: initialHandle, displayName }));
+      } catch (cause) {
+        if (!(cause instanceof ApiError) || cause.code !== "TEAM_NAME_CONFLICT") throw cause;
+        onCreated(await browserApi.createTeam({ name: handleWithSuffix(suggestedHandle, handleSuffix), displayName }));
+      }
     } catch (cause) {
       if (cause instanceof ApiError && cause.status === 401 && onUnauthenticated) {
         onUnauthenticated();
         return;
       }
-      setError(cause instanceof Error ? cause.message : "The Team could not be created");
+      setError(
+        cause instanceof ApiError && cause.code === "TEAM_NAME_CONFLICT"
+          ? "We couldn't create a unique team address. Try again."
+          : cause instanceof Error
+            ? cause.message
+            : "The Team could not be created",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -61,46 +69,19 @@ export function CreateTeamForm({
   return (
     <form className="form-card" onSubmit={submit}>
       <label>
-        Display name
+        Team name
         <input
           name="displayName"
+          autoComplete="organization"
+          maxLength={120}
+          placeholder="e.g. Platform team"
           required
           value={displayName}
-          onChange={(event) => {
-            const value = event.currentTarget.value;
-            setDisplayName(value);
-            if (!nameEdited) setName(toTeamHandle(value));
-          }}
+          onChange={(event) => setDisplayName(event.currentTarget.value)}
         />
       </label>
-      <label>
-        Canonical name
-        <input
-          name="name"
-          required
-          pattern="[a-z0-9][a-z0-9-]*"
-          maxLength={64}
-          value={name}
-          onChange={(event) => {
-            const value = event.currentTarget.value;
-            // Emptying the field hands control back to the display name instead of latching it off.
-            setNameEdited(value.length > 0);
-            setName(value);
-          }}
-        />
-      </label>
-      {displayName && dropsCharactersFromHandle(displayName) ? (
-        <p className="notice" role="status">
-          A canonical name can only use lowercase letters, digits and hyphens, so the suggestion above leaves out the
-          rest of “{displayName}”. Write the name you want teammates to type in the CLI.
-        </p>
-      ) : null}
-      <p className="muted">
-        Lowercase letters, digits and hyphens. This is the CLI --team selector and must be unique across OpenTag; Team
-        Admins can change it later.
-      </p>
       <button className="button" type="submit" disabled={submitting}>
-        {submitLabel}
+        {submitting ? "Creating…" : submitLabel}
       </button>
       {error ? (
         <div className="notice error" role="alert">

--- a/apps/web/src/create-team-form.tsx
+++ b/apps/web/src/create-team-form.tsx
@@ -17,6 +17,12 @@ function handleWithSuffix(handle: string, suffix: string): string {
   return `${base}-${suffix}`;
 }
 
+function randomHandleSuffix(): string {
+  return crypto.randomUUID().replaceAll("-", "").slice(0, 8);
+}
+
+const MAX_HANDLE_ATTEMPTS = 4;
+
 /**
  * The single Team creation form. It is mounted both by the standalone `/teams/new` page and by the first
  * onboarding step, so creating a Team behaves identically whether it is a first-run or an additional Team.
@@ -32,7 +38,6 @@ export function CreateTeamForm({
   submitLabel?: string;
 }) {
   const [displayName, setDisplayName] = useState("");
-  const [handleSuffix] = useState(() => crypto.randomUUID().replaceAll("-", "").slice(0, 8));
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string>();
 
@@ -42,12 +47,21 @@ export function CreateTeamForm({
     try {
       setError(undefined);
       const suggestedHandle = toTeamHandle(displayName);
-      const initialHandle = suggestedHandle || handleWithSuffix(suggestedHandle, handleSuffix);
-      try {
-        onCreated(await browserApi.createTeam({ name: initialHandle, displayName }));
-      } catch (cause) {
-        if (!(cause instanceof ApiError) || cause.code !== "TEAM_NAME_CONFLICT") throw cause;
-        onCreated(await browserApi.createTeam({ name: handleWithSuffix(suggestedHandle, handleSuffix), displayName }));
+      for (let attempt = 0; attempt < MAX_HANDLE_ATTEMPTS; attempt += 1) {
+        const name =
+          attempt === 0 && suggestedHandle ? suggestedHandle : handleWithSuffix(suggestedHandle, randomHandleSuffix());
+        try {
+          onCreated(await browserApi.createTeam({ name, displayName }));
+          return;
+        } catch (cause) {
+          if (
+            !(cause instanceof ApiError) ||
+            cause.code !== "TEAM_NAME_CONFLICT" ||
+            attempt === MAX_HANDLE_ATTEMPTS - 1
+          ) {
+            throw cause;
+          }
+        }
       }
     } catch (cause) {
       if (cause instanceof ApiError && cause.status === 401 && onUnauthenticated) {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -251,8 +251,8 @@ function NewTeamPage() {
   return (
     <main className="center-card">
       <span className="eyebrow">OpenTag</span>
-      <h1>Create Team</h1>
-      <p>A Team holds your members, Agents and permissions. You become its first Team Admin.</p>
+      <h1>Create your team</h1>
+      <p>You can invite people and add Agents next.</p>
       <CreateTeamForm
         onCreated={(created) => {
           window.localStorage.setItem(SELECTED_TEAM_STORAGE_KEY, created.id);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1114,7 +1114,7 @@ code {
   display: block;
   width: 38px;
   height: 38px;
-  margin-bottom: 36px;
+  margin-bottom: 28px;
   border: 1px solid var(--brand-ink);
   border-radius: 50%;
   background: var(--success);
@@ -1128,11 +1128,21 @@ code {
 }
 
 .center-card h1 {
+  margin-bottom: 8px;
   font-size: clamp(2rem, 6vw, 2.5rem);
 }
 
-.center-card p {
+.center-card > p {
+  max-width: 38ch;
+  margin: 0;
   color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.center-card > .form-card {
+  gap: 18px;
+  border-top: 0;
+  padding: 28px 0 0;
 }
 
 .center-card .actions {


### PR DESCRIPTION
## Summary

- reduce Team creation to one user-facing Team name field
- generate the internal CLI handle automatically, including Unicode-safe fallback values
- retry handle collisions with a short suffix instead of asking the user to understand canonical names
- shorten the onboarding copy and tighten the card layout

## Testing

- Git-tracked files pass Biome checks; third-party notices verified
- pnpm build
- pnpm typecheck
- Web: 46 tests passed
- CLI: 112 tests passed with TMPDIR=/private/tmp
- Full pnpm test passed for scripts, shared, web, client, and server. Its default CLI invocation hit two existing macOS /tmp versus /private/tmp path assertions; the same CLI suite passes when TMPDIR uses the canonical macOS path.

## Breaking changes

None. The API contract is unchanged; the Web form now owns handle generation.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [x] Build and typecheck pass; environment-specific check/test details are documented above.
- [x] No credentials, private data, or generated build output are included.
- [x] No documentation mirror changes are required.