### PR TITLE
feat(web): add Team invitation shortcut

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -621,6 +621,34 @@ describe("OpenTag Web App Shell", () => {
     expect(document.activeElement).toBe(teamTrigger);
   });
 
+  it("keeps the Members invitation panel in sync after rotating from the Team-picker dialog", async () => {
+    installApi("admin", { invitationExists: true });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "clipboard", { configurable: true, value: { writeText } });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+
+    const pageLink = (await screen.findByLabelText("Invitation link")) as HTMLInputElement;
+    expect(pageLink.value).toContain("/invites/AAA");
+    fireEvent.click(screen.getByRole("button", { name: "Example" }));
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "Invite people" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Rotate invitation link" }));
+    await waitFor(() =>
+      expect((within(dialog).getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/BBB"),
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close invitation dialog" }));
+
+    const refreshedPageLink = screen.getByLabelText("Invitation link") as HTMLInputElement;
+    expect(refreshedPageLink.value).toContain("/invites/BBB");
+    fireEvent.click(screen.getByRole("button", { name: "Copy invitation link" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(refreshedPageLink.value));
+    confirm.mockRestore();
+  });
+
   it("does not expose the Team-picker invitation shortcut to regular members", async () => {
     installApi("member");
     render(<App />);

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -641,13 +641,14 @@ describe("OpenTag Web App Shell", () => {
       within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
     );
     const dialog = await screen.findByRole("dialog", { name: "Invite people" });
+    expect(screen.getAllByLabelText("Invitation link")).toHaveLength(1);
     fireEvent.click(within(dialog).getByRole("button", { name: "Rotate invitation link" }));
     await waitFor(() =>
       expect((within(dialog).getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/BBB"),
     );
     fireEvent.click(within(dialog).getByRole("button", { name: "Close invitation dialog" }));
 
-    const refreshedPageLink = screen.getByLabelText("Invitation link") as HTMLInputElement;
+    const refreshedPageLink = (await screen.findByLabelText("Invitation link")) as HTMLInputElement;
     expect(refreshedPageLink.value).toContain("/invites/BBB");
     fireEvent.click(screen.getByRole("button", { name: "Copy invitation link" }));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(refreshedPageLink.value));

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -37,6 +37,7 @@ function installApi(
     bindingReauth?: boolean;
     bound?: boolean;
     initialStatus?: "active" | "suspended";
+    invitationCreate?: () => Promise<Response> | Response;
     invitationExists?: boolean;
     invitationRotate?: () => Promise<Response> | Response;
     provider?: "feishu" | "slack";
@@ -226,6 +227,11 @@ function installApi(
       return invitationExists ? json(invitation()) : new Response(null, { status: 204 });
     }
     if (path === `/api/v1/teams/${teamId}/invitation` && init?.method === "POST") {
+      if (options.invitationCreate) {
+        const response = await options.invitationCreate();
+        if (response.ok) invitationExists = true;
+        return response;
+      }
       invitationExists = true;
       return json(invitation(), 201);
     }
@@ -733,6 +739,42 @@ describe("OpenTag Web App Shell", () => {
       ).toBe(false),
     );
     confirm.mockRestore();
+  });
+
+  it("uses the dialog card as the focus fallback while invitation creation is pending", async () => {
+    let resolveCreate: (response: Response) => void = () => undefined;
+    const pendingCreate = new Promise<Response>((resolve) => {
+      resolveCreate = resolve;
+    });
+    installApi("admin", { invitationCreate: () => pendingCreate });
+    render(<App />);
+
+    const teamTrigger = await screen.findByRole("button", { name: "Example" });
+    fireEvent.click(teamTrigger);
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "Invite people" });
+    fireEvent.click(await within(dialog).findByRole("button", { name: "Create invitation link" }));
+
+    teamTrigger.focus();
+    fireEvent.keyDown(teamTrigger, { key: "Tab" });
+    expect(document.activeElement).toBe(dialog);
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(screen.getByRole("dialog", { name: "Invite people" })).toBe(dialog);
+
+    resolveCreate(
+      json(
+        {
+          token: "A".repeat(43),
+          inviteUrl: `https://opentag.example.com/invites/${"A".repeat(43)}`,
+          role: "member",
+          expiresAt: "2026-08-27T00:00:00.000Z",
+        },
+        201,
+      ),
+    );
+    expect(await within(dialog).findByLabelText("Invitation link")).toBeTruthy();
   });
 
   it("replaces a locally rotated invitation with a newer successful server read", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -83,7 +83,7 @@ function installApi(
   let memberRole: "admin" | "member" = "member";
   let otherMemberRole: "admin" | "member" = "member";
   let invitationExists = options.invitationExists ?? false;
-  let invitationVersion: "A" | "B" = "A";
+  let invitationVersion: "A" | "B" | "C" = "A";
   let joinedInvitation = options.alreadyJoinedInvitation ?? false;
   let teamNameConflicts = options.teamNameConflicts ?? (options.teamNameConflict ? 1 : 0);
   const invitation = () => ({
@@ -327,6 +327,11 @@ function installApi(
     if (path === "/api/v1/auth/browser/logout" && init?.method === "POST") return new Response(null, { status: 204 });
     throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${path}`);
   });
+  return {
+    setInvitationVersion(value: "A" | "B" | "C") {
+      invitationVersion = value;
+    },
+  };
 }
 
 describe("OpenTag Web App Shell", () => {
@@ -646,6 +651,30 @@ describe("OpenTag Web App Shell", () => {
     expect(refreshedPageLink.value).toContain("/invites/BBB");
     fireEvent.click(screen.getByRole("button", { name: "Copy invitation link" }));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(refreshedPageLink.value));
+    confirm.mockRestore();
+  });
+
+  it("replaces a locally rotated invitation with a newer successful server read", async () => {
+    const api = installApi("admin", { invitationExists: true });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+
+    expect(((await screen.findByLabelText("Invitation link")) as HTMLInputElement).value).toContain("/invites/AAA");
+    fireEvent.click(screen.getByRole("button", { name: "Rotate invitation link" }));
+    await waitFor(() =>
+      expect((screen.getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/BBB"),
+    );
+
+    api.setInvitationVersion("C");
+    fireEvent.click(screen.getByRole("link", { name: "Agents" }));
+    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
+    fireEvent.click(await screen.findByRole("link", { name: "Members" }));
+
+    await waitFor(() =>
+      expect((screen.getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/CCC"),
+    );
     confirm.mockRestore();
   });
 

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -38,6 +38,7 @@ function installApi(
     bound?: boolean;
     initialStatus?: "active" | "suspended";
     invitationExists?: boolean;
+    invitationRotate?: () => Promise<Response> | Response;
     provider?: "feishu" | "slack";
     profileUpdate?: (displayName: string) => Promise<Response> | Response;
     profileUpdateFails?: boolean;
@@ -229,6 +230,11 @@ function installApi(
       return json(invitation(), 201);
     }
     if (path === `/api/v1/teams/${teamId}/invitation/rotate` && init?.method === "POST") {
+      if (options.invitationRotate) {
+        const response = await options.invitationRotate();
+        if (response.ok) invitationVersion = "B";
+        return response;
+      }
       invitationVersion = "B";
       return json(invitation());
     }
@@ -652,6 +658,42 @@ describe("OpenTag Web App Shell", () => {
     expect(refreshedPageLink.value).toContain("/invites/BBB");
     fireEvent.click(screen.getByRole("button", { name: "Copy invitation link" }));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(refreshedPageLink.value));
+    confirm.mockRestore();
+  });
+
+  it("prevents switching invitation surfaces while a rotation is pending", async () => {
+    let resolveRotate: (response: Response) => void = () => undefined;
+    const pendingRotate = new Promise<Response>((resolve) => {
+      resolveRotate = resolve;
+    });
+    installApi("admin", { invitationExists: true, invitationRotate: () => pendingRotate });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+
+    await screen.findByLabelText("Invitation link");
+    fireEvent.click(screen.getByRole("button", { name: "Rotate invitation link" }));
+    fireEvent.click(screen.getByRole("button", { name: "Example" }));
+    const teamPicker = screen.getByRole("dialog", { name: "Switch Team" });
+    const inviteAction = within(teamPicker).getByRole("button", { name: "Invite people" }) as HTMLButtonElement;
+    expect(inviteAction.disabled).toBe(true);
+    fireEvent.click(inviteAction);
+    expect(screen.queryByRole("dialog", { name: "Invite people" })).toBeNull();
+
+    resolveRotate(
+      json({
+        token: "B".repeat(43),
+        inviteUrl: `https://opentag.example.com/invites/${"B".repeat(43)}`,
+        role: "member",
+        expiresAt: "2026-08-27T00:00:00.000Z",
+      }),
+    );
+    await waitFor(() => expect(inviteAction.disabled).toBe(false));
+    fireEvent.click(inviteAction);
+    const dialog = await screen.findByRole("dialog", { name: "Invite people" });
+    await waitFor(() =>
+      expect((within(dialog).getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/BBB"),
+    );
     confirm.mockRestore();
   });
 

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -364,7 +364,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("member");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-    expect(screen.getByText("ada@example.com")).toBeTruthy();
+    expect(screen.queryByText("ada@example.com")).toBeNull();
     expect(await screen.findByText("Reviewer")).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Create Agent" })).toBeNull();
   });
@@ -599,6 +599,34 @@ describe("OpenTag Web App Shell", () => {
     await waitFor(() => expect(link.value).toBe(`https://opentag.example.com/invites/${"B".repeat(43)}`));
     expect(confirm).toHaveBeenCalledOnce();
     confirm.mockRestore();
+  });
+
+  it("opens invitation-link management directly from the Team picker", async () => {
+    installApi("admin", { invitationExists: true });
+    render(<App />);
+    const teamTrigger = await screen.findByRole("button", { name: "Example" });
+    fireEvent.click(teamTrigger);
+    const teamPicker = screen.getByRole("dialog", { name: "Switch Team" });
+    fireEvent.click(within(teamPicker).getByRole("button", { name: "Invite people" }));
+
+    const invitationDialog = await screen.findByRole("dialog", { name: "Invite people" });
+    expect(screen.queryByRole("dialog", { name: "Switch Team" })).toBeNull();
+    expect((within(invitationDialog).getByLabelText("Invitation link") as HTMLInputElement).value).toBe(
+      `https://opentag.example.com/invites/${"A".repeat(43)}`,
+    );
+    const closeButton = within(invitationDialog).getByRole("button", { name: "Close invitation dialog" });
+    expect(document.activeElement).toBe(closeButton);
+    fireEvent.keyDown(closeButton, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Invite people" })).toBeNull();
+    expect(document.activeElement).toBe(teamTrigger);
+  });
+
+  it("does not expose the Team-picker invitation shortcut to regular members", async () => {
+    installApi("member");
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Example" }));
+    const teamPicker = screen.getByRole("dialog", { name: "Switch Team" });
+    expect(within(teamPicker).queryByRole("button", { name: "Invite people" })).toBeNull();
   });
 
   it("keeps invitation-link management hidden from regular members", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -775,6 +775,15 @@ describe("OpenTag Web App Shell", () => {
       ),
     );
     expect(await within(dialog).findByLabelText("Invitation link")).toBeTruthy();
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+      expect(document.activeElement).not.toBe(dialog);
+    });
+
+    dialog.focus();
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(dialog.contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).not.toBe(teamTrigger);
   });
 
   it("replaces a locally rotated invitation with a newer successful server read", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -697,6 +697,44 @@ describe("OpenTag Web App Shell", () => {
     confirm.mockRestore();
   });
 
+  it("keeps focus inside the invitation dialog while a rotation is pending", async () => {
+    let resolveRotate: (response: Response) => void = () => undefined;
+    const pendingRotate = new Promise<Response>((resolve) => {
+      resolveRotate = resolve;
+    });
+    installApi("admin", { invitationExists: true, invitationRotate: () => pendingRotate });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<App />);
+
+    const teamTrigger = await screen.findByRole("button", { name: "Example" });
+    fireEvent.click(teamTrigger);
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
+    );
+    const dialog = await screen.findByRole("dialog", { name: "Invite people" });
+    fireEvent.click(await within(dialog).findByRole("button", { name: "Rotate invitation link" }));
+
+    expect(dialog.contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).not.toBe(teamTrigger);
+    fireEvent.keyDown(document.activeElement ?? dialog, { key: "Escape" });
+    expect(screen.getByRole("dialog", { name: "Invite people" })).toBe(dialog);
+
+    resolveRotate(
+      json({
+        token: "B".repeat(43),
+        inviteUrl: `https://opentag.example.com/invites/${"B".repeat(43)}`,
+        role: "member",
+        expiresAt: "2026-08-27T00:00:00.000Z",
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        (within(dialog).getByRole("button", { name: "Close invitation dialog" }) as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+    confirm.mockRestore();
+  });
+
   it("replaces a locally rotated invitation with a newer successful server read", async () => {
     const api = installApi("admin", { invitationExists: true });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,7 +8,6 @@ import type {
   MeMembership,
   MeResponse,
   TeamComputerSummary,
-  TeamInvitation,
   TeamMemberSummary,
   UpdateAgentRuntimeConfig,
 } from "@opentag/shared/browser";
@@ -25,7 +24,18 @@ import {
   useRef,
   useState,
 } from "react";
-import { Link, Navigate, NavLink, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
+import {
+  Link,
+  Navigate,
+  NavLink,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useOutletContext,
+  useParams,
+} from "react-router-dom";
 import { ApiError, browserApi } from "./api.js";
 import { ComputerSetup } from "./computer-setup.js";
 import { CreateTeamForm } from "./create-team-form.js";
@@ -81,17 +91,8 @@ interface TeamSession {
   selectTeam: (teamId: string) => void;
 }
 
-interface InvitationState {
-  create: (teamId: string) => Promise<TeamInvitation>;
-  refresh: (teamId: string) => void;
-  rotate: (teamId: string) => Promise<TeamInvitation>;
-  stateByTeam: Readonly<Record<string, LoadState<TeamInvitation | undefined>>>;
-}
-
 const teamContext = createContext<TeamSession | undefined>(undefined);
 const TeamContext = teamContext.Provider;
-const invitationContext = createContext<InvitationState | undefined>(undefined);
-const InvitationContext = invitationContext.Provider;
 
 function useTeam(): TeamSession {
   const value = useContext(teamContext);
@@ -99,81 +100,27 @@ function useTeam(): TeamSession {
   return value;
 }
 
-function useInvitationState(): InvitationState {
-  const value = useContext(invitationContext);
-  if (!value) throw new Error("Invitation context is missing");
-  return value;
-}
-
 export function AppRouter() {
-  const [invitationStates, setInvitationStates] = useState<Record<string, LoadState<TeamInvitation | undefined>>>({});
-  const invitationLoadRequests = useRef(new Map<string, number>());
-  const invitationMutationGenerations = useRef(new Map<string, number>());
-  const refreshInvitation = useCallback((teamId: string) => {
-    const requestId = (invitationLoadRequests.current.get(teamId) ?? 0) + 1;
-    const mutationGeneration = invitationMutationGenerations.current.get(teamId) ?? 0;
-    invitationLoadRequests.current.set(teamId, requestId);
-    setInvitationStates((current) => ({ ...current, [teamId]: { kind: "loading" } }));
-    void browserApi.invitation(teamId).then(
-      (invitation) => {
-        if (
-          invitationLoadRequests.current.get(teamId) !== requestId ||
-          (invitationMutationGenerations.current.get(teamId) ?? 0) !== mutationGeneration
-        )
-          return;
-        setInvitationStates((current) => ({ ...current, [teamId]: { kind: "ready", value: invitation } }));
-      },
-      (error: unknown) => {
-        if (
-          invitationLoadRequests.current.get(teamId) !== requestId ||
-          (invitationMutationGenerations.current.get(teamId) ?? 0) !== mutationGeneration
-        )
-          return;
-        setInvitationStates((current) => ({
-          ...current,
-          [teamId]: { kind: "error", error: error instanceof Error ? error : new Error(String(error)) },
-        }));
-      },
-    );
-  }, []);
-  const mutateInvitation = useCallback(async (teamId: string, action: "create" | "rotate") => {
-    const invitation =
-      action === "create" ? await browserApi.createInvitation(teamId) : await browserApi.rotateInvitation(teamId);
-    invitationMutationGenerations.current.set(teamId, (invitationMutationGenerations.current.get(teamId) ?? 0) + 1);
-    setInvitationStates((current) => ({ ...current, [teamId]: { kind: "ready", value: invitation } }));
-    return invitation;
-  }, []);
-  const createInvitation = useCallback((teamId: string) => mutateInvitation(teamId, "create"), [mutateInvitation]);
-  const rotateInvitation = useCallback((teamId: string) => mutateInvitation(teamId, "rotate"), [mutateInvitation]);
   return (
-    <InvitationContext
-      value={{
-        create: createInvitation,
-        refresh: refreshInvitation,
-        rotate: rotateInvitation,
-        stateByTeam: invitationStates,
-      }}
-    >
-      <Routes>
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/invites/:token" element={<InvitePage />} />
-        <Route path="/teams/new" element={<NewTeamPage />} />
-        <Route element={<AuthenticatedTeamGate />}>
-          <Route path="/onboarding" element={<OnboardingPage />} />
-          <Route element={<AppShell />}>
-            <Route index element={<Navigate replace to="/agents" />} />
-            <Route path="/agents" element={<AgentsPage />} />
-            <Route path="/agents/new" element={<NewAgentPage />} />
-            <Route path="/agents/:agentId" element={<Navigate replace to="general" />} />
-            <Route path="/agents/:agentId/:tab" element={<AgentDetailPage />} />
-            <Route path="/account" element={<AccountPage />} />
-            <Route path="/settings" element={<Navigate replace to="account" />} />
-            <Route path="/settings/:section" element={<SettingsPage />} />
-          </Route>
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/invites/:token" element={<InvitePage />} />
+      <Route path="/teams/new" element={<NewTeamPage />} />
+      <Route element={<AuthenticatedTeamGate />}>
+        <Route path="/onboarding" element={<OnboardingPage />} />
+        <Route element={<AppShell />}>
+          <Route index element={<Navigate replace to="/agents" />} />
+          <Route path="/agents" element={<AgentsPage />} />
+          <Route path="/agents/new" element={<NewAgentPage />} />
+          <Route path="/agents/:agentId" element={<Navigate replace to="general" />} />
+          <Route path="/agents/:agentId/:tab" element={<AgentDetailPage />} />
+          <Route path="/account" element={<AccountPage />} />
+          <Route path="/settings" element={<Navigate replace to="account" />} />
+          <Route path="/settings/:section" element={<SettingsPage />} />
         </Route>
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </InvitationContext>
+      </Route>
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
   );
 }
 
@@ -629,7 +576,7 @@ function AppShell() {
           </button>
         </header>
         <main className="content">
-          <Outlet />
+          <Outlet context={{ invitationOpen }} />
         </main>
       </div>
       {invitationOpen ? (
@@ -1351,6 +1298,7 @@ const settingsSections = [
 
 function SettingsPage() {
   const { section = "team" } = useParams();
+  const { invitationOpen } = useOutletContext<{ invitationOpen: boolean }>();
   const navigate = useNavigate();
   const { me, membership, refreshMe } = useTeam();
   const currentSection = settingsSections.find((item) => item.key === section);
@@ -1390,6 +1338,7 @@ function SettingsPage() {
             <MembersSettings
               canManage={membership.role === "admin"}
               currentUserId={me.user.id}
+              invitationDialogOpen={invitationOpen}
               refreshMe={refreshMe}
               teamId={membership.teamId}
             />
@@ -1534,11 +1483,13 @@ function TeamSettings({ membership, refreshMe }: { membership: MeMembership; ref
 function MembersSettings({
   canManage,
   currentUserId,
+  invitationDialogOpen,
   refreshMe,
   teamId,
 }: {
   canManage: boolean;
   currentUserId: string;
+  invitationDialogOpen: boolean;
   refreshMe: () => void;
   teamId: string;
 }) {
@@ -1568,7 +1519,7 @@ function MembersSettings({
 
   return (
     <>
-      {canManage ? <InvitationSettings teamId={teamId} /> : null}
+      {canManage && !invitationDialogOpen ? <InvitationSettings teamId={teamId} /> : null}
       <section className="panel">
         <h2>Team members</h2>
         <AsyncState state={state}>
@@ -1696,29 +1647,27 @@ function InvitationDialog({
 }
 
 function InvitationSettings({ presentation = "panel", teamId }: { presentation?: "dialog" | "panel"; teamId: string }) {
-  const { create, refresh, rotate, stateByTeam } = useInvitationState();
-  const state = stateByTeam[teamId] ?? ({ kind: "loading" } satisfies LoadState<TeamInvitation | undefined>);
+  const state = useResource(() => browserApi.invitation(teamId), teamId);
+  const [current, setCurrent] = useState<Awaited<ReturnType<typeof browserApi.invitation>>>();
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string>();
   const [error, setError] = useState<string>();
 
-  useEffect(() => refresh(teamId), [refresh, teamId]);
-
   async function createInvitation() {
-    await mutateInvitation(() => create(teamId), "Invitation link created.");
+    await mutateInvitation(() => browserApi.createInvitation(teamId), "Invitation link created.");
   }
 
   async function rotateInvitation() {
     if (!window.confirm("Rotate this invitation link? The current link will stop working immediately.")) return;
-    await mutateInvitation(() => rotate(teamId), "Invitation link rotated.");
+    await mutateInvitation(() => browserApi.rotateInvitation(teamId), "Invitation link rotated.");
   }
 
-  async function mutateInvitation(action: () => Promise<TeamInvitation>, successMessage: string) {
+  async function mutateInvitation(action: () => Promise<NonNullable<typeof current>>, successMessage: string) {
     setBusy(true);
     setError(undefined);
     setMessage(undefined);
     try {
-      await action();
+      setCurrent(await action());
       setMessage(successMessage);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Unable to update the invitation link");
@@ -1748,8 +1697,9 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
         </>
       ) : null}
       <AsyncState state={state}>
-        {(invitation) =>
-          invitation ? (
+        {(loaded) => {
+          const invitation = current ?? loaded;
+          return invitation ? (
             <>
               <label className="invite-link">
                 Invitation link
@@ -1769,8 +1719,8 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
             <button className="button" disabled={busy} type="button" onClick={() => void createInvitation()}>
               {busy ? "Creating…" : "Create invitation link"}
             </button>
-          )
-        }
+          );
+        }}
       </AsyncState>
       {message ? <p className="notice success">{message}</p> : null}
       {error ? (

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -82,8 +82,10 @@ interface TeamSession {
 }
 
 interface InvitationState {
-  publishedByTeam: Readonly<Record<string, TeamInvitation>>;
-  publish: (teamId: string, invitation: TeamInvitation) => void;
+  create: (teamId: string) => Promise<TeamInvitation>;
+  refresh: (teamId: string) => void;
+  rotate: (teamId: string) => Promise<TeamInvitation>;
+  stateByTeam: Readonly<Record<string, LoadState<TeamInvitation | undefined>>>;
 }
 
 const teamContext = createContext<TeamSession | undefined>(undefined);
@@ -104,12 +106,54 @@ function useInvitationState(): InvitationState {
 }
 
 export function AppRouter() {
-  const [publishedInvitations, setPublishedInvitations] = useState<Record<string, TeamInvitation>>({});
-  const publishInvitation = useCallback((teamId: string, invitation: TeamInvitation) => {
-    setPublishedInvitations((current) => ({ ...current, [teamId]: invitation }));
+  const [invitationStates, setInvitationStates] = useState<Record<string, LoadState<TeamInvitation | undefined>>>({});
+  const invitationLoadRequests = useRef(new Map<string, number>());
+  const invitationMutationGenerations = useRef(new Map<string, number>());
+  const refreshInvitation = useCallback((teamId: string) => {
+    const requestId = (invitationLoadRequests.current.get(teamId) ?? 0) + 1;
+    const mutationGeneration = invitationMutationGenerations.current.get(teamId) ?? 0;
+    invitationLoadRequests.current.set(teamId, requestId);
+    setInvitationStates((current) => ({ ...current, [teamId]: { kind: "loading" } }));
+    void browserApi.invitation(teamId).then(
+      (invitation) => {
+        if (
+          invitationLoadRequests.current.get(teamId) !== requestId ||
+          (invitationMutationGenerations.current.get(teamId) ?? 0) !== mutationGeneration
+        )
+          return;
+        setInvitationStates((current) => ({ ...current, [teamId]: { kind: "ready", value: invitation } }));
+      },
+      (error: unknown) => {
+        if (
+          invitationLoadRequests.current.get(teamId) !== requestId ||
+          (invitationMutationGenerations.current.get(teamId) ?? 0) !== mutationGeneration
+        )
+          return;
+        setInvitationStates((current) => ({
+          ...current,
+          [teamId]: { kind: "error", error: error instanceof Error ? error : new Error(String(error)) },
+        }));
+      },
+    );
   }, []);
+  const mutateInvitation = useCallback(async (teamId: string, action: "create" | "rotate") => {
+    const invitation =
+      action === "create" ? await browserApi.createInvitation(teamId) : await browserApi.rotateInvitation(teamId);
+    invitationMutationGenerations.current.set(teamId, (invitationMutationGenerations.current.get(teamId) ?? 0) + 1);
+    setInvitationStates((current) => ({ ...current, [teamId]: { kind: "ready", value: invitation } }));
+    return invitation;
+  }, []);
+  const createInvitation = useCallback((teamId: string) => mutateInvitation(teamId, "create"), [mutateInvitation]);
+  const rotateInvitation = useCallback((teamId: string) => mutateInvitation(teamId, "rotate"), [mutateInvitation]);
   return (
-    <InvitationContext value={{ publishedByTeam: publishedInvitations, publish: publishInvitation }}>
+    <InvitationContext
+      value={{
+        create: createInvitation,
+        refresh: refreshInvitation,
+        rotate: rotateInvitation,
+        stateByTeam: invitationStates,
+      }}
+    >
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/invites/:token" element={<InvitePage />} />
@@ -1652,19 +1696,21 @@ function InvitationDialog({
 }
 
 function InvitationSettings({ presentation = "panel", teamId }: { presentation?: "dialog" | "panel"; teamId: string }) {
-  const { publish, publishedByTeam } = useInvitationState();
-  const state = useResource(() => browserApi.invitation(teamId), teamId);
+  const { create, refresh, rotate, stateByTeam } = useInvitationState();
+  const state = stateByTeam[teamId] ?? ({ kind: "loading" } satisfies LoadState<TeamInvitation | undefined>);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string>();
   const [error, setError] = useState<string>();
 
+  useEffect(() => refresh(teamId), [refresh, teamId]);
+
   async function createInvitation() {
-    await mutateInvitation(() => browserApi.createInvitation(teamId), "Invitation link created.");
+    await mutateInvitation(() => create(teamId), "Invitation link created.");
   }
 
   async function rotateInvitation() {
     if (!window.confirm("Rotate this invitation link? The current link will stop working immediately.")) return;
-    await mutateInvitation(() => browserApi.rotateInvitation(teamId), "Invitation link rotated.");
+    await mutateInvitation(() => rotate(teamId), "Invitation link rotated.");
   }
 
   async function mutateInvitation(action: () => Promise<TeamInvitation>, successMessage: string) {
@@ -1672,7 +1718,7 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
     setError(undefined);
     setMessage(undefined);
     try {
-      publish(teamId, await action());
+      await action();
       setMessage(successMessage);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Unable to update the invitation link");
@@ -1702,9 +1748,8 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
         </>
       ) : null}
       <AsyncState state={state}>
-        {(loaded) => {
-          const invitation = publishedByTeam[teamId] ?? loaded;
-          return invitation ? (
+        {(invitation) =>
+          invitation ? (
             <>
               <label className="invite-link">
                 Invitation link
@@ -1724,8 +1769,8 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
             <button className="button" disabled={busy} type="button" onClick={() => void createInvitation()}>
               {busy ? "Creating…" : "Create invitation link"}
             </button>
-          );
-        }}
+          )
+        }
       </AsyncState>
       {message ? <p className="notice success">{message}</p> : null}
       {error ? (

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -90,6 +90,12 @@ interface TeamSession {
   selectTeam: (teamId: string) => void;
 }
 
+interface AppShellOutletContext {
+  invitationMutationPending: boolean;
+  invitationOpen: boolean;
+  setInvitationMutationPending: (pending: boolean) => void;
+}
+
 const teamContext = createContext<TeamSession | undefined>(undefined);
 const TeamContext = teamContext.Provider;
 
@@ -318,6 +324,7 @@ function AppShell() {
   const [navigationOpen, setNavigationOpen] = useState(false);
   const [openMenu, setOpenMenu] = useState<"team" | "account">();
   const [invitationOpen, setInvitationOpen] = useState(false);
+  const [invitationMutationPending, setInvitationMutationPending] = useState(false);
   const [teamQuery, setTeamQuery] = useState("");
   const [loggingOut, setLoggingOut] = useState(false);
   const [accountError, setAccountError] = useState<string>();
@@ -474,8 +481,10 @@ function AppShell() {
                   {membership.role === "admin" ? (
                     <button
                       className="team-menu-action"
+                      disabled={invitationMutationPending}
                       type="button"
                       onClick={() => {
+                        if (invitationMutationPending) return;
                         setOpenMenu(undefined);
                         setNavigationOpen(false);
                         setInvitationOpen(true);
@@ -575,11 +584,13 @@ function AppShell() {
           </button>
         </header>
         <main className="content">
-          <Outlet context={{ invitationOpen }} />
+          <Outlet context={{ invitationMutationPending, invitationOpen, setInvitationMutationPending }} />
         </main>
       </div>
       {invitationOpen ? (
         <InvitationDialog
+          mutationPending={invitationMutationPending}
+          onMutationPendingChange={setInvitationMutationPending}
           returnFocusRef={teamTriggerRef}
           teamDisplayName={membership.teamDisplayName}
           teamId={membership.teamId}
@@ -1215,7 +1226,7 @@ const settingsSections = [
 
 function SettingsPage() {
   const { section = "team" } = useParams();
-  const { invitationOpen } = useOutletContext<{ invitationOpen: boolean }>();
+  const { invitationOpen, setInvitationMutationPending } = useOutletContext<AppShellOutletContext>();
   const navigate = useNavigate();
   const { me, membership, refreshMe } = useTeam();
   const currentSection = settingsSections.find((item) => item.key === section);
@@ -1256,6 +1267,7 @@ function SettingsPage() {
               canManage={membership.role === "admin"}
               currentUserId={me.user.id}
               invitationDialogOpen={invitationOpen}
+              onInvitationMutationPendingChange={setInvitationMutationPending}
               refreshMe={refreshMe}
               teamId={membership.teamId}
             />
@@ -1401,12 +1413,14 @@ function MembersSettings({
   canManage,
   currentUserId,
   invitationDialogOpen,
+  onInvitationMutationPendingChange,
   refreshMe,
   teamId,
 }: {
   canManage: boolean;
   currentUserId: string;
   invitationDialogOpen: boolean;
+  onInvitationMutationPendingChange: (pending: boolean) => void;
   refreshMe: () => void;
   teamId: string;
 }) {
@@ -1436,7 +1450,9 @@ function MembersSettings({
 
   return (
     <>
-      {canManage && !invitationDialogOpen ? <InvitationSettings teamId={teamId} /> : null}
+      {canManage && !invitationDialogOpen ? (
+        <InvitationSettings teamId={teamId} onMutationPendingChange={onInvitationMutationPendingChange} />
+      ) : null}
       <section className="panel">
         <h2>Team members</h2>
         <AsyncState state={state}>
@@ -1477,12 +1493,16 @@ function MembersSettings({
 }
 
 function InvitationDialog({
+  mutationPending,
   onClose,
+  onMutationPendingChange,
   returnFocusRef,
   teamDisplayName,
   teamId,
 }: {
+  mutationPending: boolean;
   onClose: () => void;
+  onMutationPendingChange: (pending: boolean) => void;
   returnFocusRef: { current: HTMLButtonElement | null };
   teamDisplayName: string;
   teamId: string;
@@ -1495,6 +1515,7 @@ function InvitationDialog({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
+        if (mutationPending) return;
         onClose();
         return;
       }
@@ -1520,13 +1541,14 @@ function InvitationDialog({
       document.removeEventListener("keydown", onKeyDown);
       returnFocusRef.current?.focus();
     };
-  }, [onClose, returnFocusRef]);
+  }, [mutationPending, onClose, returnFocusRef]);
 
   return (
     <div className="dialog-layer">
       <button
         aria-label="Dismiss invitation dialog"
         className="dialog-backdrop"
+        disabled={mutationPending}
         tabIndex={-1}
         type="button"
         onClick={onClose}
@@ -1547,6 +1569,7 @@ function InvitationDialog({
           <button
             aria-label="Close invitation dialog"
             className="dialog-close"
+            disabled={mutationPending}
             ref={closeButtonRef}
             type="button"
             onClick={onClose}
@@ -1557,13 +1580,21 @@ function InvitationDialog({
         <p className="dialog-description" id="invitation-dialog-description">
           Anyone with the active link can join this Team as a member until the link expires.
         </p>
-        <InvitationSettings presentation="dialog" teamId={teamId} />
+        <InvitationSettings presentation="dialog" teamId={teamId} onMutationPendingChange={onMutationPendingChange} />
       </div>
     </div>
   );
 }
 
-function InvitationSettings({ presentation = "panel", teamId }: { presentation?: "dialog" | "panel"; teamId: string }) {
+function InvitationSettings({
+  onMutationPendingChange,
+  presentation = "panel",
+  teamId,
+}: {
+  onMutationPendingChange: (pending: boolean) => void;
+  presentation?: "dialog" | "panel";
+  teamId: string;
+}) {
   const state = useResource(() => browserApi.invitation(teamId), teamId);
   const [current, setCurrent] = useState<Awaited<ReturnType<typeof browserApi.invitation>>>();
   const [busy, setBusy] = useState(false);
@@ -1581,6 +1612,7 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
 
   async function mutateInvitation(action: () => Promise<NonNullable<typeof current>>, successMessage: string) {
     setBusy(true);
+    onMutationPendingChange(true);
     setError(undefined);
     setMessage(undefined);
     try {
@@ -1590,6 +1622,7 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
       setError(cause instanceof Error ? cause.message : "Unable to update the invitation link");
     } finally {
       setBusy(false);
+      onMutationPendingChange(false);
     }
   }
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1509,14 +1509,27 @@ function InvitationDialog({
 }) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const mutationPendingRef = useRef(mutationPending);
+  const onCloseRef = useRef(onClose);
+  mutationPendingRef.current = mutationPending;
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!mutationPending || dialogRef.current?.contains(document.activeElement)) return;
+    dialogRef.current
+      ?.querySelector<HTMLElement>(
+        "button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled])",
+      )
+      ?.focus();
+  }, [mutationPending]);
 
   useEffect(() => {
     closeButtonRef.current?.focus();
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        if (mutationPending) return;
-        onClose();
+        if (mutationPendingRef.current) return;
+        onCloseRef.current();
         return;
       }
       if (event.key !== "Tab") return;
@@ -1528,7 +1541,10 @@ function InvitationDialog({
       if (focusable.length === 0) return;
       const first = focusable[0];
       const last = focusable.at(-1);
-      if (event.shiftKey && document.activeElement === first) {
+      if (!dialogRef.current?.contains(document.activeElement)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first)?.focus();
+      } else if (event.shiftKey && document.activeElement === first) {
         event.preventDefault();
         last?.focus();
       } else if (!event.shiftKey && document.activeElement === last) {
@@ -1541,7 +1557,7 @@ function InvitationDialog({
       document.removeEventListener("keydown", onKeyDown);
       returnFocusRef.current?.focus();
     };
-  }, [mutationPending, onClose, returnFocusRef]);
+  }, [returnFocusRef]);
 
   return (
     <div className="dialog-layer">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1516,11 +1516,11 @@ function InvitationDialog({
 
   useEffect(() => {
     if (!mutationPending || dialogRef.current?.contains(document.activeElement)) return;
-    dialogRef.current
-      ?.querySelector<HTMLElement>(
-        "button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled])",
-      )
-      ?.focus();
+    const dialog = dialogRef.current;
+    const target = dialog?.querySelector<HTMLElement>(
+      "button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled])",
+    );
+    (target ?? dialog)?.focus();
   }, [mutationPending]);
 
   useEffect(() => {
@@ -1538,7 +1538,11 @@ function InvitationDialog({
           'button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
         ) ?? [],
       );
-      if (focusable.length === 0) return;
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current?.focus();
+        return;
+      }
       const first = focusable[0];
       const last = focusable.at(-1);
       if (!dialogRef.current?.contains(document.activeElement)) {
@@ -1576,6 +1580,7 @@ function InvitationDialog({
         className="dialog-card invitation-dialog"
         ref={dialogRef}
         role="dialog"
+        tabIndex={-1}
       >
         <header className="dialog-header">
           <div>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -104,26 +104,32 @@ function useInvitationState(): InvitationState {
 }
 
 export function AppRouter() {
+  const [publishedInvitations, setPublishedInvitations] = useState<Record<string, TeamInvitation>>({});
+  const publishInvitation = useCallback((teamId: string, invitation: TeamInvitation) => {
+    setPublishedInvitations((current) => ({ ...current, [teamId]: invitation }));
+  }, []);
   return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/invites/:token" element={<InvitePage />} />
-      <Route path="/teams/new" element={<NewTeamPage />} />
-      <Route element={<AuthenticatedTeamGate />}>
-        <Route path="/onboarding" element={<OnboardingPage />} />
-        <Route element={<AppShell />}>
-          <Route index element={<Navigate replace to="/agents" />} />
-          <Route path="/agents" element={<AgentsPage />} />
-          <Route path="/agents/new" element={<NewAgentPage />} />
-          <Route path="/agents/:agentId" element={<Navigate replace to="general" />} />
-          <Route path="/agents/:agentId/:tab" element={<AgentDetailPage />} />
-          <Route path="/account" element={<AccountPage />} />
-          <Route path="/settings" element={<Navigate replace to="account" />} />
-          <Route path="/settings/:section" element={<SettingsPage />} />
+    <InvitationContext value={{ publishedByTeam: publishedInvitations, publish: publishInvitation }}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/invites/:token" element={<InvitePage />} />
+        <Route path="/teams/new" element={<NewTeamPage />} />
+        <Route element={<AuthenticatedTeamGate />}>
+          <Route path="/onboarding" element={<OnboardingPage />} />
+          <Route element={<AppShell />}>
+            <Route index element={<Navigate replace to="/agents" />} />
+            <Route path="/agents" element={<AgentsPage />} />
+            <Route path="/agents/new" element={<NewAgentPage />} />
+            <Route path="/agents/:agentId" element={<Navigate replace to="general" />} />
+            <Route path="/agents/:agentId/:tab" element={<AgentDetailPage />} />
+            <Route path="/account" element={<AccountPage />} />
+            <Route path="/settings" element={<Navigate replace to="account" />} />
+            <Route path="/settings/:section" element={<SettingsPage />} />
+          </Route>
         </Route>
-      </Route>
-      <Route path="*" element={<NotFoundPage />} />
-    </Routes>
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </InvitationContext>
   );
 }
 
@@ -322,7 +328,6 @@ function AppShell() {
   const [navigationOpen, setNavigationOpen] = useState(false);
   const [openMenu, setOpenMenu] = useState<"team" | "account">();
   const [invitationOpen, setInvitationOpen] = useState(false);
-  const [publishedInvitations, setPublishedInvitations] = useState<Record<string, TeamInvitation>>({});
   const [teamQuery, setTeamQuery] = useState("");
   const [loggingOut, setLoggingOut] = useState(false);
   const [accountError, setAccountError] = useState<string>();
@@ -393,212 +398,205 @@ function AppShell() {
       setLoggingOut(false);
     }
   }
-  const publishInvitation = useCallback((teamId: string, invitation: TeamInvitation) => {
-    setPublishedInvitations((current) => ({ ...current, [teamId]: invitation }));
-  }, []);
   return (
-    <InvitationContext value={{ publishedByTeam: publishedInvitations, publish: publishInvitation }}>
-      <div className="shell">
-        {navigationOpen ? (
-          <button
-            aria-label="Close navigation"
-            className="sidebar-backdrop is-visible"
-            type="button"
-            onClick={() => setNavigationOpen(false)}
-          />
-        ) : null}
-        <aside className={`sidebar${navigationOpen ? " is-open" : ""}`} aria-label="Primary navigation">
-          <div className="sidebar-top">
-            <Link className="brand" to="/agents" onClick={() => setNavigationOpen(false)}>
-              OpenTag
-            </Link>
-            <div className="team-menu" ref={teamMenuRef}>
-              <button
-                aria-controls="team-menu-popover"
-                aria-expanded={openMenu === "team"}
-                aria-haspopup="dialog"
-                className="team-switcher"
-                ref={teamTriggerRef}
-                type="button"
-                onClick={() => {
-                  setTeamQuery("");
-                  setOpenMenu((value) => (value === "team" ? undefined : "team"));
-                }}
-              >
-                <span className="team-avatar" aria-hidden="true">
-                  {initials(membership.teamDisplayName)}
-                </span>
-                <span>{membership.teamDisplayName}</span>
-                <span className="team-menu-chevron" aria-hidden="true">
-                  {openMenu === "team" ? "⌃" : "⌄"}
-                </span>
-              </button>
-              {openMenu === "team" ? (
-                <section aria-label="Switch Team" className="team-menu-popover" id="team-menu-popover" role="dialog">
-                  <span className="menu-label">Switch Team</span>
-                  {me.memberships.length > 6 ? (
-                    <label className="team-search">
-                      <span className="visually-hidden">Search Teams</span>
-                      <input
-                        placeholder="Search Teams"
-                        type="search"
-                        value={teamQuery}
-                        onChange={(event) => setTeamQuery(event.currentTarget.value)}
-                      />
-                    </label>
-                  ) : null}
-                  <div className="team-menu-list">
-                    {filteredMemberships.map((item: MeMembership) => {
-                      const current = item.teamId === membership.teamId;
-                      return (
-                        <button
-                          aria-current={current ? "true" : undefined}
-                          className="team-menu-option"
-                          key={item.teamId}
-                          type="button"
-                          onClick={() => {
-                            setOpenMenu(undefined);
-                            setNavigationOpen(false);
-                            if (!current) selectTeam(item.teamId);
-                          }}
-                        >
-                          <span className="team-avatar" aria-hidden="true">
-                            {initials(item.teamDisplayName)}
-                          </span>
-                          <span className="team-option-copy">
-                            <strong>{item.teamDisplayName}</strong>
-                            <small>{titleCase(item.role)}</small>
-                          </span>
-                          {current ? (
-                            <span className="team-option-check" aria-hidden="true">
-                              ✓
-                            </span>
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                    {filteredMemberships.length === 0 ? (
-                      <span className="team-menu-empty">No matching Teams</span>
-                    ) : null}
-                  </div>
-                  <div className="team-menu-actions">
-                    {membership.role === "admin" ? (
+    <div className="shell">
+      {navigationOpen ? (
+        <button
+          aria-label="Close navigation"
+          className="sidebar-backdrop is-visible"
+          type="button"
+          onClick={() => setNavigationOpen(false)}
+        />
+      ) : null}
+      <aside className={`sidebar${navigationOpen ? " is-open" : ""}`} aria-label="Primary navigation">
+        <div className="sidebar-top">
+          <Link className="brand" to="/agents" onClick={() => setNavigationOpen(false)}>
+            OpenTag
+          </Link>
+          <div className="team-menu" ref={teamMenuRef}>
+            <button
+              aria-controls="team-menu-popover"
+              aria-expanded={openMenu === "team"}
+              aria-haspopup="dialog"
+              className="team-switcher"
+              ref={teamTriggerRef}
+              type="button"
+              onClick={() => {
+                setTeamQuery("");
+                setOpenMenu((value) => (value === "team" ? undefined : "team"));
+              }}
+            >
+              <span className="team-avatar" aria-hidden="true">
+                {initials(membership.teamDisplayName)}
+              </span>
+              <span>{membership.teamDisplayName}</span>
+              <span className="team-menu-chevron" aria-hidden="true">
+                {openMenu === "team" ? "⌃" : "⌄"}
+              </span>
+            </button>
+            {openMenu === "team" ? (
+              <section aria-label="Switch Team" className="team-menu-popover" id="team-menu-popover" role="dialog">
+                <span className="menu-label">Switch Team</span>
+                {me.memberships.length > 6 ? (
+                  <label className="team-search">
+                    <span className="visually-hidden">Search Teams</span>
+                    <input
+                      placeholder="Search Teams"
+                      type="search"
+                      value={teamQuery}
+                      onChange={(event) => setTeamQuery(event.currentTarget.value)}
+                    />
+                  </label>
+                ) : null}
+                <div className="team-menu-list">
+                  {filteredMemberships.map((item: MeMembership) => {
+                    const current = item.teamId === membership.teamId;
+                    return (
                       <button
-                        className="team-menu-action"
+                        aria-current={current ? "true" : undefined}
+                        className="team-menu-option"
+                        key={item.teamId}
                         type="button"
                         onClick={() => {
                           setOpenMenu(undefined);
                           setNavigationOpen(false);
-                          setInvitationOpen(true);
+                          if (!current) selectTeam(item.teamId);
                         }}
                       >
-                        <span aria-hidden="true">↗</span>
-                        Invite people
+                        <span className="team-avatar" aria-hidden="true">
+                          {initials(item.teamDisplayName)}
+                        </span>
+                        <span className="team-option-copy">
+                          <strong>{item.teamDisplayName}</strong>
+                          <small>{titleCase(item.role)}</small>
+                        </span>
+                        {current ? (
+                          <span className="team-option-check" aria-hidden="true">
+                            ✓
+                          </span>
+                        ) : null}
                       </button>
-                    ) : null}
-                    <Link
+                    );
+                  })}
+                  {filteredMemberships.length === 0 ? <span className="team-menu-empty">No matching Teams</span> : null}
+                </div>
+                <div className="team-menu-actions">
+                  {membership.role === "admin" ? (
+                    <button
                       className="team-menu-action"
-                      to="/teams/new"
+                      type="button"
                       onClick={() => {
                         setOpenMenu(undefined);
                         setNavigationOpen(false);
+                        setInvitationOpen(true);
                       }}
                     >
-                      <span aria-hidden="true">＋</span>
-                      Create Team
-                    </Link>
-                  </div>
-                </section>
-              ) : null}
-            </div>
-            <nav aria-label="Workspace" className="primary-nav">
-              <NavLink to="/agents" onClick={() => setNavigationOpen(false)}>
-                Agents
-              </NavLink>
-              <span className="nav-placeholder" aria-disabled="true">
-                Tasks
-              </span>
-              <NavLink to="/settings" onClick={() => setNavigationOpen(false)}>
-                Settings
-              </NavLink>
-            </nav>
-          </div>
-          <div className="sidebar-bottom">
-            <div className="account-menu" ref={accountMenuRef}>
-              <button
-                aria-label="Account menu"
-                aria-controls="account-menu-popover"
-                aria-expanded={openMenu === "account"}
-                aria-haspopup="menu"
-                className="account-row"
-                ref={accountTriggerRef}
-                type="button"
-                onClick={() => setOpenMenu((value) => (value === "account" ? undefined : "account"))}
-              >
-                <span className="account-avatar" aria-hidden="true">
-                  {initials(me.user.displayName)}
-                </span>
-                <span className="account-copy">
-                  <strong>{me.user.displayName}</strong>
-                </span>
-                <span className="account-menu-dots" aria-hidden="true">
-                  ⋮
-                </span>
-              </button>
-              {openMenu === "account" ? (
-                <div
-                  aria-label="Account"
-                  className="account-menu-popover"
-                  id="account-menu-popover"
-                  role="menu"
-                  onKeyDown={handleAccountMenuKeyDown}
-                >
+                      <span aria-hidden="true">↗</span>
+                      Invite people
+                    </button>
+                  ) : null}
                   <Link
-                    role="menuitem"
-                    to="/account"
+                    className="team-menu-action"
+                    to="/teams/new"
                     onClick={() => {
                       setOpenMenu(undefined);
                       setNavigationOpen(false);
                     }}
                   >
-                    Account settings
+                    <span aria-hidden="true">＋</span>
+                    Create Team
                   </Link>
-                  <button disabled={loggingOut} role="menuitem" type="button" onClick={() => void logout()}>
-                    {loggingOut ? "Signing out…" : "Sign out"}
-                  </button>
-                  {accountError ? (
-                    <span className="account-menu-error" role="alert">
-                      {accountError}
-                    </span>
-                  ) : null}
                 </div>
-              ) : null}
-            </div>
+              </section>
+            ) : null}
           </div>
-        </aside>
-        <div className="app-main">
-          <header className="mobile-shell-bar">
-            <Link className="mobile-brand" to="/agents" onClick={() => setNavigationOpen(false)}>
-              OpenTag
-            </Link>
-            <button className="secondary compact-button" type="button" onClick={() => setNavigationOpen(true)}>
-              Menu
-            </button>
-          </header>
-          <main className="content">
-            <Outlet />
-          </main>
+          <nav aria-label="Workspace" className="primary-nav">
+            <NavLink to="/agents" onClick={() => setNavigationOpen(false)}>
+              Agents
+            </NavLink>
+            <span className="nav-placeholder" aria-disabled="true">
+              Tasks
+            </span>
+            <NavLink to="/settings" onClick={() => setNavigationOpen(false)}>
+              Settings
+            </NavLink>
+          </nav>
         </div>
-        {invitationOpen ? (
-          <InvitationDialog
-            returnFocusRef={teamTriggerRef}
-            teamDisplayName={membership.teamDisplayName}
-            teamId={membership.teamId}
-            onClose={() => setInvitationOpen(false)}
-          />
-        ) : null}
+        <div className="sidebar-bottom">
+          <div className="account-menu" ref={accountMenuRef}>
+            <button
+              aria-label="Account menu"
+              aria-controls="account-menu-popover"
+              aria-expanded={openMenu === "account"}
+              aria-haspopup="menu"
+              className="account-row"
+              ref={accountTriggerRef}
+              type="button"
+              onClick={() => setOpenMenu((value) => (value === "account" ? undefined : "account"))}
+            >
+              <span className="account-avatar" aria-hidden="true">
+                {initials(me.user.displayName)}
+              </span>
+              <span className="account-copy">
+                <strong>{me.user.displayName}</strong>
+              </span>
+              <span className="account-menu-dots" aria-hidden="true">
+                ⋮
+              </span>
+            </button>
+            {openMenu === "account" ? (
+              <div
+                aria-label="Account"
+                className="account-menu-popover"
+                id="account-menu-popover"
+                role="menu"
+                onKeyDown={handleAccountMenuKeyDown}
+              >
+                <Link
+                  role="menuitem"
+                  to="/account"
+                  onClick={() => {
+                    setOpenMenu(undefined);
+                    setNavigationOpen(false);
+                  }}
+                >
+                  Account settings
+                </Link>
+                <button disabled={loggingOut} role="menuitem" type="button" onClick={() => void logout()}>
+                  {loggingOut ? "Signing out…" : "Sign out"}
+                </button>
+                {accountError ? (
+                  <span className="account-menu-error" role="alert">
+                    {accountError}
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </aside>
+      <div className="app-main">
+        <header className="mobile-shell-bar">
+          <Link className="mobile-brand" to="/agents" onClick={() => setNavigationOpen(false)}>
+            OpenTag
+          </Link>
+          <button className="secondary compact-button" type="button" onClick={() => setNavigationOpen(true)}>
+            Menu
+          </button>
+        </header>
+        <main className="content">
+          <Outlet />
+        </main>
       </div>
-    </InvitationContext>
+      {invitationOpen ? (
+        <InvitationDialog
+          returnFocusRef={teamTriggerRef}
+          teamDisplayName={membership.teamDisplayName}
+          teamId={membership.teamId}
+          onClose={() => setInvitationOpen(false)}
+        />
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1515,12 +1515,16 @@ function InvitationDialog({
   onCloseRef.current = onClose;
 
   useEffect(() => {
-    if (!mutationPending || dialogRef.current?.contains(document.activeElement)) return;
     const dialog = dialogRef.current;
+    if (!dialog) return;
     const target = dialog?.querySelector<HTMLElement>(
       "button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled])",
     );
-    (target ?? dialog)?.focus();
+    if (mutationPending) {
+      if (!dialog.contains(document.activeElement)) (target ?? dialog).focus();
+    } else if (document.activeElement === dialog) {
+      target?.focus();
+    }
   }, [mutationPending]);
 
   useEffect(() => {
@@ -1545,7 +1549,7 @@ function InvitationDialog({
       }
       const first = focusable[0];
       const last = focusable.at(-1);
-      if (!dialogRef.current?.contains(document.activeElement)) {
+      if (!dialogRef.current?.contains(document.activeElement) || document.activeElement === dialogRef.current) {
         event.preventDefault();
         (event.shiftKey ? last : first)?.focus();
       } else if (event.shiftKey && document.activeElement === first) {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,6 +8,7 @@ import type {
   MeMembership,
   MeResponse,
   TeamComputerSummary,
+  TeamInvitation,
   TeamMemberSummary,
   UpdateAgentRuntimeConfig,
 } from "@opentag/shared/browser";
@@ -80,12 +81,25 @@ interface TeamSession {
   selectTeam: (teamId: string) => void;
 }
 
+interface InvitationState {
+  publishedByTeam: Readonly<Record<string, TeamInvitation>>;
+  publish: (teamId: string, invitation: TeamInvitation) => void;
+}
+
 const teamContext = createContext<TeamSession | undefined>(undefined);
 const TeamContext = teamContext.Provider;
+const invitationContext = createContext<InvitationState | undefined>(undefined);
+const InvitationContext = invitationContext.Provider;
 
 function useTeam(): TeamSession {
   const value = useContext(teamContext);
   if (!value) throw new Error("Team context is missing");
+  return value;
+}
+
+function useInvitationState(): InvitationState {
+  const value = useContext(invitationContext);
+  if (!value) throw new Error("Invitation context is missing");
   return value;
 }
 
@@ -308,6 +322,7 @@ function AppShell() {
   const [navigationOpen, setNavigationOpen] = useState(false);
   const [openMenu, setOpenMenu] = useState<"team" | "account">();
   const [invitationOpen, setInvitationOpen] = useState(false);
+  const [publishedInvitations, setPublishedInvitations] = useState<Record<string, TeamInvitation>>({});
   const [teamQuery, setTeamQuery] = useState("");
   const [loggingOut, setLoggingOut] = useState(false);
   const [accountError, setAccountError] = useState<string>();
@@ -378,205 +393,212 @@ function AppShell() {
       setLoggingOut(false);
     }
   }
+  const publishInvitation = useCallback((teamId: string, invitation: TeamInvitation) => {
+    setPublishedInvitations((current) => ({ ...current, [teamId]: invitation }));
+  }, []);
   return (
-    <div className="shell">
-      {navigationOpen ? (
-        <button
-          aria-label="Close navigation"
-          className="sidebar-backdrop is-visible"
-          type="button"
-          onClick={() => setNavigationOpen(false)}
-        />
-      ) : null}
-      <aside className={`sidebar${navigationOpen ? " is-open" : ""}`} aria-label="Primary navigation">
-        <div className="sidebar-top">
-          <Link className="brand" to="/agents" onClick={() => setNavigationOpen(false)}>
-            OpenTag
-          </Link>
-          <div className="team-menu" ref={teamMenuRef}>
-            <button
-              aria-controls="team-menu-popover"
-              aria-expanded={openMenu === "team"}
-              aria-haspopup="dialog"
-              className="team-switcher"
-              ref={teamTriggerRef}
-              type="button"
-              onClick={() => {
-                setTeamQuery("");
-                setOpenMenu((value) => (value === "team" ? undefined : "team"));
-              }}
-            >
-              <span className="team-avatar" aria-hidden="true">
-                {initials(membership.teamDisplayName)}
-              </span>
-              <span>{membership.teamDisplayName}</span>
-              <span className="team-menu-chevron" aria-hidden="true">
-                {openMenu === "team" ? "⌃" : "⌄"}
-              </span>
-            </button>
-            {openMenu === "team" ? (
-              <section aria-label="Switch Team" className="team-menu-popover" id="team-menu-popover" role="dialog">
-                <span className="menu-label">Switch Team</span>
-                {me.memberships.length > 6 ? (
-                  <label className="team-search">
-                    <span className="visually-hidden">Search Teams</span>
-                    <input
-                      placeholder="Search Teams"
-                      type="search"
-                      value={teamQuery}
-                      onChange={(event) => setTeamQuery(event.currentTarget.value)}
-                    />
-                  </label>
-                ) : null}
-                <div className="team-menu-list">
-                  {filteredMemberships.map((item: MeMembership) => {
-                    const current = item.teamId === membership.teamId;
-                    return (
+    <InvitationContext value={{ publishedByTeam: publishedInvitations, publish: publishInvitation }}>
+      <div className="shell">
+        {navigationOpen ? (
+          <button
+            aria-label="Close navigation"
+            className="sidebar-backdrop is-visible"
+            type="button"
+            onClick={() => setNavigationOpen(false)}
+          />
+        ) : null}
+        <aside className={`sidebar${navigationOpen ? " is-open" : ""}`} aria-label="Primary navigation">
+          <div className="sidebar-top">
+            <Link className="brand" to="/agents" onClick={() => setNavigationOpen(false)}>
+              OpenTag
+            </Link>
+            <div className="team-menu" ref={teamMenuRef}>
+              <button
+                aria-controls="team-menu-popover"
+                aria-expanded={openMenu === "team"}
+                aria-haspopup="dialog"
+                className="team-switcher"
+                ref={teamTriggerRef}
+                type="button"
+                onClick={() => {
+                  setTeamQuery("");
+                  setOpenMenu((value) => (value === "team" ? undefined : "team"));
+                }}
+              >
+                <span className="team-avatar" aria-hidden="true">
+                  {initials(membership.teamDisplayName)}
+                </span>
+                <span>{membership.teamDisplayName}</span>
+                <span className="team-menu-chevron" aria-hidden="true">
+                  {openMenu === "team" ? "⌃" : "⌄"}
+                </span>
+              </button>
+              {openMenu === "team" ? (
+                <section aria-label="Switch Team" className="team-menu-popover" id="team-menu-popover" role="dialog">
+                  <span className="menu-label">Switch Team</span>
+                  {me.memberships.length > 6 ? (
+                    <label className="team-search">
+                      <span className="visually-hidden">Search Teams</span>
+                      <input
+                        placeholder="Search Teams"
+                        type="search"
+                        value={teamQuery}
+                        onChange={(event) => setTeamQuery(event.currentTarget.value)}
+                      />
+                    </label>
+                  ) : null}
+                  <div className="team-menu-list">
+                    {filteredMemberships.map((item: MeMembership) => {
+                      const current = item.teamId === membership.teamId;
+                      return (
+                        <button
+                          aria-current={current ? "true" : undefined}
+                          className="team-menu-option"
+                          key={item.teamId}
+                          type="button"
+                          onClick={() => {
+                            setOpenMenu(undefined);
+                            setNavigationOpen(false);
+                            if (!current) selectTeam(item.teamId);
+                          }}
+                        >
+                          <span className="team-avatar" aria-hidden="true">
+                            {initials(item.teamDisplayName)}
+                          </span>
+                          <span className="team-option-copy">
+                            <strong>{item.teamDisplayName}</strong>
+                            <small>{titleCase(item.role)}</small>
+                          </span>
+                          {current ? (
+                            <span className="team-option-check" aria-hidden="true">
+                              ✓
+                            </span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                    {filteredMemberships.length === 0 ? (
+                      <span className="team-menu-empty">No matching Teams</span>
+                    ) : null}
+                  </div>
+                  <div className="team-menu-actions">
+                    {membership.role === "admin" ? (
                       <button
-                        aria-current={current ? "true" : undefined}
-                        className="team-menu-option"
-                        key={item.teamId}
+                        className="team-menu-action"
                         type="button"
                         onClick={() => {
                           setOpenMenu(undefined);
                           setNavigationOpen(false);
-                          if (!current) selectTeam(item.teamId);
+                          setInvitationOpen(true);
                         }}
                       >
-                        <span className="team-avatar" aria-hidden="true">
-                          {initials(item.teamDisplayName)}
-                        </span>
-                        <span className="team-option-copy">
-                          <strong>{item.teamDisplayName}</strong>
-                          <small>{titleCase(item.role)}</small>
-                        </span>
-                        {current ? (
-                          <span className="team-option-check" aria-hidden="true">
-                            ✓
-                          </span>
-                        ) : null}
+                        <span aria-hidden="true">↗</span>
+                        Invite people
                       </button>
-                    );
-                  })}
-                  {filteredMemberships.length === 0 ? <span className="team-menu-empty">No matching Teams</span> : null}
-                </div>
-                <div className="team-menu-actions">
-                  {membership.role === "admin" ? (
-                    <button
+                    ) : null}
+                    <Link
                       className="team-menu-action"
-                      type="button"
+                      to="/teams/new"
                       onClick={() => {
                         setOpenMenu(undefined);
                         setNavigationOpen(false);
-                        setInvitationOpen(true);
                       }}
                     >
-                      <span aria-hidden="true">↗</span>
-                      Invite people
-                    </button>
-                  ) : null}
+                      <span aria-hidden="true">＋</span>
+                      Create Team
+                    </Link>
+                  </div>
+                </section>
+              ) : null}
+            </div>
+            <nav aria-label="Workspace" className="primary-nav">
+              <NavLink to="/agents" onClick={() => setNavigationOpen(false)}>
+                Agents
+              </NavLink>
+              <span className="nav-placeholder" aria-disabled="true">
+                Tasks
+              </span>
+              <NavLink to="/settings" onClick={() => setNavigationOpen(false)}>
+                Settings
+              </NavLink>
+            </nav>
+          </div>
+          <div className="sidebar-bottom">
+            <div className="account-menu" ref={accountMenuRef}>
+              <button
+                aria-label="Account menu"
+                aria-controls="account-menu-popover"
+                aria-expanded={openMenu === "account"}
+                aria-haspopup="menu"
+                className="account-row"
+                ref={accountTriggerRef}
+                type="button"
+                onClick={() => setOpenMenu((value) => (value === "account" ? undefined : "account"))}
+              >
+                <span className="account-avatar" aria-hidden="true">
+                  {initials(me.user.displayName)}
+                </span>
+                <span className="account-copy">
+                  <strong>{me.user.displayName}</strong>
+                </span>
+                <span className="account-menu-dots" aria-hidden="true">
+                  ⋮
+                </span>
+              </button>
+              {openMenu === "account" ? (
+                <div
+                  aria-label="Account"
+                  className="account-menu-popover"
+                  id="account-menu-popover"
+                  role="menu"
+                  onKeyDown={handleAccountMenuKeyDown}
+                >
                   <Link
-                    className="team-menu-action"
-                    to="/teams/new"
+                    role="menuitem"
+                    to="/account"
                     onClick={() => {
                       setOpenMenu(undefined);
                       setNavigationOpen(false);
                     }}
                   >
-                    <span aria-hidden="true">＋</span>
-                    Create Team
+                    Account settings
                   </Link>
+                  <button disabled={loggingOut} role="menuitem" type="button" onClick={() => void logout()}>
+                    {loggingOut ? "Signing out…" : "Sign out"}
+                  </button>
+                  {accountError ? (
+                    <span className="account-menu-error" role="alert">
+                      {accountError}
+                    </span>
+                  ) : null}
                 </div>
-              </section>
-            ) : null}
+              ) : null}
+            </div>
           </div>
-          <nav aria-label="Workspace" className="primary-nav">
-            <NavLink to="/agents" onClick={() => setNavigationOpen(false)}>
-              Agents
-            </NavLink>
-            <span className="nav-placeholder" aria-disabled="true">
-              Tasks
-            </span>
-            <NavLink to="/settings" onClick={() => setNavigationOpen(false)}>
-              Settings
-            </NavLink>
-          </nav>
-        </div>
-        <div className="sidebar-bottom">
-          <div className="account-menu" ref={accountMenuRef}>
-            <button
-              aria-label="Account menu"
-              aria-controls="account-menu-popover"
-              aria-expanded={openMenu === "account"}
-              aria-haspopup="menu"
-              className="account-row"
-              ref={accountTriggerRef}
-              type="button"
-              onClick={() => setOpenMenu((value) => (value === "account" ? undefined : "account"))}
-            >
-              <span className="account-avatar" aria-hidden="true">
-                {initials(me.user.displayName)}
-              </span>
-              <span className="account-copy">
-                <strong>{me.user.displayName}</strong>
-              </span>
-              <span className="account-menu-dots" aria-hidden="true">
-                ⋮
-              </span>
+        </aside>
+        <div className="app-main">
+          <header className="mobile-shell-bar">
+            <Link className="mobile-brand" to="/agents" onClick={() => setNavigationOpen(false)}>
+              OpenTag
+            </Link>
+            <button className="secondary compact-button" type="button" onClick={() => setNavigationOpen(true)}>
+              Menu
             </button>
-            {openMenu === "account" ? (
-              <div
-                aria-label="Account"
-                className="account-menu-popover"
-                id="account-menu-popover"
-                role="menu"
-                onKeyDown={handleAccountMenuKeyDown}
-              >
-                <Link
-                  role="menuitem"
-                  to="/account"
-                  onClick={() => {
-                    setOpenMenu(undefined);
-                    setNavigationOpen(false);
-                  }}
-                >
-                  Account settings
-                </Link>
-                <button disabled={loggingOut} role="menuitem" type="button" onClick={() => void logout()}>
-                  {loggingOut ? "Signing out…" : "Sign out"}
-                </button>
-                {accountError ? (
-                  <span className="account-menu-error" role="alert">
-                    {accountError}
-                  </span>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
+          </header>
+          <main className="content">
+            <Outlet />
+          </main>
         </div>
-      </aside>
-      <div className="app-main">
-        <header className="mobile-shell-bar">
-          <Link className="mobile-brand" to="/agents" onClick={() => setNavigationOpen(false)}>
-            OpenTag
-          </Link>
-          <button className="secondary compact-button" type="button" onClick={() => setNavigationOpen(true)}>
-            Menu
-          </button>
-        </header>
-        <main className="content">
-          <Outlet />
-        </main>
+        {invitationOpen ? (
+          <InvitationDialog
+            returnFocusRef={teamTriggerRef}
+            teamDisplayName={membership.teamDisplayName}
+            teamId={membership.teamId}
+            onClose={() => setInvitationOpen(false)}
+          />
+        ) : null}
       </div>
-      {invitationOpen ? (
-        <InvitationDialog
-          returnFocusRef={teamTriggerRef}
-          teamDisplayName={membership.teamDisplayName}
-          teamId={membership.teamId}
-          onClose={() => setInvitationOpen(false)}
-        />
-      ) : null}
-    </div>
+    </InvitationContext>
   );
 }
 
@@ -1632,8 +1654,8 @@ function InvitationDialog({
 }
 
 function InvitationSettings({ presentation = "panel", teamId }: { presentation?: "dialog" | "panel"; teamId: string }) {
+  const { publish, publishedByTeam } = useInvitationState();
   const state = useResource(() => browserApi.invitation(teamId), teamId);
-  const [current, setCurrent] = useState<Awaited<ReturnType<typeof browserApi.invitation>>>();
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string>();
   const [error, setError] = useState<string>();
@@ -1647,12 +1669,12 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
     await mutateInvitation(() => browserApi.rotateInvitation(teamId), "Invitation link rotated.");
   }
 
-  async function mutateInvitation(action: () => Promise<NonNullable<typeof current>>, successMessage: string) {
+  async function mutateInvitation(action: () => Promise<TeamInvitation>, successMessage: string) {
     setBusy(true);
     setError(undefined);
     setMessage(undefined);
     try {
-      setCurrent(await action());
+      publish(teamId, await action());
       setMessage(successMessage);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Unable to update the invitation link");
@@ -1683,7 +1705,7 @@ function InvitationSettings({ presentation = "panel", teamId }: { presentation?:
       ) : null}
       <AsyncState state={state}>
         {(loaded) => {
-          const invitation = current ?? loaded;
+          const invitation = publishedByTeam[teamId] ?? loaded;
           return invitation ? (
             <>
               <label className="invite-link">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -307,6 +307,7 @@ function AppShell() {
   const navigate = useNavigate();
   const [navigationOpen, setNavigationOpen] = useState(false);
   const [openMenu, setOpenMenu] = useState<"team" | "account">();
+  const [invitationOpen, setInvitationOpen] = useState(false);
   const [teamQuery, setTeamQuery] = useState("");
   const [loggingOut, setLoggingOut] = useState(false);
   const [accountError, setAccountError] = useState<string>();
@@ -459,17 +460,33 @@ function AppShell() {
                   })}
                   {filteredMemberships.length === 0 ? <span className="team-menu-empty">No matching Teams</span> : null}
                 </div>
-                <Link
-                  className="team-menu-action"
-                  to="/teams/new"
-                  onClick={() => {
-                    setOpenMenu(undefined);
-                    setNavigationOpen(false);
-                  }}
-                >
-                  <span aria-hidden="true">＋</span>
-                  Create Team
-                </Link>
+                <div className="team-menu-actions">
+                  {membership.role === "admin" ? (
+                    <button
+                      className="team-menu-action"
+                      type="button"
+                      onClick={() => {
+                        setOpenMenu(undefined);
+                        setNavigationOpen(false);
+                        setInvitationOpen(true);
+                      }}
+                    >
+                      <span aria-hidden="true">↗</span>
+                      Invite people
+                    </button>
+                  ) : null}
+                  <Link
+                    className="team-menu-action"
+                    to="/teams/new"
+                    onClick={() => {
+                      setOpenMenu(undefined);
+                      setNavigationOpen(false);
+                    }}
+                  >
+                    <span aria-hidden="true">＋</span>
+                    Create Team
+                  </Link>
+                </div>
               </section>
             ) : null}
           </div>
@@ -502,7 +519,6 @@ function AppShell() {
               </span>
               <span className="account-copy">
                 <strong>{me.user.displayName}</strong>
-                <small>{me.user.email}</small>
               </span>
               <span className="account-menu-dots" aria-hidden="true">
                 ⋮
@@ -552,6 +568,14 @@ function AppShell() {
           <Outlet />
         </main>
       </div>
+      {invitationOpen ? (
+        <InvitationDialog
+          returnFocusRef={teamTriggerRef}
+          teamDisplayName={membership.teamDisplayName}
+          teamId={membership.teamId}
+          onClose={() => setInvitationOpen(false)}
+        />
+      ) : null}
     </div>
   );
 }
@@ -1520,7 +1544,94 @@ function MembersSettings({
   );
 }
 
-function InvitationSettings({ teamId }: { teamId: string }) {
+function InvitationDialog({
+  onClose,
+  returnFocusRef,
+  teamDisplayName,
+  teamId,
+}: {
+  onClose: () => void;
+  returnFocusRef: { current: HTMLButtonElement | null };
+  teamDisplayName: string;
+  teamId: string;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      returnFocusRef.current?.focus();
+    };
+  }, [onClose, returnFocusRef]);
+
+  return (
+    <div className="dialog-layer">
+      <button
+        aria-label="Dismiss invitation dialog"
+        className="dialog-backdrop"
+        tabIndex={-1}
+        type="button"
+        onClick={onClose}
+      />
+      <div
+        aria-describedby="invitation-dialog-description"
+        aria-labelledby="invitation-dialog-title"
+        aria-modal="true"
+        className="dialog-card invitation-dialog"
+        ref={dialogRef}
+        role="dialog"
+      >
+        <header className="dialog-header">
+          <div>
+            <span className="eyebrow dialog-eyebrow">{teamDisplayName}</span>
+            <h2 id="invitation-dialog-title">Invite people</h2>
+          </div>
+          <button
+            aria-label="Close invitation dialog"
+            className="dialog-close"
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </header>
+        <p className="dialog-description" id="invitation-dialog-description">
+          Anyone with the active link can join this Team as a member until the link expires.
+        </p>
+        <InvitationSettings presentation="dialog" teamId={teamId} />
+      </div>
+    </div>
+  );
+}
+
+function InvitationSettings({ presentation = "panel", teamId }: { presentation?: "dialog" | "panel"; teamId: string }) {
   const state = useResource(() => browserApi.invitation(teamId), teamId);
   const [current, setCurrent] = useState<Awaited<ReturnType<typeof browserApi.invitation>>>();
   const [busy, setBusy] = useState(false);
@@ -1563,9 +1674,13 @@ function InvitationSettings({ teamId }: { teamId: string }) {
   }
 
   return (
-    <section className="panel">
-      <h2>Invite people</h2>
-      <p>Anyone with the active link can join this Team as a member until the link expires.</p>
+    <section className={presentation === "dialog" ? "invitation-dialog-content" : "panel"}>
+      {presentation === "panel" ? (
+        <>
+          <h2>Invite people</h2>
+          <p>Anyone with the active link can join this Team as a member until the link expires.</p>
+        </>
+      ) : null}
       <AsyncState state={state}>
         {(loaded) => {
           const invitation = current ?? loaded;
@@ -1576,7 +1691,7 @@ function InvitationSettings({ teamId }: { teamId: string }) {
                 <input aria-label="Invitation link" readOnly type="url" value={invitation.inviteUrl} />
               </label>
               <p className="muted">Expires {formatDate(invitation.expiresAt)}.</p>
-              <div className="actions">
+              <div className={presentation === "dialog" ? "actions dialog-actions" : "actions"}>
                 <button type="button" onClick={() => void copyInvitation(invitation.inviteUrl)}>
                   Copy invitation link
                 </button>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -430,21 +430,34 @@ button.danger:hover {
   padding: 14px 8px;
 }
 
-.team-menu-action {
-  display: flex;
-  min-height: 39px;
-  align-items: center;
-  gap: 9px;
+.team-menu-actions {
+  display: grid;
+  gap: 2px;
   margin-top: 7px;
   border-top: 1px solid var(--border);
+  padding-top: 7px;
+}
+
+.team-menu-action {
+  display: flex;
+  width: 100%;
+  min-height: 39px;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 9px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
   color: var(--secondary-foreground);
   font-size: 0.8rem;
   font-weight: 560;
-  padding: 9px 8px 0;
+  padding: 0 8px;
   text-decoration: none;
 }
 
 .team-menu-action:hover {
+  border-color: transparent;
+  background: var(--brand-light);
   color: var(--brand-ink);
 }
 
@@ -577,6 +590,98 @@ button.danger:hover {
 .sidebar-backdrop,
 .mobile-shell-bar {
   display: none;
+}
+
+.dialog-layer {
+  position: fixed;
+  z-index: calc(var(--layer-sidebar) + 10);
+  display: grid;
+  overflow-y: auto;
+  place-items: center;
+  inset: 0;
+  padding: 24px;
+}
+
+.dialog-backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  background: rgb(22 33 27 / 42%);
+  padding: 0;
+}
+
+.dialog-backdrop:active {
+  transform: none;
+}
+
+.dialog-card {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 560px);
+  max-height: calc(100dvh - 48px);
+  overflow-y: auto;
+  border: 1px solid var(--strong-border);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 24px 70px rgb(22 33 27 / 22%);
+  padding: 24px;
+}
+
+.dialog-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.dialog-eyebrow {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.dialog-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.dialog-close {
+  display: inline-grid;
+  width: 34px;
+  min-height: 34px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 1.4rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.dialog-close:hover {
+  border-color: var(--border);
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.dialog-description {
+  max-width: 50ch;
+  margin: 14px 0 22px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.invitation-dialog-content {
+  display: grid;
+  gap: 14px;
+}
+
+.dialog-actions {
+  margin-top: 4px;
 }
 
 .app-main {
@@ -1250,6 +1355,17 @@ code {
 }
 
 @media (max-width: 720px) {
+  .dialog-layer {
+    align-items: end;
+    padding: 12px;
+  }
+
+  .dialog-card {
+    max-height: calc(100dvh - 24px);
+    border-radius: 14px;
+    padding: 20px;
+  }
+
   .page-header,
   .object-title-row {
     align-items: stretch;


### PR DESCRIPTION
## Summary

- add an admin-only **Invite people** action to the Team switcher
- open invitation-link management in an accessible modal without leaving the current page
- retain the existing Settings > Members invitation controls
- remove the email subtitle from the sidebar account control

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @opentag/web test` (89 tests)
- isolated rerun of the Server observability timing test that failed once during the first full-suite run (passed)