### PR TITLE
feat(web): consolidate Team settings navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This records the Agent identity and Computer binding only; it does not start a C
 Configure `OPENTAG_GOOGLE_CLIENT_ID` and `OPENTAG_GOOGLE_CLIENT_SECRET` to enable Google sign-in, then open
 `http://127.0.0.1:8000/`. Active Team members share the same App Shell and member-safe views; Team Admins additionally
 manage Agents, runtime configuration, IM bindings, and Local Computer setup. The Computers page lists timestamped Team
-Computer observations, and Admins can generate a short-lived install/login command. **Settings → Members** lets Team
+Computer observations, and Admins can generate a short-lived install/login command. **Settings → Team** lets Team
 Admins create, copy, and rotate the bearer invitation link. Invitees can preview the link before signing in; after
 redemption, the Web selects the joined Team. Membership role and lifecycle changes remain explicit CLI operations:
 

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -430,11 +430,15 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("link", { name: "Settings" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "New Agent" })).toBeTruthy();
     expect(screen.getByText("Tasks").getAttribute("aria-disabled")).toBe("true");
+    const workspaceNavigation = screen.getByRole("navigation", { name: "Workspace" });
     expect(
-      within(screen.getByRole("navigation", { name: "Workspace" }))
+      within(workspaceNavigation)
         .getAllByText(/Agents|Tasks|Settings/)
         .map((item) => item.textContent),
     ).toEqual(["Agents", "Tasks", "Settings"]);
+    const navigationIcons = workspaceNavigation.querySelectorAll(".primary-nav-icon");
+    expect(navigationIcons).toHaveLength(3);
+    expect(Array.from(navigationIcons).every((icon) => icon.getAttribute("aria-hidden") === "true")).toBe(true);
   });
 
   it.each(["/", "/agents"])("redirects unauthenticated protected path %s to login", async (path) => {
@@ -629,12 +633,12 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Ada")).toBeTruthy();
   });
 
