### PR TITLE
refactor(web): extract Feishu setup lifecycle

### DIFF
--- a/apps/web/src/im/feishu-setup.test.tsx
+++ b/apps/web/src/im/feishu-setup.test.tsx
@@ -194,6 +194,57 @@ describe("FeishuSetup", () => {
     expect(screen.getByRole("button", { name: "Retry Feishu setup" })).toBeTruthy();
   });
 
+  it("does not regress a terminal poll with a late reused start snapshot", async () => {
+    vi.useFakeTimers();
+    let resolveReplacement: (value: FeishuSetupAttempt) => void = () => undefined;
+    const replacement = new Promise<FeishuSetupAttempt>((resolve) => {
+      resolveReplacement = resolve;
+    });
+    vi.spyOn(browserApi, "createFeishuSetupAttempt")
+      .mockResolvedValueOnce(attempt({ id: firstAttemptId, intent: "reauthorize", state: "awaiting_user" }))
+      .mockReturnValueOnce(replacement);
+    const poll = vi
+      .spyOn(browserApi, "feishuSetupAttempt")
+      .mockResolvedValue(attempt({ id: firstAttemptId, intent: "reauthorize", state: "succeeded" }));
+    const onSuccess = vi.fn();
+    render(<Harness onSuccess={onSuccess} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reauthorize" }));
+    await act(async () => undefined);
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+    await act(async () =>
+      resolveReplacement(attempt({ id: firstAttemptId, intent: "reauthorize", state: "awaiting_user" })),
+    );
+
+    expect(screen.getByText(/State: succeeded/)).toBeTruthy();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(3_000));
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a failed intent-switch error while the retained attempt keeps polling", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(browserApi, "createFeishuSetupAttempt")
+      .mockResolvedValueOnce(attempt({ id: firstAttemptId, intent: "reauthorize", state: "awaiting_user" }))
+      .mockRejectedValueOnce(new Error("Replacement unavailable"));
+    const poll = vi
+      .spyOn(browserApi, "feishuSetupAttempt")
+      .mockResolvedValue(attempt({ id: firstAttemptId, intent: "reauthorize", state: "validating" }));
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reauthorize" }));
+    await act(async () => undefined);
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+    await act(async () => undefined);
+    expect(screen.getByRole("alert").textContent).toBe("Replacement unavailable");
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+
+    expect(screen.getByText(/State: validating/)).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toBe("Replacement unavailable");
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes non-Error failures into a stable error state", async () => {
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockRejectedValue("network unavailable");
     render(<Harness />);

--- a/apps/web/src/im/feishu-setup.test.tsx
+++ b/apps/web/src/im/feishu-setup.test.tsx
@@ -245,6 +245,31 @@ describe("FeishuSetup", () => {
     expect(poll).toHaveBeenCalledTimes(1);
   });
 
+  it("clears a retained poll error when a replacement attempt is accepted", async () => {
+    vi.useFakeTimers();
+    let resolveReplacement: (value: FeishuSetupAttempt) => void = () => undefined;
+    const replacement = new Promise<FeishuSetupAttempt>((resolve) => {
+      resolveReplacement = resolve;
+    });
+    vi.spyOn(browserApi, "createFeishuSetupAttempt")
+      .mockResolvedValueOnce(attempt({ id: firstAttemptId, intent: "reauthorize", state: "awaiting_user" }))
+      .mockReturnValueOnce(replacement);
+    vi.spyOn(browserApi, "feishuSetupAttempt").mockRejectedValue(new Error("Old attempt poll failed"));
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reauthorize" }));
+    await act(async () => undefined);
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+    expect(screen.getByRole("alert").textContent).toBe("Old attempt poll failed");
+    await act(async () =>
+      resolveReplacement(attempt({ id: secondAttemptId, intent: "replace", state: "awaiting_user" })),
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText(/State: awaiting_user/)).toBeTruthy();
+  });
+
   it("normalizes non-Error failures into a stable error state", async () => {
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockRejectedValue("network unavailable");
     render(<Harness />);

--- a/apps/web/src/im/feishu-setup.test.tsx
+++ b/apps/web/src/im/feishu-setup.test.tsx
@@ -115,6 +115,8 @@ describe("FeishuSetup", () => {
 
     await act(async () => vi.advanceTimersByTimeAsync(1_500));
     expect(poll).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText(/State: succeeded/)).toBeTruthy();
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/im/feishu-setup.test.tsx
+++ b/apps/web/src/im/feishu-setup.test.tsx
@@ -171,6 +171,29 @@ describe("FeishuSetup", () => {
     expect(create.mock.calls.map(([, intent]) => intent)).toEqual(["replace", "replace"]);
   });
 
+  it("retains the Server-owned terminal attempt when its retry fails to start", async () => {
+    vi.spyOn(browserApi, "createFeishuSetupAttempt")
+      .mockResolvedValueOnce(
+        attempt({
+          id: firstAttemptId,
+          intent: "replace",
+          state: "failed",
+          errorCode: "FEISHU_APP_ALREADY_BOUND",
+        }),
+      )
+      .mockRejectedValueOnce(new Error("Retry unavailable"));
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+    expect(await screen.findByText(/already connected to another Agent/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry Feishu setup" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("Retry unavailable");
+    expect(screen.getByText(/State: failed/)).toBeTruthy();
+    expect(screen.getByText(/already connected to another Agent/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry Feishu setup" })).toBeTruthy();
+  });
+
   it("normalizes non-Error failures into a stable error state", async () => {
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockRejectedValue("network unavailable");
     render(<Harness />);

--- a/apps/web/src/im/feishu-setup.test.tsx
+++ b/apps/web/src/im/feishu-setup.test.tsx
@@ -1,0 +1,180 @@
+import type { FeishuSetupAttempt, FeishuSetupIntent } from "@opentag/shared/browser";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { browserApi } from "../api.js";
+import { FeishuSetup } from "./feishu-setup.js";
+
+const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
+const firstAttemptId = "2a63a21e-f6c7-4474-91ea-4dabf0566a24";
+const secondAttemptId = "3a63a21e-f6c7-4474-91ea-4dabf0566a24";
+
+function attempt(
+  overrides: Partial<FeishuSetupAttempt> & Pick<FeishuSetupAttempt, "id" | "intent" | "state">,
+): FeishuSetupAttempt {
+  return {
+    agentId,
+    qrUrl: null,
+    expiresAt: "2026-08-20T00:15:00.000Z",
+    errorCode: null,
+    completedAt: null,
+    createdAt: "2026-08-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function Harness({ onSuccess = () => undefined }: { onSuccess?: () => void }) {
+  return (
+    <FeishuSetup agentId={agentId} onSuccess={onSuccess}>
+      {(setup) => (
+        <>
+          <button type="button" onClick={() => void setup.start("create")}>
+            Create
+          </button>
+          <button type="button" onClick={() => void setup.start("reauthorize")}>
+            Reauthorize
+          </button>
+          <button type="button" onClick={() => void setup.start("replace")}>
+            Replace
+          </button>
+          {setup.feedback}
+        </>
+      )}
+    </FeishuSetup>
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("FeishuSetup", () => {
+  it("renders the setup link and generated QR without creating duplicate attempts", async () => {
+    const create = vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(
+      attempt({
+        id: firstAttemptId,
+        intent: "create",
+        state: "awaiting_user",
+        qrUrl: "https://open.feishu.cn/setup",
+      }),
+    );
+    render(<Harness />);
+
+    const button = screen.getByRole("button", { name: "Create" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    const link = (await screen.findByRole("link", { name: "Open Feishu authorization" })) as HTMLAnchorElement;
+    expect(link.href).toBe("https://open.feishu.cn/setup");
+    expect(await screen.findByRole("img", { name: "Scan this QR code in Feishu" })).toBeTruthy();
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls a pending attempt to success once and invokes the narrow success callback", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(
+      attempt({ id: firstAttemptId, intent: "reauthorize", state: "awaiting_user" }),
+    );
+    const poll = vi
+      .spyOn(browserApi, "feishuSetupAttempt")
+      .mockResolvedValue(attempt({ id: firstAttemptId, intent: "reauthorize", state: "succeeded" }));
+    const onSuccess = vi.fn();
+    render(<Harness onSuccess={onSuccess} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reauthorize" }));
+    await act(async () => undefined);
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+
+    expect(screen.getByText(/State: succeeded/)).toBeTruthy();
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(poll).toHaveBeenCalledWith(firstAttemptId);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    await act(async () => vi.advanceTimersByTimeAsync(3_000));
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes polling errors and keeps the active lifecycle polling", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(
+      attempt({ id: firstAttemptId, intent: "create", state: "awaiting_user" }),
+    );
+    const poll = vi
+      .spyOn(browserApi, "feishuSetupAttempt")
+      .mockRejectedValueOnce("network unavailable")
+      .mockResolvedValueOnce(attempt({ id: firstAttemptId, intent: "create", state: "succeeded" }));
+    const onSuccess = vi.fn();
+    render(<Harness onSuccess={onSuccess} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await act(async () => undefined);
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+
+    expect(screen.getByRole("alert").textContent).toBe("Unable to refresh setup");
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+    expect(poll).toHaveBeenCalledTimes(2);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces the active polling lifecycle and cleans it up on unmount", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(browserApi, "createFeishuSetupAttempt").mockImplementation(
+      async (_agentId: string, intent: FeishuSetupIntent = "create") =>
+        attempt({
+          id: intent === "replace" ? secondAttemptId : firstAttemptId,
+          intent,
+          state: "awaiting_user",
+        }),
+    );
+    const poll = vi
+      .spyOn(browserApi, "feishuSetupAttempt")
+      .mockImplementation(async (attemptId) => attempt({ id: attemptId, intent: "replace", state: "validating" }));
+    const view = render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await act(async () => undefined);
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+    await act(async () => undefined);
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(poll).toHaveBeenCalledWith(secondAttemptId);
+
+    view.unmount();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a terminal attempt with its original intent", async () => {
+    const create = vi
+      .spyOn(browserApi, "createFeishuSetupAttempt")
+      .mockResolvedValueOnce(
+        attempt({
+          id: firstAttemptId,
+          intent: "replace",
+          state: "failed",
+          errorCode: "FEISHU_APP_ALREADY_BOUND",
+        }),
+      )
+      .mockResolvedValueOnce(attempt({ id: secondAttemptId, intent: "replace", state: "awaiting_user" }));
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+    expect(await screen.findByText(/already connected to another Agent/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry Feishu setup" }));
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
+    expect(create.mock.calls.map(([, intent]) => intent)).toEqual(["replace", "replace"]);
+  });
+
+  it("normalizes non-Error failures into a stable error state", async () => {
+    vi.spyOn(browserApi, "createFeishuSetupAttempt").mockRejectedValue("network unavailable");
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("Unable to start setup");
+  });
+});

--- a/apps/web/src/im/feishu-setup.tsx
+++ b/apps/web/src/im/feishu-setup.tsx
@@ -1,0 +1,214 @@
+import type { FeishuSetupAttempt, FeishuSetupIntent } from "@opentag/shared/browser";
+import { toString as qrToString } from "qrcode";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { browserApi } from "../api.js";
+
+const ACTIVE_STATES: readonly FeishuSetupAttempt["state"][] = ["awaiting_user", "validating"];
+const RETRYABLE_STATES: readonly FeishuSetupAttempt["state"][] = ["expired", "failed", "canceled"];
+const POLL_INTERVAL_MS = 1_500;
+
+export interface FeishuSetupControl {
+  /** Starts one setup intent. False means no new attempt was started. */
+  start: (intent?: FeishuSetupIntent) => Promise<boolean>;
+  /** Opaque lifecycle feedback for the caller to place in its existing layout. */
+  feedback: ReactNode;
+}
+
+interface FeishuSetupProps {
+  agentId: string;
+  children: (control: FeishuSetupControl) => ReactNode;
+  onSuccess: () => void;
+}
+
+/**
+ * Owns one Feishu setup lifecycle for an Agent behind a small rendering seam.
+ * ImTab refreshes its binding on success; onboarding can use the same callback
+ * to reload fresh Server facts and derive its next step without learning setup internals.
+ */
+export function FeishuSetup({ agentId, children, onSuccess }: FeishuSetupProps) {
+  return (
+    <FeishuSetupLifecycle agentId={agentId} key={agentId} onSuccess={onSuccess}>
+      {children}
+    </FeishuSetupLifecycle>
+  );
+}
+
+function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps) {
+  const [attempt, setAttempt] = useState<FeishuSetupAttempt>();
+  const [error, setError] = useState<string>();
+  const attemptRef = useRef<FeishuSetupAttempt>(undefined);
+  const creatingRef = useRef(false);
+  const lifecycleRef = useRef(0);
+  const onSuccessRef = useRef(onSuccess);
+  onSuccessRef.current = onSuccess;
+
+  useEffect(
+    () => () => {
+      lifecycleRef.current += 1;
+    },
+    [],
+  );
+
+  const start = useCallback(
+    async (intent: FeishuSetupIntent = "create") => {
+      const current = attemptRef.current;
+      if (creatingRef.current || (current?.intent === intent && ACTIVE_STATES.includes(current.state))) return false;
+
+      const lifecycle = lifecycleRef.current + 1;
+      lifecycleRef.current = lifecycle;
+      creatingRef.current = true;
+      attemptRef.current = undefined;
+      setAttempt(undefined);
+      setError(undefined);
+      try {
+        const started = await browserApi.createFeishuSetupAttempt(agentId, intent);
+        if (lifecycleRef.current !== lifecycle) return false;
+        attemptRef.current = started;
+        setAttempt(started);
+        if (started.state === "succeeded") onSuccessRef.current();
+        return true;
+      } catch (cause) {
+        if (lifecycleRef.current !== lifecycle) return false;
+        setError(normalizeError(cause, "Unable to start setup"));
+        return false;
+      } finally {
+        if (lifecycleRef.current === lifecycle) creatingRef.current = false;
+      }
+    },
+    [agentId],
+  );
+
+  const activeAttemptId = attempt && ACTIVE_STATES.includes(attempt.state) ? attempt.id : undefined;
+  useEffect(() => {
+    if (!activeAttemptId) return;
+    const lifecycle = lifecycleRef.current;
+    let active = true;
+    let timer: number | undefined;
+
+    const poll = async () => {
+      try {
+        const next = await browserApi.feishuSetupAttempt(activeAttemptId);
+        if (!active || lifecycleRef.current !== lifecycle) return;
+        attemptRef.current = next;
+        setAttempt(next);
+        if (next.state === "succeeded") {
+          onSuccessRef.current();
+          return;
+        }
+        if (ACTIVE_STATES.includes(next.state)) timer = window.setTimeout(poll, POLL_INTERVAL_MS);
+      } catch (cause) {
+        if (!active || lifecycleRef.current !== lifecycle) return;
+        setError(normalizeError(cause, "Unable to refresh setup"));
+        timer = window.setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    };
+
+    timer = window.setTimeout(poll, POLL_INTERVAL_MS);
+    return () => {
+      active = false;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [activeAttemptId]);
+
+  return children({
+    start,
+    feedback: (
+      <>
+        {attempt ? <FeishuSetupFeedback attempt={attempt} onRetry={start} /> : null}
+        {error ? (
+          <div className="notice error" role="alert">
+            {error}
+          </div>
+        ) : null}
+      </>
+    ),
+  });
+}
+
+function FeishuSetupFeedback({
+  attempt,
+  onRetry,
+}: {
+  attempt: FeishuSetupAttempt;
+  onRetry: (intent: FeishuSetupIntent) => Promise<boolean>;
+}) {
+  const recovery = setupRecovery(attempt);
+  return (
+    <div className="notice">
+      <strong>Feishu setup started</strong>
+      <br />
+      {attempt.intent === "reauthorize"
+        ? "Confirm the updated permissions for the current Feishu Bot."
+        : "Choose an existing Feishu Bot or create a new one, then confirm the requested permissions."}
+      <br />
+      State: {attempt.state}. Expires {formatSetupDate(attempt.expiresAt)}.
+      {recovery ? (
+        <>
+          <br />
+          {recovery}
+        </>
+      ) : null}
+      {attempt.qrUrl ? (
+        <>
+          <br />
+          <FeishuQrCode value={attempt.qrUrl} />
+          <a href={attempt.qrUrl} rel="noreferrer" target="_blank">
+            Open Feishu authorization
+          </a>
+        </>
+      ) : null}
+      {RETRYABLE_STATES.includes(attempt.state) ? (
+        <>
+          <br />
+          <button className="button" type="button" onClick={() => void onRetry(attempt.intent)}>
+            Retry Feishu setup
+          </button>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function FeishuQrCode({ value }: { value: string }) {
+  const [source, setSource] = useState<string>();
+  useEffect(() => {
+    let active = true;
+    void qrToString(value, { margin: 1, type: "svg", width: 240 }).then(
+      (svg) => active && setSource(`data:image/svg+xml,${encodeURIComponent(svg)}`),
+    );
+    return () => {
+      active = false;
+    };
+  }, [value]);
+  return source ? <img alt="Scan this QR code in Feishu" className="setup-qr" src={source} /> : null;
+}
+
+function setupRecovery(attempt: FeishuSetupAttempt): string | undefined {
+  const messages: Record<string, string> = {
+    FEISHU_APP_ALREADY_BOUND:
+      "This Feishu Bot is already connected to another Agent. Choose a different Bot or disable its current binding first.",
+    FEISHU_SCOPE_REAUTH_REQUIRED:
+      "Feishu did not grant every required permission. Retry and approve all requested permissions.",
+    IM_BINDING_SCOPE_REAUTH_REQUIRED:
+      "Feishu did not grant every required permission. Retry and approve all requested permissions.",
+    FEISHU_SETUP_DENIED: "Feishu authorization was declined. Retry and approve the requested permissions.",
+    FEISHU_SETUP_EXPIRED: "This Feishu authorization expired. Retry to scan a new QR code.",
+    FEISHU_SETUP_CANCELED: "Feishu setup was canceled. Retry when you are ready.",
+    FEISHU_SETUP_OWNER_RESTARTED: "The server restarted during Feishu setup. Retry to generate a new QR code.",
+    FEISHU_BINDING_IDENTITY_MISMATCH:
+      "The authorized Feishu Bot identity does not match the current binding. Retry with the current Bot or use Replace.",
+  };
+  if (attempt.errorCode && messages[attempt.errorCode]) return messages[attempt.errorCode];
+  if (attempt.state === "expired") return messages.FEISHU_SETUP_EXPIRED;
+  if (attempt.state === "canceled") return messages.FEISHU_SETUP_CANCELED;
+  if (attempt.state === "failed") return "Feishu setup failed. Retry or contact a Team admin for help.";
+  return undefined;
+}
+
+function normalizeError(cause: unknown, fallback: string): string {
+  return cause instanceof Error ? cause.message : fallback;
+}
+
+function formatSetupDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+}

--- a/apps/web/src/im/feishu-setup.tsx
+++ b/apps/web/src/im/feishu-setup.tsx
@@ -20,6 +20,11 @@ interface FeishuSetupProps {
   onSuccess: () => void;
 }
 
+interface FeishuSetupError {
+  message: string;
+  source: "poll" | "start";
+}
+
 /**
  * Owns one Feishu setup lifecycle for an Agent behind a small rendering seam.
  * ImTab refreshes its binding on success; onboarding can use the same callback
@@ -35,7 +40,7 @@ export function FeishuSetup({ agentId, children, onSuccess }: FeishuSetupProps) 
 
 function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps) {
   const [attempt, setAttempt] = useState<FeishuSetupAttempt>();
-  const [error, setError] = useState<string>();
+  const [error, setError] = useState<FeishuSetupError>();
   const attemptRef = useRef<FeishuSetupAttempt>(undefined);
   const creatingRef = useRef(false);
   const lifecycleRef = useRef(0);
@@ -61,6 +66,7 @@ function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps
         const started = await browserApi.createFeishuSetupAttempt(agentId, intent);
         if (lifecycleRef.current !== lifecycle) return false;
         creatingRef.current = false;
+        if (current && attemptRef.current !== current && started.id === current.id) return true;
         if (attemptRef.current?.id !== started.id || !ACTIVE_STATES.includes(started.state)) {
           lifecycleRef.current = lifecycle + 1;
         }
@@ -70,7 +76,7 @@ function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps
         return true;
       } catch (cause) {
         if (lifecycleRef.current !== lifecycle) return false;
-        setError(normalizeError(cause, "Unable to start setup"));
+        setError({ message: normalizeError(cause, "Unable to start setup"), source: "start" });
         return false;
       } finally {
         if (lifecycleRef.current === lifecycle) creatingRef.current = false;
@@ -92,7 +98,7 @@ function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps
         if (!active || lifecycleRef.current !== lifecycle) return;
         attemptRef.current = next;
         setAttempt(next);
-        setError(undefined);
+        setError((currentError) => (currentError?.source === "poll" ? undefined : currentError));
         if (next.state === "succeeded") {
           onSuccessRef.current();
           return;
@@ -100,7 +106,11 @@ function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps
         if (ACTIVE_STATES.includes(next.state)) timer = window.setTimeout(poll, POLL_INTERVAL_MS);
       } catch (cause) {
         if (!active || lifecycleRef.current !== lifecycle) return;
-        setError(normalizeError(cause, "Unable to refresh setup"));
+        setError((currentError) =>
+          currentError?.source === "start"
+            ? currentError
+            : { message: normalizeError(cause, "Unable to refresh setup"), source: "poll" },
+        );
         timer = window.setTimeout(poll, POLL_INTERVAL_MS);
       }
     };
@@ -119,7 +129,7 @@ function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps
         {attempt ? <FeishuSetupFeedback attempt={attempt} onRetry={start} /> : null}
         {error ? (
           <div className="notice error" role="alert">
-            {error}
+            {error.message}
           </div>
         ) : null}
       </>

--- a/apps/web/src/im/feishu-setup.tsx
+++ b/apps/web/src/im/feishu-setup.tsx
@@ -91,6 +91,7 @@ function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps
         if (!active || lifecycleRef.current !== lifecycle) return;
         attemptRef.current = next;
         setAttempt(next);
+        setError(undefined);
         if (next.state === "succeeded") {
           onSuccessRef.current();
           return;

--- a/apps/web/src/im/feishu-setup.tsx
+++ b/apps/web/src/im/feishu-setup.tsx
@@ -54,15 +54,16 @@ function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps
       const current = attemptRef.current;
       if (creatingRef.current || (current?.intent === intent && ACTIVE_STATES.includes(current.state))) return false;
 
-      const lifecycle = lifecycleRef.current + 1;
-      lifecycleRef.current = lifecycle;
+      const lifecycle = lifecycleRef.current;
       creatingRef.current = true;
-      attemptRef.current = undefined;
-      setAttempt(undefined);
       setError(undefined);
       try {
         const started = await browserApi.createFeishuSetupAttempt(agentId, intent);
         if (lifecycleRef.current !== lifecycle) return false;
+        creatingRef.current = false;
+        if (attemptRef.current?.id !== started.id || !ACTIVE_STATES.includes(started.state)) {
+          lifecycleRef.current = lifecycle + 1;
+        }
         attemptRef.current = started;
         setAttempt(started);
         if (started.state === "succeeded") onSuccessRef.current();

--- a/apps/web/src/im/feishu-setup.tsx
+++ b/apps/web/src/im/feishu-setup.tsx
@@ -67,6 +67,7 @@ function FeishuSetupLifecycle({ agentId, children, onSuccess }: FeishuSetupProps
         if (lifecycleRef.current !== lifecycle) return false;
         creatingRef.current = false;
         if (current && attemptRef.current !== current && started.id === current.id) return true;
+        setError(undefined);
         if (attemptRef.current?.id !== started.id || !ACTIVE_STATES.includes(started.state)) {
           lifecycleRef.current = lifecycle + 1;
         }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -4,7 +4,6 @@ import type {
   AgentSummary,
   AuthProvidersResponse,
   Computer,
-  FeishuSetupAttempt,
   MeMembership,
   MeResponse,
   TeamComputerSummary,
@@ -12,7 +11,6 @@ import type {
   UpdateAgentRuntimeConfig,
 } from "@opentag/shared/browser";
 import { MembershipRoleSchema } from "@opentag/shared/browser";
-import { toString as qrToString } from "qrcode";
 import {
   createContext,
   type FormEvent,
@@ -27,6 +25,7 @@ import {
 import { Link, Navigate, NavLink, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import { ApiError, browserApi } from "./api.js";
 import { CreateTeamForm } from "./create-team-form.js";
+import { FeishuSetup } from "./im/feishu-setup.js";
 
 type LoadState<T> = { kind: "loading" } | { kind: "error"; error: Error } | { kind: "ready"; value: T };
 
@@ -1029,59 +1028,11 @@ function nullableText(value: FormDataEntryValue | null): string | null {
   return text || null;
 }
 
-function feishuSetupRecovery(attempt: FeishuSetupAttempt): string | undefined {
-  const messages: Record<string, string> = {
-    FEISHU_APP_ALREADY_BOUND:
-      "This Feishu Bot is already connected to another Agent. Choose a different Bot or disable its current binding first.",
-    FEISHU_SCOPE_REAUTH_REQUIRED:
-      "Feishu did not grant every required permission. Retry and approve all requested permissions.",
-    IM_BINDING_SCOPE_REAUTH_REQUIRED:
-      "Feishu did not grant every required permission. Retry and approve all requested permissions.",
-    FEISHU_SETUP_DENIED: "Feishu authorization was declined. Retry and approve the requested permissions.",
-    FEISHU_SETUP_EXPIRED: "This Feishu authorization expired. Retry to scan a new QR code.",
-    FEISHU_SETUP_CANCELED: "Feishu setup was canceled. Retry when you are ready.",
-    FEISHU_SETUP_OWNER_RESTARTED: "The server restarted during Feishu setup. Retry to generate a new QR code.",
-    FEISHU_BINDING_IDENTITY_MISMATCH:
-      "The authorized Feishu Bot identity does not match the current binding. Retry with the current Bot or use Replace.",
-  };
-  if (attempt.errorCode && messages[attempt.errorCode]) return messages[attempt.errorCode];
-  if (attempt.state === "expired") return messages.FEISHU_SETUP_EXPIRED;
-  if (attempt.state === "canceled") return messages.FEISHU_SETUP_CANCELED;
-  if (attempt.state === "failed") return "Feishu setup failed. Retry or contact a Team admin for help.";
-  return undefined;
-}
-
 function ImTab({ agent }: { agent: AgentDetail }) {
   const [reload, setReload] = useState(0);
-  const [attempt, setAttempt] = useState<FeishuSetupAttempt>();
   const [error, setError] = useState<string>();
   const [reauthorizationNeeded, setReauthorizationNeeded] = useState(false);
   const state = useResource(() => browserApi.imBinding(agent.id), `${agent.id}:${reload}`);
-  const connect = useCallback(
-    async (intent: "create" | "reauthorize" | "replace" = "create") => {
-      try {
-        setError(undefined);
-        setAttempt(await browserApi.createFeishuSetupAttempt(agent.id, intent));
-        setReauthorizationNeeded(false);
-      } catch (cause) {
-        setError(cause instanceof Error ? cause.message : "Unable to start setup");
-      }
-    },
-    [agent.id],
-  );
-  useEffect(() => {
-    if (!attempt || !["awaiting_user", "validating"].includes(attempt.state)) return;
-    const timer = window.setInterval(() => {
-      void browserApi.feishuSetupAttempt(attempt.id).then(
-        (next) => {
-          setAttempt(next);
-          if (next.state === "succeeded") setReload((value) => value + 1);
-        },
-        (cause: unknown) => setError(cause instanceof Error ? cause.message : "Unable to refresh setup"),
-      );
-    }, 1_500);
-    return () => window.clearInterval(timer);
-  }, [attempt]);
   async function changeReceiveMode(receiveMode: "mention_only" | "all_message") {
     if (
       receiveMode === "all_message" &&
@@ -1102,138 +1053,104 @@ function ImTab({ agent }: { agent: AgentDetail }) {
     }
   }
   return (
-    <AsyncState state={state}>
-      {(binding) => (
-        <>
-          {binding ? (
-            <DefinitionList
-              rows={[
-                ["Provider", binding.provider],
-                [
-                  "Binding state",
-                  binding.bindingState === "reauthorization_required" && binding.provider === "feishu"
-                    ? "Online · permissions update required"
-                    : binding.bindingState,
-                ],
-                ["Receive mode", binding.receiveMode],
-                ["Last confirmed", binding.lastConfirmedAt ? formatDate(binding.lastConfirmedAt) : "Unable to confirm"],
-              ]}
-            />
-          ) : (
-            <EmptyState title="No IM binding">Connect a supported IM bot when the Agent is ready.</EmptyState>
-          )}
-          {agent.viewerCapabilities.canManage ? (
-            <div className="actions">
-              {!binding ? (
-                <button className="button" type="button" onClick={() => void connect()}>
-                  Connect existing or new Feishu Bot
-                </button>
-              ) : null}
-              {(binding?.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
-              binding?.provider === "feishu" ? (
-                <button className="button" type="button" onClick={() => void connect("reauthorize")}>
-                  Reauthorize Feishu
-                </button>
-              ) : null}
-              {(binding?.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
-              binding?.provider === "slack" ? (
-                <span className="notice">Slack reauthorization is not available in this release.</span>
-              ) : null}
-              {binding?.receiveMode === "mention_only" ? (
-                <button type="button" onClick={() => void changeReceiveMode("all_message")}>
-                  Enable all messages
-                </button>
-              ) : binding ? (
-                <button type="button" onClick={() => void changeReceiveMode("mention_only")}>
-                  Use mentions only
-                </button>
-              ) : null}
-              {binding?.provider === "feishu" ? (
-                <button type="button" onClick={() => void connect("replace")}>
-                  Replace with existing or new Feishu Bot
-                </button>
-              ) : null}
-              {binding ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (
-                      !window.confirm(
-                        "Disable this IM binding? New IM work will stop until another binding is connected.",
-                      )
-                    )
-                      return;
-                    void browserApi.disableImBinding(binding.id).then(
-                      () => setReload((value) => value + 1),
-                      (cause: unknown) =>
-                        setError(cause instanceof Error ? cause.message : "Unable to disable IM binding"),
-                    );
-                  }}
-                >
-                  Disable IM binding
-                </button>
-              ) : null}
-            </div>
-          ) : (
-            <p className="muted">IM setup is managed by Team Admins.</p>
-          )}
-          {attempt ? (
-            <div className="notice">
-              <strong>Feishu setup started</strong>
-              <br />
-              {attempt.intent === "reauthorize"
-                ? "Confirm the updated permissions for the current Feishu Bot."
-                : "Choose an existing Feishu Bot or create a new one, then confirm the requested permissions."}
-              <br />
-              State: {attempt.state}. Expires {formatDate(attempt.expiresAt)}.
-              {feishuSetupRecovery(attempt) ? (
-                <>
-                  <br />
-                  {feishuSetupRecovery(attempt)}
-                </>
-              ) : null}
-              {attempt.qrUrl ? (
-                <>
-                  <br />
-                  <FeishuQrCode value={attempt.qrUrl} />
-                  <a href={attempt.qrUrl} rel="noreferrer" target="_blank">
-                    Open Feishu authorization
-                  </a>
-                </>
-              ) : null}
-              {["expired", "failed", "canceled"].includes(attempt.state) ? (
-                <>
-                  <br />
-                  <button className="button" type="button" onClick={() => void connect(attempt.intent)}>
-                    Retry Feishu setup
-                  </button>
-                </>
-              ) : null}
-            </div>
-          ) : null}
-          {error ? (
-            <div className="notice error" role="alert">
-              {error}
-            </div>
-          ) : null}
-        </>
-      )}
-    </AsyncState>
+    <FeishuSetup agentId={agent.id} onSuccess={() => setReload((value) => value + 1)}>
+      {(setup) => {
+        const connect = async (intent: "create" | "reauthorize" | "replace" = "create") => {
+          setError(undefined);
+          if (await setup.start(intent)) setReauthorizationNeeded(false);
+        };
+        return (
+          <AsyncState state={state}>
+            {(binding) => (
+              <>
+                {binding ? (
+                  <DefinitionList
+                    rows={[
+                      ["Provider", binding.provider],
+                      [
+                        "Binding state",
+                        binding.bindingState === "reauthorization_required" && binding.provider === "feishu"
+                          ? "Online · permissions update required"
+                          : binding.bindingState,
+                      ],
+                      ["Receive mode", binding.receiveMode],
+                      [
+                        "Last confirmed",
+                        binding.lastConfirmedAt ? formatDate(binding.lastConfirmedAt) : "Unable to confirm",
+                      ],
+                    ]}
+                  />
+                ) : (
+                  <EmptyState title="No IM binding">Connect a supported IM bot when the Agent is ready.</EmptyState>
+                )}
+                {agent.viewerCapabilities.canManage ? (
+                  <div className="actions">
+                    {!binding ? (
+                      <button className="button" type="button" onClick={() => void connect()}>
+                        Connect existing or new Feishu Bot
+                      </button>
+                    ) : null}
+                    {(binding?.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
+                    binding?.provider === "feishu" ? (
+                      <button className="button" type="button" onClick={() => void connect("reauthorize")}>
+                        Reauthorize Feishu
+                      </button>
+                    ) : null}
+                    {(binding?.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
+                    binding?.provider === "slack" ? (
+                      <span className="notice">Slack reauthorization is not available in this release.</span>
+                    ) : null}
+                    {binding?.receiveMode === "mention_only" ? (
+                      <button type="button" onClick={() => void changeReceiveMode("all_message")}>
+                        Enable all messages
+                      </button>
+                    ) : binding ? (
+                      <button type="button" onClick={() => void changeReceiveMode("mention_only")}>
+                        Use mentions only
+                      </button>
+                    ) : null}
+                    {binding?.provider === "feishu" ? (
+                      <button type="button" onClick={() => void connect("replace")}>
+                        Replace with existing or new Feishu Bot
+                      </button>
+                    ) : null}
+                    {binding ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (
+                            !window.confirm(
+                              "Disable this IM binding? New IM work will stop until another binding is connected.",
+                            )
+                          )
+                            return;
+                          void browserApi.disableImBinding(binding.id).then(
+                            () => setReload((value) => value + 1),
+                            (cause: unknown) =>
+                              setError(cause instanceof Error ? cause.message : "Unable to disable IM binding"),
+                          );
+                        }}
+                      >
+                        Disable IM binding
+                      </button>
+                    ) : null}
+                  </div>
+                ) : (
+                  <p className="muted">IM setup is managed by Team Admins.</p>
+                )}
+                {setup.feedback}
+                {error ? (
+                  <div className="notice error" role="alert">
+                    {error}
+                  </div>
+                ) : null}
+              </>
+            )}
+          </AsyncState>
+        );
+      }}
+    </FeishuSetup>
   );
-}
-
-function FeishuQrCode({ value }: { value: string }) {
-  const [source, setSource] = useState<string>();
-  useEffect(() => {
-    let active = true;
-    void qrToString(value, { margin: 1, type: "svg", width: 240 }).then(
-      (svg) => active && setSource(`data:image/svg+xml,${encodeURIComponent(svg)}`),
-    );
-    return () => {
-      active = false;
-    };
-  }, [value]);
-  return source ? <img alt="Scan this QR code in Feishu" className="setup-qr" src={source} /> : null;
 }
 
 function AccessTab({ agent }: { agent: AgentDetail }) {


### PR DESCRIPTION
## Summary

- extract Feishu create, reauthorize, and replace setup into a reusable Web module
- keep polling, lifecycle cleanup, QR rendering, terminal recovery, retry, duplicate-attempt prevention, and setup error normalization behind the module interface
- leave receive-mode and disable controls in ImTab, with a narrow success callback that refreshes binding facts and can later advance onboarding from fresh Server facts
- add focused DOM and timer coverage for QR/link rendering, success polling, poll recovery, intent replacement, unmount cleanup, terminal retry, and start errors

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `TMPDIR=/private/tmp TURBO_ENV_MODE=loose pnpm test`
- `TMPDIR=/private/tmp pnpm --filter @opentag/client test:agent-runtime:coverage`
- `TMPDIR=/private/tmp pnpm test:coverage`

The canonical temp path avoids macOS `/tmp` and `/var` symlink aliases in existing path-sensitive tests.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.