### PR TITLE
fix(web): focus Agent overview on usage

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -727,7 +727,7 @@ describe("OpenTag Web App Shell", () => {
           ),
       ).toHaveLength(2),
     );
-    expect(await screen.findByText("Agent is suspended")).toBeTruthy();
+    expect(await screen.findByText("Not receiving new work")).toBeTruthy();
     expect(await screen.findByRole("button", { name: "Reactivate Agent" })).toBeTruthy();
     const deleteButton = await screen.findByRole("button", { name: "Delete Agent permanently" });
     fireEvent.click(deleteButton);
@@ -751,7 +751,7 @@ describe("OpenTag Web App Shell", () => {
       within(navigation)
         .getAllByRole("link")
         .map((link) => link.textContent),
-    ).toEqual(["Overview", "Runtime", "IM", "Resources", "Integrations", "Access"]);
+    ).toEqual(["Overview", "Runtime", "Messaging", "Access"]);
   });
 
   it("refreshes Agent availability when the page regains focus", async () => {
@@ -763,33 +763,38 @@ describe("OpenTag Web App Shell", () => {
 
     computerStatus = "offline";
     fireEvent(window, new Event("focus"));
-    expect(await screen.findByText("Computer is offline")).toBeTruthy();
+    expect(await screen.findByText("Cannot receive new work")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Review runtime" })).toBeTruthy();
   });
 
-  it("keeps the Agent list bounded to Team-level evidence", async () => {
+  it("keeps infrastructure details and dependency reads out of the Agent list", async () => {
     installApi("admin", { bound: true, computerEvidenceFails: true });
     window.history.replaceState({}, "", "/agents");
     render(<App />);
 
     expect(await screen.findByText("Reviewer")).toBeTruthy();
-    expect(screen.getByText("Unconfirmed")).toBeTruthy();
-    expect(screen.getByText("Unable to confirm Computer")).toBeTruthy();
+    expect(screen.getByText("Active")).toBeTruthy();
+    expect(screen.queryByText("Ada's Mac")).toBeNull();
+    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes("/computers"))).toBe(false);
     expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes(`/agents/${agentId}/im-binding`))).toBe(
       false,
     );
   });
 
-  it("reports one combined handoff dependency without inventing component causes", async () => {
+  it("keeps readiness implementation details out of the Agent overview", async () => {
     installApi("admin", { bound: true, handoffReady: false });
     window.history.replaceState({}, "", `/agents/${agentId}/general`);
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    const handoffCard = screen.getByText("Handoff").closest("article");
-    expect(handoffCard).toBeTruthy();
-    expect(within(handoffCard as HTMLElement).getByText("Needs attention")).toBeTruthy();
-    expect(within(handoffCard as HTMLElement).getByText("Handoff needs attention")).toBeTruthy();
-    expect(screen.queryByText("Runtime capability unavailable")).toBeNull();
+    expect(screen.getByRole("heading", { name: "Use this Agent" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Message @reviewer" })).toBeTruthy();
+    expect(screen.getByText("Send a direct message, or mention @reviewer in a Feishu conversation.")).toBeTruthy();
+    expect(screen.getByText("Cannot receive new work")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Review messaging" })).toBeTruthy();
+    expect(screen.queryByText("Handoff")).toBeNull();
+    expect(screen.queryByText("Computer")).toBeNull();
+    expect(screen.queryByText("Ada's Mac")).toBeNull();
   });
 
   it("preserves the Agent detail when handoff evidence cannot be confirmed", async () => {
@@ -798,7 +803,8 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    expect((await screen.findAllByText("Unable to confirm handoff")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Status temporarily unavailable")).toBeTruthy();
+    expect(screen.queryByText("Handoff")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
@@ -828,7 +834,7 @@ describe("OpenTag Web App Shell", () => {
     expect(agentReads).toBe(2);
 
     releaseAgentRead();
-    expect(await screen.findByText("Computer is offline")).toBeTruthy();
+    expect(await screen.findByText("Cannot receive new work")).toBeTruthy();
   });
 
   it("invalidates a stale Agent detail after a background not-found response", async () => {
@@ -849,7 +855,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", { agentListStatus: () => agentListStatus });
     window.history.replaceState({}, "", "/agents");
     render(<App />);
-    expect(await screen.findByText("Computer online")).toBeTruthy();
+    expect(await screen.findByText("Active")).toBeTruthy();
 
     agentListStatus = 503;
     fireEvent(window, new Event("focus"));

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -791,7 +791,8 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("heading", { name: "Message @reviewer" })).toBeTruthy();
     expect(screen.getByText("Send a direct message, or mention @reviewer in a Feishu conversation.")).toBeTruthy();
     expect(screen.getByText("Cannot receive new work")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Review messaging" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Review messaging" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Review runtime" })).toBeNull();
     expect(screen.queryByText("Handoff")).toBeNull();
     expect(screen.queryByText("Computer")).toBeNull();
     expect(screen.queryByText("Ada's Mac")).toBeNull();
@@ -804,8 +805,22 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
     expect(await screen.findByText("Status temporarily unavailable")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Messaging status unavailable" })).toBeTruthy();
+    expect(screen.getByText("The messaging identity could not be confirmed. Try again in a moment.")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Connect Feishu or Slack" })).toBeNull();
+    expect(screen.queryByText("This Agent needs a messaging identity before teammates can send it work.")).toBeNull();
     expect(screen.queryByText("Handoff")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("offers messaging setup only when the missing binding is confirmed", async () => {
+    installApi("admin", { bound: false });
+    window.history.replaceState({}, "", `/agents/${agentId}/general`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Connect Feishu or Slack" })).toBeTruthy();
+    expect(screen.getByText("This Agent needs a messaging identity before teammates can send it work.")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Messaging status unavailable" })).toBeNull();
   });
 
   it("does not overlap focus refreshes while an Agent read is still pending", async () => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -66,6 +66,7 @@ type AgentAvailability = {
       lastConfirmedAt: string | null;
     };
     channel: {
+      state: "connected" | "not_connected" | "unconfirmed";
       provider: "feishu" | "slack" | null;
       botDisplayName: string | null;
     };
@@ -80,18 +81,20 @@ function projectAgentAvailability(
   computer: TeamComputerSummary | undefined,
   binding: ImBindingSummary | undefined,
   handoff: ImBindingHandoffStatus | undefined,
-  evidenceConfirmed: boolean,
+  bindingEvidenceConfirmed: boolean,
+  handoffEvidenceConfirmed: boolean,
 ): AgentAvailability {
   const computerReady = computer?.connectionStatus === "online";
-  const handoffState = !evidenceConfirmed
-    ? ("unconfirmed" as const)
-    : !binding
-      ? ("not_connected" as const)
-      : binding.bindingState === "provisioning"
-        ? ("setting_up" as const)
-        : binding.bindingState === "active" && handoff?.handoffReady
-          ? ("ready" as const)
-          : ("action_required" as const);
+  const handoffState =
+    !bindingEvidenceConfirmed || !handoffEvidenceConfirmed
+      ? ("unconfirmed" as const)
+      : !binding
+        ? ("not_connected" as const)
+        : binding.bindingState === "provisioning"
+          ? ("setting_up" as const)
+          : binding.bindingState === "active" && handoff?.handoffReady
+            ? ("ready" as const)
+            : ("action_required" as const);
   const dependencies: AgentAvailability["dependencies"] = {
     computer: {
       state: computer ? (computerReady ? "ready" : "action_required") : "unconfirmed",
@@ -99,6 +102,7 @@ function projectAgentAvailability(
     },
     handoff: { state: handoffState, lastConfirmedAt: binding?.lastConfirmedAt ?? null },
     channel: {
+      state: !bindingEvidenceConfirmed ? "unconfirmed" : binding ? "connected" : "not_connected",
       provider: binding?.provider ?? null,
       botDisplayName: binding?.bot.displayName ?? null,
     },
@@ -120,7 +124,7 @@ function projectAgentAvailability(
   if (agent.runtimeProvider !== "codex") {
     return { state: "action_required", reason: "runtime_unavailable", lastConfirmedAt: null, dependencies };
   }
-  if (!evidenceConfirmed) {
+  if (!bindingEvidenceConfirmed || !handoffEvidenceConfirmed) {
     return { state: "unconfirmed", reason: "handoff_unconfirmed", lastConfirmedAt: null, dependencies };
   }
   if (!binding) return { state: "not_connected", reason: "im_not_connected", lastConfirmedAt: null, dependencies };
@@ -176,7 +180,8 @@ async function loadAgentDetail(agentId: string): Promise<AgentDetailView> {
       computers.find((computer) => computer.id === agent.computer.id),
       binding,
       handoff,
-      bindingResult.status === "fulfilled" && handoffResult.status === "fulfilled",
+      bindingResult.status === "fulfilled",
+      handoffResult.status === "fulfilled",
     ),
   };
 }
@@ -197,6 +202,7 @@ function markAgentDetailUnconfirmed(agent: AgentDetailView): AgentDetailView {
         ...agent.availability.dependencies,
         computer: { state: "unconfirmed", lastConfirmedAt: null },
         handoff: { state: "unconfirmed", lastConfirmedAt: null },
+        channel: { ...agent.availability.dependencies.channel, state: "unconfirmed" },
       },
     },
   };
@@ -1419,7 +1425,7 @@ function GeneralTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgent
             {agent.viewerCapabilities.canManage ? "Manage messaging" : "View messaging"}
           </Link>
         </div>
-        {channelLabel ? (
+        {channel.state === "connected" && channelLabel ? (
           <div className="agent-use-panel">
             <div className="agent-use-copy">
               <span className="agent-use-channel">{channelLabel}</span>
@@ -1431,12 +1437,20 @@ function GeneralTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgent
               <small>{receiveModeLabel(agent.receiveMode)}</small>
             </div>
           </div>
-        ) : (
+        ) : channel.state === "not_connected" ? (
           <div className="agent-use-panel empty">
             <div className="agent-use-copy">
               <span className="agent-use-channel">Messaging</span>
               <h4>Connect Feishu or Slack</h4>
               <p>This Agent needs a messaging identity before teammates can send it work.</p>
+            </div>
+          </div>
+        ) : (
+          <div className="agent-use-panel empty">
+            <div className="agent-use-copy">
+              <span className="agent-use-channel">Messaging</span>
+              <h4>Messaging status unavailable</h4>
+              <p>The messaging identity could not be confirmed. Try again in a moment.</p>
             </div>
           </div>
         )}
@@ -2846,12 +2860,11 @@ function agentAvailabilityRecovery(agent: AgentDetailView): { label: string; to:
     agent.availability.reason === "im_not_connected" ||
     agent.availability.reason === "im_provisioning" ||
     agent.availability.reason === "im_reauthorization_required" ||
-    agent.availability.reason === "im_error" ||
-    agent.availability.reason === "handoff_unavailable" ||
-    agent.availability.reason === "handoff_unconfirmed"
+    agent.availability.reason === "im_error"
   ) {
     return { label: "Review messaging", to: `/agents/${agent.id}/im` };
   }
+  if (agent.availability.reason === "handoff_unavailable") return undefined;
   if (agent.availability.state === "unconfirmed") return undefined;
   return { label: "Review runtime", to: `/agents/${agent.id}/runtime` };
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -72,7 +72,7 @@ type AgentAvailability = {
   };
 };
 
-type AgentListItem = AgentSummary & { computerState: TeamComputerSummary | undefined };
+type AgentListItem = AgentSummary & { evidenceConfirmed: boolean };
 type AgentDetailView = AgentDetail & { availability: AgentAvailability };
 
 function projectAgentAvailability(
@@ -155,16 +155,8 @@ function projectAgentAvailability(
 }
 
 async function loadAgentList(teamId: string): Promise<{ agents: AgentListItem[] }> {
-  const [{ agents }, computersResult] = await Promise.all([
-    browserApi.agents(teamId),
-    browserApi.computers(teamId).catch(() => ({ computers: [] })),
-  ]);
-  return {
-    agents: agents.map((agent) => ({
-      ...agent,
-      computerState: computersResult.computers.find((computer) => computer.id === agent.computer.id),
-    })),
-  };
+  const { agents } = await browserApi.agents(teamId);
+  return { agents: agents.map((agent) => ({ ...agent, evidenceConfirmed: true })) };
 }
 
 async function loadAgentDetail(agentId: string): Promise<AgentDetailView> {
@@ -190,7 +182,7 @@ async function loadAgentDetail(agentId: string): Promise<AgentDetailView> {
 }
 
 function markAgentListUnconfirmed(value: { agents: AgentListItem[] }): { agents: AgentListItem[] } {
-  return { agents: value.agents.map((agent) => ({ ...agent, computerState: undefined })) };
+  return { agents: value.agents.map((agent) => ({ ...agent, evidenceConfirmed: false })) };
 }
 
 function markAgentDetailUnconfirmed(agent: AgentDetailView): AgentDetailView {
@@ -877,7 +869,7 @@ function AgentsPage() {
     <>
       <Page
         title="Agents"
-        description="Shared agents your team can use in Feishu or Slack."
+        description="Shared AI teammates configured for your Team."
         action={
           membership.role === "admin" ? (
             <button className="button" ref={createTriggerRef} type="button" onClick={() => setCreateOpen(true)}>
@@ -912,8 +904,7 @@ function AgentList({ agents }: { agents: AgentListItem[] }) {
       <div className="agent-table">
         <div className="agent-table-header" aria-hidden="true">
           <span>Agent</span>
-          <span>Status</span>
-          <span>Runtime</span>
+          <span>State</span>
           <span />
         </div>
         <div className="agent-table-body">
@@ -927,23 +918,12 @@ function AgentList({ agents }: { agents: AgentListItem[] }) {
 }
 
 function AgentRow({ agent }: { agent: AgentListItem }) {
-  const computerStatus = agent.computerState?.connectionStatus;
   const status =
     agent.status === "suspended"
-      ? { label: "Suspended", reason: "Agent is suspended", tone: "suspended" }
-      : computerStatus === "online"
-        ? {
-            label: "Computer online",
-            reason: lastConfirmedLabel(agent.computerState?.lastSeenAt ?? null),
-            tone: "ready",
-          }
-        : computerStatus === "offline"
-          ? {
-              label: "Computer offline",
-              reason: lastConfirmedLabel(agent.computerState?.lastSeenAt ?? null),
-              tone: "action-required",
-            }
-          : { label: "Unconfirmed", reason: "Unable to confirm Computer", tone: "unconfirmed" };
+      ? { label: "Suspended", reason: "Not receiving new work", tone: "suspended" }
+      : agent.evidenceConfirmed
+        ? { label: "Active", reason: undefined, tone: "ready" }
+        : { label: "Unconfirmed", reason: "Unable to refresh Agent", tone: "unconfirmed" };
   return (
     <div className="agent-row">
       <Link aria-label={`Open ${agent.displayName}`} className="agent-row-link" to={`/agents/${agent.id}/general`} />
@@ -953,21 +933,17 @@ function AgentRow({ agent }: { agent: AgentListItem }) {
         </span>
         <span>
           <strong>{agent.displayName}</strong>
-          <small>@{agent.name}</small>
+          <small>
+            @{agent.name} · {providerLabel(agent.runtimeProvider)}
+          </small>
         </span>
       </span>
-      <span className="cell-stack availability-cell" data-label="Status">
+      <span className="cell-stack availability-cell" data-label="State">
         <strong>
           <i className={`availability-dot ${status.tone}`} aria-hidden="true" />
           {status.label}
         </strong>
-        <small>{status.reason}</small>
-      </span>
-      <span className="cell-stack" data-label="Runtime">
-        <strong>{providerLabel(agent.runtimeProvider)}</strong>
-        <small>
-          {agent.computer.displayName} · {titleCase(agent.computer.platform)}
-        </small>
+        {status.reason ? <small>{status.reason}</small> : null}
       </span>
       <span className="agent-row-action" aria-hidden="true">
         ›
@@ -1342,9 +1318,7 @@ function providerReadinessMessage(
 const agentSections = [
   { key: "general", label: "Overview" },
   { key: "runtime", label: "Runtime" },
-  { key: "im", label: "IM" },
-  { key: "resources", label: "Resources" },
-  { key: "integrations", label: "Integrations" },
+  { key: "im", label: "Messaging" },
   { key: "access", label: "Access" },
 ] as const;
 
@@ -1428,48 +1402,44 @@ function AgentTab({ agent, tab, onAgentChanged }: { agent: AgentDetailView; tab:
   if (tab === "general") return <GeneralTab agent={agent} onAgentChanged={onAgentChanged} />;
   if (tab === "runtime") return <RuntimeTab agent={agent} />;
   if (tab === "im") return <ImTab agent={agent} onAgentChanged={onAgentChanged} />;
-  if (tab === "resources")
-    return (
-      <EmptyState title="No Team Resources assigned">
-        The Team Resource model is not enabled in this release.
-      </EmptyState>
-    );
-  if (tab === "integrations")
-    return (
-      <EmptyState title="No Agent Integrations supported">
-        IM bot connections are managed separately on the IM tab.
-      </EmptyState>
-    );
   if (tab === "access") return <AccessTab agent={agent} />;
   return <NotFoundPage />;
 }
 
 function GeneralTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChanged: () => void }) {
+  const channel = agent.availability.dependencies.channel;
+  const channelLabel = channel.provider ? titleCase(channel.provider) : undefined;
+  const botDisplayName = channel.botDisplayName ?? agent.displayName;
   return (
     <div className="overview-stack">
-      <section className="overview-section" aria-labelledby="availability-heading">
-        <h3 id="availability-heading">Availability</h3>
-        <p className="overview-section-copy">
-          These dependencies jointly determine whether {agent.displayName} can receive work.
-        </p>
-        <div className="dependency-grid">
-          <DependencyCard
-            title="Computer"
-            state={agent.availability.dependencies.computer.state}
-            primary={agent.computer.displayName}
-            secondary={lastConfirmedLabel(agent.availability.dependencies.computer.lastConfirmedAt)}
-          />
-          <DependencyCard
-            title="Handoff"
-            state={agent.availability.dependencies.handoff.state}
-            primary={
-              agent.availability.dependencies.channel.provider
-                ? `${titleCase(agent.availability.dependencies.channel.provider)} · ${providerLabel(agent.runtimeProvider)}`
-                : providerLabel(agent.runtimeProvider)
-            }
-            secondary={handoffDetailLabel(agent.availability.dependencies.handoff.state)}
-          />
+      <section className="overview-section" aria-labelledby="use-agent-heading">
+        <div className="overview-section-heading">
+          <h3 id="use-agent-heading">Use this Agent</h3>
+          <Link to={`/agents/${agent.id}/im`}>
+            {agent.viewerCapabilities.canManage ? "Manage messaging" : "View messaging"}
+          </Link>
         </div>
+        {channelLabel ? (
+          <div className="agent-use-panel">
+            <div className="agent-use-copy">
+              <span className="agent-use-channel">{channelLabel}</span>
+              <h4>Message @{agent.name}</h4>
+              <p>{agentUseInstruction(agent, channelLabel)}</p>
+            </div>
+            <div className="agent-use-identity">
+              <span>{botDisplayName}</span>
+              <small>{receiveModeLabel(agent.receiveMode)}</small>
+            </div>
+          </div>
+        ) : (
+          <div className="agent-use-panel empty">
+            <div className="agent-use-copy">
+              <span className="agent-use-channel">Messaging</span>
+              <h4>Connect Feishu or Slack</h4>
+              <p>This Agent needs a messaging identity before teammates can send it work.</p>
+            </div>
+          </div>
+        )}
       </section>
       <section className="overview-section" aria-labelledby="identity-access-heading">
         <div className="overview-section-heading">
@@ -1478,7 +1448,6 @@ function GeneralTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgent
         </div>
         <DefinitionList
           rows={[
-            ["Bot identity", agent.availability.dependencies.channel.botDisplayName ?? `@${agent.name}`],
             ["Manager", agent.manager.displayName],
             ["Who can use", "Team members"],
           ]}
@@ -1490,6 +1459,7 @@ function GeneralTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgent
 }
 
 function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
+  const recovery = agentAvailabilityRecovery(agent);
   return (
     <div className={`availability-action ${availabilityTone(agent.availability.state)}`}>
       <span>
@@ -1497,33 +1467,10 @@ function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
           <i className={`availability-dot ${availabilityTone(agent.availability.state)}`} aria-hidden="true" />
           {availabilityStateLabel(agent.availability.state)}
         </strong>
-        <small>{availabilityReasonLabel(agent.availability.reason)}</small>
+        <small>{agentAvailabilitySummary(agent)}</small>
       </span>
+      {recovery ? <Link to={recovery.to}>{recovery.label}</Link> : null}
     </div>
-  );
-}
-
-function DependencyCard({
-  title,
-  state,
-  primary,
-  secondary,
-}: {
-  title: string;
-  state: AgentAvailability["dependencies"]["handoff"]["state"];
-  primary: string;
-  secondary: string;
-}) {
-  return (
-    <article className="dependency-card">
-      <span>{title}</span>
-      <strong>
-        <i className={`availability-dot ${availabilityTone(state)}`} aria-hidden="true" />
-        {dependencyStateLabel(state)}
-      </strong>
-      <p>{primary}</p>
-      <small>{secondary}</small>
-    </article>
   );
 }
 
@@ -2869,57 +2816,44 @@ function availabilityStateLabel(state: AgentAvailability["state"]): string {
   return labels[state];
 }
 
-function dependencyStateLabel(state: AgentAvailability["dependencies"]["handoff"]["state"]): string {
-  const labels = {
-    ready: "Ready",
-    action_required: "Needs attention",
-    setting_up: "Setting up",
-    not_connected: "Not connected",
-    unconfirmed: "Unable to confirm",
-  } satisfies Record<AgentAvailability["dependencies"]["handoff"]["state"], string>;
-  return labels[state];
+function agentUseInstruction(agent: AgentDetailView, channelLabel: string): string {
+  if (agent.receiveMode === "all_message") {
+    return `Send a direct message to @${agent.name}. In connected ${channelLabel} conversations, it can also receive messages without a mention.`;
+  }
+  return `Send a direct message, or mention @${agent.name} in a ${channelLabel} conversation.`;
 }
 
-function handoffDetailLabel(state: AgentAvailability["dependencies"]["handoff"]["state"]): string {
-  const labels = {
-    ready: "Ready to receive work",
-    action_required: "Handoff needs attention",
-    setting_up: "IM setup in progress",
-    not_connected: "No IM binding",
-    unconfirmed: "Unable to confirm handoff",
-  } satisfies Record<AgentAvailability["dependencies"]["handoff"]["state"], string>;
-  return labels[state];
+function agentAvailabilitySummary(agent: AgentDetailView): string {
+  if (agent.availability.state === "ready") {
+    const provider = agent.availability.dependencies.channel.provider;
+    return provider ? `Available in ${titleCase(provider)}` : "Ready for new work";
+  }
+  return {
+    action_required: "Cannot receive new work",
+    setting_up: "Messaging setup in progress",
+    not_connected: "Messaging is not connected",
+    suspended: "Not receiving new work",
+    unconfirmed: "Status temporarily unavailable",
+  }[agent.availability.state];
 }
 
-function availabilityReasonLabel(reason: AgentAvailability["reason"]): string {
-  if (!reason) return "All dependencies healthy";
-  const labels = {
-    agent_suspended: "Agent is suspended",
-    agent_unconfirmed: "Unable to refresh Agent status",
-    computer_offline: "Computer is offline",
-    runtime_unavailable: "Runtime message tools unavailable",
-    im_not_connected: "Connect Feishu or Slack",
-    im_provisioning: "IM connection is being prepared",
-    im_reauthorization_required: "IM permissions need updating",
-    im_error: "IM connection needs attention",
-    handoff_unavailable: "Handoff needs attention",
-    computer_unconfirmed: "Unable to confirm Computer",
-    handoff_unconfirmed: "Unable to confirm handoff",
-  } satisfies Record<NonNullable<AgentAvailability["reason"]>, string>;
-  return labels[reason];
-}
-
-function lastConfirmedLabel(value: string | null): string {
-  if (!value) return "Not yet confirmed";
-  const elapsedSeconds = Math.round((new Date(value).getTime() - Date.now()) / 1000);
-  const absoluteSeconds = Math.abs(elapsedSeconds);
-  const formatter = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-  if (absoluteSeconds < 60) return `Confirmed ${formatter.format(elapsedSeconds, "second")}`;
-  const elapsedMinutes = Math.round(elapsedSeconds / 60);
-  if (Math.abs(elapsedMinutes) < 60) return `Confirmed ${formatter.format(elapsedMinutes, "minute")}`;
-  const elapsedHours = Math.round(elapsedMinutes / 60);
-  if (Math.abs(elapsedHours) < 24) return `Confirmed ${formatter.format(elapsedHours, "hour")}`;
-  return `Confirmed ${formatter.format(Math.round(elapsedHours / 24), "day")}`;
+function agentAvailabilityRecovery(agent: AgentDetailView): { label: string; to: string } | undefined {
+  if (!agent.viewerCapabilities.canManage || agent.availability.state === "ready") return undefined;
+  if (agent.availability.reason === "agent_suspended") {
+    return { label: "Manage", to: `/agents/${agent.id}/general#admin-controls` };
+  }
+  if (
+    agent.availability.reason === "im_not_connected" ||
+    agent.availability.reason === "im_provisioning" ||
+    agent.availability.reason === "im_reauthorization_required" ||
+    agent.availability.reason === "im_error" ||
+    agent.availability.reason === "handoff_unavailable" ||
+    agent.availability.reason === "handoff_unconfirmed"
+  ) {
+    return { label: "Review messaging", to: `/agents/${agent.id}/im` };
+  }
+  if (agent.availability.state === "unconfirmed") return undefined;
+  return { label: "Review runtime", to: `/agents/${agent.id}/runtime` };
 }
 
 function initials(value: string): string {
@@ -2933,11 +2867,9 @@ function initials(value: string): string {
 
 function agentSectionDescription(section: (typeof agentSections)[number]["key"]): string {
   const descriptions = {
-    general: "Review identity, readiness dependencies, and the configuration that needs attention.",
+    general: "See how teammates use this Agent and who can access it.",
     runtime: "Inspect the bound Computer, provider, model, instructions, and execution limits.",
-    im: "Manage the Agent-owned Feishu or Slack bot connection and receive policy.",
-    resources: "Team Resources are not enabled for Agents in this release.",
-    integrations: "Agent Integrations are not enabled; supported bot connections are managed on the IM tab.",
+    im: "Manage the Agent's Feishu or Slack bot and message policy.",
     access: "Understand who can use, inspect, and manage this Agent.",
   } satisfies Record<(typeof agentSections)[number]["key"], string>;
   return descriptions[section];

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -855,7 +855,7 @@ button.danger:hover {
 .agent-table-header,
 .agent-row {
   display: grid;
-  grid-template-columns: minmax(205px, 1.25fr) minmax(185px, 1fr) minmax(185px, 1fr) minmax(76px, auto);
+  grid-template-columns: minmax(205px, 1fr) minmax(185px, 0.45fr) minmax(76px, auto);
   gap: 20px;
 }
 
@@ -968,8 +968,7 @@ button.danger:hover {
 }
 
 .availability-cell strong,
-.availability-action strong,
-.dependency-card > strong {
+.availability-action strong {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -1173,52 +1172,6 @@ button.danger:hover {
   color: var(--brand-ink);
   font-size: 0.78rem;
   font-weight: 620;
-}
-
-.dependency-grid {
-  display: grid;
-  overflow: hidden;
-  border: 1px solid var(--strong-border);
-  border-radius: 10px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.dependency-card {
-  min-width: 0;
-  border-right: 1px solid var(--border);
-  padding: 18px;
-}
-
-.dependency-card:last-child {
-  border-right: 0;
-}
-
-.dependency-card > span {
-  display: block;
-  margin-bottom: 12px;
-  color: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 620;
-  text-transform: uppercase;
-}
-
-.dependency-card > strong {
-  font-size: 0.86rem;
-}
-
-.dependency-card p {
-  overflow: hidden;
-  margin: 10px 0 2px;
-  color: var(--foreground);
-  font-size: 0.82rem;
-  font-weight: 590;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.dependency-card small {
-  color: var(--muted);
-  font-size: 0.72rem;
 }
 
 .admin-controls {
@@ -1666,6 +1619,15 @@ code {
   font-size: 0.75rem;
 }
 
+.availability-action a {
+  color: currentColor;
+  font-size: 0.72rem;
+  font-weight: 680;
+  text-decoration: underline;
+  text-decoration-color: rgb(40 64 30 / 28%);
+  text-underline-offset: 3px;
+}
+
 .object-identity p {
   color: var(--muted);
   font-size: 0.8rem;
@@ -1719,62 +1681,66 @@ code {
   font-weight: 660;
 }
 
-.overview-section-copy {
-  margin: -7px 0 13px;
-  color: var(--muted);
-  font-size: 0.75rem;
-}
-
-.dependency-grid {
-  display: grid;
-  overflow: visible;
-  border: 0;
+.agent-use-panel {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 32px;
   border-radius: var(--radius);
   background: var(--brand-light);
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  padding: 21px 22px;
+  padding: 24px;
 }
 
-.dependency-card {
-  position: relative;
+.agent-use-panel.empty {
+  background: var(--surface-soft);
+}
+
+.agent-use-copy {
   min-width: 0;
-  border-right: 0;
-  padding: 0 32px 0 0;
 }
 
-.dependency-card:not(:last-child)::after {
-  position: absolute;
-  top: 10px;
-  right: 16px;
-  width: 20px;
-  height: 1px;
-  background: #b9c99b;
-  content: "";
+.agent-use-channel {
+  display: block;
+  margin-bottom: 9px;
+  color: var(--brand-ink);
+  font-size: 0.72rem;
+  font-weight: 680;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.dependency-card > span {
-  margin-bottom: 0;
-  color: var(--muted);
-  font-size: 0.75rem;
-  font-weight: 620;
-  text-transform: none;
+.agent-use-copy h4 {
+  margin-bottom: 7px;
+  color: var(--foreground);
+  font-size: 1.05rem;
 }
 
-.dependency-card > strong {
-  margin-top: 13px;
+.agent-use-copy p {
+  max-width: 510px;
+  margin: 0;
   color: var(--secondary-foreground);
-  font-size: 0.75rem;
+  font-size: 0.84rem;
+  line-height: 1.6;
 }
 
-.dependency-card p {
-  margin: 8px 0 2px;
-  font-size: 0.88rem;
-  font-weight: 650;
+.agent-use-identity {
+  display: grid;
+  flex: 0 0 auto;
+  justify-items: end;
+  gap: 5px;
+  padding-top: 3px;
+  text-align: right;
 }
 
-.dependency-card small {
+.agent-use-identity > span {
+  color: var(--foreground);
+  font-size: 0.82rem;
+  font-weight: 660;
+}
+
+.agent-use-identity small {
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
 }
 
 .overview-section .definition-list {
@@ -1783,7 +1749,7 @@ code {
   border: 0;
   border-radius: var(--radius);
   background: var(--surface-soft);
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   padding: 20px 22px;
 }
 
@@ -2791,19 +2757,15 @@ textarea:focus {
     justify-self: end;
   }
 
-  .dependency-grid {
+  .agent-use-panel {
+    flex-direction: column;
     gap: 18px;
-    grid-template-columns: 1fr;
+    padding: 20px;
   }
 
-  .dependency-card {
-    border-right: 0;
-    border-bottom: 0;
-    padding: 0;
-  }
-
-  .dependency-card:not(:last-child)::after {
-    display: none;
+  .agent-use-identity {
+    justify-items: start;
+    text-align: left;
   }
 
   .overview-section .definition-list {


### PR DESCRIPTION
## Summary

- replace the Computer/Handoff dependency topology with a task-focused usage panel
- keep one aggregate readiness status with actionable Runtime or Messaging recovery links
- simplify Agent navigation and remove machine details and dependency reads from the Agent list

## Validation

- pnpm check
- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/web test (144 passed)
- pnpm --filter @opentag/client test:agent-runtime:coverage (273 passed, 100% coverage)
- desktop and mobile production-preview visual QA

Full-repository test and coverage runs expose five unrelated existing failures: four macOS /var vs /private/var path assertions and one RuntimeSession observability timing assertion. The same five failures reproduce on the untouched main commit.