### PR TITLE
fix(web): scope decorative backgrounds

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -453,6 +453,24 @@ describe("OpenTag Web App Shell", () => {
     expect(window.location.search).toBe(`?next=${encodeURIComponent(expectedNext)}`);
   });
 
+  it("keeps authenticated invalid Agent tabs on the plain workspace canvas", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", `/agents/${agentId}/unknown`);
+    render(<App />);
+
+    const heading = await screen.findByRole("heading", { name: "Page not found" });
+    expect(heading.closest(".center-card")?.classList.contains("decorative-page")).toBe(false);
+    expect(screen.getByRole("main").classList.contains("decorative-page")).toBe(false);
+  });
+
+  it("keeps the standalone not-found route on the decorative canvas", async () => {
+    window.history.replaceState({}, "", "/unknown");
+    render(<App />);
+
+    const heading = await screen.findByRole("heading", { name: "Page not found" });
+    expect(heading.closest("main")?.classList.contains("decorative-page")).toBe(true);
+  });
+
   it("lets members enter the same shell without admin controls", async () => {
     installApi("member");
     render(<App />);

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -427,6 +427,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    expect(screen.getByRole("main").classList.contains("decorative-page")).toBe(false);
     expect(screen.getByRole("link", { name: "Agents" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "Settings" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "New Agent" })).toBeTruthy();
@@ -446,7 +447,8 @@ describe("OpenTag Web App Shell", () => {
     installApi("member", { unauthenticated: true });
     window.history.replaceState({}, "", path);
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Sign in" })).toBeTruthy();
+    const heading = await screen.findByRole("heading", { name: "Sign in" });
+    expect(heading.closest("main")?.classList.contains("decorative-page")).toBe(true);
     const expectedNext = path === "/" ? "/agents" : path;
     expect(window.location.search).toBe(`?next=${encodeURIComponent(expectedNext)}`);
   });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -348,7 +348,7 @@ export function AppRouter() {
           <Route path="/settings/:section" element={<SettingsPage />} />
         </Route>
       </Route>
-      <Route path="*" element={<NotFoundPage />} />
+      <Route path="*" element={<StandaloneNotFoundPage />} />
     </Routes>
   );
 }
@@ -2793,15 +2793,25 @@ function EmptyState({ title, children }: { title: string; children: ReactNode })
 
 function UnavailablePage({ title }: { title: string }) {
   return (
-    <main className="center-card decorative-page">
+    <section className="center-card">
       <h1>{title}</h1>
       <p>This capability is not available in the current release.</p>
       <Link to="/agents">Back to Agents</Link>
-    </main>
+    </section>
   );
 }
 
 function NotFoundPage() {
+  return (
+    <section className="center-card">
+      <h1>Page not found</h1>
+      <p>The requested OpenTag page is not available.</p>
+      <Link to="/agents">Back to Agents</Link>
+    </section>
+  );
+}
+
+function StandaloneNotFoundPage() {
   return (
     <main className="center-card decorative-page">
       <h1>Page not found</h1>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -357,7 +357,7 @@ function LoginPage() {
   const providers = useResource(() => browserApi.authProviders(), "auth-providers");
   const next = new URLSearchParams(useLocation().search).get("next") ?? "/agents";
   return (
-    <main className="center-card">
+    <main className="center-card decorative-page">
       <span className="eyebrow">OpenTag</span>
       <h1>Sign in</h1>
       <p>Choose an available sign-in method. Team permissions are checked by the server on every request.</p>
@@ -434,7 +434,7 @@ function InvitePage() {
     void completeJoin(selectedTeamHint);
   }
   return (
-    <main className="center-card">
+    <main className="center-card decorative-page">
       <AsyncState state={preview}>
         {(value) => (
           <>
@@ -490,7 +490,7 @@ function clearPendingInvitation(token: string): void {
 function NewTeamPage() {
   const navigate = useNavigate();
   return (
-    <main className="center-card">
+    <main className="center-card decorative-page">
       <span className="eyebrow">OpenTag</span>
       <h1>Create your team</h1>
       <p>You can invite people and add Agents next.</p>
@@ -2793,7 +2793,7 @@ function EmptyState({ title, children }: { title: string; children: ReactNode })
 
 function UnavailablePage({ title }: { title: string }) {
   return (
-    <main className="center-card">
+    <main className="center-card decorative-page">
       <h1>{title}</h1>
       <p>This capability is not available in the current release.</p>
       <Link to="/agents">Back to Agents</Link>
@@ -2803,7 +2803,7 @@ function UnavailablePage({ title }: { title: string }) {
 
 function NotFoundPage() {
   return (
-    <main className="center-card">
+    <main className="center-card decorative-page">
       <h1>Page not found</h1>
       <p>The requested OpenTag page is not available.</p>
       <Link to="/agents">Back to Agents</Link>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -45,7 +45,8 @@ body {
   background: var(--background);
 }
 
-body:has(.center-card)::before {
+/* The grid belongs to isolated entry and recovery pages, never the product workspace. */
+body:has(.decorative-page)::before {
   position: fixed;
   inset: 0;
   z-index: -1;
@@ -55,6 +56,17 @@ body:has(.center-card)::before {
   background-size: 36px 36px;
   content: "";
   mask-image: radial-gradient(circle at center, black, transparent 78%);
+  pointer-events: none;
+}
+
+body:has(.decorative-page)::after {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.82' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23noise)' opacity='.55'/%3E%3C/svg%3E");
+  content: "";
+  opacity: 0.025;
+  pointer-events: none;
 }
 
 button,
@@ -1360,16 +1372,9 @@ dd {
   position: relative;
   width: min(100%, 760px);
   overflow: hidden;
-  border: 1px dashed var(--strong-border);
+  border: 0;
   border-radius: var(--radius);
-  background:
-    linear-gradient(rgb(253 252 246 / 90%), rgb(253 252 246 / 90%)),
-    linear-gradient(to right, var(--border) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--border) 1px, transparent 1px);
-  background-size:
-    auto,
-    28px 28px,
-    28px 28px;
+  background: var(--surface-soft);
   padding: 28px;
 }
 
@@ -1938,11 +1943,6 @@ textarea:focus {
 .definition-list div {
   border-bottom: 0;
   padding: 12px 0;
-}
-
-.empty-state {
-  border: 0;
-  background: var(--surface-soft);
 }
 
 .list {


### PR DESCRIPTION
## Summary
- explicitly mark entry and recovery pages that use the branded grid background
- keep decorative grid and subtle grain out of the authenticated product workspace
- consolidate the duplicate empty-state background rules
- add coverage for decorative-page scoping

## Verification
- pnpm exec biome check apps/web/src/router.tsx apps/web/src/styles.css apps/web/src/__tests__/app.test.tsx
- pnpm --filter @opentag/shared build
- pnpm --filter @opentag/web test
- pnpm --filter @opentag/web typecheck
- pnpm --filter @opentag/web build