### PR TITLE
fix(web): hand a finished onboarding back to the application

### DIFF
--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -203,6 +203,34 @@ describe("OnboardingPage", () => {
     expect(await screen.findByRole("heading", { name: "OpenTag is ready" })).toBeTruthy();
   });
 
+  it("hands a completed setup over to the Agent it created", async () => {
+    installFacts({
+      agents: [agent],
+      computers: [
+        {
+          ...computerA,
+          providerReadiness: [{ provider: "codex", status: "ready", observedAt: "2026-08-20T00:00:00.000Z" }],
+        },
+      ],
+      handoff: { bindingState: "active", handoffReady: true },
+    });
+    render(<OnboardingPage membership={admin} user={user} />);
+    expect(await screen.findByRole("heading", { name: "OpenTag is ready" })).toBeTruthy();
+
+    const manage = screen.getByRole("link", { name: "Manage this Agent" }) as HTMLAnchorElement;
+    expect(new URL(manage.href).pathname).toBe(`/agents/${agentId}/general`);
+    expect(screen.getByRole("link", { name: "Open Feishu" })).toBeTruthy();
+  });
+
+  it("leaves the application reachable from the page header", async () => {
+    installFacts();
+    renderPage();
+    expect(await screen.findByRole("heading", { name: "Connect a Local Computer" })).toBeTruthy();
+
+    const brand = screen.getByRole("link", { name: "OpenTag" }) as HTMLAnchorElement;
+    expect(new URL(brand.href).pathname).toBe("/agents");
+  });
+
   it("shows Provider recovery when authoritative facts say no route is runnable", async () => {
     installFacts({ computers: [computerA] });
     renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: false }]) });

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -28,6 +28,12 @@ import {
 
 const FEISHU_BOT_APP_LINK = "https://applink.feishu.cn/client/bot/open";
 const CREATE_INTENT_VERSION = 1;
+/** The application route this page hands the Team over to once setup is complete. */
+const AGENTS_ROUTE = "/agents";
+
+function agentGeneralRoute(agentId: string): string {
+  return `${AGENTS_ROUTE}/${agentId}/general`;
+}
 
 type PageLoadState =
   | { readonly kind: "loading" }
@@ -231,7 +237,7 @@ function OnboardingHeader({ user }: { user: UserProfile }) {
   }
   return (
     <header className="onboarding-header">
-      <a className="brand" href="/onboarding">
+      <a className="brand" href={AGENTS_ROUTE}>
         OpenTag
       </a>
       <div className="onboarding-account">
@@ -538,9 +544,14 @@ function OnboardingContent({
       title="OpenTag is ready"
       description="Add the Bot to a Feishu group, then mention OpenTag with your first task."
     >
-      <a className="button" href={FEISHU_BOT_APP_LINK} rel="noreferrer" target="_blank">
-        Open Feishu
-      </a>
+      <div className="actions">
+        <a className="button" href={FEISHU_BOT_APP_LINK} rel="noreferrer" target="_blank">
+          Open Feishu
+        </a>
+        <a className="button secondary" href={agentGeneralRoute(current.agent.id)}>
+          Manage this Agent
+        </a>
+      </div>
       <p className="onboarding-helper">Setup is complete.</p>
     </ActionSection>
   );


### PR DESCRIPTION
## Summary

The completed page offered only an external Feishu link, and its header brand linked to onboarding itself, so a Team that finished setup had no way into the application it had just prepared.

- link the created Agent from the ready state
- point the header brand at the Agent list

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test`
- `pnpm --filter @opentag/web test` — new cases assert the ready state links `/agents/<id>/general` and the header brand links `/agents`

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzHQwLVMKFoRoA4b9c9g4E)_