### PR TITLE
fix(web): simplify Team identity settings

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -639,7 +639,7 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
-    expect(screen.getAllByLabelText("Display name")).toHaveLength(1);
+    expect(screen.getAllByLabelText("Team name")).toHaveLength(1);
     expect(screen.queryByRole("button", { name: "Save account profile" })).toBeNull();
   });
 
@@ -855,7 +855,7 @@ describe("OpenTag Web App Shell", () => {
     ).toBeNull();
   });
 
-  it("combines Team profile, members, and invitations in task order", async () => {
+  it("groups invitations with Team members", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings/team");
     render(<App />);
@@ -867,7 +867,10 @@ describe("OpenTag Web App Shell", () => {
       within(teamSettings)
         .getAllByRole("heading", { level: 2 })
         .map((heading) => heading.textContent),
-    ).toEqual(["Team profile", "Team members", "Invite people"]);
+    ).toEqual(["Team profile", "Team members"]);
+    const membersSection = document.querySelector<HTMLElement>("#members");
+    if (!membersSection) throw new Error("Team members section was not rendered");
+    expect(within(membersSection).getByRole("heading", { level: 3, name: "Invite members" })).toBeTruthy();
   });
 
   it("redirects the legacy Members URL to the merged Team page", async () => {
@@ -925,21 +928,31 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("table")).toBeNull();
   });
 
