### PR TITLE
fix(cli): tolerate launchd activation races

### DIFF
--- a/apps/cli/src/__tests__/daemon-service-renderers.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-renderers.test.ts
@@ -665,6 +665,41 @@ describe("launchd service backend", () => {
     );
   });
 
+  it("fails activation immediately when launchctl status times out", async () => {
+    const userHome = await temporaryDirectory("opentag-launchd-");
+    const home = join(userHome, ".opentag");
+    let loaded = false;
+    let activationChecks = 0;
+    const wait = vi.fn(async () => undefined);
+    const runner = fakeRunner((_, args) => {
+      if (args[0] === "print" && args[1] === "gui/501") return result(0, "domain", "");
+      if (args[0] === "print") {
+        if (!loaded) return result(113, "", "Could not find service");
+        activationChecks += 1;
+        return { code: null, stderr: "", stdout: "", timedOut: true };
+      }
+      if (args[0] === "bootout") return result(3, "", "Boot-out failed: 3: No such process");
+      if (args[0] === "bootstrap") loaded = true;
+      return result(0, "", "");
+    });
+    const backend = createLaunchdBackend({
+      activationAttempts: 50,
+      activationDelayMs: 100,
+      evictionDelayMs: 0,
+      home,
+      invocation: { args: [], program: "/usr/local/bin/opentag" },
+      runner,
+      serviceId: "opentag",
+      sleep: wait,
+      uid: 501,
+      userHome,
+    });
+
+    await expect(backend.installAndStart()).rejects.toThrow("launchd activation status check timed out");
+    expect(activationChecks).toBe(1);
+    expect(wait).not.toHaveBeenCalled();
+  });
+
   it("reports a loaded waiting LaunchAgent without a PID as inactive", async () => {
     const userHome = await temporaryDirectory("opentag-launchd-");
     const home = join(userHome, ".opentag");

--- a/apps/cli/src/__tests__/daemon-service-renderers.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-renderers.test.ts
@@ -553,6 +553,118 @@ describe("launchd service backend", () => {
     expect(plist).not.toContain("relative");
   });
 
+  it("treats launchctl bootout no such process as an already unloaded service", async () => {
+    const userHome = await temporaryDirectory("opentag-launchd-");
+    const home = join(userHome, ".opentag");
+    const calls: string[] = [];
+    let loaded = false;
+    const runner = fakeRunner((_, args) => {
+      calls.push(args.join(" "));
+      if (args[0] === "print" && args[1] === "gui/501") return result(0, "domain", "");
+      if (args[0] === "print") {
+        return loaded ? result(0, "state = running\npid = 77", "") : result(113, "", "Could not find service");
+      }
+      if (args[0] === "bootout") return result(3, "", "Boot-out failed: 3: No such process");
+      if (args[0] === "bootstrap") loaded = true;
+      return result(0, "", "");
+    });
+    const backend = createLaunchdBackend({
+      activationDelayMs: 0,
+      evictionDelayMs: 0,
+      home,
+      invocation: { args: [], program: "/usr/local/bin/opentag" },
+      runner,
+      serviceId: "opentag",
+      sleep: async () => undefined,
+      uid: 501,
+      userHome,
+    });
+
+    await expect(backend.installAndStart()).resolves.toMatchObject({ pid: 77, state: "active" });
+    expect(calls).toContain("bootout gui/501/opentag");
+    expect(calls).toContain(`bootstrap gui/501 ${join(userHome, "Library", "LaunchAgents", "opentag.plist")}`);
+  });
+
+  it.each(["installAndStart", "start", "restart"] as const)(
+    "waits for launchd to leave xpcproxy after %s",
+    async (mutation) => {
+      const userHome = await temporaryDirectory("opentag-launchd-");
+      const home = join(userHome, ".opentag");
+      const invocation = { args: [], program: "/usr/local/bin/opentag" };
+      if (mutation !== "installAndStart") await writeLaunchdDefinitions({ home, invocation, userHome });
+      let loaded = mutation === "restart";
+      let activationChecks = 0;
+      let activating = false;
+      const wait = vi.fn(async () => undefined);
+      const runner = fakeRunner((_, args) => {
+        if (args[0] === "print" && args[1] === "gui/501") return result(0, "domain", "");
+        if (args[0] === "print") {
+          if (!loaded) return result(113, "", "Could not find service");
+          if (activating && activationChecks < 2) {
+            activationChecks += 1;
+            return result(0, "state = xpcproxy", "");
+          }
+          return result(0, "state = running\npid = 91", "");
+        }
+        if (args[0] === "bootout") {
+          loaded = false;
+          return result(0, "", "");
+        }
+        if (args[0] === "bootstrap" || args[0] === "kickstart") {
+          activating = true;
+          loaded = true;
+        }
+        return result(0, "", "");
+      });
+      const backend = createLaunchdBackend({
+        activationAttempts: 3,
+        activationDelayMs: 0,
+        evictionDelayMs: 0,
+        home,
+        invocation,
+        runner,
+        serviceId: "opentag",
+        sleep: wait,
+        uid: 501,
+        userHome,
+      });
+
+      await expect(backend[mutation]()).resolves.toMatchObject({ pid: 91, state: "active" });
+      expect(wait).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("fails activation with the last launchd state after a bounded wait", async () => {
+    const userHome = await temporaryDirectory("opentag-launchd-");
+    const home = join(userHome, ".opentag");
+    const invocation = { args: [], program: "/usr/local/bin/opentag" };
+    await writeLaunchdDefinitions({ home, invocation, userHome });
+    let loaded = false;
+    const runner = fakeRunner((_, args) => {
+      if (args[0] === "print" && args[1] === "gui/501") return result(0, "domain", "");
+      if (args[0] === "print") {
+        return loaded ? result(0, "state = xpcproxy", "") : result(113, "", "Could not find service");
+      }
+      if (args[0] === "bootstrap") loaded = true;
+      return result(0, "", "");
+    });
+    const backend = createLaunchdBackend({
+      activationAttempts: 2,
+      activationDelayMs: 0,
+      home,
+      invocation,
+      runner,
+      serviceId: "opentag",
+      sleep: async () => undefined,
+      uid: 501,
+      userHome,
+    });
+
+    await expect(backend.start()).rejects.toThrow(
+      "last state: inactive (LaunchAgent is loaded but process state is xpcproxy)",
+    );
+  });
+
   it("reports a loaded waiting LaunchAgent without a PID as inactive", async () => {
     const userHome = await temporaryDirectory("opentag-launchd-");
     const home = join(userHome, ".opentag");

--- a/apps/cli/src/core/daemon/service/launchd.ts
+++ b/apps/cli/src/core/daemon/service/launchd.ts
@@ -21,6 +21,8 @@ import { DaemonServiceError } from "./types.js";
 const LAUNCHD_TIMEOUT_MS = 15_000;
 
 export interface LaunchdBackendOptions {
+  activationAttempts?: number;
+  activationDelayMs?: number;
   evictionAttempts?: number;
   evictionDelayMs?: number;
   home: string;
@@ -107,6 +109,8 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
     wrapperPath,
   });
   const wait = options.sleep ?? sleep;
+  const activationAttempts = options.activationAttempts ?? 50;
+  const activationDelayMs = options.activationDelayMs ?? 100;
   const evictionAttempts = options.evictionAttempts ?? 20;
   const evictionDelayMs = options.evictionDelayMs ?? 100;
 
@@ -212,6 +216,20 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
     }
   };
 
+  const waitForActivation = async (): Promise<DaemonServiceInfo> => {
+    let current: DaemonServiceInfo | undefined;
+    for (let attempt = 0; attempt < activationAttempts; attempt += 1) {
+      current = await status();
+      if (current.state === "active") return current;
+      if (attempt + 1 < activationAttempts) await wait(activationDelayMs);
+    }
+    const lastState = current ? `; last state: ${current.state}${current.detail ? ` (${current.detail})` : ""}` : "";
+    throw new DaemonServiceError(
+      "OPERATION_FAILED",
+      `launchd reported that the OpenTag service did not become active${lastState}`,
+    );
+  };
+
   return {
     platform: "launchd",
     preflight,
@@ -224,14 +242,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
       await waitForEviction();
       await bootstrap();
       await runRequired(options.runner, launchctl, ["enable", target], "launchd enable");
-      const current = await status();
-      if (current.state !== "active") {
-        throw new DaemonServiceError(
-          "OPERATION_FAILED",
-          "launchd reported that the OpenTag service did not become active",
-        );
-      }
-      return current;
+      return waitForActivation();
     },
     async start() {
       await preflight();
@@ -254,7 +265,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
           `launchd start state check failed: ${loaded.stderr || "unknown error"}`,
         );
       }
-      return status();
+      return waitForActivation();
     },
     async stop() {
       if ((await readRegularFile(plistPath)) === undefined) return info("not-installed", { drifted: true });
@@ -270,7 +281,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
       await bootout();
       await waitForEviction();
       await bootstrap();
-      return status();
+      return waitForActivation();
     },
     status,
     async uninstall() {

--- a/apps/cli/src/core/daemon/service/launchd.ts
+++ b/apps/cli/src/core/daemon/service/launchd.ts
@@ -114,11 +114,14 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
   const evictionAttempts = options.evictionAttempts ?? 20;
   const evictionDelayMs = options.evictionDelayMs ?? 100;
 
-  const status = async (): Promise<DaemonServiceInfo> => {
+  const readStatus = async (failOnTimeout = false): Promise<DaemonServiceInfo> => {
     const plist = await readRegularFile(plistPath);
     if (plist === undefined) {
       const orphaned = await options.runner.run(launchctl, ["print", target], { timeoutMs: LAUNCHD_TIMEOUT_MS });
       if (orphaned.timedOut) {
+        if (failOnTimeout) {
+          throw new DaemonServiceError("OPERATION_FAILED", "launchd activation status check timed out");
+        }
         return info("unknown", {
           detail: "launchctl could not verify whether a definition-less service target is loaded",
           drifted: true,
@@ -147,7 +150,12 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
     }
     const result = await options.runner.run(launchctl, ["print", target], { timeoutMs: LAUNCHD_TIMEOUT_MS });
     const drifted = plist !== expectedPlist || wrapper !== expectedWrapper;
-    if (result.timedOut) return info("unknown", { configuredHome, detail: "launchctl print timed out", drifted });
+    if (result.timedOut) {
+      if (failOnTimeout) {
+        throw new DaemonServiceError("OPERATION_FAILED", "launchd activation status check timed out");
+      }
+      return info("unknown", { configuredHome, detail: "launchctl print timed out", drifted });
+    }
     if (result.code !== 0) {
       return isManagerNotLoaded(result)
         ? info("inactive", { configuredHome, drifted })
@@ -172,6 +180,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
       drifted,
     });
   };
+  const status = (): Promise<DaemonServiceInfo> => readStatus();
 
   const preflight = async (): Promise<void> => {
     const result = await options.runner.run(launchctl, ["print", domain], { timeoutMs: LAUNCHD_TIMEOUT_MS });
@@ -219,7 +228,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
   const waitForActivation = async (): Promise<DaemonServiceInfo> => {
     let current: DaemonServiceInfo | undefined;
     for (let attempt = 0; attempt < activationAttempts; attempt += 1) {
-      current = await status();
+      current = await readStatus(true);
       if (current.state === "active") return current;
       if (attempt + 1 < activationAttempts) await wait(activationDelayMs);
     }

--- a/apps/cli/src/core/daemon/service/shared.ts
+++ b/apps/cli/src/core/daemon/service/shared.ts
@@ -276,7 +276,10 @@ export function isManagerNotLoaded(result: CommandResult): boolean {
   const detail = `${result.stdout}\n${result.stderr}`.toLowerCase();
   return (
     result.code !== 0 &&
-    (detail.includes("not loaded") || detail.includes("could not find service") || detail.includes("not found"))
+    (detail.includes("not loaded") ||
+      detail.includes("could not find service") ||
+      detail.includes("not found") ||
+      detail.includes("no such process"))
   );
 }
 


### PR DESCRIPTION
## Summary

- treat launchctl's `No such process` bootout response as an already-unloaded service so fresh installs can continue to bootstrap
- wait for launchd to move from transient `xpcproxy` state to an active daemon after install, start, and restart
- retry responsive status checks with a bounded attempt count, fail on the first timed-out status command, and include the last observed state when responsive checks never become active
- cover the fresh-install response, all three activation paths, timeout fail-fast behavior, and bounded responsive-state exhaustion

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm check` (passes; reports 8 pre-existing E2E environment-variable warnings)
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter open-tag exec vitest run src/__tests__/daemon-service-renderers.test.ts --maxWorkers=1 -t 'launchd service backend'` (14/14 passed)
- `TMPDIR=<real non-symlink directory> pnpm --filter open-tag test` (119/119 passed)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (273/273 passed; 100% statements, branches, functions, and lines)
- `pnpm test` (default local macOS run: 116/118 CLI tests passed; two pre-existing assertions compare `/tmp` or `/var` with canonical `/private/tmp` or `/private/var` paths)
- `pnpm test:coverage` (1055/1059 passed; the same path-alias issue accounts for all four failures across CLI and client tests)

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (`pnpm test` has the disclosed macOS path-alias baseline failures; package tests pass with a real temp path.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
