### PR TITLE
fix(web): refine invite dialog copy

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -973,12 +973,14 @@ describe("OpenTag Web App Shell", () => {
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
     window.history.replaceState({}, "", "/settings/members");
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "Create invitation link" }));
-    const link = (await screen.findByLabelText("Invitation link")) as HTMLInputElement;
+    expect(await screen.findByText("This link lets anyone join the Team as a member until it expires.")).toBeTruthy();
+    fireEvent.click(await screen.findByRole("button", { name: "Create invite link" }));
+    const link = (await screen.findByLabelText("Invite link")) as HTMLInputElement;
     expect(link.value).toBe(`https://opentag.example.com/invites/${"A".repeat(43)}`);
-    fireEvent.click(screen.getByRole("button", { name: "Copy invitation link" }));
+    expect(screen.getByText(/^Expires Aug 27, 2026 at /)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith((link as HTMLInputElement).value));
-    fireEvent.click(screen.getByRole("button", { name: "Rotate invitation link" }));
+    fireEvent.click(screen.getByRole("button", { name: "Replace link" }));
     await waitFor(() => expect(link.value).toBe(`https://opentag.example.com/invites/${"B".repeat(43)}`));
     expect(confirm).toHaveBeenCalledOnce();
     confirm.mockRestore();
