### PR TITLE
feat(agent-runtime): enable Claude Code production turns

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -36,6 +36,7 @@ function installApi(
     alreadyJoinedInvitation?: boolean;
     bindingReauth?: boolean;
     bound?: boolean;
+    computers?: readonly Record<string, unknown>[];
     initialStatus?: "active" | "suspended";
     invitationExists?: boolean;
     provider?: "feishu" | "slack";
@@ -174,6 +175,15 @@ function installApi(
         updatedAt: "2026-08-20T00:01:00.000Z",
       });
     }
+    if (/^\/api\/v1\/teams\/[^/]+\/agents$/.test(path) && init?.method === "POST") {
+      const body = JSON.parse(String(init.body)) as {
+        computerId: string;
+        displayName: string;
+        name: string;
+        runtimeProvider: "codex" | "claude-code";
+      };
+      return json({ ...adminConfig(), ...body, id: agentId }, 201);
+    }
     // Any Team id, so a Team created during the test is served like the seeded and invited ones.
     if (/^\/api\/v1\/teams\/[^/]+\/agents$/.test(path)) {
       return json({
@@ -249,7 +259,7 @@ function installApi(
       });
     }
     if (/^\/api\/v1\/teams\/[^/]+\/computers$/.test(path)) return json({ computers: [] });
-    if (path === "/api/v1/me/computers") return json({ computers: [] });
+    if (path === "/api/v1/me/computers") return json({ computers: options.computers ?? [] });
     if (path === "/api/v1/me/connect-codes" && init?.method === "POST") {
       return json(
         {
@@ -811,6 +821,49 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Connect a Local Computer first" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "Computer settings" }).getAttribute("href")).toBe("/settings/computers");
+  });
+
+  it("shows exact Computer and Provider readiness without blocking Agent creation or offering fallback", async () => {
+    installApi("admin", {
+      computers: [
+        {
+          id: computerId,
+          ownerUserId: userId,
+          displayName: "Ada's Mac",
+          platform: "darwin",
+          arch: "arm64",
+          clientVersion: "0.0.1",
+          connectionStatus: "online",
+          providerReadiness: [
+            { provider: "codex", status: "ready", observedAt: "2026-08-20T00:00:00.000Z" },
+            { provider: "claude-code", status: "sign-in", observedAt: "2026-08-20T00:00:00.000Z" },
+          ],
+          connectedAt: "2026-08-20T00:00:00.000Z",
+          lastSeenAt: "2026-08-20T00:00:00.000Z",
+        },
+      ],
+    });
+    window.history.replaceState({}, "", "/agents/new");
+    render(<App />);
+    expect(await screen.findByText("Codex is ready on Ada's Mac.")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Provider"), { target: { value: "claude-code" } });
+    expect(await screen.findByText(/Claude Code requires sign-in/)).toBeTruthy();
+    expect(screen.getByText(/No other Provider will be substituted/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create Agent" }).hasAttribute("disabled")).toBe(false);
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "claude-reviewer" } });
+    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Claude Reviewer" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
+    await waitFor(() => {
+      const request = vi
+        .mocked(fetch)
+        .mock.calls.find(([path, init]) => path === `/api/v1/teams/${teamId}/agents` && init?.method === "POST");
+      expect(JSON.parse(String(request?.[1]?.body))).toEqual({
+        name: "claude-reviewer",
+        displayName: "Claude Reviewer",
+        runtimeProvider: "claude-code",
+        computerId,
+      });
+    });
   });
 
   it("sends a Team-less session to Team creation and lands it on Agents", async () => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -641,23 +641,7 @@ function NewAgentPage() {
   const { membership } = useTeam();
   const navigate = useNavigate();
   const computers = useResource(() => browserApi.ownComputers(), membership.teamId);
-  const [error, setError] = useState<string>();
   if (membership.role !== "admin") return <UnavailablePage title="Team Admin access required" />;
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const data = new FormData(event.currentTarget);
-    try {
-      const created = await browserApi.createAgent(membership.teamId, {
-        name: String(data.get("name") ?? ""),
-        displayName: String(data.get("displayName") ?? ""),
-        runtimeProvider: String(data.get("runtimeProvider") ?? "codex") as "codex" | "claude-code",
-        computerId: String(data.get("computerId") ?? ""),
-      });
-      navigate(`/agents/${created.id}/general`);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Agent creation failed");
-    }
-  }
   return (
     <Page title="Create Agent" description="Create the identity first. Complete its setup from the Agent overview.">
       <AsyncState state={computers}>
@@ -667,47 +651,123 @@ function NewAgentPage() {
               Open <Link to="/settings/computers">Computer settings</Link> to generate a connection command.
             </EmptyState>
           ) : (
-            <form className="form-card" onSubmit={submit}>
-              <label>
-                Name
-                <input name="name" required pattern="[a-z0-9][a-z0-9-]*" />
-              </label>
-              <label>
-                Display name
-                <input name="displayName" required />
-              </label>
-              <label>
-                Provider
-                <select name="runtimeProvider">
-                  <option value="codex">Codex</option>
-                  <option value="claude-code">Claude Code</option>
-                </select>
-              </label>
-              <label>
-                Computer
-                <select name="computerId" required>
-                  {value.computers.map((computer: Computer) => (
-                    <option value={computer.id} key={computer.id}>
-                      {computer.displayName}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <p className="muted">New Agents receive only direct mentions by default.</p>
-              <button className="button" type="submit">
-                Create Agent
-              </button>
-              {error ? (
-                <div className="notice error" role="alert">
-                  {error}
-                </div>
-              ) : null}
-            </form>
+            <NewAgentForm
+              computers={value.computers}
+              teamId={membership.teamId}
+              onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
+            />
           )
         }
       </AsyncState>
     </Page>
   );
+}
+
+function NewAgentForm({
+  computers,
+  onCreated,
+  teamId,
+}: {
+  computers: readonly Computer[];
+  onCreated(agentId: string): void;
+  teamId: string;
+}) {
+  const [computerId, setComputerId] = useState(computers[0]?.id ?? "");
+  const [runtimeProvider, setRuntimeProvider] = useState<"codex" | "claude-code">("codex");
+  const [error, setError] = useState<string>();
+  const computer = computers.find((candidate) => candidate.id === computerId) ?? computers[0];
+  const readiness = computer?.providerReadiness?.find((entry) => entry.provider === runtimeProvider);
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    try {
+      const created = await browserApi.createAgent(teamId, {
+        name: String(data.get("name") ?? ""),
+        displayName: String(data.get("displayName") ?? ""),
+        runtimeProvider,
+        computerId,
+      });
+      onCreated(created.id);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Agent creation failed");
+    }
+  }
+  return (
+    <form className="form-card" onSubmit={submit}>
+      <label>
+        Name
+        <input name="name" required pattern="[a-z0-9][a-z0-9-]*" />
+      </label>
+      <label>
+        Display name
+        <input name="displayName" required />
+      </label>
+      <label>
+        Provider
+        <select
+          name="runtimeProvider"
+          value={runtimeProvider}
+          onChange={(event) => setRuntimeProvider(event.currentTarget.value as "codex" | "claude-code")}
+        >
+          <option value="codex">Codex</option>
+          <option value="claude-code">Claude Code</option>
+        </select>
+      </label>
+      <label>
+        Computer
+        <select
+          name="computerId"
+          required
+          value={computerId}
+          onChange={(event) => setComputerId(event.currentTarget.value)}
+        >
+          {computers.map((candidate) => (
+            <option value={candidate.id} key={candidate.id}>
+              {candidate.displayName}
+            </option>
+          ))}
+        </select>
+      </label>
+      <div
+        className={`notice ${readiness?.status === "ready" && computer?.connectionStatus === "online" ? "" : "warning"}`}
+        role="status"
+      >
+        {providerReadinessMessage(computer, runtimeProvider, readiness?.status)}
+      </div>
+      <p className="muted">New Agents receive only direct mentions by default.</p>
+      <button className="button" type="submit">
+        Create Agent
+      </button>
+      {error ? (
+        <div className="notice error" role="alert">
+          {error}
+        </div>
+      ) : null}
+    </form>
+  );
+}
+
+function providerReadinessMessage(
+  computer: Computer | undefined,
+  provider: "codex" | "claude-code",
+  status: "checking" | "install" | "sign-in" | "ready" | "unavailable" | undefined,
+): string {
+  const label = providerLabel(provider);
+  if (computer?.connectionStatus === "offline") {
+    return `${computer.displayName} is offline. You can still create this Agent; ${label} Turns will fail without starting and can be retried when this Computer reconnects. No other Provider will be substituted.`;
+  }
+  if (status === "ready") return `${label} is ready on ${computer?.displayName ?? "this Computer"}.`;
+  const action =
+    status === "checking"
+      ? "readiness is still being checked"
+      : status === "install"
+        ? "must be installed"
+        : status === "sign-in"
+          ? "requires sign-in"
+          : status === "unavailable"
+            ? "is currently unavailable"
+            : "readiness has not been reported by this Computer";
+  return `${label} ${action}. You can still create this Agent; its Turns will fail without starting and can be retried after readiness is restored. No other Provider will be substituted.`;
 }
 
 const agentSections = [

--- a/packages/client/src/__tests__/agent-runtime-provider-registry.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-provider-registry.test.ts
@@ -19,6 +19,7 @@ describe("AgentRuntimeProviderRegistry", () => {
     const claude = registration(factory("claude-code"), "b".repeat(64));
     const providers = new AgentRuntimeProviderRegistry([codex, claude]);
 
+    expect(providers.providerIds()).toEqual(["codex", "claude-code"]);
     expect(providers.registration("codex")).toMatchObject({ factory: codex.factory, artifactIdentity: "a".repeat(64) });
     expect(Object.isFrozen(providers.registration("codex"))).toBe(true);
     expect(providers.artifactIdentity("claude-code")).toBe("b".repeat(64));
@@ -77,7 +78,11 @@ describe("AgentRuntimeProviderRegistry", () => {
     });
     expect(providers.isReady("codex")).toBe(false);
     expect(providers.validate(snapshot())).toBe("provider_unavailable");
-    await expect(providers.ensureReady("codex")).rejects.toThrow("artifact_missing: missing");
+    await expect(providers.ensureReady("codex")).rejects.toMatchObject({
+      name: "AgentRuntimeProviderUnavailableError",
+      providerId: "codex",
+      result: { issues: [{ code: "artifact_missing" }] },
+    });
   });
 
   it("deduplicates the underlying probe while each waiter retains its own cancellation", async () => {
@@ -168,6 +173,11 @@ describe("AgentRuntimeProviderRegistry", () => {
     ]);
     await expect(verificationFailure.refresh("codex")).resolves.toBe(false);
     expect(verificationFailure.isReady("codex")).toBe(false);
+    await expect(verificationFailure.ensureReady("codex")).rejects.toMatchObject({
+      name: "AgentRuntimeProviderUnavailableError",
+      providerId: "codex",
+      result: { issues: [{ code: "temporarily_unavailable" }] },
+    });
 
     let release!: () => void;
     let completions = 0;

--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { type DirectImMessageDeliveryRequest, RUNTIME_FINAL_TEXT_MAX_BYTES } from "@opentag/shared";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentRunResult, AgentRuntimeEventSink } from "../agent-runtime/types.js";
+import { AgentRuntimeProviderUnavailableError } from "../runtime/agent-runtime-provider-registry.js";
 import {
   AgentTurnRunner,
   buildAgentInput,
@@ -12,7 +13,7 @@ import {
 import type { ImResourceFetcher } from "../runtime/im-resource-fetcher.js";
 import type { RuntimeToolHost } from "../runtime/runtime-tool-host.js";
 import type { SessionBindingStore } from "../runtime/session-binding-store.js";
-import type { SessionRuntimeManager } from "../runtime/session-runtime-manager.js";
+import { ClientRuntimeProviderStartError, type SessionRuntimeManager } from "../runtime/session-runtime-manager.js";
 import type { LiveTurnOwner, TurnCustodyOwner } from "../runtime/turn-custody-owner.js";
 import type { TurnReportOwner } from "../runtime/turn-report-owner.js";
 
@@ -101,6 +102,32 @@ describe("AgentTurnRunner", () => {
       outcome: "unknown",
       errorReason: "turn_state_unknown",
     });
+    expect(
+      completionForError(
+        new AgentRuntimeProviderUnavailableError("claude-code", {
+          ready: false,
+          issues: [{ code: "credential_missing", message: "sign in" }],
+        }),
+        undefined,
+      ),
+    ).toEqual({ outcome: "failed", executionEffects: "not_started", errorReason: "credential_unavailable" });
+    expect(
+      completionForError(
+        new AgentRuntimeProviderUnavailableError("claude-code", {
+          ready: false,
+          issues: [{ code: "artifact_missing", message: "install" }],
+        }),
+        undefined,
+      ),
+    ).toEqual({ outcome: "failed", executionEffects: "not_started", errorReason: "provider_start_failed" });
+    expect(completionForError(new ClientRuntimeProviderStartError("claude-code"), undefined)).toEqual({
+      outcome: "failed",
+      executionEffects: "not_started",
+      errorReason: "provider_start_failed",
+    });
+    expect(new AgentRuntimeProviderUnavailableError("claude-code", { ready: false, issues: [] }).message).toContain(
+      "not ready",
+    );
   });
 
   it("applies budget/deadline limits and durably reports pre-provider failures", async () => {
@@ -174,7 +201,7 @@ describe("AgentTurnRunner", () => {
         submit: vi.fn(),
       } as unknown as TurnReportOwner,
       runtimeManager: {
-        runtime: () => ({
+        ensureRuntime: async () => ({
           prompt: async () => {
             await observer?.({ type: "run_started", runId: "turn-1" });
             await observer?.({
@@ -202,6 +229,46 @@ describe("AgentTurnRunner", () => {
     expect(onRuntimeEvent).toHaveBeenCalledTimes(2);
   });
 
+  it("reports unavailable credentials as a recoverable typed failure before Provider execution", async () => {
+    const create = vi.fn((input) => ({
+      ...input,
+      type: "turn:report",
+      requestId: randomUUID(),
+      resultHash: "d".repeat(64),
+    }));
+    const runner = new AgentTurnRunner({
+      bindingStore: { updateUnresolved: vi.fn(async () => undefined) } as unknown as SessionBindingStore,
+      connection: { send: vi.fn(async () => undefined) },
+      custody: {
+        markReporting: vi.fn(async () => undefined),
+        recordResult: vi.fn(),
+      } as unknown as TurnCustodyOwner,
+      reportOwner: { create, submit: vi.fn(async () => undefined) } as unknown as TurnReportOwner,
+      runtimeManager: {
+        ensureRuntime: async () => {
+          throw new AgentRuntimeProviderUnavailableError("claude-code", {
+            ready: false,
+            issues: [{ code: "credential_missing", message: "sign in" }],
+          });
+        },
+      } as unknown as SessionRuntimeManager,
+      toolHost: {} as RuntimeToolHost,
+    });
+
+    const request = delivery();
+    request.runtime.provider = "claude-code";
+    request.runtime.execution.networkAccess = true;
+    runner.start(liveOwner(request));
+    await runner.settled();
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "failed",
+        executionEffects: "not_started",
+        errorReason: "credential_unavailable",
+      }),
+    );
+  });
+
   it("aborts an active Provider Run during shutdown", async () => {
     let resolvePrompt!: (result: AgentRunResult) => void;
     const prompt = vi.fn(
@@ -227,7 +294,7 @@ describe("AgentTurnRunner", () => {
         submit: vi.fn(async () => undefined),
       } as unknown as TurnReportOwner,
       runtimeManager: {
-        runtime: () => ({ prompt }),
+        ensureRuntime: async () => ({ prompt }),
         cwd: () => "/workspace",
         observe: () => () => undefined,
       } as unknown as SessionRuntimeManager,

--- a/packages/client/src/__tests__/agent-workspace.test.ts
+++ b/packages/client/src/__tests__/agent-workspace.test.ts
@@ -292,6 +292,23 @@ describe("AgentWorkspaceManager", () => {
 
     await expect(fixture.workspace.verifyAgent(runtime, hashes)).rejects.toThrow("workspace state values are invalid");
   });
+
+  it("persists Claude Code in the existing workspace-state v2 contract", async () => {
+    const fixture = await workspaceFixture();
+    const runtime: EffectiveRuntimeSnapshot = {
+      ...snapshot("agent-claude", "workspace-claude", "session"),
+      provider: "claude-code",
+      execution: { approvalPolicy: "never", networkAccess: true },
+    };
+    const hashes = computeRuntimeSnapshotHashes(runtime);
+
+    await fixture.workspace.prepareAgent(runtime, hashes);
+    expect(JSON.parse(await readFile(fixture.workspace.paths(runtime.agentId).workspaceState, "utf8"))).toMatchObject({
+      schemaVersion: 2,
+      provider: "claude-code",
+    });
+    await expect(fixture.workspace.verifyAgent(runtime, hashes)).resolves.toBeUndefined();
+  });
 });
 
 async function workspaceFixture() {

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -485,7 +485,7 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
     const command = join(directory, "claude-fixture");
     await writeFile(
       command,
-      '#!/bin/sh\nif [ "$1" = "--version" ]; then printf "2.1.210 (Claude Code)\\n"; exit 0; fi\nif [ "$1" = "--help" ]; then printf "stream-json --session-id --resume\\n"; exit 0; fi\nif [ -n "$CLAUDE_CODE_SKIP_PROMPT_HISTORY" ]; then printf \'{"loggedIn":false}\\n\'; exit 1; fi\nprintf \'{"loggedIn":true}\\n\'\n',
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then printf "2.1.210 (Claude Code)\\n"; exit 0; fi\nif [ "$1" = "--help" ]; then printf "stream-json --session-id --resume --mcp-config --strict-mcp-config --allowedTools\\n"; exit 0; fi\nif [ -n "$CLAUDE_CODE_SKIP_PROMPT_HISTORY" ]; then printf \'{"loggedIn":false}\\n\'; exit 1; fi\nprintf \'{"loggedIn":true}\\n\'\n',
       "utf8",
     );
     await chmod(command, 0o755);
@@ -528,7 +528,7 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
             : "exit 1";
       await writeFile(
         missingCommand,
-        `#!/bin/sh\nif [ "$1" = "--version" ]; then printf "2.1.210 (Claude Code)\\n"; exit 0; fi\nif [ "$1" = "--help" ]; then printf "stream-json --session-id --resume\\n"; exit 0; fi\n${authResponse}\n`,
+        `#!/bin/sh\nif [ "$1" = "--version" ]; then printf "2.1.210 (Claude Code)\\n"; exit 0; fi\nif [ "$1" = "--help" ]; then printf "stream-json --session-id --resume --mcp-config --strict-mcp-config --allowedTools\\n"; exit 0; fi\n${authResponse}\n`,
         "utf8",
       );
       await chmod(missingCommand, 0o755);
@@ -544,7 +544,7 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
     const vanishingCommand = join(directory, "claude-vanishing");
     await writeFile(
       vanishingCommand,
-      '#!/bin/sh\nif [ "$1" = "--version" ]; then printf "2.1.210 (Claude Code)\\n"; exit 0; fi\nif [ "$1" = "--help" ]; then printf "stream-json --session-id --resume\\n"; mv "$0" "$0.gone"; exit 0; fi\n',
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then printf "2.1.210 (Claude Code)\\n"; exit 0; fi\nif [ "$1" = "--help" ]; then printf "stream-json --session-id --resume --mcp-config --strict-mcp-config --allowedTools\\n"; mv "$0" "$0.gone"; exit 0; fi\n',
       "utf8",
     );
     await chmod(vanishingCommand, 0o755);

--- a/packages/client/src/__tests__/claude-code-agent-runtime.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeEvent, CreateAgentRuntimeRequest } from "../agent-runtime/types.js";
 import {
@@ -66,7 +67,30 @@ describe("ClaudeCodeAgentRuntime", () => {
     expect(processes[0]?.args).toContain("--session-id");
     expect(processes[0]?.args).toContain(SESSION_ID);
     expect(argumentAfter(processes[0]?.args ?? [], "--permission-mode")).toBe("bypassPermissions");
+    expect(processes[0]?.args).toContain("--strict-mcp-config");
+    const mcpConfig = argumentAfter(processes[0]?.args ?? [], "--mcp-config");
+    expect(mcpConfig).toContain("opentag-claude-mcp-");
+    await expect(readFile(mcpConfig ?? "", "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    expect(processes[0]?.args).not.toContain("--allowedTools");
     expect(processes[0]?.args).not.toContain("--settings");
+    await runtime.close();
+  });
+
+  it("allows only the exact OpenTag hosted tools through the strict MCP bridge", async () => {
+    const processes: ScriptedClaudeCodeProcess[] = [];
+    const request = createRequest(() => undefined);
+    const runtime = await claudeFactory(processes, "complete").create({
+      ...request,
+      hostedTools: {
+        definitions: [{ name: "opentag_message_reply", inputSchema: { type: "object" } }],
+        handler: async () => ({ success: true, content: [] }),
+      },
+    });
+
+    await runtime.prompt({ runId: "run-hosted", input: input("reply") });
+    expect(processes[0]?.args).toContain("--allowedTools");
+    expect(processes[0]?.args).toContain("mcp__opentag__opentag_message_reply");
+    expect(processes[0]?.args).not.toContain("mcp__opentag__Read");
     await runtime.close();
   });
 
@@ -169,6 +193,7 @@ describe("ClaudeCodeAgentRuntime", () => {
         NODE_EXTRA_CA_CERTS: "/certificate.pem",
         ANTHROPIC_API_KEY: "provider-key",
         CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+        CLAUDE_CONFIG_DIR: "/home/provider/.claude",
         CLAUDE_CODE_SKIP_PROMPT_HISTORY: "1",
         CLAUDE_CODE_USE_BEDROCK: "1",
         AWS_PROFILE: "provider",
@@ -183,6 +208,7 @@ describe("ClaudeCodeAgentRuntime", () => {
       NODE_EXTRA_CA_CERTS: "/certificate.pem",
       ANTHROPIC_API_KEY: "provider-key",
       CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+      CLAUDE_CONFIG_DIR: "/home/provider/.claude",
       CLAUDE_CODE_USE_BEDROCK: "1",
       AWS_PROFILE: "provider",
       GOOGLE_APPLICATION_CREDENTIALS: "/credential.json",

--- a/packages/client/src/__tests__/claude-code-hosted-tool-bridge.test.ts
+++ b/packages/client/src/__tests__/claude-code-hosted-tool-bridge.test.ts
@@ -1,0 +1,140 @@
+import { readFile, stat } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentHostedTools } from "../agent-runtime/types.js";
+import { startClaudeCodeHostedToolBridge } from "../providers/claude-code/hosted-tool-bridge.js";
+
+describe("Claude Code hosted tool bridge", () => {
+  it("always supplies a private strict-MCP configuration and removes it idempotently", async () => {
+    const bridge = await startClaudeCodeHostedToolBridge(undefined, "run-empty", new AbortController().signal);
+    expect(bridge.allowedTools).toEqual([]);
+    await expect(readFile(bridge.configPath, "utf8")).resolves.toBe('{"mcpServers":{}}\n');
+    expect((await stat(bridge.configPath)).mode & 0o777).toBe(0o600);
+
+    await bridge.close();
+    await bridge.close();
+    await expect(readFile(bridge.configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("serves only authenticated OpenTag tools over owned loopback HTTP", async () => {
+    const handler = vi.fn<AgentHostedTools["handler"]>(async (call) => ({
+      success: call.name === "opentag_message_reply",
+      content: [{ type: "text", text: call.name }],
+      ...(call.name === "opentag_message_send" ? { error: { code: "IM_FAILED", message: "send failed" } } : {}),
+    }));
+    const bridge = await startClaudeCodeHostedToolBridge(
+      {
+        definitions: [
+          {
+            name: "opentag_message_reply",
+            description: "Reply to the current conversation",
+            inputSchema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+          },
+          { name: "opentag_message_send", inputSchema: { type: "object" } },
+        ],
+        handler,
+      },
+      "run-1",
+      new AbortController().signal,
+    );
+    const configuration = JSON.parse(await readFile(bridge.configPath, "utf8")) as {
+      mcpServers: { opentag: { headers: Record<string, string>; url: string } };
+    };
+    const endpoint = configuration.mcpServers.opentag;
+    const rpc = async (body: unknown, headers = endpoint.headers) =>
+      fetch(endpoint.url, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...headers },
+        body: typeof body === "string" ? body : JSON.stringify(body),
+      });
+
+    expect(bridge.allowedTools).toEqual(["mcp__opentag__opentag_message_reply", "mcp__opentag__opentag_message_send"]);
+    await expect(
+      rpc({ jsonrpc: "2.0", id: 1, method: "initialize" }).then((response) => response.json()),
+    ).resolves.toMatchObject({ result: { capabilities: { tools: {} }, serverInfo: { name: "OpenTag" } } });
+    await expect(
+      rpc({ jsonrpc: "2.0", id: "list", method: "tools/list" }).then((response) => response.json()),
+    ).resolves.toMatchObject({
+      result: { tools: [{ name: "opentag_message_reply" }, { name: "opentag_message_send" }] },
+    });
+    expect((await rpc({ jsonrpc: "2.0", method: "notifications/initialized" })).status).toBe(202);
+
+    await expect(
+      rpc({
+        jsonrpc: "2.0",
+        id: "call-1",
+        method: "tools/call",
+        params: { name: "opentag_message_reply", arguments: { text: "hello" } },
+      }).then((response) => response.json()),
+    ).resolves.toMatchObject({ result: { content: [{ text: "opentag_message_reply" }], isError: false } });
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        toolCallId: "call-1",
+        name: "opentag_message_reply",
+        input: { text: "hello" },
+      }),
+    );
+    await expect(
+      rpc({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "opentag_message_send", arguments: {} },
+      }).then((response) => response.json()),
+    ).resolves.toMatchObject({ result: { isError: true, structuredContent: { error: { code: "IM_FAILED" } } } });
+    await expect(
+      rpc({ jsonrpc: "2.0", id: null, method: "tools/call", params: { name: "missing", arguments: {} } }).then(
+        (response) => response.json(),
+      ),
+    ).resolves.toMatchObject({ result: { isError: true } });
+    await expect(
+      rpc({
+        jsonrpc: "2.0",
+        id: "",
+        method: "tools/call",
+        params: { name: "opentag_message_reply", arguments: undefined },
+      }).then((response) => response.json()),
+    ).resolves.toMatchObject({ result: { isError: false } });
+    await expect(
+      rpc({
+        jsonrpc: "2.0",
+        id: {},
+        method: "tools/call",
+        params: { name: "opentag_message_reply", arguments: BigInt(1).toString() },
+      }).then((response) => response.json()),
+    ).resolves.toMatchObject({ result: { isError: false } });
+    await expect(
+      rpc(
+        '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"opentag_message_reply","arguments":1e400}}',
+      ).then((response) => response.json()),
+    ).resolves.toMatchObject({ result: { isError: true } });
+    await expect(
+      rpc({ jsonrpc: "2.0", id: 4, method: "unknown" }).then((response) => response.json()),
+    ).resolves.toMatchObject({ error: { code: -32601 } });
+    expect((await rpc("not-json")).status).toBe(400);
+    expect((await rpc([])).status).toBe(400);
+    expect((await rpc({ jsonrpc: "1.0", id: 5, method: "initialize" })).status).toBe(400);
+    expect((await rpc({ jsonrpc: "2.0", id: 6, method: "initialize" }, { Authorization: "Bearer wrong" })).status).toBe(
+      404,
+    );
+    await expect(rpc("x".repeat(1024 * 1024 + 1))).rejects.toThrow();
+
+    await bridge.close();
+  });
+
+  it("rejects aborted setup and duplicate hosted definitions before opening a bridge", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("turn cancelled"));
+    await expect(startClaudeCodeHostedToolBridge(undefined, "run", controller.signal)).rejects.toThrow(
+      "turn cancelled",
+    );
+    const definition = { name: "duplicate", inputSchema: { type: "object" } } as const;
+    await expect(
+      startClaudeCodeHostedToolBridge(
+        { definitions: [definition, definition], handler: async () => ({ success: true, content: [] }) },
+        "run",
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow("unique names");
+  });
+});

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -213,7 +213,9 @@ describe("createClientRuntime production composition", () => {
       canonicalCommand,
     );
     await expect(resolveExecutable("missing", {})).rejects.toThrow("PATH is unavailable");
-    await expect(resolveExecutable("missing", { PATH: empty })).rejects.toThrow("compatible Codex executable");
+    await expect(resolveExecutable("missing", { PATH: empty })).rejects.toThrow(
+      "compatible Agent Runtime provider executable",
+    );
 
     const factory = resolvedCodexFactory({
       clientVersion: "0.0.1",

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -280,7 +280,7 @@ describe("createClientRuntime production composition", () => {
       validateClaudeCodeRuntimePolicy({
         ...claudeSnapshot,
         execution: { approvalPolicy: "on-request", networkAccess: true },
-      }),
+      } as unknown as EffectiveRuntimeSnapshot),
     ).toBe("configuration_unsupported");
     expect(
       validateClaudeCodeRuntimePolicy({

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import type { AgentRuntime, AgentRuntimeFactory } from "../agent-runtime/types.js";
 import { createLogger } from "../observability/logger.js";
+import { claudeCodeRuntimePolicy, validateClaudeCodeRuntimePolicy } from "../providers/claude-code/runtime-policy.js";
 import { CODEX_AGENT_RUNTIME_APP_SERVER_ARGS } from "../providers/codex/agent-runtime.js";
 import {
   ComposedClientRuntime,
@@ -22,6 +23,7 @@ import {
   createClientRuntimeHandlers,
   createClientRuntimePreflight,
   resolveCodexHome,
+  resolvedClaudeCodeFactory,
   resolvedCodexFactory,
   resolveExecutable,
 } from "../runtime/client-runtime-composition.js";
@@ -85,6 +87,7 @@ describe("createClientRuntime production composition", () => {
     expect(runtime.messageToolAvailable).toBe(true);
     const result = await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()));
     expect(result).toMatchObject({ status: "ready" });
+    await runtime.runtimeManager.ensureRuntime("session-1");
     expect(await runtime.bindingStore.read("agent-1", "session-1")).toMatchObject({
       schemaVersion: 2,
       runtimeBinding: { providerId: "codex", schemaVersion: 1, payload: { threadId: "thread-1" } },
@@ -100,7 +103,7 @@ describe("createClientRuntime production composition", () => {
     runtime.toolHost.close();
   });
 
-  it("keeps the daemon composable and rejects Session placement when Codex is unavailable", async () => {
+  it("keeps placement composable and defers unavailable Codex failure to the exact Turn runtime start", async () => {
     const home = await temporaryDirectory("opentag-client-unavailable-");
     const connection = runtimeConnection();
     const runtime = await createClientRuntime(connection, {
@@ -113,7 +116,11 @@ describe("createClientRuntime production composition", () => {
     expect(runtime.messageToolAvailable).toBe(false);
     await expect(
       runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot())),
-    ).resolves.toMatchObject({ status: "rejected", reason: "provider_unavailable" });
+    ).resolves.toMatchObject({ status: "ready" });
+    await expect(runtime.runtimeManager.ensureRuntime("session-1")).rejects.toMatchObject({
+      name: "AgentRuntimeProviderUnavailableError",
+      providerId: "codex",
+    });
     runtime.stop();
     runtime.reportOwner.stop();
   });
@@ -134,10 +141,10 @@ describe("createClientRuntime production composition", () => {
         clientVersion: "0.0.1",
         codexHome: resolve(home, "wrong-provider-home"),
         environment: {},
-        factory: readyFactory("claude-code"),
+        factory: readyFactory("pi"),
         home,
       }),
-    ).rejects.toThrow("only registers the reviewed Codex provider");
+    ).rejects.toThrow("does not register the unreviewed provider");
 
     const controller = new AbortController();
     const error = new Error("cancel readiness");
@@ -223,6 +230,69 @@ describe("createClientRuntime production composition", () => {
     await expect(factory.probe({ signal: aborted.signal })).rejects.toThrow("stop resolution");
   });
 
+  it("resolves the production Claude Code factory and enforces its reviewed runtime policy", async () => {
+    const home = await temporaryDirectory("opentag-client-claude-factory-");
+    const command = resolve(home, "claude-fixture");
+    await writeFile(
+      command,
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then printf "2.1.210 (Claude Code)\\n"; exit 0; fi\nif [ "$1" = "--help" ]; then printf "stream-json --session-id --resume --mcp-config --strict-mcp-config --allowedTools\\n"; exit 0; fi\nexit 1\n',
+      "utf8",
+    );
+    await chmod(command, 0o755);
+    const resolved = resolvedClaudeCodeFactory({
+      claudeCodeHome: home,
+      command,
+      environment: { PATH: process.env.PATH, ANTHROPIC_API_KEY: "fixture" },
+      sourceEnvironment: { PATH: process.env.PATH },
+    });
+    expect(() => resolved.create({} as never)).toThrow("readiness has not been established");
+    expect(() => resolved.resume({} as never)).toThrow("readiness has not been established");
+    const missing = resolvedClaudeCodeFactory({
+      claudeCodeHome: home,
+      command: resolve(home, "missing-claude"),
+      environment: {},
+      sourceEnvironment: {},
+    });
+    await expect(missing.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "artifact_missing" }],
+    });
+    const abortedMissing = new AbortController();
+    abortedMissing.abort(new Error("stop Claude resolution"));
+    await expect(missing.probe({ signal: abortedMissing.signal })).rejects.toThrow("stop Claude resolution");
+    await expect(resolved.probe({})).resolves.toMatchObject({ ready: true });
+    await expect(resolved.create({} as never)).rejects.toThrow("eventSink is required");
+    await expect(resolved.resume({} as never)).rejects.toThrow("eventSink is required");
+
+    const claudeSnapshot: EffectiveRuntimeSnapshot = {
+      ...snapshot(),
+      provider: "claude-code",
+      execution: { approvalPolicy: "never", networkAccess: true },
+    };
+    expect(claudeCodeRuntimePolicy(claudeSnapshot)).toEqual({
+      fileSystem: "unrestricted",
+      network: "enabled",
+      approvals: "never",
+      tools: { mode: "provider-default" },
+    });
+    expect(validateClaudeCodeRuntimePolicy(claudeSnapshot)).toBeUndefined();
+    expect(
+      validateClaudeCodeRuntimePolicy({
+        ...claudeSnapshot,
+        execution: { approvalPolicy: "on-request", networkAccess: true },
+      }),
+    ).toBe("configuration_unsupported");
+    expect(
+      validateClaudeCodeRuntimePolicy({
+        ...claudeSnapshot,
+        execution: { approvalPolicy: "never", networkAccess: false },
+      }),
+    ).toBe("configuration_unsupported");
+    expect(validateClaudeCodeRuntimePolicy({ ...claudeSnapshot, allowedTools: ["unknown"] })).toBe(
+      "configuration_unsupported",
+    );
+  });
+
   it("unit-tests composition delegates and every preflight outcome", async () => {
     const accepted = { result: { status: "accepted" } };
     const custody = { accept: vi.fn(async () => accepted) };
@@ -244,19 +314,14 @@ describe("createClientRuntime production composition", () => {
     await expect(handlers.onReconciled({} as never, {} as never)).resolves.toBeUndefined();
 
     const request = delivery(snapshot());
-    const ensureProviderReady = vi.fn(async () => undefined);
-    const runtime = vi.fn(() => ({ state: { phase: "idle" } }));
     const verifyAgent = vi.fn(async () => undefined);
     const validateProviderConfiguration = vi.fn(() => undefined as "configuration_unsupported" | undefined);
     const preflight = createClientRuntimePreflight({
-      providers: { ensureReady: ensureProviderReady, validateConfiguration: validateProviderConfiguration },
-      runtimeManager: { runtime } as never,
+      providers: { validateConfiguration: validateProviderConfiguration },
       workspace: { verifyAgent } as never,
     });
     await expect(preflight(request)).resolves.toBeUndefined();
-    expect(ensureProviderReady).toHaveBeenCalledWith("codex", undefined);
     expect(verifyAgent).toHaveBeenCalledOnce();
-    expect(runtime).toHaveBeenCalledWith("session-1");
 
     validateProviderConfiguration.mockReturnValue("configuration_unsupported");
     await expect(preflight(request)).resolves.toBe("configuration_unsupported");
@@ -265,7 +330,7 @@ describe("createClientRuntime production composition", () => {
     verifyAgent.mockRejectedValueOnce(new RuntimeStorageError("conflict", "binding conflict"));
     await expect(preflight(request)).resolves.toBe("session_binding_conflict");
     verifyAgent.mockRejectedValueOnce(new Error("provider failed"));
-    await expect(preflight(request)).resolves.toBe("provider_unavailable");
+    await expect(preflight(request)).resolves.toBe("configuration_unsupported");
   });
 
   it("covers ComposedClientRuntime monitor guards with deterministic component doubles", async () => {
@@ -623,7 +688,8 @@ describe("createClientRuntime production composition", () => {
     const running = runtime.run();
     await registration;
     const request = reconcileRequest(connection.computerId, snapshot());
-    const reconciling = runtime.reconciler.reconcile(request);
+    await runtime.reconciler.reconcile(request);
+    const starting = runtime.runtimeManager.ensureRuntime("session-1");
     await createStart;
 
     runtime.stop();
@@ -636,13 +702,10 @@ describe("createClientRuntime production composition", () => {
     expect(closeCalls).toBe(0);
 
     releaseCreate();
-    await expect(reconciling).rejects.toThrow("manager is closing");
+    await expect(starting).rejects.toThrow("manager is closing");
     await running;
     expect(closeCalls).toBe(1);
     expect(() => runtime.runtimeManager.runtime("session-1")).toThrow("manager is closing");
-    await expect(runtime.reconciler.reconcile({ ...request, requestId: randomUUID() })).rejects.toThrow(
-      "manager is closing",
-    );
   });
 });
 

--- a/packages/client/src/__tests__/client-turn.integration.test.ts
+++ b/packages/client/src/__tests__/client-turn.integration.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import type {
@@ -10,6 +10,9 @@ import type {
 } from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeFactory } from "../agent-runtime/types.js";
+import { ClaudeCodeAgentRuntimeFactory } from "../providers/claude-code/agent-runtime.js";
+import type { ClaudeCodeProcessClient, ClaudeCodeProcessResult } from "../providers/claude-code/process-wire.js";
+import { claudeCodeRuntimePolicy, validateClaudeCodeRuntimePolicy } from "../providers/claude-code/runtime-policy.js";
 import { CodexAgentRuntimeFactory } from "../providers/codex/agent-runtime.js";
 import type {
   CodexAppServerMessage,
@@ -70,7 +73,9 @@ describe("Agent Runtime Client Turn vertical", () => {
       finalText: "answer-1",
     });
     expect(fixture.clients).toHaveLength(1);
-    expect(fixture.clients[0]?.cwd).toBe(resolve(fixture.workspace.paths("agent-1").agentsFile, ".."));
+    expect(await realpath(fixture.clients[0]?.cwd ?? "")).toBe(
+      await realpath(resolve(fixture.workspace.paths("agent-1").agentsFile, "..")),
+    );
     await expect(readFile(resolve(fixture.clients[0]?.cwd ?? "", "AGENTS.md"), "utf8")).resolves.toContain(
       "# OpenTag managed instructions",
     );
@@ -127,6 +132,27 @@ describe("Agent Runtime Client Turn vertical", () => {
     expect(report.finalText).toBe("answer-1");
     await fixture.record(report);
     await vi.waitFor(() => expect(fixture.custody.admission.snapshot().client).toBe(0));
+    await fixture.runtimeManager.close();
+  });
+
+  it("runs a Claude Code Agent through exact Provider selection and the IM Turn path", async () => {
+    const fixture = await runtimeFixture(Promise.resolve(), Promise.resolve(), "claude-code");
+    const accepted = await fixture.custody.accept(delivery(fixture.runtime, "delivery-claude", "use Claude"));
+    await accepted.onAcceptedSent?.();
+    const report = await fixture.waitForReport(0);
+
+    expect(report).toMatchObject({
+      outcome: "completed",
+      executionEffects: "completed",
+      finalText: "claude-answer",
+    });
+    expect(fixture.claudeProcesses).toHaveLength(1);
+    expect(fixture.claudeProcesses[0]?.args).toContain("--strict-mcp-config");
+    expect(await fixture.store.read("agent-1", "session-1")).toMatchObject({
+      provider: "claude-code",
+      runtimeBinding: { providerId: "claude-code", schemaVersion: 1 },
+    });
+    await fixture.record(report);
     await fixture.runtimeManager.close();
   });
 
@@ -196,27 +222,40 @@ describe("Agent Runtime Client Turn vertical", () => {
 async function runtimeFixture(
   terminalGate: Promise<void> = Promise.resolve(),
   startingGate: Promise<void> = Promise.resolve(),
+  provider: "codex" | "claude-code" = "codex",
 ) {
   const home = await mkdtemp(resolve(tmpdir(), "opentag-turn-integration-"));
   directories.push(home);
   const computerId = randomUUID();
-  const runtime = snapshot();
+  const runtime = snapshot(1, provider);
   const store = new SessionBindingStore({ home, providerArtifactIdentity: () => "a".repeat(64) });
   const workspace = new AgentWorkspaceManager({ home, bindingStore: store });
   const connection = new FakeConnection();
   const reportOwner = new TurnReportOwner({ connection });
   const toolHost = new RuntimeToolHost(connection);
   const clients: ScriptedTurnClient[] = [];
+  const claudeProcesses: ScriptedClaudeCodeProcess[] = [];
   const logs: RecordedLog[] = [];
-  const factory = new CodexAgentRuntimeFactory({
-    clientVersion: "0.0.1",
-    createClient: (cwd) => {
-      const client = new ScriptedTurnClient(cwd, terminalGate);
-      clients.push(client);
-      return client;
-    },
-    probeRunner: async () => ({ appServer: true, credential: true, experimentalTools: true, version: "test" }),
-  });
+  const factory: AgentRuntimeFactory =
+    provider === "codex"
+      ? new CodexAgentRuntimeFactory({
+          clientVersion: "0.0.1",
+          createClient: (cwd) => {
+            const client = new ScriptedTurnClient(cwd, terminalGate);
+            clients.push(client);
+            return client;
+          },
+          probeRunner: async () => ({ appServer: true, credential: true, experimentalTools: true, version: "test" }),
+        })
+      : new ClaudeCodeAgentRuntimeFactory({
+          createSessionId: () => "11111111-1111-4111-8111-111111111111",
+          createProcess: (_cwd, args) => {
+            const process = new ScriptedClaudeCodeProcess(args, terminalGate);
+            claudeProcesses.push(process);
+            return process;
+          },
+          probeRunner: async () => ({ credential: true, streamJson: true, version: "test" }),
+        });
   const runtimeManager = new SessionRuntimeManager({
     bindingStore: store,
     providers: await providerRegistry(factory),
@@ -281,6 +320,7 @@ async function runtimeFixture(
     });
   return {
     clients,
+    claudeProcesses,
     connection,
     custody,
     logs,
@@ -303,8 +343,8 @@ async function providerRegistry(factory: AgentRuntimeFactory): Promise<AgentRunt
     {
       artifactIdentity: "a".repeat(64),
       factory,
-      policy: codexRuntimePolicy,
-      validate: validateCodexRuntimePolicy,
+      policy: factory.manifest.providerId === "codex" ? codexRuntimePolicy : claudeCodeRuntimePolicy,
+      validate: factory.manifest.providerId === "codex" ? validateCodexRuntimePolicy : validateClaudeCodeRuntimePolicy,
     },
   ]);
   await providers.refresh(factory.manifest.providerId);
@@ -435,18 +475,53 @@ class ScriptedTurnClient implements InteractiveCodexAppServerClient {
   }
 }
 
-function snapshot(revision = 1): EffectiveRuntimeSnapshot {
+class ScriptedClaudeCodeProcess implements ClaudeCodeProcessClient {
+  readonly args: readonly string[];
+  readonly #terminalGate: Promise<void>;
+
+  constructor(args: readonly string[], terminalGate: Promise<void>) {
+    this.args = args;
+    this.#terminalGate = terminalGate;
+  }
+
+  async execute(
+    _input: Readonly<Record<string, unknown>>,
+    onMessage: (message: Readonly<Record<string, unknown>>) => void,
+  ): Promise<ClaudeCodeProcessResult> {
+    await this.#terminalGate;
+    onMessage({
+      type: "system",
+      subtype: "init",
+      session_id: "11111111-1111-4111-8111-111111111111",
+    });
+    onMessage({
+      type: "result",
+      subtype: "success",
+      session_id: "11111111-1111-4111-8111-111111111111",
+      is_error: false,
+      result: "claude-answer",
+      permission_denials: [],
+      usage: {},
+    });
+    return { stderr: "" };
+  }
+
+  async interrupt(): Promise<void> {}
+  async close(): Promise<void> {}
+}
+
+function snapshot(revision = 1, provider: "codex" | "claude-code" = "codex"): EffectiveRuntimeSnapshot {
   return {
     revision: {
       agent: { sequence: revision, id: `agent-revision-${revision}` },
       session: { sequence: revision, id: `session-revision-${revision}` },
     },
     agentId: "agent-1",
-    provider: "codex",
+    provider,
     model: `model-${revision}`,
     instructions: { platform: "platform", agent: "agent", session: "session" },
     allowedTools: [],
-    execution: { approvalPolicy: "never", networkAccess: false },
+    execution: { approvalPolicy: "never", networkAccess: provider === "claude-code" },
     workspace: { workspaceId: "workspace-1", mode: "empty_on_create", sharing: "agent" },
   };
 }

--- a/packages/client/src/__tests__/session-binding-store.test.ts
+++ b/packages/client/src/__tests__/session-binding-store.test.ts
@@ -203,6 +203,25 @@ describe("SessionBindingStore", () => {
     await expect(fixture.store.read("agent-1", "session-1")).rejects.toThrow("Agent Runtime binding is invalid");
   });
 
+  it("reads Claude Code bindings from the existing Session binding v2 contract", async () => {
+    const fixture = await bindingFixture();
+    const path = sessionBindingPath(fixture.home, "agent-1", "session-1");
+    const current = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    current.provider = "claude-code";
+    current.runtimeBinding = {
+      providerId: "claude-code",
+      schemaVersion: 1,
+      payload: { sessionId: randomUUID() },
+    };
+    await writeFile(path, `${JSON.stringify(current)}\n`, "utf8");
+
+    await expect(fixture.store.read("agent-1", "session-1")).resolves.toMatchObject({
+      schemaVersion: 2,
+      provider: "claude-code",
+      runtimeBinding: { providerId: "claude-code", schemaVersion: 1 },
+    });
+  });
+
   it("reads a legacy v1 Codex thread and rewrites only the opaque v2 binding", async () => {
     const fixture = await bindingFixture();
     const path = sessionBindingPath(fixture.home, "agent-1", "session-1");
@@ -228,6 +247,19 @@ describe("SessionBindingStore", () => {
       runtimeBinding: { providerId: "codex", schemaVersion: 1, payload: { threadId: "legacy-thread" } },
     });
     expect(rewritten).not.toHaveProperty("providerThreadId");
+  });
+
+  it("does not reinterpret a legacy v1 Codex thread as a Claude Code binding", async () => {
+    const fixture = await bindingFixture();
+    const path = sessionBindingPath(fixture.home, "agent-1", "session-1");
+    const current = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    delete current.runtimeBinding;
+    current.schemaVersion = 1;
+    current.provider = "claude-code";
+    current.providerThreadId = "legacy-thread";
+    await writeFile(path, `${JSON.stringify(current)}\n`, "utf8");
+
+    await expect(fixture.store.read("agent-1", "session-1")).rejects.toThrow("Session binding values are invalid");
   });
 
   it("ignores the legacy runtime/agents binding without migrating or deleting it", async () => {

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -630,7 +630,7 @@ describe("SessionRuntimeManager", () => {
     expect(factory.runtimes[0]?.closed).toBe(true);
     await missingFinalBinding.close();
 
-    const savedBinding = { ...prepared.binding, runtimeBinding: binding("thread-saved") } as never;
+    const savedBinding = { runtimeBinding: binding("thread-saved") } as never;
     const saved = new SessionRuntimeManager({
       bindingStore: {
         saveRuntimeBinding: async () => savedBinding,

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -44,6 +44,7 @@ describe("SessionRuntimeManager", () => {
     const manager = new SessionRuntimeManager({
       bindingStore: store,
       providers: await providerRegistry(factory),
+      readinessSignal: new AbortController().signal,
       toolHost,
       workspace,
     });
@@ -51,6 +52,9 @@ describe("SessionRuntimeManager", () => {
     const first = reconcile(computerId, snapshot(1));
 
     await expect(reconciler.reconcile(first)).resolves.toMatchObject({ status: "ready" });
+    await manager.ensureRuntime("session-1");
+    await manager.ensureRuntime("session-1", new AbortController().signal);
+    expect(manager.runtime("session-1")).toBe(factory.runtimes[0]);
     expect(factory.created).toHaveLength(1);
     expect((await store.read("agent-1", "session-1"))?.runtimeBinding).toEqual(binding("thread-1"));
     await expect(
@@ -62,7 +66,8 @@ describe("SessionRuntimeManager", () => {
     });
     expect(() => manager.observe("session-1", () => undefined)).toThrow("active observer");
     await factory.runtimes[0]?.emit({ type: "provider_warning", runId: "run", code: "warning", message: "warn" });
-    expect(observed).toEqual(["provider_warning"]);
+    await factory.runtimes[0]?.emit({ type: "binding_changed", binding: binding("thread-1") });
+    expect(observed).toEqual(["provider_warning", "binding_changed"]);
     releaseObserver();
     releaseObserver();
     await expect(reconciler.reconcile({ ...first, requestId: randomUUID() })).resolves.toMatchObject({
@@ -72,9 +77,14 @@ describe("SessionRuntimeManager", () => {
 
     const upgraded = reconcile(computerId, snapshot(2));
     await expect(reconciler.reconcile(upgraded)).resolves.toMatchObject({ status: "ready" });
+    await manager.ensureRuntime("session-1");
     expect(factory.created).toHaveLength(2);
     expect(factory.runtimes[0]?.closed).toBe(true);
     expect((await store.read("agent-1", "session-1"))?.runtimeBinding).toEqual(binding("thread-2"));
+    await factory.runtimes[1]?.close();
+    await manager.prepareSession(upgraded, computeRuntimeSnapshotHashes(upgraded.runtime as never));
+    await manager.ensureRuntime("session-1");
+    expect(factory.resumed).toEqual([binding("thread-2")]);
 
     await manager.close();
     const restartedFactory = new FakeFactory();
@@ -92,6 +102,7 @@ describe("SessionRuntimeManager", () => {
     await expect(restarted.reconcile({ ...upgraded, requestId: randomUUID() })).resolves.toMatchObject({
       status: "ready",
     });
+    await restartedManager.ensureRuntime("session-1");
     expect(restartedFactory.resumed).toEqual([binding("thread-2")]);
 
     await expect(
@@ -101,7 +112,7 @@ describe("SessionRuntimeManager", () => {
     toolHost.close();
   });
 
-  it("fails closed for unregistered providers and unsupported execution policy", async () => {
+  it("validates durable configuration without treating transient readiness as placement policy", async () => {
     const manager = new SessionRuntimeManager({
       bindingStore: {} as SessionBindingStore,
       providers: await providerRegistry(),
@@ -116,7 +127,7 @@ describe("SessionRuntimeManager", () => {
       toolHost: {} as RuntimeToolHost,
       workspace: {} as AgentWorkspaceManager,
     });
-    expect(providerUnavailable.validate(snapshot(1))).toBe("provider_unavailable");
+    expect(providerUnavailable.validate(snapshot(1))).toBeUndefined();
     const registered = new SessionRuntimeManager({
       bindingStore: {} as SessionBindingStore,
       providers: await providerRegistry(factory),
@@ -128,7 +139,8 @@ describe("SessionRuntimeManager", () => {
     );
     expect(registered.validate({ ...snapshot(1), allowedTools: ["unknown"] })).toBe("configuration_unsupported");
     expect(() => registered.runtime("missing")).toThrow("not ready");
-    expect(() => registered.cwd("missing")).toThrow("not ready");
+    await expect(registered.ensureRuntime("missing")).rejects.toThrow("not been prepared");
+    expect(() => registered.cwd("missing")).toThrow("not been prepared");
     expect(() => registered.observe("missing", () => undefined)).toThrow("not ready");
     const stopSession = vi.fn(async () => undefined);
     const stoppable = new SessionRuntimeManager({
@@ -156,7 +168,8 @@ describe("SessionRuntimeManager", () => {
       workspace,
     });
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
-    await expect(reconciler.reconcile(reconcile(computerId, snapshot(1)))).rejects.toThrow("durable binding");
+    await expect(reconciler.reconcile(reconcile(computerId, snapshot(1)))).resolves.toMatchObject({ status: "ready" });
+    await expect(manager.ensureRuntime("session-1")).rejects.toThrow("durable binding");
     expect(factory.runtimes[0]?.closed).toBe(true);
     toolHost.close();
   });
@@ -177,9 +190,8 @@ describe("SessionRuntimeManager", () => {
     });
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
 
-    await expect(reconciler.reconcile(reconcile(computerId, snapshot(1)))).rejects.toThrow(
-      "creation and cleanup both failed",
-    );
+    await expect(reconciler.reconcile(reconcile(computerId, snapshot(1)))).resolves.toMatchObject({ status: "ready" });
+    await expect(manager.ensureRuntime("session-1")).rejects.toThrow("creation and cleanup both failed");
     expect(factory.runtimes[0]?.closeCalls).toBe(1);
     toolHost.close();
   });
@@ -204,6 +216,7 @@ describe("SessionRuntimeManager", () => {
     });
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
     await reconciler.reconcile(reconcile(computerId, snapshot(1)));
+    await manager.ensureRuntime("session-1");
 
     const first = manager.close();
     const second = manager.close();
@@ -246,8 +259,14 @@ describe("SessionRuntimeManager", () => {
     });
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
     const request = reconcile(computerId, snapshot(1));
-    const preparing = reconciler.reconcile(request);
+    await reconciler.reconcile(request);
+    const starting = manager.ensureRuntime("session-1");
     await createStart;
+    const cancelledWaiter = new AbortController();
+    const joined = manager.ensureRuntime("session-1", cancelledWaiter.signal);
+    await Promise.resolve();
+    cancelledWaiter.abort(new Error("stop joined start"));
+    await expect(joined).rejects.toThrow("stop joined start");
 
     const closing = manager.close();
     let settled = false;
@@ -259,7 +278,7 @@ describe("SessionRuntimeManager", () => {
     expect(factory.runtimes[0]?.closeCalls).toBe(0);
 
     releaseCreate();
-    await expect(preparing).rejects.toThrow("manager is closing");
+    await expect(starting).rejects.toThrow("manager is closing");
     await expect(closing).resolves.toBeUndefined();
     expect(factory.runtimes[0]?.closeCalls).toBe(1);
     expect(factory.runtimes[0]?.closed).toBe(true);
@@ -268,6 +287,93 @@ describe("SessionRuntimeManager", () => {
       "manager is closing",
     );
     toolHost.close();
+  });
+
+  it("waits for an in-flight Provider start before applying a snapshot upgrade", async () => {
+    const home = await mkdtemp(resolve(tmpdir(), "opentag-session-runtime-start-upgrade-"));
+    homes.push(home);
+    const store = new SessionBindingStore({ home, providerArtifactIdentity: () => "a".repeat(64) });
+    const workspace = new AgentWorkspaceManager({ home, bindingStore: store });
+    const toolHost = new RuntimeToolHost(connection());
+    let releaseCreate!: () => void;
+    const createGate = new Promise<void>((resolveCreate) => {
+      releaseCreate = resolveCreate;
+    });
+    let createStarted!: () => void;
+    const createStart = new Promise<void>((resolveStarted) => {
+      createStarted = resolveStarted;
+    });
+    const factory = new FakeFactory(false, undefined, createGate, createStarted);
+    const computerId = randomUUID();
+    const manager = new SessionRuntimeManager({
+      bindingStore: store,
+      providers: await providerRegistry(factory),
+      toolHost,
+      workspace,
+    });
+    const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
+    await reconciler.reconcile(reconcile(computerId, snapshot(1)));
+    const starting = manager.ensureRuntime("session-1");
+    await createStart;
+
+    const upgrading = reconciler.reconcile(reconcile(computerId, snapshot(2)));
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+    releaseCreate();
+    await expect(starting).resolves.toBe(factory.runtimes[0]);
+    await expect(upgrading).resolves.toMatchObject({ status: "ready" });
+    expect(factory.runtimes[0]?.closed).toBe(true);
+    expect(() => manager.runtime("session-1")).toThrow("not ready");
+    await manager.close();
+    toolHost.close();
+  });
+
+  it("continues a snapshot upgrade after an in-flight Provider start fails", async () => {
+    let releaseCreate!: () => void;
+    const createGate = new Promise<void>((resolveCreate) => {
+      releaseCreate = resolveCreate;
+    });
+    let createStarted!: () => void;
+    const createStart = new Promise<void>((resolveStarted) => {
+      createStarted = resolveStarted;
+    });
+    const base = new FakeFactory();
+    const factory = {
+      manifest: base.manifest,
+      probe: () => base.probe(),
+      create: async () => {
+        createStarted();
+        await createGate;
+        throw new Error("start failed");
+      },
+      resume: async () => {
+        throw new Error("resume failed");
+      },
+    } satisfies AgentRuntimeFactory;
+    const computerId = randomUUID();
+    const first = reconcile(computerId, snapshot(1));
+    const upgraded = reconcile(computerId, snapshot(2));
+    const prepared = { binding: { sessionId: "session-1", runtimeBinding: undefined } as never };
+    const manager = new SessionRuntimeManager({
+      bindingStore: {} as SessionBindingStore,
+      providers: await providerRegistry(factory),
+      toolHost: {
+        hostedTools: () => ({ definitions: [], handler: async () => ({ success: true, content: [] }) }),
+      } as unknown as RuntimeToolHost,
+      workspace: {
+        prepareSession: async () => prepared,
+        cwd: async () => "/workspace",
+      } as unknown as AgentWorkspaceManager,
+    });
+    await manager.prepareSession(first, computeRuntimeSnapshotHashes(first.runtime as never));
+    const starting = manager.ensureRuntime("session-1");
+    await createStart;
+
+    const upgrading = manager.prepareSession(upgraded, computeRuntimeSnapshotHashes(upgraded.runtime as never));
+    await Promise.resolve();
+    releaseCreate();
+    await expect(starting).rejects.toThrow("start failed");
+    await expect(upgrading).resolves.toBe(prepared);
+    await manager.close();
   });
 
   it("surfaces failure while closing a runtime created after shutdown starts", async () => {
@@ -293,12 +399,13 @@ describe("SessionRuntimeManager", () => {
       workspace,
     });
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
-    const preparing = reconciler.reconcile(reconcile(computerId, snapshot(1)));
+    await reconciler.reconcile(reconcile(computerId, snapshot(1)));
+    const starting = manager.ensureRuntime("session-1");
     await createStart;
 
     const closing = manager.close();
     releaseCreate();
-    await expect(preparing).rejects.toThrow("manager is closing");
+    await expect(starting).rejects.toThrow("manager is closing");
     await expect(closing).rejects.toThrow("failed to close");
     expect(factory.runtimes[0]?.closeCalls).toBe(1);
     toolHost.close();
@@ -323,7 +430,7 @@ describe("SessionRuntimeManager", () => {
       saveRuntimeBinding: async (...args: Parameters<SessionBindingStore["saveRuntimeBinding"]>) => {
         const binding = await store.saveRuntimeBinding(...args);
         saveCalls += 1;
-        if (saveCalls === 2) {
+        if (saveCalls === 1) {
           persistStarted();
           await persistGate;
         }
@@ -339,7 +446,8 @@ describe("SessionRuntimeManager", () => {
       workspace,
     });
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
-    const preparing = reconciler.reconcile(reconcile(computerId, snapshot(1)));
+    await reconciler.reconcile(reconcile(computerId, snapshot(1)));
+    const starting = manager.ensureRuntime("session-1");
     await persistStart;
 
     const closing = manager.close();
@@ -356,9 +464,9 @@ describe("SessionRuntimeManager", () => {
     expect(closeSettled).toBe(false);
     releasePersist();
 
-    await expect(preparing).rejects.toThrow("manager is closing");
-    await expect(closing).rejects.toThrow("failed to close");
-    expect(factory.runtimes[0]?.closeCalls).toBe(1);
+    await expect(starting).rejects.toThrow("manager is closing");
+    await expect(closing).resolves.toBeUndefined();
+    expect(factory.runtimes).toHaveLength(0);
     expect(() => manager.runtime("session-1")).toThrow("manager is closing");
     toolHost.close();
   });
@@ -383,6 +491,7 @@ describe("SessionRuntimeManager", () => {
     });
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
     await reconciler.reconcile(reconcile(computerId, snapshot(1)));
+    await manager.ensureRuntime("session-1");
 
     const upgrading = reconciler.reconcile(reconcile(computerId, snapshot(2)));
     await vi.waitFor(() => expect(factory.runtimes[0]?.closeCalls).toBe(1));
@@ -410,6 +519,7 @@ describe("SessionRuntimeManager", () => {
     });
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
     await reconciler.reconcile(reconcile(computerId, snapshot(1)));
+    await manager.ensureRuntime("session-1");
 
     await expect(manager.close()).rejects.toThrow("failed to close");
     expect(factory.runtimes[0]?.closeCalls).toBe(1);
@@ -452,7 +562,7 @@ describe("SessionRuntimeManager", () => {
     await expect(unavailable.prepareSession({ ...request, runtime: undefined }, hashes)).rejects.toThrow(
       "runtime snapshot",
     );
-    await expect(unavailable.prepareSession(request, hashes)).rejects.toThrow("provider is unavailable");
+    await expect(unavailable.prepareSession(request, hashes)).rejects.toThrow("provider is not registered");
 
     const factory = new FakeFactory();
     const captured: CreateAgentRuntimeRequest[] = [];
@@ -461,16 +571,25 @@ describe("SessionRuntimeManager", () => {
       probe: () => factory.probe(),
       create: async (input: CreateAgentRuntimeRequest) => {
         captured.push(input);
-        return factory.create(input);
+        const runtime = new FakeRuntime(binding("thread-missing"), input.eventSink);
+        factory.runtimes.push(runtime);
+        return runtime;
       },
       resume: (input: ResumeAgentRuntimeRequest) => factory.resume(input),
+    } satisfies AgentRuntimeFactory;
+    const emittingFactory = {
+      ...policyFactory,
+      create: async (input: CreateAgentRuntimeRequest) => {
+        captured.push(input);
+        return factory.create(input);
+      },
     } satisfies AgentRuntimeFactory;
     const missingBinding = new SessionRuntimeManager({
       bindingStore: {
         saveRuntimeBinding: async () => undefined,
         read: async () => undefined,
       } as unknown as SessionBindingStore,
-      providers: await providerRegistry(policyFactory),
+      providers: await providerRegistry(emittingFactory),
       toolHost: {
         hostedTools: () => ({ definitions: [], handler: async () => ({ success: true, content: [] }) }),
       } as unknown as RuntimeToolHost,
@@ -485,14 +604,49 @@ describe("SessionRuntimeManager", () => {
       reasoningEffort: "high",
       execution: { approvalPolicy: "never", networkAccess: true },
     } as unknown as EffectiveRuntimeSnapshot;
-    await expect(missingBinding.prepareSession({ ...request, runtime: policySnapshot }, hashes)).rejects.toThrow(
-      "binding disappeared",
-    );
+    await expect(missingBinding.prepareSession({ ...request, runtime: policySnapshot }, hashes)).resolves.toBeDefined();
+    await expect(missingBinding.ensureRuntime("session-1")).rejects.toThrow("binding disappeared");
     expect(captured[0]).toMatchObject({
       configuration: { reasoningEffort: "high" },
       policy: { approvals: "never", network: "enabled" },
     });
+    expect(factory.runtimes).toHaveLength(0);
+
+    const missingFinalBinding = new SessionRuntimeManager({
+      bindingStore: {
+        saveRuntimeBinding: async () => undefined,
+      } as unknown as SessionBindingStore,
+      providers: await providerRegistry(policyFactory),
+      toolHost: {
+        hostedTools: () => ({ definitions: [], handler: async () => ({ success: true, content: [] }) }),
+      } as unknown as RuntimeToolHost,
+      workspace: {
+        prepareSession: async () => prepared,
+        cwd: async () => "/workspace",
+      } as unknown as AgentWorkspaceManager,
+    });
+    await missingFinalBinding.prepareSession({ ...request, runtime: policySnapshot }, hashes);
+    await expect(missingFinalBinding.ensureRuntime("session-1")).rejects.toThrow("binding disappeared");
     expect(factory.runtimes[0]?.closed).toBe(true);
+    await missingFinalBinding.close();
+
+    const savedBinding = { ...prepared.binding, runtimeBinding: binding("thread-saved") } as never;
+    const saved = new SessionRuntimeManager({
+      bindingStore: {
+        saveRuntimeBinding: async () => savedBinding,
+      } as unknown as SessionBindingStore,
+      providers: await providerRegistry(policyFactory),
+      toolHost: {
+        hostedTools: () => ({ definitions: [], handler: async () => ({ success: true, content: [] }) }),
+      } as unknown as RuntimeToolHost,
+      workspace: {
+        prepareSession: async () => prepared,
+        cwd: async () => "/workspace",
+      } as unknown as AgentWorkspaceManager,
+    });
+    await saved.prepareSession({ ...request, runtime: policySnapshot }, hashes);
+    await expect(saved.ensureRuntime("session-1")).resolves.toMatchObject({ binding: binding("thread-missing") });
+    await saved.close();
   });
 });
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -139,6 +139,7 @@ export {
 export {
   type AgentRuntimeProviderRegistration,
   AgentRuntimeProviderRegistry,
+  AgentRuntimeProviderUnavailableError,
 } from "./runtime/agent-runtime-provider-registry.js";
 export { AgentTurnRunner, type AgentTurnRunnerOptions, buildAgentInput } from "./runtime/agent-turn-runner.js";
 export {
@@ -156,7 +157,10 @@ export {
   ComposedClientRuntime,
   type CreateClientRuntimeOptions,
   createClientRuntime,
+  providerReadiness,
+  type ResolvedClaudeCodeFactoryOptions,
   resolveCodexHome,
+  resolvedClaudeCodeFactory,
 } from "./runtime/client-runtime-composition.js";
 export {
   COMPUTER_IDENTITY_FILE_NAME,
@@ -210,7 +214,11 @@ export {
   type SessionRuntimeState,
   type SessionTurnIdentity,
 } from "./runtime/session-reconciler.js";
-export { SessionRuntimeManager, type SessionRuntimeManagerOptions } from "./runtime/session-runtime-manager.js";
+export {
+  ClientRuntimeProviderStartError,
+  SessionRuntimeManager,
+  type SessionRuntimeManagerOptions,
+} from "./runtime/session-runtime-manager.js";
 export {
   TURN_TRACE_BATCH_SOFT_LIMIT_BYTES,
   TURN_TRACE_MAX_BUFFER_BYTES,

--- a/packages/client/src/providers/claude-code/agent-runtime.ts
+++ b/packages/client/src/providers/claude-code/agent-runtime.ts
@@ -7,6 +7,7 @@ import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/error
 import {
   AGENT_RUNTIME_CONTRACT_VERSION,
   type AgentAbortRequest,
+  type AgentHostedTools,
   type AgentPromptRequest,
   type AgentProviderRunContext,
   type AgentProviderRunResult,
@@ -21,7 +22,13 @@ import {
   type JsonValue,
   type ResumeAgentRuntimeRequest,
 } from "../../agent-runtime/types.js";
-import { assertBinding, assertJsonValue, runWithAbortSignal } from "../../agent-runtime/validation.js";
+import {
+  assertBinding,
+  assertHostedTools,
+  assertJsonValue,
+  runWithAbortSignal,
+} from "../../agent-runtime/validation.js";
+import { type ClaudeCodeHostedToolBridge, startClaudeCodeHostedToolBridge } from "./hosted-tool-bridge.js";
 import {
   ClaudeCodeProcess,
   type ClaudeCodeProcessClient,
@@ -52,6 +59,7 @@ interface ClaudeCodeRuntimeOptions {
   readonly configuration?: AgentRunConfiguration;
   readonly createProcess: (args: readonly string[]) => ClaudeCodeProcessClient;
   readonly eventSink: AgentRuntimeEventSink;
+  readonly hostedTools?: AgentHostedTools;
   readonly resume: boolean;
 }
 
@@ -109,6 +117,7 @@ export class ClaudeCodeAgentRuntime extends BaseAgentRuntime {
   readonly #sessionId: string;
   readonly #configuration?: AgentRunConfiguration;
   readonly #createProcess: (args: readonly string[]) => ClaudeCodeProcessClient;
+  readonly #hostedTools?: AgentHostedTools;
   readonly #textBlocks = new Map<string, TextBlockState>();
   readonly #tools = new Map<string, ToolState>();
   readonly #toolBlocks = new Map<string, string>();
@@ -133,6 +142,7 @@ export class ClaudeCodeAgentRuntime extends BaseAgentRuntime {
     this.#sessionId = parseClaudeCodeBinding(options.binding);
     this.#configuration = options.configuration;
     this.#createProcess = options.createProcess;
+    this.#hostedTools = options.hostedTools;
     this.#sessionExists = options.resume;
   }
 
@@ -151,8 +161,10 @@ export class ClaudeCodeAgentRuntime extends BaseAgentRuntime {
     this.#startedModelTurns.clear();
     this.#completedModelTurns.clear();
     let process: ClaudeCodeProcessClient | undefined;
+    let hostedToolBridge: ClaudeCodeHostedToolBridge | undefined;
     try {
-      process = this.#createProcess(this.#arguments(request));
+      hostedToolBridge = await startClaudeCodeHostedToolBridge(this.#hostedTools, request.runId, context.signal);
+      process = this.#createProcess(this.#arguments(request, hostedToolBridge));
       this.#process = process;
       await process.execute(claudeCodeInput(request), (message) => this.#enqueue(message), context.signal);
       await this.#eventTail;
@@ -177,6 +189,7 @@ export class ClaudeCodeAgentRuntime extends BaseAgentRuntime {
       /* v8 ignore next -- finally is mandatory cleanup; V8 reports a synthetic branch for its closing token. */
     } finally {
       await process?.close().catch(() => undefined);
+      await hostedToolBridge?.close();
       this.#process = undefined;
       this.#context = undefined;
       this.#currentMessageId = undefined;
@@ -195,7 +208,7 @@ export class ClaudeCodeAgentRuntime extends BaseAgentRuntime {
     await this.#process?.close();
   }
 
-  #arguments(request: AgentPromptRequest): readonly string[] {
+  #arguments(request: AgentPromptRequest, hostedToolBridge: ClaudeCodeHostedToolBridge): readonly string[] {
     const configuration = mergeConfiguration(this.#configuration, request.configuration);
     const provider = parseProviderConfiguration(configuration?.provider);
     const args = [
@@ -209,6 +222,10 @@ export class ClaudeCodeAgentRuntime extends BaseAgentRuntime {
       "--no-chrome",
       "--setting-sources",
       "",
+      "--strict-mcp-config",
+      "--mcp-config",
+      hostedToolBridge.configPath,
+      ...(hostedToolBridge.allowedTools.length > 0 ? ["--allowedTools", ...hostedToolBridge.allowedTools] : []),
       ...(this.#sessionExists ? ["--resume", this.#sessionId] : ["--session-id", this.#sessionId]),
       "--permission-mode",
       "bypassPermissions",
@@ -606,6 +623,7 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
         configuration: request.configuration,
         createProcess: (args) => this.#createProcess(request.workspace.cwd, args),
         eventSink: request.eventSink,
+        hostedTools: request.hostedTools,
         resume: mode === "resume",
       });
     } catch (error) {
@@ -620,6 +638,7 @@ export function claudeCodeAgentRuntimeEnvironment(source: NodeJS.ProcessEnv = pr
   const exact = new Set([
     "APPDATA",
     "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CONFIG_DIR",
     "CLAUDE_CODE_USE_BEDROCK",
     "CLAUDE_CODE_USE_FOUNDRY",
     "CLAUDE_CODE_USE_VERTEX",
@@ -674,7 +693,10 @@ async function probeClaudeCode(
   const streamJson =
     helpResult.stdout.includes("stream-json") &&
     helpResult.stdout.includes("--session-id") &&
-    helpResult.stdout.includes("--resume");
+    helpResult.stdout.includes("--resume") &&
+    helpResult.stdout.includes("--mcp-config") &&
+    helpResult.stdout.includes("--strict-mcp-config") &&
+    helpResult.stdout.includes("--allowedTools");
   const credential =
     hasCredentialEnvironment(environment) || (await probeClaudeCodeCredential(command, execution, signal));
   return { credential, streamJson, version };
@@ -755,6 +777,15 @@ function validateFactoryRequest(request: CreateAgentRuntimeRequest): void {
     throw new AgentRuntimeError(
       "configuration_invalid",
       "Claude Code does not implement the common tool allow-list contract",
+    );
+  }
+  if (request.hostedTools) {
+    assertHostedTools(
+      {
+        ...request.policy,
+        tools: { mode: "allow-list", names: request.hostedTools.definitions.map(({ name }) => name) },
+      },
+      request.hostedTools,
     );
   }
 }

--- a/packages/client/src/providers/claude-code/hosted-tool-bridge.ts
+++ b/packages/client/src/providers/claude-code/hosted-tool-bridge.ts
@@ -1,0 +1,273 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentHostedTools, JsonValue } from "../../agent-runtime/types.js";
+import { assertJsonValue } from "../../agent-runtime/validation.js";
+
+const MAX_REQUEST_BYTES = 1024 * 1024;
+const MCP_PROTOCOL_VERSION = "2025-03-26";
+
+export interface ClaudeCodeHostedToolBridge {
+  readonly allowedTools: readonly string[];
+  readonly configPath: string;
+  close(): Promise<void>;
+}
+
+export async function startClaudeCodeHostedToolBridge(
+  hostedTools: AgentHostedTools | undefined,
+  runId: string,
+  signal: AbortSignal,
+): Promise<ClaudeCodeHostedToolBridge> {
+  signal.throwIfAborted();
+  const definitions = new Map((hostedTools?.definitions ?? []).map((definition) => [definition.name, definition]));
+  if (hostedTools && definitions.size !== hostedTools.definitions.length) {
+    throw new Error("Claude Code hosted tool definitions must have unique names");
+  }
+
+  const directory = await mkdtemp(join(tmpdir(), "opentag-claude-mcp-"));
+  const configPath = join(directory, "mcp.json");
+  let server: Server | undefined;
+  try {
+    let configuration: Record<string, unknown> = { mcpServers: {} };
+    if (hostedTools && definitions.size > 0) {
+      const token = randomBytes(32).toString("base64url");
+      server = createServer((request, response) => {
+        void handleRequest(server as Server, request, response, {
+          definitions,
+          hostedTools,
+          runId,
+          signal,
+          token,
+        }).catch(() => {
+          /* v8 ignore next 2 -- only a socket failure after response headers can reach the destroy branch. */
+          if (!response.headersSent) writeJson(response, 500, jsonRpcError(null, -32603, "Internal error"));
+          else response.destroy();
+        });
+      });
+      await listen(server);
+      const address = server.address();
+      /* v8 ignore start -- a successful TCP listen always exposes an AddressInfo object. */
+      if (!address || typeof address === "string") {
+        throw new Error("Claude Code hosted tool bridge did not bind a TCP port");
+      }
+      /* v8 ignore stop */
+      configuration = {
+        mcpServers: {
+          opentag: {
+            type: "http",
+            url: `http://127.0.0.1:${address.port}/mcp`,
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        },
+      };
+    }
+    await writeFile(configPath, `${JSON.stringify(configuration)}\n`, { encoding: "utf8", mode: 0o600 });
+    /* v8 ignore start -- deterministic setup tests cannot induce an owned 0600 temp-file write failure. */
+  } catch (error) {
+    await Promise.allSettled([
+      ...(server ? [closeServer(server)] : []),
+      rm(directory, { recursive: true, force: true }),
+    ]);
+    throw error;
+  }
+  /* v8 ignore stop */
+
+  let closePromise: Promise<void> | undefined;
+  return {
+    allowedTools: [...definitions.keys()].map((name) => `mcp__opentag__${name}`),
+    configPath,
+    close() {
+      closePromise ??= Promise.allSettled([
+        ...(server ? [closeServer(server)] : []),
+        rm(directory, { recursive: true, force: true }),
+      ]).then((results) => {
+        /* v8 ignore start -- owned server/temp-directory cleanup failures are OS-level and not deterministically injectable. */
+        const failures = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+        if (failures.length > 0) throw new AggregateError(failures, "Claude Code hosted tool bridge cleanup failed");
+        /* v8 ignore stop */
+      });
+      return closePromise;
+    },
+  };
+}
+
+interface RequestContext {
+  readonly definitions: ReadonlyMap<string, AgentHostedTools["definitions"][number]>;
+  readonly hostedTools: AgentHostedTools;
+  readonly runId: string;
+  readonly signal: AbortSignal;
+  readonly token: string;
+}
+
+async function handleRequest(
+  server: Server,
+  request: IncomingMessage,
+  response: ServerResponse,
+  context: RequestContext,
+): Promise<void> {
+  response.setHeader("Connection", "close");
+  const address = server.address();
+  /* v8 ignore next -- this owned server remains listening for the request lifetime. */
+  const expectedHost = address && typeof address !== "string" ? `127.0.0.1:${address.port}` : "";
+  if (
+    request.method !== "POST" ||
+    request.url !== "/mcp" ||
+    request.headers.host !== expectedHost ||
+    request.headers.authorization !== `Bearer ${context.token}`
+  ) {
+    writeJson(response, 404, jsonRpcError(null, -32600, "Invalid request"));
+    return;
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(await readBody(request));
+  } catch {
+    writeJson(response, 400, jsonRpcError(null, -32700, "Parse error"));
+    return;
+  }
+  const rpc = record(body);
+  if (rpc?.jsonrpc !== "2.0" || typeof rpc.method !== "string") {
+    writeJson(response, 400, jsonRpcError(null, -32600, "Invalid request"));
+    return;
+  }
+  const id = validRpcId(rpc.id) ? rpc.id : null;
+  if (rpc.id === undefined) {
+    response.writeHead(202).end();
+    return;
+  }
+  if (rpc.method === "initialize") {
+    writeJson(response, 200, {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: "OpenTag", version: "1" },
+      },
+    });
+    return;
+  }
+  if (rpc.method === "tools/list") {
+    writeJson(response, 200, {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        tools: [...context.definitions.values()].map((definition) => ({
+          name: definition.name,
+          ...(definition.description ? { description: definition.description } : {}),
+          inputSchema: definition.inputSchema,
+        })),
+      },
+    });
+    return;
+  }
+  if (rpc.method === "tools/call") {
+    const params = record(rpc.params);
+    const name = params?.name;
+    if (typeof name !== "string" || !context.definitions.has(name)) {
+      writeJson(response, 200, failedToolResult(id, "OpenTag hosted tool is unavailable."));
+      return;
+    }
+    let input: JsonValue;
+    try {
+      const candidate = params?.arguments === undefined ? {} : params.arguments;
+      assertJsonValue(candidate, "MCP tool arguments");
+      input = candidate as JsonValue;
+    } catch (error) {
+      writeJson(response, 200, failedToolResult(id, (error as Error).message));
+      return;
+    }
+    const result = await context.hostedTools.handler({
+      runId: context.runId,
+      toolCallId: rpcToolCallId(id),
+      name,
+      input,
+      signal: context.signal,
+    });
+    writeJson(response, 200, {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        content: result.content,
+        isError: !result.success,
+        ...(result.error ? { structuredContent: { error: result.error } } : {}),
+      },
+    });
+    return;
+  }
+  writeJson(response, 200, jsonRpcError(id, -32601, "Method not found"));
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    /* v8 ignore next -- port zero on loopback has no expected contention failure. */
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    /* v8 ignore next -- Node does not report a close error for this owned listening server. */
+    server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections();
+  });
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    request.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_REQUEST_BYTES) {
+        reject(new Error("MCP request is too large"));
+        request.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    /* v8 ignore next -- malformed/oversized bodies are handled before transport-level request failure. */
+    request.on("error", reject);
+  });
+}
+
+function writeJson(response: ServerResponse, status: number, value: unknown): void {
+  const body = JSON.stringify(value);
+  response.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(body),
+  });
+  response.end(body);
+}
+
+function jsonRpcError(id: string | number | null, code: number, message: string): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+function failedToolResult(id: string | number | null, text: string): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, result: { content: [{ type: "text", text }], isError: true } };
+}
+
+function rpcToolCallId(id: string | number | null): string {
+  if (typeof id === "string" && id.length > 0 && Buffer.byteLength(id, "utf8") <= 256) return id;
+  if (typeof id === "number") return String(id);
+  return randomUUID();
+}
+
+function validRpcId(value: unknown): value is string | number | null {
+  return value === null || typeof value === "string" || (typeof value === "number" && Number.isFinite(value));
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/packages/client/src/providers/claude-code/runtime-policy.ts
+++ b/packages/client/src/providers/claude-code/runtime-policy.ts
@@ -1,0 +1,21 @@
+import { type EffectiveRuntimeSnapshot, type InputRejectReason, OPENTAG_MESSAGE_TOOLS } from "@opentag/shared";
+import type { AgentRuntimePolicy } from "../../agent-runtime/types.js";
+
+const OPENTAG_TOOL_SET: ReadonlySet<string> = new Set(OPENTAG_MESSAGE_TOOLS);
+
+export function claudeCodeRuntimePolicy(_snapshot: EffectiveRuntimeSnapshot): AgentRuntimePolicy {
+  return {
+    fileSystem: "unrestricted",
+    network: "enabled",
+    approvals: "never",
+    tools: { mode: "provider-default" },
+  };
+}
+
+export function validateClaudeCodeRuntimePolicy(snapshot: EffectiveRuntimeSnapshot): InputRejectReason | undefined {
+  if (snapshot.execution.approvalPolicy !== "never" || !snapshot.execution.networkAccess) {
+    return "configuration_unsupported";
+  }
+  if (snapshot.allowedTools.some((tool) => !OPENTAG_TOOL_SET.has(tool))) return "configuration_unsupported";
+  return undefined;
+}

--- a/packages/client/src/runtime/agent-runtime-provider-registry.ts
+++ b/packages/client/src/runtime/agent-runtime-provider-registry.ts
@@ -1,4 +1,4 @@
-import type { EffectiveRuntimeSnapshot, InputRejectReason } from "@opentag/shared";
+import type { AgentRuntimeProvider, EffectiveRuntimeSnapshot, InputRejectReason } from "@opentag/shared";
 import { isAgentRuntimeProviderId } from "../agent-runtime/provider-id.js";
 import type { AgentRuntimeFactory, AgentRuntimePolicy, AgentRuntimeProbeResult } from "../agent-runtime/types.js";
 
@@ -15,6 +15,18 @@ interface ProviderProbe {
   readonly promise: Promise<void>;
   settled: boolean;
   waiters: number;
+}
+
+export class AgentRuntimeProviderUnavailableError extends Error {
+  constructor(
+    readonly providerId: string,
+    readonly result: AgentRuntimeProbeResult,
+    options?: ErrorOptions,
+  ) {
+    const detail = result.issues.map((issue) => `${issue.code}: ${issue.message}`).join("; ") || "not ready";
+    super(`Agent Runtime provider is unavailable (${providerId}): ${detail}`, options);
+    this.name = "AgentRuntimeProviderUnavailableError";
+  }
 }
 
 export class AgentRuntimeProviderRegistry {
@@ -38,6 +50,10 @@ export class AgentRuntimeProviderRegistry {
 
   registration(providerId: string): AgentRuntimeProviderRegistration | undefined {
     return this.#providers.get(providerId);
+  }
+
+  providerIds(): readonly AgentRuntimeProvider[] {
+    return [...this.#providers.keys()] as AgentRuntimeProvider[];
   }
 
   artifactIdentity(providerId: string): string | undefined {
@@ -95,7 +111,7 @@ export class AgentRuntimeProviderRegistry {
         const result = await provider.factory.probe({ signal: controller.signal });
         if (this.#probes.get(providerId) === record) this.#probeResults.set(providerId, result);
         if (!result.ready) {
-          throw new Error(result.issues.map((issue) => `${issue.code}: ${issue.message}`).join("; "));
+          throw new AgentRuntimeProviderUnavailableError(providerId, result);
         }
         try {
           await provider.verifyArtifact?.(controller.signal);
@@ -106,7 +122,14 @@ export class AgentRuntimeProviderRegistry {
               issues: [{ code: "temporarily_unavailable", message: "Provider artifact verification failed" }],
             });
           }
-          throw error;
+          throw new AgentRuntimeProviderUnavailableError(
+            providerId,
+            {
+              ready: false,
+              issues: [{ code: "temporarily_unavailable", message: "Provider artifact verification failed" }],
+            },
+            { cause: error },
+          );
         }
         controller.signal.throwIfAborted();
         if (this.#probes.get(providerId) === record) this.#ready.add(providerId);

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -7,11 +7,12 @@ import {
 } from "@opentag/shared";
 import type { AgentInput, AgentRunResult, AgentRuntimeEvent } from "../agent-runtime/types.js";
 import { type ClientLogger, createLogger } from "../observability/logger.js";
+import { AgentRuntimeProviderUnavailableError } from "./agent-runtime-provider-registry.js";
 import type { ImResourceFetcher } from "./im-resource-fetcher.js";
 import type { RuntimeConnection } from "./runtime-connection.js";
 import type { RuntimeToolHost } from "./runtime-tool-host.js";
 import type { SessionBindingStore } from "./session-binding-store.js";
-import type { SessionRuntimeManager } from "./session-runtime-manager.js";
+import { ClientRuntimeProviderStartError, type SessionRuntimeManager } from "./session-runtime-manager.js";
 import { TurnTraceBuffer } from "./trace-buffer.js";
 import type { LiveTurnOwner, TurnCustodyOwner } from "./turn-custody-owner.js";
 import type { TurnReportOwner } from "./turn-report-owner.js";
@@ -123,7 +124,7 @@ export class AgentTurnRunner {
         owner.turnId,
         "starting",
       );
-      const runtime = this.#runtimeManager.runtime(owner.request.sessionId);
+      const runtime = await this.#runtimeManager.ensureRuntime(owner.request.sessionId, signal);
       const cwd = this.#runtimeManager.cwd(owner.request.sessionId);
       const supplementalContext = await this.#resourceFetcher?.fetchForTurn(owner.request, cwd);
       releaseTools = this.#toolHost.activateRun(owner.turnId, owner.request, owner.request.runtime.allowedTools);
@@ -280,12 +281,24 @@ export function completionForResult(result: AgentRunResult, abortReason: unknown
   };
 }
 
-export function completionForError(_error: unknown, abortReason: unknown): TurnCompletion {
+export function completionForError(error: unknown, abortReason: unknown): TurnCompletion {
   if (abortReason === "client_shutdown") {
     return { outcome: "cancelled", executionEffects: "may_have_occurred", errorReason: "client_shutdown" };
   }
   if (abortReason === "turn_timeout") {
     return { outcome: "failed", executionEffects: "may_have_occurred", errorReason: "turn_timeout" };
+  }
+  if (error instanceof AgentRuntimeProviderUnavailableError) {
+    return {
+      outcome: "failed",
+      executionEffects: "not_started",
+      errorReason: error.result.issues.some((issue) => issue.code === "credential_missing")
+        ? "credential_unavailable"
+        : "provider_start_failed",
+    };
+  }
+  if (error instanceof ClientRuntimeProviderStartError) {
+    return { outcome: "failed", executionEffects: "not_started", errorReason: "provider_start_failed" };
   }
   return { outcome: "unknown", executionEffects: "may_have_occurred", errorReason: "turn_state_unknown" };
 }

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -4,6 +4,7 @@ import { access, mkdir, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { delimiter, isAbsolute, join, resolve } from "node:path";
 import {
+  type AgentRuntimeProvider,
   computeRuntimeSnapshotHashes,
   RUNTIME_CLIENT_CAPABILITY_TTL_MS,
   type RuntimeProviderReadinessObservation,
@@ -18,6 +19,12 @@ import type {
 import type { OpenTagApi } from "../api.js";
 import type { AccessTokenProvider } from "../auth/token-provider.js";
 import { type ClientLogger, createLogger } from "../observability/logger.js";
+import {
+  CLAUDE_CODE_AGENT_RUNTIME_MANIFEST,
+  ClaudeCodeAgentRuntimeFactory,
+  claudeCodeAgentRuntimeEnvironment,
+} from "../providers/claude-code/agent-runtime.js";
+import { claudeCodeRuntimePolicy, validateClaudeCodeRuntimePolicy } from "../providers/claude-code/runtime-policy.js";
 import {
   CODEX_AGENT_RUNTIME_MANIFEST,
   CodexAgentRuntimeFactory,
@@ -50,8 +57,11 @@ export interface CreateClientRuntimeOptions {
   readonly clientVersion: string;
   readonly codexCommand?: string;
   readonly codexHome?: string;
+  readonly claudeCodeCommand?: string;
+  readonly claudeCodeHome?: string;
   readonly environment?: NodeJS.ProcessEnv;
   readonly factory?: AgentRuntimeFactory;
+  readonly factories?: readonly AgentRuntimeFactory[];
   readonly home: string;
   readonly logger?: ClientLogger;
   readonly signal?: AbortSignal;
@@ -166,41 +176,72 @@ export async function createClientRuntime(
   options.signal?.throwIfAborted();
   const defaultHome = sourceEnvironment.HOME ?? homedir();
   const configuredCodexHome = resolve(options.codexHome ?? sourceEnvironment.CODEX_HOME ?? join(defaultHome, ".codex"));
+  const configuredClaudeCodeHome = resolve(
+    options.claudeCodeHome ?? sourceEnvironment.CLAUDE_CONFIG_DIR ?? join(defaultHome, ".claude"),
+  );
   await mkdir(configuredCodexHome, { recursive: true, mode: 0o700 });
+  await mkdir(configuredClaudeCodeHome, { recursive: true, mode: 0o700 });
   const codexHome = await realpath(configuredCodexHome);
-  const command = options.codexCommand ?? "codex";
+  const claudeCodeHome = await realpath(configuredClaudeCodeHome);
+  const codexCommand = options.codexCommand ?? "codex";
+  const claudeCodeCommand = options.claudeCodeCommand ?? "claude";
   options.signal?.throwIfAborted();
-  const environment = codexAgentRuntimeEnvironment({ ...sourceEnvironment, CODEX_HOME: codexHome });
-  const providerArtifactIdentity = createHash("sha256").update(codexHome, "utf8").digest("hex");
-  const factory =
-    options.factory ??
-    resolvedCodexFactory({
-      clientVersion: options.clientVersion,
-      command,
-      codexHome,
-      environment,
-      sourceEnvironment,
-    });
-  const providers = new AgentRuntimeProviderRegistry([
-    codexProviderRegistration(factory, providerArtifactIdentity, codexHome),
-  ]);
+  const codexEnvironment = codexAgentRuntimeEnvironment({ ...sourceEnvironment, CODEX_HOME: codexHome });
+  const claudeCodeEnvironment = claudeCodeAgentRuntimeEnvironment({
+    ...sourceEnvironment,
+    CLAUDE_CONFIG_DIR: claudeCodeHome,
+  });
+  const providerHomes: Readonly<Record<"codex" | "claude-code", string>> = {
+    codex: codexHome,
+    "claude-code": claudeCodeHome,
+  };
+  const providerArtifactIdentities: Readonly<Record<"codex" | "claude-code", string>> = {
+    codex: createHash("sha256").update(codexHome, "utf8").digest("hex"),
+    "claude-code": createHash("sha256").update(claudeCodeHome, "utf8").digest("hex"),
+  };
+  const factories =
+    options.factories ??
+    (options.factory
+      ? [options.factory]
+      : [
+          resolvedCodexFactory({
+            clientVersion: options.clientVersion,
+            command: codexCommand,
+            codexHome,
+            environment: codexEnvironment,
+            sourceEnvironment,
+          }),
+          resolvedClaudeCodeFactory({
+            claudeCodeHome,
+            command: claudeCodeCommand,
+            environment: claudeCodeEnvironment,
+            sourceEnvironment,
+          }),
+        ]);
+  const providers = new AgentRuntimeProviderRegistry(
+    factories.map((factory) => productionProviderRegistration(factory, providerArtifactIdentities, providerHomes)),
+  );
   const capabilityAbort = new AbortController();
   const readinessSignal = options.signal
     ? AbortSignal.any([options.signal, capabilityAbort.signal])
     : capabilityAbort.signal;
   const refreshCapability = async (): Promise<void> => {
-    const releaseReadiness = providers.isReady(CODEX_AGENT_RUNTIME_MANIFEST.providerId)
-      ? connection.leaseProviderReadiness({ provider: "codex", status: "ready" })
-      : undefined;
-    if (!releaseReadiness) connection.setProviderReadiness({ provider: "codex", status: "checking" });
-    try {
-      const available = await providers.refresh(CODEX_AGENT_RUNTIME_MANIFEST.providerId, readinessSignal);
-      readinessSignal.throwIfAborted();
-      connection.setVerifiedCapabilities({ imMessageTool: available ? 1 : 0 });
-      connection.setProviderReadiness(codexProviderReadiness(available, providers.probeResult("codex")));
-    } finally {
-      releaseReadiness?.();
-    }
+    await Promise.all(
+      providers.providerIds().map(async (providerId) => {
+        const releaseReadiness = providers.isReady(providerId)
+          ? connection.leaseProviderReadiness({ provider: providerId, status: "ready" })
+          : undefined;
+        if (!releaseReadiness) connection.setProviderReadiness({ provider: providerId, status: "checking" });
+        try {
+          const available = await providers.refresh(providerId, readinessSignal);
+          readinessSignal.throwIfAborted();
+          connection.setProviderReadiness(providerReadiness(providerId, available, providers.probeResult(providerId)));
+        } finally {
+          releaseReadiness?.();
+        }
+      }),
+    );
+    connection.setVerifiedCapabilities({ imMessageTool: providers.isReady("codex") ? 1 : 0 });
   };
   try {
     await refreshCapability();
@@ -219,6 +260,7 @@ export async function createClientRuntime(
   const runtimeManager = new SessionRuntimeManager({
     bindingStore,
     providers,
+    readinessSignal,
     toolHost,
     workspace,
   });
@@ -242,8 +284,6 @@ export async function createClientRuntime(
   let runner: AgentTurnRunner;
   const preflight = createClientRuntimePreflight({
     providers,
-    readinessSignal,
-    runtimeManager,
     workspace,
   });
   const custody = new TurnCustodyOwner({
@@ -271,7 +311,7 @@ export async function createClientRuntime(
   return new ComposedClientRuntime(runtime, {
     bindingStore,
     custody,
-    messageToolAvailable: providers.isReady(CODEX_AGENT_RUNTIME_MANIFEST.providerId),
+    messageToolAvailable: providers.providerIds().some((providerId) => providers.isReady(providerId)),
     reconciler,
     reportOwner,
     runner,
@@ -291,14 +331,22 @@ export function codexProviderReadiness(
   available: boolean,
   result: AgentRuntimeProbeResult | undefined,
 ): RuntimeProviderReadinessObservation {
-  if (available) return { provider: "codex", status: "ready" };
+  return providerReadiness("codex", available, result);
+}
+
+export function providerReadiness(
+  provider: AgentRuntimeProvider,
+  available: boolean,
+  result: AgentRuntimeProbeResult | undefined,
+): RuntimeProviderReadinessObservation {
+  if (available) return { provider, status: "ready" };
   if (result?.issues.some((issue) => issue.code === "artifact_missing")) {
-    return { provider: "codex", status: "install" };
+    return { provider, status: "install" };
   }
   if (result?.issues.some((issue) => issue.code === "credential_missing")) {
-    return { provider: "codex", status: "sign-in" };
+    return { provider, status: "sign-in" };
   }
-  return { provider: "codex", status: "unavailable" };
+  return { provider, status: "unavailable" };
 }
 
 export interface ResolvedCodexFactoryOptions {
@@ -309,24 +357,29 @@ export interface ResolvedCodexFactoryOptions {
   readonly sourceEnvironment: NodeJS.ProcessEnv;
 }
 
-function codexProviderRegistration(
+function productionProviderRegistration(
   factory: AgentRuntimeFactory,
-  artifactIdentity: string,
-  codexHome: string,
+  artifactIdentities: Readonly<Record<"codex" | "claude-code", string>>,
+  providerHomes: Readonly<Record<"codex" | "claude-code", string>>,
 ): AgentRuntimeProviderRegistration {
-  if (factory.manifest.providerId !== CODEX_AGENT_RUNTIME_MANIFEST.providerId) {
-    throw new Error("Production Client Runtime only registers the reviewed Codex provider");
+  const providerId = factory.manifest.providerId;
+  if (providerId !== "codex" && providerId !== "claude-code") {
+    throw new Error(`Production Client Runtime does not register the unreviewed provider: ${providerId}`);
   }
-  return {
-    artifactIdentity,
+  const providerHome = providerHomes[providerId];
+  const common = {
+    artifactIdentity: artifactIdentities[providerId],
     factory,
-    policy: codexRuntimePolicy,
-    validate: validateCodexRuntimePolicy,
-    verifyArtifact: async (signal) => {
+    verifyArtifact: async (signal?: AbortSignal) => {
       signal?.throwIfAborted();
-      if ((await realpath(codexHome)) !== codexHome) throw new Error("Codex Home identity changed");
+      if ((await realpath(providerHome)) !== providerHome) {
+        throw new Error(`${factory.manifest.displayName} Home identity changed`);
+      }
     },
   };
+  return providerId === "codex"
+    ? { ...common, policy: codexRuntimePolicy, validate: validateCodexRuntimePolicy }
+    : { ...common, policy: claudeCodeRuntimePolicy, validate: validateClaudeCodeRuntimePolicy };
 }
 
 export function resolvedCodexFactory(options: ResolvedCodexFactoryOptions): AgentRuntimeFactory {
@@ -364,6 +417,52 @@ function requireReadyCodexFactory(factory: CodexAgentRuntimeFactory | undefined)
   return factory;
 }
 
+export interface ResolvedClaudeCodeFactoryOptions {
+  readonly claudeCodeHome: string;
+  readonly command: string;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly sourceEnvironment: NodeJS.ProcessEnv;
+}
+
+export function resolvedClaudeCodeFactory(options: ResolvedClaudeCodeFactoryOptions): AgentRuntimeFactory {
+  let readyFactory: ClaudeCodeAgentRuntimeFactory | undefined;
+  return {
+    manifest: CLAUDE_CODE_AGENT_RUNTIME_MANIFEST,
+    async probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult> {
+      let command: string;
+      try {
+        request.signal?.throwIfAborted();
+        command = await resolveExecutable(options.command, options.sourceEnvironment);
+      } catch (error) {
+        if (request.signal?.aborted) throw error;
+        return {
+          ready: false,
+          issues: [{ code: "artifact_missing", message: "Claude Code CLI could not be executed" }],
+        };
+      }
+      const candidate = new ClaudeCodeAgentRuntimeFactory({
+        process: { command, env: options.environment },
+      });
+      const result = await candidate.probe(request);
+      if (result.ready) readyFactory = candidate;
+      return result;
+    },
+    create(request: CreateAgentRuntimeRequest) {
+      return requireReadyClaudeCodeFactory(readyFactory).create(request);
+    },
+    resume(request: ResumeAgentRuntimeRequest) {
+      return requireReadyClaudeCodeFactory(readyFactory).resume(request);
+    },
+  };
+}
+
+function requireReadyClaudeCodeFactory(
+  factory: ClaudeCodeAgentRuntimeFactory | undefined,
+): ClaudeCodeAgentRuntimeFactory {
+  if (!factory) throw new Error("Claude Code provider readiness has not been established");
+  return factory;
+}
+
 export function resolveCodexHome(environment: NodeJS.ProcessEnv = process.env): string {
   return resolve(environment.CODEX_HOME ?? join(environment.HOME ?? homedir(), ".codex"));
 }
@@ -374,7 +473,7 @@ export async function resolveExecutable(command: string, environment: NodeJS.Pro
     return realpath(command);
   }
   const path = environment.PATH;
-  if (!path) throw new Error("PATH is unavailable while locating Codex");
+  if (!path) throw new Error("PATH is unavailable while locating an Agent Runtime provider");
   /* v8 ignore next -- executable suffix probing is a Windows-only branch. */
   const extensions = process.platform === "win32" ? (environment.PATHEXT ?? ".EXE;.CMD;.BAT").split(";") : [""];
   for (const directory of path.split(delimiter)) {
@@ -389,13 +488,11 @@ export async function resolveExecutable(command: string, environment: NodeJS.Pro
       }
     }
   }
-  throw new Error("A compatible Codex executable is unavailable");
+  throw new Error("A compatible Agent Runtime provider executable is unavailable");
 }
 
 interface ClientRuntimePreflightDependencies {
-  readonly providers: Pick<AgentRuntimeProviderRegistry, "ensureReady" | "validateConfiguration">;
-  readonly readinessSignal?: AbortSignal;
-  readonly runtimeManager: Pick<SessionRuntimeManager, "runtime">;
+  readonly providers: Pick<AgentRuntimeProviderRegistry, "validateConfiguration">;
   readonly workspace: Pick<AgentWorkspaceManager, "verifyAgent">;
 }
 
@@ -406,12 +503,10 @@ export function createClientRuntimePreflight(
     const policyReason = dependencies.providers.validateConfiguration(request.runtime);
     if (policyReason) return policyReason;
     try {
-      await dependencies.providers.ensureReady(request.runtime.provider, dependencies.readinessSignal);
       await dependencies.workspace.verifyAgent(request.runtime, computeRuntimeSnapshotHashes(request.runtime));
-      dependencies.runtimeManager.runtime(request.sessionId);
       return undefined;
     } catch (error) {
-      return error instanceof RuntimeStorageError ? "session_binding_conflict" : "provider_unavailable";
+      return error instanceof RuntimeStorageError ? "session_binding_conflict" : "configuration_unsupported";
     }
   };
 }

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -8,7 +8,7 @@ import type { AgentRuntime, AgentRuntimeEventSink } from "../agent-runtime/types
 import type { AgentRuntimeProviderRegistry } from "./agent-runtime-provider-registry.js";
 import type { AgentWorkspaceManager } from "./agent-workspace.js";
 import type { RuntimeToolHost } from "./runtime-tool-host.js";
-import type { SessionBindingStore, SessionPreparationResult } from "./session-binding-store.js";
+import type { LocalSessionBinding, SessionBindingStore, SessionPreparationResult } from "./session-binding-store.js";
 import type { RuntimeLocalPolicy, RuntimePreparation } from "./session-reconciler.js";
 
 interface ManagedSessionRuntime {
@@ -16,13 +16,28 @@ interface ManagedSessionRuntime {
   readonly cwd: string;
   readonly effectiveSnapshotHash: string;
   readonly providerId: string;
-  readonly runtime: AgentRuntime;
+  readonly snapshot: EffectiveRuntimeSnapshot;
+  binding: LocalSessionBinding;
   eventSink?: AgentRuntimeEventSink;
+  runtime?: AgentRuntime;
+  start?: Promise<AgentRuntime>;
+}
+
+export class ClientRuntimeProviderStartError extends Error {
+  constructor(
+    readonly providerId: string,
+    options?: ErrorOptions,
+  ) {
+    const detail = options?.cause instanceof Error ? `: ${options.cause.message}` : "";
+    super(`Agent Runtime provider failed to start (${providerId})${detail}`, options);
+    this.name = "ClientRuntimeProviderStartError";
+  }
 }
 
 export interface SessionRuntimeManagerOptions {
   readonly bindingStore: SessionBindingStore;
   readonly providers: AgentRuntimeProviderRegistry;
+  readonly readinessSignal?: AbortSignal;
   readonly toolHost: RuntimeToolHost;
   readonly workspace: AgentWorkspaceManager;
 }
@@ -30,10 +45,12 @@ export interface SessionRuntimeManagerOptions {
 export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPolicy {
   readonly #bindingStore: SessionBindingStore;
   readonly #providers: AgentRuntimeProviderRegistry;
+  readonly #readinessSignal?: AbortSignal;
   readonly #toolHost: RuntimeToolHost;
   readonly #workspace: AgentWorkspaceManager;
   readonly #sessions = new Map<string, ManagedSessionRuntime>();
   readonly #prepares = new Set<Promise<SessionPreparationResult>>();
+  readonly #starts = new Set<Promise<AgentRuntime>>();
   readonly #closeFailures: unknown[] = [];
   #closing = false;
   #closePromise?: Promise<void>;
@@ -41,12 +58,13 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   constructor(options: SessionRuntimeManagerOptions) {
     this.#bindingStore = options.bindingStore;
     this.#providers = options.providers;
+    this.#readinessSignal = options.readinessSignal;
     this.#toolHost = options.toolHost;
     this.#workspace = options.workspace;
   }
 
   validate(snapshot: EffectiveRuntimeSnapshot): InputRejectReason | undefined {
-    return this.#providers.validate(snapshot);
+    return this.#providers.validateConfiguration(snapshot);
   }
 
   prepareAgent(snapshot: EffectiveRuntimeSnapshot, hashes: RuntimeSnapshotHashes): Promise<void> {
@@ -74,20 +92,24 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
     if (prepared.unresolvedTurn) return prepared;
     const snapshot = request.runtime;
     if (!snapshot) throw new Error("A ready Session requires a runtime snapshot");
+    if (!this.#providers.registration(snapshot.provider)) {
+      throw new Error(`Agent Runtime provider is not registered: ${snapshot.provider}`);
+    }
 
     const current = this.#sessions.get(request.sessionId);
     if (
       current &&
       current.effectiveSnapshotHash === hashes.effectiveSnapshotHash &&
-      current.providerId === snapshot.provider &&
-      current.runtime.state.phase !== "closed"
+      current.providerId === snapshot.provider
     ) {
+      current.binding = prepared.binding;
+      if (current.runtime?.state.phase === "closed") current.runtime = undefined;
       return prepared;
     }
     if (current) {
       this.#sessions.delete(request.sessionId);
       try {
-        await current.runtime.close();
+        await this.#closeManaged(current);
       } catch (error) {
         if (this.#closing) this.#closeFailures.push(error);
         throw error;
@@ -95,58 +117,97 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
       this.#assertOpen();
     }
 
-    const provider = this.#providers.registration(snapshot.provider);
-    if (!provider) throw new Error(`Agent Runtime provider is unavailable: ${snapshot.provider}`);
     const cwd = await this.#workspace.cwd(request.agentId);
     this.#assertOpen();
-    let ready: ManagedSessionRuntime | undefined;
+    this.#sessions.set(request.sessionId, {
+      agentId: request.agentId,
+      binding: prepared.binding,
+      cwd,
+      effectiveSnapshotHash: hashes.effectiveSnapshotHash,
+      providerId: snapshot.provider,
+      snapshot,
+    });
+    return prepared;
+  }
+
+  async ensureRuntime(sessionId: string, signal?: AbortSignal): Promise<AgentRuntime> {
+    this.#assertOpen();
+    const managed = this.#sessions.get(sessionId);
+    if (!managed) throw new Error("The Session Agent Runtime has not been prepared");
+    await this.#providers.ensureReady(managed.providerId, combineSignals(this.#readinessSignal, signal));
+    this.#assertOpen();
+    if (managed.runtime && managed.runtime.state.phase !== "closed") return managed.runtime;
+    if (managed.start) return waitForStart(managed.start, signal);
+
+    const start = this.#startRuntime(managed).finally(() => {
+      if (managed.start === start) managed.start = undefined;
+      this.#starts.delete(start);
+    });
+    managed.start = start;
+    this.#starts.add(start);
+    void start.catch(() => undefined);
+    return waitForStart(start, signal);
+  }
+
+  async #startRuntime(managed: ManagedSessionRuntime): Promise<AgentRuntime> {
+    const provider = this.#providers.registration(managed.providerId);
+    /* v8 ignore next -- registrations are immutable for the lifetime of a managed Session. */
+    if (!provider) throw new Error(`Agent Runtime provider is not registered: ${managed.providerId}`);
+    let bindingPersisted = false;
     const eventSink: AgentRuntimeEventSink = async (event) => {
       if (event.type === "binding_changed") {
         this.#assertOpen();
-        await this.#bindingStore.saveRuntimeBinding(
-          request.agentId,
-          request.sessionId,
-          hashes.effectiveSnapshotHash,
+        const binding = await this.#bindingStore.saveRuntimeBinding(
+          managed.agentId,
+          managed.binding.sessionId,
+          managed.effectiveSnapshotHash,
           event.binding,
         );
+        if (!binding) throw new Error("The durable Session binding disappeared");
+        managed.binding = binding;
+        bindingPersisted = true;
         this.#assertOpen();
       }
-      await ready?.eventSink?.(event);
+      await managed.eventSink?.(event);
     };
     const common = {
       eventSink,
-      hostedTools: this.#toolHost.hostedTools(snapshot.allowedTools),
-      workspace: { cwd, writableRoots: [cwd] },
-      policy: provider.policy(snapshot),
+      hostedTools: this.#toolHost.hostedTools(managed.snapshot.allowedTools),
+      workspace: { cwd: managed.cwd, writableRoots: [managed.cwd] },
+      policy: provider.policy(managed.snapshot),
       configuration: {
-        ...(snapshot.model ? { model: snapshot.model } : {}),
-        ...(snapshot.reasoningEffort ? { reasoningEffort: snapshot.reasoningEffort } : {}),
+        ...(managed.snapshot.model ? { model: managed.snapshot.model } : {}),
+        ...(managed.snapshot.reasoningEffort ? { reasoningEffort: managed.snapshot.reasoningEffort } : {}),
       },
     } as const;
     let runtime: AgentRuntime | undefined;
     try {
-      runtime = prepared.binding.runtimeBinding
-        ? await provider.factory.resume({ ...common, binding: prepared.binding.runtimeBinding })
-        : await provider.factory.create(common);
+      try {
+        runtime = managed.binding.runtimeBinding
+          ? await provider.factory.resume({ ...common, binding: managed.binding.runtimeBinding })
+          : await provider.factory.create(common);
+      } catch (error) {
+        throw new ClientRuntimeProviderStartError(managed.providerId, { cause: error });
+      }
       this.#assertOpen();
-      if (!runtime.binding) throw new Error("Agent Runtime did not produce a durable binding");
-      const binding = await this.#bindingStore.saveRuntimeBinding(
-        request.agentId,
-        request.sessionId,
-        hashes.effectiveSnapshotHash,
-        runtime.binding,
-      );
+      if (!runtime.binding) {
+        throw new ClientRuntimeProviderStartError(managed.providerId, {
+          cause: new Error("Agent Runtime did not produce a durable binding"),
+        });
+      }
+      if (!bindingPersisted) {
+        const binding = await this.#bindingStore.saveRuntimeBinding(
+          managed.agentId,
+          managed.binding.sessionId,
+          managed.effectiveSnapshotHash,
+          runtime.binding,
+        );
+        if (!binding) throw new Error("The durable Session binding disappeared");
+        managed.binding = binding;
+      }
       this.#assertOpen();
-      if (!binding) throw new Error("The durable Session binding disappeared");
-      ready = {
-        agentId: request.agentId,
-        cwd,
-        effectiveSnapshotHash: hashes.effectiveSnapshotHash,
-        providerId: snapshot.provider,
-        runtime,
-      };
-      this.#sessions.set(request.sessionId, ready);
-      return { binding };
+      managed.runtime = runtime;
+      return runtime;
     } catch (error) {
       if (runtime) {
         try {
@@ -163,8 +224,8 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   async stopSession(sessionId: string, placementGeneration: number): Promise<void> {
     const current = this.#sessions.get(sessionId);
     if (current) {
-      await current.runtime.close();
       this.#sessions.delete(sessionId);
+      await this.#closeManaged(current);
     }
     await this.#workspace.stopSession(sessionId, placementGeneration);
   }
@@ -172,7 +233,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   runtime(sessionId: string): AgentRuntime {
     this.#assertOpen();
     const managed = this.#sessions.get(sessionId);
-    if (!managed || managed.runtime.state.phase === "closed") {
+    if (!managed?.runtime || managed.runtime.state.phase === "closed") {
       throw new Error("The Session Agent Runtime is not ready");
     }
     return managed.runtime;
@@ -181,14 +242,16 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   cwd(sessionId: string): string {
     this.#assertOpen();
     const managed = this.#sessions.get(sessionId);
-    if (!managed) throw new Error("The Session Agent Runtime is not ready");
+    if (!managed) throw new Error("The Session Agent Runtime has not been prepared");
     return managed.cwd;
   }
 
   observe(sessionId: string, sink: AgentRuntimeEventSink): () => void {
     this.#assertOpen();
     const managed = this.#sessions.get(sessionId);
-    if (!managed) throw new Error("The Session Agent Runtime is not ready");
+    if (!managed?.runtime || managed.runtime.state.phase === "closed") {
+      throw new Error("The Session Agent Runtime is not ready");
+    }
     if (managed.eventSink) throw new Error("The Session Agent Runtime already has an active observer");
     managed.eventSink = sink;
     return () => {
@@ -200,10 +263,10 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
     if (this.#closePromise) return this.#closePromise;
     this.#closing = true;
     this.#closePromise = (async () => {
-      await Promise.allSettled([...this.#prepares]);
+      await Promise.allSettled([...this.#prepares, ...this.#starts]);
       const sessions = [...this.#sessions.values()];
       this.#sessions.clear();
-      const results = await Promise.allSettled(sessions.map((session) => session.runtime.close()));
+      const results = await Promise.allSettled(sessions.map((session) => this.#closeManaged(session)));
       for (const result of results) {
         if (result.status === "rejected") this.#closeFailures.push(result.reason);
       }
@@ -214,7 +277,39 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
     return this.#closePromise;
   }
 
+  async #closeManaged(managed: ManagedSessionRuntime): Promise<void> {
+    const start = managed.start;
+    if (start) await start.catch(() => undefined);
+    if (!managed.runtime || managed.runtime.state.phase === "closed") return;
+    await managed.runtime.close();
+    managed.runtime = undefined;
+  }
+
   #assertOpen(): void {
     if (this.#closing) throw new Error("The Session Runtime manager is closing");
+  }
+}
+
+function combineSignals(first: AbortSignal | undefined, second: AbortSignal | undefined): AbortSignal | undefined {
+  if (!first) return second;
+  if (!second) return first;
+  return AbortSignal.any([first, second]);
+}
+
+async function waitForStart(start: Promise<AgentRuntime>, signal?: AbortSignal): Promise<AgentRuntime> {
+  if (!signal) return start;
+  signal.throwIfAborted();
+  let rejectAborted!: (reason: unknown) => void;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAborted = reject;
+  });
+  const onAbort = () => rejectAborted(signal.reason);
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    const runtime = await Promise.race([start, aborted]);
+    signal.throwIfAborted();
+    return runtime;
+  } finally {
+    signal.removeEventListener("abort", onAbort);
   }
 }

--- a/packages/client/vitest.agent-runtime.config.ts
+++ b/packages/client/vitest.agent-runtime.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "src/__tests__/agent-turn-runner.test.ts",
       "src/__tests__/claude-code-agent-runtime.test.ts",
       "src/__tests__/claude-code-agent-runtime-exhaustive.test.ts",
+      "src/__tests__/claude-code-hosted-tool-bridge.test.ts",
       "src/__tests__/claude-code-process.test.ts",
       "src/__tests__/codex-agent-runtime.test.ts",
       "src/__tests__/codex-agent-runtime-exhaustive.test.ts",
@@ -31,7 +32,9 @@ export default defineConfig({
       include: [
         "src/agent-runtime/**/*.ts",
         "src/providers/claude-code/agent-runtime.ts",
+        "src/providers/claude-code/hosted-tool-bridge.ts",
         "src/providers/claude-code/process-wire.ts",
+        "src/providers/claude-code/runtime-policy.ts",
         "src/providers/codex/agent-runtime.ts",
         "src/providers/codex/app-server-wire.ts",
         "src/providers/codex/runtime-policy.ts",

--- a/packages/server/src/__tests__/connection-registry.test.ts
+++ b/packages/server/src/__tests__/connection-registry.test.ts
@@ -174,7 +174,10 @@ describe("ConnectionRegistry", () => {
         new Date(RUNTIME_CLIENT_CAPABILITY_TTL_MS * 2 + 4),
         registry,
       ),
-    ).toEqual([{ provider: "codex", status: "checking", observedAt: null }]);
+    ).toEqual([
+      { provider: "codex", status: "checking", observedAt: null },
+      { provider: "claude-code", status: "checking", observedAt: null },
+    ]);
     expect(registry.remove(computerId, instanceId, currentSocket)).toBe(true);
     expect(registry.providerReadiness(computerId, RUNTIME_CLIENT_CAPABILITY_TTL_MS + 3)).toEqual([]);
   });

--- a/packages/server/src/__tests__/effective-runtime-snapshot-assembler.test.ts
+++ b/packages/server/src/__tests__/effective-runtime-snapshot-assembler.test.ts
@@ -98,6 +98,17 @@ describe("EffectiveRuntimeSnapshotAssembler", () => {
     expect(snapshot.allowedTools).toEqual(DEFAULT_AGENT_RUNTIME_CONFIG.allowedTools);
   });
 
+  it("compiles the reviewed Claude Code execution policy without changing the snapshot contract", async () => {
+    const snapshot = await assembler(async () => authority({ runtimeProvider: "claude-code" })).assembleForSession(
+      sessionId,
+    );
+
+    expect(snapshot).toMatchObject({
+      provider: "claude-code",
+      execution: { approvalPolicy: "never", networkAccess: true },
+    });
+  });
+
   it.each([
     ["missing", async () => undefined, "SESSION_NOT_FOUND"],
     ["ended Session", async () => authority({ sessionEndedAt: new Date() }), "AUTHORITY_INACTIVE"],
@@ -105,7 +116,7 @@ describe("EffectiveRuntimeSnapshotAssembler", () => {
     ["suspended Agent", async () => authority({ agentStatus: "suspended" }), "AUTHORITY_INACTIVE"],
     ["deleted Agent", async () => authority({ agentStatus: "deleted" }), "AUTHORITY_INACTIVE"],
     ["missing config", async () => authority({ runtimeConfig: null }), "RUNTIME_CONFIG_MISSING"],
-    ["unsupported provider", async () => authority({ runtimeProvider: "claude-code" }), "UNSUPPORTED_PROVIDER"],
+    ["unsupported provider", async () => authority({ runtimeProvider: "pi" }), "UNSUPPORTED_PROVIDER"],
     [
       "invalid stored config",
       async () =>

--- a/packages/server/src/__tests__/integration/account-team-foundation.test.ts
+++ b/packages/server/src/__tests__/integration/account-team-foundation.test.ts
@@ -211,7 +211,10 @@ describe("account identity and Team foundation persistence", () => {
       expect(computerResult.computers.find((candidate) => candidate.id === computer.id)).toMatchObject({
         ownerUserId: userId,
         ownerDisplayName: "Product Name",
-        providerReadiness: [{ provider: "codex", status: "unavailable", observedAt: null }],
+        providerReadiness: [
+          { provider: "codex", status: "unavailable", observedAt: null },
+          { provider: "claude-code", status: "unavailable", observedAt: null },
+        ],
       });
       const agentService = new AgentService(value.database, { membershipService: value.teamService, now: () => now });
       await agentService.createForTeam(userId, primaryTeam.id, {

--- a/packages/server/src/__tests__/integration/computers.test.ts
+++ b/packages/server/src/__tests__/integration/computers.test.ts
@@ -138,7 +138,10 @@ describe("Computer persistence", () => {
           },
         });
         expect(negotiated.json().computers[0]).toMatchObject({
-          providerReadiness: [{ provider: "codex", status: "checking", observedAt: null }],
+          providerReadiness: [
+            { provider: "codex", status: "checking", observedAt: null },
+            { provider: "claude-code", status: "checking", observedAt: null },
+          ],
         });
       } finally {
         await app.close();

--- a/packages/server/src/__tests__/provider-readiness.test.ts
+++ b/packages/server/src/__tests__/provider-readiness.test.ts
@@ -14,7 +14,10 @@ describe("Computer provider readiness projection", () => {
           },
         ],
       }),
-    ).toEqual([{ provider: "codex", status: "sign-in", observedAt: "2026-08-19T23:59:59.000Z" }]);
+    ).toEqual([
+      { provider: "codex", status: "sign-in", observedAt: "2026-08-19T23:59:59.000Z" },
+      { provider: "claude-code", status: "checking", observedAt: null },
+    ]);
   });
 
   it("treats a missing or stale online observation as checking", () => {
@@ -22,7 +25,10 @@ describe("Computer provider readiness projection", () => {
       projectComputerProviderReadiness("computer-1", "online", now, {
         providerReadiness: () => [],
       }),
-    ).toEqual([{ provider: "codex", status: "checking", observedAt: null }]);
+    ).toEqual([
+      { provider: "codex", status: "checking", observedAt: null },
+      { provider: "claude-code", status: "checking", observedAt: null },
+    ]);
   });
 
   it("makes disconnect authoritative over the last observed provider state", () => {
@@ -35,6 +41,9 @@ describe("Computer provider readiness projection", () => {
           },
         ],
       }),
-    ).toEqual([{ provider: "codex", status: "unavailable", observedAt: null }]);
+    ).toEqual([
+      { provider: "codex", status: "unavailable", observedAt: null },
+      { provider: "claude-code", status: "unavailable", observedAt: null },
+    ]);
   });
 });

--- a/packages/server/src/__tests__/runtime.test.ts
+++ b/packages/server/src/__tests__/runtime.test.ts
@@ -83,7 +83,7 @@ describe("Computer runtime WebSocket", () => {
     expect(await frames.next()).toMatchObject({
       type: "server:welcome",
       protocolVersion: 1,
-      providerReadiness: { version: 1, providers: ["codex"] },
+      providerReadiness: { version: 1, providers: ["codex", "claude-code"] },
     });
 
     const register = {
@@ -177,7 +177,7 @@ describe("Computer runtime WebSocket", () => {
     socket.send(
       JSON.stringify({
         ...registerFrame(randomUUID(), randomUUID()),
-        providerReadiness: [{ provider: "claude-code", status: "ready" }],
+        providerReadiness: [{ provider: "pi", status: "ready" }],
       }),
     );
 

--- a/packages/server/src/services/runtime-config/effective-runtime-snapshot-assembler.ts
+++ b/packages/server/src/services/runtime-config/effective-runtime-snapshot-assembler.ts
@@ -9,7 +9,7 @@ import { eq } from "drizzle-orm";
 import type { DatabaseClient } from "../../db/client.js";
 import { agentRuntimeConfigs, agents, imBindings, sessions } from "../../db/schema/index.js";
 import { EffectiveRuntimeSnapshotAssemblerError } from "./errors.js";
-import { isServerAdmittedAgentRuntimeProvider } from "./provider-admission.js";
+import { isServerAdmittedAgentRuntimeProvider, serverAgentRuntimeProviderPolicy } from "./provider-admission.js";
 
 interface EffectiveRuntimeSnapshotAuthority {
   agentStatus: string;
@@ -48,6 +48,7 @@ export class EffectiveRuntimeSnapshotAssembler {
     if (!isServerAdmittedAgentRuntimeProvider(authority.runtimeProvider)) {
       throw new EffectiveRuntimeSnapshotAssemblerError("UNSUPPORTED_PROVIDER");
     }
+    const providerPolicy = serverAgentRuntimeProviderPolicy(authority.runtimeProvider);
     if (authority.runtimeConfig === null) {
       throw new EffectiveRuntimeSnapshotAssemblerError("RUNTIME_CONFIG_MISSING");
     }
@@ -71,8 +72,8 @@ export class EffectiveRuntimeSnapshotAssembler {
       config.reasoningEffort,
       null,
       config.allowedTools,
-      "never",
-      false,
+      providerPolicy.execution.approvalPolicy,
+      providerPolicy.execution.networkAccess,
       config.maxDurationMs,
     ]);
     const snapshot = EffectiveRuntimeSnapshotSchema.safeParse({
@@ -89,7 +90,7 @@ export class EffectiveRuntimeSnapshotAssembler {
         agent: config.instructions,
       },
       allowedTools: config.allowedTools,
-      execution: { approvalPolicy: "never", networkAccess: false },
+      execution: providerPolicy.execution,
       workspace: { workspaceId: authority.agentId, mode: "empty_on_create", sharing: "agent" },
       ...(config.maxDurationMs !== null ? { budget: { maxDurationMs: config.maxDurationMs } } : {}),
     });

--- a/packages/server/src/services/runtime-config/index.ts
+++ b/packages/server/src/services/runtime-config/index.ts
@@ -12,4 +12,6 @@ export {
   isServerAdmittedAgentRuntimeProvider,
   SERVER_ADMITTED_AGENT_RUNTIME_PROVIDERS,
   type ServerAdmittedAgentRuntimeProvider,
+  type ServerAgentRuntimeProviderPolicy,
+  serverAgentRuntimeProviderPolicy,
 } from "./provider-admission.js";

--- a/packages/server/src/services/runtime-config/provider-admission.ts
+++ b/packages/server/src/services/runtime-config/provider-admission.ts
@@ -1,9 +1,29 @@
-import type { AgentRuntimeProvider } from "@opentag/shared";
+import { AGENT_RUNTIME_PROVIDERS, type AgentRuntimeProvider } from "@opentag/shared";
 
-export const SERVER_ADMITTED_AGENT_RUNTIME_PROVIDERS = ["codex"] as const satisfies readonly AgentRuntimeProvider[];
+export interface ServerAgentRuntimeProviderPolicy {
+  readonly execution: {
+    readonly approvalPolicy: "never";
+    readonly networkAccess: boolean;
+  };
+}
 
-export type ServerAdmittedAgentRuntimeProvider = (typeof SERVER_ADMITTED_AGENT_RUNTIME_PROVIDERS)[number];
+const SERVER_AGENT_RUNTIME_PROVIDER_POLICIES = {
+  codex: { execution: { approvalPolicy: "never", networkAccess: false } },
+  "claude-code": { execution: { approvalPolicy: "never", networkAccess: true } },
+} as const satisfies Partial<Record<AgentRuntimeProvider, ServerAgentRuntimeProviderPolicy>>;
+
+export type ServerAdmittedAgentRuntimeProvider = keyof typeof SERVER_AGENT_RUNTIME_PROVIDER_POLICIES;
+
+export const SERVER_ADMITTED_AGENT_RUNTIME_PROVIDERS = AGENT_RUNTIME_PROVIDERS.filter(
+  (provider): provider is ServerAdmittedAgentRuntimeProvider => provider in SERVER_AGENT_RUNTIME_PROVIDER_POLICIES,
+);
 
 export function isServerAdmittedAgentRuntimeProvider(value: string): value is ServerAdmittedAgentRuntimeProvider {
   return SERVER_ADMITTED_AGENT_RUNTIME_PROVIDERS.some((provider) => provider === value);
+}
+
+export function serverAgentRuntimeProviderPolicy(
+  provider: ServerAdmittedAgentRuntimeProvider,
+): ServerAgentRuntimeProviderPolicy {
+  return SERVER_AGENT_RUNTIME_PROVIDER_POLICIES[provider];
 }

--- a/packages/shared/src/__tests__/runtime-domain.test.ts
+++ b/packages/shared/src/__tests__/runtime-domain.test.ts
@@ -21,6 +21,13 @@ import {
 describe("runtime domain contract", () => {
   it("B-01 validates every V0 domain request and result through the public schema surface", () => {
     const runtime = snapshot();
+    expect(
+      EffectiveRuntimeSnapshotSchema.parse({
+        ...runtime,
+        provider: "claude-code",
+        execution: { approvalPolicy: "never", networkAccess: true },
+      }),
+    ).toMatchObject({ provider: "claude-code" });
     const reconcile = {
       type: "session:reconcile",
       requestId: randomUUID(),

--- a/packages/shared/src/runtime-domain.ts
+++ b/packages/shared/src/runtime-domain.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { z } from "zod";
+import { AgentRuntimeProviderSchema } from "./agent.js";
 import {
   runtimeByteString as byteString,
   RUNTIME_ID_MAX_BYTES,
@@ -72,7 +73,7 @@ export const EffectiveRuntimeSnapshotSchema = z
       })
       .strict(),
     agentId: RuntimeOpaqueIdSchema,
-    provider: z.literal("codex"),
+    provider: AgentRuntimeProviderSchema,
     model: RuntimeModelSchema.optional(),
     reasoningEffort: RuntimeReasoningEffortSchema.optional(),
     instructions: RuntimeInstructionsSchema,


### PR DESCRIPTION
Relates to #53.
Depends on #73; review this PR as the Claude Code production-enablement layer on top of the negotiated Provider-readiness contract.
Context Tree: https://github.com/first-tree-ai/first-tree-context/pull/968 (draft, code-first workflow).

## Summary

- admit Codex and Claude Code through an explicit Server policy registry and provider-neutral effective snapshots
- compose separate hardened Codex and Claude Code factories, homes, artifact fences, probes, and per-Provider readiness
- defer exact-Provider start until a Turn owns custody; report credential_unavailable or provider_start_failed with executionEffects not_started and never substitute another Provider
- bridge OpenTag hosted message tools into Claude Code through a private per-Run strict MCP configuration
- retain workspace-state schema v2 and Session-binding schema v2, including the legacy schema-v1 Codex-only upgrade path
- expose exact Computer/Provider readiness and recovery guidance in Agent creation without blocking identity creation
- keep Pi outside Server admission, production Client composition, Agent API selection, and Web UI

## Verification

- pnpm check
- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/server test:integration: 131 passed
- Web tests: 117 passed after synchronizing current main
- pnpm --filter @opentag/client test:agent-runtime:coverage: 269 passed; statements, branches, functions, and lines all 100%
- pnpm test and pnpm test:coverage completed with only four pre-existing macOS canonical-path assertions failing: two Client workspace assertions and two CLI daemon assertions compare /var or /tmp with realpath /private/var or /private/tmp. The same four failures were reproduced from a clean detached origin/main at 7827ad3.
- GitHub CI reruns all Linux test, PostgreSQL integration, Agent Runtime coverage, and repository coverage gates on the final pushed head.