### PR TITLE
feat: lazily materialize thread sessions from inbound evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ This repository currently provides the engineering foundation and first control-
 - one-time connect-code login with sliding stateless refresh JWTs;
 - explicit Team membership, role, leave/remove/restore, and seven-day invitation lifecycles;
 - user-owned Computer registration and presence;
-- Team-owned Agent registry with immutable Computer/provider binding and revision fencing; and
+- Team-owned Agent registry with immutable Computer/provider binding and revision fencing;
+- durable Agent Runtime execution, delivery custody, reporting, and recovery;
+- Feishu and Slack inbound normalization, persistence, and Channel/Thread Session routing;
+- direct provider CLI credential handoff for Agent-controlled replies and reactions; and
 - a same-origin, read-only Admin Web plus `doctor`, `login`, `team`, `agent`, `computer`, and daemon service management commands.
 
-Agent execution, Feishu/Slack integrations, IM persistence, and session runtimes are not implemented yet.
+These runtime and messaging paths are implemented but remain pre-alpha. Installation, administration, and end-to-end product workflows are still being completed.
 
 ## Quick start
 
@@ -66,7 +69,7 @@ pnpm --filter open-tag start agent create \
 pnpm --filter open-tag start agent list
 ```
 
-This records the Agent identity and Computer binding only; it does not start a Codex or Claude Code turn.
+This records the Agent identity and Computer binding. Agent Runtime turns start when admitted work is delivered to that Agent.
 
 Team Admins manage model, reasoning effort, and the maximum Turn duration for Codex Agents from the Agent's **Runtime**
 tab or the corresponding `agent update` flags. A blank model or reasoning value leaves the choice to Codex; a blank
@@ -96,15 +99,16 @@ See [DEVELOPMENT.md](./DEVELOPMENT.md) for the full local workflow.
 ## Project status
 
 OpenTag is being built in small, validated vertical slices. Public APIs and package boundaries may change before the
-first stable release. The current code establishes database bootstrap, user authentication, the local Computer
-connection, the Agent registry, account/Team lifecycle, and read-only Admin Web; agent execution and messaging remain
-future vertical slices.
+first stable release. The current code includes the control plane, local Computer connection, Agent Runtime, durable IM
+delivery, Feishu/Slack inbound routing, Channel/Thread Sessions, and direct provider CLI handoff. Product administration
+and broader collaboration workflows remain under development.
 
 ## Documentation
 
 - [Development guide](./DEVELOPMENT.md)
 - [Server observability](./docs/observability.md)
 - [Direct provider CLI messaging](./docs/direct-provider-cli.md)
+- [IM Channel and Thread Sessions](./docs/thread-sessions.md)
 - [Contributing guide](./CONTRIBUTING.md)
 - [Release guide](./docs/releasing.md)
 - [Deployment guide](./docs/deploying.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 # OpenTag
 
 > Canonical source: [README.md](./README.md)
-> Last synced with: 2026-08-20
+> Last synced with: 2026-08-21
 
 OpenTag 是一个全新的独立开源产品，用于连接团队即时通信与 AI 编码 Agent。项目目前处于 **pre-alpha**
 阶段：产品工作流仍在开发中，尚不适合生产使用。
@@ -16,9 +16,12 @@ OpenTag 是一个全新的独立开源产品，用于连接团队即时通信与
 - 显式 Team membership、角色、离开/移除/恢复和七天邀请链接生命周期；
 - 用户所有的 Computer 注册与在线状态；
 - Team 所有的 Agent Registry、不可变 Computer/provider 绑定与 revision fencing；
+- 持久化 Agent Runtime 执行、delivery custody、上报与恢复；
+- 飞书和 Slack 入站标准化、持久化及 Channel/Thread Session 路由；
+- 供 Agent 自主回复和 Reaction 的 provider CLI 凭证交接；
 - 同源只读 Admin Web，以及 `doctor`、`login`、`team`、`agent`、`computer` 和 daemon 服务管理命令。
 
-仓库尚未实现 Agent 执行、飞书/Slack 集成、IM 持久化或 Session Runtime。
+这些 Runtime 与消息路径已经实现，但仍处于 pre-alpha 阶段；安装、管理和端到端产品工作流仍在完善。
 
 ## 快速开始
 
@@ -67,7 +70,7 @@ pnpm --filter open-tag start agent create \
 pnpm --filter open-tag start agent list
 ```
 
-这只会记录 Agent identity 和 Computer binding，不会启动 Codex 或 Claude Code turn。
+这会记录 Agent identity 和 Computer binding。Agent 收到已准入工作后，Agent Runtime turn 才会启动。
 
 Team Admin 可在 Codex Agent 的 **Runtime** 页面或对应的 `agent update` 参数中管理 model、reasoning effort 和单个
 Turn 的最长执行时间。model 或 reasoning 留空表示交由 Codex 管理；duration 留空则使用 OpenTag 的 30 分钟默认值。
@@ -96,14 +99,15 @@ pnpm --filter open-tag start team invitation rotate
 ## 项目状态
 
 OpenTag 正通过小型、可验证的纵向切片逐步构建。首个稳定版本发布前，公开 API 和 package 边界可能变化。
-当前代码已建立数据库 bootstrap、用户认证、本地 Computer 连接、Agent Registry、账号/Team 生命周期和只读
-Admin Web；Agent 执行与即时通信仍属于后续纵向切片。
+当前代码已包含控制面、本地 Computer 连接、Agent Runtime、持久 IM delivery、飞书/Slack 入站路由、
+Channel/Thread Session 与 provider CLI 直接交接。产品管理面和更广泛的协作工作流仍在开发中。
 
 ## 文档
 
 - [开发指南](./DEVELOPMENT.zh-CN.md)
 - [Server 可观测性](./docs/zh-CN/observability.md)
 - [直接使用 Provider CLI 发送消息](./docs/zh-CN/direct-provider-cli.md)
