### PR TITLE
feat(web): open new agent form in dialog

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -522,7 +522,11 @@ describe("OpenTag Web App Shell", () => {
           ),
       ).toHaveLength(1),
     );
-    await waitFor(() => expect(within(dialog).getByLabelText("Display name")).toBe(document.activeElement));
+    await waitFor(() => expect(dialog).toBe(document.activeElement));
+    expect((within(dialog).getByLabelText("Display name") as HTMLInputElement).disabled).toBe(true);
+    expect((within(dialog).getByLabelText("Agent name") as HTMLInputElement).disabled).toBe(true);
+    expect((within(dialog).getByLabelText("Provider") as HTMLSelectElement).disabled).toBe(true);
+    expect((within(dialog).getByLabelText("Computer") as HTMLSelectElement).disabled).toBe(true);
     expect(within(dialog).getByRole("button", { name: "Creating…" }).hasAttribute("disabled")).toBe(true);
     expect(within(dialog).getByRole("button", { name: "Cancel" }).hasAttribute("disabled")).toBe(true);
     expect(within(dialog).getByRole("button", { name: "Close new Agent dialog" }).hasAttribute("disabled")).toBe(true);

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -36,6 +36,7 @@ function installApi(
     agentRead?: () => Promise<void> | void;
     agentReadStatus?: () => number | undefined;
     agentListStatus?: () => number | undefined;
+    agentCreate?: (input: Record<string, unknown>) => Promise<void> | void;
     alreadyJoinedInvitation?: boolean;
     bindingReauth?: boolean;
     bindingEvidenceFails?: boolean;
@@ -185,6 +186,7 @@ function installApi(
       });
     }
     if (path === `/api/v1/teams/${teamId}/agents` && init?.method === "POST") {
+      await options.agentCreate?.(JSON.parse(String(init.body)) as Record<string, unknown>);
       return json(adminConfig(), 201);
     }
     // Any Team id, so a Team created during the test is served like the seeded and invited ones.
@@ -477,18 +479,83 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Create Agent" }));
 
     await waitFor(() => expect(window.location.pathname).toBe(`/agents/${agentId}/general`));
-    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
-      `/api/v1/teams/${teamId}/agents`,
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          name: "research-assistant",
-          displayName: "Research Assistant",
-          runtimeProvider: "codex",
-          computerId,
-        }),
-      }),
+    const createCall = vi
+      .mocked(fetch)
+      .mock.calls.find(
+        ([input, init]) => String(input) === `/api/v1/teams/${teamId}/agents` && init?.method === "POST",
+      );
+    expect(createCall).toBeTruthy();
+    expect(JSON.parse(String(createCall?.[1]?.body))).toEqual({
+      creationIntentId: expect.any(String),
+      name: "research-assistant",
+      displayName: "Research Assistant",
+      runtimeProvider: "codex",
+      computerId,
+    });
+  });
+
+  it("blocks duplicate Agent submissions synchronously and repairs focus while creation is pending", async () => {
+    let resolveCreate: () => void = () => undefined;
+    const pendingCreate = new Promise<void>((resolve) => {
+      resolveCreate = resolve;
+    });
+    installApi("admin", { ownComputer: true, agentCreate: () => pendingCreate });
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
+    const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+    fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "Research Assistant" } });
+    fireEvent.change(within(dialog).getByLabelText("Agent name"), { target: { value: "research-assistant" } });
+    const form = within(dialog).getByRole("button", { name: "Create Agent" }).closest("form");
+    const submitButton = within(dialog).getByRole("button", { name: "Create Agent" });
+    submitButton.focus();
+
+    if (!form) throw new Error("Expected the New Agent form");
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(fetch)
+          .mock.calls.filter(
+            ([input, init]) => String(input) === `/api/v1/teams/${teamId}/agents` && init?.method === "POST",
+          ),
+      ).toHaveLength(1),
     );