-  it("lets admins rename a Team and refreshes the UUID-selected Team context from /me", async () => {
+  it("lets admins rename a Team without changing its CLI identifier", async () => {
     installApi("admin");
     window.localStorage.setItem("opentag.selectedTeamId", teamId);
     window.history.replaceState({}, "", "/settings/team");
     render(<App />);
-    const name = await screen.findByLabelText("Canonical name");
-    const displayName = screen.getByLabelText("Display name");
-    fireEvent.change(name, { target: { value: "RENAMED-TEAM" } });
+    const displayName = await screen.findByLabelText("Team name");
+    const profileForm = displayName.closest("form");
+    if (!profileForm) throw new Error("Team profile form was not rendered");
+    const cliIdentifier = within(profileForm).getByText("example", { selector: "dd code" });
+    expect(cliIdentifier.textContent).toContain("example");
+    expect(within(profileForm).getAllByRole("textbox")).toHaveLength(1);
     fireEvent.change(displayName, { target: { value: "Renamed Team" } });
     fireEvent.click(screen.getByRole("button", { name: "Save Team profile" }));
     await waitFor(() =>
       expect(vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/v1/me")).toHaveLength(2),
     );
-    expect(await screen.findByDisplayValue("renamed-team")).toBeTruthy();
-    expect((screen.getByLabelText("Display name") as HTMLInputElement).value).toBe("Renamed Team");
+    const updateCall = vi
+      .mocked(fetch)
+      .mock.calls.find(([input, init]) => String(input) === `/api/v1/teams/${teamId}` && init?.method === "PATCH");
+    expect(JSON.parse(String(updateCall?.[1]?.body))).toEqual({ displayName: "Renamed Team" });
+    const refreshedDisplayName = (await screen.findByLabelText("Team name")) as HTMLInputElement;
+    const refreshedProfileForm = refreshedDisplayName.closest("form");
+    if (!refreshedProfileForm) throw new Error("Refreshed Team profile form was not rendered");
+    expect(refreshedDisplayName.value).toBe("Renamed Team");
+    expect(within(refreshedProfileForm).getByText("example", { selector: "dd code" })).toBeTruthy();
     expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(teamId);
   });
 
@@ -948,9 +961,9 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/settings/team");
     render(<App />);
     expect(await screen.findByText("example")).toBeTruthy();
-    expect(screen.getByText("Display name").parentElement?.querySelector("dd")?.textContent).toBe("Example");
+    expect(screen.getByText("Team name").parentElement?.querySelector("dd")?.textContent).toBe("Example");
     expect(screen.queryByRole("button", { name: "Save Team profile" })).toBeNull();
-    expect(screen.queryByLabelText("Canonical name")).toBeNull();
+    expect(screen.queryByLabelText("CLI identifier")).toBeNull();
   });
 
   it("accepts an invitation and selects the newly joined Team", async () => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2176,14 +2176,12 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
   const [message, setMessage] = useState<string>();
   const [error, setError] = useState<string>();
   const [saving, setSaving] = useState(false);
-  const [teamName, setTeamName] = useState(membership.teamName);
   const [teamDisplayName, setTeamDisplayName] = useState(membership.teamDisplayName);
-  const dirty = teamName !== membership.teamName || teamDisplayName !== membership.teamDisplayName;
+  const dirty = teamDisplayName !== membership.teamDisplayName;
 
   useEffect(() => {
-    setTeamName(membership.teamName);
     setTeamDisplayName(membership.teamDisplayName);
-  }, [membership.teamDisplayName, membership.teamName]);
+  }, [membership.teamDisplayName]);
 
   if (membership.role !== "admin") {
     return (
@@ -2197,8 +2195,8 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
         </div>
         <DefinitionList
           rows={[
-            ["Canonical name", membership.teamName],
-            ["Display name", membership.teamDisplayName],
+            ["Team name", membership.teamDisplayName],
+            ["CLI identifier", membership.teamName],
           ]}
         />
       </section>
@@ -2211,7 +2209,6 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
       setMessage(undefined);
       setError(undefined);
       await browserApi.updateTeam(membership.teamId, {
-        name: teamName,
         displayName: teamDisplayName,
       });
       refreshMe();
@@ -2228,35 +2225,11 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
       <div className="settings-field-list">
         <div className="settings-field-row">
           <div className="settings-field-copy">
-            <strong>Canonical name</strong>
-            <p>Changing this immediately changes the CLI --team selector. The Team ID stays stable.</p>
+            <strong>Team name</strong>
+            <p>What people see in navigation and invitations.</p>
           </div>
           <label>
-            Canonical name
-            <input
-              aria-label="Canonical name"
-              name="name"
-              pattern="[A-Za-z0-9][A-Za-z0-9-]*"
-              required
-              value={teamName}
-              onChange={(event) => {
-                setTeamName(event.currentTarget.value);
-                setMessage(undefined);
-                setError(undefined);
-              }}
-            />
-            <small className="settings-field-hint">
-              CLI selector: <code>--team {teamName.toLocaleLowerCase() || "team-name"}</code>
-            </small>
-          </label>
-        </div>
-        <div className="settings-field-row">
-          <div className="settings-field-copy">
-            <strong>Display name</strong>
-            <p>The human-readable Team name shown in navigation and invitations.</p>
-          </div>
-          <label>
-            Display name
+            Team name
             <input
               name="displayName"
               required
@@ -2269,6 +2242,28 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
             />
           </label>
         </div>
+        <div className="settings-field-row">
+          <div className="settings-field-copy">
+            <strong>CLI identifier</strong>
+            <p>Created automatically for CLI commands. It stays the same when you rename the Team.</p>
+          </div>
+          <dl className="settings-readonly-value">
+            <div>
+              <dt className="visually-hidden">CLI identifier</dt>
+              <dd>
+                <code>{membership.teamName}</code>
+              </dd>
+            </div>
+            <div>
+              <dt className="visually-hidden">CLI command</dt>
+              <dd>
+                <small>
+                  <code>--team {membership.teamName}</code>
+                </small>
+              </dd>
+            </div>
+          </dl>
+        </div>
       </div>
       {dirty ? (
         <div className="dirty-bar">
@@ -2279,7 +2274,6 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
               disabled={saving}
               type="button"
               onClick={() => {
-                setTeamName(membership.teamName);
                 setTeamDisplayName(membership.teamDisplayName);
                 setMessage(undefined);
                 setError(undefined);
@@ -2347,78 +2341,76 @@ function MembersSettings({
   }
 
   return (
-    <>
-      <section className="settings-list-section" id="members">
-        <AsyncState state={state}>
-          {(value) => {
-            const adminCount = value.members.filter((member: TeamMemberSummary) => member.role === "admin").length;
-            return (
-              <>
-                <header className="settings-subheader">
-                  <div>
-                    <h2>Team members</h2>
-                    <p>
-                      {value.members.length} {value.members.length === 1 ? "member" : "members"} · {adminCount}{" "}
-                      {adminCount === 1 ? "admin" : "admins"}
-                    </p>
-                  </div>
-                  {!canManage ? <span className="settings-role-badge">Read only</span> : null}
-                </header>
-                <table className="settings-member-table" aria-label="Team members">
-                  <thead>
-                    <tr className="settings-table-header">
-                      <th scope="col">Team member</th>
-                      <th scope="col">Role</th>
+    <section className="settings-list-section settings-members-section" id="members">
+      <AsyncState state={state}>
+        {(value) => {
+          const adminCount = value.members.filter((member: TeamMemberSummary) => member.role === "admin").length;
+          return (
+            <>
+              <header className="settings-subheader">
+                <div>
+                  <h2>Team members</h2>
+                  <p>
+                    {value.members.length} {value.members.length === 1 ? "member" : "members"} · {adminCount}{" "}
+                    {adminCount === 1 ? "admin" : "admins"}
+                  </p>
+                </div>
+                {!canManage ? <span className="settings-role-badge">Read only</span> : null}
+              </header>
+              <table className="settings-member-table" aria-label="Team members">
+                <thead>
+                  <tr className="settings-table-header">
+                    <th scope="col">Team member</th>
+                    <th scope="col">Role</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {value.members.map((member: TeamMemberSummary) => (
+                    <tr className="settings-member-row" key={member.userId}>
+                      <th className="settings-member-identity" scope="row">
+                        <span className="settings-member-avatar" aria-hidden="true">
+                          {initials(member.displayName)}
+                        </span>
+                        <span>
+                          <strong>{member.displayName}</strong>
+                          {member.userId === currentUserId ? <small>You</small> : null}
+                        </span>
+                      </th>
+                      <td data-label="Role">
+                        {canManage ? (
+                          <select
+                            aria-label={`Role for ${member.displayName}`}
+                            disabled={pendingUserIds.has(member.userId)}
+                            value={member.role}
+                            onChange={(event) => void changeRole(member, event.currentTarget.value)}
+                          >
+                            {MembershipRoleSchema.options.map((role) => (
+                              <option value={role} key={role}>
+                                {role}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
+                          <span className="settings-value-badge">{member.role}</span>
+                        )}
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    {value.members.map((member: TeamMemberSummary) => (
-                      <tr className="settings-member-row" key={member.userId}>
-                        <th className="settings-member-identity" scope="row">
-                          <span className="settings-member-avatar" aria-hidden="true">
-                            {initials(member.displayName)}
-                          </span>
-                          <span>
-                            <strong>{member.displayName}</strong>
-                            {member.userId === currentUserId ? <small>You</small> : null}
-                          </span>
-                        </th>
-                        <td data-label="Role">
-                          {canManage ? (
-                            <select
-                              aria-label={`Role for ${member.displayName}`}
-                              disabled={pendingUserIds.has(member.userId)}
-                              value={member.role}
-                              onChange={(event) => void changeRole(member, event.currentTarget.value)}
-                            >
-                              {MembershipRoleSchema.options.map((role) => (
-                                <option value={role} key={role}>
-                                  {role}
-                                </option>
-                              ))}
-                            </select>
-                          ) : (
-                            <span className="settings-value-badge">{member.role}</span>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </>
-            );
-          }}
-        </AsyncState>
-        {error ? (
-          <p className="notice error" role="alert">
-            {error}
-          </p>
-        ) : null}
-      </section>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          );
+        }}
+      </AsyncState>
+      {error ? (
+        <p className="notice error" role="alert">
+          {error}
+        </p>
+      ) : null}
       {canManage && !invitationDialogOpen ? (
         <InvitationSettings teamId={teamId} onMutationPendingChange={onInvitationMutationPendingChange} />
       ) : null}
-    </>
+    </section>
   );
 }
 
@@ -2597,7 +2589,7 @@ function InvitationSettings({
     <section className={presentation === "dialog" ? "invitation-dialog-content" : "settings-invitation-panel"}>
       {presentation === "panel" ? (
         <>
-          <h2>Invite people</h2>
+          <h3>Invite members</h3>
           <p>This link lets anyone join the Team as a member until it expires.</p>
         </>
       ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2167,7 +2167,7 @@ textarea:focus {
 
 .settings-profile-form > h2,
 .settings-list-section h2,
-.settings-invitation-panel h2,
+.settings-invitation-panel h3,
 .settings-readonly-panel h2,
 .settings-unavailable h2,
 .settings-policy-banner h2 {
@@ -2239,6 +2239,10 @@ textarea:focus {
   white-space: nowrap;
 }
 
+.settings-readonly-value dd {
+  margin: 0;
+}
+
 .settings-readonly-value input {
   min-height: 0;
   border: 0;
@@ -2302,10 +2306,15 @@ textarea:focus {
   display: grid;
   width: min(100%, 760px);
   gap: 14px;
-  margin-bottom: 32px;
   border-radius: var(--radius);
   background: var(--surface-soft);
   padding: 22px;
+}
+
+.settings-invitation-panel h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 680;
 }
 
 .settings-invitation-panel > p {


### PR DESCRIPTION
## Summary
- expose a single editable Team name and keep the generated CLI identifier read-only
- preserve the CLI identifier when renaming a Team
- group invitation-link management inside Team members
- update accessible structure and regression coverage

## Validation
- `pnpm --filter @opentag/web test` (137 tests)
- `pnpm --filter @opentag/web typecheck`
- `pnpm --filter @opentag/web build`
- `pnpm check`