+- [IM Channel 与 Thread Session](./docs/zh-CN/thread-sessions.md)
 - [贡献指南](./CONTRIBUTING.zh-CN.md)
 - [发布指南](./docs/zh-CN/releasing.md)
 - [部署指南](./docs/zh-CN/deploying.md)

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -641,7 +641,7 @@ describe("OpenTag Web App Shell", () => {
     expect(email.value).toBe("ada@example.com");
     expect(email.readOnly).toBe(true);
     fireEvent.change(displayName, { target: { value: "  Ada Lovelace  " } });
-    fireEvent.click(screen.getByRole("button", { name: "Save account profile" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save account profile" }));
 
     await waitFor(() =>
       expect(vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/v1/me")).toHaveLength(3),
@@ -667,7 +667,7 @@ describe("OpenTag Web App Shell", () => {
     const form = displayName.closest("form");
     if (!form) throw new Error("Account form was not rendered");
     fireEvent.change(displayName, { target: { value: "Pending Name" } });
-    fireEvent.submit(form);
+    fireEvent.click(await screen.findByRole("button", { name: "Save account profile" }));
     fireEvent.submit(form);
 
     expect(((await screen.findByRole("button", { name: "Saving…" })) as HTMLButtonElement).disabled).toBe(true);
@@ -685,7 +685,7 @@ describe("OpenTag Web App Shell", () => {
 
     const displayName = (await screen.findByLabelText("Display name")) as HTMLInputElement;
     fireEvent.change(displayName, { target: { value: "Rejected Name" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save account profile" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save account profile" }));
     expect((await screen.findByRole("alert")).textContent).toBe("Display name update failed");
     expect(displayName.value).toBe("Ada");
     expect(screen.getByText("Ada")).toBeTruthy();
@@ -972,7 +972,7 @@ describe("OpenTag Web App Shell", () => {
     const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
     expect(displayName.readOnly).toBe(false);
     fireEvent.change(displayName, { target: { value: "Legacy Account" } });
-    expect(screen.getByRole("button", { name: "Save account profile" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "Save account profile" })).toBeTruthy();
   });
 
   it("keeps unavailable Team capabilities explicit instead of inventing records", async () => {
@@ -1018,7 +1018,7 @@ describe("OpenTag Web App Shell", () => {
     expect(cliIdentifier.textContent).toContain("example");
     expect(within(profileForm).getAllByRole("textbox")).toHaveLength(1);
     fireEvent.change(displayName, { target: { value: "Renamed Team" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save Team profile" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save Team profile" }));
     await waitFor(() =>
       expect(vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/v1/me")).toHaveLength(2),
     );
@@ -1872,7 +1872,7 @@ describe("OpenTag Web App Shell", () => {
     const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
     expect(displayName.readOnly).toBe(false);
     fireEvent.change(displayName, { target: { value: "Account Menu" } });
-    expect(screen.getByRole("button", { name: "Save account profile" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "Save account profile" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Sign out" }));
     expect(await screen.findByRole("heading", { name: "Sign in" })).toBeTruthy();

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -2,7 +2,7 @@
 
 Status: active quality gate
 
-Last updated: 2026-08-20
+Last updated: 2026-08-21
 
 ## Goal and Scope
 
@@ -26,14 +26,14 @@ lowest Client execution layer. It covers these production boundaries:
 Production Client execution now uses this contract through:
 
 - `src/runtime/agent-runtime-provider-registry.ts`
-- `src/runtime/runtime-tool-host.ts`
+- `src/runtime/im-credential-environment-manager.ts`
 - `src/runtime/session-runtime-manager.ts`
 - `src/runtime/agent-turn-runner.ts`
 - `src/runtime/client-runtime-composition.ts`
 
 The required CI coverage gate enforces 100% statements, branches, functions,
 and lines for the contract, all three Provider translations and wire adapters,
-shared process ownership, hosted-tool host, Turn runner, Session Runtime
+shared process ownership, provider credential projection, Turn runner, Session Runtime
 manager, and production Client Runtime composition.
 Coverage is a floor, not the acceptance criterion by itself: production
 composition, crash recovery, protocol behavior, and live local Provider sessions

--- a/docs/thread-sessions.md
+++ b/docs/thread-sessions.md
@@ -1,0 +1,25 @@
+# IM Channel and Thread Sessions
+
+[简体中文](./zh-CN/thread-sessions.md)
+
+OpenTag keeps one long-lived Channel Session per Agent, Integration, and IM channel. A top-level message addressed to the Agent is delivered to that Channel Session; OpenTag does not pre-create a Thread Session or require the Agent to reply in a native thread.
+
+The Agent receives the provider-native message reference and `direct` or `ambient` attention in managed context. Its prompt and conversation context determine whether it replies at the top level, starts or continues a native thread, reacts, sends another message, or takes no provider action. Server routing does not encode Feishu- or Slack-specific reply preferences.
+
+## Lazy Thread continuity
+
+A Thread Session is materialized only after a real inbound provider event carries a thread scope. OpenTag delivers that event directly to the Thread Session when, in priority order:
+
+1. an active Session already owns the same thread;
+2. the current event directly addresses the Agent; or
+3. the provider supplies a reliable root identifier and that inbound root message was previously delivered directly to the same Agent's Channel Session.
+
+Without that evidence, OpenTag does not infer Thread ownership. In `all_message` mode, the Channel Session still receives its independent ambient delivery. Ending a Thread Session blocks old root evidence from implicitly reviving it; a later event that directly addresses the Agent may create a new active Session.
+
+Slack uses `thread_ts` as both the stable thread key and root message identifier. Feishu keeps `thread_id` as the thread key and uses `root_id` only when the provider supplies it; `parent_id` is never guessed to be the root.
+
+## Bootstrap history
+
+The first direct delivery to a newly materialized Thread Session includes bounded, verifiable inbound context: the visible root message when a reliable root identifier exists, followed by prior messages from the same thread. The current message is excluded from history, and sibling threads are not included.
+
+Channel and Thread Sessions remain distinct Runtime scopes. OpenTag does not copy the Channel Runtime transcript, observe Bot outbound messages, or depend on provider CLI send results to create continuity. The Agent can query additional native history with the official provider CLI when needed.

--- a/docs/zh-CN/thread-sessions.md
+++ b/docs/zh-CN/thread-sessions.md
@@ -1,0 +1,26 @@
+# IM Channel 与 Thread Session
+
+> Canonical source: [thread-sessions.md](../thread-sessions.md)
+> Last synced with: 2026-08-21
+
+OpenTag 为每个 Agent、Integration 和 IM channel 保留一个长期 Channel Session。顶层消息直接寻址 Agent 时，消息会进入该 Channel Session；OpenTag 不会提前创建 Thread Session，也不会要求 Agent 必须在 provider 原生 thread 中回复。
+
+Agent 会在 managed context 中收到 provider 原生消息引用和 `direct` 或 `ambient` attention。Agent 根据 prompt 和对话上下文自主决定平级回复、创建或继续原生 thread、Reaction、发送其他消息或不执行 provider 动作。Server routing 不编码飞书或 Slack 的回复偏好。
+
+## 惰性 Thread 连续性
+
+只有真实 provider 入站事件带有 thread scope 时，OpenTag 才物化 Thread Session。系统按以下优先级判断是否把该事件 direct 投递给 Thread Session：
+
+1. 已有 active Session 持有同一 thread；
+2. 当前事件直接寻址 Agent；
+3. provider 提供可靠根消息标识，且该入站根消息此前曾 direct 投递给同一 Agent 的 Channel Session。
+
+没有这些证据时，OpenTag 不推断 Thread 所有权。`all_message` 模式下，Channel Session 仍独立收到 ambient delivery。结束 Thread Session 后，旧的 root 证据不能隐式复活它；后续事件若再次直接寻址 Agent，则可以创建新的 active Session。
+
+Slack 使用 `thread_ts` 同时作为稳定 thread key 和根消息标识。飞书使用 `thread_id` 作为 thread key；只有 provider 提供 `root_id` 时才使用它，绝不把 `parent_id` 猜测成根消息。
+
+## Bootstrap history
+
+新物化 Thread Session 的首次 direct delivery 会包含有界且可验证的入站上下文：若存在可靠根消息标识，则先包含可见根消息，再包含同一 thread 的历史消息。当前消息不会在 history 中重复，sibling thread 也不会混入。
+
+Channel 与 Thread Session 始终是两个不同的 Runtime scope。OpenTag 不复制 Channel Runtime transcript，不观察 Bot 出站消息，也不依赖 provider CLI 发送结果建立连续性。需要更多原生历史时，Agent 可以直接使用官方 provider CLI 查询。

--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -83,6 +83,33 @@ describe("AgentTurnRunner", () => {
     expect(context).toContain("Attention does not change provider CLI or credential availability");
   });
 
+  it("exposes provider-native thread facts without adding a provider reply policy", () => {
+    const slackRequest = delivery();
+    slackRequest.content.providerRef = {
+      ...providerRef("1710000000.000002"),
+      threadTs: "1710000000.000001",
+    };
+    const slackContext = buildAgentInput(slackRequest).items[0]?.text;
+    expect(slackContext).toContain(JSON.stringify(slackRequest.content.providerRef));
+    expect(slackContext).not.toMatch(/Slack.*(?:must|always|default).*(?:thread|reply)/i);
+
+    const feishuRequest = delivery();
+    feishuRequest.content.providerRef = {
+      provider: "feishu",
+      teamBrand: "feishu",
+      appId: "cli_1",
+      botOpenId: "ou_bot",
+      chatId: "oc_1",
+      messageId: "om_reply",
+      threadId: "omt_1",
+      rootId: "om_root",
+      parentId: "om_parent",
+    };
+    const feishuContext = buildAgentInput(feishuRequest).items[0]?.text;
+    expect(feishuContext).toContain(JSON.stringify(feishuRequest.content.providerRef));
+    expect(feishuContext).not.toMatch(/Feishu.*(?:must|always|default).*(?:thread|reply)/i);
+  });
+
   it("maps every typed Agent result and abort reason to the stable Turn taxonomy", () => {
     const result = (status: AgentRunResult["status"], overrides: Partial<AgentRunResult> = {}): AgentRunResult => ({
       runId: "turn-1",

--- a/packages/server/src/__tests__/feishu-adapter.test.ts
+++ b/packages/server/src/__tests__/feishu-adapter.test.ts
@@ -40,11 +40,48 @@ describe("Feishu adapter", () => {
       providerEventId: "ev_1",
       externalAppId: "cli_1",
       externalTeamId: "team_1",
+      providerContext: {
+        provider: "feishu",
+        chatType: "group",
+        threadId: "omt_1",
+        rootId: "om_root",
+        parentId: "om_parent",
+      },
       conversation: { externalId: "oc_1", kind: "channel" },
       message: { externalId: "om_1", threadKey: "omt_1", replyToExternalId: "om_parent" },
       mentions: [{ externalId: "ou_bot", displayName: "Agent" }],
     });
     expect(event?.message.resources[0]).toMatchObject({ providerResourceKey: "img_1", kind: "image" });
+  });
+
+  it("preserves a Feishu thread without inventing a missing root", () => {
+    const message: NormalizedMessage = {
+      messageId: "om_reply",
+      chatId: "oc_1",
+      chatType: "group",
+      senderId: "ou_human",
+      content: "reply",
+      rawContentType: "text",
+      resources: [],
+      mentions: [],
+      mentionAll: false,
+      mentionedBot: false,
+      threadId: "omt_1",
+      replyToMessageId: "om_parent",
+      createTime: 1_724_025_600_000,
+      raw: { header: { event_id: "ev_2", tenant_key: "team_1" } },
+    };
+    const [event] = normalizeFeishuMessage({ appId: "cli_1", teamId: "team_1", message });
+    expect(event).toMatchObject({
+      providerContext: {
+        provider: "feishu",
+        chatType: "group",
+        threadId: "omt_1",
+        parentId: "om_parent",
+      },
+      message: { threadKey: "omt_1" },
+    });
+    expect(event?.providerContext).not.toHaveProperty("rootId");
   });
 
   it("uses the external Team authorization response as the capability authority", async () => {

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -16,7 +16,7 @@ import {
   type UpdateAgentRequest,
 } from "@opentag/shared";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
@@ -458,6 +458,39 @@ function revisionEvent(input: {
       },
     },
   };
+}
+
+function slackThreadEvent(input: {
+  providerEventId: string;
+  externalMessageId: string;
+  rootExternalMessageId: string;
+  occurredAt: string;
+  channelId?: string;
+  direct?: boolean;
+  text?: string;
+}): NormalizedInboundImEvent {
+  const event = revisionEvent({
+    providerEventId: input.providerEventId,
+    externalMessageId: input.externalMessageId,
+    operation: "created",
+    occurredAt: input.occurredAt,
+    revisionKey: "1",
+  });
+  event.providerContext = {
+    provider: "slack",
+    channelType: "channel",
+    threadTs: input.rootExternalMessageId,
+  };
+  event.conversation.externalId = input.channelId ?? "C1";
+  event.message.threadKey = input.rootExternalMessageId;
+  event.message.content = {
+    version: 1,
+    fallbackText: input.text ?? input.externalMessageId,
+    blocks: [{ type: "text", text: input.text ?? input.externalMessageId }],
+    truncated: false,
+  };
+  event.mentions = input.direct === true ? [{ externalId: "U_BOT", displayName: "Assistant" }] : [];
+  return event;
 }
 
 describe("IM binding persistence", () => {
@@ -1484,6 +1517,533 @@ describe("IM binding persistence", () => {
           runtime.context,
         ),
       ).resolves.toMatchObject({ status: "recorded" });
+      runtime.domain.close();
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("lazily materializes Slack Thread Sessions from existing, current-direct, or root-direct evidence", async () => {
+    const value = await fixture();
+    try {
+      const inbox = new ImMessageInbox(value.database);
+      const directRoot = revisionEvent({
+        providerEventId: "lazy-root",
+        externalMessageId: "2000.100",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:01.000Z",
+        revisionKey: "1",
+      });
+      expect((await inbox.ingest(value.imBindingId, 1, directRoot)).deliveryIds).toHaveLength(1);
+      expect(await value.database.select().from(sessions)).toEqual([
+        expect.objectContaining({ kind: "channel", threadKey: null }),
+      ]);
+
+      const firstReply = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "lazy-thread-first",
+          externalMessageId: "2000.101",
+          rootExternalMessageId: "2000.100",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+        }),
+      );
+      const [firstThreadDelivery] = await value.database
+        .select({ attention: imMessageDeliveries.attention, sessionId: sessions.id, kind: sessions.kind })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.id, firstReply.deliveryIds[0] as string));
+      expect(firstThreadDelivery).toMatchObject({ attention: "direct", kind: "thread" });
+
+      const followUp = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "lazy-thread-follow-up",
+          externalMessageId: "2000.102",
+          rootExternalMessageId: "2000.100",
+          occurredAt: "2026-08-19T00:00:03.000Z",
+        }),
+      );
+      const [followUpDelivery] = await value.database
+        .select({ attention: imMessageDeliveries.attention, sessionId: sessions.id, kind: sessions.kind })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.id, followUp.deliveryIds[0] as string));
+      expect(followUpDelivery).toEqual({
+        attention: "direct",
+        kind: "thread",
+        sessionId: firstThreadDelivery?.sessionId,
+      });
+
+      const unrelatedRoot = revisionEvent({
+        providerEventId: "unrelated-root",
+        externalMessageId: "3000.100",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:04.000Z",
+        revisionKey: "1",
+      });
+      unrelatedRoot.mentions = [];
+      expect((await inbox.ingest(value.imBindingId, 1, unrelatedRoot)).deliveryIds).toEqual([]);
+      expect(
+        (
+          await inbox.ingest(
+            value.imBindingId,
+            1,
+            slackThreadEvent({
+              providerEventId: "unrelated-thread",
+              externalMessageId: "3000.101",
+              rootExternalMessageId: "3000.100",
+              occurredAt: "2026-08-19T00:00:05.000Z",
+            }),
+          )
+        ).deliveryIds,
+      ).toEqual([]);
+
+      const otherChannelRoot = revisionEvent({
+        providerEventId: "other-channel-root",
+        externalMessageId: "3500.100",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:05.100Z",
+        revisionKey: "1",
+      });
+      otherChannelRoot.conversation.externalId = "C_OTHER";
+      await inbox.ingest(value.imBindingId, 1, otherChannelRoot);
+      expect(
+        (
+          await inbox.ingest(
+            value.imBindingId,
+            1,
+            slackThreadEvent({
+              providerEventId: "other-channel-thread",
+              externalMessageId: "3500.101",
+              rootExternalMessageId: "3500.100",
+              occurredAt: "2026-08-19T00:00:05.200Z",
+            }),
+          )
+        ).deliveryIds,
+      ).toEqual([]);
+
+      const otherAgent = await new AgentService(value.database).createForTeam(
+        value.bootstrap.userId,
+        value.bootstrap.teamId,
+        {
+          name: "other-assistant",
+          displayName: "Other Assistant",
+          runtimeProvider: "codex",
+          computerId: value.computer.id,
+        },
+      );
+      const otherBindingId = await value.imBindingService.activateSlack(
+        {
+          agentId: otherAgent.id,
+          appId: "A2",
+          teamId: "T2",
+          botUserId: "U_OTHER_BOT",
+          grantedBotScopes: [
+            "chat:write",
+            "app_mentions:read",
+            "im:history",
+            "channels:history",
+            "groups:history",
+            "mpim:history",
+          ],
+          botAccessToken: "xoxb-other",
+          signingSecret: "other-signing-secret",
+          installedAt: new Date("2026-08-19T00:00:00.000Z"),
+        },
+        "B_OTHER_BOT",
+      );
+      const otherBindingRoot = revisionEvent({
+        providerEventId: "other-binding-root",
+        externalMessageId: "3600.100",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:05.300Z",
+        revisionKey: "1",
+      });
+      otherBindingRoot.externalAppId = "A2";
+      otherBindingRoot.externalTeamId = "T2";
+      otherBindingRoot.mentions = [{ externalId: "U_OTHER_BOT", displayName: "Other Assistant" }];
+      await inbox.ingest(otherBindingId, 1, otherBindingRoot);
+      expect(
+        (
+          await inbox.ingest(
+            value.imBindingId,
+            1,
+            slackThreadEvent({
+              providerEventId: "other-binding-thread",
+              externalMessageId: "3600.101",
+              rootExternalMessageId: "3600.100",
+              occurredAt: "2026-08-19T00:00:05.400Z",
+            }),
+          )
+        ).deliveryIds,
+      ).toEqual([]);
+
+      const currentDirect = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "unrelated-thread-direct",
+          externalMessageId: "3000.102",
+          rootExternalMessageId: "3000.100",
+          occurredAt: "2026-08-19T00:00:06.000Z",
+          direct: true,
+        }),
+      );
+      expect(
+        await value.database
+          .select({ kind: sessions.kind, threadKey: sessions.threadKey })
+          .from(imMessageDeliveries)
+          .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+          .where(eq(imMessageDeliveries.id, currentDirect.deliveryIds[0] as string)),
+      ).toEqual([{ kind: "thread", threadKey: "3000.100" }]);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("uses only a reliable Feishu rootId for implicit Thread admission", async () => {
+    const value = await unboundFixture();
+    try {
+      const imBindingId = await value.imBindingService.activateFeishu({
+        agentId: value.agent.id,
+        appId: "cli_1",
+        teamId: "team_1",
+        botOpenId: "ou_bot",
+        teamBrand: "feishu",
+        appSecret: "secret",
+        grantedScopes: [...FEISHU_REQUIRED_TENANT_SCOPES],
+      });
+      const inbox = new ImMessageInbox(value.database);
+      const root = revisionEvent({
+        providerEventId: "feishu-root",
+        externalMessageId: "om_root",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:01.000Z",
+        revisionKey: "1",
+      });
+      root.externalAppId = "cli_1";
+      root.externalTeamId = "team_1";
+      root.providerContext = { provider: "feishu", chatType: "group" };
+      root.mentions = [{ externalId: "ou_bot", displayName: "Assistant" }];
+      await inbox.ingest(imBindingId, 1, root);
+
+      const reliable = revisionEvent({
+        providerEventId: "feishu-thread-reliable",
+        externalMessageId: "om_reply",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:02.000Z",
+        revisionKey: "1",
+      });
+      reliable.externalAppId = "cli_1";
+      reliable.externalTeamId = "team_1";
+      reliable.providerContext = { provider: "feishu", chatType: "group", threadId: "omt_1", rootId: "om_root" };
+      reliable.message.threadKey = "omt_1";
+      reliable.mentions = [];
+      expect((await inbox.ingest(imBindingId, 1, reliable)).deliveryIds).toHaveLength(1);
+
+      const secondRoot = {
+        ...root,
+        providerEventId: "feishu-root-2",
+        message: { ...root.message, externalId: "om_root_2" },
+      };
+      await inbox.ingest(imBindingId, 1, secondRoot);
+      const missingRoot = revisionEvent({
+        providerEventId: "feishu-thread-missing-root",
+        externalMessageId: "om_reply_2",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:04.000Z",
+        revisionKey: "1",
+      });
+      missingRoot.externalAppId = "cli_1";
+      missingRoot.externalTeamId = "team_1";
+      missingRoot.providerContext = {
+        provider: "feishu",
+        chatType: "group",
+        threadId: "omt_2",
+        parentId: "om_root_2",
+      };
+      missingRoot.message.threadKey = "omt_2";
+      missingRoot.mentions = [];
+      expect((await inbox.ingest(imBindingId, 1, missingRoot)).deliveryIds).toEqual([]);
+      missingRoot.providerEventId = "feishu-thread-current-direct";
+      missingRoot.message = { ...missingRoot.message, externalId: "om_reply_3" };
+      missingRoot.mentions = [{ externalId: "ou_bot", displayName: "Assistant" }];
+      expect((await inbox.ingest(imBindingId, 1, missingRoot)).deliveryIds).toHaveLength(1);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("keeps all-message Channel ambient fan-out independent and does not implicitly revive ended Threads", async () => {
+    const value = await fixture();
+    try {
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
+      const inbox = new ImMessageInbox(value.database);
+      await inbox.ingest(
+        value.imBindingId,
+        1,
+        revisionEvent({
+          providerEventId: "fanout-root",
+          externalMessageId: "4000.100",
+          operation: "created",
+          occurredAt: "2026-08-19T00:00:01.000Z",
+          revisionKey: "1",
+        }),
+      );
+      const admission = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "fanout-thread",
+          externalMessageId: "4000.101",
+          rootExternalMessageId: "4000.100",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+        }),
+      );
+      const scopes = await value.database
+        .select({ attention: imMessageDeliveries.attention, kind: sessions.kind, threadKey: sessions.threadKey })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.messageId, admission.messageId as string));
+      expect(scopes).toEqual(
+        expect.arrayContaining([
+          { attention: "direct", kind: "thread", threadKey: "4000.100" },
+          { attention: "ambient", kind: "channel", threadKey: null },
+        ]),
+      );
+      const thread = await value.database
+        .select()
+        .from(sessions)
+        .where(and(eq(sessions.kind, "thread"), eq(sessions.threadKey, "4000.100"), isNull(sessions.endedAt)))
+        .then((rows) => rows[0]);
+      if (!thread) throw new Error("Thread Session fixture was not created");
+      await new SessionService(value.database).end(thread.id);
+
+      const unmentioned = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "ended-thread-unmentioned",
+          externalMessageId: "4000.102",
+          rootExternalMessageId: "4000.100",
+          occurredAt: "2026-08-19T00:00:03.000Z",
+        }),
+      );
+      expect(
+        await value.database
+          .select({ attention: imMessageDeliveries.attention, kind: sessions.kind })
+          .from(imMessageDeliveries)
+          .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+          .where(eq(imMessageDeliveries.messageId, unmentioned.messageId as string)),
+      ).toEqual([{ attention: "ambient", kind: "channel" }]);
+      expect(
+        await value.database
+          .select({ id: sessions.id })
+          .from(sessions)
+          .where(and(eq(sessions.kind, "thread"), eq(sessions.threadKey, "4000.100"), isNull(sessions.endedAt))),
+      ).toEqual([]);
+
+      const currentDirect = slackThreadEvent({
+        providerEventId: "ended-thread-current-direct",
+        externalMessageId: "4000.103",
+        rootExternalMessageId: "4000.100",
+        occurredAt: "2026-08-19T00:00:04.000Z",
+        direct: true,
+      });
+      expect((await inbox.ingest(value.imBindingId, 1, currentDirect)).deliveryIds).toHaveLength(2);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("converges concurrent first Thread admissions on one active Session and placement", async () => {
+    const value = await fixture();
+    try {
+      const inbox = new ImMessageInbox(value.database);
+      await inbox.ingest(
+        value.imBindingId,
+        1,
+        revisionEvent({
+          providerEventId: "concurrent-root",
+          externalMessageId: "6000.100",
+          operation: "created",
+          occurredAt: "2026-08-19T00:00:01.000Z",
+          revisionKey: "1",
+        }),
+      );
+      const admissions = await Promise.all([
+        inbox.ingest(
+          value.imBindingId,
+          1,
+          slackThreadEvent({
+            providerEventId: "concurrent-thread-a",
+            externalMessageId: "6000.101",
+            rootExternalMessageId: "6000.100",
+            occurredAt: "2026-08-19T00:00:02.000Z",
+          }),
+        ),
+        inbox.ingest(
+          value.imBindingId,
+          1,
+          slackThreadEvent({
+            providerEventId: "concurrent-thread-b",
+            externalMessageId: "6000.102",
+            rootExternalMessageId: "6000.100",
+            occurredAt: "2026-08-19T00:00:03.000Z",
+          }),
+        ),
+      ]);
+      expect(admissions.every((admission) => admission.deliveryIds.length === 1)).toBe(true);
+      const threadRows = await value.database
+        .select({ id: sessions.id })
+        .from(sessions)
+        .where(and(eq(sessions.kind, "thread"), eq(sessions.threadKey, "6000.100"), isNull(sessions.endedAt)));
+      expect(threadRows).toHaveLength(1);
+      expect(
+        await value.database
+          .select({ sessionId: sessionPlacements.sessionId })
+          .from(sessionPlacements)
+          .where(eq(sessionPlacements.sessionId, threadRows[0]?.id as string)),
+      ).toHaveLength(1);
+      expect(
+        await value.database
+          .select({ sessionId: imMessageDeliveries.sessionId })
+          .from(imMessageDeliveries)
+          .where(
+            inArray(
+              imMessageDeliveries.id,
+              admissions.flatMap((admission) => admission.deliveryIds),
+            ),
+          ),
+      ).toEqual([{ sessionId: threadRows[0]?.id }, { sessionId: threadRows[0]?.id }]);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("bootstraps a cold Thread delivery with root and same-thread inbound history", async () => {
+    const value = await fixture();
+    try {
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
+      const instanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: instanceId })
+        .where(eq(computers.id, value.computer.id));
+      const runtime = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId,
+        userId: value.bootstrap.userId,
+      });
+      const inbox = new ImMessageInbox(value.database);
+      const rootEvent = revisionEvent({
+        providerEventId: "history-root",
+        externalMessageId: "7000.100",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:01.000Z",
+        revisionKey: "1",
+      });
+      rootEvent.message.content = {
+        version: 1,
+        fallbackText: "root message",
+        blocks: [{ type: "text", text: "root message" }],
+        truncated: false,
+      };
+      const root = await inbox.ingest(value.imBindingId, 1, rootEvent);
+      const firstThread = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "history-thread-first",
+          externalMessageId: "7000.101",
+          rootExternalMessageId: "7000.100",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+          text: "first thread message",
+        }),
+      );
+      const sibling = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "history-sibling",
+          externalMessageId: "8000.101",
+          rootExternalMessageId: "8000.100",
+          occurredAt: "2026-08-19T00:00:02.500Z",
+          text: "sibling thread message",
+        }),
+      );
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ state: "expired", reason: "history_fixture" })
+        .where(
+          inArray(
+            imMessageDeliveries.messageId,
+            [root.messageId, firstThread.messageId, sibling.messageId].filter(
+              (messageId): messageId is string => messageId !== undefined,
+            ),
+          ),
+        );
+      const current = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "history-thread-current",
+          externalMessageId: "7000.102",
+          rootExternalMessageId: "7000.100",
+          occurredAt: "2026-08-19T00:00:03.000Z",
+          text: "current thread message",
+        }),
+      );
+      const currentDeliveries = await value.database
+        .select({ id: imMessageDeliveries.id, kind: sessions.kind })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.messageId, current.messageId as string));
+      const threadDelivery = currentDeliveries.find((delivery) => delivery.kind === "thread");
+      if (!threadDelivery) throw new Error("Current Thread delivery fixture was not created");
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ state: "expired", reason: "history_fixture" })
+        .where(
+          inArray(
+            imMessageDeliveries.id,
+            currentDeliveries.filter((delivery) => delivery.kind !== "thread").map((delivery) => delivery.id),
+          ),
+        );
+
+      await imDeliveryWorker({
+        database: value.database,
+        registry: runtime.registry,
+        domain: runtime.domain,
+      }).runOnce();
+      const delivered = runtime.frames.find(
+        (frame) =>
+          (frame as { type?: string; deliveryId?: string }).type === "im:deliver" &&
+          (frame as { deliveryId?: string }).deliveryId === threadDelivery.id,
+      ) as DirectImMessageDeliveryRequest | undefined;
+      expect(delivered?.content.history).toEqual([
+        expect.objectContaining({
+          imMessageId: root.messageId,
+          occurredAt: "2026-08-19T00:00:01.000Z",
+          text: "root message",
+          providerRef: expect.objectContaining({ provider: "slack", messageTs: "7000.100" }),
+        }),
+        expect.objectContaining({
+          imMessageId: firstThread.messageId,
+          occurredAt: "2026-08-19T00:00:02.000Z",
+          text: "first thread message",
+          providerRef: expect.objectContaining({
+            provider: "slack",
+            messageTs: "7000.101",
+            threadTs: "7000.100",
+          }),
+        }),
+      ]);
+      expect(JSON.stringify(delivered?.content.history)).not.toContain("sibling thread message");
       runtime.domain.close();
     } finally {
       await value.sql.end();

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -1704,6 +1704,64 @@ describe("IM binding persistence", () => {
     }
   });
 
