### PR TITLE
fix(web): advance onboarding Provider readiness without a manual check

### DIFF
--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -209,6 +209,84 @@ describe("OnboardingPage", () => {
     expect(await screen.findByRole("heading", { name: "Prepare Codex or Claude Code" })).toBeTruthy();
   });
 
+  it("advances from Provider setup without asking the user to check again", async () => {
+    vi.useFakeTimers();
+    installFacts({ computers: [computerA] });
+    const computers = vi.spyOn(browserApi, "computers");
+    let runtimeReady = false;
+    const runtime: RuntimeFactsAdapter = {
+      load: vi.fn(
+        async (): Promise<RuntimeFactsResult> => ({
+          kind: "available",
+          providers: [
+            {
+              computerId: computerAId,
+              provider: "codex",
+              runtimeReady,
+              status: runtimeReady ? "ready" : "install",
+            },
+          ],
+        }),
+      ),
+    };
+    renderPage({ runtime });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByRole("heading", { name: "Install Codex" })).toBeTruthy();
+    const loadsBeforePolling = computers.mock.calls.length;
+
+    runtimeReady = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(computers.mock.calls.length).toBeGreaterThan(loadsBeforePolling);
+    expect(screen.getByRole("heading", { name: "Create your Agent" })).toBeTruthy();
+  });
+
+  it("leaves a state that waits on this user alone", async () => {
+    vi.useFakeTimers();
+    installFacts({ computers: [computerA] });
+    const computers = vi.spyOn(browserApi, "computers");
+    renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]) });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByRole("heading", { name: "Create your Agent" })).toBeTruthy();
+    const loads = computers.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(computers.mock.calls.length).toBe(loads);
+  });
+
+  it("stops polling a page that nobody has acted on for ten minutes", async () => {
+    vi.useFakeTimers();
+    installFacts({ computers: [computerA] });
+    const computers = vi.spyOn(browserApi, "computers");
+    renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: false }]) });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByRole("heading", { name: "Prepare Codex or Claude Code" })).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1_000);
+    });
+    const loads = computers.mock.calls.length;
+    expect(loads).toBeGreaterThan(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(computers.mock.calls.length).toBe(loads);
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+  });
+
   it.each([
     ["checking", "Checking Codex", "OpenTag is checking Codex readiness on Ada's Mac."],
     ["install", "Install Codex", "Install Codex on Ada's Mac, then check again."],

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -287,6 +287,37 @@ describe("OnboardingPage", () => {
     expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
   });
 
+  it("resumes polling when someone returns to a page that went quiet", async () => {
+    vi.useFakeTimers();
+    installFacts({ computers: [computerA] });
+    const computers = vi.spyOn(browserApi, "computers");
+    renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: false }]) });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1_000);
+    });
+    const quiet = computers.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(computers.mock.calls.length).toBe(quiet);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const attended = computers.mock.calls.length;
+    expect(attended).toBeGreaterThan(quiet);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(computers.mock.calls.length).toBeGreaterThan(attended);
+  });
+
   it.each([
     ["checking", "Checking Codex", "OpenTag is checking Codex readiness on Ada's Mac."],
     ["install", "Install Codex", "Install Codex on Ada's Mac, then check again."],

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -88,6 +88,7 @@ export function OnboardingPage({
     () => readCreationIntent(membership.teamId)?.request.displayName ?? "OpenTag",
   );
   const [refreshPending, setRefreshPending] = useState(false);
+  const [attendedWindow, setAttendedWindow] = useState(0);
   const creationInFlight = useRef(false);
   const refreshInFlight = useRef(false);
   const reload = useCallback(() => {
@@ -96,6 +97,14 @@ export function OnboardingPage({
     setRefreshPending(true);
     setRevision((value) => value + 1);
   }, []);
+  /**
+   * A refresh someone is present for: it reloads facts and restarts the bounded
+   * polling window, so returning to a capped page resumes automatic progress.
+   */
+  const attendedReload = useCallback(() => {
+    setAttendedWindow((value) => value + 1);
+    reload();
+  }, [reload]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: revision is the explicit Server-fact reload trigger.
   useEffect(() => {
@@ -124,9 +133,9 @@ export function OnboardingPage({
   }, [membership.teamId, revision, runtimeFacts]);
 
   useEffect(() => {
-    const refresh = () => reload();
+    const refresh = () => attendedReload();
     const refreshVisible = () => {
-      if (document.visibilityState === "visible") reload();
+      if (document.visibilityState === "visible") attendedReload();
     };
     window.addEventListener("focus", refresh);
     document.addEventListener("visibilitychange", refreshVisible);
@@ -134,7 +143,7 @@ export function OnboardingPage({
       window.removeEventListener("focus", refresh);
       document.removeEventListener("visibilitychange", refreshVisible);
     };
-  }, [reload]);
+  }, [attendedReload]);
 
   const resolved = useMemo(() => {
     if (loadState.kind !== "ready") return undefined;
@@ -147,7 +156,7 @@ export function OnboardingPage({
     let elapsedMs = 0;
     const timer = window.setInterval(() => {
       elapsedMs += RUNTIME_POLL_INTERVAL_MS;
-      // A page left open indefinitely stops polling; focus, visibility, and the explicit control still reload.
+      // An unattended page goes quiet; the next attended refresh starts a fresh window.
       if (elapsedMs >= RUNTIME_POLL_LIMIT_MS) {
         window.clearInterval(timer);
         return;
@@ -155,7 +164,7 @@ export function OnboardingPage({
       if (document.visibilityState !== "hidden") reload();
     }, RUNTIME_POLL_INTERVAL_MS);
     return () => window.clearInterval(timer);
-  }, [reload, waitingForRuntime]);
+  }, [attendedWindow, reload, waitingForRuntime]);
 
   const runAgentCreation = useCallback(
     (request: Omit<CreateAgentRequest, "creationIntentId">) => {
@@ -227,7 +236,7 @@ export function OnboardingPage({
             }}
             onAgentDisplayNameChange={setAgentDisplayName}
             onCreateAgent={(current) => runAgentCreation(normalizedAgentRequest(current, agentDisplayName))}
-            onReload={reload}
+            onReload={attendedReload}
             refreshPending={refreshPending}
             snapshot={loadState.snapshot}
             state={resolved.state}

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -28,6 +28,11 @@ import {
 
 const FEISHU_BOT_APP_LINK = "https://applink.feishu.cn/client/bot/open";
 const CREATE_INTENT_VERSION = 1;
+/** A Computer republishes Provider readiness about twice a minute, so a slower poll loses nothing. */
+const RUNTIME_POLL_INTERVAL_MS = 5_000;
+const RUNTIME_POLL_LIMIT_MS = 10 * 60 * 1_000;
+/** States that only an action taken outside this page can advance, and that no child polls for. */
+const RUNTIME_WAIT_STATES: readonly OnboardingCurrentState["kind"][] = ["provider", "agent-runtime"];
 
 type PageLoadState =
   | { readonly kind: "loading" }
@@ -135,6 +140,22 @@ export function OnboardingPage({
     if (loadState.kind !== "ready") return undefined;
     return resolveSnapshot(membership, loadState.snapshot);
   }, [loadState, membership]);
+
+  const waitingForRuntime = resolved !== undefined && RUNTIME_WAIT_STATES.includes(resolved.state.currentState.kind);
+  useEffect(() => {
+    if (!waitingForRuntime) return;
+    let elapsedMs = 0;
+    const timer = window.setInterval(() => {
+      elapsedMs += RUNTIME_POLL_INTERVAL_MS;
+      // A page left open indefinitely stops polling; focus, visibility, and the explicit control still reload.
+      if (elapsedMs >= RUNTIME_POLL_LIMIT_MS) {
+        window.clearInterval(timer);
+        return;
+      }
+      if (document.visibilityState !== "hidden") reload();
+    }, RUNTIME_POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [reload, waitingForRuntime]);
 
   const runAgentCreation = useCallback(
     (request: Omit<CreateAgentRequest, "creationIntentId">) => {

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -151,6 +151,7 @@ export function OnboardingPage({
   }, [loadState, membership]);
 
   const waitingForRuntime = resolved !== undefined && RUNTIME_WAIT_STATES.includes(resolved.state.currentState.kind);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: attendedWindow deliberately restarts the bounded window.
   useEffect(() => {
     if (!waitingForRuntime) return;
     let elapsedMs = 0;


### PR DESCRIPTION
## Summary

Onboarding refreshed Server facts on focus, visibility, and the explicit control only. A Computer prepared from another machine never blurs the browser window, so the page stayed on the Provider step until someone clicked `Check again`.

- poll the same authoritative facts while the page shows a state only an outside action can advance (`provider`, `agent-runtime`)
- pause while the tab is hidden, and stop after ten minutes so an abandoned page goes quiet
- leave the Computer and Feishu steps to the pollers their own components already own

A Computer republishes Provider readiness about twice a minute (`RUNTIME_CLIENT_CAPABILITY_TTL_MS / 2`), so a five-second poll loses nothing and no client change is needed.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test`
- `pnpm --filter @opentag/web test` — new cases cover advancing without a manual check, not polling a state that waits on the user, and stopping after ten minutes
- `node scripts/e2e/onboarding-e2e.mjs` — 16/16 steps

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzHQwLVMKFoRoA4b9c9g4E)_