-  it("keeps Members free of a second display-name write entry", async () => {
+  it("keeps account profile editing out of the merged Team page", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
-    expect(screen.queryByLabelText("Display name")).toBeNull();
+    expect(screen.getAllByLabelText("Display name")).toHaveLength(1);
     expect(screen.queryByRole("button", { name: "Save account profile" })).toBeNull();
   });
 
@@ -822,12 +826,11 @@ describe("OpenTag Web App Shell", () => {
       within(navigation)
         .getAllByRole("link")
         .map((link) => link.textContent),
-    ).toEqual(["General", "Members", "Computers", "Resources", "Integrations", "Access", "Usage", "Security"]);
+    ).toEqual(["Team", "Computers", "Resources", "Integrations", "Access", "Usage", "Security"]);
     expect(navigation.querySelector(".local-nav-group-label")).toBeNull();
     const mobileNavigation = screen.getByLabelText("Settings section");
     expect(Array.from(mobileNavigation.querySelectorAll("option"), (option) => option.textContent)).toEqual([
-      "General",
-      "Members",
+      "Team",
       "Computers",
       "Resources",
       "Integrations",
@@ -838,17 +841,42 @@ describe("OpenTag Web App Shell", () => {
     expect(mobileNavigation.querySelector("optgroup")).toBeNull();
   });
 
-  it("opens Settings on General and keeps account scope out of the Settings shell", async () => {
+  it("opens Settings on Team and keeps account scope out of the Settings shell", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "General" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Team" })).toBeTruthy();
     expect(window.location.pathname).toBe("/settings/team");
     expect(screen.getByText("Manage the current Team's identity, infrastructure, access, and security.")).toBeTruthy();
     expect(
       within(screen.getByRole("navigation", { name: "Settings" })).queryByRole("link", { name: "Account" }),
     ).toBeNull();
+  });
+
+  it("combines Team profile, members, and invitations in task order", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/settings/team");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
+    const teamSettings = document.querySelector<HTMLElement>(".settings-team-stack");
+    if (!teamSettings) throw new Error("Merged Team settings were not rendered");
+    expect(
+      within(teamSettings)
+        .getAllByRole("heading", { level: 2 })
+        .map((heading) => heading.textContent),
+    ).toEqual(["Team profile", "Team members", "Invite people"]);
+  });
+
+  it("redirects the legacy Members URL to the merged Team page", async () => {
+    installApi("member");
+    window.history.replaceState({}, "", "/settings/members");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/settings/team");
+    expect(window.location.hash).toBe("#members");
   });
 
   it("redirects the legacy Settings account URL to the editable Account page", async () => {
@@ -971,7 +999,7 @@ describe("OpenTag Web App Shell", () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, "clipboard", { configurable: true, value: { writeText } });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Create invitation link" }));
     const link = (await screen.findByLabelText("Invitation link")) as HTMLInputElement;
@@ -1009,7 +1037,7 @@ describe("OpenTag Web App Shell", () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, "clipboard", { configurable: true, value: { writeText } });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
 
     const pageLink = (await screen.findByLabelText("Invitation link")) as HTMLInputElement;
@@ -1040,7 +1068,7 @@ describe("OpenTag Web App Shell", () => {
     });
     installApi("admin", { invitationExists: true, invitationRotate: () => pendingRotate });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
 
     await screen.findByLabelText("Invitation link");
@@ -1155,7 +1183,7 @@ describe("OpenTag Web App Shell", () => {
   it("replaces a locally rotated invitation with a newer successful server read", async () => {
     const api = installApi("admin", { invitationExists: true });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
 
     expect(((await screen.findByLabelText("Invitation link")) as HTMLInputElement).value).toContain("/invites/AAA");
@@ -1168,7 +1196,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(screen.getByRole("link", { name: "Agents" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: "Settings" }));
-    fireEvent.click(await screen.findByRole("link", { name: "Members" }));
+    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
 
     await waitFor(() =>
       expect((screen.getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/CCC"),
@@ -1186,7 +1214,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("keeps invitation-link management hidden from regular members", async () => {
     installApi("member");
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Invite people" })).toBeNull();
@@ -1196,7 +1224,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("lets Team admins update another member role from the member list", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     const role = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
     fireEvent.change(role, { target: { value: "admin" } });
@@ -1219,7 +1247,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", {
       roleUpdate: (targetUserId) => (targetUserId === memberUserId ? graceUpdate : linUpdate),
     });
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     const graceRole = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
     const linRole = screen.getByLabelText("Role for Lin") as HTMLSelectElement;
@@ -1274,7 +1302,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("refreshes current membership authority after an admin demotes themself", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     fireEvent.change(await screen.findByLabelText("Role for Ada"), { target: { value: "member" } });
     await waitFor(() =>
@@ -1288,7 +1316,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("keeps the confirmed role and displays the server error when an update is rejected", async () => {
     installApi("admin", { roleUpdateFails: true });
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     const role = (await screen.findByLabelText("Role for Ada")) as HTMLSelectElement;
     fireEvent.change(role, { target: { value: "member" } });

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -420,6 +420,7 @@ describe("OpenTag Web App Shell", () => {
     window.localStorage.clear();
     window.sessionStorage.clear();
     window.history.replaceState({}, "", "/agents");
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
   });
 
   it("uses the same Agents-first shell for admins", async () => {
@@ -877,6 +878,7 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
     expect(window.location.pathname).toBe("/settings/team");
     expect(window.location.hash).toBe("#members");
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
   });
 
   it("redirects the legacy Settings account URL to the editable Account page", async () => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -344,6 +344,7 @@ export function AppRouter() {
           <Route path="/account" element={<AccountPage />} />
           <Route path="/settings" element={<Navigate replace to="team" />} />
           <Route path="/settings/account" element={<Navigate replace to="/account" />} />
+          <Route path="/settings/members" element={<Navigate replace to="/settings/team#members" />} />
           <Route path="/settings/:section" element={<SettingsPage />} />
         </Route>
       </Route>
@@ -734,12 +735,15 @@ function AppShell() {
           </div>
           <nav aria-label="Workspace" className="primary-nav">
             <NavLink to="/agents" onClick={() => setNavigationOpen(false)}>
+              <WorkspaceNavIcon name="agents" />
               Agents
             </NavLink>
             <span className="nav-placeholder" aria-disabled="true">
+              <WorkspaceNavIcon name="tasks" />
               Tasks
             </span>
             <NavLink to="/settings" onClick={() => setNavigationOpen(false)}>
+              <WorkspaceNavIcon name="settings" />
               Settings
             </NavLink>
           </nav>
@@ -821,6 +825,42 @@ function AppShell() {
         />
       ) : null}
     </div>
+  );
+}
+
+function WorkspaceNavIcon({ name }: { name: "agents" | "settings" | "tasks" }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className="primary-nav-icon"
+      fill="none"
+      focusable="false"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+    >
+      {name === "agents" ? (
+        <>
+          <circle cx="9" cy="8" r="3" />
+          <path d="M3.5 19v-1.5A4.5 4.5 0 0 1 8 13h2a4.5 4.5 0 0 1 4.5 4.5V19" />
+          <path d="M15.5 5.4a3 3 0 0 1 0 5.2M17 13.4a4.5 4.5 0 0 1 3.5 4.4V19" />
+        </>
+      ) : null}
+      {name === "tasks" ? (
+        <>
+          <rect height="17" rx="2.2" width="17" x="3.5" y="3.5" />
+          <path d="m7.5 12 3 3 6-6" />
+        </>
+      ) : null}
+      {name === "settings" ? (
+        <>
+          <path d="m9.8 3.8.6-1.6h3.2l.6 1.6 1.8.7 1.5-.7 2.3 2.3-.7 1.5.7 1.8 1.6.6v3.2l-1.6.6-.7 1.8.7 1.5-2.3 2.3-1.5-.7-1.8.7-.6 1.6h-3.2l-.6-1.6-1.8-.7-1.5.7-2.3-2.3.7-1.5-.7-1.8-1.6-.6V10l1.6-.6.7-1.8-.7-1.5 2.3-2.3 1.5.7 1.8-.7Z" />
+          <circle cx="12" cy="12" r="3" />
+        </>
+      ) : null}
+    </svg>
   );
 }
 
@@ -1870,8 +1910,7 @@ function AccessTab({ agent }: { agent: AgentDetailView }) {
 }
 
 const settingsSections = [
-  { key: "team", label: "General" },
-  { key: "members", label: "Members" },
+  { key: "team", label: "Team" },
   { key: "computers", label: "Computers" },
   { key: "resources", label: "Resources" },
   { key: "integrations", label: "Integrations" },
@@ -1916,15 +1955,13 @@ function SettingsPage() {
             <h2>{currentSection.label}</h2>
             <p>{settingsSectionDescription(currentSection.key)}</p>
           </header>
-          {section === "team" ? <TeamSettings membership={membership} refreshMe={refreshMe} /> : null}
-          {section === "members" ? (
-            <MembersSettings
-              canManage={membership.role === "admin"}
+          {section === "team" ? (
+            <TeamSettings
               currentUserId={me.user.id}
               invitationDialogOpen={invitationOpen}
+              membership={membership}
               onInvitationMutationPendingChange={setInvitationMutationPending}
               refreshMe={refreshMe}
-              teamId={membership.teamId}
             />
           ) : null}
           {section === "computers" ? (
@@ -2158,7 +2195,35 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
   );
 }
 
-function TeamSettings({ membership, refreshMe }: { membership: MeMembership; refreshMe: () => void }) {
+function TeamSettings({
+  currentUserId,
+  invitationDialogOpen,
+  membership,
+  onInvitationMutationPendingChange,
+  refreshMe,
+}: {
+  currentUserId: string;
+  invitationDialogOpen: boolean;
+  membership: MeMembership;
+  onInvitationMutationPendingChange: (pending: boolean) => void;
+  refreshMe: () => void;
+}) {
+  return (
+    <div className="settings-team-stack">
+      <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
+      <MembersSettings
+        canManage={membership.role === "admin"}
+        currentUserId={currentUserId}
+        invitationDialogOpen={invitationDialogOpen}
+        onInvitationMutationPendingChange={onInvitationMutationPendingChange}
+        refreshMe={refreshMe}
+        teamId={membership.teamId}
+      />
+    </div>
+  );
+}
+
+function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembership; refreshMe: () => void }) {
   const [message, setMessage] = useState<string>();
   const [error, setError] = useState<string>();
   const [saving, setSaving] = useState(false);
@@ -2334,10 +2399,7 @@ function MembersSettings({
 
   return (
     <>
-      {canManage && !invitationDialogOpen ? (
-        <InvitationSettings teamId={teamId} onMutationPendingChange={onInvitationMutationPendingChange} />
-      ) : null}
-      <section className="settings-list-section">
+      <section className="settings-list-section" id="members">
         <AsyncState state={state}>
           {(value) => {
             const adminCount = value.members.filter((member: TeamMemberSummary) => member.role === "admin").length;
@@ -2404,6 +2466,9 @@ function MembersSettings({
           </p>
         ) : null}
       </section>
+      {canManage && !invitationDialogOpen ? (
+        <InvitationSettings teamId={teamId} onMutationPendingChange={onInvitationMutationPendingChange} />
+      ) : null}
     </>
   );
 }
@@ -2909,8 +2974,7 @@ function agentSectionDescription(section: (typeof agentSections)[number]["key"])
 
 function settingsSectionDescription(section: (typeof settingsSections)[number]["key"]): string {
   const descriptions = {
-    team: "Manage the current Team's stable identity and display name.",
-    members: "Invite people and review the Team membership visible to you.",
+    team: "Manage the current Team's profile, members, and invitation link.",
     computers: "Connect and inspect the Computers available to the current Team.",
     resources: "Review reusable repositories, skills, tools, and prompts.",
     integrations: "Review supported Team and Agent connection surfaces.",

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1922,9 +1922,16 @@ const settingsSections = [
 function SettingsPage() {
   const { section = "team" } = useParams();
   const { invitationOpen, setInvitationMutationPending } = useOutletContext<AppShellOutletContext>();
+  const location = useLocation();
   const navigate = useNavigate();
   const { me, membership, refreshMe } = useTeam();
   const currentSection = settingsSections.find((item) => item.key === section);
+
+  useEffect(() => {
+    if (section !== "team" || location.hash !== "#members") return;
+    document.getElementById("members")?.scrollIntoView({ block: "start" });
+  }, [location.hash, section]);
+
   if (!currentSection) return <NotFoundPage />;
   return (
     <section className="settings-page">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -521,8 +521,15 @@ button.danger:hover {
   color: var(--secondary-foreground);
   font-size: 0.9rem;
   font-weight: 560;
+  gap: 10px;
   padding: 0 11px;
   text-decoration: none;
+}
+
+.primary-nav-icon {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
 }
 
 .nav-placeholder {
@@ -2135,6 +2142,15 @@ textarea:focus {
   display: grid;
   width: min(100%, 760px);
   gap: 18px;
+}
+
+.settings-team-stack {
+  display: grid;
+  gap: 52px;
+}
+
+.settings-team-stack #members {
+  scroll-margin-top: 28px;
 }
 
 .settings-profile-form > h2,


### PR DESCRIPTION
## Summary

- merge General and Members into one Team Settings destination
- present Team profile, members, and invitation-link management in task order
- redirect the legacy `/settings/members` URL to `/settings/team#members`
- keep member/admin read and mutation behavior unchanged
- add decorative line icons to the Agents, Tasks, and Settings primary navigation items without adding a dependency
- keep desktop and mobile Settings navigation on the same seven-destination source

Follow-up to #80. Team identity, membership, and invitations share one Team-management scope and do not need separate top-level Settings destinations.

## Validation

- `pnpm --filter @opentag/shared build`
- `pnpm --filter @opentag/web test` — 128 tests passed
- `pnpm --filter @opentag/web typecheck`
- `pnpm --filter @opentag/web build`
- `pnpm exec biome check apps/web/src/router.tsx apps/web/src/styles.css apps/web/src/__tests__/app.test.tsx`
- `git diff --check`