+    await waitFor(() => expect(within(dialog).getByLabelText("Display name")).toBe(document.activeElement));
+    expect(within(dialog).getByRole("button", { name: "Creating…" }).hasAttribute("disabled")).toBe(true);
+    expect(within(dialog).getByRole("button", { name: "Cancel" }).hasAttribute("disabled")).toBe(true);
+    expect(within(dialog).getByRole("button", { name: "Close new Agent dialog" }).hasAttribute("disabled")).toBe(true);
+    fireEvent.keyDown(document.activeElement ?? dialog, { key: "Escape" });
+    expect(screen.getByRole("dialog", { name: "New Agent" })).toBe(dialog);
+
+    resolveCreate();
+    await waitFor(() => expect(window.location.pathname).toBe(`/agents/${agentId}/general`));
+  });
+
+  it("reuses one creation intent when an unchanged Agent request is retried", async () => {
+    const attempts: Record<string, unknown>[] = [];
+    installApi("admin", {
+      ownComputer: true,
+      agentCreate: (input) => {
+        attempts.push(input);
+        if (attempts.length === 1) throw new Error("Connection lost after creation");
+      },
+    });
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
+    const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+    fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "Research Assistant" } });
+    fireEvent.change(within(dialog).getByLabelText("Agent name"), { target: { value: "research-assistant" } });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Create Agent" }));
+    expect((await within(dialog).findByRole("alert")).textContent).toContain("Connection lost after creation");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Create Agent" }));
+
+    await waitFor(() => expect(window.location.pathname).toBe(`/agents/${agentId}/general`));
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]?.creationIntentId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(attempts[1]?.creationIntentId).toBe(attempts[0]?.creationIntentId);
   });
 
   it.each(["admin", "member"] as const)("lets a %s update their global account display name", async (role) => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -47,6 +47,7 @@ function installApi(
     invitationCreate?: () => Promise<Response> | Response;
     invitationExists?: boolean;
     invitationRotate?: () => Promise<Response> | Response;
+    ownComputer?: boolean;
     provider?: "feishu" | "slack";
     profileUpdate?: (displayName: string) => Promise<Response> | Response;
     profileUpdateFails?: boolean;
@@ -183,8 +184,11 @@ function installApi(
         updatedAt: "2026-08-20T00:01:00.000Z",
       });
     }
+    if (path === `/api/v1/teams/${teamId}/agents` && init?.method === "POST") {
+      return json(adminConfig(), 201);
+    }
     // Any Team id, so a Team created during the test is served like the seeded and invited ones.
