### PR TITLE
refactor(web): drive typography from a token layer

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="light dark" />
+    <meta name="color-scheme" content="light" />
     <title>OpenTag</title>
   </head>
   <body>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^4.7.0",
     "jsdom": "^26.1.0",
+    "postcss": "^8.5.26",
     "vite": "^7.1.3"
   }
 }

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -101,16 +101,6 @@ function referenceProjection(value: string): string {
   return withoutStrings(value);
 }
 
-/** The properties this guard owns, alongside the token families themselves. */
-const TYPOGRAPHY_PROPERTIES = new Set([
-  "font",
-  "font-size",
-  "font-weight",
-  "font-family",
-  "line-height",
-  "letter-spacing",
-]);
-
 /**
  * What the browser sees: the decoded name, the decoded value exactly as the
  * browser validates it, where it applies, and whether it applies
@@ -193,21 +183,17 @@ function offTokenValues(css: string, property: string, allowed: RegExp, literals
   return valuesOf(css, property).filter((value) => !allowed.test(value) && !(literals?.has(value) ?? false));
 }
 
-/** A typography declaration is one this guard reads: an owned property, or a token definition. */
-function ownedByGuard(declaration: Declared): boolean {
-  return (
-    TYPOGRAPHY_PROPERTIES.has(propertyName(declaration)) ||
-    FAMILIES.some((family) => declaration.name.startsWith(`--${family}-`))
-  );
-}
-
 /**
  * An escape inside a value changes which tokens the browser consumes, so the
- * text is no longer what it looks like. The stylesheet has never needed one.
+ * text stops meaning what it looks like. References are read from every
+ * declaration, not only the ones this guard owns, so every declaration has to
+ * be canonical for that scan to be worth anything -- outside strings, where a
+ * backslash is ordinary content and no reference is read. The stylesheet has
+ * never contained one.
  */
 function escapedValues(css: string): string[] {
   return declarations(css)
-    .filter((declaration) => ownedByGuard(declaration) && declaration.value.includes("\\"))
+    .filter((declaration) => declaration.references.includes("\\"))
     .map((declaration) => `${declaration.name}: ${declaration.value}`);
 }
 
@@ -327,7 +313,7 @@ describe("typography tokens", () => {
     expect(unresolvedRoles(stylesheet)).toEqual([]);
   });
 
