### PR TITLE
fix(agent-runtime): preserve pre-input Claude spawn failures

### DIFF
--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -13,7 +13,11 @@ import {
   ClaudeCodeAgentRuntimeFactory,
   claudeCodeAgentRuntimeEnvironment,
 } from "../providers/claude-code/agent-runtime.js";
-import type { ClaudeCodeProcessClient, ClaudeCodeProcessResult } from "../providers/claude-code/process-wire.js";
+import {
+  type ClaudeCodeProcessClient,
+  ClaudeCodeProcessError,
+  type ClaudeCodeProcessResult,
+} from "../providers/claude-code/process-wire.js";
 
 const SESSION_ID = "11111111-1111-4111-8111-111111111111";
 const fixture = fileURLToPath(new URL("./fixtures/claude-code-stream.mjs", import.meta.url));
@@ -226,6 +230,19 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
       error: { code: "provider_start_failed", message: "bridge setup failed" },
     });
     await vi.waitFor(() => expect(bridgeRuntime.state.phase).toBe("closed"));
+
+    const asynchronousSpawnRuntime = await factory(
+      new ManualClaudeCodeProcess([], {
+        executeError: new ClaudeCodeProcessError("spawn", "asynchronous spawn failed"),
+      }),
+    ).create(createRequest(() => undefined));
+    await expect(
+      asynchronousSpawnRuntime.prompt({ runId: "run-asynchronous-spawn", input: input("x") }),
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "provider_start_failed", message: "asynchronous spawn failed" },
+    });
+    await vi.waitFor(() => expect(asynchronousSpawnRuntime.state.phase).toBe("closed"));
 
     const executionRuntime = await factory(new ManualClaudeCodeProcess([], { executeError: 42 })).create(
       createRequest(() => undefined),

--- a/packages/client/src/__tests__/claude-code-process.test.ts
+++ b/packages/client/src/__tests__/claude-code-process.test.ts
@@ -153,13 +153,30 @@ describe("ClaudeCodeProcess", () => {
 
     const erroredChild = fakeChild();
     const errored = fakeProcess(erroredChild);
+    const erroredRun = errored.execute({ type: "user" }, () => undefined, new AbortController().signal);
     erroredChild.emit("error", new Error("child error"));
     erroredChild.emit("error", new Error("second error"));
-    await expect(
-      errored.execute({ type: "user" }, () => undefined, new AbortController().signal),
-    ).rejects.toMatchObject({ code: "spawn" });
+    await expect(erroredRun).rejects.toMatchObject({ code: "spawn" });
     erroredChild.emit("exit", 1, null);
     await errored.close();
+
+    const failedBeforeExecuteChild = fakeChild();
+    const failedBeforeExecute = fakeProcess(failedBeforeExecuteChild);
+    failedBeforeExecuteChild.emit("error", new Error("spawn failed before execute"));
+    await expect(
+      failedBeforeExecute.execute({ type: "user" }, () => undefined, new AbortController().signal),
+    ).rejects.toMatchObject({ code: "spawn" });
+    failedBeforeExecuteChild.emit("exit", 1, null);
+    await failedBeforeExecute.close();
+
+    const startedChild = fakeChild();
+    const started = fakeProcess(startedChild);
+    startedChild.emit("spawn");
+    const startedRun = started.execute({ type: "user" }, () => undefined, new AbortController().signal);
+    startedChild.emit("error", new Error("child failed after spawn"));
+    await expect(startedRun).rejects.toMatchObject({ code: "exited" });
+    startedChild.emit("exit", 1, null);
+    await started.close();
 
     const writeChild = fakeChild();
     writeChild.stdin.write = ((_chunk: unknown, callback: (error?: Error | null) => void) => {

--- a/packages/client/src/__tests__/client-turn.integration.test.ts
+++ b/packages/client/src/__tests__/client-turn.integration.test.ts
@@ -11,7 +11,11 @@ import type {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeFactory } from "../agent-runtime/types.js";
 import { ClaudeCodeAgentRuntimeFactory } from "../providers/claude-code/agent-runtime.js";
-import type { ClaudeCodeProcessClient, ClaudeCodeProcessResult } from "../providers/claude-code/process-wire.js";
+import {
+  type ClaudeCodeProcessClient,
+  ClaudeCodeProcessError,
+  type ClaudeCodeProcessResult,
+} from "../providers/claude-code/process-wire.js";
 import { claudeCodeRuntimePolicy, validateClaudeCodeRuntimePolicy } from "../providers/claude-code/runtime-policy.js";
 import { CodexAgentRuntimeFactory } from "../providers/codex/agent-runtime.js";
 import type {
@@ -156,7 +160,11 @@ describe("Agent Runtime Client Turn vertical", () => {
     await fixture.runtimeManager.close();
   });
 
-  it.each(["bridge", "process"] as const)("reports Claude Code %s setup failure as not started", async (failure) => {
+  it.each([
+    ["bridge", 0],
+    ["process", 0],
+    ["spawn", 1],
+  ] as const)("reports Claude Code %s setup failure as not started", async (failure, processCount) => {
     const fixture = await runtimeFixture(Promise.resolve(), Promise.resolve(), "claude-code", failure);
     const accepted = await fixture.custody.accept(delivery(fixture.runtime, `delivery-${failure}`, "use Claude"));
     await accepted.onAcceptedSent?.();
@@ -167,7 +175,7 @@ describe("Agent Runtime Client Turn vertical", () => {
       executionEffects: "not_started",
       errorReason: "provider_start_failed",
     });
-    expect(fixture.claudeProcesses).toHaveLength(0);
+    expect(fixture.claudeProcesses).toHaveLength(processCount);
     await fixture.record(report);
     await fixture.runtimeManager.close();
   });
@@ -239,7 +247,7 @@ async function runtimeFixture(
   terminalGate: Promise<void> = Promise.resolve(),
   startingGate: Promise<void> = Promise.resolve(),
   provider: "codex" | "claude-code" = "codex",
-  claudeFailure?: "bridge" | "process",
+  claudeFailure?: "bridge" | "process" | "spawn",
 ) {
   const home = await mkdtemp(resolve(tmpdir(), "opentag-turn-integration-"));
   directories.push(home);
@@ -268,7 +276,7 @@ async function runtimeFixture(
           createSessionId: () => "11111111-1111-4111-8111-111111111111",
           createProcess: (_cwd, args) => {
             if (claudeFailure === "process") throw 42;
-            const process = new ScriptedClaudeCodeProcess(args, terminalGate);
+            const process = new ScriptedClaudeCodeProcess(args, terminalGate, claudeFailure === "spawn");
             claudeProcesses.push(process);
             return process;
           },
@@ -504,10 +512,12 @@ class ScriptedTurnClient implements InteractiveCodexAppServerClient {
 
 class ScriptedClaudeCodeProcess implements ClaudeCodeProcessClient {
   readonly args: readonly string[];
+  readonly #failSpawn: boolean;
   readonly #terminalGate: Promise<void>;
 
-  constructor(args: readonly string[], terminalGate: Promise<void>) {
+  constructor(args: readonly string[], terminalGate: Promise<void>, failSpawn = false) {
     this.args = args;
+    this.#failSpawn = failSpawn;
     this.#terminalGate = terminalGate;
   }
 
@@ -515,6 +525,7 @@ class ScriptedClaudeCodeProcess implements ClaudeCodeProcessClient {
     _input: Readonly<Record<string, unknown>>,
     onMessage: (message: Readonly<Record<string, unknown>>) => void,
   ): Promise<ClaudeCodeProcessResult> {
+    if (this.#failSpawn) throw new ClaudeCodeProcessError("spawn", "asynchronous spawn failed");
     await this.#terminalGate;
     onMessage({
       type: "system",

--- a/packages/client/src/providers/claude-code/agent-runtime.ts
+++ b/packages/client/src/providers/claude-code/agent-runtime.ts
@@ -188,8 +188,13 @@ export class ClaudeCodeAgentRuntime extends BaseAgentRuntime {
       this.closeForProviderFailure();
       if (this.#providerFailure) throw this.#providerFailure;
       if (error instanceof AgentProviderError) throw error;
-      if (error instanceof ClaudeCodeProcessError && error.code === "protocol") {
-        throw new AgentProviderError("provider_protocol_error", error.message, { cause: error });
+      if (error instanceof ClaudeCodeProcessError) {
+        if (error.code === "spawn") {
+          throw new AgentProviderError("provider_start_failed", error.message, { cause: error });
+        }
+        if (error.code === "protocol") {
+          throw new AgentProviderError("provider_protocol_error", error.message, { cause: error });
+        }
       }
       throw new AgentProviderError(
         "provider_error",

--- a/packages/client/src/providers/claude-code/process-wire.ts
+++ b/packages/client/src/providers/claude-code/process-wire.ts
@@ -66,6 +66,7 @@ export class ClaudeCodeProcess implements ClaudeCodeProcessClient {
   #failure?: Error;
   #closed = false;
   #closing = false;
+  #spawned = false;
   #terminalReceived = false;
   #signal?: AbortSignal;
 
@@ -95,7 +96,12 @@ export class ClaudeCodeProcess implements ClaudeCodeProcessClient {
     }
     this.#child.stdout.on("data", (chunk: Buffer) => this.#onStdout(chunk));
     this.#child.stderr.on("data", (chunk: Buffer) => this.#onStderr(chunk));
-    this.#child.on("error", (error) => this.#fail(new ClaudeCodeProcessError("spawn", error.message)));
+    this.#child.once("spawn", () => {
+      this.#spawned = true;
+    });
+    this.#child.on("error", (error) =>
+      this.#fail(new ClaudeCodeProcessError(this.#spawned ? "exited" : "spawn", error.message)),
+    );
     this.#child.on("exit", () => this.#onExit());
   }
 


### PR DESCRIPTION
## Summary

- classify Claude Code child-process errors before the successful spawn event as pre-input provider start failures
- preserve post-spawn child-process errors as potentially effectful provider failures
- cover bridge setup, process construction, and asynchronous spawn rejection through the vertical Turn Report path

Relates to #53.

## Architecture boundary

This change does not broaden automatic retry policy. Only a failure proven to occur before the Provider process has spawned is reported as provider_start_failed with not_started. Once spawn succeeds, later child-process failures remain provider_failed with may_have_occurred.

## Validation

- pnpm check
- pnpm build
- pnpm typecheck
- affected Client tests: 56 passed
- Client Agent Runtime coverage: 273 passed; 100% statements, branches, functions, and lines
- Server integration: 131 passed
- pnpm test and pnpm test:coverage exercise the full suite; both reach only four pre-existing macOS canonical-path assertions involving /tmp or /var/folders versus /private aliases, reproduced unchanged on clean merge-base c699cb3

## Non-goals

No schema, Provider registry, readiness, legacy binding, or UI semantics change.