### PR TITLE
feat(web): migrate the app shell information architecture

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app.js";
 
@@ -466,17 +467,17 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     expect(screen.getByRole("main").classList.contains("decorative-page")).toBe(false);
     expect(screen.getByRole("link", { name: "Agents" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Settings" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Settings" })).toBeNull();
     expect(screen.getByRole("button", { name: "New Agent" })).toBeTruthy();
-    expect(screen.getByText("Tasks").getAttribute("aria-disabled")).toBe("true");
-    const workspaceNavigation = screen.getByRole("navigation", { name: "Workspace" });
+    expect(screen.queryByText("Example")).toBeNull();
+    const workspaceNavigation = screen.getByRole("navigation", { name: "Product" });
     expect(
       within(workspaceNavigation)
-        .getAllByText(/Agents|Tasks|Settings/)
+        .getAllByRole("link")
         .map((item) => item.textContent),
-    ).toEqual(["Agents", "Tasks", "Settings"]);
+    ).toEqual(["Agents", "Tasks", "Integrations", "Resources", "Usage", "Members"]);
     const navigationIcons = workspaceNavigation.querySelectorAll(".primary-nav-icon");
-    expect(navigationIcons).toHaveLength(3);
+    expect(navigationIcons).toHaveLength(6);
     expect(Array.from(navigationIcons).every((icon) => icon.getAttribute("aria-hidden") === "true")).toBe(true);
   });
 
@@ -691,12 +692,12 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Ada")).toBeTruthy();
   });
 
-  it("keeps account profile editing out of the merged Team page", async () => {
+  it("keeps account and advanced Workspace editing out of Members", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
-    expect(screen.getAllByLabelText("Team name")).toHaveLength(1);
+    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
+    expect(screen.queryByLabelText("Workspace name")).toBeNull();
     expect(screen.queryByRole("button", { name: "Save account profile" })).toBeNull();
   });
 
@@ -765,7 +766,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("link", { name: "Review runtime" })).toBeTruthy();
   });
 
-  it("keeps infrastructure details and dependency reads out of the Agent list", async () => {
+  it("keeps infrastructure details out of Agent rows while loading the runtime section independently", async () => {
     installApi("admin", { bound: true, computerEvidenceFails: true });
     window.history.replaceState({}, "", "/agents");
     render(<App />);
@@ -773,7 +774,8 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByText("Reviewer")).toBeTruthy();
     expect(screen.getByText("Active")).toBeTruthy();
     expect(screen.queryByText("Ada's Mac")).toBeNull();
-    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes("/computers"))).toBe(false);
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes("/computers"))).toBe(true);
     expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes(`/agents/${agentId}/im-binding`))).toBe(
       false,
     );
@@ -895,71 +897,50 @@ describe("OpenTag Web App Shell", () => {
     confirm.mockRestore();
   });
 
