### PR TITLE
fix(web): separate Account from flat Team Settings

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -833,12 +833,20 @@ describe("OpenTag Web App Shell", () => {
       "Usage",
       "Security",
     ]);
-    expect(Array.from(navigation.querySelectorAll(".local-nav-group-label"), (label) => label.textContent)).toEqual([
-      "Personal",
-      "Team",
-      "Capabilities",
-      "Governance",
+    expect(navigation.querySelector(".local-nav-group-label")).toBeNull();
+    const mobileNavigation = screen.getByLabelText("Settings section");
+    expect(Array.from(mobileNavigation.querySelectorAll("option"), (option) => option.textContent)).toEqual([
+      "Account",
+      "General",
+      "Members",
+      "Computers",
+      "Resources",
+      "Integrations",
+      "Access",
+      "Usage",
+      "Security",
     ]);
+    expect(mobileNavigation.querySelector("optgroup")).toBeNull();
   });
 
   it("keeps unavailable Team capabilities explicit instead of inventing records", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -571,7 +571,7 @@ describe("OpenTag Web App Shell", () => {
 
   it.each(["admin", "member"] as const)("lets a %s update their global account display name", async (role) => {
     installApi(role);
-    window.history.replaceState({}, "", "/settings/account");
+    window.history.replaceState({}, "", "/account");
     render(<App />);
 
     const email = (await screen.findByLabelText("Email")) as HTMLInputElement;
@@ -598,7 +598,7 @@ describe("OpenTag Web App Shell", () => {
       resolveUpdate = resolve;
     });
     installApi("member", { profileUpdate: () => update });
-    window.history.replaceState({}, "", "/settings/account");
+    window.history.replaceState({}, "", "/account");
     render(<App />);
 
     const displayName = (await screen.findByLabelText("Display name")) as HTMLInputElement;
@@ -618,7 +618,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("restores the confirmed server name and shows the error when an account update fails", async () => {
     installApi("member", { profileUpdateFails: true });
-    window.history.replaceState({}, "", "/settings/account");
+    window.history.replaceState({}, "", "/account");
     render(<App />);
 
     const displayName = (await screen.findByLabelText("Display name")) as HTMLInputElement;
@@ -822,21 +822,10 @@ describe("OpenTag Web App Shell", () => {
       within(navigation)
         .getAllByRole("link")
         .map((link) => link.textContent),
-    ).toEqual([
-      "Account",
-      "General",
-      "Members",
-      "Computers",
-      "Resources",
-      "Integrations",
-      "Access",
-      "Usage",
-      "Security",
-    ]);
+    ).toEqual(["General", "Members", "Computers", "Resources", "Integrations", "Access", "Usage", "Security"]);
     expect(navigation.querySelector(".local-nav-group-label")).toBeNull();
     const mobileNavigation = screen.getByLabelText("Settings section");
     expect(Array.from(mobileNavigation.querySelectorAll("option"), (option) => option.textContent)).toEqual([
-      "Account",
       "General",
       "Members",
       "Computers",
@@ -847,6 +836,32 @@ describe("OpenTag Web App Shell", () => {
       "Security",
     ]);
     expect(mobileNavigation.querySelector("optgroup")).toBeNull();
+  });
+
+  it("opens Settings on General and keeps account scope out of the Settings shell", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/settings");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "General" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/settings/team");
+    expect(screen.getByText("Manage the current Team's identity, infrastructure, access, and security.")).toBeTruthy();
+    expect(
+      within(screen.getByRole("navigation", { name: "Settings" })).queryByRole("link", { name: "Account" }),
+    ).toBeNull();
+  });
+
+  it("redirects the legacy Settings account URL to the editable Account page", async () => {
+    installApi("member");
+    window.history.replaceState({}, "", "/settings/account");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Account" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/account");
+    const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
+    expect(displayName.readOnly).toBe(false);
+    fireEvent.change(displayName, { target: { value: "Legacy Account" } });
+    expect(screen.getByRole("button", { name: "Save account profile" })).toBeTruthy();
   });
 
   it("keeps unavailable Team capabilities explicit instead of inventing records", async () => {
@@ -1570,6 +1585,11 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Account settings" }));
     expect(await screen.findByRole("heading", { name: "Account" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/account");
+    const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
+    expect(displayName.readOnly).toBe(false);
+    fireEvent.change(displayName, { target: { value: "Account Menu" } });
+    expect(screen.getByRole("button", { name: "Save account profile" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Sign out" }));
     expect(await screen.findByRole("heading", { name: "Sign in" })).toBeTruthy();

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1898,18 +1898,16 @@ function AccessTab({ agent }: { agent: AgentDetailView }) {
 }
 
 const settingsSections = [
-  { key: "account", label: "Account", group: "Personal" },
-  { key: "team", label: "General", group: "Team" },
-  { key: "members", label: "Members", group: "Team" },
-  { key: "computers", label: "Computers", group: "Team" },
-  { key: "resources", label: "Resources", group: "Capabilities" },
-  { key: "integrations", label: "Integrations", group: "Capabilities" },
-  { key: "access", label: "Access", group: "Governance" },
-  { key: "usage", label: "Usage", group: "Governance" },
-  { key: "security", label: "Security", group: "Governance" },
+  { key: "account", label: "Account" },
+  { key: "team", label: "General" },
+  { key: "members", label: "Members" },
+  { key: "computers", label: "Computers" },
+  { key: "resources", label: "Resources" },
+  { key: "integrations", label: "Integrations" },
+  { key: "access", label: "Access" },
+  { key: "usage", label: "Usage" },
+  { key: "security", label: "Security" },
 ] as const;
-
-const settingsGroups = ["Personal", "Team", "Capabilities", "Governance"] as const;
 
 function SettingsPage() {
   const { section = "team" } = useParams();
@@ -1927,32 +1925,19 @@ function SettingsPage() {
       <label className="local-nav-select">
         <span>Settings section</span>
         <select value={section} onChange={(event) => navigate(`/settings/${event.currentTarget.value}`)}>
-          {settingsGroups.map((group) => (
-            <optgroup label={group} key={group}>
-              {settingsSections
-                .filter((item) => item.group === group)
-                .map((item) => (
-                  <option value={item.key} key={item.key}>
-                    {item.label}
-                  </option>
-                ))}
-            </optgroup>
+          {settingsSections.map((item) => (
+            <option value={item.key} key={item.key}>
+              {item.label}
+            </option>
           ))}
         </select>
       </label>
       <div className="settings-layout">
         <nav className="local-nav" aria-label="Settings">
-          {settingsGroups.map((group) => (
-            <div className="local-nav-group" key={group}>
-              <span className="local-nav-group-label">{group}</span>
-              {settingsSections
-                .filter((item) => item.group === group)
-                .map((item) => (
-                  <NavLink to={`/settings/${item.key}`} key={item.key}>
-                    {item.label}
-                  </NavLink>
-                ))}
-            </div>
+          {settingsSections.map((item) => (
+            <NavLink to={`/settings/${item.key}`} key={item.key}>
+              {item.label}
+            </NavLink>
           ))}
         </nav>
         <div className="settings-content">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -342,7 +342,8 @@ export function AppRouter() {
           <Route path="/agents/:agentId" element={<Navigate replace to="general" />} />
           <Route path="/agents/:agentId/:tab" element={<AgentDetailPage />} />
           <Route path="/account" element={<AccountPage />} />
-          <Route path="/settings" element={<Navigate replace to="account" />} />
+          <Route path="/settings" element={<Navigate replace to="team" />} />
+          <Route path="/settings/account" element={<Navigate replace to="/account" />} />
           <Route path="/settings/:section" element={<SettingsPage />} />
         </Route>
       </Route>
@@ -1355,39 +1356,10 @@ function AgentDetailPage() {
 }
 
 function AccountPage() {
-  const { me } = useTeam();
-  const navigate = useNavigate();
-  const [loggingOut, setLoggingOut] = useState(false);
-  const [error, setError] = useState<string>();
-  async function logout() {
-    setLoggingOut(true);
-    setError(undefined);
-    try {
-      await browserApi.logout();
-      navigate("/login", { replace: true });
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Unable to sign out");
-      setLoggingOut(false);
-    }
-  }
+  const { me, refreshMe } = useTeam();
   return (
-    <Page title="Account" description="Review the identity used to access OpenTag.">
-      <DefinitionList
-        rows={[
-          ["Display name", me.user.displayName],
-          ["Email", me.user.email],
-        ]}
-      />
-      <div className="account-page-actions">
-        <button className="secondary" disabled={loggingOut} type="button" onClick={() => void logout()}>
-          {loggingOut ? "Signing out…" : "Sign out"}
-        </button>
-        {error ? (
-          <div className="notice error" role="alert">
-            {error}
-          </div>
-        ) : null}
-      </div>
+    <Page title="Account" description="Manage the identity used across every Team you belong to.">
+      <AccountSettings refreshMe={refreshMe} user={me.user} />
     </Page>
   );
 }
@@ -1898,7 +1870,6 @@ function AccessTab({ agent }: { agent: AgentDetailView }) {
 }
 
 const settingsSections = [
-  { key: "account", label: "Account" },
   { key: "team", label: "General" },
   { key: "members", label: "Members" },
   { key: "computers", label: "Computers" },
@@ -1920,7 +1891,7 @@ function SettingsPage() {
     <section className="settings-page">
       <header className="settings-title">
         <h1>Settings</h1>
-        <p>Manage your account and the current Team's identity, infrastructure, access, and security.</p>
+        <p>Manage the current Team's identity, infrastructure, access, and security.</p>
       </header>
       <label className="local-nav-select">
         <span>Settings section</span>
@@ -1945,7 +1916,6 @@ function SettingsPage() {
             <h2>{currentSection.label}</h2>
             <p>{settingsSectionDescription(currentSection.key)}</p>
           </header>
-          {section === "account" ? <AccountSettings refreshMe={refreshMe} user={me.user} /> : null}
           {section === "team" ? <TeamSettings membership={membership} refreshMe={refreshMe} /> : null}
           {section === "members" ? (
             <MembersSettings
@@ -2939,7 +2909,6 @@ function agentSectionDescription(section: (typeof agentSections)[number]["key"])
 
 function settingsSectionDescription(section: (typeof settingsSections)[number]["key"]): string {
   const descriptions = {
-    account: "Manage the display identity shared across every Team you belong to.",
     team: "Manage the current Team's stable identity and display name.",
     members: "Invite people and review the Team membership visible to you.",
     computers: "Connect and inspect the Computers available to the current Team.",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1509,13 +1509,6 @@ code {
   margin-top: 24px;
 }
 
-.account-page-actions {
-  display: grid;
-  justify-items: start;
-  gap: 14px;
-  margin-top: 28px;
-}
-
 /* Product surfaces use spacing and tonal grouping instead of repeated rules. */
 .page-header,
 .settings-title {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2137,25 +2137,6 @@ textarea:focus {
   top: 28px;
 }
 
-.local-nav-group {
-  display: grid;
-  gap: 3px;
-}
-
-.local-nav-group + .local-nav-group {
-  margin-top: 15px;
-}
-
-.local-nav-group-label {
-  margin-bottom: 3px;
-  color: #737c72;
-  font-size: 0.66rem;
-  font-weight: 680;
-  letter-spacing: 0.09em;
-  padding: 0 11px;
-  text-transform: uppercase;
-}
-
 .settings-profile-form,
 .settings-policy-stack {
   display: grid;


### PR DESCRIPTION
## Summary

- remove Personal, Team, Capabilities, and Governance grouping from Settings
- keep desktop and mobile Settings navigation as the same flat Team-scoped destination list
- remove Account from Settings and keep the account menu pointed at the independent `/account` page
- move the editable account profile form to `/account`
- make `/settings` open General at `/settings/team`
- redirect the legacy `/settings/account` URL to `/account`
- remove account scope from the Settings title copy and delete obsolete grouping/account-page styles

Follow-up to #79. Account is user-global, while Settings is scoped to the selected Team; presenting Account as a Settings tab mixed those scopes and made the navigation hierarchy heavier than needed.

## Validation

- `pnpm --filter @opentag/shared build`
- `pnpm --filter @opentag/web test` — 126 tests passed
- `pnpm --filter @opentag/web typecheck`
- `pnpm --filter @opentag/web build`
- `pnpm exec biome check apps/web/src/router.tsx apps/web/src/styles.css apps/web/src/__tests__/app.test.tsx`
- `git diff --check`