-  it("spells every value it owns without escapes", () => {
+  it("spells every value outside a string without escapes", () => {
     expect(escapedValues(stylesheet)).toEqual([]);
   });
 
@@ -502,6 +488,16 @@ describe("the guard itself", () => {
     const role = String.raw`:root { --text-ui: var\28--fs-13\29; }`;
     expect(escapedValues(role)).toEqual([String.raw`--text-ui: var\28--fs-13\29`]);
     expect(malformedRoles(role)).toEqual([String.raw`--text-ui: var\28--fs-13\29`]);
+  });
+
+  it("refuses an escaped reference under a property it does not otherwise read", () => {
+    const css = String.raw`.row { padding: v\61 r(--fs-99); }`;
+    expect(escapedValues(css)).toEqual([String.raw`padding: v\61 r(--fs-99)`]);
+  });
+
+  it("leaves a backslash inside a string alone, where it is content", () => {
+    const css = String.raw`.row::after { content: "\201C"; }`;
+    expect(escapedValues(css)).toEqual([]);
   });
 
   it("does not read a commented-out declaration as a violation", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -43,8 +43,17 @@ const LINE_HEIGHT_LITERALS = new Set(["1", "38px"]);
  */
 const FONT_SHORTHAND_LITERALS = new Set(["inherit"]);
 
+/**
+ * A commented-out declaration is not a declaration. The browser never sees it,
+ * so neither should any check below: a token defined only inside a comment
+ * does not exist, and a rule parked inside one cannot violate anything.
+ */
+function withoutComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
 function captures(css: string, pattern: RegExp, group = 1): string[] {
-  return [...css.matchAll(pattern)]
+  return [...withoutComments(css).matchAll(pattern)]
     .map((match) => match[group])
     .filter((value): value is string => value !== undefined)
     .map((value) => value.trim());
@@ -157,6 +166,17 @@ describe("the guard itself", () => {
     const css = ":root { --text-ui: var(--fs-15); }\n.row { line-height: var(--lh-prsoe); }";
     expect(danglingReferences(css)).toEqual(["fs-15", "lh-prsoe"]);
     expect(unresolvedRoles(css)).toEqual(["fs-15"]);
+  });
+
+  it("ignores a step that exists only inside a comment", () => {
+    const css = ":root {\n  --text-ui: var(--fs-15);\n  /* --fs-15: 0.9375rem; */\n}";
+    expect(unresolvedRoles(css)).toEqual(["fs-15"]);
+    expect(danglingReferences(css)).toEqual(["fs-15"]);
+  });
+
+  it("does not read a commented-out declaration as a violation", () => {
+    const css = ".row { /* font-size: 0.83rem; */ font-size: var(--text-ui); }";
+    expect(offTokenValues(css, "font-size", /^var\(--text-[a-z]+\)$/)).toEqual([]);
   });
 
   it("does not mistake a longhand for the shorthand it starts with", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import postcss, { type Declaration } from "postcss";
+import postcss, { type Declaration, type Rule } from "postcss";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -55,6 +55,22 @@ function declarations(css: string): Declaration[] {
   return found;
 }
 
+/** The selectors a declaration applies under, or none when it sits outside a rule. */
+function selectorsOf(declaration: Declaration): string[] {
+  const parent = declaration.parent;
+  if (parent === undefined || parent.type !== "rule") return [];
+  return (parent as Rule).selector.split(",").map((selector) => selector.trim());
+}
+
+/**
+ * A custom property exists only where its selector matches. A step parked under
+ * some other rule is invisible to a :root role, so the baseline scale has to be
+ * declared at :root to count as declared at all.
+ */
+function atRoot(declaration: Declaration): boolean {
+  return selectorsOf(declaration).includes(":root");
+}
+
 /**
  * A quoted run is content, not code: `content: "--fs-15: 0.9375rem"` declares
  * no token and references none, so strings drop out before a value is read.
@@ -73,7 +89,7 @@ function valuesOf(css: string, property: string): string[] {
 function definedTokens(css: string, prefix: string): Set<string> {
   const pattern = new RegExp(`^--(${prefix}-[a-z0-9-]+)$`);
   const names = new Set<string>();
-  for (const declaration of declarations(css)) {
+  for (const declaration of declarations(css).filter(atRoot)) {
     const name = declaration.prop.match(pattern)?.[1];
     if (name !== undefined) names.add(name);
   }
@@ -117,12 +133,30 @@ function unresolvedRoles(css: string): string[] {
 
 /** Raw steps as declared: the number in the name, and the pixel value it resolves to. */
 function rawSteps(css: string): { name: number; px: number }[] {
-  return declarations(css).flatMap((declaration) => {
-    const name = declaration.prop.match(/^--fs-([0-9]+)$/)?.[1];
-    const rem = withoutStrings(declaration.value).match(/^([0-9.]+)rem$/)?.[1];
-    if (name === undefined || rem === undefined) return [];
-    return [{ name: Number(name), px: Number(rem) * 16 }];
-  });
+  return declarations(css)
+    .filter(atRoot)
+    .flatMap((declaration) => {
+      const name = declaration.prop.match(/^--fs-([0-9]+)$/)?.[1];
+      const rem = withoutStrings(declaration.value).match(/^([0-9.]+)rem$/)?.[1];
+      if (name === undefined || rem === undefined) return [];
+      return [{ name: Number(name), px: Number(rem) * 16 }];
+    });
+}
+
+/**
+ * Typography tokens declared somewhere other than :root. A surface may retune a
+ * role it inherits; it may not invent a token, because nothing outside that
+ * surface could resolve it.
+ */
+function scopedDefinitions(css: string): { token: string; selector: string }[] {
+  const pattern = new RegExp(`^--((?:${FAMILIES.join("|")})-[a-z0-9-]+)$`);
+  return declarations(css)
+    .filter((declaration) => !atRoot(declaration))
+    .flatMap((declaration) => {
+      const token = declaration.prop.match(pattern)?.[1];
+      if (token === undefined) return [];
+      return [{ token, selector: selectorsOf(declaration).join(", ") }];
+    });
 }
 
 describe("typography tokens", () => {
@@ -162,6 +196,14 @@ describe("typography tokens", () => {
     const roles = declarations(stylesheet).filter((declaration) => /^--text-[a-z]+$/.test(declaration.prop));
     expect(roles.length).toBeGreaterThan(0);
     expect(roleEdges(stylesheet).length).toBe(roles.length);
+  });
+
+  it("rebinds only roles that :root already declares, and never a raw step", () => {
+    const roles = definedTokens(stylesheet, "text");
+    const introduced = scopedDefinitions(stylesheet).filter(
+      (definition) => !definition.token.startsWith("text-") || !roles.has(definition.token),
+    );
+    expect(introduced).toEqual([]);
   });
 
   it("keeps every raw step on a whole pixel, named after the size it produces", () => {
@@ -218,6 +260,21 @@ describe("the guard itself", () => {
   it("does not read a token reference quoted inside a value", () => {
     const css = ':root { --fs-13: 0.8125rem; }\n.row::after { content: "var(--fs-99)"; }';
     expect(danglingReferences(css)).toEqual([]);
+  });
+
+  it("ignores a step declared under some other selector", () => {
+    const css = ":root { --text-ui: var(--fs-13); }\n.dead { --fs-13: 0.8125rem; }";
+    expect(unresolvedRoles(css)).toEqual(["fs-13"]);
+    expect(danglingReferences(css)).toEqual(["fs-13"]);
+    expect(rawSteps(css)).toEqual([]);
+    expect(scopedDefinitions(css)).toEqual([{ token: "fs-13", selector: ".dead" }]);
+  });
+
+  it("accepts a surface that retunes a role :root already declares", () => {
+    const css =
+      ":root { --fs-13: 0.8125rem; --fs-14: 0.875rem; --text-ui: var(--fs-13); }\n.settings-page { --text-ui: var(--fs-14); }";
+    expect(danglingReferences(css)).toEqual([]);
+    expect(scopedDefinitions(css)).toEqual([{ token: "text-ui", selector: ".settings-page" }]);
   });
 
   it("does not read a commented-out declaration as a violation", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import postcss, { type Declaration, type Rule } from "postcss";
+import postcss, { type Container, type Declaration, type Document, type Rule } from "postcss";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -9,6 +9,13 @@ import { describe, expect, it } from "vitest";
  * other. These tests keep type flowing through the token layer so the scale
  * cannot drift back apart one component at a time.
  *
+ * Surfaces that own a density, and the only selectors allowed to retune a
+ * role. Anywhere else, a rebinding is component-local drift: the thing this
+ * PR removed.
+ */
+const READING_SURFACES = new Set([".settings-page", ".onboarding-shell", ".decorative-page", ".dialog-card"]);
+
+/*
  * Every check reads parsed declarations rather than raw text. Matching CSS
  * with regular expressions cost this guard three separate holes in review —
  * the `font` shorthand read as a longhand, a token defined only inside a
@@ -62,13 +69,24 @@ function selectorsOf(declaration: Declaration): string[] {
   return (parent as Rule).selector.split(",").map((selector) => selector.trim());
 }
 
+/** A declaration wrapped in any at-rule applies only when that condition holds. */
+function unconditional(declaration: Declaration): boolean {
+  let node: Container | Document | undefined = declaration.parent;
+  while (node !== undefined) {
+    if (node.type === "atrule") return false;
+    node = node.parent;
+  }
+  return true;
+}
+
 /**
- * A custom property exists only where its selector matches. A step parked under
- * some other rule is invisible to a :root role, so the baseline scale has to be
- * declared at :root to count as declared at all.
+ * A custom property exists only where its selector matches and its conditions
+ * hold. A step parked under another rule -- or under a media query that a normal
+ * viewport never satisfies -- is invisible to a :root role, so the baseline
+ * scale has to be declared at an unconditional :root to count as declared.
  */
 function atRoot(declaration: Declaration): boolean {
-  return selectorsOf(declaration).includes(":root");
+  return unconditional(declaration) && selectorsOf(declaration).includes(":root");
 }
 
 /**
@@ -79,10 +97,15 @@ function withoutStrings(value: string): string {
   return value.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, "");
 }
 
+/** Ordinary property names are ASCII case-insensitive; custom property names are not. */
+function propertyName(declaration: Declaration): string {
+  return declaration.prop.startsWith("--") ? declaration.prop : declaration.prop.toLowerCase();
+}
+
 /** Values of one property, matched by parsed name so `font` never collects `font-size`. */
 function valuesOf(css: string, property: string): string[] {
   return declarations(css)
-    .filter((declaration) => declaration.prop === property)
+    .filter((declaration) => propertyName(declaration) === property)
     .map((declaration) => declaration.value.trim());
 }
 
@@ -131,16 +154,30 @@ function unresolvedRoles(css: string): string[] {
     .map((edge) => edge.step);
 }
 
-/** Raw steps as declared: the number in the name, and the pixel value it resolves to. */
+/** Every baseline step declaration, well-formed or not, so none is skipped silently. */
+function rootStepDeclarations(css: string): Declaration[] {
+  return declarations(css).filter((declaration) => atRoot(declaration) && declaration.prop.startsWith("--fs-"));
+}
+
+/** A step is a numeric name and a rem value; anything else does not describe one. */
+function stepOf(declaration: Declaration): { name: number; px: number } | undefined {
+  const name = declaration.prop.match(/^--fs-([0-9]+)$/)?.[1];
+  const rem = withoutStrings(declaration.value).match(/^([0-9.]+)rem$/)?.[1];
+  if (name === undefined || rem === undefined) return undefined;
+  return { name: Number(name), px: Number(rem) * 16 };
+}
+
 function rawSteps(css: string): { name: number; px: number }[] {
-  return declarations(css)
-    .filter(atRoot)
-    .flatMap((declaration) => {
-      const name = declaration.prop.match(/^--fs-([0-9]+)$/)?.[1];
-      const rem = withoutStrings(declaration.value).match(/^([0-9.]+)rem$/)?.[1];
-      if (name === undefined || rem === undefined) return [];
-      return [{ name: Number(name), px: Number(rem) * 16 }];
-    });
+  return rootStepDeclarations(css).flatMap((declaration) => {
+    const step = stepOf(declaration);
+    return step === undefined ? [] : [step];
+  });
+}
+
+function malformedSteps(css: string): string[] {
+  return rootStepDeclarations(css)
+    .filter((declaration) => stepOf(declaration) === undefined)
+    .map((declaration) => `${declaration.prop}: ${declaration.value}`);
 }
 
 /**
@@ -148,14 +185,14 @@ function rawSteps(css: string): { name: number; px: number }[] {
  * role it inherits; it may not invent a token, because nothing outside that
  * surface could resolve it.
  */
-function scopedDefinitions(css: string): { token: string; selector: string }[] {
+function scopedDefinitions(css: string): { token: string; selectors: string[] }[] {
   const pattern = new RegExp(`^--((?:${FAMILIES.join("|")})-[a-z0-9-]+)$`);
   return declarations(css)
     .filter((declaration) => !atRoot(declaration))
     .flatMap((declaration) => {
       const token = declaration.prop.match(pattern)?.[1];
       if (token === undefined) return [];
-      return [{ token, selector: selectorsOf(declaration).join(", ") }];
+      return [{ token, selectors: selectorsOf(declaration) }];
     });
 }
 
@@ -198,12 +235,20 @@ describe("typography tokens", () => {
     expect(roleEdges(stylesheet).length).toBe(roles.length);
   });
 
-  it("rebinds only roles that :root already declares, and never a raw step", () => {
+  it("retunes roles only on the reading surfaces, and never a raw step", () => {
     const roles = definedTokens(stylesheet, "text");
-    const introduced = scopedDefinitions(stylesheet).filter(
-      (definition) => !definition.token.startsWith("text-") || !roles.has(definition.token),
+    const stray = scopedDefinitions(stylesheet).filter(
+      (definition) =>
+        !definition.token.startsWith("text-") ||
+        !roles.has(definition.token) ||
+        !definition.selectors.every((selector) => READING_SURFACES.has(selector)),
     );
-    expect(introduced).toEqual([]);
+    expect(stray).toEqual([]);
+  });
+
+  it("declares every baseline step as a whole-pixel rem, with none skipped", () => {
+    expect(malformedSteps(stylesheet)).toEqual([]);
+    expect(rawSteps(stylesheet).length).toBe(rootStepDeclarations(stylesheet).length);
   });
 
   it("keeps every raw step on a whole pixel, named after the size it produces", () => {
@@ -267,14 +312,48 @@ describe("the guard itself", () => {
     expect(unresolvedRoles(css)).toEqual(["fs-13"]);
     expect(danglingReferences(css)).toEqual(["fs-13"]);
     expect(rawSteps(css)).toEqual([]);
-    expect(scopedDefinitions(css)).toEqual([{ token: "fs-13", selector: ".dead" }]);
+    expect(scopedDefinitions(css)).toEqual([{ token: "fs-13", selectors: [".dead"] }]);
   });
 
   it("accepts a surface that retunes a role :root already declares", () => {
     const css =
       ":root { --fs-13: 0.8125rem; --fs-14: 0.875rem; --text-ui: var(--fs-13); }\n.settings-page { --text-ui: var(--fs-14); }";
     expect(danglingReferences(css)).toEqual([]);
-    expect(scopedDefinitions(css)).toEqual([{ token: "text-ui", selector: ".settings-page" }]);
+    expect(scopedDefinitions(css)).toEqual([{ token: "text-ui", selectors: [".settings-page"] }]);
+  });
+
+  it("reads an upper-case property name, which the browser applies all the same", () => {
+    const css = "body { FONT-SIZE: 13px; FONT-FAMILY: Arial; }\n.row { Font: 12px Arial; }";
+    expect(offTokenValues(css, "font-size", /^var\(--text-[a-z]+\)$/)).toEqual(["13px"]);
+    expect(offTokenValues(css, "font-family", /^var\(--font-[a-z]+\)$/)).toEqual(["Arial"]);
+    expect(offTokenValues(css, "font", /^$/, FONT_SHORTHAND_LITERALS)).toEqual(["12px Arial"]);
+  });
+
+  it("reports a step that does not describe a step, rather than skipping it", () => {
+    const css = ":root { --fs-13: 13.5px; --fs-small: 0.8125rem; --fs-14: 0.875rem; }";
+    expect(malformedSteps(css)).toEqual(["--fs-13: 13.5px", "--fs-small: 0.8125rem"]);
+    expect(rawSteps(css)).toEqual([{ name: 14, px: 14 }]);
+  });
+
+  it("ignores a step declared under a condition a normal viewport never meets", () => {
+    const css = ":root { --text-ui: var(--fs-13); }\n@media (width: 0px) { :root { --fs-13: 0.8125rem; } }";
+    expect(unresolvedRoles(css)).toEqual(["fs-13"]);
+    expect(danglingReferences(css)).toEqual(["fs-13"]);
+    expect(rawSteps(css)).toEqual([]);
+    expect(scopedDefinitions(css)).toEqual([{ token: "fs-13", selectors: [":root"] }]);
+  });
+
+  it("rejects a component that retunes a role it does not own", () => {
+    const css =
+      ":root { --fs-30: 1.875rem; --text-ui: var(--fs-13); --fs-13: 0.8125rem; }\n.row { --text-ui: var(--fs-30); }";
+    const roles = definedTokens(css, "text");
+    const stray = scopedDefinitions(css).filter(
+      (definition) =>
+        !definition.token.startsWith("text-") ||
+        !roles.has(definition.token) ||
+        !definition.selectors.every((selector) => READING_SURFACES.has(selector)),
+    );
+    expect(stray).toEqual([{ token: "text-ui", selectors: [".row"] }]);
   });
 
   it("does not read a commented-out declaration as a violation", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -95,12 +95,21 @@ function withoutStrings(value: string): string {
 
 /**
  * Strings are ignorable when looking for token references, and only then: to
- * the browser a quoted run is still part of the value it validates. Strings go
- * first and escapes second, since decoding first could manufacture a quote.
+ * the browser a quoted run is still part of the value it validates.
  */
 function referenceProjection(value: string): string {
-  return decodeIdentifier(withoutStrings(value));
+  return withoutStrings(value);
 }
+
+/** The properties this guard owns, alongside the token families themselves. */
+const TYPOGRAPHY_PROPERTIES = new Set([
+  "font",
+  "font-size",
+  "font-weight",
+  "font-family",
+  "line-height",
+  "letter-spacing",
+]);
 
 /**
  * What the browser sees: the decoded name, the decoded value exactly as the
@@ -110,6 +119,12 @@ function referenceProjection(value: string): string {
  * `references` is that value with quoted runs dropped, and is for finding
  * var() references and nothing else. Validating against it would accept
  * `font-size: "poison" var(--text-ui)`, which the browser throws out.
+ *
+ * Values are recorded as written. A name is one identifier, so decoding it is
+ * exact; a value is a sequence of tokens, and CSS resolves escapes inside the
+ * token being consumed rather than across it -- `var\28--text-ui\29` is a
+ * single identifier, not a call. Rather than reimplement value tokenization to
+ * tell those apart, escapes are refused in the values this guard owns.
  *
  * Every check below reads these records. PostCSS nodes stop here on purpose --
  * twice, a check reached past the decoder to the name as written and let an
@@ -129,7 +144,7 @@ function declarations(css: string): Declared[] {
   postcss.parse(css).walkDecls((declaration) => {
     found.push({
       name: decodeIdentifier(declaration.prop),
-      value: decodeIdentifier(declaration.value).trim(),
+      value: declaration.value.trim(),
       references: referenceProjection(declaration.value),
       selectors: selectorsOf(declaration),
       unconditional: unconditional(declaration),
@@ -176,6 +191,24 @@ function definedTypographyTokens(css: string): Set<string> {
 
 function offTokenValues(css: string, property: string, allowed: RegExp, literals?: Set<string>): string[] {
   return valuesOf(css, property).filter((value) => !allowed.test(value) && !(literals?.has(value) ?? false));
+}
+
+/** A typography declaration is one this guard reads: an owned property, or a token definition. */
+function ownedByGuard(declaration: Declared): boolean {
+  return (
+    TYPOGRAPHY_PROPERTIES.has(propertyName(declaration)) ||
+    FAMILIES.some((family) => declaration.name.startsWith(`--${family}-`))
+  );
+}
+
+/**
+ * An escape inside a value changes which tokens the browser consumes, so the
+ * text is no longer what it looks like. The stylesheet has never needed one.
+ */
+function escapedValues(css: string): string[] {
+  return declarations(css)
+    .filter((declaration) => ownedByGuard(declaration) && declaration.value.includes("\\"))
+    .map((declaration) => `${declaration.name}: ${declaration.value}`);
 }
 
 function danglingReferences(css: string): string[] {
@@ -292,6 +325,10 @@ describe("typography tokens", () => {
 
   it("resolves each role to a step that is actually declared", () => {
     expect(unresolvedRoles(stylesheet)).toEqual([]);
+  });
+
+  it("spells every value it owns without escapes", () => {
+    expect(escapedValues(stylesheet)).toEqual([]);
   });
 
   it("resolves every role to a raw step rather than a bare length", () => {
@@ -455,6 +492,16 @@ describe("the guard itself", () => {
 
     const step = ':root { --fs-13: "poison" 0.8125rem; }';
     expect(malformedSteps(step)).toEqual(['--fs-13: "poison" 0.8125rem']);
+  });
+
+  it("refuses an escape in a value, which does not mean what its text says", () => {
+    const size = String.raw`body { font-size: var\28--text-ui\29; }`;
+    expect(escapedValues(size)).toEqual([String.raw`font-size: var\28--text-ui\29`]);
+    expect(danglingReferences(size)).toEqual([]);
+
+    const role = String.raw`:root { --text-ui: var\28--fs-13\29; }`;
+    expect(escapedValues(role)).toEqual([String.raw`--text-ui: var\28--fs-13\29`]);
+    expect(malformedRoles(role)).toEqual([String.raw`--text-ui: var\28--fs-13\29`]);
   });
 
   it("does not read a commented-out declaration as a violation", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -20,8 +20,18 @@ function locateStylesheet(): string {
 
 const stylesheet = readFileSync(locateStylesheet(), "utf8");
 
+/** The token families typography flows through. Adding one here extends every check below. */
+const FAMILIES = ["fs", "text", "fw", "track", "font", "lh"] as const;
+
 /** Every typography token reference, wherever it appears — including one role pointing at another. */
-const TOKEN_REFERENCE = /var\(--((?:fs|text|fw|track|font)-[a-z0-9-]+)\)/g;
+const TOKEN_REFERENCE = new RegExp(`var\\(--((?:${FAMILIES.join("|")})-[a-z0-9-]+)\\)`, "g");
+
+/**
+ * Line heights that are box geometry rather than text rhythm: `1` centres a
+ * single glyph in its own line box, and 38px matches the height of the badge
+ * it labels. Any other literal belongs in a --lh-* token.
+ */
+const LINE_HEIGHT_LITERALS = new Set(["1", "38px"]);
 
 function captures(pattern: RegExp, group = 1): string[] {
   return [...stylesheet.matchAll(pattern)]
@@ -39,7 +49,7 @@ function definedTokens(prefix: string): Set<string> {
 }
 
 function definedTypographyTokens(): Set<string> {
-  return new Set(["fs", "text", "fw", "track", "font"].flatMap((prefix) => [...definedTokens(prefix)]));
+  return new Set(FAMILIES.flatMap((prefix) => [...definedTokens(prefix)]));
 }
 
 describe("typography tokens", () => {
@@ -50,6 +60,13 @@ describe("typography tokens", () => {
 
   it("declares every font weight through a --fw-* token", () => {
     const literals = declarations("font-weight").filter((value) => !/^var\(--fw-[a-z]+\)$/.test(value));
+    expect(literals).toEqual([]);
+  });
+
+  it("declares every line height through a --lh-* token or a named geometry exception", () => {
+    const literals = declarations("line-height").filter(
+      (value) => !/^var\(--lh-[a-z]+\)$/.test(value) && !LINE_HEIGHT_LITERALS.has(value),
+    );
     expect(literals).toEqual([]);
   });
 

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import postcss, { type Declaration } from "postcss";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -8,8 +9,11 @@ import { describe, expect, it } from "vitest";
  * other. These tests keep type flowing through the token layer so the scale
  * cannot drift back apart one component at a time.
  *
- * The checks are pure functions over CSS text, so the suite below can also
- * prove that each one rejects the declaration it exists to catch.
+ * Every check reads parsed declarations rather than raw text. Matching CSS
+ * with regular expressions cost this guard three separate holes in review —
+ * the `font` shorthand read as a longhand, a token defined only inside a
+ * comment, and one quoted inside a value — so the parser draws those
+ * boundaries now, and the suite below proves each one holds.
  */
 
 /** The suite runs from apps/web and, under the coverage config, from the repo root. */
@@ -26,8 +30,7 @@ const stylesheet = readFileSync(locateStylesheet(), "utf8");
 /** The token families typography flows through. Adding one here extends every check below. */
 const FAMILIES = ["fs", "text", "fw", "track", "font", "lh"] as const;
 
-/** Every typography token reference, wherever it appears — including one role pointing at another. */
-const TOKEN_REFERENCE = new RegExp(`var\\(--((?:${FAMILIES.join("|")})-[a-z0-9-]+)\\)`, "g");
+const TOKEN_REFERENCE = new RegExp(`var\\(\\s*--((?:${FAMILIES.join("|")})-[a-z0-9-]+)`, "g");
 
 /**
  * Line heights that are box geometry rather than text rhythm: `1` centres a
@@ -43,29 +46,38 @@ const LINE_HEIGHT_LITERALS = new Set(["1", "38px"]);
  */
 const FONT_SHORTHAND_LITERALS = new Set(["inherit"]);
 
+/** Comments parse as their own nodes, so only declarations the browser applies reach any check. */
+function declarations(css: string): Declaration[] {
+  const found: Declaration[] = [];
+  postcss.parse(css).walkDecls((declaration) => {
+    found.push(declaration);
+  });
+  return found;
+}
+
 /**
- * A commented-out declaration is not a declaration. The browser never sees it,
- * so neither should any check below: a token defined only inside a comment
- * does not exist, and a rule parked inside one cannot violate anything.
+ * A quoted run is content, not code: `content: "--fs-15: 0.9375rem"` declares
+ * no token and references none, so strings drop out before a value is read.
  */
-function withoutComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+function withoutStrings(value: string): string {
+  return value.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, "");
 }
 
-function captures(css: string, pattern: RegExp, group = 1): string[] {
-  return [...withoutComments(css).matchAll(pattern)]
-    .map((match) => match[group])
-    .filter((value): value is string => value !== undefined)
-    .map((value) => value.trim());
-}
-
-/** Values of `property`, matched as a longhand so `font:` never picks up `font-size:`. */
-function declarations(css: string, property: string): string[] {
-  return captures(css, new RegExp(`(?<![\\w-])${property}:\\s*([^;]+);`, "g"));
+/** Values of one property, matched by parsed name so `font` never collects `font-size`. */
+function valuesOf(css: string, property: string): string[] {
+  return declarations(css)
+    .filter((declaration) => declaration.prop === property)
+    .map((declaration) => declaration.value.trim());
 }
 
 function definedTokens(css: string, prefix: string): Set<string> {
-  return new Set(captures(css, new RegExp(`--(${prefix}-[a-z0-9-]+):`, "g")));
+  const pattern = new RegExp(`^--(${prefix}-[a-z0-9-]+)$`);
+  const names = new Set<string>();
+  for (const declaration of declarations(css)) {
+    const name = declaration.prop.match(pattern)?.[1];
+    if (name !== undefined) names.add(name);
+  }
+  return names;
 }
 
 function definedTypographyTokens(css: string): Set<string> {
@@ -73,17 +85,44 @@ function definedTypographyTokens(css: string): Set<string> {
 }
 
 function offTokenValues(css: string, property: string, allowed: RegExp, literals?: Set<string>): string[] {
-  return declarations(css, property).filter((value) => !allowed.test(value) && !(literals?.has(value) ?? false));
+  return valuesOf(css, property).filter((value) => !allowed.test(value) && !(literals?.has(value) ?? false));
 }
 
 function danglingReferences(css: string): string[] {
   const defined = definedTypographyTokens(css);
-  return [...new Set(captures(css, TOKEN_REFERENCE).filter((name) => !defined.has(name)))];
+  const referenced = declarations(css).flatMap((declaration) =>
+    [...withoutStrings(declaration.value).matchAll(TOKEN_REFERENCE)]
+      .map((match) => match[1])
+      .filter((name): name is string => name !== undefined),
+  );
+  return [...new Set(referenced.filter((name) => !defined.has(name)))];
+}
+
+/** Steps named by a role, paired with the role, so a broken edge names both ends. */
+function roleEdges(css: string): { role: string; step: string }[] {
+  return declarations(css)
+    .filter((declaration) => /^--text-[a-z]+$/.test(declaration.prop))
+    .flatMap((declaration) => {
+      const step = withoutStrings(declaration.value).match(/^var\(\s*--(fs-[a-z0-9-]+)\s*\)$/)?.[1];
+      return step === undefined ? [] : [{ role: declaration.prop, step }];
+    });
 }
 
 function unresolvedRoles(css: string): string[] {
   const steps = definedTokens(css, "fs");
-  return captures(css, /--text-[a-z]+:\s*var\(--(fs-[a-z0-9-]+)\);/g).filter((step) => !steps.has(step));
+  return roleEdges(css)
+    .filter((edge) => !steps.has(edge.step))
+    .map((edge) => edge.step);
+}
+
+/** Raw steps as declared: the number in the name, and the pixel value it resolves to. */
+function rawSteps(css: string): { name: number; px: number }[] {
+  return declarations(css).flatMap((declaration) => {
+    const name = declaration.prop.match(/^--fs-([0-9]+)$/)?.[1];
+    const rem = withoutStrings(declaration.value).match(/^([0-9.]+)rem$/)?.[1];
+    if (name === undefined || rem === undefined) return [];
+    return [{ name: Number(name), px: Number(rem) * 16 }];
+  });
 }
 
 describe("typography tokens", () => {
@@ -119,22 +158,16 @@ describe("typography tokens", () => {
     expect(unresolvedRoles(stylesheet)).toEqual([]);
   });
 
-  it("keeps every raw step on a whole pixel", () => {
-    const steps = captures(stylesheet, /--fs-[0-9]+:\s*([0-9.]+)rem;/g).map((value) => Number(value) * 16);
-    expect(steps.length).toBeGreaterThan(0);
-    expect(steps.filter((px) => !Number.isInteger(px))).toEqual([]);
-  });
-
-  it("names each step after the pixel size it produces", () => {
-    const named = captures(stylesheet, /--fs-([0-9]+):\s*([0-9.]+)rem;/g);
-    const values = captures(stylesheet, /--fs-([0-9]+):\s*([0-9.]+)rem;/g, 2);
-    expect(named.filter((name, index) => Number(name) !== Number(values[index]) * 16)).toEqual([]);
-  });
-
-  it("resolves each role to a raw step rather than a bare length", () => {
-    const roles = captures(stylesheet, /--text-[a-z]+:\s*([^;]+);/g);
+  it("resolves every role to a raw step rather than a bare length", () => {
+    const roles = declarations(stylesheet).filter((declaration) => /^--text-[a-z]+$/.test(declaration.prop));
     expect(roles.length).toBeGreaterThan(0);
-    expect(roles.filter((value) => !/^var\(--fs-[0-9]+\)$/.test(value))).toEqual([]);
+    expect(roleEdges(stylesheet).length).toBe(roles.length);
+  });
+
+  it("keeps every raw step on a whole pixel, named after the size it produces", () => {
+    const steps = rawSteps(stylesheet);
+    expect(steps.length).toBeGreaterThan(0);
+    expect(steps.filter((step) => !Number.isInteger(step.px) || step.name !== step.px)).toEqual([]);
   });
 });
 
@@ -172,6 +205,19 @@ describe("the guard itself", () => {
     const css = ":root {\n  --text-ui: var(--fs-15);\n  /* --fs-15: 0.9375rem; */\n}";
     expect(unresolvedRoles(css)).toEqual(["fs-15"]);
     expect(danglingReferences(css)).toEqual(["fs-15"]);
+    expect(rawSteps(css)).toEqual([]);
+  });
+
+  it("ignores a step that exists only inside a string", () => {
+    const css = ':root { --text-ui: var(--fs-15); }\n.row::after { content: "--fs-15: 0.9375rem;"; }';
+    expect(unresolvedRoles(css)).toEqual(["fs-15"]);
+    expect(danglingReferences(css)).toEqual(["fs-15"]);
+    expect(rawSteps(css)).toEqual([]);
+  });
+
+  it("does not read a token reference quoted inside a value", () => {
+    const css = ':root { --fs-13: 0.8125rem; }\n.row::after { content: "var(--fs-99)"; }';
+    expect(danglingReferences(css)).toEqual([]);
   });
 
   it("does not read a commented-out declaration as a violation", () => {
@@ -181,6 +227,6 @@ describe("the guard itself", () => {
 
   it("does not mistake a longhand for the shorthand it starts with", () => {
     const css = "body { font-size: var(--text-ui); font-synthesis: none; }";
-    expect(declarations(css, "font")).toEqual([]);
+    expect(valuesOf(css, "font")).toEqual([]);
   });
 });

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The stylesheet once carried 35 distinct font sizes and 19 font weights as
+ * literals written at the point of use, most of them within a pixel of each
+ * other. These tests keep type flowing through the token layer so the scale
+ * cannot drift back apart one component at a time.
+ */
+
+const stylesheet = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
+
+function captures(pattern: RegExp, group = 1): string[] {
+  return [...stylesheet.matchAll(pattern)]
+    .map((match) => match[group])
+    .filter((value): value is string => value !== undefined)
+    .map((value) => value.trim());
+}
+
+function declarations(property: string): string[] {
+  return captures(new RegExp(`(?<![\\w-])${property}:\\s*([^;]+);`, "g"));
+}
+
+function definedTokens(prefix: string): Set<string> {
+  return new Set(captures(new RegExp(`--(${prefix}-[a-z0-9-]+):`, "g")));
+}
+
+function referencedTokens(property: string): string[] {
+  return declarations(property)
+    .map((value) => /^var\(--([a-z0-9-]+)\)$/.exec(value)?.[1])
+    .filter((name): name is string => name !== undefined);
+}
+
+describe("typography tokens", () => {
+  it("declares every font size through a --text-* role", () => {
+    const literals = declarations("font-size").filter((value) => !/^var\(--text-[a-z]+\)$/.test(value));
+    expect(literals).toEqual([]);
+  });
+
+  it("declares every font weight through a --fw-* token", () => {
+    const literals = declarations("font-weight").filter((value) => !/^var\(--fw-[a-z]+\)$/.test(value));
+    expect(literals).toEqual([]);
+  });
+
+  it("declares every letter spacing through a --track-* token", () => {
+    const literals = declarations("letter-spacing").filter((value) => !/^var\(--track-[a-z]+\)$/.test(value));
+    expect(literals).toEqual([]);
+  });
+
+  it("references only tokens that exist", () => {
+    const defined = new Set([
+      ...definedTokens("text"),
+      ...definedTokens("fw"),
+      ...definedTokens("track"),
+      ...definedTokens("font"),
+    ]);
+    const referenced = [
+      ...referencedTokens("font-size"),
+      ...referencedTokens("font-weight"),
+      ...referencedTokens("letter-spacing"),
+      ...referencedTokens("font-family"),
+    ];
+    expect(referenced.filter((name) => !defined.has(name))).toEqual([]);
+  });
+
+  it("keeps every raw step on a whole pixel", () => {
+    const steps = captures(/--fs-[0-9]+:\s*([0-9.]+)rem;/g).map((value) => Number(value) * 16);
+    expect(steps.length).toBeGreaterThan(0);
+    expect(steps.filter((px) => !Number.isInteger(px))).toEqual([]);
+  });
+
+  it("names each step after the pixel size it produces", () => {
+    const named = captures(/--fs-([0-9]+):\s*([0-9.]+)rem;/g);
+    const values = captures(/--fs-([0-9]+):\s*([0-9.]+)rem;/g, 2);
+    const mismatched = named.filter((name, index) => Number(name) !== Number(values[index]) * 16);
+    expect(mismatched).toEqual([]);
+  });
+
+  it("resolves each role to a raw step rather than a bare length", () => {
+    const roles = captures(/--text-[a-z]+:\s*([^;]+);/g);
+    expect(roles.length).toBeGreaterThan(0);
+    expect(roles.filter((value) => !/^var\(--fs-[0-9]+\)$/.test(value))).toEqual([]);
+  });
+});

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -40,18 +40,21 @@ const FAMILIES = ["fs", "text", "fw", "track", "font", "lh"] as const;
 const TOKEN_REFERENCE = new RegExp(`var\\(\\s*--((?:${FAMILIES.join("|")})-[a-z0-9-]+)`, "g");
 
 /**
- * Line heights that are box geometry rather than text rhythm: `1` centres a
- * single glyph in its own line box, and 38px matches the height of the badge
- * it labels. Any other literal belongs in a --lh-* token.
+ * The declarations that may stand outside the token layer, each pinned to the
+ * selectors that earn it. A value alone is not the exception -- `line-height: 1`
+ * centres a single glyph in its own line box, which is true of a chevron and
+ * not of a paragraph -- so an exception names the property, the value, and
+ * where it applies.
  */
-const LINE_HEIGHT_LITERALS = new Set(["1", "38px"]);
-
-/**
- * The `font` shorthand resets size, line height, weight, style and family at
- * once, so it can leave the token layer behind in a single declaration. Form
- * controls legitimately adopt the inherited font; nothing else may use it.
- */
-const FONT_SHORTHAND_LITERALS = new Set(["inherit"]);
+const EXCEPTIONS: { property: string; value: string; selectors: Set<string> }[] = [
+  {
+    property: "line-height",
+    value: "1",
+    selectors: new Set([".team-menu-chevron", ".account-menu-dots", ".dialog-close"]),
+  },
+  { property: "line-height", value: "38px", selectors: new Set([".center-card::before"]) },
+  { property: "font", value: "inherit", selectors: new Set(["button", "input", "select", "textarea"]) },
+];
 
 /** The selectors a declaration applies under, or none when it sits outside a rule. */
 function selectorsOf(declaration: Declaration): string[] {
@@ -179,8 +182,22 @@ function definedTypographyTokens(css: string): Set<string> {
   return new Set(FAMILIES.flatMap((prefix) => [...definedTokens(css, prefix)]));
 }
 
-function offTokenValues(css: string, property: string, allowed: RegExp, literals?: Set<string>): string[] {
-  return valuesOf(css, property).filter((value) => !allowed.test(value) && !(literals?.has(value) ?? false));
+/** An exception holds only where it was granted: same property, same value, and no other selector. */
+function excepted(declaration: Declared, property: string): boolean {
+  return EXCEPTIONS.some(
+    (exception) =>
+      exception.property === property &&
+      exception.value === declaration.value &&
+      declaration.selectors.length > 0 &&
+      declaration.selectors.every((selector) => exception.selectors.has(selector)),
+  );
+}
+
+function offTokenValues(css: string, property: string, allowed: RegExp): string[] {
+  return declarations(css)
+    .filter((declaration) => propertyName(declaration) === property)
+    .filter((declaration) => !allowed.test(declaration.value) && !excepted(declaration, property))
+    .map((declaration) => declaration.value);
 }
 
 /**
@@ -294,11 +311,11 @@ describe("typography tokens", () => {
   });
 
   it("keeps the font shorthand to the controls that inherit it", () => {
-    expect(offTokenValues(stylesheet, "font", /^$/, FONT_SHORTHAND_LITERALS)).toEqual([]);
+    expect(offTokenValues(stylesheet, "font", /^$/)).toEqual([]);
   });
 
   it("declares every line height through a --lh-* token or a named geometry exception", () => {
-    expect(offTokenValues(stylesheet, "line-height", /^var\(--lh-[a-z]+\)$/, LINE_HEIGHT_LITERALS)).toEqual([]);
+    expect(offTokenValues(stylesheet, "line-height", /^var\(--lh-[a-z]+\)$/)).toEqual([]);
   });
 
   it("declares every letter spacing through a --track-* token", () => {
@@ -348,12 +365,28 @@ describe("typography tokens", () => {
 describe("the guard itself", () => {
   it("rejects the font shorthand, which escapes four token families at once", () => {
     const css = "body { font: 13px/1 Arial, sans-serif; }";
-    expect(offTokenValues(css, "font", /^$/, FONT_SHORTHAND_LITERALS)).toEqual(["13px/1 Arial, sans-serif"]);
+    expect(offTokenValues(css, "font", /^$/)).toEqual(["13px/1 Arial, sans-serif"]);
   });
 
   it("allows the font shorthand only where controls inherit it", () => {
-    const css = "button { font: inherit; }";
-    expect(offTokenValues(css, "font", /^$/, FONT_SHORTHAND_LITERALS)).toEqual([]);
+    const granted = "button,\ninput,\nselect,\ntextarea { font: inherit; }";
+    expect(offTokenValues(granted, "font", /^$/)).toEqual([]);
+
+    const elsewhere = ".card { font: inherit; }";
+    expect(offTokenValues(elsewhere, "font", /^$/)).toEqual(["inherit"]);
+  });
+
+  it("allows a geometric line height only on the selectors that earn it", () => {
+    const granted = ".dialog-close { line-height: 1; }\n.center-card::before { line-height: 38px; }";
+    expect(offTokenValues(granted, "line-height", /^var\(--lh-[a-z]+\)$/)).toEqual([]);
+
+    const elsewhere = ".copy { line-height: 1; }\n.banner { line-height: 38px; }";
+    expect(offTokenValues(elsewhere, "line-height", /^var\(--lh-[a-z]+\)$/)).toEqual(["1", "38px"]);
+  });
+
+  it("does not extend an exception to a rule that adds a selector", () => {
+    const css = ".dialog-close, .copy { line-height: 1; }";
+    expect(offTokenValues(css, "line-height", /^var\(--lh-[a-z]+\)$/)).toEqual(["1"]);
   });
 
   it("rejects a literal font family", () => {
@@ -366,7 +399,7 @@ describe("the guard itself", () => {
     expect(offTokenValues(css, "font-size", /^var\(--text-[a-z]+\)$/)).toEqual(["0.83rem"]);
     expect(offTokenValues(css, "font-weight", /^var\(--fw-[a-z]+\)$/)).toEqual(["615"]);
     expect(offTokenValues(css, "letter-spacing", /^var\(--track-[a-z]+\)$/)).toEqual(["0.03em"]);
-    expect(offTokenValues(css, "line-height", /^var\(--lh-[a-z]+\)$/, LINE_HEIGHT_LITERALS)).toEqual(["1.42"]);
+    expect(offTokenValues(css, "line-height", /^var\(--lh-[a-z]+\)$/)).toEqual(["1.42"]);
   });
 
   it("rejects a reference to a token that was never declared", () => {
@@ -413,7 +446,7 @@ describe("the guard itself", () => {
     const css = "body { FONT-SIZE: 13px; FONT-FAMILY: Arial; }\n.row { Font: 12px Arial; }";
     expect(offTokenValues(css, "font-size", /^var\(--text-[a-z]+\)$/)).toEqual(["13px"]);
     expect(offTokenValues(css, "font-family", /^var\(--font-[a-z]+\)$/)).toEqual(["Arial"]);
-    expect(offTokenValues(css, "font", /^$/, FONT_SHORTHAND_LITERALS)).toEqual(["12px Arial"]);
+    expect(offTokenValues(css, "font", /^$/)).toEqual(["12px Arial"]);
   });
 
   it("reports a step that does not describe a step, rather than skipping it", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -86,7 +86,28 @@ function unconditional(declaration: Declaration): boolean {
  * scale has to be declared at an unconditional :root to count as declared.
  */
 function atRoot(declaration: Declaration): boolean {
-  return unconditional(declaration) && selectorsOf(declaration).includes(":root");
+  const selectors = selectorsOf(declaration);
+  return unconditional(declaration) && selectors.length > 0 && selectors.every((selector) => selector === ":root");
+}
+
+/**
+ * The browser decodes identifier escapes before it matches a property name;
+ * PostCSS hands them over as written. `f\6f nt-size` is `font-size` to the
+ * page, so it has to be `font-size` here too -- and `--text\2d ui` is the
+ * `--text-ui` role, not a name of its own.
+ */
+function decodeIdentifier(name: string): string {
+  return name.replace(/\\(?:([0-9a-fA-F]{1,6})[ \t\n\r\f]?|(.))/gs, (_match, hex?: string, literal?: string) => {
+    if (hex === undefined) return literal ?? "";
+    const code = Number.parseInt(hex, 16);
+    const unrepresentable = code === 0 || code > 0x10ffff || (code >= 0xd800 && code <= 0xdfff);
+    return unrepresentable ? "\uFFFD" : String.fromCodePoint(code);
+  });
+}
+
+/** The name a declaration carries once decoded: what the browser matches against. */
+function declaredName(declaration: Declaration): string {
+  return decodeIdentifier(declaration.prop);
 }
 
 /**
@@ -97,9 +118,15 @@ function withoutStrings(value: string): string {
   return value.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, "");
 }
 
+/** Strings go first, then escapes: decoding first could manufacture a quote. */
+function readableValue(value: string): string {
+  return decodeIdentifier(withoutStrings(value));
+}
+
 /** Ordinary property names are ASCII case-insensitive; custom property names are not. */
 function propertyName(declaration: Declaration): string {
-  return declaration.prop.startsWith("--") ? declaration.prop : declaration.prop.toLowerCase();
+  const name = declaredName(declaration);
+  return name.startsWith("--") ? name : name.toLowerCase();
 }
 
 /** Values of one property, matched by parsed name so `font` never collects `font-size`. */
@@ -113,7 +140,7 @@ function definedTokens(css: string, prefix: string): Set<string> {
   const pattern = new RegExp(`^--(${prefix}-[a-z0-9-]+)$`);
   const names = new Set<string>();
   for (const declaration of declarations(css).filter(atRoot)) {
-    const name = declaration.prop.match(pattern)?.[1];
+    const name = declaredName(declaration).match(pattern)?.[1];
     if (name !== undefined) names.add(name);
   }
   return names;
@@ -130,7 +157,7 @@ function offTokenValues(css: string, property: string, allowed: RegExp, literals
 function danglingReferences(css: string): string[] {
   const defined = definedTypographyTokens(css);
   const referenced = declarations(css).flatMap((declaration) =>
-    [...withoutStrings(declaration.value).matchAll(TOKEN_REFERENCE)]
+    [...readableValue(declaration.value).matchAll(TOKEN_REFERENCE)]
       .map((match) => match[1])
       .filter((name): name is string => name !== undefined),
   );
@@ -140,10 +167,10 @@ function danglingReferences(css: string): string[] {
 /** Steps named by a role, paired with the role, so a broken edge names both ends. */
 function roleEdges(css: string): { role: string; step: string }[] {
   return declarations(css)
-    .filter((declaration) => /^--text-[a-z]+$/.test(declaration.prop))
+    .filter((declaration) => /^--text-[a-z]+$/.test(declaredName(declaration)))
     .flatMap((declaration) => {
-      const step = withoutStrings(declaration.value).match(/^var\(\s*--(fs-[a-z0-9-]+)\s*\)$/)?.[1];
-      return step === undefined ? [] : [{ role: declaration.prop, step }];
+      const step = readableValue(declaration.value).match(/^var\(\s*--(fs-[a-z0-9-]+)\s*\)$/)?.[1];
+      return step === undefined ? [] : [{ role: declaredName(declaration), step }];
     });
 }
 
@@ -156,13 +183,15 @@ function unresolvedRoles(css: string): string[] {
 
 /** Every baseline step declaration, well-formed or not, so none is skipped silently. */
 function rootStepDeclarations(css: string): Declaration[] {
-  return declarations(css).filter((declaration) => atRoot(declaration) && declaration.prop.startsWith("--fs-"));
+  return declarations(css).filter(
+    (declaration) => atRoot(declaration) && declaredName(declaration).startsWith("--fs-"),
+  );
 }
 
 /** A step is a numeric name and a rem value; anything else does not describe one. */
 function stepOf(declaration: Declaration): { name: number; px: number } | undefined {
-  const name = declaration.prop.match(/^--fs-([0-9]+)$/)?.[1];
-  const rem = withoutStrings(declaration.value).match(/^([0-9.]+)rem$/)?.[1];
+  const name = declaredName(declaration).match(/^--fs-([0-9]+)$/)?.[1];
+  const rem = readableValue(declaration.value).match(/^([0-9.]+)rem$/)?.[1];
   if (name === undefined || rem === undefined) return undefined;
   return { name: Number(name), px: Number(rem) * 16 };
 }
@@ -177,7 +206,7 @@ function rawSteps(css: string): { name: number; px: number }[] {
 function malformedSteps(css: string): string[] {
   return rootStepDeclarations(css)
     .filter((declaration) => stepOf(declaration) === undefined)
-    .map((declaration) => `${declaration.prop}: ${declaration.value}`);
+    .map((declaration) => `${declaredName(declaration)}: ${declaration.value}`);
 }
 
 /**
@@ -190,7 +219,7 @@ function scopedDefinitions(css: string): { token: string; selectors: string[] }[
   return declarations(css)
     .filter((declaration) => !atRoot(declaration))
     .flatMap((declaration) => {
-      const token = declaration.prop.match(pattern)?.[1];
+      const token = declaredName(declaration).match(pattern)?.[1];
       if (token === undefined) return [];
       return [{ token, selectors: selectorsOf(declaration) }];
     });
@@ -354,6 +383,27 @@ describe("the guard itself", () => {
         !definition.selectors.every((selector) => READING_SURFACES.has(selector)),
     );
     expect(stray).toEqual([{ token: "text-ui", selectors: [".row"] }]);
+  });
+
+  it("decodes an escaped ordinary property name the way the browser does", () => {
+    const css = String.raw`body { f\6f nt-size: 23px; }`;
+    expect(offTokenValues(css, "font-size", /^var\(--text-[a-z]+\)$/)).toEqual(["23px"]);
+  });
+
+  it("decodes an escaped custom property name, which names an existing role", () => {
+    const css = String.raw`.row { --text\2d ui: var(--fs-30); }`;
+    expect(scopedDefinitions(css)).toEqual([{ token: "text-ui", selectors: [".row"] }]);
+  });
+
+  it("keeps a decoded custom property name case-sensitive, as CSS defines it", () => {
+    const css = String.raw`:root { --TEXT\2d UI: 13px; --text-ui: var(--fs-13); --fs-13: 0.8125rem; }`;
+    expect([...definedTokens(css, "text")]).toEqual(["text-ui"]);
+  });
+
+  it("refuses a baseline that shares its rule with another selector", () => {
+    const css =
+      ":root { --fs-13: 0.8125rem; --text-ui: var(--fs-14); --fs-14: 0.875rem; }\n:root, .row { --text-ui: var(--fs-13); }";
+    expect(scopedDefinitions(css)).toEqual([{ token: "text-ui", selectors: [":root", ".row"] }]);
   });
 
   it("does not read a commented-out declaration as a violation", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -93,20 +93,35 @@ function withoutStrings(value: string): string {
   return value.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, "");
 }
 
-/** Strings go first, then escapes: decoding first could manufacture a quote. */
-function readableValue(value: string): string {
+/**
+ * Strings are ignorable when looking for token references, and only then: to
+ * the browser a quoted run is still part of the value it validates. Strings go
+ * first and escapes second, since decoding first could manufacture a quote.
+ */
+function referenceProjection(value: string): string {
   return decodeIdentifier(withoutStrings(value));
 }
 
 /**
- * What the browser sees: the decoded name, the value with strings removed and
- * escapes resolved, where it applies, and whether it applies unconditionally.
+ * What the browser sees: the decoded name, the decoded value exactly as the
+ * browser validates it, where it applies, and whether it applies
+ * unconditionally.
+ *
+ * `references` is that value with quoted runs dropped, and is for finding
+ * var() references and nothing else. Validating against it would accept
+ * `font-size: "poison" var(--text-ui)`, which the browser throws out.
  *
  * Every check below reads these records. PostCSS nodes stop here on purpose --
  * twice, a check reached past the decoder to the name as written and let an
  * escaped declaration through, so the spelling is no longer reachable.
  */
-type Declared = { name: string; value: string; selectors: string[]; unconditional: boolean };
+type Declared = {
+  name: string;
+  value: string;
+  references: string;
+  selectors: string[];
+  unconditional: boolean;
+};
 
 /** Comments parse as their own nodes, so only declarations the browser applies reach any check. */
 function declarations(css: string): Declared[] {
@@ -114,7 +129,8 @@ function declarations(css: string): Declared[] {
   postcss.parse(css).walkDecls((declaration) => {
     found.push({
       name: decodeIdentifier(declaration.prop),
-      value: readableValue(declaration.value).trim(),
+      value: decodeIdentifier(declaration.value).trim(),
+      references: referenceProjection(declaration.value),
       selectors: selectorsOf(declaration),
       unconditional: unconditional(declaration),
     });
@@ -165,7 +181,7 @@ function offTokenValues(css: string, property: string, allowed: RegExp, literals
 function danglingReferences(css: string): string[] {
   const defined = definedTypographyTokens(css);
   const referenced = declarations(css).flatMap((declaration) =>
-    [...declaration.value.matchAll(TOKEN_REFERENCE)]
+    [...declaration.references.matchAll(TOKEN_REFERENCE)]
       .map((match) => match[1])
       .filter((name): name is string => name !== undefined),
   );
@@ -428,6 +444,17 @@ describe("the guard itself", () => {
   it("reports an escaped root role that overrides a good one", () => {
     const css = ":root { --fs-13: 0.8125rem; --text-ui: var(--fs-13); }\n:root { --text\\2d ui: 13.5px; }";
     expect(malformedRoles(css)).toEqual(["--text-ui: 13.5px"]);
+  });
+
+  it("rejects a value the browser throws out, even where it names a token", () => {
+    const size = 'body { font-size: "poison" var(--text-ui); }';
+    expect(offTokenValues(size, "font-size", /^var\(--text-[a-z]+\)$/)).toEqual(['"poison" var(--text-ui)']);
+
+    const role = ':root { --text-ui: "poison" var(--fs-13); }';
+    expect(malformedRoles(role)).toEqual(['--text-ui: "poison" var(--fs-13)']);
+
+    const step = ':root { --fs-13: "poison" 0.8125rem; }';
+    expect(malformedSteps(step)).toEqual(['--fs-13: "poison" 0.8125rem']);
   });
 
   it("does not read a commented-out declaration as a violation", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -7,6 +7,9 @@ import { describe, expect, it } from "vitest";
  * literals written at the point of use, most of them within a pixel of each
  * other. These tests keep type flowing through the token layer so the scale
  * cannot drift back apart one component at a time.
+ *
+ * The checks are pure functions over CSS text, so the suite below can also
+ * prove that each one rejects the declaration it exists to catch.
  */
 
 /** The suite runs from apps/web and, under the coverage config, from the repo root. */
@@ -33,76 +36,131 @@ const TOKEN_REFERENCE = new RegExp(`var\\(--((?:${FAMILIES.join("|")})-[a-z0-9-]
  */
 const LINE_HEIGHT_LITERALS = new Set(["1", "38px"]);
 
-function captures(pattern: RegExp, group = 1): string[] {
-  return [...stylesheet.matchAll(pattern)]
+/**
+ * The `font` shorthand resets size, line height, weight, style and family at
+ * once, so it can leave the token layer behind in a single declaration. Form
+ * controls legitimately adopt the inherited font; nothing else may use it.
+ */
+const FONT_SHORTHAND_LITERALS = new Set(["inherit"]);
+
+function captures(css: string, pattern: RegExp, group = 1): string[] {
+  return [...css.matchAll(pattern)]
     .map((match) => match[group])
     .filter((value): value is string => value !== undefined)
     .map((value) => value.trim());
 }
 
-function declarations(property: string): string[] {
-  return captures(new RegExp(`(?<![\\w-])${property}:\\s*([^;]+);`, "g"));
+/** Values of `property`, matched as a longhand so `font:` never picks up `font-size:`. */
+function declarations(css: string, property: string): string[] {
+  return captures(css, new RegExp(`(?<![\\w-])${property}:\\s*([^;]+);`, "g"));
 }
 
-function definedTokens(prefix: string): Set<string> {
-  return new Set(captures(new RegExp(`--(${prefix}-[a-z0-9-]+):`, "g")));
+function definedTokens(css: string, prefix: string): Set<string> {
+  return new Set(captures(css, new RegExp(`--(${prefix}-[a-z0-9-]+):`, "g")));
 }
 
-function definedTypographyTokens(): Set<string> {
-  return new Set(FAMILIES.flatMap((prefix) => [...definedTokens(prefix)]));
+function definedTypographyTokens(css: string): Set<string> {
+  return new Set(FAMILIES.flatMap((prefix) => [...definedTokens(css, prefix)]));
+}
+
+function offTokenValues(css: string, property: string, allowed: RegExp, literals?: Set<string>): string[] {
+  return declarations(css, property).filter((value) => !allowed.test(value) && !(literals?.has(value) ?? false));
+}
+
+function danglingReferences(css: string): string[] {
+  const defined = definedTypographyTokens(css);
+  return [...new Set(captures(css, TOKEN_REFERENCE).filter((name) => !defined.has(name)))];
+}
+
+function unresolvedRoles(css: string): string[] {
+  const steps = definedTokens(css, "fs");
+  return captures(css, /--text-[a-z]+:\s*var\(--(fs-[a-z0-9-]+)\);/g).filter((step) => !steps.has(step));
 }
 
 describe("typography tokens", () => {
   it("declares every font size through a --text-* role", () => {
-    const literals = declarations("font-size").filter((value) => !/^var\(--text-[a-z]+\)$/.test(value));
-    expect(literals).toEqual([]);
+    expect(offTokenValues(stylesheet, "font-size", /^var\(--text-[a-z]+\)$/)).toEqual([]);
   });
 
   it("declares every font weight through a --fw-* token", () => {
-    const literals = declarations("font-weight").filter((value) => !/^var\(--fw-[a-z]+\)$/.test(value));
-    expect(literals).toEqual([]);
+    expect(offTokenValues(stylesheet, "font-weight", /^var\(--fw-[a-z]+\)$/)).toEqual([]);
+  });
+
+  it("declares every font family through a --font-* token", () => {
+    expect(offTokenValues(stylesheet, "font-family", /^var\(--font-[a-z]+\)$/)).toEqual([]);
+  });
+
+  it("keeps the font shorthand to the controls that inherit it", () => {
+    expect(offTokenValues(stylesheet, "font", /^$/, FONT_SHORTHAND_LITERALS)).toEqual([]);
   });
 
   it("declares every line height through a --lh-* token or a named geometry exception", () => {
-    const literals = declarations("line-height").filter(
-      (value) => !/^var\(--lh-[a-z]+\)$/.test(value) && !LINE_HEIGHT_LITERALS.has(value),
-    );
-    expect(literals).toEqual([]);
+    expect(offTokenValues(stylesheet, "line-height", /^var\(--lh-[a-z]+\)$/, LINE_HEIGHT_LITERALS)).toEqual([]);
   });
 
   it("declares every letter spacing through a --track-* token", () => {
-    const literals = declarations("letter-spacing").filter((value) => !/^var\(--track-[a-z]+\)$/.test(value));
-    expect(literals).toEqual([]);
+    expect(offTokenValues(stylesheet, "letter-spacing", /^var\(--track-[a-z]+\)$/)).toEqual([]);
   });
 
   it("references only tokens that exist, including one role pointing at a step", () => {
-    const defined = definedTypographyTokens();
-    const dangling = captures(TOKEN_REFERENCE).filter((name) => !defined.has(name));
-    expect([...new Set(dangling)]).toEqual([]);
+    expect(danglingReferences(stylesheet)).toEqual([]);
+  });
+
+  it("resolves each role to a step that is actually declared", () => {
+    expect(unresolvedRoles(stylesheet)).toEqual([]);
   });
 
   it("keeps every raw step on a whole pixel", () => {
-    const steps = captures(/--fs-[0-9]+:\s*([0-9.]+)rem;/g).map((value) => Number(value) * 16);
+    const steps = captures(stylesheet, /--fs-[0-9]+:\s*([0-9.]+)rem;/g).map((value) => Number(value) * 16);
     expect(steps.length).toBeGreaterThan(0);
     expect(steps.filter((px) => !Number.isInteger(px))).toEqual([]);
   });
 
   it("names each step after the pixel size it produces", () => {
-    const named = captures(/--fs-([0-9]+):\s*([0-9.]+)rem;/g);
-    const values = captures(/--fs-([0-9]+):\s*([0-9.]+)rem;/g, 2);
-    const mismatched = named.filter((name, index) => Number(name) !== Number(values[index]) * 16);
-    expect(mismatched).toEqual([]);
-  });
-
-  it("resolves each role to a step that is actually declared", () => {
-    const steps = definedTokens("fs");
-    const unresolved = captures(/--text-[a-z]+:\s*var\(--(fs-[a-z0-9-]+)\);/g).filter((step) => !steps.has(step));
-    expect(unresolved).toEqual([]);
+    const named = captures(stylesheet, /--fs-([0-9]+):\s*([0-9.]+)rem;/g);
+    const values = captures(stylesheet, /--fs-([0-9]+):\s*([0-9.]+)rem;/g, 2);
+    expect(named.filter((name, index) => Number(name) !== Number(values[index]) * 16)).toEqual([]);
   });
 
   it("resolves each role to a raw step rather than a bare length", () => {
-    const roles = captures(/--text-[a-z]+:\s*([^;]+);/g);
+    const roles = captures(stylesheet, /--text-[a-z]+:\s*([^;]+);/g);
     expect(roles.length).toBeGreaterThan(0);
     expect(roles.filter((value) => !/^var\(--fs-[0-9]+\)$/.test(value))).toEqual([]);
+  });
+});
+
+describe("the guard itself", () => {
+  it("rejects the font shorthand, which escapes four token families at once", () => {
+    const css = "body { font: 13px/1 Arial, sans-serif; }";
+    expect(offTokenValues(css, "font", /^$/, FONT_SHORTHAND_LITERALS)).toEqual(["13px/1 Arial, sans-serif"]);
+  });
+
+  it("allows the font shorthand only where controls inherit it", () => {
+    const css = "button { font: inherit; }";
+    expect(offTokenValues(css, "font", /^$/, FONT_SHORTHAND_LITERALS)).toEqual([]);
+  });
+
+  it("rejects a literal font family", () => {
+    const css = ".brand { font-family: Arial, sans-serif; }";
+    expect(offTokenValues(css, "font-family", /^var\(--font-[a-z]+\)$/)).toEqual(["Arial, sans-serif"]);
+  });
+
+  it("rejects a literal font size, weight, tracking and line height", () => {
+    const css = ".row { font-size: 0.83rem; font-weight: 615; letter-spacing: 0.03em; line-height: 1.42; }";
+    expect(offTokenValues(css, "font-size", /^var\(--text-[a-z]+\)$/)).toEqual(["0.83rem"]);
+    expect(offTokenValues(css, "font-weight", /^var\(--fw-[a-z]+\)$/)).toEqual(["615"]);
+    expect(offTokenValues(css, "letter-spacing", /^var\(--track-[a-z]+\)$/)).toEqual(["0.03em"]);
+    expect(offTokenValues(css, "line-height", /^var\(--lh-[a-z]+\)$/, LINE_HEIGHT_LITERALS)).toEqual(["1.42"]);
+  });
+
+  it("rejects a reference to a token that was never declared", () => {
+    const css = ":root { --text-ui: var(--fs-15); }\n.row { line-height: var(--lh-prsoe); }";
+    expect(danglingReferences(css)).toEqual(["fs-15", "lh-prsoe"]);
+    expect(unresolvedRoles(css)).toEqual(["fs-15"]);
+  });
+
+  it("does not mistake a longhand for the shorthand it starts with", () => {
+    const css = "body { font-size: var(--text-ui); font-synthesis: none; }";
+    expect(declarations(css, "font")).toEqual([]);
   });
 });

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -9,7 +9,19 @@ import { describe, expect, it } from "vitest";
  * cannot drift back apart one component at a time.
  */
 
-const stylesheet = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8");
+/** The suite runs from apps/web and, under the coverage config, from the repo root. */
+function locateStylesheet(): string {
+  for (const candidate of ["src/styles.css", "apps/web/src/styles.css"]) {
+    const path = resolve(process.cwd(), candidate);
+    if (existsSync(path)) return path;
+  }
+  throw new Error(`The Web stylesheet was not found from ${process.cwd()}`);
+}
+
+const stylesheet = readFileSync(locateStylesheet(), "utf8");
+
+/** Every typography token reference, wherever it appears — including one role pointing at another. */
+const TOKEN_REFERENCE = /var\(--((?:fs|text|fw|track|font)-[a-z0-9-]+)\)/g;
 
 function captures(pattern: RegExp, group = 1): string[] {
   return [...stylesheet.matchAll(pattern)]
@@ -26,10 +38,8 @@ function definedTokens(prefix: string): Set<string> {
   return new Set(captures(new RegExp(`--(${prefix}-[a-z0-9-]+):`, "g")));
 }
 
-function referencedTokens(property: string): string[] {
-  return declarations(property)
-    .map((value) => /^var\(--([a-z0-9-]+)\)$/.exec(value)?.[1])
-    .filter((name): name is string => name !== undefined);
+function definedTypographyTokens(): Set<string> {
+  return new Set(["fs", "text", "fw", "track", "font"].flatMap((prefix) => [...definedTokens(prefix)]));
 }
 
 describe("typography tokens", () => {
@@ -48,20 +58,10 @@ describe("typography tokens", () => {
     expect(literals).toEqual([]);
   });
 
-  it("references only tokens that exist", () => {
-    const defined = new Set([
-      ...definedTokens("text"),
-      ...definedTokens("fw"),
-      ...definedTokens("track"),
-      ...definedTokens("font"),
-    ]);
-    const referenced = [
-      ...referencedTokens("font-size"),
-      ...referencedTokens("font-weight"),
-      ...referencedTokens("letter-spacing"),
-      ...referencedTokens("font-family"),
-    ];
-    expect(referenced.filter((name) => !defined.has(name))).toEqual([]);
+  it("references only tokens that exist, including one role pointing at a step", () => {
+    const defined = definedTypographyTokens();
+    const dangling = captures(TOKEN_REFERENCE).filter((name) => !defined.has(name));
+    expect([...new Set(dangling)]).toEqual([]);
   });
 
   it("keeps every raw step on a whole pixel", () => {
@@ -75,6 +75,12 @@ describe("typography tokens", () => {
     const values = captures(/--fs-([0-9]+):\s*([0-9.]+)rem;/g, 2);
     const mismatched = named.filter((name, index) => Number(name) !== Number(values[index]) * 16);
     expect(mismatched).toEqual([]);
+  });
+
+  it("resolves each role to a step that is actually declared", () => {
+    const steps = definedTokens("fs");
+    const unresolved = captures(/--text-[a-z]+:\s*var\(--(fs-[a-z0-9-]+)\);/g).filter((step) => !steps.has(step));
+    expect(unresolved).toEqual([]);
   });
 
   it("resolves each role to a raw step rather than a bare length", () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -53,15 +53,6 @@ const LINE_HEIGHT_LITERALS = new Set(["1", "38px"]);
  */
 const FONT_SHORTHAND_LITERALS = new Set(["inherit"]);
 
-/** Comments parse as their own nodes, so only declarations the browser applies reach any check. */
-function declarations(css: string): Declaration[] {
-  const found: Declaration[] = [];
-  postcss.parse(css).walkDecls((declaration) => {
-    found.push(declaration);
-  });
-  return found;
-}
-
 /** The selectors a declaration applies under, or none when it sits outside a rule. */
 function selectorsOf(declaration: Declaration): string[] {
   const parent = declaration.parent;
@@ -80,17 +71,6 @@ function unconditional(declaration: Declaration): boolean {
 }
 
 /**
- * A custom property exists only where its selector matches and its conditions
- * hold. A step parked under another rule -- or under a media query that a normal
- * viewport never satisfies -- is invisible to a :root role, so the baseline
- * scale has to be declared at an unconditional :root to count as declared.
- */
-function atRoot(declaration: Declaration): boolean {
-  const selectors = selectorsOf(declaration);
-  return unconditional(declaration) && selectors.length > 0 && selectors.every((selector) => selector === ":root");
-}
-
-/**
  * The browser decodes identifier escapes before it matches a property name;
  * PostCSS hands them over as written. `f\6f nt-size` is `font-size` to the
  * page, so it has to be `font-size` here too -- and `--text\2d ui` is the
@@ -103,11 +83,6 @@ function decodeIdentifier(name: string): string {
     const unrepresentable = code === 0 || code > 0x10ffff || (code >= 0xd800 && code <= 0xdfff);
     return unrepresentable ? "\uFFFD" : String.fromCodePoint(code);
   });
-}
-
-/** The name a declaration carries once decoded: what the browser matches against. */
-function declaredName(declaration: Declaration): string {
-  return decodeIdentifier(declaration.prop);
 }
 
 /**
@@ -123,9 +98,42 @@ function readableValue(value: string): string {
   return decodeIdentifier(withoutStrings(value));
 }
 
+/**
+ * What the browser sees: the decoded name, the value with strings removed and
+ * escapes resolved, where it applies, and whether it applies unconditionally.
+ *
+ * Every check below reads these records. PostCSS nodes stop here on purpose --
+ * twice, a check reached past the decoder to the name as written and let an
+ * escaped declaration through, so the spelling is no longer reachable.
+ */
+type Declared = { name: string; value: string; selectors: string[]; unconditional: boolean };
+
+/** Comments parse as their own nodes, so only declarations the browser applies reach any check. */
+function declarations(css: string): Declared[] {
+  const found: Declared[] = [];
+  postcss.parse(css).walkDecls((declaration) => {
+    found.push({
+      name: decodeIdentifier(declaration.prop),
+      value: readableValue(declaration.value).trim(),
+      selectors: selectorsOf(declaration),
+      unconditional: unconditional(declaration),
+    });
+  });
+  return found;
+}
+
+/** A baseline definition applies everywhere: unconditional, and :root alone. */
+function atRoot(declaration: Declared): boolean {
+  return (
+    declaration.unconditional &&
+    declaration.selectors.length > 0 &&
+    declaration.selectors.every((selector) => selector === ":root")
+  );
+}
+
 /** Ordinary property names are ASCII case-insensitive; custom property names are not. */
-function propertyName(declaration: Declaration): string {
-  const name = declaredName(declaration);
+function propertyName(declaration: Declared): string {
+  const name = declaration.name;
   return name.startsWith("--") ? name : name.toLowerCase();
 }
 
@@ -133,14 +141,14 @@ function propertyName(declaration: Declaration): string {
 function valuesOf(css: string, property: string): string[] {
   return declarations(css)
     .filter((declaration) => propertyName(declaration) === property)
-    .map((declaration) => declaration.value.trim());
+    .map((declaration) => declaration.value);
 }
 
 function definedTokens(css: string, prefix: string): Set<string> {
   const pattern = new RegExp(`^--(${prefix}-[a-z0-9-]+)$`);
   const names = new Set<string>();
   for (const declaration of declarations(css).filter(atRoot)) {
-    const name = declaredName(declaration).match(pattern)?.[1];
+    const name = declaration.name.match(pattern)?.[1];
     if (name !== undefined) names.add(name);
   }
   return names;
@@ -157,21 +165,35 @@ function offTokenValues(css: string, property: string, allowed: RegExp, literals
 function danglingReferences(css: string): string[] {
   const defined = definedTypographyTokens(css);
   const referenced = declarations(css).flatMap((declaration) =>
-    [...readableValue(declaration.value).matchAll(TOKEN_REFERENCE)]
+    [...declaration.value.matchAll(TOKEN_REFERENCE)]
       .map((match) => match[1])
       .filter((name): name is string => name !== undefined),
   );
   return [...new Set(referenced.filter((name) => !defined.has(name)))];
 }
 
+/** Every role declaration, so a role cannot be counted by one check and skipped by another. */
+function roleDeclarations(css: string): Declared[] {
+  return declarations(css).filter((declaration) => /^--text-[a-z]+$/.test(declaration.name));
+}
+
+/** A role names one raw step; anything else is not a role binding. */
+function stepNamedBy(declaration: Declared): string | undefined {
+  return declaration.value.match(/^var\(\s*--(fs-[a-z0-9-]+)\s*\)$/)?.[1];
+}
+
 /** Steps named by a role, paired with the role, so a broken edge names both ends. */
 function roleEdges(css: string): { role: string; step: string }[] {
-  return declarations(css)
-    .filter((declaration) => /^--text-[a-z]+$/.test(declaredName(declaration)))
-    .flatMap((declaration) => {
-      const step = readableValue(declaration.value).match(/^var\(\s*--(fs-[a-z0-9-]+)\s*\)$/)?.[1];
-      return step === undefined ? [] : [{ role: declaredName(declaration), step }];
-    });
+  return roleDeclarations(css).flatMap((declaration) => {
+    const step = stepNamedBy(declaration);
+    return step === undefined ? [] : [{ role: declaration.name, step }];
+  });
+}
+
+function malformedRoles(css: string): string[] {
+  return roleDeclarations(css)
+    .filter((declaration) => stepNamedBy(declaration) === undefined)
+    .map((declaration) => `${declaration.name}: ${declaration.value}`);
 }
 
 function unresolvedRoles(css: string): string[] {
@@ -182,16 +204,14 @@ function unresolvedRoles(css: string): string[] {
 }
 
 /** Every baseline step declaration, well-formed or not, so none is skipped silently. */
-function rootStepDeclarations(css: string): Declaration[] {
-  return declarations(css).filter(
-    (declaration) => atRoot(declaration) && declaredName(declaration).startsWith("--fs-"),
-  );
+function rootStepDeclarations(css: string): Declared[] {
+  return declarations(css).filter((declaration) => atRoot(declaration) && declaration.name.startsWith("--fs-"));
 }
 
 /** A step is a numeric name and a rem value; anything else does not describe one. */
-function stepOf(declaration: Declaration): { name: number; px: number } | undefined {
-  const name = declaredName(declaration).match(/^--fs-([0-9]+)$/)?.[1];
-  const rem = readableValue(declaration.value).match(/^([0-9.]+)rem$/)?.[1];
+function stepOf(declaration: Declared): { name: number; px: number } | undefined {
+  const name = declaration.name.match(/^--fs-([0-9]+)$/)?.[1];
+  const rem = declaration.value.match(/^([0-9.]+)rem$/)?.[1];
   if (name === undefined || rem === undefined) return undefined;
   return { name: Number(name), px: Number(rem) * 16 };
 }
@@ -206,7 +226,7 @@ function rawSteps(css: string): { name: number; px: number }[] {
 function malformedSteps(css: string): string[] {
   return rootStepDeclarations(css)
     .filter((declaration) => stepOf(declaration) === undefined)
-    .map((declaration) => `${declaredName(declaration)}: ${declaration.value}`);
+    .map((declaration) => `${declaration.name}: ${declaration.value}`);
 }
 
 /**
@@ -219,9 +239,9 @@ function scopedDefinitions(css: string): { token: string; selectors: string[] }[
   return declarations(css)
     .filter((declaration) => !atRoot(declaration))
     .flatMap((declaration) => {
-      const token = declaredName(declaration).match(pattern)?.[1];
+      const token = declaration.name.match(pattern)?.[1];
       if (token === undefined) return [];
-      return [{ token, selectors: selectorsOf(declaration) }];
+      return [{ token, selectors: declaration.selectors }];
     });
 }
 
@@ -259,9 +279,8 @@ describe("typography tokens", () => {
   });
 
   it("resolves every role to a raw step rather than a bare length", () => {
-    const roles = declarations(stylesheet).filter((declaration) => /^--text-[a-z]+$/.test(declaration.prop));
-    expect(roles.length).toBeGreaterThan(0);
-    expect(roleEdges(stylesheet).length).toBe(roles.length);
+    expect(malformedRoles(stylesheet)).toEqual([]);
+    expect(roleEdges(stylesheet).length).toBeGreaterThan(0);
   });
 
   it("retunes roles only on the reading surfaces, and never a raw step", () => {
@@ -404,6 +423,11 @@ describe("the guard itself", () => {
     const css =
       ":root { --fs-13: 0.8125rem; --text-ui: var(--fs-14); --fs-14: 0.875rem; }\n:root, .row { --text-ui: var(--fs-13); }";
     expect(scopedDefinitions(css)).toEqual([{ token: "text-ui", selectors: [":root", ".row"] }]);
+  });
+
+  it("reports an escaped root role that overrides a good one", () => {
+    const css = ":root { --fs-13: 0.8125rem; --text-ui: var(--fs-13); }\n:root { --text\\2d ui: 13.5px; }";
+    expect(malformedRoles(css)).toEqual(["--text-ui: 13.5px"]);
   });
 
   it("does not read a commented-out declaration as a violation", () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4,9 +4,17 @@
   font-family: var(--font-sans);
   font-synthesis: none;
 
-  --font-sans: "Geist Variable", Geist, ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "Geist Mono Variable", "SFMono-Regular", Consolas, monospace;
-  --font-display: "Bricolage Grotesque Variable", "Geist Variable", sans-serif;
+  /* Team, agent and member names are frequently Chinese and none of the
+     Latin faces carry CJK glyphs. Name the CJK fallback explicitly, ahead
+     of the generics, so those runs land on a chosen face instead of
+     whatever the platform picks. */
+  --font-sans:
+    "Geist Variable", Geist, "PingFang SC", "HarmonyOS Sans SC", "Microsoft YaHei", "Noto Sans SC", ui-sans-serif,
+    system-ui, sans-serif;
+  --font-mono: "Geist Mono Variable", "SFMono-Regular", Consolas, "PingFang SC", "Microsoft YaHei", monospace;
+  --font-display:
+    "Bricolage Grotesque Variable", "Geist Variable", "PingFang SC", "HarmonyOS Sans SC", "Microsoft YaHei",
+    "Noto Sans SC", sans-serif;
 
   /* Raw steps. Whole pixels only: fractional rem values round differently
      across engines. Nothing outside this block may introduce a new step. */
@@ -44,6 +52,8 @@
   --lh-ui: 1.45;
   --lh-prose: 1.6;
 
+  /* Kept mild because headings carry user-supplied names: tight Latin
+     tracking crowds CJK, which has no side bearings to give back. */
   --track-tight: -0.02em;
   --track-label: 0.06em;
 
@@ -282,6 +292,21 @@ p {
 code,
 pre {
   font-family: var(--font-mono);
+}
+
+/* Counts, timestamps and identifiers sit in columns or update in place;
+   proportional digits make them jitter. */
+.agent-row,
+.agent-summary-strip,
+.definition-list,
+.row,
+.settings-member-row,
+.settings-computer-row,
+.timestamp,
+.mono,
+code,
+pre {
+  font-variant-numeric: tabular-nums;
 }
 
 .visually-hidden {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,8 +1,49 @@
 :root {
   color: #16211b;
   background: #f8f7f0;
-  font-family: "Geist Variable", Geist, ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-sans);
   font-synthesis: none;
+
+  --font-sans: "Geist Variable", Geist, ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Geist Mono Variable", "SFMono-Regular", Consolas, monospace;
+  --font-display: "Bricolage Grotesque Variable", "Geist Variable", sans-serif;
+
+  /* Raw steps. Whole pixels only: fractional rem values round differently
+     across engines. Nothing outside this block may introduce a new step. */
+  --fs-12: 0.75rem;
+  --fs-13: 0.8125rem;
+  --fs-14: 0.875rem;
+  --fs-16: 1rem;
+  --fs-20: 1.25rem;
+  --fs-24: 1.5rem;
+  --fs-30: 1.875rem;
+  --fs-32: 2rem;
+  --fs-44: 2.75rem;
+
+  /* Roles. Components reference these, never the steps above.
+     micro and meta share a step on dense surfaces and separate on the
+     reading surfaces further down; case and tracking carry them apart. */
+  --text-micro: var(--fs-12);
+  --text-meta: var(--fs-12);
+  --text-ui: var(--fs-13);
+  --text-body: var(--fs-14);
+  --text-subsection: var(--fs-16);
+  --text-section: var(--fs-20);
+  --text-title: var(--fs-24);
+  --text-display: var(--fs-30);
+
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
+  --lh-tight: 1.2;
+  --lh-ui: 1.45;
+  --lh-prose: 1.6;
+
+  --track-tight: -0.02em;
+  --track-label: 0.06em;
+
   --background: #f8f7f0;
   --surface: #fdfcf7;
   --sidebar: #f1f1e8;
@@ -43,6 +84,8 @@ body {
   min-height: 100dvh;
   margin: 0;
   background: var(--background);
+  font-size: var(--text-ui);
+  line-height: var(--lh-ui);
 }
 
 /* The grid belongs to isolated entry and recovery pages, never the product workspace. */
@@ -87,7 +130,8 @@ button,
   background: var(--brand);
   color: #fff;
   cursor: pointer;
-  font-weight: 650;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
   padding: 0.58rem 0.95rem;
   text-decoration: none;
   transition:
@@ -189,33 +233,33 @@ p {
 h1,
 .brand,
 .mobile-brand {
-  font-family: "Bricolage Grotesque Variable", "Geist Variable", sans-serif;
+  font-family: var(--font-display);
 }
 
 h1 {
   margin-bottom: 0.45rem;
-  font-size: clamp(2rem, 3vw, 2.25rem);
-  font-weight: 650;
-  letter-spacing: -0.045em;
-  line-height: 1.08;
+  font-size: var(--text-title);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--track-tight);
+  line-height: var(--lh-tight);
 }
 
 h2 {
   color: var(--foreground);
-  font-size: 1rem;
-  font-weight: 650;
-  letter-spacing: -0.015em;
+  font-size: var(--text-subsection);
+  font-weight: var(--fw-semibold);
 }
 
 p {
   color: var(--secondary-foreground);
-  line-height: 1.55;
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
 }
 
 .mono,
 code,
 pre {
-  font-family: "Geist Mono Variable", "SFMono-Regular", Consolas, monospace;
+  font-family: var(--font-mono);
 }
 
 .visually-hidden {
@@ -238,8 +282,8 @@ pre {
   border: 1px solid var(--strong-border);
   border-radius: 999px;
   color: var(--muted);
-  font-size: 0.68rem;
-  font-weight: 620;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
 }
 
 .status-chip.suspended {
@@ -287,9 +331,9 @@ button.danger:hover {
   width: fit-content;
   margin: 0 10px 3px;
   color: var(--foreground);
-  font-size: 1.5rem;
-  font-weight: 720;
-  letter-spacing: -0.04em;
+  font-size: var(--text-title);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--track-tight);
   text-decoration: none;
 }
 
@@ -310,8 +354,8 @@ button.danger:hover {
   border-radius: 8px;
   background: #e6e8dc;
   color: var(--secondary-foreground);
-  font-size: 0.84rem;
-  font-weight: 560;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-medium);
   padding: 5px 10px;
   text-align: left;
   transition:
@@ -335,7 +379,7 @@ button.danger:hover {
 
 .team-menu-chevron {
   color: var(--muted);
-  font-size: 0.76rem;
+  font-size: var(--text-meta);
   line-height: 1;
   text-align: right;
 }
@@ -349,9 +393,9 @@ button.danger:hover {
   border: 1px solid var(--strong-border);
   background: var(--brand-light);
   color: var(--brand-ink);
-  font-size: 0.7rem;
-  font-weight: 720;
-  letter-spacing: -0.02em;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--track-tight);
 }
 
 .team-avatar {
@@ -394,10 +438,10 @@ button.danger:hover {
 .menu-label {
   padding: 7px 8px 6px;
   color: var(--muted);
-  font-family: "Geist Mono Variable", monospace;
-  font-size: 0.66rem;
-  font-weight: 650;
-  letter-spacing: 0.08em;
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--track-label);
   text-transform: uppercase;
 }
 
@@ -459,26 +503,26 @@ button.danger:hover {
 }
 
 .team-option-copy strong {
-  font-size: 0.82rem;
-  font-weight: 610;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .team-option-copy small {
   margin-top: 2px;
   color: var(--muted);
-  font-size: 0.69rem;
+  font-size: var(--text-meta);
 }
 
 .team-option-check {
   color: var(--brand-ink);
-  font-size: 0.86rem;
-  font-weight: 760;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-bold);
   text-align: right;
 }
 
 .team-menu-empty {
   color: var(--muted);
-  font-size: 0.78rem;
+  font-size: var(--text-meta);
   padding: 14px 8px;
 }
 
@@ -501,8 +545,8 @@ button.danger:hover {
   border-radius: 7px;
   background: transparent;
   color: var(--secondary-foreground);
-  font-size: 0.8rem;
-  font-weight: 560;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-medium);
   padding: 0 8px;
   text-decoration: none;
 }
@@ -531,8 +575,8 @@ button.danger:hover {
   align-items: center;
   border-radius: 9px;
   color: var(--secondary-foreground);
-  font-size: 0.9rem;
-  font-weight: 560;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-medium);
   gap: 10px;
   padding: 0 11px;
   text-decoration: none;
@@ -590,14 +634,14 @@ button.danger:hover {
 }
 
 .account-row strong {
-  font-size: 0.84rem;
-  font-weight: 600;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .account-row small {
   margin-top: 2px;
   color: var(--muted);
-  font-size: 0.72rem;
+  font-size: var(--text-meta);
 }
 
 .account-menu-dots {
@@ -626,8 +670,8 @@ button.danger:hover {
   border-radius: 7px;
   background: transparent;
   color: var(--secondary-foreground);
-  font-size: 0.8rem;
-  font-weight: 560;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-medium);
   padding: 0 9px;
   text-decoration: none;
 }
@@ -641,8 +685,8 @@ button.danger:hover {
 
 .account-menu-error {
   color: var(--error);
-  font-size: 0.7rem;
-  line-height: 1.4;
+  font-size: var(--text-meta);
+  line-height: var(--lh-ui);
   padding: 6px 9px;
 }
 
@@ -703,7 +747,7 @@ button.danger:hover {
 
 .dialog-header h2 {
   margin: 0;
-  font-size: 1.35rem;
+  font-size: var(--text-section);
 }
 
 .dialog-close {
@@ -716,7 +760,7 @@ button.danger:hover {
   border-radius: 8px;
   background: transparent;
   color: var(--muted);
-  font-size: 1.4rem;
+  font-size: var(--text-section);
   line-height: 1;
   padding: 0;
 }
@@ -731,7 +775,7 @@ button.danger:hover {
   max-width: 50ch;
   margin: 14px 0 22px;
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: var(--text-body);
 }
 
 .invitation-dialog-content {
@@ -805,7 +849,7 @@ button.danger:hover {
   max-width: 640px;
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 0.94rem;
+  font-size: var(--text-body);
 }
 
 .eyebrow,
@@ -813,9 +857,9 @@ button.danger:hover {
   display: block;
   margin-bottom: 8px;
   color: var(--brand-ink);
-  font-size: 0.7rem;
-  font-weight: 720;
-  letter-spacing: 0.11em;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--track-label);
   text-transform: uppercase;
 }
 
@@ -840,7 +884,7 @@ button.danger:hover {
   gap: 8px;
   border-right: 0;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
   padding: 0 12px 0 0;
 }
 
@@ -864,8 +908,8 @@ button.danger:hover {
   align-items: center;
   border-bottom: 0;
   color: var(--muted);
-  font-size: 0.75rem;
-  font-weight: 620;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
   padding: 0 15px;
 }
 
@@ -875,7 +919,7 @@ button.danger:hover {
   align-items: center;
   border-bottom: 1px solid var(--border);
   color: var(--secondary-foreground);
-  font-size: 0.84rem;
+  font-size: var(--text-ui);
   transition: background-color 130ms ease;
 }
 
@@ -904,8 +948,8 @@ button.danger:hover {
   z-index: 2;
   justify-self: end;
   color: var(--brand-ink);
-  font-size: 0.8rem;
-  font-weight: 650;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
   text-decoration: none;
 }
 
@@ -913,8 +957,8 @@ button.danger:hover {
   border: 1px solid #d9a04c;
   border-radius: 8px;
   color: #975a13;
-  font-size: 0.76rem;
-  font-weight: 650;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-semibold);
   padding: 0.48rem 0.65rem;
 }
 
@@ -939,7 +983,7 @@ button.danger:hover {
 .agent-avatar.large {
   width: 46px;
   height: 46px;
-  font-size: 0.85rem;
+  font-size: var(--text-ui);
 }
 
 .agent-identity strong,
@@ -955,14 +999,14 @@ button.danger:hover {
 .agent-identity strong,
 .cell-stack strong {
   color: var(--foreground);
-  font-weight: 610;
+  font-weight: var(--fw-semibold);
 }
 
 .agent-identity small,
 .cell-stack small {
   margin-top: 3px;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
 }
 
 .cell-stack.align-end {
@@ -1017,7 +1061,7 @@ button.danger:hover {
   display: inline-block;
   margin-bottom: 18px;
   color: var(--muted);
-  font-size: 0.82rem;
+  font-size: var(--text-ui);
   text-decoration: none;
 }
 
@@ -1061,7 +1105,7 @@ button.danger:hover {
 .availability-action small {
   margin-top: 4px;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
 }
 
 .object-identity {
@@ -1071,7 +1115,7 @@ button.danger:hover {
 
 .object-identity h1 {
   margin-bottom: 5px;
-  font-size: clamp(1.8rem, 2.5vw, 2.1rem);
+  font-size: var(--text-title);
 }
 
 .object-identity p {
@@ -1080,7 +1124,7 @@ button.danger:hover {
   gap: 9px 18px;
   margin: 0;
   color: var(--muted);
-  font-size: 0.8rem;
+  font-size: var(--text-meta);
 }
 
 .object-layout,
@@ -1104,8 +1148,8 @@ button.danger:hover {
   border-left: 0;
   border-radius: 9px;
   color: var(--muted);
-  font-size: 0.82rem;
-  font-weight: 570;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-medium);
   padding: 0 11px;
   text-decoration: none;
 }
@@ -1114,7 +1158,7 @@ button.danger:hover {
 .local-nav a.active {
   background: var(--brand-light);
   color: var(--brand-ink);
-  font-weight: 650;
+  font-weight: var(--fw-semibold);
 }
 
 .local-nav-select {
@@ -1135,16 +1179,16 @@ button.danger:hover {
 
 .section-header h2 {
   margin-bottom: 7px;
-  font-family: "Bricolage Grotesque Variable", "Geist Variable", sans-serif;
-  font-size: 1.55rem;
-  letter-spacing: -0.035em;
+  font-family: var(--font-display);
+  font-size: var(--text-section);
+  letter-spacing: var(--track-tight);
 }
 
 .section-header p {
   max-width: 640px;
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 0.88rem;
+  font-size: var(--text-body);
 }
 
 .overview-stack {
@@ -1159,8 +1203,8 @@ button.danger:hover {
 .overview-section > h3,
 .overview-section-heading h3 {
   margin-bottom: 13px;
-  font-size: 0.9rem;
-  font-weight: 670;
+  font-size: var(--text-subsection);
+  font-weight: var(--fw-semibold);
 }
 
 .overview-section-heading {
@@ -1172,8 +1216,8 @@ button.danger:hover {
 
 .overview-section-heading a {
   color: var(--brand-ink);
-  font-size: 0.75rem;
-  font-weight: 660;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-semibold);
 }
 
 .admin-controls {
@@ -1190,8 +1234,8 @@ button.danger:hover {
   background: transparent;
   color: var(--brand-ink);
   cursor: pointer;
-  font-size: 0.8rem;
-  font-weight: 620;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
   padding: 0;
 }
 
@@ -1235,7 +1279,7 @@ button.danger:hover {
 .form-card h2,
 .panel h2 {
   margin-bottom: 0;
-  font-size: 1rem;
+  font-size: var(--text-subsection);
 }
 
 .form-card label,
@@ -1243,14 +1287,14 @@ button.danger:hover {
   display: grid;
   gap: 7px;
   color: var(--secondary-foreground);
-  font-size: 0.8rem;
-  font-weight: 620;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .field-error {
   color: var(--error);
-  font-size: 0.78rem;
-  font-weight: 520;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-regular);
 }
 
 .form-field {
@@ -1260,9 +1304,9 @@ button.danger:hover {
 
 .field-help {
   color: var(--muted);
-  font-size: 0.76rem;
-  font-weight: 430;
-  line-height: 1.45;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-regular);
+  line-height: var(--lh-ui);
 }
 
 input,
@@ -1319,13 +1363,13 @@ textarea::placeholder {
 
 dt {
   color: var(--muted);
-  font-size: 0.82rem;
+  font-size: var(--text-ui);
 }
 
 dd {
   margin: 0;
   color: var(--secondary-foreground);
-  font-size: 0.86rem;
+  font-size: var(--text-ui);
   overflow-wrap: anywhere;
 }
 
@@ -1341,14 +1385,14 @@ dd {
 
 .empty-state h2 {
   margin-bottom: 8px;
-  font-size: 1rem;
+  font-size: var(--text-subsection);
 }
 
 .empty-state p {
   max-width: 560px;
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 0.88rem;
+  font-size: var(--text-body);
 }
 
 .notice {
@@ -1358,8 +1402,9 @@ dd {
   border-radius: var(--radius);
   background: var(--surface);
   color: var(--secondary-foreground);
+  font-size: var(--text-body);
   padding: 14px 16px;
-  line-height: 1.5;
+  line-height: var(--lh-prose);
 }
 
 .notice.error,
@@ -1398,13 +1443,13 @@ dd {
 }
 
 .row strong {
-  font-size: 0.86rem;
+  font-size: var(--text-ui);
 }
 
 .row small {
   margin-top: 3px;
   color: var(--muted);
-  font-size: 0.74rem;
+  font-size: var(--text-meta);
 }
 
 .steps {
@@ -1417,6 +1462,7 @@ dd {
 
 .steps li {
   border-bottom: 1px solid var(--border);
+  font-size: var(--text-body);
   padding: 13px 6px;
 }
 
@@ -1465,23 +1511,23 @@ code {
   background: var(--success);
   color: var(--brand-ink);
   content: "OT";
-  font-family: "Geist Mono Variable", monospace;
-  font-size: 0.72rem;
-  font-weight: 800;
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  font-weight: var(--fw-bold);
   line-height: 38px;
   text-align: center;
 }
 
 .center-card h1 {
   margin-bottom: 8px;
-  font-size: clamp(2rem, 6vw, 2.5rem);
+  font-size: var(--text-display);
 }
 
 .center-card > p {
   max-width: 38ch;
   margin: 0;
   color: var(--muted);
-  font-size: 0.94rem;
+  font-size: var(--text-body);
 }
 
 .center-card > .form-card {
@@ -1526,7 +1572,7 @@ code {
   align-items: center;
   gap: 14px;
   color: var(--secondary-foreground);
-  font-size: 0.82rem;
+  font-size: var(--text-ui);
 }
 
 .onboarding-main {
@@ -1542,7 +1588,7 @@ code {
 
 .onboarding-title h1 {
   margin-bottom: 8px;
-  font-size: clamp(2.25rem, 5vw, 3.5rem);
+  font-size: var(--text-display);
 }
 
 .onboarding-title p {
@@ -1576,16 +1622,16 @@ code {
 
 .onboarding-action-heading h2 {
   margin-bottom: 8px;
-  font-family: "Bricolage Grotesque Variable", "Geist Variable", sans-serif;
-  font-size: clamp(1.45rem, 3vw, 1.8rem);
-  letter-spacing: -0.035em;
+  font-family: var(--font-display);
+  font-size: var(--text-section);
+  letter-spacing: var(--track-tight);
 }
 
 .onboarding-action-heading p {
   max-width: 640px;
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 0.94rem;
+  font-size: var(--text-body);
 }
 
 .onboarding-action-heading .status-chip {
@@ -1628,8 +1674,8 @@ code {
   display: grid;
   gap: 7px;
   color: var(--secondary-foreground);
-  font-size: 0.82rem;
-  font-weight: 620;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .onboarding-choice-list {
@@ -1671,13 +1717,13 @@ code {
 
 .onboarding-choice span {
   color: var(--muted);
-  font-size: 0.78rem;
+  font-size: var(--text-meta);
 }
 
 .onboarding-helper {
   margin: 8px 0 0;
   color: var(--muted);
-  font-size: 0.84rem;
+  font-size: var(--text-ui);
 }
 
 /* Product surfaces use spacing and tonal grouping instead of repeated rules. */
@@ -1777,8 +1823,8 @@ code {
 
 .availability-action a {
   color: currentColor;
-  font-size: 0.72rem;
-  font-weight: 680;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-semibold);
   text-decoration: underline;
   text-decoration-color: rgb(40 64 30 / 28%);
   text-underline-offset: 3px;
@@ -1822,24 +1868,24 @@ code {
   display: block;
   margin-bottom: 9px;
   color: var(--brand-ink);
-  font-size: 0.72rem;
-  font-weight: 680;
-  letter-spacing: 0.04em;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--track-label);
   text-transform: uppercase;
 }
 
 .agent-use-copy h4 {
   margin-bottom: 7px;
   color: var(--foreground);
-  font-size: 1.05rem;
+  font-size: var(--text-subsection);
 }
 
 .agent-use-copy p {
   max-width: 510px;
   margin: 0;
   color: var(--secondary-foreground);
-  font-size: 0.84rem;
-  line-height: 1.6;
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
 }
 
 .agent-use-identity {
@@ -1853,13 +1899,13 @@ code {
 
 .agent-use-identity > span {
   color: var(--foreground);
-  font-size: 0.82rem;
-  font-weight: 660;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .agent-use-identity small {
   color: var(--muted);
-  font-size: 0.72rem;
+  font-size: var(--text-meta);
 }
 
 .overview-section .definition-list {
@@ -1880,12 +1926,12 @@ code {
 
 .overview-section .definition-list dt {
   margin-bottom: 7px;
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
 }
 
 .overview-section .definition-list dd {
-  font-size: 0.82rem;
-  font-weight: 650;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .admin-controls {
@@ -1928,7 +1974,7 @@ select,
 textarea {
   border-color: var(--border);
   background: var(--surface);
-  font-size: 0.88rem;
+  font-size: var(--text-ui);
 }
 
 input:focus,
@@ -1966,9 +2012,9 @@ textarea:focus {
 
 .field-hint {
   color: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 450;
-  line-height: 1.45;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-regular);
+  line-height: var(--lh-ui);
 }
 
 .agent-name-input {
@@ -1984,7 +2030,7 @@ textarea:focus {
   border-radius: 9px 0 0 9px;
   background: var(--background);
   color: var(--muted);
-  font-family: "Geist Mono Variable", "SFMono-Regular", Consolas, monospace;
+  font-family: var(--font-mono);
   padding: 0 11px;
 }
 
@@ -1999,7 +2045,7 @@ textarea:focus {
   border-radius: 9px;
   background: var(--background);
   color: var(--muted);
-  font-size: 0.78rem;
+  font-size: var(--text-meta);
   padding: 10px 12px;
 }
 
@@ -2051,14 +2097,14 @@ textarea:focus {
 
 .im-section h3 {
   margin-bottom: 0;
-  font-size: 0.9rem;
-  font-weight: 670;
+  font-size: var(--text-subsection);
+  font-weight: var(--fw-semibold);
 }
 
 .im-section-heading p {
   margin: 4px 0 0;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
 }
 
 .binding-status {
@@ -2083,14 +2129,14 @@ textarea:focus {
 }
 
 .binding-status-main strong {
-  font-size: 0.88rem;
+  font-size: var(--text-ui);
 }
 
 .binding-status-main small,
 .binding-status > small {
   margin-top: 4px;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
 }
 
 .message-policy {
@@ -2105,13 +2151,13 @@ textarea:focus {
 .message-policy-copy strong {
   display: block;
   margin-bottom: 5px;
-  font-size: 0.8rem;
+  font-size: var(--text-ui);
 }
 
 .message-policy-copy p {
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
 }
 
 .segmented-control {
@@ -2133,8 +2179,8 @@ textarea:focus {
   border-radius: 7px;
   background: transparent;
   color: var(--muted);
-  font-size: 0.75rem;
-  font-weight: 620;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
   padding: 0 10px;
   text-align: center;
 }
@@ -2174,13 +2220,13 @@ textarea:focus {
 .team-profile-copy strong {
   display: block;
   margin: 2px 0 5px;
-  font-size: 0.8rem;
+  font-size: var(--text-ui);
 }
 
 .team-profile-copy p {
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
 }
 
 .team-profile-row label {
@@ -2203,7 +2249,7 @@ textarea:focus {
   align-items: center;
   gap: 8px;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: var(--text-meta);
 }
 
 .dirty-bar > span::before {
@@ -2253,8 +2299,8 @@ textarea:focus {
 .settings-unavailable h2,
 .settings-policy-banner h2 {
   margin-bottom: 0;
-  font-size: 1rem;
-  font-weight: 680;
+  font-size: var(--text-subsection);
+  font-weight: var(--fw-semibold);
 }
 
 .settings-field-list {
@@ -2273,8 +2319,8 @@ textarea:focus {
 .settings-field-copy strong,
 .settings-field-row label {
   color: var(--secondary-foreground);
-  font-size: 0.82rem;
-  font-weight: 650;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .settings-field-copy p,
@@ -2286,9 +2332,9 @@ textarea:focus {
 .settings-compact-empty p {
   margin: 5px 0 0;
   color: var(--muted);
-  font-size: 0.75rem;
-  font-weight: 450;
-  line-height: 1.5;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-regular);
+  line-height: var(--lh-prose);
 }
 
 .settings-field-row label {
@@ -2298,7 +2344,7 @@ textarea:focus {
 
 .settings-field-hint code {
   color: var(--secondary-foreground);
-  font-size: 0.73rem;
+  font-size: var(--text-meta);
 }
 
 .settings-readonly-value {
@@ -2311,7 +2357,7 @@ textarea:focus {
   border-radius: 9px;
   background: rgb(253 252 247 / 58%);
   color: var(--secondary-foreground);
-  font-size: 0.86rem;
+  font-size: var(--text-ui);
   padding: 0.62rem 0.72rem;
 }
 
@@ -2341,7 +2387,7 @@ textarea:focus {
   margin: 0;
   border: 0;
   border-radius: 8px;
-  font-size: 0.78rem;
+  font-size: var(--text-meta);
   padding: 8px 11px;
 }
 
@@ -2377,8 +2423,8 @@ textarea:focus {
   border-radius: 7px;
   background: var(--surface);
   color: var(--secondary-foreground);
-  font-size: 0.72rem;
-  font-weight: 620;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
   padding: 5px 8px;
   white-space: nowrap;
 }
@@ -2394,15 +2440,15 @@ textarea:focus {
 
 .settings-invitation-panel h3 {
   margin: 0;
-  font-size: 0.9rem;
-  font-weight: 680;
+  font-size: var(--text-subsection);
+  font-weight: var(--fw-semibold);
 }
 
 .settings-invitation-panel > p {
   max-width: 590px;
   margin: -7px 0 1px;
   color: var(--muted);
-  font-size: 0.78rem;
+  font-size: var(--text-meta);
 }
 
 .settings-invitation-panel .invite-link {
@@ -2449,8 +2495,8 @@ textarea:focus {
 .settings-table-header {
   min-height: 38px;
   color: var(--muted);
-  font-size: 0.7rem;
-  font-weight: 640;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
 }
 
 .settings-member-table .settings-table-header,
@@ -2478,8 +2524,8 @@ textarea:focus {
 
 .settings-member-identity strong,
 .settings-computer-row strong {
-  font-size: 0.83rem;
-  font-weight: 650;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .settings-member-identity small,
@@ -2487,7 +2533,7 @@ textarea:focus {
   display: block;
   margin-top: 3px;
   color: var(--muted);
-  font-size: 0.71rem;
+  font-size: var(--text-meta);
 }
 
 .settings-member-avatar {
@@ -2500,13 +2546,13 @@ textarea:focus {
   border-radius: 9px;
   background: var(--brand-ink);
   color: #fff;
-  font-size: 0.7rem;
-  font-weight: 690;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-bold);
 }
 
 .settings-member-row select {
   min-height: 36px;
-  font-size: 0.78rem;
+  font-size: var(--text-ui);
   padding-block: 0.35rem;
 }
 
@@ -2518,7 +2564,7 @@ textarea:focus {
 .settings-computer-row {
   min-height: 70px;
   color: var(--secondary-foreground);
-  font-size: 0.77rem;
+  font-size: var(--text-ui);
   padding: 10px 0;
 }
 
@@ -2570,7 +2616,7 @@ textarea:focus {
 }
 
 .settings-compact-empty strong {
-  font-size: 0.86rem;
+  font-size: var(--text-ui);
 }
 
 .settings-unavailable {
@@ -2585,9 +2631,9 @@ textarea:focus {
   width: fit-content;
   margin-bottom: 12px;
   color: var(--brand-ink);
-  font-size: 0.67rem;
-  font-weight: 720;
-  letter-spacing: 0.08em;
+  font-size: var(--text-micro);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--track-label);
   text-transform: uppercase;
 }
 
@@ -2595,8 +2641,8 @@ textarea:focus {
   max-width: 610px;
   margin: 8px 0 22px;
   color: var(--muted);
-  font-size: 0.84rem;
-  line-height: 1.55;
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
 }
 
 .settings-unavailable ul {
@@ -2609,7 +2655,7 @@ textarea:focus {
   position: relative;
   border-top: 1px solid var(--border);
   color: var(--secondary-foreground);
-  font-size: 0.78rem;
+  font-size: var(--text-ui);
   padding: 12px 12px 12px 22px;
 }
 
@@ -2626,8 +2672,8 @@ textarea:focus {
 
 .settings-state-action {
   color: var(--brand-ink);
-  font-size: 0.8rem;
-  font-weight: 650;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
   text-decoration: none;
 }
 
@@ -2658,7 +2704,7 @@ textarea:focus {
 .settings-footnote {
   margin: 0;
   color: var(--muted);
-  font-size: 0.74rem;
+  font-size: var(--text-meta);
 }
 
 @media (max-width: 1320px) {
@@ -2667,8 +2713,8 @@ textarea:focus {
     gap: 7px;
     margin-top: 22px;
     color: var(--muted);
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: var(--text-meta);
+    font-weight: var(--fw-semibold);
   }
 
   .settings-page .settings-layout {
@@ -2709,8 +2755,8 @@ textarea:focus {
     margin-bottom: 5px;
     color: var(--muted);
     content: attr(data-label);
-    font-size: 0.68rem;
-    font-weight: 600;
+    font-size: var(--text-micro);
+    font-weight: var(--fw-semibold);
   }
 }
 
@@ -2768,9 +2814,9 @@ textarea:focus {
   }
 
   .mobile-brand {
-    font-size: 1.25rem;
-    font-weight: 700;
-    letter-spacing: -0.04em;
+    font-size: var(--text-section);
+    font-weight: var(--fw-bold);
+    letter-spacing: var(--track-tight);
     text-decoration: none;
   }
 
@@ -2793,8 +2839,8 @@ textarea:focus {
     gap: 7px;
     margin-top: 22px;
     color: var(--muted);
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: var(--text-meta);
+    font-weight: var(--fw-semibold);
   }
 
   .object-content,
@@ -2850,7 +2896,7 @@ textarea:focus {
   }
 
   .onboarding-action pre {
-    font-size: 0.78rem;
+    font-size: var(--text-meta);
   }
 
   .dialog-layer {
@@ -2971,8 +3017,8 @@ textarea:focus {
     margin-bottom: 5px;
     color: var(--muted);
     content: attr(data-label);
-    font-size: 0.68rem;
-    font-weight: 600;
+    font-size: var(--text-micro);
+    font-weight: var(--fw-semibold);
   }
 
   .settings-unavailable {
@@ -2989,8 +3035,8 @@ textarea:focus {
     margin-bottom: 5px;
     color: var(--muted);
     content: attr(data-label);
-    font-size: 0.68rem;
-    font-weight: 600;
+    font-size: var(--text-micro);
+    font-weight: var(--fw-semibold);
   }
 
   .definition-list div {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1543,7 +1543,8 @@ code {
 .connect-command-meta {
   margin: 8px 0 0;
   color: var(--muted);
-  font-size: 0.84rem;
+  font-size: var(--text-meta);
+  line-height: var(--lh-ui);
 }
 
 .connect-command-actions .connect-command-meta {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -835,13 +835,13 @@ button.danger:hover {
 
 .agent-summary-strip > span {
   display: inline-flex;
-  min-height: 24px;
+  min-height: 0;
   align-items: center;
   gap: 8px;
-  border-right: 1px solid var(--strong-border);
-  color: var(--secondary-foreground);
-  font-size: 0.82rem;
-  padding: 0 18px;
+  border-right: 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  padding: 0 12px 0 0;
 }
 
 .agent-summary-strip > span:last-child {
@@ -860,12 +860,13 @@ button.danger:hover {
 }
 
 .agent-table-header {
-  min-height: 42px;
+  min-height: 34px;
   align-items: center;
-  border-bottom: 1px solid var(--strong-border);
+  border-bottom: 0;
   color: var(--muted);
-  font-size: 0.72rem;
+  font-size: 0.75rem;
   font-weight: 620;
+  padding: 0 15px;
 }
 
 .agent-row {
@@ -902,8 +903,9 @@ button.danger:hover {
   position: relative;
   z-index: 2;
   justify-self: end;
-  color: var(--muted);
-  font-size: 1.25rem;
+  color: var(--brand-ink);
+  font-size: 0.8rem;
+  font-weight: 650;
   text-decoration: none;
 }
 
@@ -960,7 +962,7 @@ button.danger:hover {
 .cell-stack small {
   margin-top: 3px;
   color: var(--muted);
-  font-size: 0.73rem;
+  font-size: 0.75rem;
 }
 
 .cell-stack.align-end {
@@ -1078,7 +1080,7 @@ button.danger:hover {
   gap: 9px 18px;
   margin: 0;
   color: var(--muted);
-  font-size: 0.78rem;
+  font-size: 0.8rem;
 }
 
 .object-layout,
@@ -1099,20 +1101,20 @@ button.danger:hover {
   display: flex;
   min-height: 38px;
   align-items: center;
-  border-left: 2px solid transparent;
-  border-radius: 0 8px 8px 0;
+  border-left: 0;
+  border-radius: 9px;
   color: var(--muted);
-  font-size: 0.84rem;
-  font-weight: 540;
+  font-size: 0.82rem;
+  font-weight: 570;
   padding: 0 11px;
   text-decoration: none;
 }
 
 .local-nav a:hover,
 .local-nav a.active {
-  border-left-color: var(--brand);
   background: var(--brand-light);
   color: var(--brand-ink);
+  font-weight: 650;
 }
 
 .local-nav-select {
@@ -1142,7 +1144,7 @@ button.danger:hover {
   max-width: 640px;
   margin-bottom: 0;
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
 }
 
 .overview-stack {
@@ -1156,9 +1158,9 @@ button.danger:hover {
 
 .overview-section > h3,
 .overview-section-heading h3 {
-  margin-bottom: 16px;
-  font-size: 0.95rem;
-  font-weight: 650;
+  margin-bottom: 13px;
+  font-size: 0.9rem;
+  font-weight: 670;
 }
 
 .overview-section-heading {
@@ -1170,8 +1172,8 @@ button.danger:hover {
 
 .overview-section-heading a {
   color: var(--brand-ink);
-  font-size: 0.78rem;
-  font-weight: 620;
+  font-size: 0.75rem;
+  font-weight: 660;
 }
 
 .admin-controls {
@@ -1182,7 +1184,7 @@ button.danger:hover {
 
 .admin-controls-trigger {
   width: fit-content;
-  min-height: 0;
+  min-height: 34px;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -1241,7 +1243,7 @@ button.danger:hover {
   display: grid;
   gap: 7px;
   color: var(--secondary-foreground);
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   font-weight: 620;
 }
 
@@ -1697,14 +1699,6 @@ code {
   padding: 11px 14px;
 }
 
-.agent-summary-strip > span {
-  min-height: 0;
-  border-right: 0;
-  color: var(--muted);
-  font-size: 0.75rem;
-  padding: 0 12px 0 0;
-}
-
 .agent-summary-strip > span + span {
   padding-left: 10px;
 }
@@ -1712,13 +1706,6 @@ code {
 .agent-table-body {
   display: grid;
   gap: 7px;
-}
-
-.agent-table-header {
-  min-height: 34px;
-  border-bottom: 0;
-  font-size: 0.75rem;
-  padding: 0 15px;
 }
 
 .agent-row {
@@ -1741,12 +1728,6 @@ code {
   background: var(--brand-light);
 }
 
-.agent-row-action {
-  color: var(--brand-ink);
-  font-size: 0.8rem;
-  font-weight: 650;
-}
-
 .agent-row-action.prominent {
   border: 0;
   background: var(--warning-surface);
@@ -1766,12 +1747,6 @@ code {
 
 .agent-avatar.large {
   border-radius: 13px;
-}
-
-.agent-identity small,
-.cell-stack small {
-  color: var(--muted);
-  font-size: 0.75rem;
 }
 
 .object-header {
@@ -1800,11 +1775,6 @@ code {
   color: var(--secondary-foreground);
 }
 
-.availability-action small {
-  color: var(--muted);
-  font-size: 0.75rem;
-}
-
 .availability-action a {
   color: currentColor;
   font-size: 0.72rem;
@@ -1814,31 +1784,10 @@ code {
   text-underline-offset: 3px;
 }
 
-.object-identity p {
-  color: var(--muted);
-  font-size: 0.8rem;
-}
-
 .object-layout,
 .settings-layout {
   gap: 50px;
   padding-top: 38px;
-}
-
-.local-nav a {
-  border-left: 0;
-  border-radius: 9px;
-  color: var(--muted);
-  font-size: 0.82rem;
-  font-weight: 570;
-}
-
-.local-nav a:hover,
-.local-nav a.active {
-  border-left-color: transparent;
-  background: var(--brand-light);
-  color: var(--brand-ink);
-  font-weight: 650;
 }
 
 .section-header {
@@ -1847,24 +1796,8 @@ code {
   padding-bottom: 0;
 }
 
-.section-header p {
-  font-size: 0.88rem;
-}
-
 .overview-stack {
   gap: 31px;
-}
-
-.overview-section > h3,
-.overview-section-heading h3 {
-  margin-bottom: 13px;
-  font-size: 0.9rem;
-  font-weight: 670;
-}
-
-.overview-section-heading a {
-  font-size: 0.75rem;
-  font-weight: 660;
 }
 
 .agent-use-panel {
@@ -1960,11 +1893,6 @@ code {
   padding-top: 0;
 }
 
-.admin-controls-trigger {
-  min-height: 34px;
-  font-size: 0.8rem;
-}
-
 .settings-title {
   border-bottom: 0;
   padding-bottom: 0;
@@ -1993,11 +1921,6 @@ code {
 .section-header + .form-card,
 .form-card:first-child {
   padding: 22px;
-}
-
-.form-card label,
-.invite-link {
-  font-size: 0.8rem;
 }
 
 input,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -32,6 +32,9 @@
   --text-title: var(--fs-24);
   --text-display: var(--fs-30);
 
+  /* The wordmark is fixed: it must not follow a surface's scale. */
+  --text-brand: var(--fs-24);
+
   --fw-regular: 400;
   --fw-medium: 500;
   --fw-semibold: 600;
@@ -67,6 +70,25 @@
   --local-nav-width: 170px;
   --layer-sidebar: 30;
   --layer-backdrop: 20;
+}
+
+/* Density follows the surface, not the reader. Dense surfaces are scanned
+   by operators; configuration and entry surfaces are read, often by
+   non-technical admins, and lose nothing by stepping each role up. Same
+   token names, same steps — only the value each role points at moves. */
+.settings-page,
+.onboarding-shell,
+.decorative-page {
+  --text-meta: var(--fs-13);
+  --text-ui: var(--fs-14);
+  --text-body: var(--fs-16);
+}
+
+/* Entry surfaces are also where the brand voice is spent. */
+.onboarding-shell,
+.decorative-page {
+  --text-title: var(--fs-32);
+  --text-display: var(--fs-44);
 }
 
 * {
@@ -331,7 +353,7 @@ button.danger:hover {
   width: fit-content;
   margin: 0 10px 3px;
   color: var(--foreground);
-  font-size: var(--text-title);
+  font-size: var(--text-brand);
   font-weight: var(--fw-bold);
   letter-spacing: var(--track-tight);
   text-decoration: none;
@@ -1520,7 +1542,7 @@ code {
 
 .center-card h1 {
   margin-bottom: 8px;
-  font-size: var(--text-display);
+  font-size: var(--text-title);
 }
 
 .center-card > p {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -85,10 +85,13 @@
 /* Density follows the surface, not the reader. Dense surfaces are scanned
    by operators; configuration and entry surfaces are read, often by
    non-technical admins, and lose nothing by stepping each role up. Same
-   token names, same steps — only the value each role points at moves. */
+   token names, same steps — only the value each role points at moves.
+   Dialogs bind here directly: they mount as a sibling of the routed page,
+   so they inherit nothing from the surface they were opened from. */
 .settings-page,
 .onboarding-shell,
-.decorative-page {
+.decorative-page,
+.dialog-card {
   --text-meta: var(--fs-13);
   --text-ui: var(--fs-14);
   --text-body: var(--fs-16);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      postcss:
+        specifier: ^8.5.26
+        version: 8.5.26
       vite:
         specifier: ^7.1.3
         version: 7.3.6(@types/node@22.20.1)(tsx@4.23.12)(yaml@2.9.0)


### PR DESCRIPTION
## Summary

`apps/web/src/styles.css` carried 121 `font-size` declarations across 35 distinct values, 19 distinct font weights between 430 and 800, and eight scattered line heights — all literals written at the point of use, with no token layer and nothing preventing the next component from adding a 36th size. Twelve selectors declared type twice, with a later override layer silently winning the cascade, so editing the first declaration had no effect on the rendered page.

The branch is in two parts.

**The migration**, in five independently revertible commits:

| Commit | Change |
| --- | --- |
| `45013fe` | Hoist the winning value of 12 shadowed selectors and drop the override; computed styles unchanged |
| `e6ba060` | Introduce `--fs-*` steps and `--text-*` roles; map every size, weight, tracking and font stack onto them |
| `6d6cc48` | Rebind the role tokens on `.settings-page` / `.onboarding-shell` / `.decorative-page` so density follows the surface |
| `d43aabe` | Name CJK fallbacks in each stack, opt tables into tabular numerals, stop advertising an unimplemented dark scheme |
| `3b887d1` | Assert the token layer holds, so the scale cannot drift back apart |

Result: 35 sizes to 9 whole-pixel steps behind 9 semantic roles, 19 weights to 4, 8 line heights to 3 tokens, 31 fractional-pixel values to 0.

Values follow a dense-console scale — 13px interface text, 14px prose, 12px floor for labels — with the reading surfaces stepping each role up one, because the product is used both by operators living in the agent and computer tables and by team admins who mostly touch settings and onboarding.

Notable rendered changes: page `h1` 32–36px to 24px, section `h2` 24.8px to 20px, sidebar nav and inputs to 13px, buttons 16px to 13px (they previously inherited the user-agent default), micro labels up from 10.5–11.5px to a 12px floor. `h4` no longer renders larger than `h3`, `h2` no longer has three sizes, and `body`/`p` carry explicit sizes instead of falling back to 16px wherever nothing overrode them.

**The guard**, in the remaining commits. It began as regular expressions over the stylesheet text and was rewritten across review into a PostCSS-based check with a canonical-source policy. Thirteen rounds of review found thirteen ways a declaration could reach the browser while the guard read it as something else — the `font` shorthand read as a longhand, tokens defined only inside a comment or a string, case-insensitive property names, escaped identifiers, definitions hidden under `@media` or an unrelated selector, exceptions allowed by value rather than by selector. Every one was real. The guard now:

- reads parsed declarations, never stylesheet text, and never the name as written — identifier escapes are decoded before any comparison, and PostCSS nodes do not leave the parse layer
- refuses escapes in the non-string portion of any value rather than reimplementing CSS value tokenization, since the stylesheet has never contained one
- resolves the baseline only from an unconditional `:root`, limits role rebinding to the four reading surfaces, and binds each literal exception to the exact selectors that earn it
- tests itself: 22 of its 40 cases assert that it rejects what it exists to catch, including both the escaped and quoted forms of each bypass

It has already earned its place twice: it caught `.connect-command-meta { font-size: 0.84rem }` arriving from `main` mid-review, and it caught a regression I introduced while refactoring it.

Two findings from the audit are deliberately left alone: Bricolage Grotesque stays (dropping it would save ~70KB but removes the brand voice from entry pages — a product call, not a cleanup), and `pnpm dev` is broken by a `@babel/generator@7` versus pinned `@babel/parser@8.0.0-rc.2` mismatch that predates this branch and needs its own fix.

Supersedes #87, which was opened from a branch prefix the branch-name check rejects.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test` — pass in CI; all six checks are green on `f17e2f0`.
- `pnpm --filter @opentag/web test` — 238 passed, 40 of them the typography guard.
- Thirteen injections re-run against the real stylesheet after every change, each rejected: literal size, literal `font-family`, `font` shorthand, uppercase property, escaped property, escaped custom property, escaped parenthesis forging a `var()` call, escaped reference under an unowned property, poisoned string in a value, token defined only in a comment, only in a string, only under `@media`, and a role retuned by an arbitrary component. Two negative cases confirm the guard has not simply been tightened: `content: "var(--fs-99)"` raises nothing, and a backslash inside a string is left alone.
- Visual check on the production build via `vite preview` with stubbed API responses: sign-in, Agents list, Team settings and Computer settings compared before and after, including Chinese team, agent and member names.

Locally, two `@opentag/client` process-group tests fail in the sandbox this branch was developed in. They fail identically at the base commit and pass on the runner, so they are an artifact of the sandbox rather than of this change.

## Breaking changes

None for the API or build output. The change is visual: interface text renders smaller across product surfaces and larger on configuration and entry surfaces, as described above.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable. — no documentation changed.
