### PR TITLE
feat(web): redesign Settings experience

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -826,6 +826,37 @@ describe("OpenTag Web App Shell", () => {
       "Usage",
       "Security",
     ]);
+    expect(Array.from(navigation.querySelectorAll(".local-nav-group-label"), (label) => label.textContent)).toEqual([
+      "Personal",
+      "Team",
+      "Capabilities",
+      "Governance",
+    ]);
+  });
+
+  it("keeps unavailable Team capabilities explicit instead of inventing records", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/settings/resources");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Team Resources are not enabled" })).toBeTruthy();
+    expect(screen.getByText("This page does not create or infer Team Resource records.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: "Integrations" }));
+    expect(await screen.findByRole("heading", { name: "Team Integrations are not enabled" })).toBeTruthy();
+    expect(screen.getByText("Connections remain owned by individual Agents.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: "Usage" }));
+    expect(await screen.findByRole("heading", { name: "Usage reporting is not enabled" })).toBeTruthy();
+  });
+
+  it("shows the fixed Team access policy as read-only server boundaries", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/settings/access");
+    render(<App />);
+
+    expect(await screen.findByText("Fixed v0.1 policy")).toBeTruthy();
+    const policy = screen.getByRole("table", { name: "Effective Team access policy" });
+    expect(within(policy).getByRole("rowheader", { name: "Agents" })).toBeTruthy();
+    expect(screen.getByText("Custom roles and per-resource policies are not enabled in this version.")).toBeTruthy();
   });
 
   it("lets admins rename a Team and refreshes the UUID-selected Team context from /me", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -841,22 +841,28 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Team Resources are not enabled" })).toBeTruthy();
     expect(screen.getByText("This page does not create or infer Team Resource records.")).toBeTruthy();
+    expect(screen.getByText("No Resource assignment projection is exposed by the current API.")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Review Agent resources" })).toBeNull();
     fireEvent.click(screen.getByRole("link", { name: "Integrations" }));
     expect(await screen.findByRole("heading", { name: "Team Integrations are not enabled" })).toBeTruthy();
-    expect(screen.getByText("Connections remain owned by individual Agents.")).toBeTruthy();
+    expect(
+      screen.getByText("Open an Agent's IM tab to review its current Feishu or Slack connection state."),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Open Agents" })).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: "Usage" }));
     expect(await screen.findByRole("heading", { name: "Usage reporting is not enabled" })).toBeTruthy();
   });
 
-  it("shows the fixed Team access policy as read-only server boundaries", async () => {
+  it("shows the server-returned membership without inventing a capability matrix", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings/access");
     render(<App />);
 
-    expect(await screen.findByText("Fixed v0.1 policy")).toBeTruthy();
-    const policy = screen.getByRole("table", { name: "Effective Team access policy" });
-    expect(within(policy).getByRole("rowheader", { name: "Agents" })).toBeTruthy();
-    expect(screen.getByText("Custom roles and per-resource policies are not enabled in this version.")).toBeTruthy();
+    expect(await screen.findByText("Server-returned membership")).toBeTruthy();
+    expect(screen.getByText("Your role: Admin")).toBeTruthy();
+    expect(screen.getByText("The current API does not publish a complete Team capability matrix.")).toBeTruthy();
+    expect(screen.getByText("Not exposed by the API")).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
   });
 
   it("lets admins rename a Team and refreshes the UUID-selected Team context from /me", async () => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1837,16 +1837,18 @@ function AccessTab({ agent }: { agent: AgentDetailView }) {
 }
 
 const settingsSections = [
-  { key: "account", label: "Account" },
-  { key: "team", label: "General" },
-  { key: "members", label: "Members" },
-  { key: "computers", label: "Computers" },
-  { key: "resources", label: "Resources" },
-  { key: "integrations", label: "Integrations" },
-  { key: "access", label: "Access" },
-  { key: "usage", label: "Usage" },
-  { key: "security", label: "Security" },
+  { key: "account", label: "Account", group: "Personal" },
+  { key: "team", label: "General", group: "Team" },
+  { key: "members", label: "Members", group: "Team" },
+  { key: "computers", label: "Computers", group: "Team" },
+  { key: "resources", label: "Resources", group: "Capabilities" },
+  { key: "integrations", label: "Integrations", group: "Capabilities" },
+  { key: "access", label: "Access", group: "Governance" },
+  { key: "usage", label: "Usage", group: "Governance" },
+  { key: "security", label: "Security", group: "Governance" },
 ] as const;
+
+const settingsGroups = ["Personal", "Team", "Capabilities", "Governance"] as const;
 
 function SettingsPage() {
   const { section = "team" } = useParams();
@@ -1864,19 +1866,32 @@ function SettingsPage() {
       <label className="local-nav-select">
         <span>Settings section</span>
         <select value={section} onChange={(event) => navigate(`/settings/${event.currentTarget.value}`)}>
-          {settingsSections.map((item) => (
-            <option value={item.key} key={item.key}>
-              {item.label}
-            </option>
+          {settingsGroups.map((group) => (
+            <optgroup label={group} key={group}>
+              {settingsSections
+                .filter((item) => item.group === group)
+                .map((item) => (
+                  <option value={item.key} key={item.key}>
+                    {item.label}
+                  </option>
+                ))}
+            </optgroup>
           ))}
         </select>
       </label>
       <div className="settings-layout">
         <nav className="local-nav" aria-label="Settings">
-          {settingsSections.map((item) => (
-            <NavLink to={`/settings/${item.key}`} key={item.key}>
-              {item.label}
-            </NavLink>
+          {settingsGroups.map((group) => (
+            <div className="local-nav-group" key={group}>
+              <span className="local-nav-group-label">{group}</span>
+              {settingsSections
+                .filter((item) => item.group === group)
+                .map((item) => (
+                  <NavLink to={`/settings/${item.key}`} key={item.key}>
+                    {item.label}
+                  </NavLink>
+                ))}
+            </div>
           ))}
         </nav>
         <div className="settings-content">
@@ -1900,27 +1915,140 @@ function SettingsPage() {
             <ComputersSettings canManage={membership.role === "admin"} teamId={membership.teamId} />
           ) : null}
           {section === "resources" ? (
-            <EmptyState title="Team Resources not enabled">No Resource records are created by this page.</EmptyState>
+            <SettingsUnavailable
+              action={{ label: "Review Agent resources", to: "/agents" }}
+              details={[
+                "This page does not create or infer Team Resource records.",
+                "Resource assignments returned by the server remain visible on each Agent.",
+              ]}
+              title="Team Resources are not enabled"
+            >
+              Repositories, skills, tools, and prompts will appear here only after OpenTag has an authoritative Team
+              Resource model.
+            </SettingsUnavailable>
           ) : null}
           {section === "integrations" ? (
-            <EmptyState title="Team Integrations not enabled">
-              Agent-owned connections remain visible from each Agent's IM and Integrations sections.
-            </EmptyState>
+            <SettingsUnavailable
+              action={{ label: "Review Agent connections", to: "/agents" }}
+              details={[
+                "Connections remain owned by individual Agents.",
+                "Open an Agent's IM or Integrations section to review its current connection state.",
+              ]}
+              title="Team Integrations are not enabled"
+            >
+              OpenTag does not promote Agent credentials into shared Team connections or imply that a provider is
+              available Team-wide.
+            </SettingsUnavailable>
           ) : null}
-          {section === "access" ? (
-            <EmptyState title="Team access uses the current membership policy">
-              Team Admins manage membership while Agent access stays visible on each Agent.
-            </EmptyState>
-          ) : null}
+          {section === "access" ? <AccessSettings membership={membership} /> : null}
           {section === "usage" ? (
-            <EmptyState title="Usage reporting not enabled">No inferred or estimated usage is shown.</EmptyState>
+            <SettingsUnavailable
+              details={[
+                "Task, Turn, and provider totals are not estimated from partial activity.",
+                "Cost reporting will require authoritative provider billing metadata.",
+              ]}
+              title="Usage reporting is not enabled"
+            >
+              This page will stay intentionally empty until OpenTag can report complete, measured Team activity.
+            </SettingsUnavailable>
           ) : null}
           {section === "security" ? (
-            <EmptyState title="Security overview">Sensitive credentials are never returned to the browser.</EmptyState>
+            <SettingsUnavailable
+              details={[
+                "Sensitive credentials are never returned to the browser.",
+                "Team administration remains limited to active Admin memberships.",
+                "Browser sessions and audit events are not available in this version.",
+              ]}
+              status="Current safeguards"
+              title="Security data is intentionally limited"
+            >
+              OpenTag only reports security state that the server can verify. It does not show inferred checks or an
+              unsupported all-clear status.
+            </SettingsUnavailable>
           ) : null}
         </div>
       </div>
     </section>
+  );
+}
+
+function SettingsUnavailable({
+  action,
+  children,
+  details,
+  status = "Not enabled",
+  title,
+}: {
+  action?: { label: string; to: string };
+  children: ReactNode;
+  details: readonly string[];
+  status?: string;
+  title: string;
+}) {
+  return (
+    <section className="settings-unavailable">
+      <span className="settings-state-label">{status}</span>
+      <h2>{title}</h2>
+      <p>{children}</p>
+      <ul>
+        {details.map((detail) => (
+          <li key={detail}>{detail}</li>
+        ))}
+      </ul>
+      {action ? (
+        <Link className="settings-state-action" to={action.to}>
+          {action.label} <span aria-hidden="true">→</span>
+        </Link>
+      ) : null}
+    </section>
+  );
+}
+
+function AccessSettings({ membership }: { membership: MeMembership }) {
+  const rows = [
+    ["Team profile", "View", "Manage"],
+    ["Team membership", "View", "Manage"],
+    ["Agents", "Use", "Manage"],
+    ["Computers", "Inspect", "Connect"],
+  ] as const;
+  return (
+    <div className="settings-policy-stack">
+      <section className="settings-policy-banner">
+        <div>
+          <span className="settings-state-label">Fixed v0.1 policy</span>
+          <h2>Membership defines Team access</h2>
+          <p>Active members can view Team state and use Agents. Admins manage identity and infrastructure.</p>
+        </div>
+        <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
+      </section>
+      <section className="settings-list-section">
+        <header className="settings-subheader">
+          <div>
+            <h2>Effective policy</h2>
+            <p>Current server-enforced boundaries for active Team memberships.</p>
+          </div>
+        </header>
+        <table className="settings-policy-table" aria-label="Effective Team access policy">
+          <thead>
+            <tr className="settings-table-header">
+              <th scope="col">Capability</th>
+              <th scope="col">Members</th>
+              <th scope="col">Admins</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(([capability, memberAccess, adminAccess]) => (
+              <tr className="settings-policy-row" key={capability}>
+                <th scope="row">{capability}</th>
+                <td data-label="Members">{memberAccess}</td>
+                <td data-label="Admins">{adminAccess}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p className="settings-footnote">Custom roles and per-resource policies are not enabled in this version.</p>
+      </section>
+    </div>
   );
 }
 
@@ -1930,8 +2058,11 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string>();
   const [error, setError] = useState<string>();
+  const dirty = displayName !== user.displayName;
 
-  useEffect(() => setDisplayName(user.displayName), [user.displayName]);
+  useEffect(() => {
+    setDisplayName(user.displayName);
+  }, [user.displayName]);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -1955,27 +2086,68 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
   }
 
   return (
-    <form className="form-card" onSubmit={submit}>
+    <form className="settings-profile-form" onSubmit={submit}>
       <h2>Account profile</h2>
-      <label>
-        Email
-        <input name="email" readOnly type="email" value={user.email} />
-      </label>
-      <label>
-        Display name
-        <input
-          maxLength={255}
-          name="displayName"
-          onChange={(event) => setDisplayName(event.currentTarget.value)}
-          required
-          value={displayName}
-        />
-      </label>
-      <p className="muted">This name is shared across every Team you belong to.</p>
-      <button className="button commit" disabled={saving} type="submit">
-        {saving ? "Saving…" : "Save account profile"}
-      </button>
-      {message ? <p role="status">{message}</p> : null}
+      <div className="settings-field-list">
+        <div className="settings-field-row">
+          <div className="settings-field-copy">
+            <strong>Email</strong>
+            <p>Your sign-in email cannot be changed here.</p>
+          </div>
+          <div className="settings-readonly-value">
+            <input aria-label="Email" name="email" readOnly type="email" value={user.email} />
+            <small>Read only</small>
+          </div>
+        </div>
+        <div className="settings-field-row">
+          <div className="settings-field-copy">
+            <strong>Display name</strong>
+            <p>This identity is shared across every Team you belong to.</p>
+          </div>
+          <label>
+            Display name
+            <input
+              autoComplete="name"
+              maxLength={255}
+              name="displayName"
+              onChange={(event) => {
+                setDisplayName(event.currentTarget.value);
+                setMessage(undefined);
+                setError(undefined);
+              }}
+              required
+              value={displayName}
+            />
+          </label>
+        </div>
+      </div>
+      {dirty ? (
+        <div className="dirty-bar">
+          <span>Unsaved changes</span>
+          <div className="dirty-actions">
+            <button
+              className="tertiary"
+              disabled={saving}
+              type="button"
+              onClick={() => {
+                setDisplayName(user.displayName);
+                setMessage(undefined);
+                setError(undefined);
+              }}
+            >
+              Discard
+            </button>
+            <button className="button commit" disabled={saving} type="submit">
+              {saving ? "Saving…" : "Save account profile"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+      {message ? (
+        <p className="settings-inline-status success" role="status">
+          {message}
+        </p>
+      ) : null}
       {error ? (
         <p className="notice error" role="alert">
           {error}
@@ -1986,67 +2158,100 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
 }
 
 function TeamSettings({ membership, refreshMe }: { membership: MeMembership; refreshMe: () => void }) {
-  const formRef = useRef<HTMLFormElement>(null);
   const [message, setMessage] = useState<string>();
-  const [dirty, setDirty] = useState(false);
+  const [error, setError] = useState<string>();
+  const [saving, setSaving] = useState(false);
+  const [teamName, setTeamName] = useState(membership.teamName);
+  const [teamDisplayName, setTeamDisplayName] = useState(membership.teamDisplayName);
+  const dirty = teamName !== membership.teamName || teamDisplayName !== membership.teamDisplayName;
+
+  useEffect(() => {
+    setTeamName(membership.teamName);
+    setTeamDisplayName(membership.teamDisplayName);
+  }, [membership.teamDisplayName, membership.teamName]);
+
   if (membership.role !== "admin") {
     return (
-      <DefinitionList
-        rows={[
-          ["Canonical name", membership.teamName],
-          ["Display name", membership.teamDisplayName],
-          ["Your role", membership.role],
-        ]}
-      />
+      <section className="settings-readonly-panel">
+        <div className="settings-readonly-heading">
+          <div>
+            <h2>Team profile</h2>
+            <p>Only Team Admins can change these fields.</p>
+          </div>
+          <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
+        </div>
+        <DefinitionList
+          rows={[
+            ["Canonical name", membership.teamName],
+            ["Display name", membership.teamDisplayName],
+          ]}
+        />
+      </section>
     );
   }
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const data = new FormData(event.currentTarget);
+    setSaving(true);
     try {
       setMessage(undefined);
+      setError(undefined);
       await browserApi.updateTeam(membership.teamId, {
-        name: String(data.get("name") ?? ""),
-        displayName: String(data.get("displayName") ?? ""),
+        name: teamName,
+        displayName: teamDisplayName,
       });
-      setDirty(false);
       refreshMe();
       setMessage("Team profile saved.");
     } catch (cause) {
-      setMessage(cause instanceof Error ? cause.message : "Unable to save the Team profile");
+      setError(cause instanceof Error ? cause.message : "Unable to save the Team profile");
+    } finally {
+      setSaving(false);
     }
   }
   return (
-    <form
-      className="form-card team-profile-form"
-      key={`${membership.teamName}:${membership.teamDisplayName}`}
-      ref={formRef}
-      onChange={() => {
-        setDirty(true);
-        setMessage(undefined);
-      }}
-      onSubmit={submit}
-    >
+    <form className="settings-profile-form" onSubmit={submit}>
       <h2>Team profile</h2>
-      <div className="team-profile-fields">
-        <div className="team-profile-row">
-          <div className="team-profile-copy">
+      <div className="settings-field-list">
+        <div className="settings-field-row">
+          <div className="settings-field-copy">
             <strong>Canonical name</strong>
             <p>Changing this immediately changes the CLI --team selector. The Team ID stays stable.</p>
           </div>
           <label>
             Canonical name
-            <input defaultValue={membership.teamName} name="name" pattern="[A-Za-z0-9][A-Za-z0-9-]*" required />
+            <input
+              aria-label="Canonical name"
+              name="name"
+              pattern="[A-Za-z0-9][A-Za-z0-9-]*"
+              required
+              value={teamName}
+              onChange={(event) => {
+                setTeamName(event.currentTarget.value);
+                setMessage(undefined);
+                setError(undefined);
+              }}
+            />
+            <small className="settings-field-hint">
+              CLI selector: <code>--team {teamName.toLocaleLowerCase() || "team-name"}</code>
+            </small>
           </label>
         </div>
-        <div className="team-profile-row">
-          <div className="team-profile-copy">
+        <div className="settings-field-row">
+          <div className="settings-field-copy">
             <strong>Display name</strong>
             <p>The human-readable Team name shown in navigation and invitations.</p>
           </div>
           <label>
             Display name
-            <input defaultValue={membership.teamDisplayName} name="displayName" required />
+            <input
+              name="displayName"
+              required
+              value={teamDisplayName}
+              onChange={(event) => {
+                setTeamDisplayName(event.currentTarget.value);
+                setMessage(undefined);
+                setError(undefined);
+              }}
+            />
           </label>
         </div>
       </div>
@@ -2056,22 +2261,33 @@ function TeamSettings({ membership, refreshMe }: { membership: MeMembership; ref
           <div className="dirty-actions">
             <button
               className="tertiary"
+              disabled={saving}
               type="button"
               onClick={() => {
-                formRef.current?.reset();
-                setDirty(false);
+                setTeamName(membership.teamName);
+                setTeamDisplayName(membership.teamDisplayName);
                 setMessage(undefined);
+                setError(undefined);
               }}
             >
               Discard
             </button>
-            <button className="button commit" type="submit">
-              Save Team profile
+            <button className="button commit" disabled={saving} type="submit">
+              {saving ? "Saving…" : "Save Team profile"}
             </button>
           </div>
         </div>
       ) : null}
-      {message ? <p role="status">{message}</p> : null}
+      {message ? (
+        <p className="settings-inline-status success" role="status">
+          {message}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="notice error" role="alert">
+          {error}
+        </p>
+      ) : null}
     </form>
   );
 }
@@ -2120,34 +2336,66 @@ function MembersSettings({
       {canManage && !invitationDialogOpen ? (
         <InvitationSettings teamId={teamId} onMutationPendingChange={onInvitationMutationPendingChange} />
       ) : null}
-      <section className="panel">
-        <h2>Team members</h2>
+      <section className="settings-list-section">
         <AsyncState state={state}>
-          {(value) => (
-            <div className="list">
-              {value.members.map((member: TeamMemberSummary) => (
-                <div className="row" key={member.userId}>
-                  <strong>{member.displayName}</strong>
-                  {canManage ? (
-                    <select
-                      aria-label={`Role for ${member.displayName}`}
-                      disabled={pendingUserIds.has(member.userId)}
-                      value={member.role}
-                      onChange={(event) => void changeRole(member, event.currentTarget.value)}
-                    >
-                      {MembershipRoleSchema.options.map((role) => (
-                        <option value={role} key={role}>
-                          {role}
-                        </option>
-                      ))}
-                    </select>
-                  ) : (
-                    <span>{member.role}</span>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
+          {(value) => {
+            const adminCount = value.members.filter((member: TeamMemberSummary) => member.role === "admin").length;
+            return (
+              <>
+                <header className="settings-subheader">
+                  <div>
+                    <h2>Team members</h2>
+                    <p>
+                      {value.members.length} {value.members.length === 1 ? "member" : "members"} · {adminCount}{" "}
+                      {adminCount === 1 ? "admin" : "admins"}
+                    </p>
+                  </div>
+                  {!canManage ? <span className="settings-role-badge">Read only</span> : null}
+                </header>
+                <table className="settings-member-table" aria-label="Team members">
+                  <thead>
+                    <tr className="settings-table-header">
+                      <th scope="col">Team member</th>
+                      <th scope="col">Role</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {value.members.map((member: TeamMemberSummary) => (
+                      <tr className="settings-member-row" key={member.userId}>
+                        <th className="settings-member-identity" scope="row">
+                          <span className="settings-member-avatar" aria-hidden="true">
+                            {initials(member.displayName)}
+                          </span>
+                          <span>
+                            <strong>{member.displayName}</strong>
+                            {member.userId === currentUserId ? <small>You</small> : null}
+                          </span>
+                        </th>
+                        <td data-label="Role">
+                          {canManage ? (
+                            <select
+                              aria-label={`Role for ${member.displayName}`}
+                              disabled={pendingUserIds.has(member.userId)}
+                              value={member.role}
+                              onChange={(event) => void changeRole(member, event.currentTarget.value)}
+                            >
+                              {MembershipRoleSchema.options.map((role) => (
+                                <option value={role} key={role}>
+                                  {role}
+                                </option>
+                              ))}
+                            </select>
+                          ) : (
+                            <span className="settings-value-badge">{member.role}</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </>
+            );
+          }}
         </AsyncState>
         {error ? (
           <p className="notice error" role="alert">
@@ -2331,7 +2579,7 @@ function InvitationSettings({
   }
 
   return (
-    <section className={presentation === "dialog" ? "invitation-dialog-content" : "panel"}>
+    <section className={presentation === "dialog" ? "invitation-dialog-content" : "settings-invitation-panel"}>
       {presentation === "panel" ? (
         <>
           <h2>Invite people</h2>
@@ -2382,22 +2630,70 @@ function ComputersSettings({ canManage, teamId }: { canManage: boolean; teamId: 
       {canManage ? <ComputerSetup teamId={teamId} onConnected={() => setReload((current) => current + 1)} /> : null}
       <AsyncState state={state}>
         {(value) => (
-          <div className="list">
-            {value.computers.map((computer: TeamComputerSummary) => (
-              <div className="row" key={computer.id}>
-                <span>
-                  <strong>{computer.displayName}</strong>
-                  <small>
-                    {computer.ownerDisplayName} ({computer.platform})
-                  </small>
-                </span>
-                <span className="cell-stack align-end">
-                  <strong>{titleCase(computer.connectionStatus)}</strong>
-                  <small>Observed {formatDate(computer.observedAt)}</small>
-                </span>
+          <section className="settings-list-section">
+            <header className="settings-subheader">
+              <div>
+                <h2>Team computers</h2>
+                <p>
+                  {value.computers.length} {value.computers.length === 1 ? "computer" : "computers"} ·{" "}
+                  {
+                    value.computers.filter((computer: TeamComputerSummary) => computer.connectionStatus === "online")
+                      .length
+                  }{" "}
+                  online
+                </p>
               </div>
-            ))}
-          </div>
+              {!canManage ? <span className="settings-role-badge">Read only</span> : null}
+            </header>
+            {value.computers.length === 0 ? (
+              <div className="settings-compact-empty">
+                <strong>No computers connected</strong>
+                <p>
+                  {canManage ? "Use the connection flow above to add one." : "A Team Admin must connect a computer."}
+                </p>
+              </div>
+            ) : (
+              <table className="settings-computer-table" aria-label="Team computers">
+                <thead>
+                  <tr className="settings-table-header">
+                    <th scope="col">Computer</th>
+                    <th scope="col">Owner &amp; system</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Last seen</th>
+                    <th scope="col">Agents</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {value.computers.map((computer: TeamComputerSummary) => (
+                    <tr className="settings-computer-row" key={computer.id}>
+                      <th className="settings-computer-identity" scope="row">
+                        <span className="settings-computer-icon" aria-hidden="true" />
+                        <strong>{computer.displayName}</strong>
+                      </th>
+                      <td data-label="Owner & system">
+                        <strong>{computer.ownerDisplayName}</strong>
+                        <small>
+                          {computer.platform === "darwin"
+                            ? "macOS"
+                            : computer.platform === "win32"
+                              ? "Windows"
+                              : "Linux"}
+                        </small>
+                      </td>
+                      <td data-label="Status">
+                        <span className="settings-status">
+                          <span className={`settings-status-dot ${computer.connectionStatus}`} aria-hidden="true" />
+                          {titleCase(computer.connectionStatus)}
+                        </span>
+                      </td>
+                      <td data-label="Last seen">{formatDate(computer.lastSeenAt)}</td>
+                      <td data-label="Agents">{computer.agentIds.length}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </section>
         )}
       </AsyncState>
     </>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1916,10 +1916,9 @@ function SettingsPage() {
           ) : null}
           {section === "resources" ? (
             <SettingsUnavailable
-              action={{ label: "Review Agent resources", to: "/agents" }}
               details={[
                 "This page does not create or infer Team Resource records.",
-                "Resource assignments returned by the server remain visible on each Agent.",
+                "No Resource assignment projection is exposed by the current API.",
               ]}
               title="Team Resources are not enabled"
             >
@@ -1929,10 +1928,10 @@ function SettingsPage() {
           ) : null}
           {section === "integrations" ? (
             <SettingsUnavailable
-              action={{ label: "Review Agent connections", to: "/agents" }}
+              action={{ label: "Open Agents", to: "/agents" }}
               details={[
-                "Connections remain owned by individual Agents.",
-                "Open an Agent's IM or Integrations section to review its current connection state.",
+                "Supported bot connections remain owned by individual Agents.",
+                "Open an Agent's IM tab to review its current Feishu or Slack connection state.",
               ]}
               title="Team Integrations are not enabled"
             >
@@ -2005,48 +2004,34 @@ function SettingsUnavailable({
 }
 
 function AccessSettings({ membership }: { membership: MeMembership }) {
-  const rows = [
-    ["Team profile", "View", "Manage"],
-    ["Team membership", "View", "Manage"],
-    ["Agents", "Use", "Manage"],
-    ["Computers", "Inspect", "Connect"],
-  ] as const;
   return (
     <div className="settings-policy-stack">
       <section className="settings-policy-banner">
         <div>
-          <span className="settings-state-label">Fixed v0.1 policy</span>
-          <h2>Membership defines Team access</h2>
-          <p>Active members can view Team state and use Agents. Admins manage identity and infrastructure.</p>
+          <span className="settings-state-label">Server-returned membership</span>
+          <h2>Authorization follows your active Team membership</h2>
+          <p>OpenTag checks authorization on every request. This page only reports facts exposed by the API.</p>
         </div>
         <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
       </section>
       <section className="settings-list-section">
         <header className="settings-subheader">
           <div>
-            <h2>Effective policy</h2>
-            <p>Current server-enforced boundaries for active Team memberships.</p>
+            <h2>Available policy detail</h2>
+            <p>The current API does not publish a complete Team capability matrix.</p>
           </div>
         </header>
-        <table className="settings-policy-table" aria-label="Effective Team access policy">
-          <thead>
-            <tr className="settings-table-header">
-              <th scope="col">Capability</th>
-              <th scope="col">Members</th>
-              <th scope="col">Admins</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map(([capability, memberAccess, adminAccess]) => (
-              <tr className="settings-policy-row" key={capability}>
-                <th scope="row">{capability}</th>
-                <td data-label="Members">{memberAccess}</td>
-                <td data-label="Admins">{adminAccess}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <p className="settings-footnote">Custom roles and per-resource policies are not enabled in this version.</p>
+        <DefinitionList
+          rows={[
+            ["Selected Team role", titleCase(membership.role)],
+            ["Custom roles", "Not enabled"],
+            ["Per-resource policies", "Not exposed by the API"],
+          ]}
+        />
+        <p className="settings-footnote">
+          Management controls use server-returned capabilities where available; the server remains authoritative for
+          every operation.
+        </p>
       </section>
     </div>
   );
@@ -2899,8 +2884,8 @@ function agentSectionDescription(section: (typeof agentSections)[number]["key"])
     general: "Review identity, readiness dependencies, and the configuration that needs attention.",
     runtime: "Inspect the bound Computer, provider, model, instructions, and execution limits.",
     im: "Manage the Agent-owned Feishu or Slack bot connection and receive policy.",
-    resources: "Review the Team Resources authorized for this Agent.",
-    integrations: "Review external services available to this Agent's runtime.",
+    resources: "Team Resources are not enabled for Agents in this release.",
+    integrations: "Agent Integrations are not enabled; supported bot connections are managed on the IM tab.",
     access: "Understand who can use, inspect, and manage this Agent.",
   } satisfies Record<(typeof agentSections)[number]["key"], string>;
   return descriptions[section];

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2322,8 +2322,7 @@ textarea:focus {
 }
 
 .settings-member-table,
-.settings-computer-table,
-.settings-policy-table {
+.settings-computer-table {
   display: block;
   width: 100%;
   border-top: 1px solid var(--strong-border);
@@ -2333,18 +2332,14 @@ textarea:focus {
 .settings-member-table thead,
 .settings-member-table tbody,
 .settings-computer-table thead,
-.settings-computer-table tbody,
-.settings-policy-table thead,
-.settings-policy-table tbody {
+.settings-computer-table tbody {
   display: block;
 }
 
 .settings-member-table th,
 .settings-member-table td,
 .settings-computer-table th,
-.settings-computer-table td,
-.settings-policy-table th,
-.settings-policy-table td {
+.settings-computer-table td {
   min-width: 0;
   padding: 0;
   text-align: left;
@@ -2352,8 +2347,7 @@ textarea:focus {
 
 .settings-table-header,
 .settings-member-row,
-.settings-computer-row,
-.settings-policy-row {
+.settings-computer-row {
   display: grid;
   align-items: center;
   border-bottom: 1px solid var(--border);
@@ -2567,27 +2561,6 @@ textarea:focus {
 
 .settings-policy-banner p {
   max-width: 530px;
-}
-
-.settings-policy-table .settings-table-header,
-.settings-policy-row {
-  grid-template-columns: minmax(0, 1fr) 130px 130px;
-}
-
-.settings-policy-row {
-  min-height: 56px;
-  font-size: 0.8rem;
-}
-
-.settings-policy-row > td {
-  width: fit-content;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--surface);
-  color: var(--secondary-foreground);
-  font-size: 0.72rem;
-  font-weight: 620;
-  padding: 5px 8px;
 }
 
 .settings-footnote {
@@ -2860,7 +2833,6 @@ textarea:focus {
   }
 
   .settings-computer-row [data-label]::before,
-  .settings-policy-row [data-label]::before,
   .settings-member-row [data-label]::before {
     display: block;
     margin-bottom: 5px;
@@ -2868,16 +2840,6 @@ textarea:focus {
     content: attr(data-label);
     font-size: 0.68rem;
     font-weight: 600;
-  }
-
-  .settings-policy-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 12px;
-    padding: 14px 0;
-  }
-
-  .settings-policy-row > th {
-    grid-column: 1 / -1;
   }
 
   .settings-unavailable {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2126,6 +2126,529 @@ textarea:focus {
   gap: 7px;
 }
 
+.settings-page .settings-title {
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 26px;
+}
+
+.settings-page .local-nav {
+  position: sticky;
+  top: 28px;
+}
+
+.local-nav-group {
+  display: grid;
+  gap: 3px;
+}
+
+.local-nav-group + .local-nav-group {
+  margin-top: 15px;
+}
+
+.local-nav-group-label {
+  margin-bottom: 3px;
+  color: #737c72;
+  font-size: 0.66rem;
+  font-weight: 680;
+  letter-spacing: 0.09em;
+  padding: 0 11px;
+  text-transform: uppercase;
+}
+
+.settings-profile-form,
+.settings-policy-stack {
+  display: grid;
+  width: min(100%, 760px);
+  gap: 18px;
+}
+
+.settings-profile-form > h2,
+.settings-list-section h2,
+.settings-invitation-panel h2,
+.settings-readonly-panel h2,
+.settings-unavailable h2,
+.settings-policy-banner h2 {
+  margin-bottom: 0;
+  font-size: 1rem;
+  font-weight: 680;
+}
+
+.settings-field-list {
+  border-top: 1px solid var(--strong-border);
+}
+
+.settings-field-row {
+  display: grid;
+  align-items: start;
+  border-bottom: 1px solid var(--border);
+  grid-template-columns: minmax(180px, 0.7fr) minmax(260px, 1.3fr);
+  gap: 34px;
+  padding: 21px 0;
+}
+
+.settings-field-copy strong,
+.settings-field-row label {
+  color: var(--secondary-foreground);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.settings-field-copy p,
+.settings-field-hint,
+.settings-readonly-value small,
+.settings-subheader p,
+.settings-policy-banner p,
+.settings-readonly-heading p,
+.settings-compact-empty p {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 450;
+  line-height: 1.5;
+}
+
+.settings-field-row label {
+  display: grid;
+  gap: 7px;
+}
+
+.settings-field-hint code {
+  color: var(--secondary-foreground);
+  font-size: 0.73rem;
+}
+
+.settings-readonly-value {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: rgb(253 252 247 / 58%);
+  color: var(--secondary-foreground);
+  font-size: 0.86rem;
+  padding: 0.62rem 0.72rem;
+}
+
+.settings-readonly-value small {
+  margin: 0;
+  white-space: nowrap;
+}
+
+.settings-readonly-value input {
+  min-height: 0;
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.settings-readonly-value input:focus {
+  border: 0;
+  outline: 0;
+}
+
+.settings-inline-status {
+  width: fit-content;
+  margin: 0;
+  border: 0;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  padding: 8px 11px;
+}
+
+.settings-readonly-panel,
+.settings-list-section {
+  display: grid;
+  width: min(100%, 760px);
+  gap: 18px;
+}
+
+.settings-content > .panel .button {
+  justify-self: start;
+}
+
+.settings-readonly-heading,
+.settings-subheader {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.settings-readonly-panel .definition-list {
+  width: 100%;
+  margin: 0;
+}
+
+.settings-role-badge,
+.settings-value-badge {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--secondary-foreground);
+  font-size: 0.72rem;
+  font-weight: 620;
+  padding: 5px 8px;
+  white-space: nowrap;
+}
+
+.settings-invitation-panel {
+  display: grid;
+  width: min(100%, 760px);
+  gap: 14px;
+  margin-bottom: 32px;
+  border-radius: var(--radius);
+  background: var(--surface-soft);
+  padding: 22px;
+}
+
+.settings-invitation-panel > p {
+  max-width: 590px;
+  margin: -7px 0 1px;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.settings-invitation-panel .invite-link {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.settings-invitation-panel .actions {
+  justify-content: flex-end;
+}
+
+.settings-member-table,
+.settings-computer-table,
+.settings-policy-table {
+  display: block;
+  width: 100%;
+  border-top: 1px solid var(--strong-border);
+  border-collapse: collapse;
+}
+
+.settings-member-table thead,
+.settings-member-table tbody,
+.settings-computer-table thead,
+.settings-computer-table tbody,
+.settings-policy-table thead,
+.settings-policy-table tbody {
+  display: block;
+}
+
+.settings-member-table th,
+.settings-member-table td,
+.settings-computer-table th,
+.settings-computer-table td,
+.settings-policy-table th,
+.settings-policy-table td {
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.settings-table-header,
+.settings-member-row,
+.settings-computer-row,
+.settings-policy-row {
+  display: grid;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  gap: 18px;
+}
+
+.settings-table-header {
+  min-height: 38px;
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 640;
+}
+
+.settings-member-table .settings-table-header,
+.settings-member-row {
+  grid-template-columns: minmax(0, 1fr) 132px;
+}
+
+.settings-member-row {
+  min-height: 66px;
+  padding: 9px 0;
+}
+
+.settings-member-identity,
+.settings-computer-identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+}
+
+.settings-member-identity strong,
+.settings-member-identity small {
+  display: block;
+}
+
+.settings-member-identity strong,
+.settings-computer-row strong {
+  font-size: 0.83rem;
+  font-weight: 650;
+}
+
+.settings-member-identity small,
+.settings-computer-row small {
+  display: block;
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.71rem;
+}
+
+.settings-member-avatar {
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+  background: var(--brand-ink);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 690;
+}
+
+.settings-member-row select {
+  min-height: 36px;
+  font-size: 0.78rem;
+  padding-block: 0.35rem;
+}
+
+.settings-computer-table .settings-table-header,
+.settings-computer-row {
+  grid-template-columns: minmax(160px, 1.35fr) minmax(128px, 0.9fr) 90px minmax(130px, 0.85fr) 46px;
+}
+
+.settings-computer-row {
+  min-height: 70px;
+  color: var(--secondary-foreground);
+  font-size: 0.77rem;
+  padding: 10px 0;
+}
+
+.settings-computer-icon {
+  position: relative;
+  width: 24px;
+  height: 17px;
+  flex: 0 0 auto;
+  border: 1.5px solid var(--secondary-foreground);
+  border-radius: 3px;
+}
+
+.settings-computer-icon::after {
+  position: absolute;
+  right: -3px;
+  bottom: -5px;
+  left: -3px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--secondary-foreground);
+  content: "";
+}
+
+.settings-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.settings-status-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+}
+
+.settings-status-dot.online {
+  background: var(--brand);
+}
+
+.settings-status-dot.offline {
+  background: var(--warning);
+}
+
+.settings-compact-empty {
+  border-top: 1px solid var(--strong-border);
+  border-bottom: 1px solid var(--border);
+  padding: 24px 0;
+}
+
+.settings-compact-empty strong {
+  font-size: 0.86rem;
+}
+
+.settings-unavailable {
+  width: min(100%, 760px);
+  border-radius: var(--radius);
+  background: var(--surface-soft);
+  padding: 28px;
+}
+
+.settings-state-label {
+  display: block;
+  width: fit-content;
+  margin-bottom: 12px;
+  color: var(--brand-ink);
+  font-size: 0.67rem;
+  font-weight: 720;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-unavailable > p {
+  max-width: 610px;
+  margin: 8px 0 22px;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.settings-unavailable ul {
+  margin: 0 0 22px;
+  padding: 0;
+  list-style: none;
+}
+
+.settings-unavailable li {
+  position: relative;
+  border-top: 1px solid var(--border);
+  color: var(--secondary-foreground);
+  font-size: 0.78rem;
+  padding: 12px 12px 12px 22px;
+}
+
+.settings-unavailable li::before {
+  position: absolute;
+  top: 17px;
+  left: 2px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
+  content: "";
+}
+
+.settings-state-action {
+  color: var(--brand-ink);
+  font-size: 0.8rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.settings-state-action:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.settings-policy-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  border: 1px solid #cdd4bb;
+  border-radius: var(--radius);
+  background: var(--brand-light);
+  padding: 22px;
+}
+
+.settings-policy-banner .settings-state-label {
+  margin-bottom: 8px;
+}
+
+.settings-policy-banner p {
+  max-width: 530px;
+}
+
+.settings-policy-table .settings-table-header,
+.settings-policy-row {
+  grid-template-columns: minmax(0, 1fr) 130px 130px;
+}
+
+.settings-policy-row {
+  min-height: 56px;
+  font-size: 0.8rem;
+}
+
+.settings-policy-row > td {
+  width: fit-content;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--secondary-foreground);
+  font-size: 0.72rem;
+  font-weight: 620;
+  padding: 5px 8px;
+}
+
+.settings-footnote {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+
+@media (max-width: 1320px) {
+  .settings-page > .local-nav-select {
+    display: grid;
+    gap: 7px;
+    margin-top: 22px;
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .settings-page .settings-layout {
+    display: block;
+    padding-top: 22px;
+  }
+
+  .settings-page .settings-layout > .local-nav {
+    display: none;
+  }
+
+  .settings-page .settings-content {
+    width: 100%;
+  }
+
+  .settings-page .section-header {
+    margin-top: 24px;
+  }
+}
+
+@media (max-width: 820px) {
+  .settings-computer-table .settings-table-header {
+    display: none;
+  }
+
+  .settings-computer-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 15px 20px;
+    padding: 16px 0;
+  }
+
+  .settings-computer-identity {
+    grid-column: 1 / -1;
+  }
+
+  .settings-computer-row [data-label]::before {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--muted);
+    content: attr(data-label);
+    font-size: 0.68rem;
+    font-weight: 600;
+  }
+}
+
 @media (max-width: 900px) {
   .shell {
     grid-template-columns: minmax(0, 1fr);
@@ -2305,9 +2828,60 @@ textarea:focus {
   }
 
   .binding-status,
+  .settings-policy-banner,
+  .settings-readonly-heading,
+  .settings-subheader,
   .dirty-bar {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .settings-field-row {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .settings-table-header {
+    display: none;
+  }
+
+  .settings-member-row {
+    grid-template-columns: minmax(0, 1fr) 112px;
+  }
+
+  .settings-computer-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 15px 20px;
+    padding: 16px 0;
+  }
+
+  .settings-computer-identity {
+    grid-column: 1 / -1;
+  }
+
+  .settings-computer-row [data-label]::before,
+  .settings-policy-row [data-label]::before,
+  .settings-member-row [data-label]::before {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--muted);
+    content: attr(data-label);
+    font-size: 0.68rem;
+    font-weight: 600;
+  }
+
+  .settings-policy-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    padding: 14px 0;
+  }
+
+  .settings-policy-row > th {
+    grid-column: 1 / -1;
+  }
+
+  .settings-unavailable {
+    padding: 22px;
   }
 
   .dirty-actions {


### PR DESCRIPTION
## Summary

- reorganize Settings navigation into Personal, Team, Capabilities, and Governance groups
- add consistent save/discard editing states for Account and General settings
- upgrade Members, Computers, and Access using server-backed fields and fixed v0.1 policies
- replace speculative Resources, Integrations, Usage, and Security content with accurate capability states
- improve responsive layouts, semantic tables, accessibility, and test coverage

## Validation

- `pnpm --filter @opentag/web test` — 119 tests passed
- `pnpm --filter @opentag/web typecheck`
- `pnpm --filter @opentag/web build`
- `pnpm exec biome check apps/web/src/router.tsx apps/web/src/styles.css apps/web/src/__tests__/app.test.tsx`
- `node scripts/third-party-notices.mjs --check`
- visual QA at 1440px, 1280px, and 768px widths

## Notes

- Full-repo `pnpm check` is currently blocked by pre-existing nested root Biome configs under `.claude/worktrees/*`; the modified files pass the scoped Biome check.