-  it("uses a flat local navigation for Settings", async () => {
+  it("shows an honest Tasks unavailable state without synthetic records", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/tasks");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Settings" })).toBeTruthy();
-    const navigation = screen.getByRole("navigation", { name: "Settings" });
-    expect(
-      within(navigation)
-        .getAllByRole("link")
-        .map((link) => link.textContent),
-    ).toEqual(["Team", "Computers", "Resources", "Integrations", "Access", "Usage", "Security"]);
-    expect(navigation.querySelector(".local-nav-group-label")).toBeNull();
-    const mobileNavigation = screen.getByLabelText("Settings section");
-    expect(Array.from(mobileNavigation.querySelectorAll("option"), (option) => option.textContent)).toEqual([
-      "Team",
-      "Computers",
-      "Resources",
-      "Integrations",
-      "Access",
-      "Usage",
-      "Security",
-    ]);
-    expect(mobileNavigation.querySelector("optgroup")).toBeNull();
+    expect(await screen.findByRole("heading", { name: "Tasks" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Tasks are not available yet" })).toBeTruthy();
+    expect(screen.getByText("The current server does not expose a Tasks API.")).toBeTruthy();
+    expect(screen.getByText("No sample, inferred, or locally generated Task records are shown.")).toBeTruthy();
   });
 
-  it("opens Settings on Team and keeps account scope out of the Settings shell", async () => {
+  it("groups invitations with Members", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/settings");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Team" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/settings/team");
-    expect(screen.getByText("Manage the current Team's identity, infrastructure, access, and security.")).toBeTruthy();
-    expect(
-      within(screen.getByRole("navigation", { name: "Settings" })).queryByRole("link", { name: "Account" }),
-    ).toBeNull();
-  });
-
-  it("groups invitations with Team members", async () => {
-    installApi("admin");
-    window.history.replaceState({}, "", "/settings/team");
-    render(<App />);
-
-    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
-    const teamSettings = document.querySelector<HTMLElement>(".settings-team-stack");
-    if (!teamSettings) throw new Error("Merged Team settings were not rendered");
-    expect(
-      within(teamSettings)
-        .getAllByRole("heading", { level: 2 })
-        .map((heading) => heading.textContent),
-    ).toEqual(["Team profile", "Team members"]);
+    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
     const membersSection = document.querySelector<HTMLElement>("#members");
-    if (!membersSection) throw new Error("Team members section was not rendered");
+    if (!membersSection) throw new Error("Members section was not rendered");
     expect(within(membersSection).getByRole("heading", { level: 3, name: "Invite members" })).toBeTruthy();
+    const invitationPanel = document.querySelector<HTMLElement>("#member-invitations");
+    if (!invitationPanel) throw new Error("Invitation panel was not rendered");
+    fireEvent.click(screen.getByRole("button", { name: "Invite members" }));
+    expect(document.activeElement).toBe(invitationPanel);
   });
 
-  it("redirects the legacy Members URL to the merged Team page", async () => {
+  it.each(["/settings", "/settings/team", "/settings/members", "/settings/access", "/settings/security"])(
+    "redirects legacy member administration URL %s",
+    async (path) => {
+      installApi("member");
+      window.history.replaceState({}, "", path);
+      render(<App />);
+
+      expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
+      expect(window.location.pathname).toBe("/members");
+    },
+  );
+
+  it("redirects the legacy Members URL to the first-class Members page", async () => {
     installApi("member");
     window.history.replaceState({}, "", "/settings/members");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/settings/team");
-    expect(window.location.hash).toBe("#members");
-    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/members");
   });
 
   it("redirects the legacy Settings account URL to the editable Account page", async () => {
@@ -975,50 +956,36 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("button", { name: "Save account profile" })).toBeTruthy();
   });
 
-  it("keeps unavailable Team capabilities explicit instead of inventing records", async () => {
+  it("redirects legacy capability URLs to the minimal preview pages", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings/resources");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Team Resources are not enabled" })).toBeTruthy();
-    expect(screen.getByText("This page does not create or infer Team Resource records.")).toBeTruthy();
-    expect(screen.getByText("No Resource assignment projection is exposed by the current API.")).toBeTruthy();
-    expect(screen.queryByRole("link", { name: "Review Agent resources" })).toBeNull();
+    expect(await screen.findByRole("heading", { name: "Resources" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/resources");
+    expect(screen.getByText("Demo data preview")).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: "Integrations" }));
-    expect(await screen.findByRole("heading", { name: "Team Integrations are not enabled" })).toBeTruthy();
-    expect(
-      screen.getByText("Open an Agent's IM tab to review its current Feishu or Slack connection state."),
-    ).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Open Agents" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Integrations" })).toBeTruthy();
+    expect(screen.getByText("GitHub")).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: "Usage" }));
-    expect(await screen.findByRole("heading", { name: "Usage reporting is not enabled" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Usage" })).toBeTruthy();
+    expect(screen.getByLabelText("Usage metrics")).toBeTruthy();
   });
 
-  it("shows the server-returned membership without inventing a capability matrix", async () => {
-    installApi("admin");
-    window.history.replaceState({}, "", "/settings/access");
-    render(<App />);
-
-    expect(await screen.findByText("Server-returned membership")).toBeTruthy();
-    expect(screen.getByText("Your role: Admin")).toBeTruthy();
-    expect(screen.getByText("The current API does not publish a complete Team capability matrix.")).toBeTruthy();
-    expect(screen.getByText("Not exposed by the API")).toBeTruthy();
-    expect(screen.queryByRole("table")).toBeNull();
-  });
-
-  it("lets admins rename a Team without changing its CLI identifier", async () => {
+  it("lets admins rename a Workspace from advanced Account management without changing the CLI identifier", async () => {
     installApi("admin");
     window.localStorage.setItem("opentag.selectedTeamId", teamId);
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/account");
     render(<App />);
-    const displayName = await screen.findByLabelText("Team name");
+    fireEvent.click(await screen.findByText("Advanced"));
+    const displayName = await screen.findByLabelText("Workspace name");
     const profileForm = displayName.closest("form");
-    if (!profileForm) throw new Error("Team profile form was not rendered");
+    if (!profileForm) throw new Error("Workspace profile form was not rendered");
     const cliIdentifier = within(profileForm).getByText("example", { selector: "dd code" });
     expect(cliIdentifier.textContent).toContain("example");
     expect(within(profileForm).getAllByRole("textbox")).toHaveLength(1);
     fireEvent.change(displayName, { target: { value: "Renamed Team" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save Team profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save Workspace profile" }));
     await waitFor(() =>
       expect(vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/v1/me")).toHaveLength(2),
     );
@@ -1026,21 +993,22 @@ describe("OpenTag Web App Shell", () => {
       .mocked(fetch)
       .mock.calls.find(([input, init]) => String(input) === `/api/v1/teams/${teamId}` && init?.method === "PATCH");
     expect(JSON.parse(String(updateCall?.[1]?.body))).toEqual({ displayName: "Renamed Team" });
-    const refreshedDisplayName = (await screen.findByLabelText("Team name")) as HTMLInputElement;
+    const refreshedDisplayName = (await screen.findByLabelText("Workspace name")) as HTMLInputElement;
     const refreshedProfileForm = refreshedDisplayName.closest("form");
-    if (!refreshedProfileForm) throw new Error("Refreshed Team profile form was not rendered");
+    if (!refreshedProfileForm) throw new Error("Refreshed Workspace profile form was not rendered");
     expect(refreshedDisplayName.value).toBe("Renamed Team");
     expect(within(refreshedProfileForm).getByText("example", { selector: "dd code" })).toBeTruthy();
     expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(teamId);
   });
 
-  it("keeps Team profile fields read-only for members", async () => {
+  it("keeps Workspace profile fields read-only for members", async () => {
     installApi("member");
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/account");
     render(<App />);
+    fireEvent.click(await screen.findByText("Advanced"));
     expect(await screen.findByText("example")).toBeTruthy();
-    expect(screen.getByText("Team name").parentElement?.querySelector("dd")?.textContent).toBe("Example");
-    expect(screen.queryByRole("button", { name: "Save Team profile" })).toBeNull();
+    expect(screen.getByText("Workspace name").parentElement?.querySelector("dd")?.textContent).toBe("Example");
+    expect(screen.queryByRole("button", { name: "Save Workspace profile" })).toBeNull();
     expect(screen.queryByLabelText("CLI identifier")).toBeNull();
   });
 
@@ -1048,11 +1016,16 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin");
     window.history.replaceState({}, "", `/invites/${invitationToken}`);
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "Join Team" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Join Workspace" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(invitedTeamId);
     expect(window.sessionStorage.getItem("opentag.pendingInvitationToken")).toBeNull();
-    expect(screen.getByRole("button", { name: "Invited Team" }).getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
+    expect(
+      within(screen.getByRole("group", { name: "Switch Workspace" }))
+        .getByRole("menuitem", { name: /Invited Team Member/ })
+        .getAttribute("aria-current"),
+    ).toBe("true");
   });
 
   it("resumes a pending invitation after sign-in without requiring a second click", async () => {
@@ -1087,7 +1060,12 @@ describe("OpenTag Web App Shell", () => {
     try {
       render(<App />);
       expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-      expect(screen.getByRole("button", { name: "Invited Team" })).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
+      expect(
+        within(screen.getByRole("group", { name: "Switch Workspace" })).getByRole("menuitem", {
+          name: /Invited Team Member/,
+        }),
+      ).toBeTruthy();
       expect(window.location.pathname).toBe("/agents");
     } finally {
       setItem.mockRestore();
@@ -1098,7 +1076,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("member", { unauthenticated: true });
     window.history.replaceState({}, "", `/invites/${invitationToken}`);
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "Join Team" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Join Workspace" }));
     expect(await screen.findByRole("heading", { name: "Sign in" })).toBeTruthy();
     expect(window.location.search).toBe(`?next=${encodeURIComponent(`/invites/${invitationToken}`)}`);
     expect(window.sessionStorage.getItem("opentag.pendingInvitationToken")).toBe(invitationToken);
@@ -1109,9 +1087,9 @@ describe("OpenTag Web App Shell", () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, "clipboard", { configurable: true, value: { writeText } });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
-    expect(await screen.findByText("This link lets anyone join the Team as a member until it expires.")).toBeTruthy();
+    expect(await screen.findByText("This link lets anyone join as a member until it expires.")).toBeTruthy();
     fireEvent.click(await screen.findByRole("button", { name: "Create invite link" }));
     const link = (await screen.findByLabelText("Invite link")) as HTMLInputElement;
     expect(link.value).toBe(`https://opentag.example.com/invites/${"A".repeat(43)}`);
@@ -1124,178 +1102,10 @@ describe("OpenTag Web App Shell", () => {
     confirm.mockRestore();
   });
 
-  it("opens invitation-link management directly from the Team picker", async () => {
-    installApi("admin", { invitationExists: true });
-    render(<App />);
-    const teamTrigger = await screen.findByRole("button", { name: "Example" });
-    fireEvent.click(teamTrigger);
-    const teamPicker = screen.getByRole("dialog", { name: "Switch Team" });
-    fireEvent.click(within(teamPicker).getByRole("button", { name: "Invite people" }));
-
-    const invitationDialog = await screen.findByRole("dialog", { name: "Invite people" });
-    expect(screen.queryByRole("dialog", { name: "Switch Team" })).toBeNull();
-    expect((within(invitationDialog).getByLabelText("Invite link") as HTMLInputElement).value).toBe(
-      `https://opentag.example.com/invites/${"A".repeat(43)}`,
-    );
-    const closeButton = within(invitationDialog).getByRole("button", { name: "Close invitation dialog" });
-    expect(document.activeElement).toBe(closeButton);
-    fireEvent.keyDown(closeButton, { key: "Escape" });
-    expect(screen.queryByRole("dialog", { name: "Invite people" })).toBeNull();
-    expect(document.activeElement).toBe(teamTrigger);
-  });
-
-  it("keeps the Members invitation panel in sync after rotating from the Team-picker dialog", async () => {
-    installApi("admin", { invitationExists: true });
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(window.navigator, "clipboard", { configurable: true, value: { writeText } });
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/settings/team");
-    render(<App />);
-
-    const pageLink = (await screen.findByLabelText("Invite link")) as HTMLInputElement;
-    expect(pageLink.value).toContain("/invites/AAA");
-    fireEvent.click(screen.getByRole("button", { name: "Example" }));
-    fireEvent.click(
-      within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
-    );
-    const dialog = await screen.findByRole("dialog", { name: "Invite people" });
-    expect(screen.getAllByLabelText("Invite link")).toHaveLength(1);
-    fireEvent.click(within(dialog).getByRole("button", { name: "Replace link" }));
-    await waitFor(() =>
-      expect((within(dialog).getByLabelText("Invite link") as HTMLInputElement).value).toContain("/invites/BBB"),
-    );
-    fireEvent.click(within(dialog).getByRole("button", { name: "Close invitation dialog" }));
-
-    const refreshedPageLink = (await screen.findByLabelText("Invite link")) as HTMLInputElement;
-    expect(refreshedPageLink.value).toContain("/invites/BBB");
-    fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
-    await waitFor(() => expect(writeText).toHaveBeenCalledWith(refreshedPageLink.value));
-    confirm.mockRestore();
-  });
-
-  it("prevents switching invitation surfaces while a rotation is pending", async () => {
-    let resolveRotate: (response: Response) => void = () => undefined;
-    const pendingRotate = new Promise<Response>((resolve) => {
-      resolveRotate = resolve;
-    });
-    installApi("admin", { invitationExists: true, invitationRotate: () => pendingRotate });
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/settings/team");
-    render(<App />);
-
-    await screen.findByLabelText("Invite link");
-    fireEvent.click(screen.getByRole("button", { name: "Replace link" }));
-    fireEvent.click(screen.getByRole("button", { name: "Example" }));
-    const teamPicker = screen.getByRole("dialog", { name: "Switch Team" });
-    const inviteAction = within(teamPicker).getByRole("button", { name: "Invite people" }) as HTMLButtonElement;
-    expect(inviteAction.disabled).toBe(true);
-    fireEvent.click(inviteAction);
-    expect(screen.queryByRole("dialog", { name: "Invite people" })).toBeNull();
-
-    resolveRotate(
-      json({
-        token: "B".repeat(43),
-        inviteUrl: `https://opentag.example.com/invites/${"B".repeat(43)}`,
-        role: "member",
-        expiresAt: "2026-08-27T00:00:00.000Z",
-      }),
-    );
-    await waitFor(() => expect(inviteAction.disabled).toBe(false));
-    fireEvent.click(inviteAction);
-    const dialog = await screen.findByRole("dialog", { name: "Invite people" });
-    await waitFor(() =>
-      expect((within(dialog).getByLabelText("Invite link") as HTMLInputElement).value).toContain("/invites/BBB"),
-    );
-    confirm.mockRestore();
-  });
-
-  it("keeps focus inside the invitation dialog while a rotation is pending", async () => {
-    let resolveRotate: (response: Response) => void = () => undefined;
-    const pendingRotate = new Promise<Response>((resolve) => {
-      resolveRotate = resolve;
-    });
-    installApi("admin", { invitationExists: true, invitationRotate: () => pendingRotate });
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    render(<App />);
-
-    const teamTrigger = await screen.findByRole("button", { name: "Example" });
-    fireEvent.click(teamTrigger);
-    fireEvent.click(
-      within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
-    );
-    const dialog = await screen.findByRole("dialog", { name: "Invite people" });
-    fireEvent.click(await within(dialog).findByRole("button", { name: "Replace link" }));
-
-    expect(dialog.contains(document.activeElement)).toBe(true);
-    expect(document.activeElement).not.toBe(teamTrigger);
-    fireEvent.keyDown(document.activeElement ?? dialog, { key: "Escape" });
-    expect(screen.getByRole("dialog", { name: "Invite people" })).toBe(dialog);
-
-    resolveRotate(
-      json({
-        token: "B".repeat(43),
-        inviteUrl: `https://opentag.example.com/invites/${"B".repeat(43)}`,
-        role: "member",
-        expiresAt: "2026-08-27T00:00:00.000Z",
-      }),
-    );
-    await waitFor(() =>
-      expect(
-        (within(dialog).getByRole("button", { name: "Close invitation dialog" }) as HTMLButtonElement).disabled,
-      ).toBe(false),
-    );
-    confirm.mockRestore();
-  });
-
-  it("uses the dialog card as the focus fallback while invitation creation is pending", async () => {
-    let resolveCreate: (response: Response) => void = () => undefined;
-    const pendingCreate = new Promise<Response>((resolve) => {
-      resolveCreate = resolve;
-    });
-    installApi("admin", { invitationCreate: () => pendingCreate });
-    render(<App />);
-
-    const teamTrigger = await screen.findByRole("button", { name: "Example" });
-    fireEvent.click(teamTrigger);
-    fireEvent.click(
-      within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", { name: "Invite people" }),
-    );
-    const dialog = await screen.findByRole("dialog", { name: "Invite people" });
-    fireEvent.click(await within(dialog).findByRole("button", { name: "Create invite link" }));
-
-    teamTrigger.focus();
-    fireEvent.keyDown(teamTrigger, { key: "Tab" });
-    expect(document.activeElement).toBe(dialog);
-    fireEvent.keyDown(dialog, { key: "Escape" });
-    expect(screen.getByRole("dialog", { name: "Invite people" })).toBe(dialog);
-
-    resolveCreate(
-      json(
-        {
-          token: "A".repeat(43),
-          inviteUrl: `https://opentag.example.com/invites/${"A".repeat(43)}`,
-          role: "member",
-          expiresAt: "2026-08-27T00:00:00.000Z",
-        },
-        201,
-      ),
-    );
-    expect(await within(dialog).findByLabelText("Invite link")).toBeTruthy();
-    await waitFor(() => {
-      expect(dialog.contains(document.activeElement)).toBe(true);
-      expect(document.activeElement).not.toBe(dialog);
-    });
-
-    dialog.focus();
-    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
-    expect(dialog.contains(document.activeElement)).toBe(true);
-    expect(document.activeElement).not.toBe(teamTrigger);
-  });
-
   it("replaces a locally rotated invitation with a newer successful server read", async () => {
     const api = installApi("admin", { invitationExists: true });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
 
     expect(((await screen.findByLabelText("Invite link")) as HTMLInputElement).value).toContain("/invites/AAA");
@@ -1307,8 +1117,8 @@ describe("OpenTag Web App Shell", () => {
     api.setInvitationVersion("C");
     fireEvent.click(screen.getByRole("link", { name: "Agents" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
-    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: "Members" }));
+    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
 
     await waitFor(() =>
       expect((screen.getByLabelText("Invite link") as HTMLInputElement).value).toContain("/invites/CCC"),
@@ -1316,27 +1126,29 @@ describe("OpenTag Web App Shell", () => {
     confirm.mockRestore();
   });
 
-  it("does not expose the Team-picker invitation shortcut to regular members", async () => {
+  it("does not expose Workspace or invitation shortcuts to single-Workspace members", async () => {
     installApi("member");
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "Example" }));
-    const teamPicker = screen.getByRole("dialog", { name: "Switch Team" });
-    expect(within(teamPicker).queryByRole("button", { name: "Invite people" })).toBeNull();
+    fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
+    expect(screen.queryByRole("group", { name: "Switch Workspace" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Invite people" })).toBeNull();
+    expect(screen.queryByText("Create Workspace")).toBeNull();
   });
 
   it("keeps invitation-link management hidden from regular members", async () => {
     installApi("member");
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Team members" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Invite people" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Invite members" })).toBeNull();
     expect(screen.queryByLabelText("Role for Ada")).toBeNull();
     expect(await screen.findAllByText("member")).toHaveLength(3);
   });
 
   it("lets Team admins update another member role from the member list", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
     const role = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
     fireEvent.change(role, { target: { value: "admin" } });
@@ -1359,7 +1171,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", {
       roleUpdate: (targetUserId) => (targetUserId === memberUserId ? graceUpdate : linUpdate),
     });
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
     const graceRole = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
     const linRole = screen.getByLabelText("Role for Lin") as HTMLSelectElement;
@@ -1414,21 +1226,19 @@ describe("OpenTag Web App Shell", () => {
 
   it("refreshes current membership authority after an admin demotes themself", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
     fireEvent.change(await screen.findByLabelText("Role for Ada"), { target: { value: "member" } });
     await waitFor(() =>
       expect(vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/v1/me")).toHaveLength(2),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Example" }));
-    expect(await screen.findByText("Member")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Invite people" })).toBeNull();
     expect(screen.queryByLabelText("Role for Ada")).toBeNull();
   });
 
   it("keeps the confirmed role and displays the server error when an update is rejected", async () => {
     installApi("admin", { roleUpdateFails: true });
-    window.history.replaceState({}, "", "/settings/team");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
     const role = (await screen.findByLabelText("Role for Ada")) as HTMLSelectElement;
     fireEvent.change(role, { target: { value: "member" } });
@@ -1532,6 +1342,8 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings/computers");
     render(<App />);
+    expect(await screen.findByRole("heading", { name: "Agent runtime" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/agents");
     const button = await screen.findByRole("button", { name: "Generate connection command" });
     expect(vi.mocked(fetch).mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
     fireEvent.click(button);
@@ -1543,7 +1355,7 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/agents/new");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Connect a Local Computer first" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Computer settings" }).getAttribute("href")).toBe("/settings/computers");
+    expect(screen.getByRole("link", { name: "Agent runtime" }).getAttribute("href")).toBe("/agents#agent-runtime");
   });
 
   it("validates Agent name locally with an accessible field error before sending a request", async () => {
@@ -1720,21 +1532,28 @@ describe("OpenTag Web App Shell", () => {
     expect(within(dialog).getByRole("button", { name: "Create Agent" }).hasAttribute("disabled")).toBe(false);
   });
 
-  it("sends a Team-less session to Team creation and lands it on Agents", async () => {
+  it("automatically creates a default Workspace for a Team-less session", async () => {
     installApi("admin", { teamless: true });
-    render(<App />);
-    expect(await screen.findByRole("heading", { name: "Create your team" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/teams/new");
-    expect(screen.getAllByRole("textbox")).toHaveLength(1);
-    expect(screen.queryByText(/canonical name/i)).toBeNull();
-    fireEvent.change(screen.getByLabelText("Team name"), { target: { value: "First Tree AI" } });
-    fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     expect(window.location.pathname).toBe("/agents");
+    expect(screen.queryByLabelText("Workspace name")).toBeNull();
+    const createCalls = vi
+      .mocked(fetch)
+      .mock.calls.filter(([path, init]) => path === "/api/v1/teams" && init?.method === "POST");
+    expect(createCalls).toHaveLength(1);
+    expect(JSON.parse(String(createCalls[0]?.[1]?.body))).toEqual({
+      displayName: "Ada's Workspace",
+      name: "ada-s-workspace",
+    });
     expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(createdTeamId);
   });
 
-  it("lands on the created Team when Team preference storage is unavailable", async () => {
+  it("lands on the automatic default Workspace when Team preference storage is unavailable", async () => {
     installApi("admin", { teamless: true });
     window.localStorage.setItem("opentag.selectedTeamId", teamId);
     const setItem = vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
@@ -1742,10 +1561,9 @@ describe("OpenTag Web App Shell", () => {
     });
     try {
       render(<App />);
-      fireEvent.change(await screen.findByLabelText("Team name"), { target: { value: "First Tree AI" } });
-      fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
       expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-      expect(screen.getByRole("button", { name: "First Tree AI" })).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
+      expect(screen.queryByRole("group", { name: "Switch Workspace" })).toBeNull();
       expect(window.location.pathname).toBe("/agents");
       expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(teamId);
     } finally {
@@ -1753,15 +1571,15 @@ describe("OpenTag Web App Shell", () => {
     }
   });
 
-  it("keeps Team establishment out of the standalone onboarding route", async () => {
+  it("automatically establishes the default Workspace before standalone onboarding", async () => {
     installApi("admin", { teamless: true });
     window.history.replaceState({}, "", "/onboarding");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Create your team" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/teams/new");
+    expect(await screen.findByRole("heading", { name: "Reviewer needs its runtime route" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/onboarding");
     expect(
       vi.mocked(fetch).mock.calls.some(([path, init]) => path === "/api/v1/teams" && init?.method === "POST"),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("loads standalone onboarding when selected Team preference storage is unavailable", async () => {
@@ -1788,8 +1606,8 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", { teamless: true, teamNameConflict: true });
     window.history.replaceState({}, "", "/teams/new");
     render(<App />);
-    fireEvent.change(await screen.findByLabelText("Team name"), { target: { value: "Example" } });
-    fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
+    fireEvent.change(await screen.findByLabelText("Workspace name"), { target: { value: "Example" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Workspace" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     const createRequests = vi
       .mocked(fetch)
@@ -1802,12 +1620,12 @@ describe("OpenTag Web App Shell", () => {
     });
   });
 
-  it("uses a fresh internal handle for every collision on a Team name without ASCII characters", async () => {
+  it("uses a fresh internal handle for every collision on a Workspace name without ASCII characters", async () => {
     installApi("admin", { teamless: true, teamNameConflicts: 2 });
     window.history.replaceState({}, "", "/teams/new");
     render(<App />);
-    fireEvent.change(await screen.findByLabelText("Team name"), { target: { value: "示例团队" } });
-    fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
+    fireEvent.change(await screen.findByLabelText("Workspace name"), { target: { value: "示例团队" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Workspace" }));
     await screen.findByRole("heading", { name: "Agents" });
     const requests = vi
       .mocked(fetch)
@@ -1821,23 +1639,29 @@ describe("OpenTag Web App Shell", () => {
     expect(new Set(bodies.map((body) => body.name))).toHaveProperty("size", 3);
   });
 
-  it("lets an existing member create a second Team and offers both in the picker", async () => {
+  it("creates an additional Workspace from advanced Account management and offers both in the account menu", async () => {
     installApi("admin");
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "Example" }));
-    fireEvent.click(screen.getByRole("link", { name: "Create Team" }));
-    fireEvent.change(await screen.findByLabelText("Team name"), { target: { value: "Second Team" } });
-    fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Account settings" }));
+    fireEvent.click(await screen.findByText("Advanced"));
+    fireEvent.click(screen.getByRole("link", { name: "Create another Workspace" }));
+    fireEvent.change(await screen.findByLabelText("Workspace name"), { target: { value: "Second Team" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Workspace" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Second Team" }));
-    const menu = screen.getByRole("dialog", { name: "Switch Team" });
-    expect(within(menu).getByRole("button", { name: /Example Admin/ })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
+    const menu = screen.getByRole("group", { name: "Switch Workspace" });
+    expect(within(menu).getByRole("menuitem", { name: /Example Admin/ })).toBeTruthy();
     expect(
       within(menu)
-        .getByRole("button", { name: /Second Team Admin/ })
+        .getByRole("menuitem", { name: /Second Team Admin/ })
         .getAttribute("aria-current"),
     ).toBe("true");
-    expect(within(menu).queryByText("Team settings")).toBeNull();
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Manage Workspaces" }));
+    expect(await screen.findByRole("heading", { name: "Workspace management" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/account");
+    expect(window.location.hash).toBe("#workspace-management");
+    expect(screen.getByRole("link", { name: "Create another Workspace" })).toBeTruthy();
   });
 
   it("switches Teams when Team preference storage is unavailable", async () => {
@@ -1848,13 +1672,18 @@ describe("OpenTag Web App Shell", () => {
     });
     try {
       render(<App />);
-      fireEvent.click(await screen.findByRole("button", { name: "Example" }));
+      fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
       fireEvent.click(
-        within(screen.getByRole("dialog", { name: "Switch Team" })).getByRole("button", {
+        within(screen.getByRole("group", { name: "Switch Workspace" })).getByRole("menuitem", {
           name: /Invited Team Member/,
         }),
       );
-      expect(await screen.findByRole("button", { name: "Invited Team" })).toBeTruthy();
+      fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
+      expect(
+        within(screen.getByRole("group", { name: "Switch Workspace" }))
+          .getByRole("menuitem", { name: /Invited Team Member/ })
+          .getAttribute("aria-current"),
+      ).toBe("true");
       expect(window.location.pathname).toBe("/agents");
       expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(teamId);
     } finally {
@@ -1882,15 +1711,15 @@ describe("OpenTag Web App Shell", () => {
     );
   });
 
-  it("moves focus into the Team picker and returns it to the trigger on Escape", async () => {
-    installApi("admin");
+  it("moves focus into multi-Workspace account options and returns it to the trigger on Escape", async () => {
+    installApi("admin", { alreadyJoinedInvitation: true });
     render(<App />);
-    const trigger = await screen.findByRole("button", { name: "Example" });
+    const trigger = await screen.findByRole("button", { name: "Account menu" });
     fireEvent.click(trigger);
-    const currentTeam = screen.getByRole("button", { name: /Example Admin/ });
+    const currentTeam = screen.getByRole("menuitem", { name: /Example Admin/ });
     expect(document.activeElement).toBe(currentTeam);
     fireEvent.keyDown(currentTeam, { key: "Escape" });
-    expect(screen.queryByRole("dialog", { name: "Switch Team" })).toBeNull();
+    expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();
     expect(document.activeElement).toBe(trigger);
   });
 

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -922,7 +922,7 @@ describe("OpenTag Web App Shell", () => {
     expect(document.activeElement).toBe(invitationPanel);
   });
 
-  it.each(["/settings", "/settings/team", "/settings/members", "/settings/access", "/settings/security"])(
+  it.each(["/settings", "/settings/members", "/settings/access", "/settings/security"])(
     "redirects legacy member administration URL %s",
     async (path) => {
       installApi("member");
@@ -956,6 +956,17 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("button", { name: "Save account profile" })).toBeTruthy();
   });
 
+  it("redirects the legacy Team profile URL to advanced Workspace management", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/settings/team");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Workspace management" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/account");
+    expect(window.location.hash).toBe("#workspace-management");
+    expect(screen.getByLabelText("Workspace name")).toBeTruthy();
+  });
+
   it("redirects legacy capability URLs to the minimal preview pages", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings/resources");
@@ -966,7 +977,8 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Demo data preview")).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: "Integrations" }));
     expect(await screen.findByRole("heading", { name: "Integrations" })).toBeTruthy();
-    expect(screen.getByText("GitHub")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Workspace Integrations are not available yet" })).toBeTruthy();
+    expect(screen.queryByText("GitHub")).toBeNull();
     fireEvent.click(screen.getByRole("link", { name: "Usage" }));
     expect(await screen.findByRole("heading", { name: "Usage" })).toBeTruthy();
     expect(screen.getByLabelText("Usage metrics")).toBeTruthy();
@@ -1344,6 +1356,7 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Agent runtime" })).toBeTruthy();
     expect(window.location.pathname).toBe("/agents");
+    expect(window.location.hash).toBe("#agent-runtime");
     const button = await screen.findByRole("button", { name: "Generate connection command" });
     expect(vi.mocked(fetch).mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
     fireEvent.click(button);
@@ -1532,54 +1545,34 @@ describe("OpenTag Web App Shell", () => {
     expect(within(dialog).getByRole("button", { name: "Create Agent" }).hasAttribute("disabled")).toBe(false);
   });
 
-  it("automatically creates a default Workspace for a Team-less session", async () => {
+  it("keeps the Team-less authenticated gate read-only while the server finishes Workspace setup", async () => {
     installApi("admin", { teamless: true });
     render(
       <StrictMode>
         <App />
       </StrictMode>,
     );
-    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Workspace setup incomplete" })).toBeTruthy();
     expect(window.location.pathname).toBe("/agents");
-    expect(screen.queryByLabelText("Workspace name")).toBeNull();
-    const createCalls = vi
-      .mocked(fetch)
-      .mock.calls.filter(([path, init]) => path === "/api/v1/teams" && init?.method === "POST");
-    expect(createCalls).toHaveLength(1);
-    expect(JSON.parse(String(createCalls[0]?.[1]?.body))).toEqual({
-      displayName: "Ada's Workspace",
-      name: "ada-s-workspace",
-    });
-    expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(createdTeamId);
+    expect(screen.getByRole("alert").textContent).toContain("The server must finish Workspace setup");
+    expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
+    const initialMeReads = vi.mocked(fetch).mock.calls.filter(([path]) => path === "/api/v1/me").length;
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+    await waitFor(() =>
+      expect(vi.mocked(fetch).mock.calls.filter(([path]) => path === "/api/v1/me")).toHaveLength(initialMeReads + 1),
+    );
+    expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
   });
 
-  it("lands on the automatic default Workspace when Team preference storage is unavailable", async () => {
-    installApi("admin", { teamless: true });
-    window.localStorage.setItem("opentag.selectedTeamId", teamId);
-    const setItem = vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
-      throw new Error("Storage unavailable");
-    });
-    try {
-      render(<App />);
-      expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-      fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
-      expect(screen.queryByRole("group", { name: "Switch Workspace" })).toBeNull();
-      expect(window.location.pathname).toBe("/agents");
-      expect(window.localStorage.getItem("opentag.selectedTeamId")).toBe(teamId);
-    } finally {
-      setItem.mockRestore();
-    }
-  });
-
-  it("automatically establishes the default Workspace before standalone onboarding", async () => {
+  it("keeps standalone onboarding behind the read-only Workspace setup gate", async () => {
     installApi("admin", { teamless: true });
     window.history.replaceState({}, "", "/onboarding");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Reviewer needs its runtime route" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Workspace setup incomplete" })).toBeTruthy();
     expect(window.location.pathname).toBe("/onboarding");
     expect(
       vi.mocked(fetch).mock.calls.some(([path, init]) => path === "/api/v1/teams" && init?.method === "POST"),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("loads standalone onboarding when selected Team preference storage is unavailable", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1691,6 +1691,33 @@ describe("OpenTag Web App Shell", () => {
     }
   });
 
+  it.each([`/agents/${agentId}/general`, "/agents/new"])(
+    "leaves Workspace-scoped Agent route %s when switching Workspaces",
+    async (path) => {
+      installApi("admin", { alreadyJoinedInvitation: true });
+      window.history.replaceState({}, "", path);
+      render(<App />);
+
+      fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
+      const targetWorkspace = within(screen.getByRole("group", { name: "Switch Workspace" }))
+        .getAllByRole("menuitem")
+        .find(
+          (item) => item.classList.contains("account-workspace-option") && item.getAttribute("aria-current") !== "true",
+        );
+      if (!targetWorkspace) throw new Error("A second Workspace option was not rendered");
+      const targetWorkspaceName = targetWorkspace.querySelector("strong")?.textContent;
+      fireEvent.click(targetWorkspace);
+
+      expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+      expect(window.location.pathname).toBe("/agents");
+      fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
+      const selectedWorkspace = screen
+        .getByRole("group", { name: "Switch Workspace" })
+        .querySelector<HTMLElement>('[aria-current="true"]');
+      expect(selectedWorkspace?.querySelector("strong")?.textContent).toBe(targetWorkspaceName);
+    },
+  );
+
   it("keeps account controls personal and signs out from the account menu", async () => {
     installApi("admin");
     render(<App />);

--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { IntegrationsPage } from "../features/integrations-page.js";
+import { ResourcesPage } from "../features/resources-page.js";
+import { UsagePage } from "../features/usage-page.js";
+
+describe("capability mock pages", () => {
+  it("renders Resources as an explicit demo and filters the static resource list", () => {
+    render(<ResourcesPage />);
+
+    expect(screen.getByRole("heading", { name: "Resources" })).toBeTruthy();
+    expect(screen.getByText("Demo data preview")).toBeTruthy();
+    expect(screen.getByText("OpenTag workspace")).toBeTruthy();
+    expect(screen.getByText("Release notes writer")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skills" }));
+
+    expect(screen.getByText("Release notes writer")).toBeTruthy();
+    expect(screen.queryByText("OpenTag workspace")).toBeNull();
+    expect(screen.getByRole("button", { name: "Skills" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("keeps resource creation visibly unavailable", () => {
+    render(<ResourcesPage />);
+
+    const addResource = screen.getByRole("button", {
+      name: "Add resource (Coming soon)",
+    }) as HTMLButtonElement;
+    expect(addResource.disabled).toBe(true);
+    expect(addResource.textContent).toContain("Coming soon");
+  });
+
+  it("shows connected and available integration previews without actionable connects", () => {
+    render(<IntegrationsPage />);
+
+    expect(screen.getByRole("heading", { name: "Integrations" })).toBeTruthy();
+    expect(screen.getByText("Demo data preview")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Connected" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Available" })).toBeTruthy();
+    expect(screen.getByText("GitHub")).toBeTruthy();
+
+    const connectButtons = screen.getAllByRole("button", { name: "Connect (Coming soon)" });
+    expect(connectButtons.length).toBeGreaterThan(0);
+    expect(connectButtons.every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
+  });
+
+  it("updates the Usage overview when the demo range changes", () => {
+    render(<UsagePage />);
+
+    expect(screen.getByText("Demo data preview")).toBeTruthy();
+    const metrics = screen.getByLabelText("Usage metrics");
+    expect(within(metrics).getByText("146")).toBeTruthy();
+    expect(within(metrics).getByText("728")).toBeTruthy();
+    expect(screen.getByRole("img").getAttribute("aria-label")).toContain("30 days");
+
+    fireEvent.change(screen.getByLabelText("Time range"), { target: { value: "7 days" } });
+
+    expect(within(metrics).getByText("38")).toBeTruthy();
+    expect(within(metrics).getByText("184")).toBeTruthy();
+    expect(screen.getByRole("img").getAttribute("aria-label")).toContain("7 days");
+  });
+});

--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -4,7 +4,7 @@ import { IntegrationsPage } from "../features/integrations-page.js";
 import { ResourcesPage } from "../features/resources-page.js";
 import { UsagePage } from "../features/usage-page.js";
 
-describe("capability mock pages", () => {
+describe("capability entry pages", () => {
   it("renders Resources as an explicit demo and filters the static resource list", () => {
     render(<ResourcesPage />);
 
@@ -30,18 +30,16 @@ describe("capability mock pages", () => {
     expect(addResource.textContent).toContain("Coming soon");
   });
 
-  it("shows connected and available integration previews without actionable connects", () => {
+  it("keeps Integrations truthful until a Workspace Integration contract exists", () => {
     render(<IntegrationsPage />);
 
     expect(screen.getByRole("heading", { name: "Integrations" })).toBeTruthy();
-    expect(screen.getByText("Demo data preview")).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Connected" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Available" })).toBeTruthy();
-    expect(screen.getByText("GitHub")).toBeTruthy();
-
-    const connectButtons = screen.getAllByRole("button", { name: "Connect (Coming soon)" });
-    expect(connectButtons.length).toBeGreaterThan(0);
-    expect(connectButtons.every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
+    expect(screen.getByText("Coming later")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Workspace Integrations are not available yet" })).toBeTruthy();
+    expect(screen.getByText(/Provider Bot connections remain managed/)).toBeTruthy();
+    expect(screen.queryByText("GitHub")).toBeNull();
+    expect(screen.queryByText("Connected")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
   });
 
   it("updates the Usage overview when the demo range changes", () => {

--- a/apps/web/src/create-team-form.tsx
+++ b/apps/web/src/create-team-form.tsx
@@ -23,15 +23,32 @@ function randomHandleSuffix(): string {
 
 const MAX_HANDLE_ATTEMPTS = 4;
 
+/** Creates a Team without exposing its internal handle, retrying deterministic handle collisions. */
+export async function createTeamWithUniqueHandle(displayName: string): Promise<CreateTeamResponse> {
+  const suggestedHandle = toTeamHandle(displayName);
+  for (let attempt = 0; attempt < MAX_HANDLE_ATTEMPTS; attempt += 1) {
+    const name =
+      attempt === 0 && suggestedHandle ? suggestedHandle : handleWithSuffix(suggestedHandle, randomHandleSuffix());
+    try {
+      return await browserApi.createTeam({ name, displayName });
+    } catch (cause) {
+      if (!(cause instanceof ApiError) || cause.code !== "TEAM_NAME_CONFLICT" || attempt === MAX_HANDLE_ATTEMPTS - 1) {
+        throw cause;
+      }
+    }
+  }
+  throw new Error("The Workspace could not be created");
+}
+
 /**
- * The single Team creation form. It is mounted both by the standalone `/teams/new` page and by the first
- * onboarding step, so creating a Team behaves identically whether it is a first-run or an additional Team.
+ * The single Workspace creation form. It is mounted by the standalone `/workspaces/new` page for both first-run
+ * and additional Workspace creation while the backing domain continues to use Team identifiers.
  * The caller owns what happens next; this component owns the fields, the derivation and the error surface.
  */
 export function CreateTeamForm({
   onCreated,
   onUnauthenticated,
-  submitLabel = "Create Team",
+  submitLabel = "Create Workspace",
 }: {
   onCreated: (team: CreateTeamResponse) => void;
   onUnauthenticated?: () => void;
@@ -46,23 +63,7 @@ export function CreateTeamForm({
     setSubmitting(true);
     try {
       setError(undefined);
-      const suggestedHandle = toTeamHandle(displayName);
-      for (let attempt = 0; attempt < MAX_HANDLE_ATTEMPTS; attempt += 1) {
-        const name =
-          attempt === 0 && suggestedHandle ? suggestedHandle : handleWithSuffix(suggestedHandle, randomHandleSuffix());
-        try {
-          onCreated(await browserApi.createTeam({ name, displayName }));
-          return;
-        } catch (cause) {
-          if (
-            !(cause instanceof ApiError) ||
-            cause.code !== "TEAM_NAME_CONFLICT" ||
-            attempt === MAX_HANDLE_ATTEMPTS - 1
-          ) {
-            throw cause;
-          }
-        }
-      }
+      onCreated(await createTeamWithUniqueHandle(displayName));
     } catch (cause) {
       if (cause instanceof ApiError && cause.status === 401 && onUnauthenticated) {
         onUnauthenticated();
@@ -70,10 +71,10 @@ export function CreateTeamForm({
       }
       setError(
         cause instanceof ApiError && cause.code === "TEAM_NAME_CONFLICT"
-          ? "We couldn't create a unique team address. Try again."
+          ? "We couldn't create a unique Workspace address. Try again."
           : cause instanceof Error
             ? cause.message
-            : "The Team could not be created",
+            : "The Workspace could not be created",
       );
     } finally {
       setSubmitting(false);
@@ -83,12 +84,12 @@ export function CreateTeamForm({
   return (
     <form className="form-card" onSubmit={submit}>
       <label>
-        Team name
+        Workspace name
         <input
           name="displayName"
           autoComplete="organization"
           maxLength={120}
-          placeholder="e.g. Platform team"
+          placeholder="e.g. Platform Workspace"
           required
           value={displayName}
           onChange={(event) => setDisplayName(event.currentTarget.value)}

--- a/apps/web/src/features/integrations-page.tsx
+++ b/apps/web/src/features/integrations-page.tsx
@@ -1,82 +1,24 @@
-import { integrationPreviews } from "../mock/capability-data.js";
 import "../mock-pages.css";
 
 export function IntegrationsPage() {
-  const connected = integrationPreviews.filter((integration) => integration.status === "Connected");
-  const available = integrationPreviews.filter((integration) => integration.status === "Available");
-
   return (
     <section className="capability-page" aria-labelledby="integrations-page-title">
       <header className="capability-page-header">
         <div>
-          <span className="capability-preview-label">Demo data preview</span>
           <h1 id="integrations-page-title">Integrations</h1>
-          <p>Services that help Agents work with the tools used in this Workspace.</p>
+          <p>Review Workspace-level service connections when OpenTag exposes an authoritative API.</p>
         </div>
       </header>
 
-      <div className="capability-section-stack">
-        <IntegrationSection
-          title="Connected"
-          description="Sample connections currently available to Agents."
-          items={connected}
-        />
-        <IntegrationSection
-          title="Available"
-          description="Additional services planned for this Workspace."
-          items={available}
-        />
-      </div>
-    </section>
-  );
-}
-
-function IntegrationSection({
-  title,
-  description,
-  items,
-}: {
-  title: "Connected" | "Available";
-  description: string;
-  items: typeof integrationPreviews;
-}) {
-  const headingId = `integrations-${title.toLowerCase()}`;
-
-  return (
-    <section className="capability-list-section" aria-labelledby={headingId}>
-      <div className="capability-section-heading">
-        <div>
-          <h2 id={headingId}>{title}</h2>
-          <p>{description}</p>
-        </div>
-        <span>{items.length}</span>
-      </div>
-      <ul className="capability-integration-list">
-        {items.map((integration) => (
-          <li key={integration.name}>
-            <div className="capability-integration-identity">
-              <span className="capability-integration-mark" aria-hidden="true">
-                {integration.mark}
-              </span>
-              <span>
-                <strong>{integration.name}</strong>
-                <small>{integration.category}</small>
-              </span>
-            </div>
-            <span className={`capability-status ${integration.status === "Connected" ? "is-connected" : ""}`}>
-              {integration.status}
-            </span>
-            <span className="capability-agent-count">
-              {integration.agentCount} {integration.agentCount === 1 ? "Agent" : "Agents"}
-            </span>
-            {integration.status === "Available" ? (
-              <button type="button" className="secondary compact-button" disabled title="Coming soon">
-                Connect (Coming soon)
-              </button>
-            ) : null}
-          </li>
-        ))}
-      </ul>
+      <section className="settings-unavailable">
+        <span className="settings-state-label">Coming later</span>
+        <h2>Workspace Integrations are not available yet</h2>
+        <p>The current server does not expose a Workspace Integration contract.</p>
+        <ul>
+          <li>No connection state or Agent assignment is inferred or generated here.</li>
+          <li>Provider Bot connections remain managed from each Agent&apos;s Messaging page.</li>
+        </ul>
+      </section>
     </section>
   );
 }

--- a/apps/web/src/features/integrations-page.tsx
+++ b/apps/web/src/features/integrations-page.tsx
@@ -1,0 +1,82 @@
+import { integrationPreviews } from "../mock/capability-data.js";
+import "../mock-pages.css";
+
+export function IntegrationsPage() {
+  const connected = integrationPreviews.filter((integration) => integration.status === "Connected");
+  const available = integrationPreviews.filter((integration) => integration.status === "Available");
+
+  return (
+    <section className="capability-page" aria-labelledby="integrations-page-title">
+      <header className="capability-page-header">
+        <div>
+          <span className="capability-preview-label">Demo data preview</span>
+          <h1 id="integrations-page-title">Integrations</h1>
+          <p>Services that help Agents work with the tools used in this Workspace.</p>
+        </div>
+      </header>
+
+      <div className="capability-section-stack">
+        <IntegrationSection
+          title="Connected"
+          description="Sample connections currently available to Agents."
+          items={connected}
+        />
+        <IntegrationSection
+          title="Available"
+          description="Additional services planned for this Workspace."
+          items={available}
+        />
+      </div>
+    </section>
+  );
+}
+
+function IntegrationSection({
+  title,
+  description,
+  items,
+}: {
+  title: "Connected" | "Available";
+  description: string;
+  items: typeof integrationPreviews;
+}) {
+  const headingId = `integrations-${title.toLowerCase()}`;
+
+  return (
+    <section className="capability-list-section" aria-labelledby={headingId}>
+      <div className="capability-section-heading">
+        <div>
+          <h2 id={headingId}>{title}</h2>
+          <p>{description}</p>
+        </div>
+        <span>{items.length}</span>
+      </div>
+      <ul className="capability-integration-list">
+        {items.map((integration) => (
+          <li key={integration.name}>
+            <div className="capability-integration-identity">
+              <span className="capability-integration-mark" aria-hidden="true">
+                {integration.mark}
+              </span>
+              <span>
+                <strong>{integration.name}</strong>
+                <small>{integration.category}</small>
+              </span>
+            </div>
+            <span className={`capability-status ${integration.status === "Connected" ? "is-connected" : ""}`}>
+              {integration.status}
+            </span>
+            <span className="capability-agent-count">
+              {integration.agentCount} {integration.agentCount === 1 ? "Agent" : "Agents"}
+            </span>
+            {integration.status === "Available" ? (
+              <button type="button" className="secondary compact-button" disabled title="Coming soon">
+                Connect (Coming soon)
+              </button>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/features/resources-page.tsx
+++ b/apps/web/src/features/resources-page.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { type ResourceFilter, resourcePreviews, resourceTypes } from "../mock/capability-data.js";
+import "../mock-pages.css";
+
+const filters: readonly ResourceFilter[] = ["All", ...resourceTypes];
+
+export function ResourcesPage() {
+  const [activeFilter, setActiveFilter] = useState<ResourceFilter>("All");
+  const visibleResources =
+    activeFilter === "All" ? resourcePreviews : resourcePreviews.filter((resource) => resource.type === activeFilter);
+
+  return (
+    <section className="capability-page" aria-labelledby="resources-page-title">
+      <header className="capability-page-header">
+        <div>
+          <span className="capability-preview-label">Demo data preview</span>
+          <h1 id="resources-page-title">Resources</h1>
+          <p>Reusable context and capabilities available across this Workspace.</p>
+        </div>
+        <div className="capability-future-action">
+          <button type="button" disabled>
+            Add resource (Coming soon)
+          </button>
+        </div>
+      </header>
+
+      <fieldset className="capability-filter-bar">
+        <legend className="capability-filter-label">Filter resources</legend>
+        {filters.map((filter) => (
+          <button
+            className={activeFilter === filter ? "is-active" : undefined}
+            type="button"
+            aria-pressed={activeFilter === filter}
+            onClick={() => setActiveFilter(filter)}
+            key={filter}
+          >
+            {filter}
+          </button>
+        ))}
+      </fieldset>
+
+      <table className="capability-table" aria-label={`${activeFilter} resources`}>
+        <thead>
+          <tr className="capability-table-header capability-resource-grid">
+            <th scope="col">Name</th>
+            <th scope="col">Type</th>
+            <th scope="col">Agents</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visibleResources.map((resource) => (
+            <tr className="capability-table-row capability-resource-grid" key={resource.name}>
+              <td className="capability-primary-cell">
+                <strong>{resource.name}</strong>
+                <small>{resource.description}</small>
+              </td>
+              <td data-label="Type">
+                <span className="capability-type-badge">{resource.type}</span>
+              </td>
+              <td data-label="Agents">
+                {resource.agentCount} {resource.agentCount === 1 ? "Agent" : "Agents"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/apps/web/src/features/usage-page.tsx
+++ b/apps/web/src/features/usage-page.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { type UsageRange, usageRanges, usageSnapshots } from "../mock/capability-data.js";
+import "../mock-pages.css";
+
+export function UsagePage() {
+  const [range, setRange] = useState<UsageRange>("30 days");
+  const snapshot = usageSnapshots[range];
+  const trendPoints = makeTrendPoints(snapshot.trend);
+
+  return (
+    <section className="capability-page" aria-labelledby="usage-page-title">
+      <header className="capability-page-header capability-usage-header">
+        <div>
+          <span className="capability-preview-label">Demo data preview</span>
+          <h1 id="usage-page-title">Usage</h1>
+          <p>A simple view of sample Agent activity across this Workspace.</p>
+        </div>
+        <label className="capability-range-field">
+          <span>Time range</span>
+          <select value={range} onChange={(event) => setRange(event.currentTarget.value as UsageRange)}>
+            {usageRanges.map((option) => (
+              <option value={option} key={option}>
+                Last {option}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      <dl className="capability-metric-grid" aria-label="Usage metrics" aria-live="polite">
+        <Metric label="Tasks" value={snapshot.metrics.tasks} />
+        <Metric label="Turns" value={snapshot.metrics.turns} />
+        <Metric label="Active Agents" value={snapshot.metrics.activeAgents} />
+        <Metric label="Providers" value={snapshot.metrics.providers} />
+      </dl>
+
+      <div className="capability-usage-grid">
+        <section className="capability-chart-panel" aria-labelledby="activity-trend-title">
+          <div className="capability-section-heading">
+            <div>
+              <h2 id="activity-trend-title">Activity trend</h2>
+              <p>Turns completed during the selected demo period.</p>
+            </div>
+            <span>{range}</span>
+          </div>
+          <svg
+            className="capability-trend-chart"
+            viewBox="0 0 640 220"
+            role="img"
+            aria-label={`Demo activity trend for the last ${range}`}
+            preserveAspectRatio="none"
+          >
+            <line x1="0" y1="40" x2="640" y2="40" />
+            <line x1="0" y1="110" x2="640" y2="110" />
+            <line x1="0" y1="180" x2="640" y2="180" />
+            <polyline points={trendPoints} />
+          </svg>
+        </section>
+
+        <section className="capability-provider-panel" aria-labelledby="provider-usage-title">
+          <div className="capability-section-heading">
+            <div>
+              <h2 id="provider-usage-title">Provider usage</h2>
+              <p>Share of demo Turns.</p>
+            </div>
+          </div>
+          <ul className="capability-provider-list">
+            {snapshot.providers.map((provider) => (
+              <li key={provider.name}>
+                <div>
+                  <strong>{provider.name}</strong>
+                  <span>{provider.turns.toLocaleString()} Turns</span>
+                </div>
+                <small>{provider.share}%</small>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <dt>{label}</dt>
+      <dd>{value.toLocaleString()}</dd>
+    </div>
+  );
+}
+
+function makeTrendPoints(values: readonly number[]): string {
+  const maximum = Math.max(...values, 1);
+  const divisor = Math.max(values.length - 1, 1);
+
+  return values
+    .map((value, index) => {
+      const x = (index / divisor) * 640;
+      const y = 190 - (value / maximum) * 150;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}

--- a/apps/web/src/im/feishu-setup.tsx
+++ b/apps/web/src/im/feishu-setup.tsx
@@ -216,7 +216,7 @@ function setupRecovery(attempt: FeishuSetupAttempt): string | undefined {
   if (attempt.errorCode && FEISHU_SETUP_MESSAGES[attempt.errorCode]) return FEISHU_SETUP_MESSAGES[attempt.errorCode];
   if (attempt.state === "expired") return FEISHU_SETUP_MESSAGES.FEISHU_SETUP_EXPIRED;
   if (attempt.state === "canceled") return FEISHU_SETUP_MESSAGES.FEISHU_SETUP_CANCELED;
-  if (attempt.state === "failed") return "Feishu setup failed. Retry or contact a Team admin for help.";
+  if (attempt.state === "failed") return "Feishu setup failed. Retry or contact an admin for help.";
   return undefined;
 }
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import "@fontsource-variable/geist";
 import "@fontsource-variable/geist-mono";
 import { App } from "./app.js";
 import "./styles.css";
+import "./ui/design-system.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("OpenTag root element is missing");

--- a/apps/web/src/mock-pages.css
+++ b/apps/web/src/mock-pages.css
@@ -1,0 +1,528 @@
+.capability-page {
+  width: min(100%, 960px);
+  margin: 0 auto;
+  color: var(--foreground, #16211b);
+}
+
+.capability-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 32px;
+}
+
+.capability-page-header h1 {
+  margin: 0 0 7px;
+  font-family: var(--font-display, sans-serif);
+  font-size: var(--text-title, 1.5rem);
+  font-weight: var(--fw-semibold, 600);
+  letter-spacing: var(--track-tight, -0.02em);
+  line-height: var(--lh-tight, 1.2);
+}
+
+.capability-page-header p,
+.capability-section-heading p {
+  max-width: 620px;
+  margin: 0;
+  color: var(--muted, #616b62);
+  font-size: var(--text-body, 0.875rem);
+  line-height: var(--lh-prose, 1.6);
+}
+
+.capability-preview-label {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 9px;
+  border-radius: 999px;
+  background: var(--brand-light, #edf3df);
+  color: var(--brand-ink, #385a04);
+  font-size: var(--text-micro, 0.75rem);
+  font-weight: var(--fw-bold, 700);
+  letter-spacing: 0.04em;
+  padding: 5px 9px;
+  text-transform: uppercase;
+}
+
+.capability-future-action {
+  display: grid;
+  flex: 0 0 auto;
+  justify-items: center;
+}
+
+.capability-future-action button:disabled,
+.capability-future-action button:disabled:hover {
+  border: 1px solid var(--border, #d6d9ca);
+  background: var(--surface-soft, #eff0e6);
+  color: var(--muted, #616b62);
+  opacity: 1;
+}
+
+.capability-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 22px;
+  border: 0;
+  padding: 0;
+}
+
+.capability-filter-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.capability-filter-bar button {
+  min-height: 34px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted, #616b62);
+  font-size: var(--text-ui, 0.8125rem);
+  font-weight: var(--fw-medium, 500);
+  padding: 0 11px;
+}
+
+.capability-filter-bar button:hover {
+  border-color: var(--border, #d6d9ca);
+  background: var(--surface, #fdfcf7);
+  color: var(--foreground, #16211b);
+}
+
+.capability-filter-bar button.is-active {
+  border-color: var(--border, #d6d9ca);
+  background: var(--brand-light, #edf3df);
+  color: var(--brand-ink, #385a04);
+}
+
+.capability-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.capability-table thead,
+.capability-table tbody {
+  display: block;
+}
+
+.capability-table th,
+.capability-table td {
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.capability-resource-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.6fr) minmax(130px, 0.75fr) minmax(100px, 0.55fr);
+  gap: 24px;
+}
+
+.capability-table-header {
+  min-height: 38px;
+  align-items: center;
+  border-bottom: 1px solid var(--border, #d6d9ca);
+  color: var(--muted, #616b62);
+  font-size: var(--text-micro, 0.75rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.capability-table-row {
+  min-height: 70px;
+  align-items: center;
+  border-bottom: 1px solid var(--border, #d6d9ca);
+  color: var(--secondary-foreground, #3a453e);
+  font-size: var(--text-ui, 0.8125rem);
+  padding: 10px 0;
+}
+
+.capability-table-row:last-child {
+  border-bottom: 0;
+}
+
+.capability-primary-cell strong,
+.capability-primary-cell small {
+  display: block;
+}
+
+.capability-primary-cell strong {
+  color: var(--foreground, #16211b);
+  font-size: var(--text-ui, 0.8125rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.capability-primary-cell small {
+  margin-top: 3px;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.capability-type-badge,
+.capability-status {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border: 1px solid var(--border, #d6d9ca);
+  border-radius: 7px;
+  background: var(--surface, #fdfcf7);
+  color: var(--secondary-foreground, #3a453e);
+  font-size: var(--text-micro, 0.75rem);
+  font-weight: var(--fw-semibold, 600);
+  padding: 5px 8px;
+  white-space: nowrap;
+}
+
+.capability-section-stack {
+  display: grid;
+  gap: 42px;
+}
+
+.capability-list-section,
+.capability-chart-panel,
+.capability-provider-panel {
+  min-width: 0;
+}
+
+.capability-section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 14px;
+}
+
+.capability-section-heading h2 {
+  margin: 0 0 4px;
+  color: var(--foreground, #16211b);
+  font-size: var(--text-subsection, 1rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.capability-section-heading > span {
+  flex: 0 0 auto;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.capability-integration-list,
+.capability-provider-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.capability-integration-list li {
+  display: grid;
+  min-height: 72px;
+  align-items: center;
+  grid-template-columns: minmax(180px, 1.3fr) 100px 92px minmax(132px, auto);
+  gap: 18px;
+  border-bottom: 1px solid var(--border, #d6d9ca);
+  padding: 10px 0;
+}
+
+.capability-integration-list li:last-child {
+  border-bottom: 0;
+}
+
+.capability-integration-identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+}
+
+.capability-integration-identity strong,
+.capability-integration-identity small {
+  display: block;
+}
+
+.capability-integration-identity strong {
+  font-size: var(--text-ui, 0.8125rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.capability-integration-identity small {
+  margin-top: 3px;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.capability-integration-mark {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--strong-border, #c9ccbb);
+  border-radius: 9px;
+  background: var(--surface, #fdfcf7);
+  color: var(--brand-ink, #385a04);
+  font-size: var(--text-micro, 0.75rem);
+  font-weight: var(--fw-bold, 700);
+}
+
+.capability-status.is-connected {
+  border-color: #b9d98a;
+  background: var(--brand-light, #edf3df);
+  color: var(--brand-ink, #385a04);
+}
+
+.capability-agent-count {
+  color: var(--secondary-foreground, #3a453e);
+  font-size: var(--text-ui, 0.8125rem);
+  font-variant-numeric: tabular-nums;
+}
+
+.capability-integration-list button {
+  justify-self: end;
+}
+
+.capability-integration-list button:disabled,
+.capability-integration-list button:disabled:hover {
+  border: 1px solid var(--border, #d6d9ca);
+  background: var(--surface-soft, #eff0e6);
+  color: var(--muted, #616b62);
+  opacity: 1;
+}
+
+.capability-range-field {
+  display: grid;
+  width: 150px;
+  flex: 0 0 auto;
+  gap: 6px;
+  color: var(--muted, #616b62);
+  font-size: var(--text-micro, 0.75rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.capability-range-field select {
+  min-height: 38px;
+  padding-block: 0.4rem;
+}
+
+.capability-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0 0 36px;
+  border-top: 1px solid var(--strong-border, #c9ccbb);
+  border-bottom: 1px solid var(--border, #d6d9ca);
+}
+
+.capability-metric-grid > div {
+  display: grid;
+  gap: 5px;
+  border-right: 1px solid var(--border, #d6d9ca);
+  padding: 18px 20px;
+}
+
+.capability-metric-grid > div:first-child {
+  padding-left: 0;
+}
+
+.capability-metric-grid > div:last-child {
+  border-right: 0;
+}
+
+.capability-metric-grid dt {
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.capability-metric-grid dd {
+  margin: 0;
+  color: var(--foreground, #16211b);
+  font-family: var(--font-display, sans-serif);
+  font-size: var(--text-section, 1.25rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--fw-semibold, 600);
+}
+
+.capability-usage-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(250px, 0.85fr);
+  gap: 44px;
+}
+
+.capability-trend-chart {
+  display: block;
+  width: 100%;
+  height: 220px;
+  overflow: visible;
+}
+
+.capability-trend-chart line {
+  stroke: var(--border, #d6d9ca);
+  stroke-dasharray: 4 7;
+  stroke-width: 1;
+}
+
+.capability-trend-chart polyline {
+  fill: none;
+  stroke: var(--brand, #4e7a06);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 4;
+  vector-effect: non-scaling-stroke;
+}
+
+.capability-provider-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 34px;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid var(--border, #d6d9ca);
+  padding: 13px 0;
+}
+
+.capability-provider-list li:last-child {
+  border-bottom: 0;
+}
+
+.capability-provider-list strong,
+.capability-provider-list span {
+  display: block;
+}
+
+.capability-provider-list strong {
+  font-size: var(--text-ui, 0.8125rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.capability-provider-list div > span,
+.capability-provider-list small {
+  color: var(--muted, #616b62);
+  font-size: var(--text-micro, 0.75rem);
+  font-variant-numeric: tabular-nums;
+}
+
+.capability-provider-list small {
+  text-align: right;
+}
+
+@media (max-width: 720px) {
+  .capability-page-header {
+    display: grid;
+    gap: 18px;
+  }
+
+  .capability-future-action {
+    width: fit-content;
+    justify-items: start;
+  }
+
+  .capability-resource-grid {
+    grid-template-columns: minmax(0, 1fr) 110px 92px;
+    gap: 14px;
+  }
+
+  .capability-integration-list li {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 9px 16px;
+    padding: 14px 0;
+  }
+
+  .capability-integration-identity {
+    grid-column: 1;
+    grid-row: span 2;
+  }
+
+  .capability-status {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  .capability-agent-count {
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: end;
+  }
+
+  .capability-integration-list button {
+    grid-column: 1 / -1;
+    grid-row: 3;
+    justify-self: end;
+  }
+
+  .capability-usage-header {
+    grid-template-columns: minmax(0, 1fr) 150px;
+  }
+
+  .capability-usage-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .capability-filter-bar {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 2px;
+    scrollbar-width: none;
+  }
+
+  .capability-filter-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .capability-table-header {
+    display: none;
+  }
+
+  .capability-table-row.capability-resource-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    padding: 15px 0;
+  }
+
+  .capability-primary-cell {
+    grid-column: 1 / -1;
+  }
+
+  .capability-table-row [data-label]::before {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--muted, #616b62);
+    content: attr(data-label);
+    font-size: var(--text-micro, 0.75rem);
+  }
+
+  .capability-usage-header {
+    grid-template-columns: 1fr;
+  }
+
+  .capability-range-field {
+    width: min(100%, 180px);
+  }
+
+  .capability-metric-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .capability-metric-grid > div,
+  .capability-metric-grid > div:first-child {
+    border-right: 0;
+    border-bottom: 1px solid var(--border, #d6d9ca);
+    padding: 14px 0;
+  }
+
+  .capability-metric-grid > div:nth-child(odd) {
+    border-right: 1px solid var(--border, #d6d9ca);
+  }
+
+  .capability-metric-grid > div:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+
+  .capability-metric-grid > div:nth-child(even) {
+    padding-left: 16px;
+  }
+}

--- a/apps/web/src/mock/capability-data.ts
+++ b/apps/web/src/mock/capability-data.ts
@@ -43,22 +43,6 @@ export const resourcePreviews: readonly ResourcePreview[] = [
   },
 ];
 
-export type IntegrationPreview = {
-  name: string;
-  category: string;
-  status: "Connected" | "Available";
-  agentCount: number;
-  mark: string;
-};
-
-export const integrationPreviews: readonly IntegrationPreview[] = [
-  { name: "GitHub", category: "Source control", status: "Connected", agentCount: 4, mark: "GH" },
-  { name: "Slack", category: "Messaging", status: "Connected", agentCount: 2, mark: "SL" },
-  { name: "Linear", category: "Issue tracking", status: "Available", agentCount: 0, mark: "LI" },
-  { name: "Notion", category: "Knowledge", status: "Available", agentCount: 0, mark: "NO" },
-  { name: "Google Drive", category: "Files", status: "Available", agentCount: 0, mark: "GD" },
-];
-
 export const usageRanges = ["7 days", "30 days", "90 days"] as const;
 
 export type UsageRange = (typeof usageRanges)[number];

--- a/apps/web/src/mock/capability-data.ts
+++ b/apps/web/src/mock/capability-data.ts
@@ -1,0 +1,109 @@
+export const resourceTypes = ["Repositories", "Skills", "Tools", "Prompts"] as const;
+
+export type ResourceType = (typeof resourceTypes)[number];
+export type ResourceFilter = "All" | ResourceType;
+
+export type ResourcePreview = {
+  name: string;
+  type: ResourceType;
+  agentCount: number;
+  description: string;
+};
+
+export const resourcePreviews: readonly ResourcePreview[] = [
+  {
+    name: "OpenTag workspace",
+    type: "Repositories",
+    agentCount: 4,
+    description: "Product and runtime source",
+  },
+  {
+    name: "Support playbook",
+    type: "Repositories",
+    agentCount: 2,
+    description: "Response guidelines and examples",
+  },
+  {
+    name: "Release notes writer",
+    type: "Skills",
+    agentCount: 3,
+    description: "Turns merged changes into clear release notes",
+  },
+  {
+    name: "Browser runner",
+    type: "Tools",
+    agentCount: 2,
+    description: "Checks product flows in a browser",
+  },
+  {
+    name: "Issue triage",
+    type: "Prompts",
+    agentCount: 5,
+    description: "Shared intake and prioritization guidance",
+  },
+];
+
+export type IntegrationPreview = {
+  name: string;
+  category: string;
+  status: "Connected" | "Available";
+  agentCount: number;
+  mark: string;
+};
+
+export const integrationPreviews: readonly IntegrationPreview[] = [
+  { name: "GitHub", category: "Source control", status: "Connected", agentCount: 4, mark: "GH" },
+  { name: "Slack", category: "Messaging", status: "Connected", agentCount: 2, mark: "SL" },
+  { name: "Linear", category: "Issue tracking", status: "Available", agentCount: 0, mark: "LI" },
+  { name: "Notion", category: "Knowledge", status: "Available", agentCount: 0, mark: "NO" },
+  { name: "Google Drive", category: "Files", status: "Available", agentCount: 0, mark: "GD" },
+];
+
+export const usageRanges = ["7 days", "30 days", "90 days"] as const;
+
+export type UsageRange = (typeof usageRanges)[number];
+
+export type UsageSnapshot = {
+  metrics: {
+    tasks: number;
+    turns: number;
+    activeAgents: number;
+    providers: number;
+  };
+  trend: readonly number[];
+  providers: readonly {
+    name: string;
+    turns: number;
+    share: number;
+  }[];
+};
+
+export const usageSnapshots: Record<UsageRange, UsageSnapshot> = {
+  "7 days": {
+    metrics: { tasks: 38, turns: 184, activeAgents: 6, providers: 3 },
+    trend: [18, 27, 21, 34, 29, 31, 24],
+    providers: [
+      { name: "OpenAI", turns: 112, share: 61 },
+      { name: "Anthropic", turns: 52, share: 28 },
+      { name: "Local", turns: 20, share: 11 },
+    ],
+  },
+  "30 days": {
+    metrics: { tasks: 146, turns: 728, activeAgents: 9, providers: 3 },
+    trend: [92, 118, 104, 133, 126, 155],
+    providers: [
+      { name: "OpenAI", turns: 451, share: 62 },
+      { name: "Anthropic", turns: 204, share: 28 },
+      { name: "Local", turns: 73, share: 10 },
+    ],
+  },
+  "90 days": {
+    metrics: { tasks: 411, turns: 2096, activeAgents: 12, providers: 3 },
+    trend: [224, 286, 312, 295, 354, 387, 412],
+    providers: [
+      { name: "OpenAI", turns: 1314, share: 63 },
+      { name: "Anthropic", turns: 572, share: 27 },
+      { name: "Local", turns: 210, share: 10 },
+    ],
+  },
+};

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -142,7 +142,26 @@ describe("OnboardingPage", () => {
     expect(await screen.findByRole("heading", { name: "Connect a Local Computer" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Generate connection command" })).toBeTruthy();
     expect(screen.queryByRole("navigation", { name: "Workspace" })).toBeNull();
-    expect(screen.queryByText("Create Team")).toBeNull();
+    expect(screen.queryByText("Create Workspace")).toBeNull();
+  });
+
+  it("presents the conditional setup as two product-level steps", async () => {
+    installFacts();
+    renderPage();
+    expect(await screen.findByRole("heading", { name: "Connect a Local Computer" })).toBeTruthy();
+
+    const steps = screen.getByRole("navigation", { name: "Onboarding steps" });
+    expect(steps.querySelectorAll("li")).toHaveLength(2);
+    expect(steps.textContent).toContain("Prepare your Agent");
+    expect(steps.textContent).toContain("Add to Feishu");
+    expect(steps.textContent).toContain("In progress");
+    expect(steps.textContent).toContain("Up next");
+
+    const summary = screen.getByRole("region", { name: "Agent preparation summary" });
+    expect(summary.textContent).toContain("ComputerNot connected");
+    expect(summary.textContent).toContain("RuntimeWaiting");
+    expect(summary.textContent).toContain("AgentNot created");
+    expect(screen.queryByRole("img")).toBeNull();
   });
 
   it("asks for the existing Computer to be reconnected when every Computer is offline", async () => {
@@ -393,6 +412,7 @@ describe("OnboardingPage", () => {
     renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]) });
     expect(await screen.findByRole("heading", { name: heading })).toBeTruthy();
     expect(screen.getByRole("button", { name: action })).toBeTruthy();
+    expect(screen.getByRole("region", { name: /OpenTag Agent .* Feishu/ })).toBeTruthy();
   });
 
   it("renders Ready only when runtime and authoritative handoff are both ready", async () => {
@@ -411,15 +431,15 @@ describe("OnboardingPage", () => {
     });
     expect(await screen.findByRole("heading", { name: "Connect OpenTag to Feishu" })).toBeTruthy();
     expect(screen.getByText("Read only")).toBeTruthy();
-    expect(screen.getByText(/A Team admin can complete this action/)).toBeTruthy();
+    expect(screen.getByText(/An admin can complete this action/)).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Feishu/ })).toBeNull();
   });
 
   it.each([
-    [["Ada"], "Ask a Team admin to continue: Ada."],
-    [["Ada", "Grace"], "Ask a Team admin to continue: Ada or Grace."],
-    [["Ada", "Grace", "Linus"], "Ask a Team admin to continue: Ada, Grace, or 1 more."],
-    [["Ada", "Grace", "Linus", "Ken"], "Ask a Team admin to continue: Ada, Grace, or 2 more."],
+    [["Ada"], "Ask an admin to continue: Ada."],
+    [["Ada", "Grace"], "Ask an admin to continue: Ada or Grace."],
+    [["Ada", "Grace", "Linus"], "Ask an admin to continue: Ada, Grace, or 1 more."],
+    [["Ada", "Grace", "Linus", "Ken"], "Ask an admin to continue: Ada, Grace, or 2 more."],
   ])("names the admins a member can ask", async (names, expected) => {
     installFacts({
       agents: [agent],
@@ -450,7 +470,7 @@ describe("OnboardingPage", () => {
     });
 
     expect(await screen.findByRole("heading", { name: "Prepare Codex or Claude Code" })).toBeTruthy();
-    expect(screen.getByText(/Ask a Team admin to continue: Ada or Grace\./)).toBeTruthy();
+    expect(screen.getByText(/Ask an admin to continue: Ada or Grace\./)).toBeTruthy();
     expect(screen.queryByText(/can complete this action/)).toBeNull();
   });
 
@@ -463,7 +483,7 @@ describe("OnboardingPage", () => {
     });
 
     expect(await screen.findByRole("heading", { name: "Connect OpenTag to Feishu" })).toBeTruthy();
-    expect(screen.getByText(/A Team admin can complete this action/)).toBeTruthy();
+    expect(screen.getByText(/An admin can complete this action/)).toBeTruthy();
   });
 
   it("does not ask for the member list when the viewer manages the Team", async () => {

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -73,6 +73,26 @@ interface CreationState {
   readonly message?: string;
 }
 
+type JourneyStatus = "complete" | "current" | "upcoming";
+type JourneyFactStatus = "attention" | "current" | "ready" | "waiting";
+
+interface JourneyFact {
+  readonly label: string;
+  readonly status: JourneyFactStatus;
+  readonly value: string;
+}
+
+interface OnboardingJourneyState {
+  readonly activeStep: 1 | 2;
+  readonly agentName: string;
+  readonly messaging: JourneyStatus;
+  readonly prepareFacts: readonly JourneyFact[];
+  readonly prepare: JourneyStatus;
+  readonly stageDescription: string;
+  readonly stageStatus: string;
+  readonly stageTitle: string;
+}
+
 export interface OnboardingPageProps {
   readonly membership: MeMembership;
   readonly user: UserProfile;
@@ -157,6 +177,10 @@ export function OnboardingPage({
     if (loadState.kind !== "ready") return undefined;
     return resolveSnapshot(membership, loadState.snapshot);
   }, [loadState, membership]);
+  const journey = onboardingJourney(
+    resolved?.state.currentState,
+    loadState.kind === "ready" ? loadState.snapshot : undefined,
+  );
 
   const waitingForRuntime = resolved !== undefined && RUNTIME_WAIT_STATES.includes(resolved.state.currentState.kind);
   // biome-ignore lint/correctness/useExhaustiveDependencies: attendedWindow deliberately restarts the bounded window.
@@ -217,44 +241,260 @@ export function OnboardingPage({
     <div className="onboarding-shell">
       <OnboardingHeader user={user} />
       <main className="onboarding-main">
-        <header className="onboarding-title">
-          <span className="eyebrow">Onboarding</span>
-          <h1>Set up OpenTag</h1>
-          <p>Bring your first Team Agent to Feishu.</p>
-        </header>
-        {loadState.kind === "loading" ? <OnboardingLoading /> : null}
-        {loadState.kind === "error" ? (
-          <ActionSection title="We couldn’t load setup" description={loadState.error.message}>
-            <button className="button" type="button" onClick={reload}>
-              Try again
-            </button>
-          </ActionSection>
-        ) : null}
-        {loadState.kind === "ready" && resolved ? (
-          <OnboardingContent
-            agentDisplayName={agentDisplayName}
-            canManage={resolved.state.canManage}
-            creation={creation}
-            onChooseAgent={(agentId) => {
-              rememberTargetAgent(membership.teamId, agentId);
-              reload();
-            }}
-            onChooseRoute={(selection) => {
-              rememberRouteSelection(membership.teamId, selection);
-              reload();
-            }}
-            onAgentDisplayNameChange={setAgentDisplayName}
-            onCreateAgent={(current) => runAgentCreation(normalizedAgentRequest(current, agentDisplayName))}
-            onReload={attendedReload}
-            refreshPending={refreshPending}
-            snapshot={loadState.snapshot}
-            state={resolved.state}
-            teamId={membership.teamId}
-          />
-        ) : null}
+        <div className="onboarding-layout">
+          <OnboardingJourney journey={journey} />
+          <section className="onboarding-workspace" aria-labelledby="onboarding-stage-title">
+            <OnboardingStageHeader journey={journey} />
+            <div className="onboarding-workspace-body">
+              {loadState.kind === "loading" ? <OnboardingLoading /> : null}
+              {loadState.kind === "error" ? (
+                <ActionSection title="We couldn’t load setup" description={loadState.error.message}>
+                  <button className="button" type="button" onClick={reload}>
+                    Try again
+                  </button>
+                </ActionSection>
+              ) : null}
+              {loadState.kind === "ready" && resolved ? (
+                <OnboardingContent
+                  agentDisplayName={agentDisplayName}
+                  canManage={resolved.state.canManage}
+                  creation={creation}
+                  onChooseAgent={(agentId) => {
+                    rememberTargetAgent(membership.teamId, agentId);
+                    reload();
+                  }}
+                  onChooseRoute={(selection) => {
+                    rememberRouteSelection(membership.teamId, selection);
+                    reload();
+                  }}
+                  onAgentDisplayNameChange={setAgentDisplayName}
+                  onCreateAgent={(current) => runAgentCreation(normalizedAgentRequest(current, agentDisplayName))}
+                  onReload={attendedReload}
+                  refreshPending={refreshPending}
+                  snapshot={loadState.snapshot}
+                  state={resolved.state}
+                  teamId={membership.teamId}
+                />
+              ) : null}
+            </div>
+          </section>
+        </div>
       </main>
     </div>
   );
+}
+
+function OnboardingJourney({ journey }: { journey: OnboardingJourneyState }) {
+  return (
+    <aside className="onboarding-journey">
+      <div className="onboarding-journey-intro">
+        <span className="eyebrow">Agent setup</span>
+        <h1>Set up OpenTag</h1>
+        <p>Prepare one Agent, then bring it into your team conversation.</p>
+      </div>
+      <nav aria-label="Onboarding steps">
+        <ol className="onboarding-steps">
+          <JourneyStep
+            description="Computer, runtime and identity"
+            number="01"
+            status={journey.prepare}
+            title="Prepare your Agent"
+          />
+          <JourneyStep
+            description="Authorize your team bot"
+            number="02"
+            status={journey.messaging}
+            title="Add to Feishu"
+          />
+        </ol>
+      </nav>
+      <p className="onboarding-journey-note">
+        Progress is saved from live server state. You can leave and return at any time.
+      </p>
+    </aside>
+  );
+}
+
+function JourneyStep({
+  description,
+  number,
+  status,
+  title,
+}: {
+  description: string;
+  number: string;
+  status: JourneyStatus;
+  title: string;
+}) {
+  const statusLabel = status === "complete" ? "Complete" : status === "current" ? "In progress" : "Up next";
+  return (
+    <li className="onboarding-step" data-status={status}>
+      <span aria-hidden="true" className="onboarding-step-number">
+        {status === "complete" ? "✓" : number}
+      </span>
+      <span className="onboarding-step-copy">
+        <span className="onboarding-step-status">{statusLabel}</span>
+        <strong>{title}</strong>
+        <span>{description}</span>
+      </span>
+    </li>
+  );
+}
+
+function OnboardingStageHeader({ journey }: { journey: OnboardingJourneyState }) {
+  return (
+    <header className="onboarding-stage-header">
+      <div className="onboarding-stage-copy">
+        <span className="onboarding-stage-kicker">Step {String(journey.activeStep).padStart(2, "0")} / 02</span>
+        <span className="onboarding-stage-status">{journey.stageStatus}</span>
+        <h2 id="onboarding-stage-title">{journey.stageTitle}</h2>
+        <p>{journey.stageDescription}</p>
+      </div>
+      <OnboardingStageContext journey={journey} />
+    </header>
+  );
+}
+
+function OnboardingStageContext({ journey }: { journey: OnboardingJourneyState }) {
+  if (journey.activeStep === 1) {
+    return (
+      <section aria-label="Agent preparation summary">
+        <dl className="onboarding-runtime-summary">
+          {journey.prepareFacts.map((fact) => (
+            <div data-status={fact.status} key={fact.label}>
+              <dt>{fact.label}</dt>
+              <dd>{fact.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    );
+  }
+
+  const connected = journey.messaging === "complete";
+  return (
+    <section
+      aria-label={`${journey.agentName} Agent ${connected ? "connected to" : "awaiting connection to"} Feishu`}
+      className="onboarding-messaging-connection"
+      data-status={connected ? "complete" : "current"}
+    >
+      <div className="onboarding-connection-endpoint">
+        <span aria-hidden="true" className="onboarding-endpoint-mark">
+          OT
+        </span>
+        <span>
+          <small>Agent</small>
+          <strong>{journey.agentName}</strong>
+        </span>
+      </div>
+      <div className="onboarding-messaging-bridge">
+        <span>{connected ? "Connected" : "Authorization"}</span>
+      </div>
+      <div className="onboarding-connection-endpoint onboarding-connection-endpoint-feishu">
+        <span aria-hidden="true" className="onboarding-endpoint-mark">
+          FS
+        </span>
+        <span>
+          <small>Team chat</small>
+          <strong>Feishu</strong>
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function onboardingJourney(
+  current: OnboardingCurrentState | undefined,
+  snapshot: OnboardingSnapshot | undefined,
+): OnboardingJourneyState {
+  if (!current) {
+    return {
+      activeStep: 1,
+      agentName: snapshot?.targetAgent?.displayName ?? "OpenTag",
+      messaging: "upcoming",
+      prepareFacts: [
+        { label: "Computer", status: "current", value: "Checking" },
+        { label: "Runtime", status: "waiting", value: "Waiting" },
+        { label: "Agent", status: "waiting", value: "Not created" },
+      ],
+      prepare: "current",
+      stageDescription: "We’re reading your Computer and runtime state.",
+      stageStatus: "Checking setup",
+      stageTitle: "Prepare your Agent",
+    };
+  }
+
+  const messagingReady = snapshot?.handoff?.handoffReady === true;
+  const prepareComplete = current.kind === "handoff" || current.kind === "ready";
+  const messagingCurrent = current.kind === "handoff";
+  const setupReady = current.kind === "ready";
+  const agentNeedsAttention = current.kind === "agent-runtime";
+  const availableComputer = snapshot?.computers.find((computer) => computer.connectionStatus === "online");
+  const runtimeProvider =
+    current.kind === "agent"
+      ? current.provider.provider
+      : (snapshot?.targetAgent?.runtimeProvider ??
+        (current.kind === "handoff" || current.kind === "ready" || current.kind === "agent-runtime"
+          ? current.agent.runtimeProvider
+          : undefined));
+  const computerFact: JourneyFact =
+    current.kind === "computer"
+      ? current.availability === "none"
+        ? { label: "Computer", status: "current", value: "Not connected" }
+        : current.availability === "offline"
+          ? { label: "Computer", status: "attention", value: "Reconnect" }
+          : { label: "Computer", status: "current", value: "Choose one" }
+      : current.kind === "team"
+        ? { label: "Computer", status: "current", value: "Checking" }
+        : { label: "Computer", status: "ready", value: availableComputer?.displayName ?? "Connected" };
+  const runtimeFact: JourneyFact =
+    current.kind === "team" || current.kind === "computer"
+      ? { label: "Runtime", status: "waiting", value: "Waiting" }
+      : current.kind === "provider"
+        ? { label: "Runtime", status: "current", value: "Setup required" }
+        : current.kind === "agent-runtime"
+          ? { label: "Runtime", status: "attention", value: "Needs attention" }
+          : { label: "Runtime", status: "ready", value: runtimeProvider ? providerLabel(runtimeProvider) : "Ready" };
+  const agentFact: JourneyFact = snapshot?.targetAgent
+    ? { label: "Agent", status: agentNeedsAttention ? "attention" : "ready", value: snapshot.targetAgent.displayName }
+    : current.kind === "agent"
+      ? { label: "Agent", status: "current", value: "Name pending" }
+      : prepareComplete
+        ? { label: "Agent", status: "ready", value: "Prepared" }
+        : { label: "Agent", status: "waiting", value: "Not created" };
+
+  return {
+    activeStep: prepareComplete ? 2 : 1,
+    agentName: snapshot?.targetAgent?.displayName ?? "OpenTag",
+    prepare: prepareComplete ? "complete" : "current",
+    prepareFacts: [computerFact, runtimeFact, agentFact],
+    messaging: setupReady || messagingReady ? "complete" : messagingCurrent ? "current" : "upcoming",
+    stageDescription: prepareComplete
+      ? setupReady
+        ? "Your Agent is ready for the first conversation in Feishu."
+        : "Authorize the bot your team will mention in conversations."
+      : "Confirm where your Agent runs, then give it a clear identity.",
+    stageStatus: onboardingStageStatus(current),
+    stageTitle: prepareComplete
+      ? setupReady
+        ? "Your Agent is ready"
+        : "Add your Agent to Feishu"
+      : "Prepare your Agent",
+  };
+}
+
+function onboardingStageStatus(current: OnboardingCurrentState): string {
+  if (current.kind === "team") return "Checking Workspace";
+  if (current.kind === "computer") {
+    if (current.availability === "none") return "Computer needed";
+    if (current.availability === "offline") return "Computer offline";
+    return "Choose a Computer";
+  }
+  if (current.kind === "provider") return "Runtime needs setup";
+  if (current.kind === "agent") return "Runtime ready";
+  if (current.kind === "agent-runtime") return "Runtime needs attention";
+  if (current.kind === "handoff") return "Agent prepared";
+  return "Setup complete";
 }
 
 function OnboardingHeader({ user }: { user: UserProfile }) {
@@ -331,7 +571,7 @@ function OnboardingContent({
       <ActionSection
         readonly={!canManage}
         title="Choose the Agent to finish"
-        description="More than one existing Team Agent could be continued safely."
+        description="More than one existing Agent could be continued safely."
       >
         {canManage ? (
           <div className="onboarding-choice-list">
@@ -358,7 +598,7 @@ function OnboardingContent({
 
   const current = state.currentState;
   if (current.kind === "team") {
-    return <ActionSection title="Preparing your Team" description="OpenTag will continue automatically." pending />;
+    return <ActionSection title="Preparing OpenTag" description="Setup will continue automatically." pending />;
   }
   if (current.kind === "computer" && current.availability === "none") {
     if (canManage) {
@@ -456,7 +696,7 @@ function OnboardingContent({
       return (
         <ActionSection
           readonly
-          title="Create the Team Agent"
+          title="Create the Agent"
           description={`The runnable route is ${providerLabel(current.provider.provider)} on ${current.computer.displayName}.`}
         >
           <ReadOnlyCopy admins={snapshot.admins} />
@@ -572,7 +812,7 @@ function OnboardingContent({
       <ActionSection
         readonly={!canManage}
         title={handoffTitle(current)}
-        description="Authorize the Feishu Bot that your Team will mention."
+        description="Authorize the Feishu Bot that your team will mention."
       >
         {canManage ? (
           <FeishuSetup agentId={current.agent.id} onSuccess={onReload}>
@@ -661,10 +901,10 @@ function ReadOnlyCopy({ admins }: { admins: readonly string[] }) {
  */
 function adminGuidance(admins: readonly string[]): string {
   const [first, second, ...rest] = admins;
-  if (!first) return "A Team admin can complete this action.";
-  if (!second) return `Ask a Team admin to continue: ${first}.`;
-  if (rest.length === 0) return `Ask a Team admin to continue: ${first} or ${second}.`;
-  return `Ask a Team admin to continue: ${first}, ${second}, or ${rest.length} more.`;
+  if (!first) return "An admin can complete this action.";
+  if (!second) return `Ask an admin to continue: ${first}.`;
+  if (rest.length === 0) return `Ask an admin to continue: ${first} or ${second}.`;
+  return `Ask an admin to continue: ${first}, ${second}, or ${rest.length} more.`;
 }
 
 function FeishuAction({

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -785,7 +785,10 @@ function AppShell() {
                           onClick={() => {
                             setOpenMenu(undefined);
                             setNavigationOpen(false);
-                            if (!current) selectTeam(item.teamId);
+                            if (!current) {
+                              navigate("/agents");
+                              selectTeam(item.teamId);
+                            }
                           }}
                         >
                           <span className="team-avatar" aria-hidden="true">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -26,7 +26,7 @@ import {
 import { Link, Navigate, NavLink, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import { ApiError, browserApi } from "./api.js";
 import { ComputerSetup } from "./computer-setup.js";
-import { CreateTeamForm, createTeamWithUniqueHandle } from "./create-team-form.js";
+import { CreateTeamForm } from "./create-team-form.js";
 import { IntegrationsPage } from "./features/integrations-page.js";
 import { ResourcesPage } from "./features/resources-page.js";
 import { UsagePage } from "./features/usage-page.js";
@@ -336,11 +336,11 @@ export function AppRouter() {
           <Route path="/account" element={<AccountPage />} />
           <Route path="/settings" element={<Navigate replace to="/members" />} />
           <Route path="/settings/account" element={<Navigate replace to="/account" />} />
-          <Route path="/settings/team" element={<Navigate replace to="/members" />} />
+          <Route path="/settings/team" element={<Navigate replace to="/account#workspace-management" />} />
           <Route path="/settings/members" element={<Navigate replace to="/members" />} />
           <Route path="/settings/access" element={<Navigate replace to="/members" />} />
           <Route path="/settings/security" element={<Navigate replace to="/members" />} />
-          <Route path="/settings/computers" element={<Navigate replace to="/agents" />} />
+          <Route path="/settings/computers" element={<Navigate replace to="/agents#agent-runtime" />} />
           <Route path="/settings/resources" element={<Navigate replace to="/resources" />} />
           <Route path="/settings/integrations" element={<Navigate replace to="/integrations" />} />
           <Route path="/settings/usage" element={<Navigate replace to="/usage" />} />
@@ -521,16 +521,7 @@ function AuthenticatedTeamGate() {
         const membership =
           me.memberships.find((item: MeMembership) => item.teamId === selectedTeamId) ?? me.memberships[0];
         if (!membership) {
-          return (
-            <DefaultWorkspaceProvisioner
-              me={me}
-              onCreated={(teamId) => {
-                rememberTeamPreference(teamId);
-                setSelectedTeamId(teamId);
-                setMeRevision((value) => value + 1);
-              }}
-            />
-          );
+          return <WorkspaceSetupIncomplete onRetry={() => setMeRevision((value) => value + 1)} />;
         }
         const selectTeam = (teamId: string) => {
           if (!me.memberships.some((item: MeMembership) => item.teamId === teamId)) return;
@@ -547,61 +538,18 @@ function AuthenticatedTeamGate() {
   );
 }
 
-function DefaultWorkspaceProvisioner({ me, onCreated }: { me: MeResponse; onCreated: (teamId: string) => void }) {
-  const [attempt, setAttempt] = useState(0);
-  const [error, setError] = useState<string>();
-  const onCreatedRef = useRef(onCreated);
-  const creationRef = useRef<ReturnType<typeof createTeamWithUniqueHandle> | undefined>(undefined);
-  const lastAttemptRef = useRef(attempt);
-  onCreatedRef.current = onCreated;
-
-  useEffect(() => {
-    let active = true;
-    if (lastAttemptRef.current !== attempt) {
-      lastAttemptRef.current = attempt;
-      creationRef.current = undefined;
-    }
-    setError(undefined);
-    const ownerName = me.user.displayName.trim() || me.user.email.split("@")[0] || "Personal";
-    creationRef.current ??= createTeamWithUniqueHandle(`${ownerName}'s Workspace`);
-    void creationRef.current.then(
-      (created) => {
-        if (active) onCreatedRef.current(created.id);
-      },
-      (cause) => {
-        if (active) setError(cause instanceof Error ? cause.message : "OpenTag could not finish account setup");
-      },
-    );
-    return () => {
-      active = false;
-    };
-  }, [attempt, me.user.displayName, me.user.email]);
-
+function WorkspaceSetupIncomplete({ onRetry }: { onRetry: () => void }) {
   return (
     <main className="center-card decorative-page">
-      <span className="eyebrow">OpenTag</span>
-      <h1>{error ? "Account setup needs another try" : "Setting up your account"}</h1>
-      <p>
-        {error
-          ? "Your account is ready, but its private working space could not be prepared."
-          : "This only takes a moment."}
-      </p>
-      {error ? (
-        <>
-          <div className="notice error" role="alert">
-            {error}
-          </div>
-          <button className="button" type="button" onClick={() => setAttempt((value) => value + 1)}>
-            Try again
-          </button>
-        </>
-      ) : (
-        <div aria-label="Preparing your account" className="loading-state" role="status">
-          <span />
-          <span />
-          <span />
-        </div>
-      )}
+      <span className="eyebrow">Workspace setup</span>
+      <h1>Workspace setup incomplete</h1>
+      <p>OpenTag could not find a Workspace membership for this account.</p>
+      <div className="notice error" role="alert">
+        The server must finish Workspace setup before the Web app can continue.
+      </div>
+      <button className="button" type="button" onClick={onRetry}>
+        Check again
+      </button>
     </main>
   );
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -813,7 +813,7 @@ function AppShell() {
                       }}
                     >
                       <span>Manage Workspaces</span>
-                      <span aria-hidden="true">›</span>
+                      <Icon name="chevron-right" />
                     </Link>
                   </fieldset>
                 ) : null}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -23,24 +23,17 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  Link,
-  Navigate,
-  NavLink,
-  Outlet,
-  Route,
-  Routes,
-  useLocation,
-  useNavigate,
-  useOutletContext,
-  useParams,
-} from "react-router-dom";
+import { Link, Navigate, NavLink, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import { ApiError, browserApi } from "./api.js";
 import { ComputerSetup } from "./computer-setup.js";
-import { CreateTeamForm } from "./create-team-form.js";
+import { CreateTeamForm, createTeamWithUniqueHandle } from "./create-team-form.js";
+import { IntegrationsPage } from "./features/integrations-page.js";
+import { ResourcesPage } from "./features/resources-page.js";
+import { UsagePage } from "./features/usage-page.js";
 import { FeishuSetup } from "./im/feishu-setup.js";
 import { OnboardingPage } from "./onboarding/page.js";
 import { RuntimeConfigurationForm } from "./runtime-configuration.js";
+import { Button, Dialog, Field, Icon, StatusIndicator, type StatusTone } from "./ui/design-system.js";
 
 type LoadState<T> = { kind: "loading" } | { kind: "error"; error: Error } | { kind: "ready"; value: T };
 
@@ -311,12 +304,6 @@ interface TeamSession {
   selectTeam: (teamId: string) => void;
 }
 
-interface AppShellOutletContext {
-  invitationMutationPending: boolean;
-  invitationOpen: boolean;
-  setInvitationMutationPending: (pending: boolean) => void;
-}
-
 const teamContext = createContext<TeamSession | undefined>(undefined);
 const TeamContext = teamContext.Provider;
 
@@ -331,7 +318,8 @@ export function AppRouter() {
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/invites/:token" element={<InvitePage />} />
-      <Route path="/teams/new" element={<NewTeamPage />} />
+      <Route path="/teams/new" element={<Navigate replace to="/workspaces/new" />} />
+      <Route path="/workspaces/new" element={<NewTeamPage />} />
       <Route element={<AuthenticatedTeamGate />}>
         <Route path="/onboarding" element={<OnboardingRoute />} />
         <Route element={<AppShell />}>
@@ -340,11 +328,23 @@ export function AppRouter() {
           <Route path="/agents/new" element={<NewAgentPage />} />
           <Route path="/agents/:agentId" element={<Navigate replace to="general" />} />
           <Route path="/agents/:agentId/:tab" element={<AgentDetailPage />} />
+          <Route path="/tasks" element={<TasksPage />} />
+          <Route path="/integrations" element={<IntegrationsPage />} />
+          <Route path="/resources" element={<ResourcesPage />} />
+          <Route path="/usage" element={<UsagePage />} />
+          <Route path="/members" element={<MembersPage />} />
           <Route path="/account" element={<AccountPage />} />
-          <Route path="/settings" element={<Navigate replace to="team" />} />
+          <Route path="/settings" element={<Navigate replace to="/members" />} />
           <Route path="/settings/account" element={<Navigate replace to="/account" />} />
-          <Route path="/settings/members" element={<Navigate replace to="/settings/team#members" />} />
-          <Route path="/settings/:section" element={<SettingsPage />} />
+          <Route path="/settings/team" element={<Navigate replace to="/members" />} />
+          <Route path="/settings/members" element={<Navigate replace to="/members" />} />
+          <Route path="/settings/access" element={<Navigate replace to="/members" />} />
+          <Route path="/settings/security" element={<Navigate replace to="/members" />} />
+          <Route path="/settings/computers" element={<Navigate replace to="/agents" />} />
+          <Route path="/settings/resources" element={<Navigate replace to="/resources" />} />
+          <Route path="/settings/integrations" element={<Navigate replace to="/integrations" />} />
+          <Route path="/settings/usage" element={<Navigate replace to="/usage" />} />
+          <Route path="/settings/:section" element={<Navigate replace to="/members" />} />
         </Route>
       </Route>
       <Route path="*" element={<StandaloneNotFoundPage />} />
@@ -359,7 +359,7 @@ function LoginPage() {
     <main className="center-card decorative-page">
       <span className="eyebrow">OpenTag</span>
       <h1>Sign in</h1>
-      <p>Choose an available sign-in method. Team permissions are checked by the server on every request.</p>
+      <p>Choose an available sign-in method. Permissions are checked by the server on every request.</p>
       <AsyncState state={providers}>
         {(value) => (
           <div className="actions">
@@ -404,7 +404,7 @@ function InvitePage() {
         const redemption = await browserApi.redeemInvitation(token);
         const me = await browserApi.me();
         if (!me.memberships.some((membership: MeMembership) => membership.teamId === redemption.membership.teamId)) {
-          throw new Error("The invited Team is not available to the signed-in account");
+          throw new Error("The invited Workspace is not available to the signed-in account");
         }
         clearPendingInvitation(token);
         rememberTeamPreference(redemption.membership.teamId);
@@ -437,13 +437,13 @@ function InvitePage() {
       <AsyncState state={preview}>
         {(value) => (
           <>
-            <span className="eyebrow">Team invitation</span>
+            <span className="eyebrow">Workspace invitation</span>
             <h1>Join {value.teamDisplayName}</h1>
             <p>
               This invitation grants the {value.role} role and expires {formatDate(value.expiresAt)}.
             </p>
             <button className="button" disabled={joining} type="button" onClick={join}>
-              {joining ? "Joining…" : "Join Team"}
+              {joining ? "Joining…" : "Join Workspace"}
             </button>
           </>
         )}
@@ -493,7 +493,7 @@ function NewTeamPage() {
   return (
     <main className="center-card decorative-page">
       <span className="eyebrow">OpenTag</span>
-      <h1>Create your team</h1>
+      <h1>Create your Workspace</h1>
       <p>You can invite people and add Agents next.</p>
       <CreateTeamForm
         onCreated={(created) => {
@@ -520,7 +520,18 @@ function AuthenticatedTeamGate() {
       {(me) => {
         const membership =
           me.memberships.find((item: MeMembership) => item.teamId === selectedTeamId) ?? me.memberships[0];
-        if (!membership) return <Navigate replace to="/teams/new" />;
+        if (!membership) {
+          return (
+            <DefaultWorkspaceProvisioner
+              me={me}
+              onCreated={(teamId) => {
+                rememberTeamPreference(teamId);
+                setSelectedTeamId(teamId);
+                setMeRevision((value) => value + 1);
+              }}
+            />
+          );
+        }
         const selectTeam = (teamId: string) => {
           if (!me.memberships.some((item: MeMembership) => item.teamId === teamId)) return;
           rememberTeamPreference(teamId);
@@ -533,6 +544,65 @@ function AuthenticatedTeamGate() {
         );
       }}
     </AsyncState>
+  );
+}
+
+function DefaultWorkspaceProvisioner({ me, onCreated }: { me: MeResponse; onCreated: (teamId: string) => void }) {
+  const [attempt, setAttempt] = useState(0);
+  const [error, setError] = useState<string>();
+  const onCreatedRef = useRef(onCreated);
+  const creationRef = useRef<ReturnType<typeof createTeamWithUniqueHandle> | undefined>(undefined);
+  const lastAttemptRef = useRef(attempt);
+  onCreatedRef.current = onCreated;
+
+  useEffect(() => {
+    let active = true;
+    if (lastAttemptRef.current !== attempt) {
+      lastAttemptRef.current = attempt;
+      creationRef.current = undefined;
+    }
+    setError(undefined);
+    const ownerName = me.user.displayName.trim() || me.user.email.split("@")[0] || "Personal";
+    creationRef.current ??= createTeamWithUniqueHandle(`${ownerName}'s Workspace`);
+    void creationRef.current.then(
+      (created) => {
+        if (active) onCreatedRef.current(created.id);
+      },
+      (cause) => {
+        if (active) setError(cause instanceof Error ? cause.message : "OpenTag could not finish account setup");
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [attempt, me.user.displayName, me.user.email]);
+
+  return (
+    <main className="center-card decorative-page">
+      <span className="eyebrow">OpenTag</span>
+      <h1>{error ? "Account setup needs another try" : "Setting up your account"}</h1>
+      <p>
+        {error
+          ? "Your account is ready, but its private working space could not be prepared."
+          : "This only takes a moment."}
+      </p>
+      {error ? (
+        <>
+          <div className="notice error" role="alert">
+            {error}
+          </div>
+          <button className="button" type="button" onClick={() => setAttempt((value) => value + 1)}>
+            Try again
+          </button>
+        </>
+      ) : (
+        <div aria-label="Preparing your account" className="loading-state" role="status">
+          <span />
+          <span />
+          <span />
+        </div>
+      )}
+    </main>
   );
 }
 
@@ -570,42 +640,27 @@ function AppShell() {
   const { me, membership, selectTeam } = useTeam();
   const navigate = useNavigate();
   const [navigationOpen, setNavigationOpen] = useState(false);
-  const [openMenu, setOpenMenu] = useState<"team" | "account">();
-  const [invitationOpen, setInvitationOpen] = useState(false);
-  const [invitationMutationPending, setInvitationMutationPending] = useState(false);
-  const [teamQuery, setTeamQuery] = useState("");
+  const [openMenu, setOpenMenu] = useState<"account">();
   const [loggingOut, setLoggingOut] = useState(false);
   const [accountError, setAccountError] = useState<string>();
-  const teamMenuRef = useRef<HTMLDivElement>(null);
   const accountMenuRef = useRef<HTMLDivElement>(null);
-  const teamTriggerRef = useRef<HTMLButtonElement>(null);
   const accountTriggerRef = useRef<HTMLButtonElement>(null);
-  const filteredMemberships = me.memberships.filter((item) =>
-    item.teamDisplayName.toLocaleLowerCase().includes(teamQuery.trim().toLocaleLowerCase()),
-  );
   useEffect(() => {
     if (!openMenu) return;
-    const menu = openMenu === "team" ? teamMenuRef.current : accountMenuRef.current;
-    const initialFocus =
-      openMenu === "team"
-        ? (menu?.querySelector<HTMLInputElement>('input[type="search"]') ??
-          menu?.querySelector<HTMLElement>('[aria-current="true"]') ??
-          menu?.querySelector<HTMLElement>("button, a"))
-        : menu?.querySelector<HTMLElement>('[role="menuitem"]');
+    const menu = accountMenuRef.current;
+    const initialFocus = menu?.querySelector<HTMLElement>('[role="menuitem"]');
     initialFocus?.focus();
 
     const closeOutside = (event: PointerEvent) => {
       const target = event.target;
       if (!(target instanceof Node)) return;
-      const activeMenu = openMenu === "team" ? teamMenuRef.current : accountMenuRef.current;
-      if (!activeMenu?.contains(target)) setOpenMenu(undefined);
+      if (!accountMenuRef.current?.contains(target)) setOpenMenu(undefined);
     };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.preventDefault();
-      const trigger = openMenu === "team" ? teamTriggerRef.current : accountTriggerRef.current;
       setOpenMenu(undefined);
-      trigger?.focus();
+      accountTriggerRef.current?.focus();
     };
     document.addEventListener("pointerdown", closeOutside);
     document.addEventListener("keydown", closeOnEscape);
@@ -658,117 +713,30 @@ function AppShell() {
           <Link className="brand" to="/agents" onClick={() => setNavigationOpen(false)}>
             OpenTag
           </Link>
-          <div className="team-menu" ref={teamMenuRef}>
-            <button
-              aria-controls="team-menu-popover"
-              aria-expanded={openMenu === "team"}
-              aria-haspopup="dialog"
-              className="team-switcher"
-              ref={teamTriggerRef}
-              type="button"
-              onClick={() => {
-                setTeamQuery("");
-                setOpenMenu((value) => (value === "team" ? undefined : "team"));
-              }}
-            >
-              <span className="team-avatar" aria-hidden="true">
-                {initials(membership.teamDisplayName)}
-              </span>
-              <span>{membership.teamDisplayName}</span>
-              <span className="team-menu-chevron" aria-hidden="true">
-                {openMenu === "team" ? "⌃" : "⌄"}
-              </span>
-            </button>
-            {openMenu === "team" ? (
-              <section aria-label="Switch Team" className="team-menu-popover" id="team-menu-popover" role="dialog">
-                <span className="menu-label">Switch Team</span>
-                {me.memberships.length > 6 ? (
-                  <label className="team-search">
-                    <span className="visually-hidden">Search Teams</span>
-                    <input
-                      placeholder="Search Teams"
-                      type="search"
-                      value={teamQuery}
-                      onChange={(event) => setTeamQuery(event.currentTarget.value)}
-                    />
-                  </label>
-                ) : null}
-                <div className="team-menu-list">
-                  {filteredMemberships.map((item: MeMembership) => {
-                    const current = item.teamId === membership.teamId;
-                    return (
-                      <button
-                        aria-current={current ? "true" : undefined}
-                        className="team-menu-option"
-                        key={item.teamId}
-                        type="button"
-                        onClick={() => {
-                          setOpenMenu(undefined);
-                          setNavigationOpen(false);
-                          if (!current) selectTeam(item.teamId);
-                        }}
-                      >
-                        <span className="team-avatar" aria-hidden="true">
-                          {initials(item.teamDisplayName)}
-                        </span>
-                        <span className="team-option-copy">
-                          <strong>{item.teamDisplayName}</strong>
-                          <small>{titleCase(item.role)}</small>
-                        </span>
-                        {current ? (
-                          <span className="team-option-check" aria-hidden="true">
-                            ✓
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                  {filteredMemberships.length === 0 ? <span className="team-menu-empty">No matching Teams</span> : null}
-                </div>
-                <div className="team-menu-actions">
-                  {membership.role === "admin" ? (
-                    <button
-                      className="team-menu-action"
-                      disabled={invitationMutationPending}
-                      type="button"
-                      onClick={() => {
-                        if (invitationMutationPending) return;
-                        setOpenMenu(undefined);
-                        setNavigationOpen(false);
-                        setInvitationOpen(true);
-                      }}
-                    >
-                      <span aria-hidden="true">↗</span>
-                      Invite people
-                    </button>
-                  ) : null}
-                  <Link
-                    className="team-menu-action"
-                    to="/teams/new"
-                    onClick={() => {
-                      setOpenMenu(undefined);
-                      setNavigationOpen(false);
-                    }}
-                  >
-                    <span aria-hidden="true">＋</span>
-                    Create Team
-                  </Link>
-                </div>
-              </section>
-            ) : null}
-          </div>
-          <nav aria-label="Workspace" className="primary-nav">
+          <nav aria-label="Product" className="primary-nav">
             <NavLink to="/agents" onClick={() => setNavigationOpen(false)}>
               <WorkspaceNavIcon name="agents" />
               Agents
             </NavLink>
-            <span className="nav-placeholder" aria-disabled="true">
+            <NavLink to="/tasks" onClick={() => setNavigationOpen(false)}>
               <WorkspaceNavIcon name="tasks" />
               Tasks
-            </span>
-            <NavLink to="/settings" onClick={() => setNavigationOpen(false)}>
-              <WorkspaceNavIcon name="settings" />
-              Settings
+            </NavLink>
+            <NavLink to="/integrations" onClick={() => setNavigationOpen(false)}>
+              <WorkspaceNavIcon name="integrations" />
+              Integrations
+            </NavLink>
+            <NavLink to="/resources" onClick={() => setNavigationOpen(false)}>
+              <WorkspaceNavIcon name="resources" />
+              Resources
+            </NavLink>
+            <NavLink to="/usage" onClick={() => setNavigationOpen(false)}>
+              <WorkspaceNavIcon name="usage" />
+              Usage
+            </NavLink>
+            <NavLink to="/members" onClick={() => setNavigationOpen(false)}>
+              <WorkspaceNavIcon name="members" />
+              Members
             </NavLink>
           </nav>
         </div>
@@ -802,19 +770,68 @@ function AppShell() {
                 role="menu"
                 onKeyDown={handleAccountMenuKeyDown}
               >
-                <Link
-                  role="menuitem"
-                  to="/account"
-                  onClick={() => {
-                    setOpenMenu(undefined);
-                    setNavigationOpen(false);
-                  }}
-                >
-                  Account settings
-                </Link>
-                <button disabled={loggingOut} role="menuitem" type="button" onClick={() => void logout()}>
-                  {loggingOut ? "Signing out…" : "Sign out"}
-                </button>
+                {me.memberships.length > 1 ? (
+                  <fieldset className="account-workspace-group">
+                    <legend className="menu-label">Switch Workspace</legend>
+                    {me.memberships.map((item: MeMembership) => {
+                      const current = item.teamId === membership.teamId;
+                      return (
+                        <button
+                          aria-current={current ? "true" : undefined}
+                          className="account-workspace-option"
+                          key={item.teamId}
+                          role="menuitem"
+                          type="button"
+                          onClick={() => {
+                            setOpenMenu(undefined);
+                            setNavigationOpen(false);
+                            if (!current) selectTeam(item.teamId);
+                          }}
+                        >
+                          <span className="team-avatar" aria-hidden="true">
+                            {initials(item.teamDisplayName)}
+                          </span>
+                          <span className="team-option-copy">
+                            <strong>{item.teamDisplayName}</strong>
+                            <small>{titleCase(item.role)}</small>
+                          </span>
+                          {current ? (
+                            <span className="team-option-check" aria-hidden="true">
+                              ✓
+                            </span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                    <Link
+                      className="account-workspace-manage"
+                      role="menuitem"
+                      to="/account#workspace-management"
+                      onClick={() => {
+                        setOpenMenu(undefined);
+                        setNavigationOpen(false);
+                      }}
+                    >
+                      <span>Manage Workspaces</span>
+                      <span aria-hidden="true">›</span>
+                    </Link>
+                  </fieldset>
+                ) : null}
+                <div className="account-menu-actions">
+                  <Link
+                    role="menuitem"
+                    to="/account"
+                    onClick={() => {
+                      setOpenMenu(undefined);
+                      setNavigationOpen(false);
+                    }}
+                  >
+                    Account settings
+                  </Link>
+                  <button disabled={loggingOut} role="menuitem" type="button" onClick={() => void logout()}>
+                    {loggingOut ? "Signing out…" : "Sign out"}
+                  </button>
+                </div>
                 {accountError ? (
                   <span className="account-menu-error" role="alert">
                     {accountError}
@@ -835,24 +852,14 @@ function AppShell() {
           </button>
         </header>
         <main className="content">
-          <Outlet context={{ invitationMutationPending, invitationOpen, setInvitationMutationPending }} />
+          <Outlet />
         </main>
       </div>
-      {invitationOpen ? (
-        <InvitationDialog
-          mutationPending={invitationMutationPending}
-          onMutationPendingChange={setInvitationMutationPending}
-          returnFocusRef={teamTriggerRef}
-          teamDisplayName={membership.teamDisplayName}
-          teamId={membership.teamId}
-          onClose={() => setInvitationOpen(false)}
-        />
-      ) : null}
     </div>
   );
 }
 
-function WorkspaceNavIcon({ name }: { name: "agents" | "settings" | "tasks" }) {
+function WorkspaceNavIcon({ name }: { name: "agents" | "integrations" | "members" | "resources" | "tasks" | "usage" }) {
   return (
     <svg
       aria-hidden="true"
@@ -878,10 +885,30 @@ function WorkspaceNavIcon({ name }: { name: "agents" | "settings" | "tasks" }) {
           <path d="m7.5 12 3 3 6-6" />
         </>
       ) : null}
-      {name === "settings" ? (
+      {name === "integrations" ? (
         <>
-          <path d="m9.8 3.8.6-1.6h3.2l.6 1.6 1.8.7 1.5-.7 2.3 2.3-.7 1.5.7 1.8 1.6.6v3.2l-1.6.6-.7 1.8.7 1.5-2.3 2.3-1.5-.7-1.8.7-.6 1.6h-3.2l-.6-1.6-1.8-.7-1.5.7-2.3-2.3.7-1.5-.7-1.8-1.6-.6V10l1.6-.6.7-1.8-.7-1.5 2.3-2.3 1.5.7 1.8-.7Z" />
-          <circle cx="12" cy="12" r="3" />
+          <path d="M8 12h8M12 8v8" />
+          <path d="M7 4.5h10A2.5 2.5 0 0 1 19.5 7v10a2.5 2.5 0 0 1-2.5 2.5H7A2.5 2.5 0 0 1 4.5 17V7A2.5 2.5 0 0 1 7 4.5Z" />
+        </>
+      ) : null}
+      {name === "resources" ? (
+        <>
+          <path d="M4.5 7.5 12 3l7.5 4.5L12 12 4.5 7.5Z" />
+          <path d="m4.5 12 7.5 4.5 7.5-4.5M4.5 16.5 12 21l7.5-4.5" />
+        </>
+      ) : null}
+      {name === "usage" ? (
+        <>
+          <path d="M5 19V9M12 19V5M19 19v-7" />
+          <path d="M3.5 19.5h17" />
+        </>
+      ) : null}
+      {name === "members" ? (
+        <>
+          <circle cx="9" cy="8" r="3" />
+          <path d="M3.5 19v-1.5A4.5 4.5 0 0 1 8 13h2a4.5 4.5 0 0 1 4.5 4.5V19" />
+          <circle cx="17" cy="10" r="2" />
+          <path d="M16 14.5h1.5a3 3 0 0 1 3 3V19" />
         </>
       ) : null}
     </svg>
@@ -901,16 +928,26 @@ function AgentsPage() {
     <>
       <Page
         title="Agents"
-        description="Shared AI teammates configured for your Team."
+        description="Shared AI teammates configured for your team."
         action={
           membership.role === "admin" ? (
-            <button className="button" ref={createTriggerRef} type="button" onClick={() => setCreateOpen(true)}>
+            <Button ref={createTriggerRef} onClick={() => setCreateOpen(true)}>
               New Agent
-            </button>
+            </Button>
           ) : undefined
         }
       >
         <AsyncState state={state}>{(value) => <AgentsContent agents={value.agents} />}</AsyncState>
+        <section className="agent-runtime-section" id="agent-runtime">
+          <header className="settings-subheader">
+            <div>
+              <span className="eyebrow">Infrastructure</span>
+              <h2>Agent runtime</h2>
+              <p>Connect and inspect the computers available to run Agents.</p>
+            </div>
+          </header>
+          <ComputersSettings canManage={membership.role === "admin"} teamId={membership.teamId} />
+        </section>
       </Page>
       {createOpen ? <NewAgentDialog returnFocusRef={createTriggerRef} onClose={() => setCreateOpen(false)} /> : null}
     </>
@@ -919,7 +956,7 @@ function AgentsPage() {
 
 function AgentsContent({ agents }: { agents: AgentListItem[] }) {
   return agents.length === 0 ? (
-    <EmptyState title="No Agents yet">A Team Admin can create the first Agent.</EmptyState>
+    <EmptyState title="No Agents yet">An Admin can create the first Agent.</EmptyState>
   ) : (
     <AgentList agents={agents} />
   );
@@ -927,7 +964,7 @@ function AgentsContent({ agents }: { agents: AgentListItem[] }) {
 
 function AgentList({ agents }: { agents: AgentListItem[] }) {
   return (
-    <section className="agent-list-section" aria-label="Team Agents">
+    <section className="agent-list-section" aria-label="Agents">
       <div className="agent-summary-strip">
         <span>
           <strong>{agents.length}</strong> Agents
@@ -952,10 +989,10 @@ function AgentList({ agents }: { agents: AgentListItem[] }) {
 function AgentRow({ agent }: { agent: AgentListItem }) {
   const status =
     agent.status === "suspended"
-      ? { label: "Suspended", reason: "Not receiving new work", tone: "suspended" }
+      ? { label: "Suspended", reason: "Not receiving new work", tone: "neutral" as const }
       : agent.evidenceConfirmed
-        ? { label: "Active", reason: undefined, tone: "ready" }
-        : { label: "Unconfirmed", reason: "Unable to refresh Agent", tone: "unconfirmed" };
+        ? { label: "Active", reason: undefined, tone: "success" as const }
+        : { label: "Unconfirmed", reason: "Unable to refresh Agent", tone: "neutral" as const };
   return (
     <div className="agent-row">
       <Link aria-label={`Open ${agent.displayName}`} className="agent-row-link" to={`/agents/${agent.id}/general`} />
@@ -971,14 +1008,10 @@ function AgentRow({ agent }: { agent: AgentListItem }) {
         </span>
       </span>
       <span className="cell-stack availability-cell" data-label="State">
-        <strong>
-          <i className={`availability-dot ${status.tone}`} aria-hidden="true" />
-          {status.label}
-        </strong>
-        {status.reason ? <small>{status.reason}</small> : null}
+        <StatusIndicator detail={status.reason} label={status.label} tone={status.tone} />
       </span>
       <span className="agent-row-action" aria-hidden="true">
-        ›
+        <Icon name="chevron-right" />
       </span>
     </div>
   );
@@ -996,7 +1029,7 @@ function NewAgentPage() {
   const { membership } = useTeam();
   const navigate = useNavigate();
   const computers = useOwnComputersResource(membership.teamId);
-  if (membership.role !== "admin") return <UnavailablePage title="Team Admin access required" />;
+  if (membership.role !== "admin") return <UnavailablePage title="Admin access required" />;
   return (
     <Page title="Create Agent" description="Create the identity first. Complete its setup from the Agent overview.">
       <AgentCreationContent
@@ -1018,117 +1051,28 @@ function NewAgentDialog({
   const { membership } = useTeam();
   const navigate = useNavigate();
   const computers = useOwnComputersResource(membership.teamId);
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const [submitting, setSubmitting] = useState(false);
-  const submittingRef = useRef(submitting);
-  const onCloseRef = useRef(onClose);
-  submittingRef.current = submitting;
-  onCloseRef.current = onClose;
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    const target = dialog.querySelector<HTMLElement>(
-      "button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled])",
-    );
-    if (submitting) {
-      if (!activeElement || !dialog.contains(activeElement) || activeElement.matches(":disabled")) {
-        (target ?? dialog).focus();
-      }
-    } else if (activeElement === dialog) {
-      target?.focus();
-    }
-  }, [submitting]);
-
-  useEffect(() => {
-    closeButtonRef.current?.focus();
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        if (!submittingRef.current) onCloseRef.current();
-        return;
-      }
-      if (event.key !== "Tab") return;
-      const focusable = Array.from(
-        dialogRef.current?.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ) ?? [],
-      );
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialogRef.current?.focus();
-        return;
-      }
-      const first = focusable[0];
-      const last = focusable.at(-1);
-      if (!dialogRef.current?.contains(document.activeElement) || document.activeElement === dialogRef.current) {
-        event.preventDefault();
-        (event.shiftKey ? last : first)?.focus();
-      } else if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last?.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first?.focus();
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      returnFocusRef.current?.focus();
-    };
-  }, [returnFocusRef]);
 
   return (
-    <div className="dialog-layer">
-      <button
-        aria-label="Dismiss new Agent dialog"
-        className="dialog-backdrop"
-        disabled={submitting}
-        tabIndex={-1}
-        type="button"
-        onClick={onClose}
+    <Dialog
+      busy={submitting}
+      className="new-agent-dialog"
+      closeLabel="Close new Agent dialog"
+      description="Give the Agent an identity and choose where it runs. You can finish its setup from the overview."
+      eyebrow="Create"
+      returnFocusRef={returnFocusRef}
+      title="New Agent"
+      onClose={onClose}
+    >
+      <AgentCreationContent
+        computers={computers}
+        presentation="dialog"
+        teamId={membership.teamId}
+        onCancel={onClose}
+        onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
+        onSubmittingChange={setSubmitting}
       />
-      <div
-        aria-describedby="new-agent-dialog-description"
-        aria-labelledby="new-agent-dialog-title"
-        aria-modal="true"
-        className="dialog-card new-agent-dialog"
-        ref={dialogRef}
-        role="dialog"
-        tabIndex={-1}
-      >
-        <header className="dialog-header">
-          <div>
-            <span className="eyebrow dialog-eyebrow">Create</span>
-            <h2 id="new-agent-dialog-title">New Agent</h2>
-          </div>
-          <button
-            aria-label="Close new Agent dialog"
-            className="dialog-close"
-            disabled={submitting}
-            ref={closeButtonRef}
-            type="button"
-            onClick={onClose}
-          >
-            ×
-          </button>
-        </header>
-        <p className="dialog-description" id="new-agent-dialog-description">
-          Give the Agent an identity and choose where it runs. You can finish its setup from the overview.
-        </p>
-        <AgentCreationContent
-          computers={computers}
-          presentation="dialog"
-          teamId={membership.teamId}
-          onCancel={onClose}
-          onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
-          onSubmittingChange={setSubmitting}
-        />
-      </div>
-    </div>
+    </Dialog>
   );
 }
 
@@ -1214,14 +1158,24 @@ function AgentCreationContent({
         const readiness = computer?.providerReadiness?.find((entry) => entry.provider === runtimeProvider);
         return value.computers.length === 0 ? (
           <EmptyState title="Connect a Local Computer first">
-            Open <Link to="/settings/computers">Computer settings</Link> to generate a connection command.
+            Open the{" "}
+            <Link to="/agents#agent-runtime" onClick={onCancel}>
+              Agent runtime
+            </Link>{" "}
+            section to generate a connection command.
           </EmptyState>
         ) : (
           <form className="form-card agent-create-form" onSubmit={submit}>
-            <div className="agent-create-field">
-              <label htmlFor="new-agent-display-name">Display name</label>
+            <Field
+              className="agent-create-field"
+              hint="How teammates will see this Agent in lists and conversations."
+              hintId="new-agent-display-name-hint"
+              htmlFor="new-agent-display-name"
+              label="Display name"
+            >
               <input
                 aria-describedby="new-agent-display-name-hint"
+                className="ds-control"
                 id="new-agent-display-name"
                 ref={firstFieldRef}
                 name="displayName"
@@ -1229,12 +1183,16 @@ function AgentCreationContent({
                 disabled={submitting}
                 required
               />
-              <span className="field-hint" id="new-agent-display-name-hint">
-                How teammates will see this Agent in lists and conversations.
-              </span>
-            </div>
-            <div className="agent-create-field">
-              <label htmlFor="new-agent-name">Agent name</label>
+            </Field>
+            <Field
+              className="agent-create-field"
+              error={nameError}
+              errorId="agent-name-error"
+              hint="Used for mentions. Lowercase letters, numbers, and hyphens only."
+              hintId="new-agent-name-hint"
+              htmlFor="new-agent-name"
+              label="Agent name"
+            >
               <span className="agent-name-input">
                 <span aria-hidden="true">@</span>
                 <input
@@ -1248,19 +1206,11 @@ function AgentCreationContent({
                   required
                 />
               </span>
-              <span className="field-hint" id="new-agent-name-hint">
-                Used for mentions. Lowercase letters, numbers, and hyphens only.
-              </span>
-              {nameError ? (
-                <span className="field-error" id="agent-name-error" role="alert">
-                  {nameError}
-                </span>
-              ) : null}
-            </div>
+            </Field>
             <div className="agent-create-grid">
-              <div className="agent-create-field">
-                <label htmlFor="new-agent-provider">Provider</label>
+              <Field className="agent-create-field" htmlFor="new-agent-provider" label="Provider">
                 <select
+                  className="ds-control"
                   id="new-agent-provider"
                   name="runtimeProvider"
                   disabled={submitting}
@@ -1270,10 +1220,10 @@ function AgentCreationContent({
                   <option value="codex">Codex</option>
                   <option value="claude-code">Claude Code</option>
                 </select>
-              </div>
-              <div className="agent-create-field">
-                <label htmlFor="new-agent-computer">Computer</label>
+              </Field>
+              <Field className="agent-create-field" htmlFor="new-agent-computer" label="Computer">
                 <select
+                  className="ds-control"
                   id="new-agent-computer"
                   name="computerId"
                   disabled={submitting}
@@ -1287,7 +1237,7 @@ function AgentCreationContent({
                     </option>
                   ))}
                 </select>
-              </div>
+              </Field>
             </div>
             <div
               className={`notice ${readiness?.status === "ready" && computer?.connectionStatus === "online" ? "" : "warning"}`}
@@ -1303,13 +1253,13 @@ function AgentCreationContent({
             ) : null}
             <div className="agent-create-actions">
               {presentation === "dialog" ? (
-                <button className="secondary" disabled={submitting} type="button" onClick={onCancel}>
+                <Button disabled={submitting} variant="secondary" onClick={onCancel}>
                   Cancel
-                </button>
+                </Button>
               ) : null}
-              <button className="button" disabled={submitting} type="submit">
+              <Button disabled={submitting} type="submit">
                 {submitting ? "Creating…" : "Create Agent"}
-              </button>
+              </Button>
             </div>
           </form>
         );
@@ -1371,7 +1321,8 @@ function AgentDetailPage() {
         <section className="object-page">
           <header className="object-header">
             <Link className="breadcrumb" to="/agents">
-              ← Agents
+              <Icon name="arrow-left" />
+              Agents
             </Link>
             <div className="object-title-row">
               <div className="object-identity">
@@ -1422,10 +1373,38 @@ function AgentDetailPage() {
 }
 
 function AccountPage() {
-  const { me, refreshMe } = useTeam();
+  const { me, membership, refreshMe } = useTeam();
+  const location = useLocation();
   return (
-    <Page title="Account" description="Manage the identity used across every Team you belong to.">
-      <AccountSettings refreshMe={refreshMe} user={me.user} />
+    <Page title="Account" description="Manage your profile and advanced account options.">
+      <div className="account-settings-stack">
+        <AccountSettings refreshMe={refreshMe} user={me.user} />
+        <details
+          className="account-advanced"
+          id="workspace-management"
+          open={location.hash === "#workspace-management"}
+        >
+          <summary>Advanced</summary>
+          <div className="account-advanced-content">
+            <header className="settings-subheader">
+              <div>
+                <h2>Workspace management</h2>
+                <p>For people who operate more than one organization.</p>
+              </div>
+            </header>
+            <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
+            <div className="account-workspace-create">
+              <div>
+                <strong>Additional Workspace</strong>
+                <p>Create another isolated organization for a separate client or team.</p>
+              </div>
+              <Link className="secondary" to="/workspaces/new">
+                Create another Workspace
+              </Link>
+            </div>
+          </div>
+        </details>
+      </div>
     </Page>
   );
 }
@@ -1489,7 +1468,7 @@ function GeneralTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgent
         <DefinitionList
           rows={[
             ["Manager", agent.manager.displayName],
-            ["Who can use", "Team members"],
+            ["Who can use", "Members"],
           ]}
         />
       </section>
@@ -1500,15 +1479,14 @@ function GeneralTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgent
 
 function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
   const recovery = agentAvailabilityRecovery(agent);
+  const tone = availabilityTone(agent.availability.state);
   return (
-    <div className={`availability-action ${availabilityTone(agent.availability.state)}`}>
-      <span>
-        <strong>
-          <i className={`availability-dot ${availabilityTone(agent.availability.state)}`} aria-hidden="true" />
-          {availabilityStateLabel(agent.availability.state)}
-        </strong>
-        <small>{agentAvailabilitySummary(agent)}</small>
-      </span>
+    <div className={`availability-action ${tone}`}>
+      <StatusIndicator
+        detail={agentAvailabilitySummary(agent)}
+        label={availabilityStateLabel(agent.availability.state)}
+        tone={tone}
+      />
       {recovery ? <Link to={recovery.to}>{recovery.label}</Link> : null}
     </div>
   );
@@ -1589,26 +1567,30 @@ function GeneralConfigForm({
   return (
     <form className="form-card" onSubmit={submit}>
       <h2>Admin configuration</h2>
-      <label>
-        Display name
-        <input defaultValue={config.displayName} key={config.revision} name="displayName" required />
-      </label>
-      <button className="button commit" type="submit">
+      <Field htmlFor="agent-display-name" label="Display name">
+        <input
+          className="ds-control"
+          defaultValue={config.displayName}
+          id="agent-display-name"
+          key={config.revision}
+          name="displayName"
+          required
+        />
+      </Field>
+      <Button variant="commit" type="submit">
         Save General settings
-      </button>
+      </Button>
       <div className="actions">
         {config.status === "active" ? (
-          <button className="secondary" type="button" onClick={() => void changeLifecycle("suspend")}>
+          <Button variant="secondary" onClick={() => void changeLifecycle("suspend")}>
             Suspend Agent
-          </button>
+          </Button>
         ) : (
           <>
-            <button className="button" type="button" onClick={() => void changeLifecycle("reactivate")}>
-              Reactivate Agent
-            </button>
-            <button className="danger" type="button" onClick={() => void deleteAgent()}>
+            <Button onClick={() => void changeLifecycle("reactivate")}>Reactivate Agent</Button>
+            <Button variant="danger" onClick={() => void deleteAgent()}>
               Delete Agent permanently
-            </button>
+            </Button>
           </>
         )}
       </div>
@@ -1638,7 +1620,7 @@ function RuntimeTab({ agent }: { agent: AgentDetailView }) {
               save={(input) => browserApi.updateAgent(config.id, input)}
             />
           ) : (
-            <p className="muted">Runtime instructions and tuning are visible only to Team Admins.</p>
+            <p className="muted">Runtime instructions and tuning are visible only to Admins.</p>
           )}
         </>
       )}
@@ -1795,7 +1777,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                         </div>
                       </section>
                     ) : (
-                      <p className="muted">IM setup is managed by Team Admins.</p>
+                      <p className="muted">IM setup is managed by Admins.</p>
                     )}
                   </>
                 ) : (
@@ -1814,7 +1796,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                         </button>
                       </div>
                     ) : (
-                      <p className="muted">IM setup is managed by Team Admins.</p>
+                      <p className="muted">IM setup is managed by Admins.</p>
                     )}
                   </section>
                 )}
@@ -1850,137 +1832,55 @@ function AccessTab({ agent }: { agent: AgentDetailView }) {
   return (
     <DefinitionList
       rows={[
-        ["Safe read", "All active Team members"],
-        ["Use", "All active Team members (fixed v0.1 policy)"],
-        ["Manage", agent.viewerCapabilities.canManage ? "Team Admins (you can manage)" : "Team Admins"],
+        ["Safe read", "All active members"],
+        ["Use", "All active members (fixed v0.1 policy)"],
+        ["Manage", agent.viewerCapabilities.canManage ? "Admins (you can manage)" : "Admins"],
       ]}
     />
   );
 }
 
-const settingsSections = [
-  { key: "team", label: "Team" },
-  { key: "computers", label: "Computers" },
-  { key: "resources", label: "Resources" },
-  { key: "integrations", label: "Integrations" },
-  { key: "access", label: "Access" },
-  { key: "usage", label: "Usage" },
-  { key: "security", label: "Security" },
-] as const;
-
-function SettingsPage() {
-  const { section = "team" } = useParams();
-  const { invitationOpen, setInvitationMutationPending } = useOutletContext<AppShellOutletContext>();
-  const location = useLocation();
-  const navigate = useNavigate();
+function MembersPage() {
   const { me, membership, refreshMe } = useTeam();
-  const currentSection = settingsSections.find((item) => item.key === section);
-
-  useEffect(() => {
-    if (section !== "team" || location.hash !== "#members") return;
-    document.getElementById("members")?.scrollIntoView({ block: "start" });
-  }, [location.hash, section]);
-
-  if (!currentSection) return <NotFoundPage />;
+  function focusInvitationPanel() {
+    const panel = document.getElementById("member-invitations");
+    panel?.scrollIntoView({ block: "nearest" });
+    panel?.focus({ preventScroll: true });
+  }
   return (
-    <section className="settings-page">
-      <header className="settings-title">
-        <h1>Settings</h1>
-        <p>Manage the current Team's identity, infrastructure, access, and security.</p>
-      </header>
-      <label className="local-nav-select">
-        <span>Settings section</span>
-        <select value={section} onChange={(event) => navigate(`/settings/${event.currentTarget.value}`)}>
-          {settingsSections.map((item) => (
-            <option value={item.key} key={item.key}>
-              {item.label}
-            </option>
-          ))}
-        </select>
-      </label>
-      <div className="settings-layout">
-        <nav className="local-nav" aria-label="Settings">
-          {settingsSections.map((item) => (
-            <NavLink to={`/settings/${item.key}`} key={item.key}>
-              {item.label}
-            </NavLink>
-          ))}
-        </nav>
-        <div className="settings-content">
-          <header className="section-header">
-            <h2>{currentSection.label}</h2>
-            <p>{settingsSectionDescription(currentSection.key)}</p>
-          </header>
-          {section === "team" ? (
-            <TeamSettings
-              currentUserId={me.user.id}
-              invitationDialogOpen={invitationOpen}
-              membership={membership}
-              onInvitationMutationPendingChange={setInvitationMutationPending}
-              refreshMe={refreshMe}
-            />
-          ) : null}
-          {section === "computers" ? (
-            <ComputersSettings canManage={membership.role === "admin"} teamId={membership.teamId} />
-          ) : null}
-          {section === "resources" ? (
-            <SettingsUnavailable
-              details={[
-                "This page does not create or infer Team Resource records.",
-                "No Resource assignment projection is exposed by the current API.",
-              ]}
-              title="Team Resources are not enabled"
-            >
-              Repositories, skills, tools, and prompts will appear here only after OpenTag has an authoritative Team
-              Resource model.
-            </SettingsUnavailable>
-          ) : null}
-          {section === "integrations" ? (
-            <SettingsUnavailable
-              action={{ label: "Open Agents", to: "/agents" }}
-              details={[
-                "Supported bot connections remain owned by individual Agents.",
-                "Open an Agent's IM tab to review its current Feishu or Slack connection state.",
-              ]}
-              title="Team Integrations are not enabled"
-            >
-              OpenTag does not promote Agent credentials into shared Team connections or imply that a provider is
-              available Team-wide.
-            </SettingsUnavailable>
-          ) : null}
-          {section === "access" ? <AccessSettings membership={membership} /> : null}
-          {section === "usage" ? (
-            <SettingsUnavailable
-              details={[
-                "Task, Turn, and provider totals are not estimated from partial activity.",
-                "Cost reporting will require authoritative provider billing metadata.",
-              ]}
-              title="Usage reporting is not enabled"
-            >
-              This page will stay intentionally empty until OpenTag can report complete, measured Team activity.
-            </SettingsUnavailable>
-          ) : null}
-          {section === "security" ? (
-            <SettingsUnavailable
-              details={[
-                "Sensitive credentials are never returned to the browser.",
-                "Team administration remains limited to active Admin memberships.",
-                "Browser sessions and audit events are not available in this version.",
-              ]}
-              status="Current safeguards"
-              title="Security data is intentionally limited"
-            >
-              OpenTag only reports security state that the server can verify. It does not show inferred checks or an
-              unsupported all-clear status.
-            </SettingsUnavailable>
-          ) : null}
-        </div>
-      </div>
-    </section>
+    <Page
+      title="Members"
+      description="Manage members, invitations, and roles."
+      action={membership.role === "admin" ? <Button onClick={focusInvitationPanel}>Invite members</Button> : null}
+    >
+      <MembersSettings
+        canManage={membership.role === "admin"}
+        currentUserId={me.user.id}
+        refreshMe={refreshMe}
+        teamId={membership.teamId}
+      />
+    </Page>
   );
 }
 
-function SettingsUnavailable({
+function TasksPage() {
+  return (
+    <Page title="Tasks" description="Track work assigned to Agents.">
+      <CapabilityUnavailable
+        details={[
+          "The current server does not expose a Tasks API.",
+          "No sample, inferred, or locally generated Task records are shown.",
+        ]}
+        status="Coming later"
+        title="Tasks are not available yet"
+      >
+        Tasks will appear here after OpenTag can load authoritative Task records from the server.
+      </CapabilityUnavailable>
+    </Page>
+  );
+}
+
+function CapabilityUnavailable({
   action,
   children,
   details,
@@ -2009,40 +1909,6 @@ function SettingsUnavailable({
         </Link>
       ) : null}
     </section>
-  );
-}
-
-function AccessSettings({ membership }: { membership: MeMembership }) {
-  return (
-    <div className="settings-policy-stack">
-      <section className="settings-policy-banner">
-        <div>
-          <span className="settings-state-label">Server-returned membership</span>
-          <h2>Authorization follows your active Team membership</h2>
-          <p>OpenTag checks authorization on every request. This page only reports facts exposed by the API.</p>
-        </div>
-        <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
-      </section>
-      <section className="settings-list-section">
-        <header className="settings-subheader">
-          <div>
-            <h2>Available policy detail</h2>
-            <p>The current API does not publish a complete Team capability matrix.</p>
-          </div>
-        </header>
-        <DefinitionList
-          rows={[
-            ["Selected Team role", titleCase(membership.role)],
-            ["Custom roles", "Not enabled"],
-            ["Per-resource policies", "Not exposed by the API"],
-          ]}
-        />
-        <p className="settings-footnote">
-          Management controls use server-returned capabilities where available; the server remains authoritative for
-          every operation.
-        </p>
-      </section>
-    </div>
   );
 }
 
@@ -2096,7 +1962,7 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
         <div className="settings-field-row">
           <div className="settings-field-copy">
             <strong>Display name</strong>
-            <p>This identity is shared across every Team you belong to.</p>
+            <p>This identity is used throughout OpenTag.</p>
           </div>
           <label>
             Display name
@@ -2151,34 +2017,6 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
   );
 }
 
-function TeamSettings({
-  currentUserId,
-  invitationDialogOpen,
-  membership,
-  onInvitationMutationPendingChange,
-  refreshMe,
-}: {
-  currentUserId: string;
-  invitationDialogOpen: boolean;
-  membership: MeMembership;
-  onInvitationMutationPendingChange: (pending: boolean) => void;
-  refreshMe: () => void;
-}) {
-  return (
-    <div className="settings-team-stack">
-      <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
-      <MembersSettings
-        canManage={membership.role === "admin"}
-        currentUserId={currentUserId}
-        invitationDialogOpen={invitationDialogOpen}
-        onInvitationMutationPendingChange={onInvitationMutationPendingChange}
-        refreshMe={refreshMe}
-        teamId={membership.teamId}
-      />
-    </div>
-  );
-}
-
 function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembership; refreshMe: () => void }) {
   const [message, setMessage] = useState<string>();
   const [error, setError] = useState<string>();
@@ -2195,14 +2033,14 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
       <section className="settings-readonly-panel">
         <div className="settings-readonly-heading">
           <div>
-            <h2>Team profile</h2>
-            <p>Only Team Admins can change these fields.</p>
+            <h2>Workspace profile</h2>
+            <p>Only Workspace Admins can change these fields.</p>
           </div>
           <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
         </div>
         <DefinitionList
           rows={[
-            ["Team name", membership.teamDisplayName],
+            ["Workspace name", membership.teamDisplayName],
             ["CLI identifier", membership.teamName],
           ]}
         />
@@ -2219,24 +2057,24 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
         displayName: teamDisplayName,
       });
       refreshMe();
-      setMessage("Team profile saved.");
+      setMessage("Workspace profile saved.");
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Unable to save the Team profile");
+      setError(cause instanceof Error ? cause.message : "Unable to save the Workspace profile");
     } finally {
       setSaving(false);
     }
   }
   return (
     <form className="settings-profile-form" onSubmit={submit}>
-      <h2>Team profile</h2>
+      <h2 className="visually-hidden">Workspace profile fields</h2>
       <div className="settings-field-list">
         <div className="settings-field-row">
           <div className="settings-field-copy">
-            <strong>Team name</strong>
+            <strong>Workspace name</strong>
             <p>What people see in navigation and invitations.</p>
           </div>
           <label>
-            Team name
+            Workspace name
             <input
               name="displayName"
               required
@@ -2252,7 +2090,7 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
         <div className="settings-field-row">
           <div className="settings-field-copy">
             <strong>CLI identifier</strong>
-            <p>Created automatically for CLI commands. It stays the same when you rename the Team.</p>
+            <p>Created automatically for CLI commands. It stays the same when you rename the Workspace.</p>
           </div>
           <dl className="settings-readonly-value">
             <div>
@@ -2289,7 +2127,7 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
               Discard
             </button>
             <button className="button commit" disabled={saving} type="submit">
-              {saving ? "Saving…" : "Save Team profile"}
+              {saving ? "Saving…" : "Save Workspace profile"}
             </button>
           </div>
         </div>
@@ -2311,15 +2149,11 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
 function MembersSettings({
   canManage,
   currentUserId,
-  invitationDialogOpen,
-  onInvitationMutationPendingChange,
   refreshMe,
   teamId,
 }: {
   canManage: boolean;
   currentUserId: string;
-  invitationDialogOpen: boolean;
-  onInvitationMutationPendingChange: (pending: boolean) => void;
   refreshMe: () => void;
   teamId: string;
 }) {
@@ -2356,7 +2190,7 @@ function MembersSettings({
             <>
               <header className="settings-subheader">
                 <div>
-                  <h2>Team members</h2>
+                  <h2>Members</h2>
                   <p>
                     {value.members.length} {value.members.length === 1 ? "member" : "members"} · {adminCount}{" "}
                     {adminCount === 1 ? "admin" : "admins"}
@@ -2364,10 +2198,10 @@ function MembersSettings({
                 </div>
                 {!canManage ? <span className="settings-role-badge">Read only</span> : null}
               </header>
-              <table className="settings-member-table" aria-label="Team members">
+              <table className="settings-member-table" aria-label="Members">
                 <thead>
                   <tr className="settings-table-header">
-                    <th scope="col">Team member</th>
+                    <th scope="col">Member</th>
                     <th scope="col">Role</th>
                   </tr>
                 </thead>
@@ -2387,6 +2221,7 @@ function MembersSettings({
                         {canManage ? (
                           <select
                             aria-label={`Role for ${member.displayName}`}
+                            className="ds-control"
                             disabled={pendingUserIds.has(member.userId)}
                             value={member.role}
                             onChange={(event) => void changeRole(member, event.currentTarget.value)}
@@ -2414,138 +2249,17 @@ function MembersSettings({
           {error}
         </p>
       ) : null}
-      {canManage && !invitationDialogOpen ? (
-        <InvitationSettings teamId={teamId} onMutationPendingChange={onInvitationMutationPendingChange} />
-      ) : null}
+      {canManage ? <InvitationSettings teamId={teamId} /> : null}
     </section>
   );
 }
 
-function InvitationDialog({
-  mutationPending,
-  onClose,
-  onMutationPendingChange,
-  returnFocusRef,
-  teamDisplayName,
-  teamId,
-}: {
-  mutationPending: boolean;
-  onClose: () => void;
-  onMutationPendingChange: (pending: boolean) => void;
-  returnFocusRef: { current: HTMLButtonElement | null };
-  teamDisplayName: string;
-  teamId: string;
-}) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const mutationPendingRef = useRef(mutationPending);
-  const onCloseRef = useRef(onClose);
-  mutationPendingRef.current = mutationPending;
-  onCloseRef.current = onClose;
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    const target = dialog?.querySelector<HTMLElement>(
-      "button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled])",
-    );
-    if (mutationPending) {
-      if (!dialog.contains(document.activeElement)) (target ?? dialog).focus();
-    } else if (document.activeElement === dialog) {
-      target?.focus();
-    }
-  }, [mutationPending]);
-
-  useEffect(() => {
-    closeButtonRef.current?.focus();
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        if (mutationPendingRef.current) return;
-        onCloseRef.current();
-        return;
-      }
-      if (event.key !== "Tab") return;
-      const focusable = Array.from(
-        dialogRef.current?.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ) ?? [],
-      );
-      if (focusable.length === 0) {
-        event.preventDefault();
-        dialogRef.current?.focus();
-        return;
-      }
-      const first = focusable[0];
-      const last = focusable.at(-1);
-      if (!dialogRef.current?.contains(document.activeElement) || document.activeElement === dialogRef.current) {
-        event.preventDefault();
-        (event.shiftKey ? last : first)?.focus();
-      } else if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last?.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first?.focus();
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      returnFocusRef.current?.focus();
-    };
-  }, [returnFocusRef]);
-
-  return (
-    <div className="dialog-layer">
-      <button
-        aria-label="Dismiss invitation dialog"
-        className="dialog-backdrop"
-        disabled={mutationPending}
-        tabIndex={-1}
-        type="button"
-        onClick={onClose}
-      />
-      <div
-        aria-describedby="invitation-dialog-description"
-        aria-labelledby="invitation-dialog-title"
-        aria-modal="true"
-        className="dialog-card invitation-dialog"
-        ref={dialogRef}
-        role="dialog"
-        tabIndex={-1}
-      >
-        <header className="dialog-header">
-          <div>
-            <span className="eyebrow dialog-eyebrow">{teamDisplayName}</span>
-            <h2 id="invitation-dialog-title">Invite people</h2>
-          </div>
-          <button
-            aria-label="Close invitation dialog"
-            className="dialog-close"
-            disabled={mutationPending}
-            ref={closeButtonRef}
-            type="button"
-            onClick={onClose}
-          >
-            ×
-          </button>
-        </header>
-        <p className="dialog-description" id="invitation-dialog-description">
-          This link lets anyone join the Team as a member until it expires.
-        </p>
-        <InvitationSettings presentation="dialog" teamId={teamId} onMutationPendingChange={onMutationPendingChange} />
-      </div>
-    </div>
-  );
-}
-
 function InvitationSettings({
-  onMutationPendingChange,
+  onMutationPendingChange = () => undefined,
   presentation = "panel",
   teamId,
 }: {
-  onMutationPendingChange: (pending: boolean) => void;
+  onMutationPendingChange?: (pending: boolean) => void;
   presentation?: "dialog" | "panel";
   teamId: string;
 }) {
@@ -2593,11 +2307,16 @@ function InvitationSettings({
   }
 
   return (
-    <section className={presentation === "dialog" ? "invitation-dialog-content" : "settings-invitation-panel"}>
+    <section
+      aria-labelledby={presentation === "panel" ? "invite-members-heading" : undefined}
+      className={presentation === "dialog" ? "invitation-dialog-content" : "settings-invitation-panel"}
+      id={presentation === "panel" ? "member-invitations" : undefined}
+      tabIndex={presentation === "panel" ? -1 : undefined}
+    >
       {presentation === "panel" ? (
         <>
-          <h3>Invite members</h3>
-          <p>This link lets anyone join the Team as a member until it expires.</p>
+          <h3 id="invite-members-heading">Invite members</h3>
+          <p>This link lets anyone join as a member until it expires.</p>
         </>
       ) : null}
       <AsyncState state={state}>
@@ -2607,22 +2326,26 @@ function InvitationSettings({
             <>
               <label className="invite-link">
                 Invite link
-                <input aria-label="Invite link" readOnly type="url" value={invitation.inviteUrl} />
+                <input
+                  className="ds-control"
+                  aria-label="Invite link"
+                  readOnly
+                  type="url"
+                  value={invitation.inviteUrl}
+                />
               </label>
               <p className="muted">Expires {formatInviteExpiry(invitation.expiresAt)}.</p>
               <div className={presentation === "dialog" ? "actions dialog-actions" : "actions"}>
-                <button type="button" onClick={() => void copyInvitation(invitation.inviteUrl)}>
-                  Copy link
-                </button>
-                <button className="secondary" disabled={busy} type="button" onClick={() => void rotateInvitation()}>
+                <Button onClick={() => void copyInvitation(invitation.inviteUrl)}>Copy link</Button>
+                <Button disabled={busy} variant="secondary" onClick={() => void rotateInvitation()}>
                   {busy ? "Replacing…" : "Replace link"}
-                </button>
+                </Button>
               </div>
             </>
           ) : (
-            <button className="button" disabled={busy} type="button" onClick={() => void createInvitation()}>
+            <Button disabled={busy} onClick={() => void createInvitation()}>
               {busy ? "Creating…" : "Create invite link"}
-            </button>
+            </Button>
           );
         }}
       </AsyncState>
@@ -2647,7 +2370,7 @@ function ComputersSettings({ canManage, teamId }: { canManage: boolean; teamId: 
           <section className="settings-list-section">
             <header className="settings-subheader">
               <div>
-                <h2>Team computers</h2>
+                <h2>Computers</h2>
                 <p>
                   {value.computers.length} {value.computers.length === 1 ? "computer" : "computers"} ·{" "}
                   {
@@ -2662,12 +2385,10 @@ function ComputersSettings({ canManage, teamId }: { canManage: boolean; teamId: 
             {value.computers.length === 0 ? (
               <div className="settings-compact-empty">
                 <strong>No computers connected</strong>
-                <p>
-                  {canManage ? "Use the connection flow above to add one." : "A Team Admin must connect a computer."}
-                </p>
+                <p>{canManage ? "Use the connection flow above to add one." : "An Admin must connect a computer."}</p>
               </div>
             ) : (
-              <table className="settings-computer-table" aria-label="Team computers">
+              <table className="settings-computer-table" aria-label="Computers">
                 <thead>
                   <tr className="settings-table-header">
                     <th scope="col">Computer</th>
@@ -2695,10 +2416,10 @@ function ComputersSettings({ canManage, teamId }: { canManage: boolean; teamId: 
                         </small>
                       </td>
                       <td data-label="Status">
-                        <span className="settings-status">
-                          <span className={`settings-status-dot ${computer.connectionStatus}`} aria-hidden="true" />
-                          {titleCase(computer.connectionStatus)}
-                        </span>
+                        <StatusIndicator
+                          label={titleCase(computer.connectionStatus)}
+                          tone={computer.connectionStatus === "online" ? "success" : "neutral"}
+                        />
                       </td>
                       <td data-label="Last seen">{formatDate(computer.lastSeenAt)}</td>
                       <td data-label="Agents">{computer.agentIds.length}</td>
@@ -2809,13 +2530,11 @@ function receiveModeLabel(receiveMode: AgentSummary["receiveMode"]): string {
   return receiveMode === "all_message" ? "All messages" : "Mentions only";
 }
 
-function availabilityTone(state: AgentAvailability["state"]): string {
-  if (state === "ready") return "ready";
-  if (state === "setting_up") return "setting-up";
-  if (state === "suspended") return "suspended";
-  if (state === "not_connected") return "not-connected";
-  if (state === "unconfirmed") return "unconfirmed";
-  return "action-required";
+function availabilityTone(state: AgentAvailability["state"]): StatusTone {
+  if (state === "ready") return "success";
+  if (state === "setting_up") return "info";
+  if (state === "action_required") return "warning";
+  return "neutral";
 }
 
 function availabilityStateLabel(state: AgentAvailability["state"]): string {
@@ -2885,19 +2604,6 @@ function agentSectionDescription(section: (typeof agentSections)[number]["key"])
     im: "Manage the Agent's Feishu or Slack bot and message policy.",
     access: "Understand who can use, inspect, and manage this Agent.",
   } satisfies Record<(typeof agentSections)[number]["key"], string>;
-  return descriptions[section];
-}
-
-function settingsSectionDescription(section: (typeof settingsSections)[number]["key"]): string {
-  const descriptions = {
-    team: "Manage the current Team's profile, members, and invitation link.",
-    computers: "Connect and inspect the Computers available to the current Team.",
-    resources: "Review reusable repositories, skills, tools, and prompts.",
-    integrations: "Review supported Team and Agent connection surfaces.",
-    access: "Review Team-wide access and administration boundaries.",
-    usage: "Review measured Task, Turn, and provider usage when available.",
-    security: "Review authorization health without exposing credentials.",
-  } satisfies Record<(typeof settingsSections)[number]["key"], string>;
   return descriptions[section];
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -706,7 +706,49 @@ button.danger:hover {
   left: 0;
   display: grid;
   gap: 2px;
+  max-height: min(560px, calc(100dvh - 32px));
+  overflow-y: auto;
   padding: 7px;
+}
+
+.account-workspace-group {
+  display: grid;
+  max-height: min(304px, 42dvh);
+  gap: 2px;
+  overflow-y: auto;
+  min-width: 0;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 5px;
+  padding: 0 0 7px;
+}
+
+.account-menu-popover .account-workspace-option {
+  display: grid;
+  min-height: 48px;
+  grid-template-columns: 24px minmax(0, 1fr) 16px;
+  gap: 10px;
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.account-menu-popover .account-workspace-option[aria-current="true"] {
+  background: var(--brand-light);
+  color: var(--foreground);
+}
+
+.account-menu-popover .account-workspace-manage {
+  justify-content: space-between;
+  min-height: 40px;
+  margin-top: 4px;
+  border-top: 1px solid var(--border);
+  border-radius: 0 0 7px 7px;
+  padding-top: 4px;
+}
+
+.account-menu-actions {
+  display: grid;
+  gap: 2px;
 }
 
 .account-menu-popover a,
@@ -738,6 +780,48 @@ button.danger:hover {
   font-size: var(--text-meta);
   line-height: var(--lh-ui);
   padding: 6px 9px;
+}
+
+.account-settings-stack {
+  display: grid;
+  gap: 32px;
+}
+
+.account-advanced {
+  border-top: 1px solid var(--border);
+  padding-top: 18px;
+}
+
+.account-advanced > summary {
+  width: fit-content;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+}
+
+.account-advanced[open] > summary {
+  color: var(--foreground);
+}
+
+.account-advanced-content {
+  display: grid;
+  gap: 22px;
+  margin-top: 22px;
+}
+
+.account-workspace-create {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-top: 1px solid var(--border);
+  padding-top: 20px;
+}
+
+.account-workspace-create p {
+  margin: 5px 0 0;
+  color: var(--muted);
 }
 
 .sidebar-backdrop,
@@ -837,6 +921,14 @@ button.danger:hover {
   margin-top: 4px;
 }
 
+.workspace-profile-dialog {
+  width: min(100%, 760px);
+}
+
+.workspace-profile-dialog .dialog-header {
+  margin-bottom: 20px;
+}
+
 .app-main {
   min-width: 0;
 }
@@ -916,6 +1008,16 @@ button.danger:hover {
 .agent-list-section {
   display: grid;
   gap: 24px;
+}
+
+.agent-runtime-section {
+  display: grid;
+  width: min(100%, 860px);
+  gap: 24px;
+  margin-top: 64px;
+  border-top: 1px solid var(--border);
+  padding-top: 36px;
+  scroll-margin-top: 28px;
 }
 
 .agent-summary-strip {
@@ -1610,25 +1712,42 @@ code {
 }
 
 .onboarding-shell {
+  position: relative;
+  isolation: isolate;
   min-height: 100dvh;
   background:
-    linear-gradient(rgb(248 247 240 / 94%), rgb(248 247 240 / 94%)),
-    linear-gradient(to right, rgb(201 204 187 / 20%) 1px, transparent 1px),
-    linear-gradient(to bottom, rgb(201 204 187 / 20%) 1px, transparent 1px);
+    radial-gradient(circle at 88% 8%, rgb(213 224 190 / 52%), transparent 28rem),
+    linear-gradient(rgb(248 247 240 / 93%), rgb(248 247 240 / 97%)),
+    linear-gradient(to right, rgb(201 204 187 / 24%) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(201 204 187 / 24%) 1px, transparent 1px);
   background-size:
+    auto,
     auto,
     36px 36px,
     36px 36px;
 }
 
+.onboarding-shell::before {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.78' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23noise)' opacity='.45'/%3E%3C/svg%3E");
+  content: "";
+  opacity: 0.022;
+  pointer-events: none;
+}
+
 .onboarding-header {
+  position: relative;
+  z-index: 2;
   display: flex;
-  min-height: 68px;
+  min-height: 72px;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
   border-bottom: 1px solid var(--border);
-  background: var(--surface);
+  background: rgb(253 252 247 / 90%);
+  backdrop-filter: blur(14px);
   padding: 12px clamp(20px, 4vw, 56px);
 }
 
@@ -1639,39 +1758,427 @@ code {
 .onboarding-account {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 16px;
   color: var(--secondary-foreground);
   font-size: var(--text-ui);
 }
 
+.onboarding-account > span {
+  position: relative;
+  padding-right: 17px;
+}
+
+.onboarding-account > span::after {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+  content: "";
+  transform: translateY(-50%);
+}
+
 .onboarding-main {
-  width: min(920px, calc(100% - 40px));
+  width: min(1200px, calc(100% - 64px));
   margin: 0 auto;
-  padding: clamp(56px, 9vh, 96px) 0 80px;
+  padding: clamp(46px, 6.5vh, 72px) 0 80px;
 }
 
-.onboarding-title {
-  border-bottom: 1px solid var(--strong-border);
-  padding-bottom: 28px;
+.onboarding-layout {
+  display: grid;
+  align-items: start;
+  grid-template-columns: minmax(250px, 300px) minmax(0, 1fr);
+  gap: clamp(48px, 6.5vw, 86px);
 }
 
-.onboarding-title h1 {
-  margin-bottom: 8px;
+.onboarding-journey {
+  position: sticky;
+  top: 42px;
+  min-width: 0;
+  padding-top: 10px;
+}
+
+.onboarding-journey-intro h1 {
+  max-width: 8ch;
+  margin-bottom: 16px;
   font-size: var(--text-display);
+  line-height: var(--lh-tight);
+  text-wrap: balance;
 }
 
-.onboarding-title p {
-  max-width: 48ch;
+.onboarding-journey-intro p {
+  max-width: 28ch;
   margin-bottom: 0;
   color: var(--muted);
+  text-wrap: pretty;
+}
+
+.onboarding-journey nav {
+  margin-top: 42px;
+}
+
+.onboarding-steps {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--strong-border);
+  list-style: none;
+}
+
+.onboarding-step {
+  position: relative;
+  display: grid;
+  min-height: 112px;
+  align-items: start;
+  grid-template-columns: 38px minmax(0, 1fr);
+  gap: 16px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  padding: 22px 0;
+  transition:
+    color 200ms ease,
+    opacity 200ms ease;
+}
+
+.onboarding-step[data-status="current"] {
+  color: var(--foreground);
+}
+
+.onboarding-step[data-status="upcoming"] {
+  opacity: 0.62;
+}
+
+.onboarding-step-number {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--strong-border);
+  border-radius: 9px;
+  background: rgb(253 252 247 / 54%);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--fw-semibold);
+  transition:
+    background-color 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease,
+    transform 200ms ease;
+}
+
+.onboarding-step[data-status="current"] .onboarding-step-number {
+  border-color: var(--brand);
+  background: var(--brand);
+  color: #fff;
+  transform: translateY(-2px);
+}
+
+.onboarding-step[data-status="complete"] .onboarding-step-number {
+  border-color: #b8c99b;
+  background: var(--brand-light);
+  color: var(--brand-ink);
+}
+
+.onboarding-step-copy,
+.onboarding-step-copy strong,
+.onboarding-step-copy > span {
+  display: block;
+}
+
+.onboarding-step-status {
+  margin-bottom: 5px;
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  letter-spacing: var(--track-label);
+}
+
+.onboarding-step-copy strong {
+  margin-bottom: 4px;
+  color: inherit;
+  font-family: var(--font-display);
+  font-size: var(--text-subsection);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--track-tight);
+}
+
+.onboarding-step-copy > span:last-child {
+  color: var(--muted);
+  font-size: var(--text-meta);
+  line-height: var(--lh-ui);
+}
+
+.onboarding-journey-note {
+  max-width: 30ch;
+  margin: 30px 0 0;
+  border-left: 2px solid #b8c99b;
+  color: var(--muted);
+  font-size: var(--text-meta);
+  line-height: var(--lh-prose);
+  padding-left: 13px;
+}
+
+.onboarding-workspace {
+  min-width: 0;
+  min-height: 630px;
+  overflow: hidden;
+  border: 1px solid rgb(201 204 187 / 88%);
+  border-radius: 24px;
+  background: rgb(253 252 247 / 96%);
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 80%) inset,
+    0 28px 74px rgb(45 62 34 / 10%);
+}
+
+.onboarding-stage-header {
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  background:
+    radial-gradient(circle at 95% -20%, rgb(148 181 91 / 30%), transparent 23rem),
+    linear-gradient(135deg, #f4f4e9 0%, #eef1e4 100%);
+  padding: 42px 44px 38px;
+}
+
+.onboarding-stage-header::after {
+  position: absolute;
+  top: -5rem;
+  right: -4rem;
+  width: 16rem;
+  height: 16rem;
+  border: 1px solid rgb(78 122 6 / 13%);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 2.5rem rgb(78 122 6 / 4%),
+    0 0 0 5rem rgb(78 122 6 / 3%);
+  content: "";
+  pointer-events: none;
+}
+
+.onboarding-stage-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.onboarding-stage-kicker,
+.onboarding-stage-status {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--track-label);
+}
+
+.onboarding-stage-kicker {
+  color: var(--brand-ink);
+}
+
+.onboarding-stage-status {
+  margin-left: 12px;
+  border-left: 1px solid #bdc5af;
+  color: var(--muted);
+  padding-left: 12px;
+}
+
+.onboarding-stage-copy h2 {
+  max-width: 18ch;
+  margin: 18px 0 10px;
+  font-family: var(--font-display);
+  font-size: var(--text-display);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--track-tight);
+  line-height: var(--lh-tight);
+  text-wrap: balance;
+}
+
+.onboarding-stage-copy p {
+  max-width: 56ch;
+  margin-bottom: 0;
+  color: var(--muted);
+  text-wrap: pretty;
+}
+
+.onboarding-runtime-summary {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 36px 0 0;
+  border-top: 1px solid #c9cfbd;
+  border-bottom: 1px solid #c9cfbd;
+}
+
+.onboarding-runtime-summary > div {
+  min-width: 0;
+  border-left: 1px solid #c9cfbd;
+  padding: 17px 22px 18px;
+}
+
+.onboarding-runtime-summary > div:first-child {
+  border-left: 0;
+  padding-left: 0;
+}
+
+.onboarding-runtime-summary dt {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  letter-spacing: var(--track-label);
+  text-transform: uppercase;
+}
+
+.onboarding-runtime-summary dd {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+  margin: 7px 0 0;
+  color: var(--foreground);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-ui);
+  overflow-wrap: anywhere;
+}
+
+.onboarding-runtime-summary dd::before {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border: 1px solid #aeb4a4;
+  border-radius: 2px;
+  background: #f6f6ef;
+  content: "";
+}
+
+.onboarding-runtime-summary > div[data-status="current"] dd::before {
+  border-color: var(--brand);
+  background: var(--brand);
+}
+
+.onboarding-runtime-summary > div[data-status="ready"] dd::before {
+  border-color: var(--brand-ink);
+  background: var(--brand-light);
+}
+
+.onboarding-runtime-summary > div[data-status="attention"] dd {
+  color: var(--warning);
+}
+
+.onboarding-runtime-summary > div[data-status="attention"] dd::before {
+  border-color: var(--warning);
+  background: var(--warning-surface);
+}
+
+.onboarding-runtime-summary > div[data-status="waiting"] dd {
+  color: var(--muted);
+}
+
+.onboarding-messaging-connection {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 100%;
+  align-items: center;
+  grid-template-columns: minmax(150px, 1fr) minmax(120px, 0.8fr) minmax(150px, 1fr);
+  gap: 18px;
+  margin-top: 36px;
+  border-top: 1px solid #c9cfbd;
+  border-bottom: 1px solid #c9cfbd;
+  padding: 18px 0;
+}
+
+.onboarding-connection-endpoint {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+}
+
+.onboarding-connection-endpoint-feishu {
+  justify-content: flex-end;
+}
+
+.onboarding-endpoint-mark {
+  display: inline-flex;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #b6c399;
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--brand-ink);
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  font-weight: var(--fw-bold);
+}
+
+.onboarding-connection-endpoint small,
+.onboarding-connection-endpoint strong {
+  display: block;
+}
+
+.onboarding-connection-endpoint small {
+  margin-bottom: 2px;
+  color: var(--muted);
+  font-size: var(--text-micro);
+}
+
+.onboarding-connection-endpoint strong {
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.onboarding-messaging-bridge {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.onboarding-messaging-bridge::before {
+  position: absolute;
+  right: 0;
+  left: 0;
+  height: 1px;
+  background: #aeb99a;
+  content: "";
+}
+
+.onboarding-messaging-bridge span {
+  position: relative;
+  border: 1px solid #bfc8b0;
+  border-radius: 6px;
+  background: #f0f2e7;
+  color: var(--brand-ink);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
+  padding: 5px 9px;
+}
+
+.onboarding-messaging-connection[data-status="complete"] .onboarding-messaging-bridge::before {
+  background: var(--brand);
+}
+
+.onboarding-workspace-body {
+  padding: 38px 44px 48px;
 }
 
 .onboarding-loading,
 .onboarding-action {
-  margin-top: 34px;
-}
-
-.onboarding-action {
+  margin: 0;
   min-width: 0;
 }
 
@@ -1686,18 +2193,20 @@ code {
   align-items: flex-start;
   justify-content: space-between;
   gap: 28px;
-  margin-bottom: 24px;
+  margin-bottom: 28px;
 }
 
 .onboarding-action-heading h2 {
-  margin-bottom: 8px;
+  margin-bottom: 9px;
   font-family: var(--font-display);
-  font-size: var(--text-section);
+  font-size: var(--text-title);
   letter-spacing: var(--track-tight);
+  line-height: var(--lh-tight);
+  text-wrap: balance;
 }
 
 .onboarding-action-heading p {
-  max-width: 640px;
+  max-width: 58ch;
   margin-bottom: 0;
   color: var(--muted);
   font-size: var(--text-body);
@@ -1721,19 +2230,26 @@ code {
   gap: 14px;
 }
 
+.onboarding-action .button:not(.compact-button) {
+  min-height: 46px;
+  min-width: 190px;
+  border-radius: 10px;
+  padding-inline: 20px;
+}
+
 .onboarding-feedback .notice {
   margin-top: 0;
 }
 
 .onboarding-agent-form {
   display: grid;
-  width: min(100%, 560px);
-  gap: 20px;
+  width: min(100%, 600px);
+  gap: 24px;
 }
 
 .onboarding-route-change {
   display: grid;
-  width: min(100%, 560px);
+  width: min(100%, 600px);
   justify-items: start;
   gap: 8px;
   margin-bottom: 18px;
@@ -1749,14 +2265,14 @@ code {
 
 .onboarding-choice-list {
   display: grid;
-  width: min(100%, 760px);
+  width: 100%;
   border-top: 1px solid var(--strong-border);
 }
 
 .onboarding-choice {
   display: flex;
   width: 100%;
-  min-height: 64px;
+  min-height: 68px;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
@@ -1765,7 +2281,7 @@ code {
   border-radius: 0;
   background: transparent;
   color: var(--foreground);
-  padding: 12px 4px;
+  padding: 13px 8px;
   text-align: left;
 }
 
@@ -1793,6 +2309,69 @@ code {
   margin: 8px 0 0;
   color: var(--muted);
   font-size: var(--text-ui);
+}
+
+.onboarding-action > .panel h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-title);
+  letter-spacing: var(--track-tight);
+  line-height: var(--lh-tight);
+}
+
+.onboarding-action > .panel > p {
+  max-width: 58ch;
+  color: var(--muted);
+}
+
+@media (max-width: 980px) {
+  .onboarding-main {
+    width: min(820px, calc(100% - 48px));
+  }
+
+  .onboarding-layout {
+    grid-template-columns: 1fr;
+    gap: 34px;
+  }
+
+  .onboarding-journey {
+    position: static;
+    display: grid;
+    align-items: end;
+    grid-template-columns: minmax(0, 1fr) minmax(360px, 1.2fr);
+    gap: 34px;
+    padding-top: 0;
+  }
+
+  .onboarding-journey-intro h1 {
+    max-width: none;
+  }
+
+  .onboarding-journey-intro p {
+    max-width: 38ch;
+  }
+
+  .onboarding-journey nav {
+    margin-top: 0;
+  }
+
+  .onboarding-steps {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .onboarding-step {
+    min-height: 122px;
+    border-right: 1px solid var(--border);
+    padding: 18px;
+  }
+
+  .onboarding-step:last-child {
+    border-right: 0;
+  }
+
+  .onboarding-journey-note {
+    display: none;
+  }
 }
 
 /* Product surfaces use spacing and tonal grouping instead of repeated rules. */
@@ -2467,6 +3046,11 @@ textarea:focus {
   gap: 18px;
 }
 
+.agent-runtime-section > .panel,
+.agent-runtime-section > .settings-list-section {
+  width: 100%;
+}
+
 .settings-content > .panel .button {
   justify-self: start;
 }
@@ -2505,6 +3089,11 @@ textarea:focus {
   border-radius: var(--radius);
   background: var(--surface-soft);
   padding: 22px;
+}
+
+.settings-invitation-panel:focus-visible {
+  outline: 3px solid var(--brand-ink);
+  outline-offset: 3px;
 }
 
 .settings-invitation-panel h3 {
@@ -2923,6 +3512,16 @@ textarea:focus {
 }
 
 @media (max-width: 720px) {
+  .account-workspace-create {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .account-workspace-create .secondary {
+    justify-content: center;
+    width: 100%;
+  }
+
   .onboarding-header {
     min-height: 60px;
     padding: 10px 18px;
@@ -2933,12 +3532,78 @@ textarea:focus {
   }
 
   .onboarding-main {
-    width: min(100% - 32px, 920px);
-    padding: 42px 0 56px;
+    width: min(100% - 28px, 680px);
+    padding: 32px 0 48px;
   }
 
-  .onboarding-title {
-    padding-bottom: 22px;
+  .onboarding-journey {
+    display: block;
+  }
+
+  .onboarding-journey-intro h1 {
+    font-size: var(--text-title);
+    line-height: var(--lh-tight);
+  }
+
+  .onboarding-journey-intro p {
+    max-width: 34ch;
+    font-size: var(--text-ui);
+  }
+
+  .onboarding-journey nav {
+    margin-top: 26px;
+  }
+
+  .onboarding-steps {
+    display: block;
+  }
+
+  .onboarding-step {
+    min-height: 0;
+    border-right: 0;
+    grid-template-columns: 34px minmax(0, 1fr);
+    padding: 16px 0;
+  }
+
+  .onboarding-step-number {
+    width: 32px;
+    height: 32px;
+  }
+
+  .onboarding-workspace {
+    min-height: 0;
+    border-radius: 17px;
+  }
+
+  .onboarding-stage-header,
+  .onboarding-workspace-body {
+    padding-right: 22px;
+    padding-left: 22px;
+  }
+
+  .onboarding-stage-header {
+    padding-top: 28px;
+    padding-bottom: 27px;
+  }
+
+  .onboarding-stage-copy h2 {
+    margin-top: 14px;
+    font-size: var(--text-title);
+  }
+
+  .onboarding-runtime-summary,
+  .onboarding-messaging-connection {
+    margin-top: 28px;
+  }
+
+  .onboarding-runtime-summary > div {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .onboarding-workspace-body {
+    padding-top: 28px;
+    padding-bottom: 34px;
   }
 
   .onboarding-action-heading,

--- a/apps/web/src/ui/design-system.css
+++ b/apps/web/src/ui/design-system.css
@@ -5,18 +5,21 @@
   --color-bg-surface: var(--surface);
   --color-bg-subtle: var(--surface-soft);
   --color-bg-hover: #e9ebe1;
+  --color-bg-hover-strong: #dde1d3;
   --color-bg-selected: var(--brand-light);
   --color-text-primary: var(--foreground);
   --color-text-secondary: var(--secondary-foreground);
   --color-text-muted: var(--muted);
   --color-border-divider: var(--border);
-  --color-border-control: #929a8e;
+  --color-border-control: #899184;
   --color-border-strong: var(--strong-border);
   --color-brand: var(--brand);
   --color-brand-hover: var(--brand-ink);
   --color-brand-subtle: var(--brand-light);
-  --color-status-success: #4d7413;
-  --color-status-success-surface: #edf3df;
+  --color-on-accent: #fff;
+  --color-text-primary-hover: #26332c;
+  --color-status-success: #2f6f59;
+  --color-status-success-surface: #e7f1ec;
   --color-status-info: #356775;
   --color-status-info-surface: #e8f1f2;
   --color-status-warning: #94510d;
@@ -60,7 +63,7 @@
 
 .ds-button--primary {
   background: var(--color-brand);
-  color: #fff;
+  color: var(--color-on-accent);
 }
 
 .ds-button--primary:hover {
@@ -73,17 +76,17 @@
 }
 
 .ds-button--secondary:hover {
-  background: #dde1d3;
+  background: var(--color-bg-hover-strong);
   color: var(--color-text-primary);
 }
 
 .ds-button--commit {
   background: var(--color-text-primary);
-  color: #fff;
+  color: var(--color-on-accent);
 }
 
 .ds-button--commit:hover {
-  background: #26332c;
+  background: var(--color-text-primary-hover);
 }
 
 .ds-button--tertiary,

--- a/apps/web/src/ui/design-system.css
+++ b/apps/web/src/ui/design-system.css
@@ -1,0 +1,299 @@
+:root {
+  /* Semantic aliases keep the current visual character while separating
+     brand, structure and operational state. */
+  --color-bg-canvas: var(--background);
+  --color-bg-surface: var(--surface);
+  --color-bg-subtle: var(--surface-soft);
+  --color-bg-hover: #e9ebe1;
+  --color-bg-selected: var(--brand-light);
+  --color-text-primary: var(--foreground);
+  --color-text-secondary: var(--secondary-foreground);
+  --color-text-muted: var(--muted);
+  --color-border-divider: var(--border);
+  --color-border-control: #929a8e;
+  --color-border-strong: var(--strong-border);
+  --color-brand: var(--brand);
+  --color-brand-hover: var(--brand-ink);
+  --color-brand-subtle: var(--brand-light);
+  --color-status-success: #4d7413;
+  --color-status-success-surface: #edf3df;
+  --color-status-info: #356775;
+  --color-status-info-surface: #e8f1f2;
+  --color-status-warning: #94510d;
+  --color-status-warning-surface: #fff1d8;
+  --color-status-danger: var(--error);
+  --color-status-danger-surface: var(--error-surface);
+  --color-status-neutral: #616961;
+  --color-status-neutral-surface: #eff0e9;
+  --focus-ring: rgb(78 122 6 / 22%);
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --radius-control: 9px;
+  --radius-panel: 13px;
+  --radius-overlay: 16px;
+}
+
+.ds-button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  cursor: pointer;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+  padding: 0.58rem 0.95rem;
+  text-decoration: none;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+  white-space: nowrap;
+}
+
+.ds-button--primary {
+  background: var(--color-brand);
+  color: #fff;
+}
+
+.ds-button--primary:hover {
+  background: var(--color-brand-hover);
+}
+
+.ds-button--secondary {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.ds-button--secondary:hover {
+  background: #dde1d3;
+  color: var(--color-text-primary);
+}
+
+.ds-button--commit {
+  background: var(--color-text-primary);
+  color: #fff;
+}
+
+.ds-button--commit:hover {
+  background: #26332c;
+}
+
+.ds-button--tertiary,
+.ds-button--danger {
+  min-height: 34px;
+  background: transparent;
+  padding: 0 0.45rem;
+}
+
+.ds-button--tertiary {
+  color: var(--color-text-muted);
+}
+
+.ds-button--tertiary:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.ds-button--danger {
+  color: var(--color-status-danger);
+}
+
+.ds-button--danger:hover {
+  background: var(--color-status-danger-surface);
+  color: var(--color-status-danger);
+}
+
+.ds-button--compact {
+  min-height: 36px;
+  padding: 0.42rem 0.75rem;
+}
+
+.ds-button:active {
+  transform: translateY(1px);
+}
+
+.ds-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.ds-field {
+  display: grid;
+  gap: 7px;
+}
+
+.ds-field__label {
+  color: var(--color-text-secondary);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+}
+
+.ds-field input,
+.ds-field select,
+.ds-field textarea,
+input.ds-control,
+select.ds-control,
+textarea.ds-control {
+  border-color: var(--color-border-control);
+  border-radius: var(--radius-control);
+  background: var(--color-bg-surface);
+}
+
+.ds-field input:focus,
+.ds-field select:focus,
+.ds-field textarea:focus,
+input.ds-control:focus,
+select.ds-control:focus,
+textarea.ds-control:focus {
+  border-color: var(--color-brand);
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 0;
+}
+
+.ds-field__hint,
+.ds-field__error {
+  font-size: var(--text-meta);
+  font-weight: var(--fw-regular);
+  line-height: var(--lh-ui);
+}
+
+.ds-field__hint {
+  color: var(--color-text-muted);
+}
+
+.ds-field__error {
+  color: var(--color-status-danger);
+}
+
+.ds-status {
+  --status-color: var(--color-status-neutral);
+  --status-surface: var(--color-status-neutral-surface);
+  display: inline-flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: var(--space-2);
+  color: var(--color-text-primary);
+}
+
+.ds-status--success {
+  --status-color: var(--color-status-success);
+  --status-surface: var(--color-status-success-surface);
+}
+
+.ds-status--info {
+  --status-color: var(--color-status-info);
+  --status-surface: var(--color-status-info-surface);
+}
+
+.ds-status--warning {
+  --status-color: var(--color-status-warning);
+  --status-surface: var(--color-status-warning-surface);
+}
+
+.ds-status--danger {
+  --status-color: var(--color-status-danger);
+  --status-surface: var(--color-status-danger-surface);
+}
+
+.ds-status__dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  margin-top: 0.42em;
+  border-radius: 999px;
+  background: var(--status-color);
+  box-shadow: 0 0 0 3px var(--status-surface);
+}
+
+.ds-status__copy,
+.ds-status__copy strong,
+.ds-status__copy small {
+  display: block;
+  min-width: 0;
+}
+
+.ds-status__copy strong {
+  color: var(--color-text-primary);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+}
+
+.ds-status__copy small {
+  margin-top: 3px;
+  color: var(--color-text-muted);
+  font-size: var(--text-meta);
+}
+
+.ds-icon {
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.75;
+}
+
+.dialog-card {
+  border-radius: var(--radius-overlay);
+}
+
+.dialog-close.ds-button {
+  width: 34px;
+  padding: 0;
+}
+
+.dialog-close .ds-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.agent-row-action .ds-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.availability-action .ds-status {
+  display: inline-flex;
+  flex: 1;
+}
+
+.availability-action.success {
+  border-left-color: var(--color-status-success);
+}
+
+.availability-action.info {
+  border-left-color: var(--color-status-info);
+}
+
+.availability-action.warning {
+  border-left-color: var(--color-status-warning);
+}
+
+.availability-action.neutral {
+  border-left-color: var(--color-status-neutral);
+}
+
+.breadcrumb:has(.ds-icon) {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.settings-member-row select.ds-control {
+  min-height: 36px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ds-button {
+    transition: none;
+  }
+}

--- a/apps/web/src/ui/design-system.test.tsx
+++ b/apps/web/src/ui/design-system.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createRef, useState } from "react";
+import { describe, expect, it } from "vitest";
+import { Button, Dialog, Field, Icon, StatusIndicator } from "./design-system.js";
+
+describe("design system primitives", () => {
+  it("maps button intent to an explicit visual variant", () => {
+    render(<Button variant="secondary">Cancel</Button>);
+    expect(screen.getByRole("button", { name: "Cancel" }).className).toContain("ds-button--secondary");
+  });
+
+  it("keeps field labels, help and errors associated with the control", () => {
+    render(
+      <Field
+        error="Choose another name"
+        errorId="name-error"
+        hint="Lowercase letters only"
+        hintId="name-hint"
+        htmlFor="agent-name"
+        label="Agent name"
+      >
+        <input aria-describedby="name-hint name-error" id="agent-name" />
+      </Field>,
+    );
+    expect(screen.getByLabelText("Agent name")).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toBe("Choose another name");
+  });
+
+  it("keeps operational status independent from brand styling", () => {
+    render(<StatusIndicator detail="Ready for work" label="Online" tone="success" />);
+    expect(screen.getByText("Online").closest(".ds-status")?.className).toContain("ds-status--success");
+    expect(screen.getByText("Ready for work")).toBeTruthy();
+  });
+
+  it("provides consistent vector icons", () => {
+    const { container } = render(<Icon name="chevron-right" />);
+    expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+    expect(container.querySelector("path")).toBeTruthy();
+  });
+
+  it("closes dialogs on Escape and returns focus", () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    function Example() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button ref={triggerRef} type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          {open ? (
+            <Dialog returnFocusRef={triggerRef} title="Example" onClose={() => setOpen(false)}>
+              <button type="button">Action</button>
+            </Dialog>
+          ) : null}
+        </>
+      );
+    }
+    render(<Example />);
+    const trigger = screen.getByRole("button", { name: "Open" });
+    fireEvent.click(trigger);
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -1,0 +1,249 @@
+import {
+  type ButtonHTMLAttributes,
+  forwardRef,
+  type HTMLAttributes,
+  type ReactNode,
+  type RefObject,
+  type SVGAttributes,
+  useEffect,
+  useId,
+  useRef,
+} from "react";
+
+function classes(...values: Array<string | false | null | undefined>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+export type ButtonVariant = "primary" | "secondary" | "commit" | "tertiary" | "danger";
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  size?: "default" | "compact";
+  variant?: ButtonVariant;
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { className, size = "default", variant = "primary", type = "button", ...props },
+  ref,
+) {
+  return (
+    <button
+      className={classes("ds-button", `ds-button--${variant}`, size === "compact" && "ds-button--compact", className)}
+      ref={ref}
+      type={type}
+      {...props}
+    />
+  );
+});
+
+export function Field({
+  children,
+  className,
+  error,
+  errorId,
+  hint,
+  hintId,
+  htmlFor,
+  label,
+}: {
+  children: ReactNode;
+  className?: string;
+  error?: ReactNode;
+  errorId?: string;
+  hint?: ReactNode;
+  hintId?: string;
+  htmlFor: string;
+  label: ReactNode;
+}) {
+  return (
+    <div className={classes("ds-field", className)}>
+      <label className="ds-field__label" htmlFor={htmlFor}>
+        {label}
+      </label>
+      {children}
+      {hint ? (
+        <span className="ds-field__hint" id={hintId}>
+          {hint}
+        </span>
+      ) : null}
+      {error ? (
+        <span className="ds-field__error" id={errorId} role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export type StatusTone = "success" | "info" | "warning" | "danger" | "neutral";
+
+export function StatusIndicator({
+  className,
+  detail,
+  label,
+  tone = "neutral",
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & {
+  detail?: ReactNode;
+  label: ReactNode;
+  tone?: StatusTone;
+}) {
+  return (
+    <span className={classes("ds-status", `ds-status--${tone}`, className)} {...props}>
+      <span className="ds-status__dot" aria-hidden="true" />
+      <span className="ds-status__copy">
+        <strong>{label}</strong>
+        {detail ? <small>{detail}</small> : null}
+      </span>
+    </span>
+  );
+}
+
+export type IconName = "arrow-left" | "arrow-right" | "chevron-right" | "close";
+
+export function Icon({ className, name, ...props }: SVGAttributes<SVGSVGElement> & { name: IconName }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={classes("ds-icon", className)}
+      fill="none"
+      focusable="false"
+      viewBox="0 0 20 20"
+      {...props}
+    >
+      {name === "close" ? <path d="m5 5 10 10M15 5 5 15" /> : null}
+      {name === "chevron-right" ? <path d="m7.5 4.5 5.5 5.5-5.5 5.5" /> : null}
+      {name === "arrow-right" ? <path d="M3.5 10h13m-5-5 5 5-5 5" /> : null}
+      {name === "arrow-left" ? <path d="M16.5 10h-13m5-5-5 5 5 5" /> : null}
+    </svg>
+  );
+}
+
+const FOCUSABLE =
+  'button:not([disabled]), input:not([disabled]), a[href], select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function Dialog({
+  busy = false,
+  children,
+  className,
+  closeLabel,
+  description,
+  eyebrow,
+  onClose,
+  returnFocusRef,
+  title,
+}: {
+  busy?: boolean;
+  children: ReactNode;
+  className?: string;
+  closeLabel?: string;
+  description?: ReactNode;
+  eyebrow?: ReactNode;
+  onClose: () => void;
+  returnFocusRef?: RefObject<HTMLElement | null>;
+  title: ReactNode;
+}) {
+  const generatedId = useId().replaceAll(":", "");
+  const titleId = `dialog-${generatedId}-title`;
+  const descriptionId = description ? `dialog-${generatedId}-description` : undefined;
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const busyRef = useRef(busy);
+  const onCloseRef = useRef(onClose);
+  busyRef.current = busy;
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const target = dialog.querySelector<HTMLElement>(FOCUSABLE);
+    if (busy) {
+      if (!activeElement || !dialog.contains(activeElement) || activeElement.matches(":disabled")) {
+        (target ?? dialog).focus();
+      }
+    } else if (activeElement === dialog) {
+      target?.focus();
+    }
+  }, [busy]);
+
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        if (!busyRef.current) onCloseRef.current();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      const focusable = Array.from(dialog?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (!dialog?.contains(document.activeElement) || document.activeElement === dialog) {
+        event.preventDefault();
+        (event.shiftKey ? last : first)?.focus();
+      } else if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      returnFocusRef?.current?.focus();
+    };
+  }, [returnFocusRef]);
+
+  return (
+    <div className="dialog-layer">
+      <button
+        aria-label="Dismiss dialog"
+        className="dialog-backdrop"
+        disabled={busy}
+        tabIndex={-1}
+        type="button"
+        onClick={onClose}
+      />
+      <div
+        aria-describedby={descriptionId}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className={classes("dialog-card", className)}
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        <header className="dialog-header">
+          <div>
+            {eyebrow ? <span className="eyebrow dialog-eyebrow">{eyebrow}</span> : null}
+            <h2 id={titleId}>{title}</h2>
+          </div>
+          <Button
+            aria-label={closeLabel ?? `Close ${typeof title === "string" ? title : "dialog"}`}
+            className="dialog-close"
+            disabled={busy}
+            ref={closeButtonRef}
+            variant="tertiary"
+            onClick={onClose}
+          >
+            <Icon name="close" />
+          </Button>
+        </header>
+        {description ? (
+          <p className="dialog-description" id={descriptionId}>
+            {description}
+          </p>
+        ) : null}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/server/src/__tests__/integration/account-team-foundation.test.ts
+++ b/packages/server/src/__tests__/integration/account-team-foundation.test.ts
@@ -246,6 +246,12 @@ describe("account identity and Team foundation persistence", () => {
       expect(await value.database.select().from(memberships).where(eq(memberships.userId, userId))).toEqual([
         expect.objectContaining({ teamId: selectedTeamId, role: "admin", status: "active" }),
       ]);
+      expect(
+        await value.database
+          .select()
+          .from(teams)
+          .where(eq(teams.id, selectedTeamId ?? "")),
+      ).toEqual([expect.objectContaining({ displayName: "Google solo's Workspace" })]);
       expect(await value.database.select().from(teams)).toHaveLength(2);
     } finally {
       await value.sql.end();

--- a/packages/server/src/services/teams/team-membership-service.ts
+++ b/packages/server/src/services/teams/team-membership-service.ts
@@ -205,7 +205,7 @@ export class TeamMembershipService {
     await transaction.insert(teams).values({
       id: teamId,
       name: `team-${teamId}`,
-      displayName: `${user.displayName}'s Team`.slice(0, 120),
+      displayName: `${user.displayName}'s Workspace`.slice(0, 120),
       createdAt: now,
       updatedAt: now,
     });


### PR DESCRIPTION
## Summary

- make Agents the default destination and replace Settings with the final Agents, Tasks, Integrations, Resources, Usage, and Members navigation
- keep Workspace implicit for single-membership users, expose switching only in the account menu for multi-Workspace users, and move creation and profile management under Account → Advanced
- automatically provision a default Workspace for new non-invited users without asking for a name
- preserve real member, invitation, role, Computer connection, and runtime management flows in their new locations
- add truthful Tasks unavailability plus replaceable Resources, Integrations, and Usage preview entries
- retain legacy Settings URLs through compatibility redirects and align onboarding and shared UI patterns with the new shell
- reset Workspace-scoped Agent detail and creation routes when switching Workspaces

## Validation

- pnpm typecheck (apps/web)
- pnpm test (apps/web): 11 files, 249 tests passed
- pnpm build (apps/web)
- pnpm exec biome check apps/web/src
- git diff --check

## Notes

- supersedes #102, which GitHub automatically closed when its non-compliant branch was renamed
- backend Team/teamId contracts remain unchanged
- docs/design/settings-ui-concepts remains untracked and is not included in this PR