@@ -994,7 +996,7 @@ describe("OpenTag Web App Shell", () => {
 
     const invitationDialog = await screen.findByRole("dialog", { name: "Invite people" });
     expect(screen.queryByRole("dialog", { name: "Switch Team" })).toBeNull();
-    expect((within(invitationDialog).getByLabelText("Invitation link") as HTMLInputElement).value).toBe(
+    expect((within(invitationDialog).getByLabelText("Invite link") as HTMLInputElement).value).toBe(
       `https://opentag.example.com/invites/${"A".repeat(43)}`,
     );
     const closeButton = within(invitationDialog).getByRole("button", { name: "Close invitation dialog" });
@@ -1012,23 +1014,23 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/settings/members");
     render(<App />);
 
-    const pageLink = (await screen.findByLabelText("Invitation link")) as HTMLInputElement;
+    const pageLink = (await screen.findByLabelText("Invite link")) as HTMLInputElement;
     expect(pageLink.value).toContain("/invites/AAA");
     fireEvent.click(screen.getByRole("button", { name: "Example" }));
     fireEvent.click(
       within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
     );
     const dialog = await screen.findByRole("dialog", { name: "Invite people" });
-    expect(screen.getAllByLabelText("Invitation link")).toHaveLength(1);
-    fireEvent.click(within(dialog).getByRole("button", { name: "Rotate invitation link" }));
+    expect(screen.getAllByLabelText("Invite link")).toHaveLength(1);
+    fireEvent.click(within(dialog).getByRole("button", { name: "Replace link" }));
     await waitFor(() =>
-      expect((within(dialog).getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/BBB"),
+      expect((within(dialog).getByLabelText("Invite link") as HTMLInputElement).value).toContain("/invites/BBB"),
     );
     fireEvent.click(within(dialog).getByRole("button", { name: "Close invitation dialog" }));
 
-    const refreshedPageLink = (await screen.findByLabelText("Invitation link")) as HTMLInputElement;
+    const refreshedPageLink = (await screen.findByLabelText("Invite link")) as HTMLInputElement;
     expect(refreshedPageLink.value).toContain("/invites/BBB");
-    fireEvent.click(screen.getByRole("button", { name: "Copy invitation link" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(refreshedPageLink.value));
     confirm.mockRestore();
   });
@@ -1043,8 +1045,8 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/settings/members");
     render(<App />);
 
-    await screen.findByLabelText("Invitation link");
-    fireEvent.click(screen.getByRole("button", { name: "Rotate invitation link" }));
+    await screen.findByLabelText("Invite link");
+    fireEvent.click(screen.getByRole("button", { name: "Replace link" }));
     fireEvent.click(screen.getByRole("button", { name: "Example" }));
     const teamPicker = screen.getByRole("dialog", { name: "Switch Team" });
     const inviteAction = within(teamPicker).getByRole("button", { name: "Invite people" }) as HTMLButtonElement;
@@ -1064,7 +1066,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(inviteAction);
     const dialog = await screen.findByRole("dialog", { name: "Invite people" });
     await waitFor(() =>
-      expect((within(dialog).getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/BBB"),
+      expect((within(dialog).getByLabelText("Invite link") as HTMLInputElement).value).toContain("/invites/BBB"),
     );
     confirm.mockRestore();
   });
@@ -1084,7 +1086,7 @@ describe("OpenTag Web App Shell", () => {
       within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
     );
     const dialog = await screen.findByRole("dialog", { name: "Invite people" });
-    fireEvent.click(await within(dialog).findByRole("button", { name: "Rotate invitation link" }));
+    fireEvent.click(await within(dialog).findByRole("button", { name: "Replace link" }));
 
     expect(dialog.contains(document.activeElement)).toBe(true);
     expect(document.activeElement).not.toBe(teamTrigger);
@@ -1121,7 +1123,7 @@ describe("OpenTag Web App Shell", () => {
       within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
     );
     const dialog = await screen.findByRole("dialog", { name: "Invite people" });
-    fireEvent.click(await within(dialog).findByRole("button", { name: "Create invitation link" }));
+    fireEvent.click(await within(dialog).findByRole("button", { name: "Create invite link" }));
 
     teamTrigger.focus();
     fireEvent.keyDown(teamTrigger, { key: "Tab" });
@@ -1140,7 +1142,7 @@ describe("OpenTag Web App Shell", () => {
         201,
       ),
     );
-    expect(await within(dialog).findByLabelText("Invitation link")).toBeTruthy();
+    expect(await within(dialog).findByLabelText("Invite link")).toBeTruthy();
     await waitFor(() => {
       expect(dialog.contains(document.activeElement)).toBe(true);
       expect(document.activeElement).not.toBe(dialog);
@@ -1158,10 +1160,10 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/settings/members");
     render(<App />);
 
-    expect(((await screen.findByLabelText("Invitation link")) as HTMLInputElement).value).toContain("/invites/AAA");
-    fireEvent.click(screen.getByRole("button", { name: "Rotate invitation link" }));
+    expect(((await screen.findByLabelText("Invite link")) as HTMLInputElement).value).toContain("/invites/AAA");
+    fireEvent.click(screen.getByRole("button", { name: "Replace link" }));
     await waitFor(() =>
-      expect((screen.getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/BBB"),
+      expect((screen.getByLabelText("Invite link") as HTMLInputElement).value).toContain("/invites/BBB"),
     );
 
     api.setInvitationVersion("C");
@@ -1171,7 +1173,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(await screen.findByRole("link", { name: "Members" }));
 
     await waitFor(() =>
-      expect((screen.getByLabelText("Invitation link") as HTMLInputElement).value).toContain("/invites/CCC"),
+      expect((screen.getByLabelText("Invite link") as HTMLInputElement).value).toContain("/invites/CCC"),
     );
     confirm.mockRestore();
   });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2519,7 +2519,7 @@ function InvitationDialog({
           </button>
         </header>
         <p className="dialog-description" id="invitation-dialog-description">
-          Anyone with the active link can join this Team as a member until the link expires.
+          This link lets anyone join the Team as a member until it expires.
         </p>
         <InvitationSettings presentation="dialog" teamId={teamId} onMutationPendingChange={onMutationPendingChange} />
       </div>
@@ -2543,12 +2543,12 @@ function InvitationSettings({
   const [error, setError] = useState<string>();
 
   async function createInvitation() {
-    await mutateInvitation(() => browserApi.createInvitation(teamId), "Invitation link created.");
+    await mutateInvitation(() => browserApi.createInvitation(teamId), "Invite link created.");
   }
 
   async function rotateInvitation() {
-    if (!window.confirm("Rotate this invitation link? The current link will stop working immediately.")) return;
-    await mutateInvitation(() => browserApi.rotateInvitation(teamId), "Invitation link rotated.");
+    if (!window.confirm("Replace this invite link? The current link will stop working immediately.")) return;
+    await mutateInvitation(() => browserApi.rotateInvitation(teamId), "Invite link replaced.");
   }
 
   async function mutateInvitation(action: () => Promise<NonNullable<typeof current>>, successMessage: string) {
@@ -2560,7 +2560,7 @@ function InvitationSettings({
       setCurrent(await action());
       setMessage(successMessage);
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Unable to update the invitation link");
+      setError(cause instanceof Error ? cause.message : "Unable to update the invite link");
     } finally {
       setBusy(false);
       onMutationPendingChange(false);
@@ -2573,9 +2573,9 @@ function InvitationSettings({
     try {
       if (!window.navigator.clipboard) throw new Error("Clipboard access is unavailable in this browser");
       await window.navigator.clipboard.writeText(inviteUrl);
-      setMessage("Invitation link copied.");
+      setMessage("Invite link copied.");
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Unable to copy the invitation link");
+      setError(cause instanceof Error ? cause.message : "Unable to copy the invite link");
     }
   }
 
@@ -2584,7 +2584,7 @@ function InvitationSettings({
       {presentation === "panel" ? (
         <>
           <h2>Invite people</h2>
-          <p>Anyone with the active link can join this Team as a member until the link expires.</p>
+          <p>This link lets anyone join the Team as a member until it expires.</p>
         </>
       ) : null}
       <AsyncState state={state}>
@@ -2593,22 +2593,22 @@ function InvitationSettings({
           return invitation ? (
             <>
               <label className="invite-link">
-                Invitation link
-                <input aria-label="Invitation link" readOnly type="url" value={invitation.inviteUrl} />
+                Invite link
+                <input aria-label="Invite link" readOnly type="url" value={invitation.inviteUrl} />
               </label>
               <p className="muted">Expires {formatDate(invitation.expiresAt)}.</p>
               <div className={presentation === "dialog" ? "actions dialog-actions" : "actions"}>
                 <button type="button" onClick={() => void copyInvitation(invitation.inviteUrl)}>
-                  Copy invitation link
+                  Copy link
                 </button>
                 <button className="secondary" disabled={busy} type="button" onClick={() => void rotateInvitation()}>
-                  {busy ? "Rotating…" : "Rotate invitation link"}
+                  {busy ? "Replacing…" : "Replace link"}
                 </button>
               </div>
             </>
           ) : (
             <button className="button" disabled={busy} type="button" onClick={() => void createInvitation()}>
-              {busy ? "Creating…" : "Create invitation link"}
+              {busy ? "Creating…" : "Create invite link"}
             </button>
           );
         }}
@@ -2922,5 +2922,8 @@ function settingsSectionDescription(section: (typeof settingsSections)[number]["
 }
 
 function formatDate(value: string) {
-  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+  const date = new Date(value);
+  const day = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(date);
+  const time = new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format(date);
+  return `${day} at ${time}`;
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2596,7 +2596,7 @@ function InvitationSettings({
                 Invite link
                 <input aria-label="Invite link" readOnly type="url" value={invitation.inviteUrl} />
               </label>
-              <p className="muted">Expires {formatDate(invitation.expiresAt)}.</p>
+              <p className="muted">Expires {formatInviteExpiry(invitation.expiresAt)}.</p>
               <div className={presentation === "dialog" ? "actions dialog-actions" : "actions"}>
                 <button type="button" onClick={() => void copyInvitation(invitation.inviteUrl)}>
                   Copy link
@@ -2922,6 +2922,10 @@ function settingsSectionDescription(section: (typeof settingsSections)[number]["
 }
 
 function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+}
+
+function formatInviteExpiry(value: string) {
   const date = new Date(value);
   const day = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(date);
   const time = new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format(date);


### PR DESCRIPTION
## Summary

- keep invite expiry dates consistently English with explicit `en-US` formatting
- tighten invite dialog labels, actions, confirmations, and status copy
- add regression coverage for the refined copy and English expiry format

## Testing

- `pnpm build` — passed
- `pnpm typecheck` — passed
- `pnpm --filter @opentag/web test` — passed, 126 tests
- `pnpm exec biome check apps/web/src/router.tsx apps/web/src/__tests__/app.test.tsx` — passed
- `node scripts/third-party-notices.mjs --check` — passed
- `pnpm check` — locally blocked by unrelated nested Biome roots under `.claude/worktrees`
- `pnpm test` — changed web suite passed; unrelated existing failures remain in server observability outcome expectations and macOS `/tmp` path assertions in client workspace tests

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` all pass locally; exceptions are documented above.
- [x] No credentials, private data, or generated build output are included.
- [x] No canonical documentation mirrors are affected.