### PR TITLE
fix(web): tell a member which admin can finish onboarding

### DIFF
--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -280,10 +280,10 @@ describe("OnboardingPage", () => {
   });
 
   it.each([
-    [["Ada"], "Ada can complete this action."],
-    [["Ada", "Grace"], "Ada or Grace can complete this action."],
-    [["Ada", "Grace", "Linus"], "Ada, Grace, or 1 more Team admin can complete this action."],
-    [["Ada", "Grace", "Linus", "Ken"], "Ada, Grace, or 2 more Team admins can complete this action."],
+    [["Ada"], "Ask a Team admin to continue: Ada."],
+    [["Ada", "Grace"], "Ask a Team admin to continue: Ada or Grace."],
+    [["Ada", "Grace", "Linus"], "Ask a Team admin to continue: Ada, Grace, or 1 more."],
+    [["Ada", "Grace", "Linus", "Ken"], "Ask a Team admin to continue: Ada, Grace, or 2 more."],
   ])("names the admins a member can ask", async (names, expected) => {
     installFacts({
       agents: [agent],
@@ -300,6 +300,22 @@ describe("OnboardingPage", () => {
 
     expect(await screen.findByRole("heading", { name: "Connect OpenTag to Feishu" })).toBeTruthy();
     expect(screen.getByText(`${expected} Your factual progress will update here.`)).toBeTruthy();
+  });
+
+  it("does not claim a named admin can finish a step tied to one Computer owner", async () => {
+    const ownerAdminId = "00000001-0000-4000-8000-000000000001";
+    installFacts({
+      computers: [{ ...computerA, ownerUserId: ownerAdminId, ownerDisplayName: "Ada" }],
+      members: [teamAdmin("Ada", ownerAdminId), teamAdmin("Grace", "00000002-0000-4000-8000-000000000002")],
+    });
+    renderPage({
+      membership: member,
+      runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: false }]),
+    });
+
+    expect(await screen.findByRole("heading", { name: "Prepare Codex or Claude Code" })).toBeTruthy();
+    expect(screen.getByText(/Ask a Team admin to continue: Ada or Grace\./)).toBeTruthy();
+    expect(screen.queryByText(/can complete this action/)).toBeNull();
   });
 
   it("keeps a member's facts readable when the member list is unavailable", async () => {

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -6,6 +6,7 @@ import type {
   ImBindingHandoffStatus,
   MeMembership,
   TeamComputerSummary,
+  TeamMemberSummary,
   UserProfile,
 } from "@opentag/shared/browser";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -98,15 +99,22 @@ function installFacts({
   agents = [],
   computers = [],
   handoff,
+  members = [],
 }: {
   agents?: AgentSummary[];
   computers?: TeamComputerSummary[];
   handoff?: ImBindingHandoffStatus;
+  members?: TeamMemberSummary[];
 } = {}) {
   vi.spyOn(browserApi, "computers").mockResolvedValue({ computers });
   vi.spyOn(browserApi, "agents").mockResolvedValue({ agents });
   vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(handoff);
+  vi.spyOn(browserApi, "members").mockResolvedValue({ members });
   vi.spyOn(browserApi, "logout").mockResolvedValue();
+}
+
+function teamAdmin(displayName: string, id: string): TeamMemberSummary {
+  return { userId: id, displayName, role: "admin" };
 }
 
 function renderPage({
@@ -269,6 +277,50 @@ describe("OnboardingPage", () => {
     expect(screen.getByText("Read only")).toBeTruthy();
     expect(screen.getByText(/A Team admin can complete this action/)).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Feishu/ })).toBeNull();
+  });
+
+  it.each([
+    [["Ada"], "Ada can complete this action."],
+    [["Ada", "Grace"], "Ada or Grace can complete this action."],
+    [["Ada", "Grace", "Linus"], "Ada, Grace, or 1 more Team admin can complete this action."],
+    [["Ada", "Grace", "Linus", "Ken"], "Ada, Grace, or 2 more Team admins can complete this action."],
+  ])("names the admins a member can ask", async (names, expected) => {
+    installFacts({
+      agents: [agent],
+      computers: [computerA],
+      members: [
+        ...names.map((name, index) => teamAdmin(name, `0000000${index}-0000-4000-8000-00000000000${index}`)),
+        { userId, displayName: "Ada Member", role: "member" },
+      ],
+    });
+    renderPage({
+      membership: member,
+      runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]),
+    });
+
+    expect(await screen.findByRole("heading", { name: "Connect OpenTag to Feishu" })).toBeTruthy();
+    expect(screen.getByText(`${expected} Your factual progress will update here.`)).toBeTruthy();
+  });
+
+  it("keeps a member's facts readable when the member list is unavailable", async () => {
+    installFacts({ agents: [agent], computers: [computerA] });
+    vi.spyOn(browserApi, "members").mockRejectedValue(new Error("Members unavailable"));
+    renderPage({
+      membership: member,
+      runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]),
+    });
+
+    expect(await screen.findByRole("heading", { name: "Connect OpenTag to Feishu" })).toBeTruthy();
+    expect(screen.getByText(/A Team admin can complete this action/)).toBeTruthy();
+  });
+
+  it("does not ask for the member list when the viewer manages the Team", async () => {
+    installFacts({ agents: [agent], computers: [computerA] });
+    const members = vi.spyOn(browserApi, "members");
+    renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]) });
+
+    expect(await screen.findByRole("heading", { name: "Connect OpenTag to Feishu" })).toBeTruthy();
+    expect(members).not.toHaveBeenCalled();
   });
 
   it("keeps OpenTag editable and waits for the explicit Agent creation action", async () => {

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -611,13 +611,18 @@ function ReadOnlyCopy({ admins }: { admins: readonly string[] }) {
   return <p className="notice">{`${adminGuidance(admins)} Your factual progress will update here.`}</p>;
 }
 
-/** Names at most two admins so the sentence stays readable in a large Team. */
+/**
+ * Names people to ask, not people who can act: whether a given admin can finish
+ * the current step also depends on facts this page does not decide, such as who
+ * owns the Computer the route runs on. At most two names keep the sentence
+ * readable in a large Team.
+ */
 function adminGuidance(admins: readonly string[]): string {
   const [first, second, ...rest] = admins;
   if (!first) return "A Team admin can complete this action.";
-  if (!second) return `${first} can complete this action.`;
-  if (rest.length === 0) return `${first} or ${second} can complete this action.`;
-  return `${first}, ${second}, or ${rest.length} more Team ${rest.length === 1 ? "admin" : "admins"} can complete this action.`;
+  if (!second) return `Ask a Team admin to continue: ${first}.`;
+  if (rest.length === 0) return `Ask a Team admin to continue: ${first} or ${second}.`;
+  return `Ask a Team admin to continue: ${first}, ${second}, or ${rest.length} more.`;
 }
 
 function FeishuAction({

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -41,6 +41,8 @@ interface OnboardingSnapshot {
   readonly targetCandidates: readonly AgentSummary[];
   readonly handoff: OnboardingFacts["handoff"];
   readonly runtime: RuntimeFactsResult;
+  /** Team admins a member can ask; empty whenever the viewer manages the Team. */
+  readonly admins: readonly string[];
 }
 
 interface RouteSelection {
@@ -96,7 +98,7 @@ export function OnboardingPage({
   useEffect(() => {
     let active = true;
     setLoadState((current) => (current.kind === "ready" ? current : { kind: "loading" }));
-    void loadSnapshot(membership.teamId, runtimeFacts).then(
+    void loadSnapshot(membership.teamId, runtimeFacts, membership.role !== "admin").then(
       (snapshot) => {
         if (!active) return;
         refreshInFlight.current = false;
@@ -311,7 +313,7 @@ function OnboardingContent({
             ))}
           </div>
         ) : (
-          <ReadOnlyCopy />
+          <ReadOnlyCopy admins={snapshot.admins} />
         )}
       </ActionSection>
     );
@@ -335,7 +337,7 @@ function OnboardingContent({
         title="Connect a Local Computer"
         description="Run one secure command in Terminal. OpenTag continues when the Computer connects."
       >
-        <ReadOnlyCopy />
+        <ReadOnlyCopy admins={snapshot.admins} />
       </ActionSection>
     );
   }
@@ -346,7 +348,11 @@ function OnboardingContent({
         title="Reconnect your Computer"
         description={`Open OpenTag on ${current.computers.map((computer) => computer.displayName).join(", ")}.`}
       >
-        {canManage ? <ReloadButton pending={refreshPending} onReload={onReload} /> : <ReadOnlyCopy />}
+        {canManage ? (
+          <ReloadButton pending={refreshPending} onReload={onReload} />
+        ) : (
+          <ReadOnlyCopy admins={snapshot.admins} />
+        )}
       </ActionSection>
     );
   }
@@ -380,7 +386,7 @@ function OnboardingContent({
             })}
           </div>
         ) : (
-          <ReadOnlyCopy />
+          <ReadOnlyCopy admins={snapshot.admins} />
         )}
       </ActionSection>
     );
@@ -400,7 +406,11 @@ function OnboardingContent({
             : `Finish Provider setup on ${current.computer.displayName}, then check again.`)
         }
       >
-        {canManage ? <ReloadButton pending={refreshPending} onReload={onReload} /> : <ReadOnlyCopy />}
+        {canManage ? (
+          <ReloadButton pending={refreshPending} onReload={onReload} />
+        ) : (
+          <ReadOnlyCopy admins={snapshot.admins} />
+        )}
       </ActionSection>
     );
   }
@@ -412,7 +422,7 @@ function OnboardingContent({
           title="Create the Team Agent"
           description={`The runnable route is ${providerLabel(current.provider.provider)} on ${current.computer.displayName}.`}
         >
-          <ReadOnlyCopy />
+          <ReadOnlyCopy admins={snapshot.admins} />
         </ActionSection>
       );
     }
@@ -512,7 +522,11 @@ function OnboardingContent({
             : "The Agent identity and Feishu setup are unchanged. Restore its bound Computer and Provider, then check again."
         }
       >
-        {canManage ? <ReloadButton pending={refreshPending} onReload={onReload} /> : <ReadOnlyCopy />}
+        {canManage ? (
+          <ReloadButton pending={refreshPending} onReload={onReload} />
+        ) : (
+          <ReadOnlyCopy admins={snapshot.admins} />
+        )}
       </ActionSection>
     );
   }
@@ -528,7 +542,7 @@ function OnboardingContent({
             {(control) => <FeishuAction control={control} progress={current.progress} />}
           </FeishuSetup>
         ) : (
-          <ReadOnlyCopy />
+          <ReadOnlyCopy admins={snapshot.admins} />
         )}
       </ActionSection>
     );
