### PR TITLE
fix(web): preserve immediate account profile edits

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1865,6 +1865,7 @@ function CapabilityUnavailable({
 
 function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeResponse["user"] }) {
   const saveInFlight = useRef(false);
+  const confirmedDisplayNameRef = useRef(user.displayName);
   const [displayName, setDisplayName] = useState(user.displayName);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string>();
@@ -1872,6 +1873,8 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
   const dirty = displayName !== user.displayName;
 
   useEffect(() => {
+    if (confirmedDisplayNameRef.current === user.displayName) return;
+    confirmedDisplayNameRef.current = user.displayName;
     setDisplayName(user.displayName);
   }, [user.displayName]);
 


### PR DESCRIPTION
## Summary

- skip the redundant initial account profile synchronization effect
- continue syncing the input when the confirmed server display name actually changes
- prevent an immediate user edit from being reset before the save controls render

Fixes the flaky Web failure observed in [CI run 32456314275](https://github.com/first-tree-ai/opentag/actions/runs/32456314275/job/96694191774).

## Validation

- failing account profile test repeated 20 times: passed
- Web test suite: 248/248 passed
- `pnpm build`: passed
- `pnpm typecheck`: passed
- Biome on the changed file, notices check, and `git diff --check`: passed

## Unrelated local-environment failures

Full repository test/coverage commands still expose pre-existing non-Web failures: macOS canonical `/private/tmp` path assertions, the RuntimeSession observability timing assertion, and one local provider-probe timeout. None are touched by this one-file fix.