### PR TITLE
fix(web): keep the Computer connection command copyable and time-boxed

### DIFF
--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -48,6 +48,7 @@ describe("ComputerSetup", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+    Reflect.deleteProperty(navigator, "clipboard");
   });
 
   it("captures the owned-Computer baseline before issuing a connect code", async () => {
@@ -290,6 +291,88 @@ describe("ComputerSetup", () => {
     expect(screen.getByRole("status").textContent).toBe("Computer connected.");
     expect(onConnected).toHaveBeenCalledTimes(1);
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("copies the command and counts down on the existing poll cycle", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [] });
+    vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+
+    expect(screen.getByText("Expires in 15:00")).toBeTruthy();
+    // The command owns no timer of its own: the poll cycle and the expiry deadline stay the only two.
+    expect(vi.getTimerCount()).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+    expect(screen.getByText("Expires in 14:59")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(bootstrapCommand);
+    expect(screen.getByRole("button", { name: "Copied" })).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+  });
+
+  it("selects the command when the browser denies clipboard access", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    vi.spyOn(browserApi, "ownComputers").mockResolvedValue({ computers: [] });
+    vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    });
+
+    expect(
+      screen.getByText("Copying is unavailable here. The command is selected; press Ctrl or Cmd + C."),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+    expect(window.getSelection()?.rangeCount).toBe(1);
+  });
+
+  it("stops showing the countdown once the Computer connects", async () => {
+    vi.spyOn(browserApi, "ownComputers")
+      .mockResolvedValueOnce({ computers: [existingComputer] })
+      .mockResolvedValue({ computers: [existingComputer, newComputer] });
+    vi.spyOn(browserApi, "issueConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(<ComputerSetup teamId={teamId} />);
+    await clickGenerate();
+    expect(screen.getByText("Expires in 15:00")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+
+    expect(screen.getByRole("status").textContent).toBe("Computer connected.");
+    expect(screen.queryByText(/^Expires in/)).toBeNull();
   });
 
   it("normalizes connect-code issuance errors", async () => {

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -3,7 +3,9 @@ import { useEffect, useRef, useState } from "react";
 import { browserApi } from "./api.js";
 
 const COMPUTER_POLL_INTERVAL_MS = 1_500;
+const COPY_FEEDBACK_MS = 2_000;
 const CONNECT_CODE_EXPIRED_MESSAGE = "This Computer connection command expired. Generate a new one to continue.";
+const COPY_FALLBACK_HINT = "Copying is unavailable here. The command is selected; press Ctrl or Cmd + C.";
 
 export interface ComputerSetupProps {
   teamId: string;
@@ -12,6 +14,22 @@ export interface ComputerSetupProps {
 
 function errorMessage(cause: unknown, fallback: string): string {
   return cause instanceof Error && cause.message ? cause.message : fallback;
+}
+
+/** Selects the command so a browser without clipboard access still allows a manual copy. */
+function selectCommand(node: HTMLElement | null): void {
+  const selection = window.getSelection?.();
+  if (!node || !selection) return;
+  const range = document.createRange();
+  range.selectNodeContents(node);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+/** Renders the remaining connect-code validity as m:ss without rounding a live second up. */
+function formatRemaining(remainingMs: number): string {
+  const seconds = Math.max(0, Math.ceil(remainingMs / 1_000));
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
 }
 
 export function ComputerSetup({ teamId, onConnected }: ComputerSetupProps) {
@@ -24,10 +42,15 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
   const [waitingForComputer, setWaitingForComputer] = useState(false);
   const [computerConnected, setComputerConnected] = useState(false);
   const [pollCycle, setPollCycle] = useState(0);
+  const [remainingMs, setRemainingMs] = useState<number>();
+  const [copied, setCopied] = useState(false);
+  const [copyHint, setCopyHint] = useState<string>();
   const baselineConnections = useRef<Map<string, string | null>>(new Map());
   const connectCodeExpiresAt = useRef(0);
   const connectAttempt = useRef(0);
   const activePollCycle = useRef(0);
+  const copyResetTimer = useRef(0);
+  const commandRef = useRef<HTMLElement>(null);
   const mounted = useRef(false);
   const onConnectedRef = useRef(onConnected);
   onConnectedRef.current = onConnected;
@@ -38,8 +61,27 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
       mounted.current = false;
       connectAttempt.current += 1;
       activePollCycle.current += 1;
+      window.clearTimeout(copyResetTimer.current);
     };
   }, []);
+
+  async function copyCommand(command: string) {
+    try {
+      await navigator.clipboard.writeText(command);
+      if (!mounted.current) return;
+      setCopyHint(undefined);
+      setCopied(true);
+      window.clearTimeout(copyResetTimer.current);
+      copyResetTimer.current = window.setTimeout(() => {
+        if (mounted.current) setCopied(false);
+      }, COPY_FEEDBACK_MS);
+    } catch {
+      if (!mounted.current) return;
+      setCopied(false);
+      selectCommand(commandRef.current);
+      setCopyHint(COPY_FALLBACK_HINT);
+    }
+  }
 
   async function connectComputer() {
     const attempt = connectAttempt.current + 1;
@@ -59,6 +101,9 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
       setError(undefined);
       setBootstrapCommand(issued.bootstrapCommand);
       setComputerConnected(false);
+      setRemainingMs(Math.max(0, connectCodeExpiresAt.current - Date.now()));
+      setCopied(false);
+      setCopyHint(undefined);
       setPollCycle(cycle);
       setWaitingForComputer(true);
     } catch (cause) {
@@ -81,11 +126,14 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
         window.clearInterval(pollTimer);
         setWaitingForComputer(false);
         setComputerConnected(false);
+        setRemainingMs(undefined);
         setError(CONNECT_CODE_EXPIRED_MESSAGE);
       },
       Math.max(0, expiresAt - Date.now()),
     );
     pollTimer = window.setInterval(() => {
+      // The existing poll cycle also drives the countdown, so the command needs no timer of its own.
+      setRemainingMs(Math.max(0, expiresAt - Date.now()));
       void browserApi.ownComputers().then(
         (value) => {
           if (!active || completed || activePollCycle.current !== pollCycle) return;
@@ -103,6 +151,7 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
           window.clearTimeout(expiryTimer);
           setWaitingForComputer(false);
           setComputerConnected(true);
+          setRemainingMs(undefined);
           onConnectedRef.current?.();
         },
         (cause: unknown) => {
@@ -129,8 +178,17 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
       {bootstrapCommand ? (
         <>
           <pre>
-            <code>{bootstrapCommand}</code>
+            <code ref={commandRef}>{bootstrapCommand}</code>
           </pre>
+          <div className="connect-command-actions">
+            <button className="button secondary" type="button" onClick={() => void copyCommand(bootstrapCommand)}>
+              {copied ? "Copied" : "Copy command"}
+            </button>
+            {waitingForComputer && remainingMs !== undefined ? (
+              <p className="connect-command-meta">Expires in {formatRemaining(remainingMs)}</p>
+            ) : null}
+          </div>
+          {copyHint ? <p className="connect-command-meta">{copyHint}</p> : null}
           {waitingForComputer || computerConnected ? (
             <p role="status">{waitingForComputer ? "Waiting for the Computer to connect…" : "Computer connected."}</p>
           ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1434,6 +1434,24 @@ code {
   overflow-wrap: anywhere;
 }
 
+.connect-command-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.connect-command-meta {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.connect-command-actions .connect-command-meta {
+  margin: 0;
+}
+
 .setup-qr {
   display: block;
   width: min(240px, 100%);


### PR DESCRIPTION
## Summary

The Computer connection command could only be selected by hand, and its validity was invisible until the code expired.

- add a copy control that falls back to selecting the command when the browser denies clipboard access
- show the remaining validity from the connect code the Server already returns

The countdown runs on the existing Computer poll cycle, so the panel still owns exactly two timers and the existing cleanup assertions are unchanged.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test`
- `pnpm --filter @opentag/web test` — new cases cover copying, the clipboard-denied fallback, the countdown following the poll cycle, and the countdown disappearing once the Computer connects
- `node scripts/e2e/onboarding-e2e.mjs` — 16/16 steps

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzHQwLVMKFoRoA4b9c9g4E)_