@@ -593,8 +607,17 @@ function ReloadButton({ onReload, pending }: { onReload: () => void; pending: bo
   );
 }
 
-function ReadOnlyCopy() {
-  return <p className="notice">A Team admin can complete this action. Your factual progress will update here.</p>;
+function ReadOnlyCopy({ admins }: { admins: readonly string[] }) {
+  return <p className="notice">{`${adminGuidance(admins)} Your factual progress will update here.`}</p>;
+}
+
+/** Names at most two admins so the sentence stays readable in a large Team. */
+function adminGuidance(admins: readonly string[]): string {
+  const [first, second, ...rest] = admins;
+  if (!first) return "A Team admin can complete this action.";
+  if (!second) return `${first} can complete this action.`;
+  if (rest.length === 0) return `${first} or ${second} can complete this action.`;
+  return `${first}, ${second}, or ${rest.length} more Team ${rest.length === 1 ? "admin" : "admins"} can complete this action.`;
 }
 
 function FeishuAction({
@@ -631,8 +654,16 @@ function handoffTitle(current: Extract<OnboardingCurrentState, { kind: "handoff"
     : "Repair Feishu authorization";
 }
 
-async function loadSnapshot(teamId: string, runtimeFacts: RuntimeFactsAdapter): Promise<OnboardingSnapshot> {
-  const [{ computers }, { agents }] = await Promise.all([browserApi.computers(teamId), browserApi.agents(teamId)]);
+async function loadSnapshot(
+  teamId: string,
+  runtimeFacts: RuntimeFactsAdapter,
+  withAdmins: boolean,
+): Promise<OnboardingSnapshot> {
+  const [{ computers }, { agents }, admins] = await Promise.all([
+    browserApi.computers(teamId),
+    browserApi.agents(teamId),
+    withAdmins ? loadTeamAdmins(teamId) : Promise.resolve<readonly string[]>([]),
+  ]);
   const targetCandidates = agents.filter((agent) => agent.status === "active");
   const remembered = readTargetAgent(teamId);
   const targetAgent =
@@ -643,7 +674,21 @@ async function loadSnapshot(teamId: string, runtimeFacts: RuntimeFactsAdapter): 
     runtimeFacts.load({ teamId, agents, computers }),
     targetAgent ? browserApi.imBindingHandoff(targetAgent.id) : Promise.resolve(undefined),
   ]);
-  return { agents, computers, targetAgent, targetCandidates, handoff, runtime };
+  return { agents, computers, targetAgent, targetCandidates, handoff, runtime, admins };
+}
+
+/**
+ * Names the admins a member can ask. Their absence only costs the member a
+ * name, so an unavailable member list degrades to the generic guidance instead
+ * of failing the page's authoritative facts.
+ */
+async function loadTeamAdmins(teamId: string): Promise<readonly string[]> {
+  try {
+    const { members } = await browserApi.members(teamId);
+    return members.filter((member) => member.role === "admin").map((member) => member.displayName);
+  } catch {
+    return [];
+  }
 }
 
 function resolveSnapshot(membership: MeMembership, snapshot: OnboardingSnapshot): { state: OnboardingState } {


### PR DESCRIPTION
## Summary

The read-only state told a member that "a Team admin" could act, without naming one, so a member had no next step.

- name the Team admins the member can ask, from the member list the Server already exposes to any active member
- fetch that list only for a viewer who cannot manage the Team
- fall back to the current guidance when the list is unavailable, instead of failing the page's authoritative facts

The sentence names at most two admins and counts the rest, so it stays readable in a large Team.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test`
- `pnpm --filter @opentag/web test` — new cases cover one, two, three, and four admins, an unavailable member list, and no member request for a viewer who manages the Team

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzHQwLVMKFoRoA4b9c9g4E)_