-    if (/^\/api\/v1\/teams\/[^/]+\/agents$/.test(path)) {
+    if (/^\/api\/v1\/teams\/[^/]+\/agents$/.test(path) && init?.method === undefined) {
       const failureStatus = options.agentListStatus?.();
       if (failureStatus) return json({ error: { message: "Agent list unavailable" } }, failureStatus);
       return json({
@@ -288,7 +292,25 @@ function installApi(
         ],
       });
     }
-    if (path === "/api/v1/me/computers") return json({ computers: [] });
+    if (path === "/api/v1/me/computers") {
+      return json({
+        computers: options.ownComputer
+          ? [
+              {
+                id: computerId,
+                ownerUserId: userId,
+                displayName: "Ada's Mac",
+                platform: "darwin",
+                arch: "arm64",
+                clientVersion: "0.0.1",
+                connectionStatus: "online",
+                connectedAt: "2026-08-20T00:00:00.000Z",
+                lastSeenAt: "2026-08-20T00:00:01.000Z",
+              },
+            ]
+          : [],
+      });
+    }
     if (path === "/api/v1/me/connect-codes" && init?.method === "POST") {
       return json(
         {
@@ -397,7 +419,7 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "Agents" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "Settings" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Create Agent" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "New Agent" })).toBeTruthy();
     expect(screen.getByText("Tasks").getAttribute("aria-disabled")).toBe("true");
     expect(
       within(screen.getByRole("navigation", { name: "Workspace" }))
@@ -421,7 +443,52 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     expect(screen.queryByText("ada@example.com")).toBeNull();
     expect(await screen.findByText("Reviewer")).toBeTruthy();
-    expect(screen.queryByRole("link", { name: "Create Agent" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "New Agent" })).toBeNull();
+  });
+
+  it("opens the complete New Agent form in a dialog and returns focus when cancelled", async () => {
+    installApi("admin", { ownComputer: true });
+    render(<App />);
+    const trigger = await screen.findByRole("button", { name: "New Agent" });
+
+    fireEvent.click(trigger);
+
+    const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+    expect(window.location.pathname).toBe("/agents");
+    await waitFor(() => expect(within(dialog).getByLabelText("Display name")).toBe(document.activeElement));
+    expect(within(dialog).getByLabelText("Agent name")).toBeTruthy();
+    expect(within(dialog).getByLabelText("Provider")).toBeTruthy();
+    expect(within(dialog).getByLabelText("Computer")).toBeTruthy();
+    expect(within(dialog).getByRole("button", { name: "Create Agent" })).toBeTruthy();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog", { name: "New Agent" })).toBeNull();
+    expect(trigger).toBe(document.activeElement);
+  });
+
+  it("creates an Agent from the dialog without a second creation screen", async () => {
+    installApi("admin", { ownComputer: true });
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
+    const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+
+    fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "Research Assistant" } });
+    fireEvent.change(within(dialog).getByLabelText("Agent name"), { target: { value: "research-assistant" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Create Agent" }));
+
+    await waitFor(() => expect(window.location.pathname).toBe(`/agents/${agentId}/general`));
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      `/api/v1/teams/${teamId}/agents`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "research-assistant",
+          displayName: "Research Assistant",
+          runtimeProvider: "codex",
+          computerId,
+        }),
+      }),
+    );
   });
 
   it.each(["admin", "member"] as const)("lets a %s update their global account display name", async (role) => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -970,6 +970,22 @@ function NewAgentDialog({
   onCloseRef.current = onClose;
 
   useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const target = dialog.querySelector<HTMLElement>(
+      "button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled])",
+    );
+    if (submitting) {
+      if (!activeElement || !dialog.contains(activeElement) || activeElement.matches(":disabled")) {
+        (target ?? dialog).focus();
+      }
+    } else if (activeElement === dialog) {
+      target?.focus();
+    }
+  }, [submitting]);
+
+  useEffect(() => {
     closeButtonRef.current?.focus();
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -1077,6 +1093,8 @@ function AgentCreationContent({
   const [error, setError] = useState<string>();
   const [submitting, setSubmitting] = useState(false);
   const firstFieldRef = useRef<HTMLInputElement>(null);
+  const inFlightRef = useRef(false);
+  const creationIntentRef = useRef<{ fingerprint: string; id: string } | null>(null);
 
   useEffect(() => {
     if (presentation === "dialog" && computers.kind === "ready") firstFieldRef.current?.focus();
@@ -1084,22 +1102,32 @@ function AgentCreationContent({
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (submitting) return;
+    if (inFlightRef.current) return;
     const data = new FormData(event.currentTarget);
+    const input = {
+      name: String(data.get("name") ?? ""),
+      displayName: String(data.get("displayName") ?? ""),
+      runtimeProvider: String(data.get("runtimeProvider") ?? "codex") as "codex" | "claude-code",
+      computerId: String(data.get("computerId") ?? ""),
+    };
+    const fingerprint = JSON.stringify(input);
+    if (creationIntentRef.current?.fingerprint !== fingerprint) {
+      creationIntentRef.current = { fingerprint, id: crypto.randomUUID() };
+    }
+    inFlightRef.current = true;
     setError(undefined);
     setSubmitting(true);
     onSubmittingChange?.(true);
     try {
       const created = await browserApi.createAgent(teamId, {
-        name: String(data.get("name") ?? ""),
-        displayName: String(data.get("displayName") ?? ""),
-        runtimeProvider: String(data.get("runtimeProvider") ?? "codex") as "codex" | "claude-code",
-        computerId: String(data.get("computerId") ?? ""),
+        creationIntentId: creationIntentRef.current.id,
+        ...input,
       });
       onCreated(created.id);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Agent creation failed");
     } finally {
+      inFlightRef.current = false;
       setSubmitting(false);
       onSubmittingChange?.(false);
     }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -825,25 +825,30 @@ function AppShell() {
 
 function AgentsPage() {
   const { membership } = useTeam();
+  const [createOpen, setCreateOpen] = useState(false);
+  const createTriggerRef = useRef<HTMLButtonElement>(null);
   const state = useResource(() => loadAgentList(membership.teamId), membership.teamId, {
     onBackgroundError: markAgentListUnconfirmed,
     revalidateMs: 30_000,
     refreshOnFocus: true,
   });
   return (
-    <Page
-      title="Agents"
-      description="Shared agents your team can use in Feishu or Slack."
-      action={
-        membership.role === "admin" ? (
-          <Link className="button" to="/agents/new">
-            Create Agent
-          </Link>
-        ) : undefined
-      }
-    >
-      <AsyncState state={state}>{(value) => <AgentsContent agents={value.agents} />}</AsyncState>
-    </Page>
+    <>
+      <Page
+        title="Agents"
+        description="Shared agents your team can use in Feishu or Slack."
+        action={
+          membership.role === "admin" ? (
+            <button className="button" ref={createTriggerRef} type="button" onClick={() => setCreateOpen(true)}>
+              New Agent
+            </button>
+          ) : undefined
+        }
+      >
+        <AsyncState state={state}>{(value) => <AgentsContent agents={value.agents} />}</AsyncState>
+      </Page>
+      {createOpen ? <NewAgentDialog returnFocusRef={createTriggerRef} onClose={() => setCreateOpen(false)} /> : null}
+    </>
   );
 }
 
@@ -934,72 +939,251 @@ function NewAgentPage() {
   const { membership } = useTeam();
   const navigate = useNavigate();
   const computers = useResource(() => browserApi.ownComputers(), membership.teamId);
-  const [error, setError] = useState<string>();
   if (membership.role !== "admin") return <UnavailablePage title="Team Admin access required" />;
+  return (
+    <Page title="Create Agent" description="Create the identity first. Complete its setup from the Agent overview.">
+      <AgentCreationContent
+        computers={computers}
+        teamId={membership.teamId}
+        onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
+      />
+    </Page>
+  );
+}
+
+function NewAgentDialog({
+  onClose,
+  returnFocusRef,
+}: {
+  onClose: () => void;
+  returnFocusRef: { current: HTMLButtonElement | null };
+}) {
+  const { membership } = useTeam();
+  const navigate = useNavigate();
+  const computers = useResource(() => browserApi.ownComputers(), membership.teamId);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(submitting);
+  const onCloseRef = useRef(onClose);
+  submittingRef.current = submitting;
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        if (!submittingRef.current) onCloseRef.current();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (!dialogRef.current?.contains(document.activeElement) || document.activeElement === dialogRef.current) {
+        event.preventDefault();
+        (event.shiftKey ? last : first)?.focus();
+      } else if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      returnFocusRef.current?.focus();
+    };
+  }, [returnFocusRef]);
+
+  return (
+    <div className="dialog-layer">
+      <button
+        aria-label="Dismiss new Agent dialog"
+        className="dialog-backdrop"
+        disabled={submitting}
+        tabIndex={-1}
+        type="button"
+        onClick={onClose}
+      />
+      <div
+        aria-describedby="new-agent-dialog-description"
+        aria-labelledby="new-agent-dialog-title"
+        aria-modal="true"
+        className="dialog-card new-agent-dialog"
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        <header className="dialog-header">
+          <div>
+            <span className="eyebrow dialog-eyebrow">Create</span>
+            <h2 id="new-agent-dialog-title">New Agent</h2>
+          </div>
+          <button
+            aria-label="Close new Agent dialog"
+            className="dialog-close"
+            disabled={submitting}
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </header>
+        <p className="dialog-description" id="new-agent-dialog-description">
+          Give the Agent an identity and choose where it runs. You can finish its setup from the overview.
+        </p>
+        <AgentCreationContent
+          computers={computers}
+          presentation="dialog"
+          teamId={membership.teamId}
+          onCancel={onClose}
+          onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
+          onSubmittingChange={setSubmitting}
+        />
+      </div>
+    </div>
+  );
+}
+
+function AgentCreationContent({
+  computers,
+  onCancel,
+  onCreated,
+  onSubmittingChange,
+  presentation = "page",
+  teamId,
+}: {
+  computers: LoadState<{ computers: Computer[] }>;
+  onCancel?: () => void;
+  onCreated: (agentId: string) => void;
+  onSubmittingChange?: (submitting: boolean) => void;
+  presentation?: "dialog" | "page";
+  teamId: string;
+}) {
+  const [error, setError] = useState<string>();
+  const [submitting, setSubmitting] = useState(false);
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (presentation === "dialog" && computers.kind === "ready") firstFieldRef.current?.focus();
+  }, [computers.kind, presentation]);
+
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (submitting) return;
     const data = new FormData(event.currentTarget);
+    setError(undefined);
+    setSubmitting(true);
+    onSubmittingChange?.(true);
     try {
-      const created = await browserApi.createAgent(membership.teamId, {
+      const created = await browserApi.createAgent(teamId, {
         name: String(data.get("name") ?? ""),
         displayName: String(data.get("displayName") ?? ""),
         runtimeProvider: String(data.get("runtimeProvider") ?? "codex") as "codex" | "claude-code",
         computerId: String(data.get("computerId") ?? ""),
       });
-      navigate(`/agents/${created.id}/general`);
+      onCreated(created.id);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Agent creation failed");
+    } finally {
+      setSubmitting(false);
+      onSubmittingChange?.(false);
     }
   }
+
   return (
-    <Page title="Create Agent" description="Create the identity first. Complete its setup from the Agent overview.">
-      <AsyncState state={computers}>
-        {(value) =>
-          value.computers.length === 0 ? (
-            <EmptyState title="Connect a Local Computer first">
-              Open <Link to="/settings/computers">Computer settings</Link> to generate a connection command.
-            </EmptyState>
-          ) : (
-            <form className="form-card" onSubmit={submit}>
-              <label>
-                Name
-                <input name="name" required pattern="[a-z0-9][a-z0-9-]*" />
-              </label>
-              <label>
-                Display name
-                <input name="displayName" required />
-              </label>
-              <label>
-                Provider
-                <select name="runtimeProvider">
+    <AsyncState state={computers}>
+      {(value) =>
+        value.computers.length === 0 ? (
+          <EmptyState title="Connect a Local Computer first">
+            Open <Link to="/settings/computers">Computer settings</Link> to generate a connection command.
+          </EmptyState>
+        ) : (
+          <form className="form-card agent-create-form" onSubmit={submit}>
+            <div className="agent-create-field">
+              <label htmlFor="new-agent-display-name">Display name</label>
+              <input
+                aria-describedby="new-agent-display-name-hint"
+                id="new-agent-display-name"
+                ref={firstFieldRef}
+                name="displayName"
+                placeholder="Research Assistant"
+                required
+              />
+              <span className="field-hint" id="new-agent-display-name-hint">
+                How teammates will see this Agent in lists and conversations.
+              </span>
+            </div>
+            <div className="agent-create-field">
+              <label htmlFor="new-agent-name">Agent name</label>
+              <span className="agent-name-input">
+                <span aria-hidden="true">@</span>
+                <input
+                  aria-describedby="new-agent-name-hint"
+                  id="new-agent-name"
+                  name="name"
+                  pattern="[a-z0-9][a-z0-9-]*"
+                  placeholder="research-assistant"
+                  required
+                />
+              </span>
+              <span className="field-hint" id="new-agent-name-hint">
+                Used for mentions. Lowercase letters, numbers, and hyphens only.
+              </span>
+            </div>
+            <div className="agent-create-grid">
+              <div className="agent-create-field">
+                <label htmlFor="new-agent-provider">Provider</label>
+                <select id="new-agent-provider" name="runtimeProvider">
                   <option value="codex">Codex</option>
                   <option value="claude-code">Claude Code</option>
                 </select>
-              </label>
-              <label>
-                Computer
-                <select name="computerId" required>
+              </div>
+              <div className="agent-create-field">
+                <label htmlFor="new-agent-computer">Computer</label>
+                <select id="new-agent-computer" name="computerId" required>
                   {value.computers.map((computer: Computer) => (
                     <option value={computer.id} key={computer.id}>
                       {computer.displayName}
                     </option>
                   ))}
                 </select>
-              </label>
-              <p className="muted">New Agents receive only direct mentions by default.</p>
-              <button className="button" type="submit">
-                Create Agent
-              </button>
-              {error ? (
-                <div className="notice error" role="alert">
-                  {error}
-                </div>
+              </div>
+            </div>
+            <p className="agent-create-note">New Agents receive only direct mentions by default.</p>
+            {error ? (
+              <div className="notice error" role="alert">
+                {error}
+              </div>
+            ) : null}
+            <div className="agent-create-actions">
+              {presentation === "dialog" ? (
+                <button className="secondary" disabled={submitting} type="button" onClick={onCancel}>
+                  Cancel
+                </button>
               ) : null}
-            </form>
-          )
-        }
-      </AsyncState>
-    </Page>
+              <button className="button" disabled={submitting} type="submit">
+                {submitting ? "Creating…" : "Create Agent"}
+              </button>
+            </div>
+          </form>
+        )
+      }
+    </AsyncState>
   );
 }
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1150,6 +1150,7 @@ function AgentCreationContent({
                 ref={firstFieldRef}
                 name="displayName"
                 placeholder="Research Assistant"
+                disabled={submitting}
                 required
               />
               <span className="field-hint" id="new-agent-display-name-hint">
@@ -1166,6 +1167,7 @@ function AgentCreationContent({
                   name="name"
                   pattern="[a-z0-9][a-z0-9-]*"
                   placeholder="research-assistant"
+                  disabled={submitting}
                   required
                 />
               </span>
@@ -1176,14 +1178,14 @@ function AgentCreationContent({
             <div className="agent-create-grid">
               <div className="agent-create-field">
                 <label htmlFor="new-agent-provider">Provider</label>
-                <select id="new-agent-provider" name="runtimeProvider">
+                <select id="new-agent-provider" name="runtimeProvider" disabled={submitting}>
                   <option value="codex">Codex</option>
                   <option value="claude-code">Claude Code</option>
                 </select>
               </div>
               <div className="agent-create-field">
                 <label htmlFor="new-agent-computer">Computer</label>
-                <select id="new-agent-computer" name="computerId" required>
+                <select id="new-agent-computer" name="computerId" disabled={submitting} required>
                   {value.computers.map((computer: Computer) => (
                     <option value={computer.id} key={computer.id}>
                       {computer.displayName}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1841,6 +1841,79 @@ textarea:focus {
   outline-offset: 0;
 }
 
+.new-agent-dialog {
+  width: min(100%, 620px);
+}
+
+.new-agent-dialog .form-card {
+  width: 100%;
+  padding: 0;
+  background: transparent;
+}
+
+.agent-create-form {
+  gap: 18px;
+}
+
+.agent-create-field {
+  display: grid;
+  gap: 7px;
+}
+
+.agent-create-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field-hint {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 450;
+  line-height: 1.45;
+}
+
+.agent-name-input {
+  display: flex;
+  align-items: stretch;
+}
+
+.agent-name-input > span {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-right: 0;
+  border-radius: 9px 0 0 9px;
+  background: var(--background);
+  color: var(--muted);
+  font-family: "Geist Mono Variable", "SFMono-Regular", Consolas, monospace;
+  padding: 0 11px;
+}
+
+.agent-name-input input {
+  min-width: 0;
+  border-radius: 0 9px 9px 0;
+}
+
+.agent-create-note {
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--background);
+  color: var(--muted);
+  font-size: 0.78rem;
+  padding: 10px 12px;
+}
+
+.agent-create-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 2px;
+  border-top: 1px solid var(--border);
+  padding-top: 18px;
+}
+
 .definition-list {
   display: grid;
   gap: 0;
@@ -2156,6 +2229,10 @@ textarea:focus {
     max-height: calc(100dvh - 24px);
     border-radius: 14px;
     padding: 20px;
+  }
+
+  .agent-create-grid {
+    grid-template-columns: 1fr;
   }
 
   .page-header,


### PR DESCRIPTION
## Summary

- replace the Agents page creation link with a New Agent dialog that keeps users in list context
- share the complete creation form with the direct /agents/new route
- add focus management, cancellation, duplicate-submit protection, responsive styling, and creation-flow coverage

## Testing

- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/web test (115 tests passed)
- pnpm exec biome check apps/web/src/router.tsx apps/web/src/styles.css apps/web/src/__tests__/app.test.tsx
- node scripts/third-party-notices.mjs --check

Local full-suite exceptions unrelated to this change:

- pnpm check is blocked by nested root Biome configs in local .claude/worktrees directories
- pnpm test reaches a pre-existing macOS /tmp versus /private/tmp assertion mismatch in client tests; after installing locked dependencies, server tests passed 189/190 with one existing observability timing assertion

## Breaking changes

None.

## Important non-goals

- the direct /agents/new route remains available as a fallback and deep link
- no Agent API or creation contract changes

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [ ] All repository-wide commands pass locally; see environment exceptions above.
- [x] No credentials, private data, or generated build output are included.
- [x] No canonical documentation mirrors require updates.