+  it("reconciles a Thread reply that commits before its direct root", async () => {
+    const value = await fixture();
+    try {
+      const replyHeld = deferred<void>();
+      const releaseReply = deferred<void>();
+      const replyInbox = new ImMessageInbox(value.database, {
+        afterMessageAuthority: async () => {
+          replyHeld.resolve();
+          await releaseReply.promise;
+        },
+      });
+      const replyRun = replyInbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "reordered-thread-reply",
+          externalMessageId: "2100.101",
+          rootExternalMessageId: "2100.100",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+        }),
+      );
+      await replyHeld.promise;
+
+      let rootSettled = false;
+      const rootRun = new ImMessageInbox(value.database)
+        .ingest(
+          value.imBindingId,
+          1,
+          revisionEvent({
+            providerEventId: "reordered-direct-root",
+            externalMessageId: "2100.100",
+            operation: "created",
+            occurredAt: "2026-08-19T00:00:01.000Z",
+            revisionKey: "1",
+          }),
+        )
+        .finally(() => {
+          rootSettled = true;
+        });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(rootSettled).toBe(false);
+      releaseReply.resolve();
+
+      const [reply, root] = await Promise.all([replyRun, rootRun]);
+      expect(reply.deliveryIds).toEqual([]);
+      expect(root.deliveryIds).toHaveLength(1);
+      expect(
+        await value.database
+          .select({ attention: imMessageDeliveries.attention, kind: sessions.kind, threadKey: sessions.threadKey })
+          .from(imMessageDeliveries)
+          .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+          .where(eq(imMessageDeliveries.messageId, reply.messageId as string)),
+      ).toEqual([{ attention: "direct", kind: "thread", threadKey: "2100.100" }]);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
   it("uses only a reliable Feishu rootId for implicit Thread admission", async () => {
     const value = await unboundFixture();
     try {
@@ -1772,6 +1830,76 @@ describe("IM binding persistence", () => {
       missingRoot.message = { ...missingRoot.message, externalId: "om_reply_3" };
       missingRoot.mentions = [{ externalId: "ou_bot", displayName: "Assistant" }];
       expect((await inbox.ingest(imBindingId, 1, missingRoot)).deliveryIds).toHaveLength(1);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("inherits an unknown Feishu revision when only a Thread Session exists", async () => {
+    const value = await unboundFixture();
+    try {
+      const imBindingId = await value.imBindingService.activateFeishu({
+        agentId: value.agent.id,
+        appId: "cli_revision",
+        teamId: "team_revision",
+        botOpenId: "ou_revision_bot",
+        teamBrand: "feishu",
+        appSecret: "secret",
+        grantedScopes: [...FEISHU_REQUIRED_TENANT_SCOPES],
+      });
+      const inbox = new ImMessageInbox(value.database);
+      const created = revisionEvent({
+        providerEventId: "feishu-thread-created",
+        externalMessageId: "om_thread_message",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:01.000Z",
+        revisionKey: "1",
+      });
+      created.externalAppId = "cli_revision";
+      created.externalTeamId = "team_revision";
+      created.providerContext = {
+        provider: "feishu",
+        chatType: "group",
+        threadId: "omt_revision",
+        rootId: "om_unseen_root",
+      };
+      created.message.threadKey = "omt_revision";
+      created.mentions = [{ externalId: "ou_revision_bot", displayName: "Assistant" }];
+      const first = await inbox.ingest(imBindingId, 1, created);
+      const [firstTarget] = await value.database
+        .select({ sessionId: sessions.id, kind: sessions.kind })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.id, first.deliveryIds[0] as string));
+      expect(firstTarget).toMatchObject({ kind: "thread" });
+      expect(await value.database.select().from(sessions).where(eq(sessions.kind, "channel"))).toEqual([]);
+
+      const recalled = revisionEvent({
+        providerEventId: "feishu-thread-recalled",
+        externalMessageId: "om_thread_message",
+        operation: "deleted",
+        occurredAt: "2026-08-19T00:00:02.000Z",
+        revisionKey: "2",
+      });
+      recalled.externalAppId = "cli_revision";
+      recalled.externalTeamId = "team_revision";
+      recalled.providerContext = { provider: "feishu" };
+      recalled.conversation.kind = "unknown";
+      recalled.message.threadKey = null;
+      recalled.mentions = [];
+      const revision = await inbox.ingest(imBindingId, 1, recalled);
+      const [revisionTarget] = await value.database
+        .select({ sessionId: sessions.id, kind: sessions.kind })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.id, revision.deliveryIds[0] as string));
+      expect(revisionTarget).toEqual(firstTarget);
+      expect(
+        await value.database
+          .select({ threadKey: imMessages.threadKey })
+          .from(imMessages)
+          .where(eq(imMessages.id, revision.messageId as string)),
+      ).toEqual([{ threadKey: "omt_revision" }]);
     } finally {
       await value.sql.end();
     }
@@ -1954,6 +2082,20 @@ describe("IM binding persistence", () => {
         truncated: false,
       };
       const root = await inbox.ingest(value.imBindingId, 1, rootEvent);
+      const rootEditEvent = revisionEvent({
+        providerEventId: "history-root-edit",
+        externalMessageId: "7000.100",
+        operation: "edited",
+        occurredAt: "2026-08-19T00:00:01.500Z",
+        revisionKey: "2",
+      });
+      rootEditEvent.message.content = {
+        version: 1,
+        fallbackText: "edited root message",
+        blocks: [{ type: "text", text: "edited root message" }],
+        truncated: false,
+      };
+      const rootEdit = await inbox.ingest(value.imBindingId, 1, rootEditEvent);
       const firstThread = await inbox.ingest(
         value.imBindingId,
         1,
@@ -1965,6 +2107,17 @@ describe("IM binding persistence", () => {
           text: "first thread message",
         }),
       );
+      const firstThreadDeleteEvent = revisionEvent({
+        providerEventId: "history-thread-first-delete",
+        externalMessageId: "7000.101",
+        operation: "deleted",
+        occurredAt: "2026-08-19T00:00:02.250Z",
+        revisionKey: "2",
+      });
+      firstThreadDeleteEvent.conversation.kind = "unknown";
+      firstThreadDeleteEvent.message.threadKey = null;
+      firstThreadDeleteEvent.mentions = [];
+      const firstThreadDelete = await inbox.ingest(value.imBindingId, 1, firstThreadDeleteEvent);
       const sibling = await inbox.ingest(
         value.imBindingId,
         1,
@@ -1982,9 +2135,13 @@ describe("IM binding persistence", () => {
         .where(
           inArray(
             imMessageDeliveries.messageId,
-            [root.messageId, firstThread.messageId, sibling.messageId].filter(
-              (messageId): messageId is string => messageId !== undefined,
-            ),
+            [
+              root.messageId,
+              rootEdit.messageId,
+              firstThread.messageId,
+              firstThreadDelete.messageId,
+              sibling.messageId,
+            ].filter((messageId): messageId is string => messageId !== undefined),
           ),
         );
       const current = await inbox.ingest(
@@ -2027,23 +2184,25 @@ describe("IM binding persistence", () => {
       ) as DirectImMessageDeliveryRequest | undefined;
       expect(delivered?.content.history).toEqual([
         expect.objectContaining({
-          imMessageId: root.messageId,
-          occurredAt: "2026-08-19T00:00:01.000Z",
-          text: "root message",
+          imMessageId: rootEdit.messageId,
+          occurredAt: "2026-08-19T00:00:01.500Z",
+          text: "edited root message",
           providerRef: expect.objectContaining({ provider: "slack", messageTs: "7000.100" }),
         }),
         expect.objectContaining({
-          imMessageId: firstThread.messageId,
-          occurredAt: "2026-08-19T00:00:02.000Z",
-          text: "first thread message",
+          imMessageId: firstThreadDelete.messageId,
+          occurredAt: "2026-08-19T00:00:02.250Z",
+          text: "[deleted]",
           providerRef: expect.objectContaining({
             provider: "slack",
             messageTs: "7000.101",
-            threadTs: "7000.100",
           }),
         }),
       ]);
-      expect(JSON.stringify(delivered?.content.history)).not.toContain("sibling thread message");
+      const serializedHistory = JSON.stringify(delivered?.content.history);
+      expect(serializedHistory).not.toContain('"text":"root message"');
+      expect(serializedHistory).not.toContain("first thread message");
+      expect(serializedHistory).not.toContain("sibling thread message");
       runtime.domain.close();
     } finally {
       await value.sql.end();

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -2144,7 +2144,7 @@ describe("IM binding persistence", () => {
             ].filter((messageId): messageId is string => messageId !== undefined),
           ),
         );
-      const current = await inbox.ingest(
+      await inbox.ingest(
         value.imBindingId,
         1,
         slackThreadEvent({
@@ -2152,9 +2152,19 @@ describe("IM binding persistence", () => {
           externalMessageId: "7000.102",
           rootExternalMessageId: "7000.100",
           occurredAt: "2026-08-19T00:00:03.000Z",
-          text: "current thread message",
+          text: "deleted current thread message",
         }),
       );
+      const currentDeleteEvent = slackThreadEvent({
+        providerEventId: "history-thread-current-delete",
+        externalMessageId: "7000.102",
+        rootExternalMessageId: "7000.100",
+        occurredAt: "2026-08-19T00:00:03.250Z",
+        text: "deleted current thread message",
+      });
+      currentDeleteEvent.message.operation = "deleted";
+      currentDeleteEvent.message.revisionKey = "2";
+      const current = await inbox.ingest(value.imBindingId, 1, currentDeleteEvent);
       const currentDeliveries = await value.database
         .select({ id: imMessageDeliveries.id, kind: sessions.kind })
         .from(imMessageDeliveries)
@@ -2182,6 +2192,7 @@ describe("IM binding persistence", () => {
           (frame as { type?: string; deliveryId?: string }).type === "im:deliver" &&
           (frame as { deliveryId?: string }).deliveryId === threadDelivery.id,
       ) as DirectImMessageDeliveryRequest | undefined;
+      expect(delivered?.content.text).toBe("[deleted]");
       expect(delivered?.content.history).toEqual([
         expect.objectContaining({
           imMessageId: rootEdit.messageId,
@@ -2202,6 +2213,7 @@ describe("IM binding persistence", () => {
       const serializedHistory = JSON.stringify(delivered?.content.history);
       expect(serializedHistory).not.toContain('"text":"root message"');
       expect(serializedHistory).not.toContain("first thread message");
+      expect(serializedHistory).not.toContain("deleted current thread message");
       expect(serializedHistory).not.toContain("sibling thread message");
       runtime.domain.close();
     } finally {

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -2221,6 +2221,99 @@ describe("IM binding persistence", () => {
     }
   });
 
+  it("reserves the verified root beyond the rolling Thread history item cap", async () => {
+    const value = await fixture();
+    try {
+      const instanceId = crypto.randomUUID();
+      await value.database
+        .update(computers)
+        .set({ currentInstanceId: instanceId })
+        .where(eq(computers.id, value.computer.id));
+      const runtime = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId,
+        userId: value.bootstrap.userId,
+      });
+      const inbox = new ImMessageInbox(value.database);
+      const rootEvent = revisionEvent({
+        providerEventId: "history-cap-root",
+        externalMessageId: "7100.100",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:01.000Z",
+        revisionKey: "1",
+      });
+      rootEvent.message.content = {
+        version: 1,
+        fallbackText: "reserved root message",
+        blocks: [{ type: "text", text: "reserved root message" }],
+        truncated: false,
+      };
+      const root = await inbox.ingest(value.imBindingId, 1, rootEvent);
+      const priorMessageIds = [root.messageId];
+      for (let index = 0; index < 101; index += 1) {
+        const reply = await inbox.ingest(
+          value.imBindingId,
+          1,
+          slackThreadEvent({
+            providerEventId: `history-cap-thread-${index}`,
+            externalMessageId: `7100.${index + 101}`,
+            rootExternalMessageId: "7100.100",
+            occurredAt: new Date(Date.parse("2026-08-19T00:00:02.000Z") + index * 1_000).toISOString(),
+            text: `boundary thread message ${index}`,
+          }),
+        );
+        priorMessageIds.push(reply.messageId);
+      }
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ state: "expired", reason: "history_fixture" })
+        .where(
+          inArray(
+            imMessageDeliveries.messageId,
+            priorMessageIds.filter((messageId): messageId is string => messageId !== undefined),
+          ),
+        );
+      const current = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "history-cap-current",
+          externalMessageId: "7100.999",
+          rootExternalMessageId: "7100.100",
+          occurredAt: "2026-08-19T00:03:00.000Z",
+          text: "current message after history cap",
+        }),
+      );
+      const [currentDelivery] = await value.database
+        .select({ id: imMessageDeliveries.id })
+        .from(imMessageDeliveries)
+        .where(eq(imMessageDeliveries.messageId, current.messageId as string));
+      if (!currentDelivery) throw new Error("Current Thread delivery fixture was not created");
+
+      await imDeliveryWorker({
+        database: value.database,
+        registry: runtime.registry,
+        domain: runtime.domain,
+      }).runOnce();
+      const delivered = runtime.frames.find(
+        (frame) =>
+          (frame as { type?: string; deliveryId?: string }).type === "im:deliver" &&
+          (frame as { deliveryId?: string }).deliveryId === currentDelivery.id,
+      ) as DirectImMessageDeliveryRequest | undefined;
+      expect(delivered?.content.history).toHaveLength(100);
+      expect(delivered?.content.history?.[0]).toEqual(expect.objectContaining({ text: "reserved root message" }));
+      expect(delivered?.content.history?.[1]).toEqual(expect.objectContaining({ text: "boundary thread message 2" }));
+      expect(delivered?.content.history?.[99]).toEqual(
+        expect.objectContaining({ text: "boundary thread message 100" }),
+      );
+      expect(delivered?.content.historyTruncated).toBe(true);
+      runtime.domain.close();
+    } finally {
+      await value.sql.end();
+    }
+  });
+
   it("inherits DM scope for a Feishu recall without guessing provider fields", async () => {
     const value = await fixture();
     try {

--- a/packages/server/src/__tests__/slack-adapter.test.ts
+++ b/packages/server/src/__tests__/slack-adapter.test.ts
@@ -45,6 +45,7 @@ describe("Slack installed-binding adapter", () => {
     });
     expect(event).toMatchObject({
       providerEventId: "Ev1",
+      providerContext: { provider: "slack", channelType: "channel", threadTs: "1724025500.000" },
       conversation: { externalId: "C1", kind: "channel" },
       message: { externalId: "1724025600.123", threadKey: "1724025500.000" },
       mentions: [{ externalId: "U1" }],

--- a/packages/server/src/runtime/im-delivery-worker.ts
+++ b/packages/server/src/runtime/im-delivery-worker.ts
@@ -4,6 +4,7 @@ import {
   type DirectImMessageDeliveryRequest,
   DirectImMessageDeliveryRequestSchema,
   type EffectiveRuntimeSnapshot,
+  type ProviderInboundContext,
   RUNTIME_DIRECT_TEXT_MAX_BYTES,
   RUNTIME_IM_HISTORY_MAX_BYTES,
   RUNTIME_MAX_FRAME_BYTES,
@@ -29,6 +30,7 @@ import {
   setActiveSpanAttributes,
   traceDeliveryClaim,
 } from "../observability/index.js";
+import { threadRootExternalId } from "../services/im/provider-thread-context.js";
 import {
   type EffectiveRuntimeSnapshotAssembler,
   EffectiveRuntimeSnapshotAssemblerError,
@@ -408,8 +410,15 @@ export class ImDeliveryWorker {
       }
       const resources = row.message.content.resources ?? [];
       const history =
-        row.agent.receiveMode === "mention_only" && row.delivery.attention === "direct"
-          ? await this.#history(row.session, row.message.occurredAt, row.message.providerRevisionKey, row.message.id)
+        row.delivery.attention === "direct" &&
+        (row.agent.receiveMode === "mention_only" || row.session.kind === "thread")
+          ? await this.#history(
+              row.session,
+              row.message.providerContext,
+              row.message.occurredAt,
+              row.message.providerRevisionKey,
+              row.message.id,
+            )
           : { items: [], truncated: false };
       const request: DirectImMessageDeliveryRequest = {
         type: "im:deliver",
@@ -741,6 +750,7 @@ export class ImDeliveryWorker {
 
   async #history(
     session: typeof sessions.$inferSelect,
+    providerContext: ProviderInboundContext,
     occurredAt: Date,
     providerRevisionKey: string,
     messageId: string,
@@ -753,6 +763,7 @@ export class ImDeliveryWorker {
     }>;
     truncated: boolean;
   }> {
+    const rootExternalId = threadRootExternalId(providerContext);
     const [lastAccepted] = await this.#database
       .select({
         id: imMessages.id,
@@ -787,7 +798,14 @@ export class ImDeliveryWorker {
           eq(imMessages.imBindingId, session.imBindingId),
           eq(imMessages.channelId, session.channelId),
           eq(imMessages.direction, "inbound"),
-          ...(session.kind === "thread" && session.threadKey ? [eq(imMessages.threadKey, session.threadKey)] : []),
+          ...(session.kind === "thread" && session.threadKey
+            ? [
+                or(
+                  eq(imMessages.threadKey, session.threadKey),
+                  ...(rootExternalId ? [eq(imMessages.externalMessageId, rootExternalId)] : []),
+                ),
+              ]
+            : []),
           messageBefore(occurredAt, providerRevisionKey, messageId),
           ...(lastAccepted
             ? [messageAfter(lastAccepted.occurredAt, lastAccepted.providerRevisionKey, lastAccepted.id)]

--- a/packages/server/src/runtime/im-delivery-worker.ts
+++ b/packages/server/src/runtime/im-delivery-worker.ts
@@ -784,16 +784,83 @@ export class ImDeliveryWorker {
       )
       .orderBy(desc(imMessages.occurredAt), desc(imMessages.providerRevisionKey), desc(imMessages.id))
       .limit(1);
+    const historyBoundary = and(
+      messageBefore(occurredAt, providerRevisionKey, messageId),
+      ...(lastAccepted
+        ? [messageAfter(lastAccepted.occurredAt, lastAccepted.providerRevisionKey, lastAccepted.id)]
+        : []),
+      notExists(
+        this.#database
+          .select({ id: newerHistoryRevisions.id })
+          .from(newerHistoryRevisions)
+          .where(
+            and(
+              eq(newerHistoryRevisions.imBindingId, imMessages.imBindingId),
+              eq(newerHistoryRevisions.channelId, imMessages.channelId),
+              eq(newerHistoryRevisions.externalMessageId, imMessages.externalMessageId),
+              eq(newerHistoryRevisions.direction, "inbound"),
+              or(
+                gt(newerHistoryRevisions.occurredAt, imMessages.occurredAt),
+                and(
+                  eq(newerHistoryRevisions.occurredAt, imMessages.occurredAt),
+                  or(
+                    gt(newerHistoryRevisions.providerRevisionKey, imMessages.providerRevisionKey),
+                    and(
+                      eq(newerHistoryRevisions.providerRevisionKey, imMessages.providerRevisionKey),
+                      gt(newerHistoryRevisions.id, imMessages.id),
+                    ),
+                  ),
+                ),
+              ),
+              or(
+                lt(newerHistoryRevisions.occurredAt, occurredAt),
+                and(
+                  eq(newerHistoryRevisions.occurredAt, occurredAt),
+                  or(
+                    lt(newerHistoryRevisions.providerRevisionKey, providerRevisionKey),
+                    and(
+                      eq(newerHistoryRevisions.providerRevisionKey, providerRevisionKey),
+                      lt(newerHistoryRevisions.id, messageId),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ),
+    );
+    const selection = {
+      id: imMessages.id,
+      operation: imMessages.operation,
+      occurredAt: imMessages.occurredAt,
+      content: imMessages.content,
+      channelId: imMessages.channelId,
+      externalMessageId: imMessages.externalMessageId,
+      providerContext: imMessages.providerContext,
+      imBinding: imBindings,
+    };
+    const [root] =
+      session.kind === "thread" && rootExternalId
+        ? await this.#database
+            .select(selection)
+            .from(imMessages)
+            .innerJoin(imBindings, eq(imBindings.id, imMessages.imBindingId))
+            .where(
+              and(
+                eq(imMessages.imBindingId, session.imBindingId),
+                eq(imMessages.channelId, session.channelId),
+                eq(imMessages.direction, "inbound"),
+                eq(imMessages.externalMessageId, rootExternalId),
+                ne(imMessages.externalMessageId, externalMessageId),
+                historyBoundary,
+              ),
+            )
+            .orderBy(desc(imMessages.occurredAt), desc(imMessages.providerRevisionKey), desc(imMessages.id))
+            .limit(1)
+        : [];
     const rows = await this.#database
       .select({
-        id: imMessages.id,
-        operation: imMessages.operation,
-        occurredAt: imMessages.occurredAt,
-        content: imMessages.content,
-        channelId: imMessages.channelId,
-        externalMessageId: imMessages.externalMessageId,
-        providerContext: imMessages.providerContext,
-        imBinding: imBindings,
+        ...selection,
       })
       .from(imMessages)
       .innerJoin(imBindings, eq(imBindings.id, imMessages.imBindingId))
@@ -803,62 +870,13 @@ export class ImDeliveryWorker {
           eq(imMessages.channelId, session.channelId),
           eq(imMessages.direction, "inbound"),
           ne(imMessages.externalMessageId, externalMessageId),
-          ...(session.kind === "thread" && session.threadKey
-            ? [
-                or(
-                  eq(imMessages.threadKey, session.threadKey),
-                  ...(rootExternalId ? [eq(imMessages.externalMessageId, rootExternalId)] : []),
-                ),
-              ]
-            : []),
-          messageBefore(occurredAt, providerRevisionKey, messageId),
-          ...(lastAccepted
-            ? [messageAfter(lastAccepted.occurredAt, lastAccepted.providerRevisionKey, lastAccepted.id)]
-            : []),
-          notExists(
-            this.#database
-              .select({ id: newerHistoryRevisions.id })
-              .from(newerHistoryRevisions)
-              .where(
-                and(
-                  eq(newerHistoryRevisions.imBindingId, imMessages.imBindingId),
-                  eq(newerHistoryRevisions.channelId, imMessages.channelId),
-                  eq(newerHistoryRevisions.externalMessageId, imMessages.externalMessageId),
-                  eq(newerHistoryRevisions.direction, "inbound"),
-                  or(
-                    gt(newerHistoryRevisions.occurredAt, imMessages.occurredAt),
-                    and(
-                      eq(newerHistoryRevisions.occurredAt, imMessages.occurredAt),
-                      or(
-                        gt(newerHistoryRevisions.providerRevisionKey, imMessages.providerRevisionKey),
-                        and(
-                          eq(newerHistoryRevisions.providerRevisionKey, imMessages.providerRevisionKey),
-                          gt(newerHistoryRevisions.id, imMessages.id),
-                        ),
-                      ),
-                    ),
-                  ),
-                  or(
-                    lt(newerHistoryRevisions.occurredAt, occurredAt),
-                    and(
-                      eq(newerHistoryRevisions.occurredAt, occurredAt),
-                      or(
-                        lt(newerHistoryRevisions.providerRevisionKey, providerRevisionKey),
-                        and(
-                          eq(newerHistoryRevisions.providerRevisionKey, providerRevisionKey),
-                          lt(newerHistoryRevisions.id, messageId),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-          ),
+          ...(session.kind === "thread" && session.threadKey ? [eq(imMessages.threadKey, session.threadKey)] : []),
+          historyBoundary,
         ),
       )
       .orderBy(desc(imMessages.occurredAt), desc(imMessages.providerRevisionKey), desc(imMessages.id))
       .limit(101);
-    const selected = rows.slice(0, 100);
+    const selected = rows.slice(0, root ? 99 : 100);
     const items: Array<{
       imMessageId: string;
       occurredAt: string;
@@ -867,6 +885,18 @@ export class ImDeliveryWorker {
     }> = [];
     let bytes = 2;
     let truncated = rows.length > selected.length;
+    const rootItem = root
+      ? {
+          imMessageId: root.id,
+          occurredAt: root.occurredAt.toISOString(),
+          text:
+            root.operation === "deleted"
+              ? "[deleted]"
+              : truncateUtf8(root.content.fallbackText, RUNTIME_DIRECT_TEXT_MAX_BYTES),
+          providerRef: runtimeProviderMessageRef(root, root.imBinding),
+        }
+      : undefined;
+    if (rootItem) bytes += Buffer.byteLength(JSON.stringify(rootItem), "utf8");
     for (const row of selected) {
       const item = {
         imMessageId: row.id,
@@ -877,7 +907,7 @@ export class ImDeliveryWorker {
             : truncateUtf8(row.content.fallbackText, RUNTIME_DIRECT_TEXT_MAX_BYTES),
         providerRef: runtimeProviderMessageRef(row, row.imBinding),
       };
-      const itemBytes = Buffer.byteLength(JSON.stringify(item), "utf8") + (items.length > 0 ? 1 : 0);
+      const itemBytes = Buffer.byteLength(JSON.stringify(item), "utf8") + (items.length > 0 || rootItem ? 1 : 0);
       if (bytes + itemBytes > RUNTIME_IM_HISTORY_MAX_BYTES) {
         truncated = true;
         break;
@@ -885,7 +915,7 @@ export class ImDeliveryWorker {
       items.push(item);
       bytes += itemBytes;
     }
-    return { items: items.reverse(), truncated };
+    return { items: [...(rootItem ? [rootItem] : []), ...items.reverse()], truncated };
   }
 }
 

--- a/packages/server/src/runtime/im-delivery-worker.ts
+++ b/packages/server/src/runtime/im-delivery-worker.ts
@@ -49,6 +49,7 @@ const acceptedDeliveries = alias(imMessageDeliveries, "agent_accepted_deliveries
 const acceptedSessions = alias(sessions, "agent_accepted_sessions");
 const acceptedImBindings = alias(imBindings, "agent_accepted_im_bindings");
 const acceptedAgents = alias(agents, "agent_accepted_agents");
+const newerHistoryRevisions = alias(imMessages, "newer_history_revisions");
 
 export class ImDeliveryWorker {
   readonly #database: DatabaseClient;
@@ -784,6 +785,7 @@ export class ImDeliveryWorker {
     const rows = await this.#database
       .select({
         id: imMessages.id,
+        operation: imMessages.operation,
         occurredAt: imMessages.occurredAt,
         content: imMessages.content,
         channelId: imMessages.channelId,
@@ -810,6 +812,45 @@ export class ImDeliveryWorker {
           ...(lastAccepted
             ? [messageAfter(lastAccepted.occurredAt, lastAccepted.providerRevisionKey, lastAccepted.id)]
             : []),
+          notExists(
+            this.#database
+              .select({ id: newerHistoryRevisions.id })
+              .from(newerHistoryRevisions)
+              .where(
+                and(
+                  eq(newerHistoryRevisions.imBindingId, imMessages.imBindingId),
+                  eq(newerHistoryRevisions.channelId, imMessages.channelId),
+                  eq(newerHistoryRevisions.externalMessageId, imMessages.externalMessageId),
+                  eq(newerHistoryRevisions.direction, "inbound"),
+                  or(
+                    gt(newerHistoryRevisions.occurredAt, imMessages.occurredAt),
+                    and(
+                      eq(newerHistoryRevisions.occurredAt, imMessages.occurredAt),
+                      or(
+                        gt(newerHistoryRevisions.providerRevisionKey, imMessages.providerRevisionKey),
+                        and(
+                          eq(newerHistoryRevisions.providerRevisionKey, imMessages.providerRevisionKey),
+                          gt(newerHistoryRevisions.id, imMessages.id),
+                        ),
+                      ),
+                    ),
+                  ),
+                  or(
+                    lt(newerHistoryRevisions.occurredAt, occurredAt),
+                    and(
+                      eq(newerHistoryRevisions.occurredAt, occurredAt),
+                      or(
+                        lt(newerHistoryRevisions.providerRevisionKey, providerRevisionKey),
+                        and(
+                          eq(newerHistoryRevisions.providerRevisionKey, providerRevisionKey),
+                          lt(newerHistoryRevisions.id, messageId),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ),
         ),
       )
       .orderBy(desc(imMessages.occurredAt), desc(imMessages.providerRevisionKey), desc(imMessages.id))
@@ -827,7 +868,10 @@ export class ImDeliveryWorker {
       const item = {
         imMessageId: row.id,
         occurredAt: row.occurredAt.toISOString(),
-        text: truncateUtf8(row.content.fallbackText, RUNTIME_DIRECT_TEXT_MAX_BYTES),
+        text:
+          row.operation === "deleted"
+            ? "[deleted]"
+            : truncateUtf8(row.content.fallbackText, RUNTIME_DIRECT_TEXT_MAX_BYTES),
         providerRef: runtimeProviderMessageRef(row, row.imBinding),
       };
       const itemBytes = Buffer.byteLength(JSON.stringify(item), "utf8") + (items.length > 0 ? 1 : 0);

--- a/packages/server/src/runtime/im-delivery-worker.ts
+++ b/packages/server/src/runtime/im-delivery-worker.ts
@@ -416,6 +416,7 @@ export class ImDeliveryWorker {
           ? await this.#history(
               row.session,
               row.message.providerContext,
+              row.message.externalMessageId,
               row.message.occurredAt,
               row.message.providerRevisionKey,
               row.message.id,
@@ -752,6 +753,7 @@ export class ImDeliveryWorker {
   async #history(
     session: typeof sessions.$inferSelect,
     providerContext: ProviderInboundContext,
+    externalMessageId: string,
     occurredAt: Date,
     providerRevisionKey: string,
     messageId: string,
@@ -800,6 +802,7 @@ export class ImDeliveryWorker {
           eq(imMessages.imBindingId, session.imBindingId),
           eq(imMessages.channelId, session.channelId),
           eq(imMessages.direction, "inbound"),
+          ne(imMessages.externalMessageId, externalMessageId),
           ...(session.kind === "thread" && session.threadKey
             ? [
                 or(

--- a/packages/server/src/services/im/im-message-inbox.ts
+++ b/packages/server/src/services/im/im-message-inbox.ts
@@ -1,5 +1,5 @@
 import { ImContentV1Schema, type NormalizedInboundImEvent, NormalizedInboundImEventSchema } from "@opentag/shared";
-import { and, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
 import type { DatabaseClient, DatabaseTransaction } from "../../db/client.js";
 import {
   agents,
@@ -10,6 +10,8 @@ import {
   sessions,
 } from "../../db/schema/index.js";
 import { imAttrs, outcomeAttrs, setActiveSpanAttributes, withSpan } from "../../observability/index.js";
+import { SessionService } from "../sessions/index.js";
+import { threadRootExternalId } from "./provider-thread-context.js";
 
 const DIRECT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const AMBIENT_TTL_MS = 24 * 60 * 60 * 1000;
@@ -46,6 +48,7 @@ export class ImMessageInbox {
   readonly #beforeSupersedeDeliveries: (() => Promise<void>) | undefined;
   readonly #database: DatabaseClient;
   readonly #now: () => Date;
+  readonly #sessions: SessionService;
 
   constructor(
     database: DatabaseClient,
@@ -61,6 +64,7 @@ export class ImMessageInbox {
     this.#afterAdmissionFence = options.afterAdmissionFence;
     this.#afterMessageAuthority = options.afterMessageAuthority;
     this.#beforeSupersedeDeliveries = options.beforeSupersedeDeliveries;
+    this.#sessions = new SessionService(database, { now: this.#now });
   }
 
   async ingest(
@@ -319,16 +323,6 @@ export class ImMessageInbox {
             if (event.conversation.kind === "unknown") {
               deliveries.push(...inheritedDeliveries);
             } else {
-              const channel = await this.#ensureChatSession(
-                transaction,
-                imBindingId,
-                event.conversation.externalId,
-                conversationKind,
-                "channel",
-                null,
-                scope.agent.computerId,
-                now,
-              );
               if (threadKey) {
                 const existingThread = await this.#findChatSession(
                   transaction,
@@ -337,28 +331,63 @@ export class ImMessageInbox {
                   "thread",
                   threadKey,
                 );
-                if (existingThread || direct) {
-                  const thread =
-                    existingThread ??
-                    (await this.#ensureChatSession(
+                const endedThreadExists = existingThread
+                  ? false
+                  : await this.#hasEndedThreadSession(
                       transaction,
                       imBindingId,
                       event.conversation.externalId,
-                      conversationKind,
-                      "thread",
                       threadKey,
-                      scope.agent.computerId,
+                    );
+                const rootExternalId = threadRootExternalId(event.providerContext);
+                const rootWasDirect =
+                  !existingThread && !direct && !endedThreadExists && rootExternalId
+                    ? await this.#rootWasDirectToChannelSession(
+                        transaction,
+                        imBindingId,
+                        event.conversation.externalId,
+                        rootExternalId,
+                      )
+                    : false;
+                if (existingThread || direct || rootWasDirect) {
+                  const thread =
+                    existingThread ??
+                    (await this.#ensureChatSession(transaction, {
+                      imBindingId,
+                      channelId: event.conversation.externalId,
+                      conversationKind,
+                      kind: "thread",
+                      threadKey,
+                      computerId: scope.agent.computerId,
                       now,
-                    ));
+                    }));
                   deliveries.push({ sessionId: thread.id, attention: "direct", generation: thread.generation });
                 }
                 if (scope.agent.receiveMode === "all_message") {
+                  const channel = await this.#ensureChatSession(transaction, {
+                    imBindingId,
+                    channelId: event.conversation.externalId,
+                    conversationKind,
+                    kind: "channel",
+                    computerId: scope.agent.computerId,
+                    now,
+                  });
                   deliveries.push({ sessionId: channel.id, attention: "ambient", generation: channel.generation });
                 }
-              } else if (direct) {
-                deliveries.push({ sessionId: channel.id, attention: "direct", generation: channel.generation });
-              } else if (scope.agent.receiveMode === "all_message") {
-                deliveries.push({ sessionId: channel.id, attention: "ambient", generation: channel.generation });
+              } else if (direct || scope.agent.receiveMode === "all_message") {
+                const channel = await this.#ensureChatSession(transaction, {
+                  imBindingId,
+                  channelId: event.conversation.externalId,
+                  conversationKind,
+                  kind: "channel",
+                  computerId: scope.agent.computerId,
+                  now,
+                });
+                deliveries.push({
+                  sessionId: channel.id,
+                  attention: direct ? "direct" : "ambient",
+                  generation: channel.generation,
+                });
               }
             }
 
@@ -466,45 +495,26 @@ export class ImMessageInbox {
 
   async #ensureChatSession(
     transaction: DatabaseTransaction,
-    imBindingId: string,
-    channelId: string,
-    conversationKind: "channel" | "dm" | "group_dm",
-    kind: "channel" | "thread",
-    threadKey: string | null,
-    computerId: string,
-    now: Date,
+    input: {
+      imBindingId: string;
+      channelId: string;
+      conversationKind: "channel" | "dm" | "group_dm";
+      kind: "channel" | "thread";
+      threadKey?: string;
+      computerId: string;
+      now: Date;
+    },
   ): Promise<{ id: string; generation: number }> {
-    const existing = await this.#findChatSession(transaction, imBindingId, channelId, kind, threadKey);
-    if (existing) return existing;
-    const [created] = await transaction
-      .insert(sessions)
-      .values({ imBindingId, channelId, conversationKind, kind, threadKey, createdAt: now })
-      .onConflictDoNothing()
-      .returning({ id: sessions.id });
-    const sessionId = created?.id ?? (await this.#findSessionId(transaction, imBindingId, channelId, kind, threadKey));
-    if (!sessionId) throw new Error("Session ensure did not converge");
-    const [placement] = await transaction
-      .insert(sessionPlacements)
-      .values({ sessionId, computerId, generation: 1, updatedAt: now })
-      .onConflictDoNothing()
-      .returning({ generation: sessionPlacements.generation });
-    if (placement) return { id: sessionId, generation: placement.generation };
-    const [currentPlacement] = await transaction
-      .select({ generation: sessionPlacements.generation })
-      .from(sessionPlacements)
-      .where(eq(sessionPlacements.sessionId, sessionId))
-      .limit(1);
-    if (!currentPlacement) throw new Error("Session placement ensure did not converge");
-    return { id: sessionId, generation: currentPlacement.generation };
+    const result = await this.#sessions.ensureChatSessionInTransaction(transaction, input);
+    return { id: result.session.id, generation: result.placement.generation };
   }
 
-  async #findSessionId(
+  async #hasEndedThreadSession(
     transaction: DatabaseTransaction,
     imBindingId: string,
     channelId: string,
-    kind: "channel" | "thread",
-    threadKey: string | null,
-  ): Promise<string | undefined> {
+    threadKey: string,
+  ): Promise<boolean> {
     const [row] = await transaction
       .select({ id: sessions.id })
       .from(sessions)
@@ -512,12 +522,40 @@ export class ImMessageInbox {
         and(
           eq(sessions.imBindingId, imBindingId),
           eq(sessions.channelId, channelId),
-          eq(sessions.kind, kind),
-          threadKey === null ? isNull(sessions.threadKey) : eq(sessions.threadKey, threadKey),
-          isNull(sessions.endedAt),
+          eq(sessions.kind, "thread"),
+          eq(sessions.threadKey, threadKey),
+          isNotNull(sessions.endedAt),
         ),
       )
       .limit(1);
-    return row?.id;
+    return row !== undefined;
+  }
+
+  async #rootWasDirectToChannelSession(
+    transaction: DatabaseTransaction,
+    imBindingId: string,
+    channelId: string,
+    rootExternalId: string,
+  ): Promise<boolean> {
+    const [row] = await transaction
+      .select({ id: imMessageDeliveries.id })
+      .from(imMessageDeliveries)
+      .innerJoin(imMessages, eq(imMessages.id, imMessageDeliveries.messageId))
+      .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+      .where(
+        and(
+          eq(imMessages.imBindingId, imBindingId),
+          eq(imMessages.channelId, channelId),
+          eq(imMessages.externalMessageId, rootExternalId),
+          eq(imMessages.direction, "inbound"),
+          eq(imMessageDeliveries.attention, "direct"),
+          eq(sessions.imBindingId, imBindingId),
+          eq(sessions.channelId, channelId),
+          eq(sessions.kind, "channel"),
+          isNull(sessions.threadKey),
+        ),
+      )
+      .limit(1);
+    return row !== undefined;
   }
 }

--- a/packages/server/src/services/im/im-message-inbox.ts
+++ b/packages/server/src/services/im/im-message-inbox.ts
@@ -1,5 +1,5 @@
 import { ImContentV1Schema, type NormalizedInboundImEvent, NormalizedInboundImEventSchema } from "@opentag/shared";
-import { and, desc, eq, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
 import type { DatabaseClient, DatabaseTransaction } from "../../db/client.js";
 import {
   agents,
@@ -202,6 +202,7 @@ export class ImMessageInbox {
                       sessionId: imMessageDeliveries.sessionId,
                       attention: imMessageDeliveries.attention,
                       generation: sessionPlacements.generation,
+                      conversationKind: sessions.conversationKind,
                     })
                     .from(imMessageDeliveries)
                     .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
@@ -216,7 +217,9 @@ export class ImMessageInbox {
                     )
                 : [];
             const conversationKind =
-              event.conversation.kind === "unknown" ? (previousConversationKind ?? null) : event.conversation.kind;
+              event.conversation.kind === "unknown"
+                ? (inheritedDeliveries[0]?.conversationKind ?? previousConversationKind ?? null)
+                : event.conversation.kind;
             const threadKey =
               event.conversation.kind === "unknown"
                 ? (previousCurrent?.threadKey ?? null)
@@ -321,7 +324,13 @@ export class ImMessageInbox {
               event.mentions.some((mention) => mention.externalId === scope.imBinding.externalBotId);
             const deliveries: Array<{ sessionId: string; attention: "direct" | "ambient"; generation: number }> = [];
             if (event.conversation.kind === "unknown") {
-              deliveries.push(...inheritedDeliveries);
+              deliveries.push(
+                ...inheritedDeliveries.map(({ sessionId, attention, generation }) => ({
+                  sessionId,
+                  attention,
+                  generation,
+                })),
+              );
             } else {
               if (threadKey) {
                 const existingThread = await this.#findChatSession(
@@ -409,6 +418,66 @@ export class ImMessageInbox {
                 .returning({ id: imMessageDeliveries.id });
               if (deliveryRow) deliveryIds.push(deliveryRow.id);
               await this.#expireOverflow(transaction, delivery.sessionId, delivery.attention);
+            }
+            if (direct && threadKey === null) {
+              const pendingThreadMessages = await transaction
+                .select({
+                  id: imMessages.id,
+                  externalMessageId: imMessages.externalMessageId,
+                  threadKey: imMessages.threadKey,
+                  providerContext: imMessages.providerContext,
+                  occurredAt: imMessages.occurredAt,
+                  providerRevisionKey: imMessages.providerRevisionKey,
+                })
+                .from(imMessages)
+                .where(
+                  and(
+                    eq(imMessages.imBindingId, imBindingId),
+                    eq(imMessages.channelId, event.conversation.externalId),
+                    eq(imMessages.direction, "inbound"),
+                    isNotNull(imMessages.threadKey),
+                    or(gt(imMessages.occurredAt, created.occurredAt), eq(imMessages.occurredAt, created.occurredAt)),
+                  ),
+                )
+                .orderBy(desc(imMessages.occurredAt), desc(imMessages.providerRevisionKey), desc(imMessages.id));
+              const seenExternalMessageIds = new Set<string>();
+              for (const pending of pendingThreadMessages) {
+                if (seenExternalMessageIds.has(pending.externalMessageId)) continue;
+                seenExternalMessageIds.add(pending.externalMessageId);
+                if (
+                  !pending.threadKey ||
+                  threadRootExternalId(pending.providerContext) !== event.message.externalId ||
+                  (await this.#hasEndedThreadSession(
+                    transaction,
+                    imBindingId,
+                    event.conversation.externalId,
+                    pending.threadKey,
+                  ))
+                ) {
+                  continue;
+                }
+                const thread = await this.#ensureChatSession(transaction, {
+                  imBindingId,
+                  channelId: event.conversation.externalId,
+                  conversationKind,
+                  kind: "thread",
+                  threadKey: pending.threadKey,
+                  computerId: scope.agent.computerId,
+                  now,
+                });
+                await transaction
+                  .insert(imMessageDeliveries)
+                  .values({
+                    messageId: pending.id,
+                    sessionId: thread.id,
+                    attention: "direct",
+                    placementGeneration: thread.generation,
+                    nextAttemptAt: now,
+                    expiresAt: new Date(now.getTime() + DIRECT_TTL_MS),
+                  })
+                  .onConflictDoNothing();
+                await this.#expireOverflow(transaction, thread.id, "direct");
+              }
             }
             return finish(
               { duplicate: false, messageId: created.id, deliveryIds },

--- a/packages/server/src/services/im/provider-thread-context.ts
+++ b/packages/server/src/services/im/provider-thread-context.ts
@@ -1,0 +1,5 @@
+import type { ProviderInboundContext } from "@opentag/shared";
+
+export function threadRootExternalId(context: ProviderInboundContext): string | null {
+  return context.provider === "slack" ? (context.threadTs ?? null) : (context.rootId ?? null);
+}

--- a/packages/server/src/services/sessions/index.ts
+++ b/packages/server/src/services/sessions/index.ts
@@ -1,1 +1,5 @@
-export { SessionService, SessionServiceError } from "./session-service.js";
+export {
+  type EnsureChatSessionInTransactionInput,
+  SessionService,
+  SessionServiceError,
+} from "./session-service.js";

--- a/packages/server/src/services/sessions/session-service.ts
+++ b/packages/server/src/services/sessions/session-service.ts
@@ -6,6 +6,16 @@ import { agents, imBindings, imMessageDeliveries, sessionPlacements, sessions } 
 type SessionRow = typeof sessions.$inferSelect;
 type PlacementRow = typeof sessionPlacements.$inferSelect;
 
+export interface EnsureChatSessionInTransactionInput {
+  imBindingId: string;
+  channelId: string;
+  conversationKind: ImConversationKind;
+  kind: Exclude<SessionKind, "internal">;
+  threadKey?: string;
+  computerId: string;
+  now: Date;
+}
+
 function toSession(row: SessionRow): Session {
   return {
     id: row.id,
@@ -55,28 +65,54 @@ export class SessionService {
     kind: Exclude<SessionKind, "internal">,
     threadKey?: string,
   ): Promise<{ session: Session; placement: SessionPlacement }> {
-    if (kind === "channel" && threadKey !== undefined) {
+    return this.#database.transaction(async (transaction) => {
+      const computerId = await this.#resolveComputer(transaction, scope.imBindingId);
+      return this.ensureChatSessionInTransaction(transaction, {
+        ...scope,
+        kind,
+        ...(threadKey ? { threadKey } : {}),
+        computerId,
+        now: this.#now(),
+      });
+    });
+  }
+
+  async ensureChatSessionInTransaction(
+    transaction: DatabaseTransaction,
+    input: EnsureChatSessionInTransactionInput,
+  ): Promise<{ session: Session; placement: SessionPlacement }> {
+    if (input.kind === "channel" && input.threadKey !== undefined) {
       throw new SessionServiceError("SESSION_SCOPE_INVALID", "A channel Session cannot have a thread key");
     }
-    if (kind === "thread" && !threadKey) {
+    if (input.kind === "thread" && !input.threadKey) {
       throw new SessionServiceError("SESSION_SCOPE_INVALID", "A thread Session requires a thread key");
     }
 
-    return this.#database.transaction(async (transaction) => {
-      const computerId = await this.#resolveComputer(transaction, scope.imBindingId);
-      const existing = await this.#findActive(transaction, scope.imBindingId, scope.channelId, kind, threadKey);
-      if (existing) return this.#withPlacement(transaction, existing, computerId);
+    const existing = await this.#findActive(
+      transaction,
+      input.imBindingId,
+      input.channelId,
+      input.kind,
+      input.threadKey,
+    );
+    if (existing) return this.#withPlacement(transaction, existing, input.computerId, input.now);
 
-      const [created] = await transaction
-        .insert(sessions)
-        .values({ ...scope, kind, threadKey: threadKey ?? null, createdAt: this.#now() })
-        .onConflictDoNothing()
-        .returning();
-      const session =
-        created ?? (await this.#findActive(transaction, scope.imBindingId, scope.channelId, kind, threadKey));
-      if (!session) throw new Error("Active Session ensure did not converge");
-      return this.#withPlacement(transaction, session, computerId);
-    });
+    const [created] = await transaction
+      .insert(sessions)
+      .values({
+        imBindingId: input.imBindingId,
+        channelId: input.channelId,
+        conversationKind: input.conversationKind,
+        kind: input.kind,
+        threadKey: input.threadKey ?? null,
+        createdAt: input.now,
+      })
+      .onConflictDoNothing()
+      .returning();
+    const session =
+      created ?? (await this.#findActive(transaction, input.imBindingId, input.channelId, input.kind, input.threadKey));
+    if (!session) throw new Error("Active Session ensure did not converge");
+    return this.#withPlacement(transaction, session, input.computerId, input.now);
   }
 
   async createInternalSession(creatorSessionId: string): Promise<{ session: Session; placement: SessionPlacement }> {
@@ -275,6 +311,7 @@ export class SessionService {
     transaction: DatabaseTransaction,
     session: SessionRow,
     computerId: string,
+    now = this.#now(),
   ): Promise<{ session: Session; placement: SessionPlacement }> {
     const [existing] = await transaction
       .select()
@@ -286,7 +323,7 @@ export class SessionService {
       (
         await transaction
           .insert(sessionPlacements)
-          .values({ sessionId: session.id, computerId, generation: 1, updatedAt: this.#now() })
+          .values({ sessionId: session.id, computerId, generation: 1, updatedAt: now })
           .onConflictDoNothing()
           .returning()
       )[0];


### PR DESCRIPTION
## Summary

- keep top-level direct messages on the Channel Session and lazily materialize Thread Sessions only from real inbound thread facts
- admit the first Thread delivery from existing ownership, a current direct mention, or verified root-direct evidence while preserving independent `all_message` ambient fan-out
- bootstrap new Thread runtimes with bounded root and same-thread inbound history, and document the provider-neutral prompt-driven behavior

## Implementation

- centralizes transaction-aware Chat Session and placement creation in `SessionService`
- normalizes reliable Slack and Feishu root references without treating Feishu `parent_id` as a root
- blocks old root evidence from implicitly reviving an ended Thread Session
- keeps direct-provider CLI messaging and `direct`/`ambient` credential behavior unchanged
- adds decision-matrix, concurrency, history-boundary, adapter, and prompt fixtures

## Verification

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/server test:integration`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (100% statements, branches, functions, and lines)
- `pnpm test:coverage`
