### PR TITLE
refactor(web): complete incremental design system migration

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -963,8 +963,12 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
+    expect(screen.getAllByRole("heading", { name: "Members" })).toHaveLength(1);
     const membersSection = document.querySelector<HTMLElement>("#members");
     if (!membersSection) throw new Error("Members section was not rendered");
+    const memberRows = within(membersSection).getAllByRole("rowheader");
+    expect(memberRows[0]?.textContent).toContain("Ada");
+    expect(screen.getByLabelText("Role for Ada").classList.contains("ds-control--compact")).toBe(true);
     expect(within(membersSection).getByRole("heading", { level: 3, name: "Invite members" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Invite members" })).toBeNull();
   });

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -780,7 +780,7 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    expect(screen.getByText("Ada's Mac")).toBeTruthy();
+    expect(await screen.findByText("Ada's Mac")).toBeTruthy();
     expect(screen.getByText("macOS")).toBeTruthy();
     expect(screen.getByText("Online")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Execution choices" })).toBeTruthy();
@@ -984,21 +984,36 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Account" })).toBeTruthy();
     expect(window.location.pathname).toBe("/account");
+    expect(screen.getByRole("navigation", { name: "Account settings" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Profile" }).getAttribute("aria-current")).toBe("page");
+    expect(screen.getByRole("link", { name: "Workspace" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Create Workspace" })).toBeNull();
     const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
     expect(displayName.readOnly).toBe(false);
     fireEvent.change(displayName, { target: { value: "Legacy Account" } });
     expect(await screen.findByRole("button", { name: "Save account profile" })).toBeTruthy();
   });
 
-  it("redirects the legacy Team profile URL to advanced Workspace management", async () => {
+  it("redirects the legacy Team profile URL to the Workspace Account tab", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings/team");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Workspace management" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/account");
-    expect(window.location.hash).toBe("#workspace-management");
+    expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/account/workspace");
+    expect(window.location.hash).toBe("");
+    expect(screen.getByRole("link", { name: "Workspace" }).getAttribute("aria-current")).toBe("page");
     expect(screen.getByLabelText("Workspace name")).toBeTruthy();
+  });
+
+  it("keeps the legacy Workspace management hash compatible with the Workspace Account tab", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/account#workspace-management");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/account/workspace");
+    expect(window.location.hash).toBe("");
   });
 
   it.each(["/resources", "/settings/resources"])(
@@ -1029,12 +1044,11 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByLabelText("Usage metrics")).toBeTruthy();
   });
 
-  it("lets admins rename a Workspace from advanced Account management without changing the CLI identifier", async () => {
+  it("lets admins rename a Workspace from the Workspace Account tab without changing the CLI identifier", async () => {
     installApi("admin");
     window.localStorage.setItem("opentag.selectedTeamId", teamId);
-    window.history.replaceState({}, "", "/account");
+    window.history.replaceState({}, "", "/account/workspace");
     render(<App />);
-    fireEvent.click(await screen.findByText("Advanced"));
     const displayName = await screen.findByLabelText("Workspace name");
     const profileForm = displayName.closest("form");
     if (!profileForm) throw new Error("Workspace profile form was not rendered");
@@ -1060,9 +1074,8 @@ describe("OpenTag Web App Shell", () => {
 
   it("keeps Workspace profile fields read-only for members", async () => {
     installApi("member");
-    window.history.replaceState({}, "", "/account");
+    window.history.replaceState({}, "", "/account/workspace");
     render(<App />);
-    fireEvent.click(await screen.findByText("Advanced"));
     expect(await screen.findByText("example")).toBeTruthy();
     expect(screen.getByText("Workspace name").parentElement?.querySelector("dd")?.textContent).toBe("Example");
     expect(screen.queryByRole("button", { name: "Save Workspace profile" })).toBeNull();
@@ -1079,7 +1092,7 @@ describe("OpenTag Web App Shell", () => {
     expect(window.sessionStorage.getItem("opentag.pendingInvitationToken")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
     expect(
-      within(screen.getByRole("group", { name: "Switch Workspace" }))
+      within(screen.getByRole("group", { name: "Workspaces" }))
         .getByRole("menuitem", { name: /Invited Team Member/ })
         .getAttribute("aria-current"),
     ).toBe("true");
@@ -1119,7 +1132,7 @@ describe("OpenTag Web App Shell", () => {
       expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
       fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
       expect(
-        within(screen.getByRole("group", { name: "Switch Workspace" })).getByRole("menuitem", {
+        within(screen.getByRole("group", { name: "Workspaces" })).getByRole("menuitem", {
           name: /Invited Team Member/,
         }),
       ).toBeTruthy();
@@ -1185,11 +1198,13 @@ describe("OpenTag Web App Shell", () => {
     confirm.mockRestore();
   });
 
-  it("does not expose Workspace or invitation shortcuts to single-Workspace members", async () => {
+  it("shows the current Workspace without exposing switch or invitation shortcuts to single-Workspace members", async () => {
     installApi("member");
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
-    expect(screen.queryByRole("group", { name: "Switch Workspace" })).toBeNull();
+    const workspaces = screen.getByRole("group", { name: "Workspaces" });
+    expect(within(workspaces).getByText("Example").closest('[aria-current="true"]')).toBeTruthy();
+    expect(within(workspaces).queryByRole("menuitem")).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Invite people" })).toBeNull();
     expect(screen.queryByText("Create Workspace")).toBeNull();
   });
@@ -1680,29 +1695,30 @@ describe("OpenTag Web App Shell", () => {
     expect(new Set(bodies.map((body) => body.name))).toHaveProperty("size", 3);
   });
 
-  it("creates an additional Workspace from advanced Account management and offers both in the account menu", async () => {
+  it("creates an additional Workspace from the Workspace Account tab and offers both in the account menu", async () => {
     installApi("admin");
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
-    fireEvent.click(screen.getByRole("menuitem", { name: "Account settings" }));
-    fireEvent.click(await screen.findByText("Advanced"));
-    fireEvent.click(screen.getByRole("link", { name: "Create another Workspace" }));
+    expect(screen.queryByRole("menuitem", { name: "Create Workspace" })).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Profile" }));
+    fireEvent.click(await screen.findByRole("link", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("link", { name: "Create Workspace" }));
     fireEvent.change(await screen.findByLabelText("Workspace name"), { target: { value: "Second Team" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Workspace" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
-    const menu = screen.getByRole("group", { name: "Switch Workspace" });
+    const menu = screen.getByRole("group", { name: "Workspaces" });
     expect(within(menu).getByRole("menuitem", { name: /Example Admin/ })).toBeTruthy();
     expect(
       within(menu)
         .getByRole("menuitem", { name: /Second Team Admin/ })
         .getAttribute("aria-current"),
     ).toBe("true");
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Manage Workspaces" }));
-    expect(await screen.findByRole("heading", { name: "Workspace management" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/account");
-    expect(window.location.hash).toBe("#workspace-management");
-    expect(screen.getByRole("link", { name: "Create another Workspace" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Workspace" }));
+    expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/account/workspace");
+    expect(window.location.hash).toBe("");
+    expect(screen.getByRole("link", { name: "Create Workspace" })).toBeTruthy();
   });
 
   it("switches Teams when Team preference storage is unavailable", async () => {
@@ -1715,13 +1731,13 @@ describe("OpenTag Web App Shell", () => {
       render(<App />);
       fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
       fireEvent.click(
-        within(screen.getByRole("group", { name: "Switch Workspace" })).getByRole("menuitem", {
+        within(screen.getByRole("group", { name: "Workspaces" })).getByRole("menuitem", {
           name: /Invited Team Member/,
         }),
       );
       fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
       expect(
-        within(screen.getByRole("group", { name: "Switch Workspace" }))
+        within(screen.getByRole("group", { name: "Workspaces" }))
           .getByRole("menuitem", { name: /Invited Team Member/ })
           .getAttribute("aria-current"),
       ).toBe("true");
@@ -1740,7 +1756,7 @@ describe("OpenTag Web App Shell", () => {
       render(<App />);
 
       fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
-      const targetWorkspace = within(screen.getByRole("group", { name: "Switch Workspace" }))
+      const targetWorkspace = within(screen.getByRole("group", { name: "Workspaces" }))
         .getAllByRole("menuitem")
         .find(
           (item) => item.classList.contains("account-workspace-option") && item.getAttribute("aria-current") !== "true",
@@ -1753,7 +1769,7 @@ describe("OpenTag Web App Shell", () => {
       expect(window.location.pathname).toBe("/agents");
       fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
       const selectedWorkspace = screen
-        .getByRole("group", { name: "Switch Workspace" })
+        .getByRole("group", { name: "Workspaces" })
         .querySelector<HTMLElement>('[aria-current="true"]');
       expect(selectedWorkspace?.querySelector("strong")?.textContent).toBe(targetWorkspaceName);
     },
@@ -1763,7 +1779,9 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin");
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
-    fireEvent.click(screen.getByRole("menuitem", { name: "Account settings" }));
+    expect(within(screen.getByRole("group", { name: "Workspaces" })).getByText("Example")).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Workspace" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Profile" }));
     expect(await screen.findByRole("heading", { name: "Account" })).toBeTruthy();
     expect(window.location.pathname).toBe("/account");
     const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
@@ -1796,14 +1814,17 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     const trigger = await screen.findByRole("button", { name: "Account menu" });
     fireEvent.click(trigger);
-    const accountSettings = screen.getByRole("menuitem", { name: "Account settings" });
+    const profile = screen.getByRole("menuitem", { name: "Profile" });
+    const workspace = screen.getByRole("menuitem", { name: "Workspace" });
     const signOut = screen.getByRole("menuitem", { name: "Sign out" });
-    expect(document.activeElement).toBe(accountSettings);
-    fireEvent.keyDown(accountSettings, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(profile);
+    fireEvent.keyDown(profile, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(workspace);
+    fireEvent.keyDown(workspace, { key: "ArrowDown" });
     expect(document.activeElement).toBe(signOut);
     fireEvent.keyDown(signOut, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(accountSettings);
-    fireEvent.keyDown(accountSettings, { key: "End" });
+    expect(document.activeElement).toBe(profile);
+    fireEvent.keyDown(profile, { key: "End" });
     expect(document.activeElement).toBe(signOut);
     fireEvent.keyDown(signOut, { key: "Escape" });
     expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -766,7 +766,8 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
     const navigation = screen.getByRole("navigation", { name: "Agent settings" });
-    expect(navigation.className).toBe("object-tabs");
+    expect(navigation.className).toContain("ds-tabs");
+    expect(navigation.className).toContain("ds-tabs--collapsible");
     expect(
       within(navigation)
         .getAllByRole("link")

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -966,10 +966,7 @@ describe("OpenTag Web App Shell", () => {
     const membersSection = document.querySelector<HTMLElement>("#members");
     if (!membersSection) throw new Error("Members section was not rendered");
     expect(within(membersSection).getByRole("heading", { level: 3, name: "Invite members" })).toBeTruthy();
-    const invitationPanel = document.querySelector<HTMLElement>("#member-invitations");
-    if (!invitationPanel) throw new Error("Invitation panel was not rendered");
-    fireEvent.click(screen.getByRole("button", { name: "Invite members" }));
-    expect(document.activeElement).toBe(invitationPanel);
+    expect(screen.queryByRole("button", { name: "Invite members" })).toBeNull();
   });
 
   it.each(["/settings", "/settings/members", "/settings/access", "/settings/security"])(

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -37,6 +37,7 @@ function installApi(
     agentRead?: () => Promise<void> | void;
     agentReadStatus?: () => number | undefined;
     agentListStatus?: () => number | undefined;
+    emptyAgents?: boolean;
     agentCreate?: (input: Record<string, unknown>) => Promise<void> | void;
     alreadyJoinedInvitation?: boolean;
     agentCreateError?: "generic" | "name";
@@ -222,11 +223,13 @@ function installApi(
       const failureStatus = options.agentListStatus?.();
       if (failureStatus) return json({ error: { message: "Agent list unavailable" } }, failureStatus);
       return json({
-        agents: [
-          path.includes(invitedTeamId)
-            ? { ...agentSummary, teamId: invitedTeamId, status: lifecycleStatus }
-            : { ...agentSummary, status: lifecycleStatus },
-        ],
+        agents: options.emptyAgents
+          ? []
+          : [
+              path.includes(invitedTeamId)
+                ? { ...agentSummary, teamId: invitedTeamId, status: lifecycleStatus }
+                : { ...agentSummary, status: lifecycleStatus },
+            ],
       });
     }
     if (path === `/api/v1/teams/${teamId}/members`) {
@@ -471,9 +474,11 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("main").classList.contains("decorative-page")).toBe(false);
     expect(screen.getByRole("link", { name: "Agents" })).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Settings" })).toBeNull();
-    expect(screen.getByRole("button", { name: "New Agent" })).toBeTruthy();
     expect(screen.queryByText("Example")).toBeNull();
-    expect(await screen.findByRole("link", { name: "Open Reviewer" })).toBeTruthy();
+    const agentLink = await screen.findByRole("link", { name: "Open Reviewer" });
+    const createAgent = screen.getByRole("button", { name: "New Agent" });
+    expect(createAgent.closest(".agent-card-grid")?.firstElementChild).toBe(createAgent);
+    expect(agentLink.closest(".agent-card-grid")).toBe(createAgent.closest(".agent-card-grid"));
     expect(screen.getByText("Ada's Mac · macOS")).toBeTruthy();
     expect(screen.getByText("Mentions only")).toBeTruthy();
     const workspaceNavigation = screen.getByRole("navigation", { name: "Product" });
@@ -522,6 +527,16 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByText("ada@example.com")).toBeNull();
     expect(await screen.findByText("Reviewer")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "New Agent" })).toBeNull();
+  });
+
+  it("uses the New Agent card as the sole empty-state action for admins", async () => {
+    installApi("admin", { emptyAgents: true });
+    render(<App />);
+
+    const agents = await screen.findByRole("region", { name: "Agents" });
+    expect(within(agents).getByRole("button", { name: "New Agent" })).toBeTruthy();
+    expect(within(agents).queryByRole("link")).toBeNull();
+    expect(screen.queryByText("No Agents yet")).toBeNull();
   });
 
   it("opens the complete New Agent form in a dialog and returns focus when cancelled", async () => {
@@ -985,36 +1000,49 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Account" })).toBeTruthy();
     expect(window.location.pathname).toBe("/account");
-    expect(screen.getByRole("navigation", { name: "Account settings" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Profile" }).getAttribute("aria-current")).toBe("page");
-    expect(screen.getByRole("link", { name: "Workspace" })).toBeTruthy();
+    expect(screen.queryByRole("navigation", { name: "Account settings" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Create Workspace" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
+    expect(screen.getByRole("menuitem", { name: "Account settings" }).getAttribute("aria-current")).toBe("page");
+    expect(screen.getByRole("menuitem", { name: "Workspace settings" }).getAttribute("aria-current")).toBeNull();
     const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
     expect(displayName.readOnly).toBe(false);
     fireEvent.change(displayName, { target: { value: "Legacy Account" } });
     expect(await screen.findByRole("button", { name: "Save account profile" })).toBeTruthy();
   });
 
-  it("redirects the legacy Team profile URL to the Workspace Account tab", async () => {
+  it("redirects the legacy Team profile URL to the first-class Workspace page", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings/team");
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/account/workspace");
+    expect(screen.getByRole("heading", { name: "Workspace", level: 1 })).toBeTruthy();
+    expect(window.location.pathname).toBe("/workspace");
     expect(window.location.hash).toBe("");
-    expect(screen.getByRole("link", { name: "Workspace" }).getAttribute("aria-current")).toBe("page");
     expect(screen.getByLabelText("Workspace name")).toBeTruthy();
   });
 
-  it("keeps the legacy Workspace management hash compatible with the Workspace Account tab", async () => {
+  it("keeps the legacy Workspace management hash compatible with the Workspace page", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/account#workspace-management");
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/account/workspace");
+    expect(window.location.pathname).toBe("/workspace");
     expect(window.location.hash).toBe("");
+  });
+
+  it("redirects the former nested Workspace URL to the top-level Workspace page", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/account/workspace");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Workspace", level: 1 })).toBeTruthy();
+    expect(window.location.pathname).toBe("/workspace");
+    expect(screen.queryByRole("navigation", { name: "Account settings" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
+    expect(screen.getByRole("menuitem", { name: "Workspace settings" }).getAttribute("aria-current")).toBe("page");
   });
 
   it.each(["/resources", "/settings/resources"])(
@@ -1045,10 +1073,10 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByLabelText("Usage metrics")).toBeTruthy();
   });
 
-  it("lets admins rename a Workspace from the Workspace Account tab without changing the CLI identifier", async () => {
+  it("lets admins rename a Workspace from its top-level page without changing the CLI identifier", async () => {
     installApi("admin");
     window.localStorage.setItem("opentag.selectedTeamId", teamId);
-    window.history.replaceState({}, "", "/account/workspace");
+    window.history.replaceState({}, "", "/workspace");
     render(<App />);
     const displayName = await screen.findByLabelText("Workspace name");
     const profileForm = displayName.closest("form");
@@ -1075,7 +1103,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("keeps Workspace profile fields read-only for members", async () => {
     installApi("member");
-    window.history.replaceState({}, "", "/account/workspace");
+    window.history.replaceState({}, "", "/workspace");
     render(<App />);
     expect(await screen.findByText("example")).toBeTruthy();
     expect(screen.getByText("Workspace name").parentElement?.querySelector("dd")?.textContent).toBe("Example");
@@ -1218,7 +1246,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("heading", { name: "Invite people" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Invite members" })).toBeNull();
     expect(screen.queryByLabelText("Role for Ada")).toBeNull();
-    expect(await screen.findAllByText("member")).toHaveLength(3);
+    expect(await screen.findAllByRole("cell", { name: "Member" })).toHaveLength(3);
   });
 
   it("lets Team admins update another member role from the member list", async () => {
@@ -1226,6 +1254,8 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/members");
     render(<App />);
     const role = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
+    expect(within(role).getByRole("option", { name: "Admin" })).toBeTruthy();
+    expect(within(role).getByRole("option", { name: "Member" })).toBeTruthy();
     fireEvent.change(role, { target: { value: "admin" } });
     await waitFor(() => expect((screen.getByLabelText("Role for Grace") as HTMLSelectElement).value).toBe("admin"));
     expect(vi.mocked(fetch)).toHaveBeenCalledWith(
@@ -1696,13 +1726,12 @@ describe("OpenTag Web App Shell", () => {
     expect(new Set(bodies.map((body) => body.name))).toHaveProperty("size", 3);
   });
 
-  it("creates an additional Workspace from the Workspace Account tab and offers both in the account menu", async () => {
+  it("creates an additional Workspace from the top-level Workspace page and offers both in the account menu", async () => {
     installApi("admin");
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
     expect(screen.queryByRole("menuitem", { name: "Create Workspace" })).toBeNull();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Profile" }));
-    fireEvent.click(await screen.findByRole("link", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Workspace settings" }));
     fireEvent.click(screen.getByRole("link", { name: "Create Workspace" }));
     fireEvent.change(await screen.findByLabelText("Workspace name"), { target: { value: "Second Team" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Workspace" }));
@@ -1715,9 +1744,9 @@ describe("OpenTag Web App Shell", () => {
         .getByRole("menuitem", { name: /Second Team Admin/ })
         .getAttribute("aria-current"),
     ).toBe("true");
-    fireEvent.click(screen.getByRole("menuitem", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Workspace settings" }));
     expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/account/workspace");
+    expect(window.location.pathname).toBe("/workspace");
     expect(window.location.hash).toBe("");
     expect(screen.getByRole("link", { name: "Create Workspace" })).toBeTruthy();
   });
@@ -1781,8 +1810,8 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
     expect(within(screen.getByRole("group", { name: "Workspaces" })).getByText("Example")).toBeTruthy();
-    expect(screen.getByRole("menuitem", { name: "Workspace" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Profile" }));
+    expect(screen.getByRole("menuitem", { name: "Workspace settings" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Account settings" }));
     expect(await screen.findByRole("heading", { name: "Account" })).toBeTruthy();
     expect(window.location.pathname).toBe("/account");
     const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
@@ -1815,17 +1844,17 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     const trigger = await screen.findByRole("button", { name: "Account menu" });
     fireEvent.click(trigger);
-    const profile = screen.getByRole("menuitem", { name: "Profile" });
-    const workspace = screen.getByRole("menuitem", { name: "Workspace" });
+    const account = screen.getByRole("menuitem", { name: "Account settings" });
+    const workspace = screen.getByRole("menuitem", { name: "Workspace settings" });
     const signOut = screen.getByRole("menuitem", { name: "Sign out" });
-    expect(document.activeElement).toBe(profile);
-    fireEvent.keyDown(profile, { key: "ArrowDown" });
     expect(document.activeElement).toBe(workspace);
     fireEvent.keyDown(workspace, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(account);
+    fireEvent.keyDown(account, { key: "ArrowDown" });
     expect(document.activeElement).toBe(signOut);
     fireEvent.keyDown(signOut, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(profile);
-    fireEvent.keyDown(profile, { key: "End" });
+    expect(document.activeElement).toBe(workspace);
+    fireEvent.keyDown(workspace, { key: "End" });
     expect(document.activeElement).toBe(signOut);
     fireEvent.keyDown(signOut, { key: "Escape" });
     expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -465,11 +465,17 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    expect(screen.queryByText("Infrastructure")).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Agent runtime" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Computers" })).toBeNull();
     expect(screen.getByRole("main").classList.contains("decorative-page")).toBe(false);
     expect(screen.getByRole("link", { name: "Agents" })).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Settings" })).toBeNull();
     expect(screen.getByRole("button", { name: "New Agent" })).toBeTruthy();
     expect(screen.queryByText("Example")).toBeNull();
+    expect(await screen.findByRole("link", { name: "Open Reviewer" })).toBeTruthy();
+    expect(screen.getByText("Ada's Mac · macOS")).toBeTruthy();
+    expect(screen.getByText("Mentions only")).toBeTruthy();
     const workspaceNavigation = screen.getByRole("navigation", { name: "Product" });
     expect(
       within(workspaceNavigation)
@@ -526,6 +532,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(trigger);
 
     const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+    expect(within(dialog).queryByText("Create")).toBeNull();
     expect(window.location.pathname).toBe("/agents");
     await waitFor(() => expect(within(dialog).getByLabelText("Display name")).toBe(document.activeElement));
     expect(within(dialog).getByLabelText("Agent name")).toBeTruthy();
@@ -536,6 +543,17 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
     expect(screen.queryByRole("dialog", { name: "New Agent" })).toBeNull();
     expect(trigger).toBe(document.activeElement);
+  });
+
+  it("keeps Computer connection inside the New Agent dialog when no runtime is available", async () => {
+    installApi("admin");
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+    expect(within(dialog).getByRole("heading", { name: "Connect a Local Computer" })).toBeTruthy();
+    expect(within(dialog).getByRole("button", { name: "Generate connection command" })).toBeTruthy();
+    expect(within(dialog).queryByRole("link", { name: "Agent runtime" })).toBeNull();
   });
 
   it("creates an Agent from the dialog without a second creation screen", async () => {
@@ -756,6 +774,18 @@ describe("OpenTag Web App Shell", () => {
     ).toEqual(["Overview", "Runtime", "Messaging", "Access"]);
   });
 
+  it("keeps bound Computer details with the individual Agent runtime", async () => {
+    installApi("admin", { bound: true });
+    window.history.replaceState({}, "", `/agents/${agentId}/runtime`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    expect(screen.getByText("Ada's Mac")).toBeTruthy();
+    expect(screen.getByText("macOS")).toBeTruthy();
+    expect(screen.getByText("Online")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Execution choices" })).toBeTruthy();
+  });
+
   it("refreshes Agent availability when the page regains focus", async () => {
     let computerStatus: "online" | "offline" = "online";
     installApi("admin", { bound: true, computerStatus: () => computerStatus });
@@ -769,15 +799,16 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("link", { name: "Review runtime" })).toBeTruthy();
   });
 
-  it("keeps infrastructure details out of Agent rows while loading the runtime section independently", async () => {
+  it("keeps Agent cards useful when Computer status cannot be confirmed", async () => {
     installApi("admin", { bound: true, computerEvidenceFails: true });
     window.history.replaceState({}, "", "/agents");
     render(<App />);
 
     expect(await screen.findByText("Reviewer")).toBeTruthy();
-    expect(screen.getByText("Active")).toBeTruthy();
-    expect(screen.queryByText("Ada's Mac")).toBeNull();
-    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Unconfirmed")).toBeTruthy();
+    expect(screen.getByText("Unable to confirm runtime")).toBeTruthy();
+    expect(screen.getByText("Ada's Mac · macOS")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
     expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes("/computers"))).toBe(true);
     expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes(`/agents/${agentId}/im-binding`))).toBe(
       false,
@@ -1370,9 +1401,9 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin");
     window.history.replaceState({}, "", "/settings/computers");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Agent runtime" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/agents");
-    expect(window.location.hash).toBe("#agent-runtime");
+    expect(await screen.findByRole("heading", { name: "Create Agent" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Connect a Local Computer" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/agents/new");
     const button = await screen.findByRole("button", { name: "Generate connection command" });
     expect(vi.mocked(fetch).mock.calls.filter(([, init]) => init?.method === "POST")).toHaveLength(0);
     fireEvent.click(button);
@@ -1383,8 +1414,9 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin");
     window.history.replaceState({}, "", "/agents/new");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Connect a Local Computer first" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Agent runtime" }).getAttribute("href")).toBe("/agents#agent-runtime");
+    expect(await screen.findByRole("heading", { name: "Connect a Local Computer" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Generate connection command" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Agent runtime" })).toBeNull();
   });
 
   it("validates Agent name locally with an accessible field error before sending a request", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -966,9 +966,11 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getAllByRole("heading", { name: "Members" })).toHaveLength(1);
     const membersSection = document.querySelector<HTMLElement>("#members");
     if (!membersSection) throw new Error("Members section was not rendered");
-    const memberRows = within(membersSection).getAllByRole("rowheader");
+    const memberRows = await within(membersSection).findAllByRole("rowheader");
     expect(memberRows[0]?.textContent).toContain("Ada");
-    expect(screen.getByLabelText("Role for Ada").classList.contains("ds-control--compact")).toBe(true);
+    const currentRoleSelect = await screen.findByLabelText("Role for Ada");
+    expect(currentRoleSelect.classList.contains("ds-control--compact")).toBe(true);
+    expect(currentRoleSelect.classList.contains("ds-control--quiet")).toBe(true);
     expect(within(membersSection).getByRole("heading", { level: 3, name: "Invite members" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Invite members" })).toBeNull();
   });

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -970,7 +970,6 @@ describe("OpenTag Web App Shell", () => {
     expect(memberRows[0]?.textContent).toContain("Ada");
     const currentRoleSelect = await screen.findByLabelText("Role for Ada");
     expect(currentRoleSelect.classList.contains("ds-control--compact")).toBe(true);
-    expect(currentRoleSelect.classList.contains("ds-control--quiet")).toBe(true);
     expect(within(membersSection).getByRole("heading", { level: 3, name: "Invite members" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Invite members" })).toBeNull();
   });

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1115,7 +1115,9 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/members");
     render(<App />);
     expect(await screen.findByText("This link lets anyone join as a member until it expires.")).toBeTruthy();
-    fireEvent.click(await screen.findByRole("button", { name: "Create invite link" }));
+    const createInviteLink = await screen.findByRole("button", { name: "Create invite link" });
+    expect(createInviteLink.parentElement?.classList.contains("actions")).toBe(true);
+    fireEvent.click(createInviteLink);
     const link = (await screen.findByLabelText("Invite link")) as HTMLInputElement;
     expect(link.value).toBe(`https://opentag.example.com/invites/${"A".repeat(43)}`);
     expect(screen.getByText(/^Expires Aug 27, 2026 at /)).toBeTruthy();

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -742,12 +742,13 @@ describe("OpenTag Web App Shell", () => {
     confirm.mockRestore();
   });
 
-  it("uses a flat local navigation for Agent detail", async () => {
+  it("uses top tabs for Agent detail navigation", async () => {
     installApi("admin");
     window.history.replaceState({}, "", `/agents/${agentId}/general`);
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
     const navigation = screen.getByRole("navigation", { name: "Agent settings" });
+    expect(navigation.className).toBe("object-tabs");
     expect(
       within(navigation)
         .getAllByRole("link")

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -641,6 +641,8 @@ describe("OpenTag Web App Shell", () => {
     const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
     expect(email.value).toBe("ada@example.com");
     expect(email.readOnly).toBe(true);
+    expect(email.closest(".ds-field")).toBeTruthy();
+    expect(displayName.closest(".ds-field")).toBeTruthy();
     fireEvent.change(displayName, { target: { value: "  Ada Lovelace  " } });
     fireEvent.click(await screen.findByRole("button", { name: "Save account profile" }));
 
@@ -1318,7 +1320,7 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", `/agents/${agentId}/im`);
     render(<App />);
 
-    expect(await screen.findByText("Configured")).toBeTruthy();
+    expect((await screen.findByText("Configured")).closest(".ds-status")).toBeTruthy();
     expect(screen.queryByText(/Online/)).toBeNull();
   });
 

--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -47,7 +47,10 @@ describe("capability entry pages", () => {
     expect(within(metrics).getByText("728")).toBeTruthy();
     expect(screen.getByRole("img").getAttribute("aria-label")).toContain("30 days");
 
-    fireEvent.change(screen.getByLabelText("Time range"), { target: { value: "7 days" } });
+    const timeRange = screen.getByLabelText("Time range");
+    expect(timeRange.className).toContain("ds-control");
+    expect(timeRange.closest(".ds-field")).toBeTruthy();
+    fireEvent.change(timeRange, { target: { value: "7 days" } });
 
     expect(within(metrics).getByText("38")).toBeTruthy();
     expect(within(metrics).getByText("184")).toBeTruthy();

--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -50,6 +50,10 @@ describe("capability entry pages", () => {
     const timeRange = screen.getByLabelText("Time range");
     expect(timeRange.className).toContain("ds-control");
     expect(timeRange.closest(".ds-field")).toBeTruthy();
+    expect(timeRange.closest(".capability-usage-toolbar")).toBeTruthy();
+    expect(timeRange.closest(".capability-page-header")).toBeNull();
+    expect(metrics.closest(".capability-usage-summary")).toBeTruthy();
+    expect(document.querySelector(".capability-section-heading > span")).toBeNull();
     fireEvent.change(timeRange, { target: { value: "7 days" } });
 
     expect(within(metrics).getByText("38")).toBeTruthy();

--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { IntegrationsPage } from "../features/integrations-page.js";
 import { SkillsPage } from "../features/skills-page.js";
@@ -38,7 +38,7 @@ describe("capability entry pages", () => {
     expect(screen.queryByRole("button")).toBeNull();
   });
 
-  it("updates the Usage overview when the demo range changes", () => {
+  it("renders the fixed 30-day Usage overview without a range control", () => {
     render(<UsagePage />);
 
     expect(screen.getByText("Demo data preview")).toBeTruthy();
@@ -47,17 +47,9 @@ describe("capability entry pages", () => {
     expect(within(metrics).getByText("728")).toBeTruthy();
     expect(screen.getByRole("img").getAttribute("aria-label")).toContain("30 days");
 
-    const timeRange = screen.getByLabelText("Time range");
-    expect(timeRange.className).toContain("ds-control");
-    expect(timeRange.closest(".ds-field")).toBeTruthy();
-    expect(timeRange.closest(".capability-usage-toolbar")).toBeTruthy();
-    expect(timeRange.closest(".capability-page-header")).toBeNull();
+    expect(screen.queryByLabelText("Time range")).toBeNull();
     expect(metrics.closest(".capability-usage-summary")).toBeTruthy();
     expect(document.querySelector(".capability-section-heading > span")).toBeNull();
-    fireEvent.change(timeRange, { target: { value: "7 days" } });
-
-    expect(within(metrics).getByText("38")).toBeTruthy();
-    expect(within(metrics).getByText("184")).toBeTruthy();
-    expect(screen.getByRole("img").getAttribute("aria-label")).toContain("7 days");
+    expect(screen.getByText("Turns completed during the last 30 days.")).toBeTruthy();
   });
 });

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -77,6 +77,5 @@ describe("workspace page layout", () => {
     expect(declarationValue(designSystemStyles, ".ds-settings-list", "border-radius")).toBe("var(--radius-panel)");
     expect(declarationValue(designSystemStyles, ".ds-settings-row", "padding")).toBe("var(--space-6)");
     expect(declarationValue(designSystemStyles, "select.ds-control--compact", "min-height")).toBe("36px");
-    expect(declarationValue(designSystemStyles, "select.ds-control--quiet", "border-color")).toBe("transparent");
   });
 });

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -36,6 +36,7 @@ function topLevelDeclarationValue(stylesheet: Root, selector: string, property: 
 }
 
 const appStyles = postcss.parse(readFileSync(locateStylesheet("src/styles.css"), "utf8"));
+const designSystemStyles = postcss.parse(readFileSync(locateStylesheet("src/ui/design-system.css"), "utf8"));
 const capabilityStyles = postcss.parse(readFileSync(locateStylesheet("src/mock-pages.css"), "utf8"));
 
 describe("workspace page layout", () => {
@@ -66,5 +67,14 @@ describe("workspace page layout", () => {
     expect(declarationValue(appStyles, ".overview-section", "width")).toBe("100%");
     expect(declarationValue(appStyles, ".settings-profile-form", "width")).toBe("100%");
     expect(declarationValue(appStyles, ".settings-list-section", "width")).toBe("100%");
+  });
+
+  it("centralizes tab and settings-row geometry in the design system", () => {
+    expect(declarationValue(designSystemStyles, ".ds-tabs", "gap")).toBe("var(--space-8)");
+    expect(declarationValue(designSystemStyles, ".ds-tabs", "border-bottom")).toBe(
+      "1px solid var(--color-border-divider)",
+    );
+    expect(declarationValue(designSystemStyles, ".ds-settings-list", "border-radius")).toBe("var(--radius-panel)");
+    expect(declarationValue(designSystemStyles, ".ds-settings-row", "padding")).toBe("var(--space-6)");
   });
 });

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -76,5 +76,6 @@ describe("workspace page layout", () => {
     );
     expect(declarationValue(designSystemStyles, ".ds-settings-list", "border-radius")).toBe("var(--radius-panel)");
     expect(declarationValue(designSystemStyles, ".ds-settings-row", "padding")).toBe("var(--space-6)");
+    expect(declarationValue(designSystemStyles, "select.ds-control--compact", "min-height")).toBe("36px");
   });
 });

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import postcss, { type Root } from "postcss";
+import { describe, expect, it } from "vitest";
+
+function locateStylesheet(relativePath: string): string {
+  for (const candidate of [relativePath, `apps/web/${relativePath}`]) {
+    const path = resolve(process.cwd(), candidate);
+    if (existsSync(path)) return path;
+  }
+  throw new Error(`The Web stylesheet ${relativePath} was not found from ${process.cwd()}`);
+}
+
+function declarationValue(stylesheet: Root, selector: string, property: string): string {
+  let value: string | undefined;
+  stylesheet.walkRules((rule) => {
+    if (!rule.selectors.includes(selector)) return;
+    rule.walkDecls(property, (declaration) => {
+      value = declaration.value;
+    });
+  });
+  if (!value) throw new Error(`Missing ${property} declaration for ${selector}`);
+  return value;
+}
+
+const appStyles = postcss.parse(readFileSync(locateStylesheet("src/styles.css"), "utf8"));
+const capabilityStyles = postcss.parse(readFileSync(locateStylesheet("src/mock-pages.css"), "utf8"));
+
+describe("workspace page layout", () => {
+  it("uses one 960px width contract for top-level workspace routes", () => {
+    expect(declarationValue(appStyles, ":root", "--workspace-page-width")).toBe("960px");
+    expect(declarationValue(appStyles, ".page", "width")).toBe("min(100%, var(--workspace-page-width))");
+    expect(declarationValue(capabilityStyles, ".capability-page", "width")).toBe(
+      "min(100%, var(--workspace-page-width, 960px))",
+    );
+  });
+
+  it("lets list-heavy Agent and Member sections use the shared page width", () => {
+    expect(declarationValue(appStyles, ".agent-runtime-section", "width")).toBe("100%");
+    expect(declarationValue(appStyles, ".settings-members-section", "width")).toBe("100%");
+    expect(declarationValue(appStyles, ".settings-members-section .settings-invitation-panel", "width")).toBe("100%");
+  });
+});

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -55,7 +55,7 @@ describe("workspace page layout", () => {
   });
 
   it("lets list-heavy Agent and Member sections use the shared page width", () => {
-    expect(declarationValue(appStyles, ".agent-runtime-section", "width")).toBe("100%");
+    expect(declarationValue(appStyles, ".agent-list-section", "width")).toBe("100%");
     expect(declarationValue(appStyles, ".settings-members-section", "width")).toBe("100%");
     expect(declarationValue(appStyles, ".settings-members-section .settings-invitation-panel", "width")).toBe("100%");
   });

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -23,15 +23,34 @@ function declarationValue(stylesheet: Root, selector: string, property: string):
   return value;
 }
 
+function topLevelDeclarationValue(stylesheet: Root, selector: string, property: string): string {
+  let value: string | undefined;
+  stylesheet.walkRules((rule) => {
+    if (rule.parent?.type !== "root" || !rule.selectors.includes(selector)) return;
+    rule.walkDecls(property, (declaration) => {
+      value = declaration.value;
+    });
+  });
+  if (!value) throw new Error(`Missing top-level ${property} declaration for ${selector}`);
+  return value;
+}
+
 const appStyles = postcss.parse(readFileSync(locateStylesheet("src/styles.css"), "utf8"));
 const capabilityStyles = postcss.parse(readFileSync(locateStylesheet("src/mock-pages.css"), "utf8"));
 
 describe("workspace page layout", () => {
-  it("uses one 960px width contract for top-level workspace routes", () => {
+  it("uses one 1024px frame with a 960px visible content contract", () => {
+    expect(declarationValue(appStyles, ":root", "--workspace-page-frame")).toBe("1024px");
+    expect(declarationValue(appStyles, ":root", "--workspace-page-gutter")).toBe("32px");
     expect(declarationValue(appStyles, ":root", "--workspace-page-width")).toBe("960px");
-    expect(declarationValue(appStyles, ".page", "width")).toBe("min(100%, var(--workspace-page-width))");
+    expect(declarationValue(appStyles, ".page", "width")).toBe("min(100%, var(--workspace-page-frame))");
+    expect(declarationValue(appStyles, ".object-page", "width")).toBe("min(100%, var(--workspace-page-frame))");
+    expect(declarationValue(appStyles, ".settings-page", "width")).toBe("min(100%, var(--workspace-page-frame))");
     expect(declarationValue(capabilityStyles, ".capability-page", "width")).toBe(
-      "min(100%, var(--workspace-page-width, 960px))",
+      "min(100%, var(--workspace-page-frame, 1024px))",
+    );
+    expect(topLevelDeclarationValue(capabilityStyles, ".capability-page", "padding-inline")).toBe(
+      "var(--workspace-page-gutter, 32px)",
     );
   });
 
@@ -39,5 +58,13 @@ describe("workspace page layout", () => {
     expect(declarationValue(appStyles, ".agent-runtime-section", "width")).toBe("100%");
     expect(declarationValue(appStyles, ".settings-members-section", "width")).toBe("100%");
     expect(declarationValue(appStyles, ".settings-members-section .settings-invitation-panel", "width")).toBe("100%");
+  });
+
+  it("does not introduce nested page-level width contracts", () => {
+    expect(declarationValue(appStyles, ".object-content", "width")).toBe("100%");
+    expect(declarationValue(appStyles, ".settings-content", "width")).toBe("100%");
+    expect(declarationValue(appStyles, ".overview-section", "width")).toBe("100%");
+    expect(declarationValue(appStyles, ".settings-profile-form", "width")).toBe("100%");
+    expect(declarationValue(appStyles, ".settings-list-section", "width")).toBe("100%");
   });
 });

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -77,5 +77,6 @@ describe("workspace page layout", () => {
     expect(declarationValue(designSystemStyles, ".ds-settings-list", "border-radius")).toBe("var(--radius-panel)");
     expect(declarationValue(designSystemStyles, ".ds-settings-row", "padding")).toBe("var(--space-6)");
     expect(declarationValue(designSystemStyles, "select.ds-control--compact", "min-height")).toBe("36px");
+    expect(declarationValue(designSystemStyles, "select.ds-control--quiet", "border-color")).toBe("transparent");
   });
 });

--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -63,6 +63,9 @@ describe("ComputerSetup", () => {
     });
 
     render(<ComputerSetup teamId={teamId} />);
+    expect(
+      screen.getByRole("button", { name: "Generate connection command" }).classList.contains("connect-command-primary"),
+    ).toBe(true);
     await clickGenerate();
 
     expect(calls).toEqual(["baseline", "issue"]);

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -1,6 +1,7 @@
 import type { Computer } from "@opentag/shared/browser";
 import { useEffect, useRef, useState } from "react";
 import { browserApi } from "./api.js";
+import { Button } from "./ui/design-system.js";
 
 const COMPUTER_POLL_INTERVAL_MS = 1_500;
 const COPY_FEEDBACK_MS = 2_000;
@@ -172,18 +173,16 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
     <section className="panel">
       <h2>Connect a Local Computer</h2>
       <p>Generate a short-lived command, then run it in a terminal on the Computer.</p>
-      <button className="button" type="button" onClick={() => void connectComputer()}>
-        Generate connection command
-      </button>
+      <Button onClick={() => void connectComputer()}>Generate connection command</Button>
       {bootstrapCommand ? (
         <>
           <pre>
             <code ref={commandRef}>{bootstrapCommand}</code>
           </pre>
           <div className="connect-command-actions">
-            <button className="button secondary" type="button" onClick={() => void copyCommand(bootstrapCommand)}>
+            <Button variant="secondary" onClick={() => void copyCommand(bootstrapCommand)}>
               {copied ? "Copied" : "Copy command"}
-            </button>
+            </Button>
             {waitingForComputer && remainingMs !== undefined ? (
               <p className="connect-command-meta">Expires in {formatRemaining(remainingMs)}</p>
             ) : null}

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -173,7 +173,9 @@ function ComputerSetupLifecycle({ teamId, onConnected }: ComputerSetupProps) {
     <section className="panel">
       <h2>Connect a Local Computer</h2>
       <p>Generate a short-lived command, then run it in a terminal on the Computer.</p>
-      <Button onClick={() => void connectComputer()}>Generate connection command</Button>
+      <Button className="connect-command-primary" onClick={() => void connectComputer()}>
+        Generate connection command
+      </Button>
       {bootstrapCommand ? (
         <>
           <pre>

--- a/apps/web/src/create-team-form.tsx
+++ b/apps/web/src/create-team-form.tsx
@@ -1,6 +1,7 @@
 import type { CreateTeamResponse } from "@opentag/shared/browser";
 import { type FormEvent, useState } from "react";
 import { ApiError, browserApi } from "./api.js";
+import { Button, Field } from "./ui/design-system.js";
 
 /** Derives the internal Team handle suggested by a user-facing name. */
 export function toTeamHandle(displayName: string): string {
@@ -83,9 +84,9 @@ export function CreateTeamForm({
 
   return (
     <form className="form-card" onSubmit={submit}>
-      <label>
-        Workspace name
+      <Field htmlFor="workspace-display-name" label="Workspace name">
         <input
+          id="workspace-display-name"
           name="displayName"
           autoComplete="organization"
           maxLength={120}
@@ -94,10 +95,10 @@ export function CreateTeamForm({
           value={displayName}
           onChange={(event) => setDisplayName(event.currentTarget.value)}
         />
-      </label>
-      <button className="button" type="submit" disabled={submitting}>
+      </Field>
+      <Button type="submit" disabled={submitting}>
         {submitting ? "Creating…" : submitLabel}
-      </button>
+      </Button>
       {error ? (
         <div className="notice error" role="alert">
           {error}

--- a/apps/web/src/features/usage-page.tsx
+++ b/apps/web/src/features/usage-page.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { type UsageRange, usageRanges, usageSnapshots } from "../mock/capability-data.js";
+import { Field } from "../ui/design-system.js";
 import "../mock-pages.css";
 
 export function UsagePage() {
@@ -15,16 +16,20 @@ export function UsagePage() {
           <h1 id="usage-page-title">Usage</h1>
           <p>A simple view of sample Agent activity across this Workspace.</p>
         </div>
-        <label className="capability-range-field">
-          <span>Time range</span>
-          <select value={range} onChange={(event) => setRange(event.currentTarget.value as UsageRange)}>
+        <Field className="capability-range-field" htmlFor="usage-range" label="Time range">
+          <select
+            className="ds-control"
+            id="usage-range"
+            value={range}
+            onChange={(event) => setRange(event.currentTarget.value as UsageRange)}
+          >
             {usageRanges.map((option) => (
               <option value={option} key={option}>
                 Last {option}
               </option>
             ))}
           </select>
-        </label>
+        </Field>
       </header>
 
       <dl className="capability-metric-grid" aria-label="Usage metrics" aria-live="polite">

--- a/apps/web/src/features/usage-page.tsx
+++ b/apps/web/src/features/usage-page.tsx
@@ -1,11 +1,8 @@
-import { useState } from "react";
-import { type UsageRange, usageRanges, usageSnapshots } from "../mock/capability-data.js";
-import { Field } from "../ui/design-system.js";
+import { usageSnapshots } from "../mock/capability-data.js";
 import "../mock-pages.css";
 
 export function UsagePage() {
-  const [range, setRange] = useState<UsageRange>("30 days");
-  const snapshot = usageSnapshots[range];
+  const snapshot = usageSnapshots["30 days"];
   const trendPoints = makeTrendPoints(snapshot.trend);
 
   return (
@@ -19,23 +16,6 @@ export function UsagePage() {
       </header>
 
       <div className="capability-usage-summary">
-        <div className="capability-usage-toolbar">
-          <Field className="capability-range-field" htmlFor="usage-range" label="Time range">
-            <select
-              className="ds-control"
-              id="usage-range"
-              value={range}
-              onChange={(event) => setRange(event.currentTarget.value as UsageRange)}
-            >
-              {usageRanges.map((option) => (
-                <option value={option} key={option}>
-                  Last {option}
-                </option>
-              ))}
-            </select>
-          </Field>
-        </div>
-
         <dl className="capability-metric-grid" aria-label="Usage metrics" aria-live="polite">
           <Metric label="Tasks" value={snapshot.metrics.tasks} />
           <Metric label="Turns" value={snapshot.metrics.turns} />
@@ -49,14 +29,14 @@ export function UsagePage() {
           <div className="capability-section-heading">
             <div>
               <h2 id="activity-trend-title">Activity trend</h2>
-              <p>Turns completed during the selected demo period.</p>
+              <p>Turns completed during the last 30 days.</p>
             </div>
           </div>
           <svg
             className="capability-trend-chart"
             viewBox="0 0 640 220"
             role="img"
-            aria-label={`Demo activity trend for the last ${range}`}
+            aria-label="Demo activity trend for the last 30 days"
             preserveAspectRatio="none"
           >
             <line x1="0" y1="40" x2="640" y2="40" />

--- a/apps/web/src/features/usage-page.tsx
+++ b/apps/web/src/features/usage-page.tsx
@@ -10,34 +10,39 @@ export function UsagePage() {
 
   return (
     <section className="capability-page" aria-labelledby="usage-page-title">
-      <header className="capability-page-header capability-usage-header">
+      <header className="capability-page-header">
         <div>
           <span className="capability-preview-label">Demo data preview</span>
           <h1 id="usage-page-title">Usage</h1>
           <p>A simple view of sample Agent activity across this Workspace.</p>
         </div>
-        <Field className="capability-range-field" htmlFor="usage-range" label="Time range">
-          <select
-            className="ds-control"
-            id="usage-range"
-            value={range}
-            onChange={(event) => setRange(event.currentTarget.value as UsageRange)}
-          >
-            {usageRanges.map((option) => (
-              <option value={option} key={option}>
-                Last {option}
-              </option>
-            ))}
-          </select>
-        </Field>
       </header>
 
-      <dl className="capability-metric-grid" aria-label="Usage metrics" aria-live="polite">
-        <Metric label="Tasks" value={snapshot.metrics.tasks} />
-        <Metric label="Turns" value={snapshot.metrics.turns} />
-        <Metric label="Active Agents" value={snapshot.metrics.activeAgents} />
-        <Metric label="Providers" value={snapshot.metrics.providers} />
-      </dl>
+      <div className="capability-usage-summary">
+        <div className="capability-usage-toolbar">
+          <Field className="capability-range-field" htmlFor="usage-range" label="Time range">
+            <select
+              className="ds-control"
+              id="usage-range"
+              value={range}
+              onChange={(event) => setRange(event.currentTarget.value as UsageRange)}
+            >
+              {usageRanges.map((option) => (
+                <option value={option} key={option}>
+                  Last {option}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <dl className="capability-metric-grid" aria-label="Usage metrics" aria-live="polite">
+          <Metric label="Tasks" value={snapshot.metrics.tasks} />
+          <Metric label="Turns" value={snapshot.metrics.turns} />
+          <Metric label="Active Agents" value={snapshot.metrics.activeAgents} />
+          <Metric label="Providers" value={snapshot.metrics.providers} />
+        </dl>
+      </div>
 
       <div className="capability-usage-grid">
         <section className="capability-chart-panel" aria-labelledby="activity-trend-title">
@@ -46,7 +51,6 @@ export function UsagePage() {
               <h2 id="activity-trend-title">Activity trend</h2>
               <p>Turns completed during the selected demo period.</p>
             </div>
-            <span>{range}</span>
           </div>
           <svg
             className="capability-trend-chart"

--- a/apps/web/src/im/feishu-setup.tsx
+++ b/apps/web/src/im/feishu-setup.tsx
@@ -2,6 +2,7 @@ import type { FeishuSetupAttempt, FeishuSetupIntent } from "@opentag/shared/brow
 import { toString as qrToString } from "qrcode";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, browserApi } from "../api.js";
+import { Button } from "../ui/design-system.js";
 
 const ACTIVE_STATES: readonly FeishuSetupAttempt["state"][] = ["awaiting_user", "validating"];
 const RETRYABLE_STATES: readonly FeishuSetupAttempt["state"][] = ["expired", "failed", "canceled"];
@@ -189,9 +190,7 @@ function FeishuSetupFeedback({
       {RETRYABLE_STATES.includes(attempt.state) ? (
         <>
           <br />
-          <button className="button" type="button" onClick={() => void onRetry(attempt.intent)}>
-            Retry Feishu setup
-          </button>
+          <Button onClick={() => void onRetry(attempt.intent)}>Retry Feishu setup</Button>
         </>
       ) : null}
     </div>

--- a/apps/web/src/mock-pages.css
+++ b/apps/web/src/mock-pages.css
@@ -247,6 +247,17 @@
   font-weight: var(--fw-semibold, 600);
 }
 
+.capability-usage-summary {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 36px;
+}
+
+.capability-usage-toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .capability-range-field select {
   min-height: 38px;
   padding-block: 0.4rem;
@@ -255,7 +266,7 @@
 .capability-metric-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  margin: 0 0 36px;
+  margin: 0;
   border-top: 1px solid var(--strong-border, #c9ccbb);
   border-bottom: 1px solid var(--border, #d6d9ca);
 }
@@ -397,10 +408,6 @@
     justify-self: end;
   }
 
-  .capability-usage-header {
-    grid-template-columns: minmax(0, 1fr) 150px;
-  }
-
   .capability-usage-grid {
     grid-template-columns: 1fr;
   }
@@ -429,12 +436,12 @@
     font-size: var(--text-micro, 0.75rem);
   }
 
-  .capability-usage-header {
-    grid-template-columns: 1fr;
-  }
-
   .capability-range-field {
     width: min(100%, 180px);
+  }
+
+  .capability-usage-toolbar {
+    justify-content: flex-start;
   }
 
   .capability-metric-grid {

--- a/apps/web/src/mock-pages.css
+++ b/apps/web/src/mock-pages.css
@@ -237,30 +237,8 @@
   opacity: 1;
 }
 
-.capability-range-field {
-  display: grid;
-  width: 150px;
-  flex: 0 0 auto;
-  gap: 6px;
-  color: var(--muted, #616b62);
-  font-size: var(--text-micro, 0.75rem);
-  font-weight: var(--fw-semibold, 600);
-}
-
 .capability-usage-summary {
-  display: grid;
-  gap: 14px;
   margin-bottom: 36px;
-}
-
-.capability-usage-toolbar {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.capability-range-field select {
-  min-height: 38px;
-  padding-block: 0.4rem;
 }
 
 .capability-metric-grid {
@@ -434,14 +412,6 @@
     color: var(--muted, #616b62);
     content: attr(data-label);
     font-size: var(--text-micro, 0.75rem);
-  }
-
-  .capability-range-field {
-    width: min(100%, 180px);
-  }
-
-  .capability-usage-toolbar {
-    justify-content: flex-start;
   }
 
   .capability-metric-grid {

--- a/apps/web/src/mock-pages.css
+++ b/apps/web/src/mock-pages.css
@@ -1,5 +1,5 @@
 .capability-page {
-  width: min(100%, 960px);
+  width: min(100%, var(--workspace-page-width, 960px));
   margin: 0 auto;
   color: var(--foreground, #16211b);
 }

--- a/apps/web/src/mock-pages.css
+++ b/apps/web/src/mock-pages.css
@@ -1,7 +1,8 @@
 .capability-page {
-  width: min(100%, var(--workspace-page-width, 960px));
+  width: min(100%, var(--workspace-page-frame, 1024px));
   margin: 0 auto;
   color: var(--foreground, #16211b);
+  padding-inline: var(--workspace-page-gutter, 32px);
 }
 
 .capability-page-header {
@@ -15,7 +16,7 @@
 .capability-page-header h1 {
   margin: 0 0 7px;
   font-family: var(--font-display, sans-serif);
-  font-size: var(--text-title, 1.5rem);
+  font-size: var(--text-display, 1.875rem);
   font-weight: var(--fw-semibold, 600);
   letter-spacing: var(--track-tight, -0.02em);
   line-height: var(--lh-tight, 1.2);
@@ -348,6 +349,12 @@
 
 .capability-provider-list small {
   text-align: right;
+}
+
+@media (max-width: 900px) {
+  .capability-page {
+    padding-inline: 0;
+  }
 }
 
 @media (max-width: 720px) {

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -10,6 +10,7 @@ import { type FormEvent, type ReactNode, useCallback, useEffect, useMemo, useRef
 import { browserApi } from "../api.js";
 import { ComputerSetup } from "../computer-setup.js";
 import { FeishuSetup, type FeishuSetupControl } from "../im/feishu-setup.js";
+import { Button, buttonClassName, Field } from "../ui/design-system.js";
 import {
   deriveOnboardingState,
   type OnboardingAgent,
@@ -249,9 +250,7 @@ export function OnboardingPage({
               {loadState.kind === "loading" ? <OnboardingLoading /> : null}
               {loadState.kind === "error" ? (
                 <ActionSection title="We couldn’t load setup" description={loadState.error.message}>
-                  <button className="button" type="button" onClick={reload}>
-                    Try again
-                  </button>
+                  <Button onClick={reload}>Try again</Button>
                 </ActionSection>
               ) : null}
               {loadState.kind === "ready" && resolved ? (
@@ -539,14 +538,9 @@ function OnboardingHeader({ user }: { user: UserProfile }) {
       </a>
       <div className="onboarding-account">
         <span>{user.displayName}</span>
-        <button
-          className="secondary compact-button"
-          disabled={logoutState === "pending"}
-          type="button"
-          onClick={logout}
-        >
+        <Button size="compact" variant="secondary" disabled={logoutState === "pending"} onClick={logout}>
           {logoutState === "pending" ? "Signing out…" : logoutState === "error" ? "Retry sign out" : "Sign out"}
-        </button>
+        </Button>
       </div>
     </header>
   );
@@ -736,15 +730,15 @@ function OnboardingContent({
       >
         {current.alternatives.length > 0 ? (
           <div className="onboarding-route-change">
-            <button
+            <Button
               aria-expanded={routeChangeOpen}
-              className="tertiary compact-button"
               disabled={pending}
-              type="button"
+              size="compact"
+              variant="tertiary"
               onClick={() => setRouteChangeOpen((open) => !open)}
             >
               Change
-            </button>
+            </Button>
             {routeChangeOpen ? (
               <div className="onboarding-choice-list">
                 {current.alternatives.map((alternative) => (
@@ -776,24 +770,24 @@ function OnboardingContent({
             onCreateAgent(current);
           }}
         >
-          <label>
-            Agent display name
+          <Field htmlFor="onboarding-agent-display-name" label="Agent display name">
             <input
               autoComplete="off"
               disabled={pending}
+              id="onboarding-agent-display-name"
               maxLength={120}
               required
               value={agentDisplayName}
               onChange={(event) => onAgentDisplayNameChange(event.target.value)}
             />
-          </label>
+          </Field>
           <div className="onboarding-feedback">
             {creation?.kind === "error" ? (
               <div className="notice error" role="alert">
                 {creation.message}
               </div>
             ) : null}
-            <button className="button" disabled={pending} type="submit">
+            <Button disabled={pending} type="submit">
               {refreshPending
                 ? "Updating route…"
                 : creationPending
@@ -801,7 +795,7 @@ function OnboardingContent({
                   : creation?.kind === "error"
                     ? "Try again"
                     : "Create agent"}
-            </button>
+            </Button>
             {refreshPending ? <p role="status">Confirming the selected runtime route…</p> : null}
             {creationPending ? <p role="status">Creating Agent identity and runtime binding…</p> : null}
           </div>
@@ -854,10 +848,10 @@ function OnboardingContent({
       description="Add the Bot to a Feishu group, then mention OpenTag with your first task."
     >
       <div className="actions">
-        <a className="button" href={FEISHU_BOT_APP_LINK} rel="noreferrer" target="_blank">
+        <a className={buttonClassName()} href={FEISHU_BOT_APP_LINK} rel="noreferrer" target="_blank">
           Open Feishu
         </a>
-        <a className="button secondary" href={agentGeneralRoute(current.agent.id)}>
+        <a className={buttonClassName({ variant: "secondary" })} href={agentGeneralRoute(current.agent.id)}>
           Manage this Agent
         </a>
       </div>
@@ -901,9 +895,9 @@ function ActionSection({
 function ReloadButton({ onReload, pending }: { onReload: () => void; pending: boolean }) {
   return (
     <div className="onboarding-feedback">
-      <button className="button" disabled={pending} type="button" onClick={onReload}>
+      <Button disabled={pending} onClick={onReload}>
         {pending ? "Checking…" : "Check again"}
-      </button>
+      </Button>
       {pending ? (
         <p className="onboarding-helper" role="status">
           Refreshing Server facts…
@@ -948,9 +942,7 @@ function FeishuAction({
         : "Resume Feishu setup";
   return (
     <div className="onboarding-feedback">
-      <button className="button" type="button" onClick={() => void control.start(intent)}>
-        {label}
-      </button>
+      <Button onClick={() => void control.start(intent)}>{label}</Button>
       {control.feedback}
     </div>
   );

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -734,7 +734,7 @@ function OnboardingContent({
               aria-expanded={routeChangeOpen}
               disabled={pending}
               size="compact"
-              variant="tertiary"
+              variant="ghost"
               onClick={() => setRouteChangeOpen((open) => !open)}
             >
               Change

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2282,7 +2282,7 @@ function MembersSettings({
                         {canManage ? (
                           <select
                             aria-label={`Role for ${member.displayName}`}
-                            className="ds-control ds-control--compact ds-control--quiet"
+                            className="ds-control ds-control--compact"
                             disabled={pendingUserIds.has(member.userId)}
                             value={member.role}
                             onChange={(event) => void changeRole(member, event.currentTarget.value)}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2320,9 +2320,11 @@ function InvitationSettings({
               </div>
             </>
           ) : (
-            <Button disabled={busy} onClick={() => void createInvitation()}>
-              {busy ? "Creating…" : "Create invite link"}
-            </Button>
+            <div className="actions">
+              <Button disabled={busy} onClick={() => void createInvitation()}>
+                {busy ? "Creating…" : "Create invite link"}
+              </Button>
+            </div>
           );
         }}
       </AsyncState>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1915,17 +1915,8 @@ function AccessTab({ agent }: { agent: AgentDetailView }) {
 
 function MembersPage() {
   const { me, membership, refreshMe } = useTeam();
-  function focusInvitationPanel() {
-    const panel = document.getElementById("member-invitations");
-    panel?.scrollIntoView({ block: "nearest" });
-    panel?.focus({ preventScroll: true });
-  }
   return (
-    <Page
-      title="Members"
-      description="Manage members, invitations, and roles."
-      action={membership.role === "admin" ? <Button onClick={focusInvitationPanel}>Invite members</Button> : null}
-    >
+    <Page title="Members" description="Manage members, invitations, and roles.">
       <MembersSettings
         canManage={membership.role === "admin"}
         currentUserId={me.user.id}
@@ -2378,8 +2369,6 @@ function InvitationSettings({
     <section
       aria-labelledby={presentation === "panel" ? "invite-members-heading" : undefined}
       className={presentation === "dialog" ? "invitation-dialog-content" : "settings-invitation-panel"}
-      id={presentation === "panel" ? "member-invitations" : undefined}
-      tabIndex={presentation === "panel" ? -1 : undefined}
     >
       {presentation === "panel" ? (
         <>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2245,18 +2245,20 @@ function MembersSettings({
       <AsyncState state={state}>
         {(value) => {
           const adminCount = value.members.filter((member: TeamMemberSummary) => member.role === "admin").length;
+          const members = [...value.members].sort((left, right) => {
+            if (left.userId === currentUserId) return -1;
+            if (right.userId === currentUserId) return 1;
+            return left.displayName.localeCompare(right.displayName) || left.userId.localeCompare(right.userId);
+          });
           return (
-            <>
-              <header className="settings-subheader">
-                <div>
-                  <h2>Members</h2>
-                  <p>
-                    {value.members.length} {value.members.length === 1 ? "member" : "members"} · {adminCount}{" "}
-                    {adminCount === 1 ? "admin" : "admins"}
-                  </p>
-                </div>
+            <div className="settings-member-list">
+              <div className="settings-member-summary">
+                <p>
+                  {value.members.length} {value.members.length === 1 ? "member" : "members"} · {adminCount}{" "}
+                  {adminCount === 1 ? "admin" : "admins"}
+                </p>
                 {!canManage ? <span className="settings-role-badge">Read only</span> : null}
-              </header>
+              </div>
               <table className="settings-member-table" aria-label="Members">
                 <thead>
                   <tr className="settings-table-header">
@@ -2265,7 +2267,7 @@ function MembersSettings({
                   </tr>
                 </thead>
                 <tbody>
-                  {value.members.map((member: TeamMemberSummary) => (
+                  {members.map((member: TeamMemberSummary) => (
                     <tr className="settings-member-row" key={member.userId}>
                       <th className="settings-member-identity" scope="row">
                         <span className="settings-member-avatar" aria-hidden="true">
@@ -2280,7 +2282,7 @@ function MembersSettings({
                         {canManage ? (
                           <select
                             aria-label={`Role for ${member.displayName}`}
-                            className="ds-control"
+                            className="ds-control ds-control--compact"
                             disabled={pendingUserIds.has(member.userId)}
                             value={member.role}
                             onChange={(event) => void changeRole(member, event.currentTarget.value)}
@@ -2299,7 +2301,7 @@ function MembersSettings({
                   ))}
                 </tbody>
               </table>
-            </>
+            </div>
           );
         }}
       </AsyncState>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -33,7 +33,7 @@ import { UsagePage } from "./features/usage-page.js";
 import { FeishuSetup } from "./im/feishu-setup.js";
 import { OnboardingPage } from "./onboarding/page.js";
 import { RuntimeConfigurationForm } from "./runtime-configuration.js";
-import { Button, Dialog, Field, Icon, StatusIndicator, type StatusTone } from "./ui/design-system.js";
+import { Button, buttonClassName, Dialog, Field, Icon, StatusIndicator, type StatusTone } from "./ui/design-system.js";
 
 type LoadState<T> = { kind: "loading" } | { kind: "error"; error: Error } | { kind: "ready"; value: T };
 
@@ -367,7 +367,11 @@ function LoginPage() {
             {value.providers
               .filter((provider: AuthProvidersResponse["providers"][number]) => provider.enabled && provider.startUrl)
               .map((provider: AuthProvidersResponse["providers"][number]) => (
-                <a className="button" href={`${provider.startUrl}?next=${encodeURIComponent(next)}`} key={provider.id}>
+                <a
+                  className={buttonClassName()}
+                  href={`${provider.startUrl}?next=${encodeURIComponent(next)}`}
+                  key={provider.id}
+                >
                   Continue with {provider.id === "google" ? "Google" : provider.id}
                 </a>
               ))}
@@ -443,9 +447,9 @@ function InvitePage() {
             <p>
               This invitation grants the {value.role} role and expires {formatDate(value.expiresAt)}.
             </p>
-            <button className="button" disabled={joining} type="button" onClick={join}>
+            <Button disabled={joining} onClick={join}>
               {joining ? "Joining…" : "Join Workspace"}
-            </button>
+            </Button>
           </>
         )}
       </AsyncState>
@@ -548,9 +552,7 @@ function WorkspaceSetupIncomplete({ onRetry }: { onRetry: () => void }) {
       <div className="notice error" role="alert">
         The server must finish Workspace setup before the Web app can continue.
       </div>
-      <button className="button" type="button" onClick={onRetry}>
-        Check again
-      </button>
+      <Button onClick={onRetry}>Check again</Button>
     </main>
   );
 }
@@ -708,7 +710,7 @@ function AppShell() {
                 <strong>{me.user.displayName}</strong>
               </span>
               <span className="account-menu-dots" aria-hidden="true">
-                ⋮
+                <Icon name="more-vertical" />
               </span>
             </button>
             {openMenu === "account" ? (
@@ -749,7 +751,7 @@ function AppShell() {
                           </span>
                           {current ? (
                             <span className="team-option-check" aria-hidden="true">
-                              ✓
+                              <Icon name="check" />
                             </span>
                           ) : null}
                         </button>
@@ -799,9 +801,9 @@ function AppShell() {
           <Link className="mobile-brand" to="/agents" onClick={() => setNavigationOpen(false)}>
             OpenTag
           </Link>
-          <button className="secondary compact-button" type="button" onClick={() => setNavigationOpen(true)}>
+          <Button size="compact" variant="secondary" onClick={() => setNavigationOpen(true)}>
             Menu
-          </button>
+          </Button>
         </header>
         <main className="content">
           <Outlet />
@@ -1350,7 +1352,7 @@ function AccountPage() {
                 <strong>Additional Workspace</strong>
                 <p>Create another isolated organization for a separate client or team.</p>
               </div>
-              <Link className="secondary" to="/workspaces/new">
+              <Link className={buttonClassName({ variant: "secondary" })} to="/workspaces/new">
                 Create another Workspace
               </Link>
             </div>
@@ -1630,15 +1632,16 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                         <p>{agent.displayName} receives messages through this dedicated identity.</p>
                       </div>
                       <div className="binding-status">
-                        <div className="binding-status-main">
-                          <span>
-                            <strong>{binding.bot.displayName}</strong>
-                            <small>
+                        <StatusIndicator
+                          detail={
+                            <>
                               <span>{titleCase(binding.provider)} · </span>
                               <span>{imBindingStateLabel(binding)}</span>
-                            </small>
-                          </span>
-                        </div>
+                            </>
+                          }
+                          label={binding.bot.displayName}
+                          tone={imBindingTone(binding)}
+                        />
                         <small>
                           {binding.lastConfirmedAt
                             ? `Confirmed ${formatDate(binding.lastConfirmedAt)}`
@@ -1649,9 +1652,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                       binding.provider === "feishu" &&
                       agent.viewerCapabilities.canManage ? (
                         <div className="im-actions">
-                          <button className="button" type="button" onClick={() => void connect("reauthorize")}>
-                            Reauthorize Feishu
-                          </button>
+                          <Button onClick={() => void connect("reauthorize")}>Reauthorize Feishu</Button>
                         </div>
                       ) : null}
                       {(binding.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
@@ -1700,13 +1701,12 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                         </div>
                         <div className="im-actions">
                           {binding.provider === "feishu" ? (
-                            <button className="secondary" type="button" onClick={() => void connect("replace")}>
+                            <Button variant="secondary" onClick={() => void connect("replace")}>
                               Replace with existing or new Feishu Bot
-                            </button>
+                            </Button>
                           ) : null}
-                          <button
-                            className="danger-text"
-                            type="button"
+                          <Button
+                            variant="danger"
                             onClick={() => {
                               if (
                                 !window.confirm(
@@ -1725,7 +1725,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                             }}
                           >
                             Disable IM binding
-                          </button>
+                          </Button>
                         </div>
                       </section>
                     ) : (
@@ -1743,9 +1743,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                     </EmptyState>
                     {agent.viewerCapabilities.canManage ? (
                       <div className="im-actions">
-                        <button className="button" type="button" onClick={() => void connect()}>
-                          Connect existing or new Feishu Bot
-                        </button>
+                        <Button onClick={() => void connect()}>Connect existing or new Feishu Bot</Button>
                       </div>
                     ) : (
                       <p className="muted">IM setup is managed by Admins.</p>
@@ -1778,6 +1776,17 @@ function imBindingStateLabel(binding: ImBindingSummary): string {
     error: "Needs attention",
     disabled: "Disabled",
   }[binding.bindingState];
+}
+
+function imBindingTone(binding: ImBindingSummary): StatusTone {
+  const tones: Record<ImBindingSummary["bindingState"], StatusTone> = {
+    active: "success",
+    provisioning: "info",
+    reauthorization_required: "warning",
+    error: "danger",
+    disabled: "neutral",
+  };
+  return tones[binding.bindingState];
 }
 
 function AccessTab({ agent }: { agent: AgentDetailView }) {
@@ -1857,7 +1866,7 @@ function CapabilityUnavailable({
       </ul>
       {action ? (
         <Link className="settings-state-action" to={action.to}>
-          {action.label} <span aria-hidden="true">→</span>
+          {action.label} <Icon name="arrow-right" />
         </Link>
       ) : null}
     </section>
@@ -1909,20 +1918,34 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
             <strong>Email</strong>
             <p>Your sign-in email cannot be changed here.</p>
           </div>
-          <div className="settings-readonly-value">
-            <input aria-label="Email" name="email" readOnly type="email" value={user.email} />
-            <small>Read only</small>
-          </div>
+          <Field
+            className="settings-profile-field"
+            hint="Read only"
+            hintId="account-email-hint"
+            htmlFor="account-email"
+            label="Email"
+          >
+            <input
+              aria-describedby="account-email-hint"
+              className="ds-control"
+              id="account-email"
+              name="email"
+              readOnly
+              type="email"
+              value={user.email}
+            />
+          </Field>
         </div>
         <div className="settings-field-row">
           <div className="settings-field-copy">
             <strong>Display name</strong>
             <p>This identity is used throughout OpenTag.</p>
           </div>
-          <label>
-            Display name
+          <Field className="settings-profile-field" htmlFor="account-display-name" label="Display name">
             <input
               autoComplete="name"
+              className="ds-control"
+              id="account-display-name"
               maxLength={255}
               name="displayName"
               onChange={(event) => {
@@ -1933,17 +1956,16 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
               required
               value={displayName}
             />
-          </label>
+          </Field>
         </div>
       </div>
       {dirty ? (
         <div className="dirty-bar">
           <span>Unsaved changes</span>
           <div className="dirty-actions">
-            <button
-              className="tertiary"
+            <Button
               disabled={saving}
-              type="button"
+              variant="tertiary"
               onClick={() => {
                 setDisplayName(user.displayName);
                 setMessage(undefined);
@@ -1951,10 +1973,10 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
               }}
             >
               Discard
-            </button>
-            <button className="button commit" disabled={saving} type="submit">
+            </Button>
+            <Button disabled={saving} type="submit" variant="commit">
               {saving ? "Saving…" : "Save account profile"}
-            </button>
+            </Button>
           </div>
         </div>
       ) : null}
@@ -2028,9 +2050,10 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
             <strong>Workspace name</strong>
             <p>What people see in navigation and invitations.</p>
           </div>
-          <label>
-            Workspace name
+          <Field className="settings-profile-field" htmlFor="workspace-profile-name" label="Workspace name">
             <input
+              className="ds-control"
+              id="workspace-profile-name"
               name="displayName"
               required
               value={teamDisplayName}
@@ -2040,7 +2063,7 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
                 setError(undefined);
               }}
             />
-          </label>
+          </Field>
         </div>
         <div className="settings-field-row">
           <div className="settings-field-copy">
@@ -2069,10 +2092,9 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
         <div className="dirty-bar">
           <span>Unsaved changes</span>
           <div className="dirty-actions">
-            <button
-              className="tertiary"
+            <Button
               disabled={saving}
-              type="button"
+              variant="tertiary"
               onClick={() => {
                 setTeamDisplayName(membership.teamDisplayName);
                 setMessage(undefined);
@@ -2080,10 +2102,10 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
               }}
             >
               Discard
-            </button>
-            <button className="button commit" disabled={saving} type="submit">
+            </Button>
+            <Button disabled={saving} type="submit" variant="commit">
               {saving ? "Saving…" : "Save Workspace profile"}
-            </button>
+            </Button>
           </div>
         </div>
       ) : null}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -17,6 +17,7 @@ import {
   type FormEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
+  type RefObject,
   useCallback,
   useContext,
   useEffect,
@@ -371,11 +372,12 @@ export function AppRouter() {
           <Route path="/resources" element={<Navigate replace to="/skills" />} />
           <Route path="/usage" element={<UsagePage />} />
           <Route path="/members" element={<MembersPage />} />
-          <Route path="/account" element={<AccountPage section="profile" />} />
-          <Route path="/account/workspace" element={<AccountPage section="workspace" />} />
+          <Route path="/account" element={<AccountPage />} />
+          <Route path="/workspace" element={<WorkspacePage />} />
+          <Route path="/account/workspace" element={<Navigate replace to="/workspace" />} />
           <Route path="/settings" element={<Navigate replace to="/members" />} />
           <Route path="/settings/account" element={<Navigate replace to="/account" />} />
-          <Route path="/settings/team" element={<Navigate replace to="/account/workspace" />} />
+          <Route path="/settings/team" element={<Navigate replace to="/workspace" />} />
           <Route path="/settings/members" element={<Navigate replace to="/members" />} />
           <Route path="/settings/access" element={<Navigate replace to="/members" />} />
           <Route path="/settings/security" element={<Navigate replace to="/members" />} />
@@ -805,7 +807,18 @@ function AppShell() {
                   })}
                 </fieldset>
                 <div className="account-menu-actions">
-                  <Link
+                  <NavLink
+                    role="menuitem"
+                    to="/workspace"
+                    onClick={() => {
+                      setOpenMenu(undefined);
+                      setNavigationOpen(false);
+                    }}
+                  >
+                    Workspace settings
+                  </NavLink>
+                  <NavLink
+                    end
                     role="menuitem"
                     to="/account"
                     onClick={() => {
@@ -813,19 +826,15 @@ function AppShell() {
                       setNavigationOpen(false);
                     }}
                   >
-                    Profile
-                  </Link>
-                  <Link
+                    Account settings
+                  </NavLink>
+                  <button
+                    className="account-signout"
+                    disabled={loggingOut}
                     role="menuitem"
-                    to="/account/workspace"
-                    onClick={() => {
-                      setOpenMenu(undefined);
-                      setNavigationOpen(false);
-                    }}
+                    type="button"
+                    onClick={() => void logout()}
                   >
-                    Workspace
-                  </Link>
-                  <button disabled={loggingOut} role="menuitem" type="button" onClick={() => void logout()}>
                     {loggingOut ? "Signing out…" : "Sign out"}
                   </button>
                 </div>
@@ -923,41 +932,79 @@ function AgentsPage() {
   });
   return (
     <>
-      <Page
-        title="Agents"
-        description="Shared AI teammates configured for your team."
-        action={
-          membership.role === "admin" ? (
-            <Button ref={createTriggerRef} onClick={() => setCreateOpen(true)}>
-              New Agent
-            </Button>
-          ) : undefined
-        }
-      >
-        <AsyncState state={state}>{(value) => <AgentsContent agents={value.agents} />}</AsyncState>
+      <Page title="Agents" description="Shared AI teammates configured for your team.">
+        <AsyncState state={state}>
+          {(value) => (
+            <AgentsContent
+              agents={value.agents}
+              canCreate={membership.role === "admin"}
+              createTriggerRef={createTriggerRef}
+              onCreate={() => setCreateOpen(true)}
+            />
+          )}
+        </AsyncState>
       </Page>
       {createOpen ? <NewAgentDialog returnFocusRef={createTriggerRef} onClose={() => setCreateOpen(false)} /> : null}
     </>
   );
 }
 
-function AgentsContent({ agents }: { agents: AgentListItem[] }) {
-  return agents.length === 0 ? (
+function AgentsContent({
+  agents,
+  canCreate,
+  createTriggerRef,
+  onCreate,
+}: {
+  agents: AgentListItem[];
+  canCreate: boolean;
+  createTriggerRef: RefObject<HTMLButtonElement | null>;
+  onCreate: () => void;
+}) {
+  return agents.length === 0 && !canCreate ? (
     <EmptyState title="No Agents yet">An Admin can create the first Agent.</EmptyState>
   ) : (
-    <AgentList agents={agents} />
+    <AgentList agents={agents} canCreate={canCreate} createTriggerRef={createTriggerRef} onCreate={onCreate} />
   );
 }
 
-function AgentList({ agents }: { agents: AgentListItem[] }) {
+function AgentList({
+  agents,
+  canCreate,
+  createTriggerRef,
+  onCreate,
+}: {
+  agents: AgentListItem[];
+  canCreate: boolean;
+  createTriggerRef: RefObject<HTMLButtonElement | null>;
+  onCreate: () => void;
+}) {
   return (
     <section className="agent-list-section" aria-label="Agents">
       <div className="agent-card-grid">
+        {canCreate ? <NewAgentCard onClick={onCreate} triggerRef={createTriggerRef} /> : null}
         {agents.map((agent) => (
           <AgentCard agent={agent} key={agent.id} />
         ))}
       </div>
     </section>
+  );
+}
+
+function NewAgentCard({
+  onClick,
+  triggerRef,
+}: {
+  onClick: () => void;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+}) {
+  return (
+    <button aria-label="New Agent" className="agent-create-card" onClick={onClick} ref={triggerRef} type="button">
+      <span className="agent-create-card-icon" aria-hidden="true">
+        <Icon name="plus" />
+      </span>
+      <strong>New Agent</strong>
+      <small>Create a shared AI teammate.</small>
+    </button>
   );
 }
 
@@ -1371,27 +1418,24 @@ function AgentDetailPage() {
   );
 }
 
-function AccountPage({ section }: { section: "profile" | "workspace" }) {
-  const { me, membership, refreshMe } = useTeam();
+function AccountPage() {
+  const { me, refreshMe } = useTeam();
   const location = useLocation();
-  if (section === "profile" && location.hash === "#workspace-management") {
-    return <Navigate replace to="/account/workspace" />;
+  if (location.hash === "#workspace-management") {
+    return <Navigate replace to="/workspace" />;
   }
   return (
-    <Page title="Account" description="Manage your profile and Workspace settings.">
-      <Tabs className="account-tabs" label="Account settings">
-        <NavLink end to="/account">
-          Profile
-        </NavLink>
-        <NavLink to="/account/workspace">Workspace</NavLink>
-      </Tabs>
-      <div className="account-settings-content">
-        {section === "profile" ? (
-          <AccountSettings refreshMe={refreshMe} user={me.user} />
-        ) : (
-          <WorkspaceSettings membership={membership} refreshMe={refreshMe} />
-        )}
-      </div>
+    <Page title="Account" description="Manage your personal account details.">
+      <AccountSettings refreshMe={refreshMe} user={me.user} />
+    </Page>
+  );
+}
+
+function WorkspacePage() {
+  const { membership, refreshMe } = useTeam();
+  return (
+    <Page title="Workspace" description="Manage the current Workspace and create additional Workspaces.">
+      <WorkspaceSettings membership={membership} refreshMe={refreshMe} />
     </Page>
   );
 }
@@ -2252,12 +2296,12 @@ function MembersSettings({
                           >
                             {MembershipRoleSchema.options.map((role) => (
                               <option value={role} key={role}>
-                                {role}
+                                {titleCase(role)}
                               </option>
                             ))}
                           </select>
                         ) : (
-                          <span className="settings-value-badge">{member.role}</span>
+                          <span className="settings-value-badge">{titleCase(member.role)}</span>
                         )}
                       </td>
                     </tr>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2282,7 +2282,7 @@ function MembersSettings({
                         {canManage ? (
                           <select
                             aria-label={`Role for ${member.displayName}`}
-                            className="ds-control ds-control--compact"
+                            className="ds-control ds-control--compact ds-control--quiet"
                             disabled={pendingUserIds.has(member.userId)}
                             value={member.role}
                             onChange={(event) => void changeRole(member, event.currentTarget.value)}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1305,7 +1305,7 @@ function AgentDetailPage() {
             </select>
           </label>
           <div className="object-layout">
-            <nav className="local-nav" aria-label="Agent settings">
+            <nav className="object-tabs" aria-label="Agent settings">
               {agentSections.map((section) => (
                 <NavLink to={`/agents/${agentId}/${section.key}`} key={section.key}>
                   {section.label}
@@ -1531,9 +1531,7 @@ function GeneralConfigForm({
           required
         />
       </Field>
-      <Button variant="commit" type="submit">
-        Save General settings
-      </Button>
+      <Button type="submit">Save General settings</Button>
       <div className="actions">
         {config.status === "active" ? (
           <Button variant="secondary" onClick={() => void changeLifecycle("suspend")}>
@@ -1965,7 +1963,7 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
           <div className="dirty-actions">
             <Button
               disabled={saving}
-              variant="tertiary"
+              variant="ghost"
               onClick={() => {
                 setDisplayName(user.displayName);
                 setMessage(undefined);
@@ -1974,7 +1972,7 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
             >
               Discard
             </Button>
-            <Button disabled={saving} type="submit" variant="commit">
+            <Button disabled={saving} type="submit">
               {saving ? "Saving…" : "Save account profile"}
             </Button>
           </div>
@@ -2094,7 +2092,7 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
           <div className="dirty-actions">
             <Button
               disabled={saving}
-              variant="tertiary"
+              variant="ghost"
               onClick={() => {
                 setTeamDisplayName(membership.teamDisplayName);
                 setMessage(undefined);
@@ -2103,7 +2101,7 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
             >
               Discard
             </Button>
-            <Button disabled={saving} type="submit" variant="commit">
+            <Button disabled={saving} type="submit">
               {saving ? "Saving…" : "Save Workspace profile"}
             </Button>
           </div>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -67,7 +67,11 @@ type AgentAvailability = {
   };
 };
 
-type AgentListItem = AgentSummary & { evidenceConfirmed: boolean };
+type AgentListItem = AgentSummary & {
+  evidenceConfirmed: boolean;
+  computerConnectionStatus: TeamComputerSummary["connectionStatus"] | null;
+  computerEvidenceConfirmed: boolean;
+};
 type AgentDetailView = AgentDetail & { availability: AgentAvailability };
 
 function projectAgentAvailability(
@@ -153,8 +157,23 @@ function projectAgentAvailability(
 }
 
 async function loadAgentList(teamId: string): Promise<{ agents: AgentListItem[] }> {
-  const { agents } = await browserApi.agents(teamId);
-  return { agents: agents.map((agent) => ({ ...agent, evidenceConfirmed: true })) };
+  const [{ agents }, computersResult] = await Promise.all([
+    browserApi.agents(teamId),
+    browserApi.computers(teamId).then(
+      (value) => ({ kind: "ready" as const, value }),
+      () => ({ kind: "unconfirmed" as const }),
+    ),
+  ]);
+  const computers = computersResult.kind === "ready" ? computersResult.value.computers : [];
+  return {
+    agents: agents.map((agent) => ({
+      ...agent,
+      evidenceConfirmed: true,
+      computerConnectionStatus:
+        computers.find((computer) => computer.id === agent.computer.id)?.connectionStatus ?? null,
+      computerEvidenceConfirmed: computersResult.kind === "ready",
+    })),
+  };
 }
 
 async function loadAgentDetail(agentId: string): Promise<AgentDetailView> {
@@ -181,7 +200,14 @@ async function loadAgentDetail(agentId: string): Promise<AgentDetailView> {
 }
 
 function markAgentListUnconfirmed(value: { agents: AgentListItem[] }): { agents: AgentListItem[] } {
-  return { agents: value.agents.map((agent) => ({ ...agent, evidenceConfirmed: false })) };
+  return {
+    agents: value.agents.map((agent) => ({
+      ...agent,
+      evidenceConfirmed: false,
+      computerConnectionStatus: null,
+      computerEvidenceConfirmed: false,
+    })),
+  };
 }
 
 function markAgentDetailUnconfirmed(agent: AgentDetailView): AgentDetailView {
@@ -341,7 +367,7 @@ export function AppRouter() {
           <Route path="/settings/members" element={<Navigate replace to="/members" />} />
           <Route path="/settings/access" element={<Navigate replace to="/members" />} />
           <Route path="/settings/security" element={<Navigate replace to="/members" />} />
-          <Route path="/settings/computers" element={<Navigate replace to="/agents#agent-runtime" />} />
+          <Route path="/settings/computers" element={<Navigate replace to="/agents/new" />} />
           <Route path="/settings/resources" element={<Navigate replace to="/skills" />} />
           <Route path="/settings/integrations" element={<Navigate replace to="/integrations" />} />
           <Route path="/settings/usage" element={<Navigate replace to="/usage" />} />
@@ -892,16 +918,6 @@ function AgentsPage() {
         }
       >
         <AsyncState state={state}>{(value) => <AgentsContent agents={value.agents} />}</AsyncState>
-        <section className="agent-runtime-section" id="agent-runtime">
-          <header className="settings-subheader">
-            <div>
-              <span className="eyebrow">Infrastructure</span>
-              <h2>Agent runtime</h2>
-              <p>Connect and inspect the computers available to run Agents.</p>
-            </div>
-          </header>
-          <ComputersSettings canManage={membership.role === "admin"} teamId={membership.teamId} />
-        </section>
       </Page>
       {createOpen ? <NewAgentDialog returnFocusRef={createTriggerRef} onClose={() => setCreateOpen(false)} /> : null}
     </>
@@ -919,60 +935,71 @@ function AgentsContent({ agents }: { agents: AgentListItem[] }) {
 function AgentList({ agents }: { agents: AgentListItem[] }) {
   return (
     <section className="agent-list-section" aria-label="Agents">
-      <div className="agent-summary-strip">
-        <span>
-          <strong>{agents.length}</strong> Agents
-        </span>
-      </div>
-      <div className="agent-table">
-        <div className="agent-table-header" aria-hidden="true">
-          <span>Agent</span>
-          <span>State</span>
-          <span />
-        </div>
-        <div className="agent-table-body">
-          {agents.map((agent) => (
-            <AgentRow agent={agent} key={agent.id} />
-          ))}
-        </div>
+      <div className="agent-card-grid">
+        {agents.map((agent) => (
+          <AgentCard agent={agent} key={agent.id} />
+        ))}
       </div>
     </section>
   );
 }
 
-function AgentRow({ agent }: { agent: AgentListItem }) {
+function AgentCard({ agent }: { agent: AgentListItem }) {
   const status =
     agent.status === "suspended"
       ? { label: "Suspended", reason: "Not receiving new work", tone: "neutral" as const }
-      : agent.evidenceConfirmed
-        ? { label: "Active", reason: undefined, tone: "success" as const }
-        : { label: "Unconfirmed", reason: "Unable to refresh Agent", tone: "neutral" as const };
+      : !agent.evidenceConfirmed
+        ? { label: "Unconfirmed", reason: "Unable to refresh Agent", tone: "neutral" as const }
+        : !agent.computerEvidenceConfirmed || agent.computerConnectionStatus === null
+          ? { label: "Unconfirmed", reason: "Unable to confirm runtime", tone: "neutral" as const }
+          : agent.computerConnectionStatus === "online"
+            ? { label: "Active", reason: "Computer online", tone: "success" as const }
+            : { label: "Action required", reason: "Computer offline", tone: "warning" as const };
   return (
-    <div className="agent-row">
-      <Link aria-label={`Open ${agent.displayName}`} className="agent-row-link" to={`/agents/${agent.id}/general`} />
-      <span className="agent-identity">
-        <span className="agent-avatar" aria-hidden="true">
-          {initials(agent.displayName)}
+    <Link aria-label={`Open ${agent.displayName}`} className="agent-card" to={`/agents/${agent.id}/general`}>
+      <article>
+        <header className="agent-card-header">
+          <span className="agent-identity">
+            <span className="agent-avatar" aria-hidden="true">
+              {initials(agent.displayName)}
+            </span>
+            <span>
+              <strong>{agent.displayName}</strong>
+              <small>@{agent.name}</small>
+            </span>
+          </span>
+          <StatusIndicator detail={status.reason} label={status.label} tone={status.tone} />
+        </header>
+        <dl className="agent-card-facts">
+          <div>
+            <dt>Runtime</dt>
+            <dd>{providerLabel(agent.runtimeProvider)}</dd>
+          </div>
+          <div>
+            <dt>Computer</dt>
+            <dd>
+              {agent.computer.displayName} · {platformLabel(agent.computer.platform)}
+            </dd>
+          </div>
+          <div>
+            <dt>Manager</dt>
+            <dd>{agent.manager.displayName}</dd>
+          </div>
+          <div>
+            <dt>Messaging</dt>
+            <dd>{receiveModeLabel(agent.receiveMode)}</dd>
+          </div>
+        </dl>
+        <span className="agent-card-action" aria-hidden="true">
+          View Agent <Icon name="chevron-right" />
         </span>
-        <span>
-          <strong>{agent.displayName}</strong>
-          <small>
-            @{agent.name} · {providerLabel(agent.runtimeProvider)}
-          </small>
-        </span>
-      </span>
-      <span className="cell-stack availability-cell" data-label="State">
-        <StatusIndicator detail={status.reason} label={status.label} tone={status.tone} />
-      </span>
-      <span className="agent-row-action" aria-hidden="true">
-        <Icon name="chevron-right" />
-      </span>
-    </div>
+      </article>
+    </Link>
   );
 }
 
-function useOwnComputersResource(teamId: string) {
-  return useResource(() => browserApi.ownComputers(), teamId, {
+function useOwnComputersResource(teamId: string, refreshVersion = 0) {
+  return useResource(() => browserApi.ownComputers(), `${teamId}:${refreshVersion}`, {
     onBackgroundError: markOwnComputersUnconfirmed,
     revalidateMs: 30_000,
     refreshOnFocus: true,
@@ -982,13 +1009,15 @@ function useOwnComputersResource(teamId: string) {
 function NewAgentPage() {
   const { membership } = useTeam();
   const navigate = useNavigate();
-  const computers = useOwnComputersResource(membership.teamId);
+  const [computerRefreshVersion, setComputerRefreshVersion] = useState(0);
+  const computers = useOwnComputersResource(membership.teamId, computerRefreshVersion);
   if (membership.role !== "admin") return <UnavailablePage title="Admin access required" />;
   return (
     <Page title="Create Agent" description="Create the identity first. Complete its setup from the Agent overview.">
       <AgentCreationContent
         computers={computers}
         teamId={membership.teamId}
+        onComputerConnected={() => setComputerRefreshVersion((current) => current + 1)}
         onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
       />
     </Page>
@@ -1004,7 +1033,8 @@ function NewAgentDialog({
 }) {
   const { membership } = useTeam();
   const navigate = useNavigate();
-  const computers = useOwnComputersResource(membership.teamId);
+  const [computerRefreshVersion, setComputerRefreshVersion] = useState(0);
+  const computers = useOwnComputersResource(membership.teamId, computerRefreshVersion);
   const [submitting, setSubmitting] = useState(false);
 
   return (
@@ -1013,7 +1043,6 @@ function NewAgentDialog({
       className="new-agent-dialog"
       closeLabel="Close new Agent dialog"
       description="Give the Agent an identity and choose where it runs. You can finish its setup from the overview."
-      eyebrow="Create"
       returnFocusRef={returnFocusRef}
       title="New Agent"
       onClose={onClose}
@@ -1023,6 +1052,7 @@ function NewAgentDialog({
         presentation="dialog"
         teamId={membership.teamId}
         onCancel={onClose}
+        onComputerConnected={() => setComputerRefreshVersion((current) => current + 1)}
         onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
         onSubmittingChange={setSubmitting}
       />
@@ -1033,6 +1063,7 @@ function NewAgentDialog({
 function AgentCreationContent({
   computers,
   onCancel,
+  onComputerConnected,
   onCreated,
   onSubmittingChange,
   presentation = "page",
@@ -1040,6 +1071,7 @@ function AgentCreationContent({
 }: {
   computers: LoadState<{ computers: Computer[] }>;
   onCancel?: () => void;
+  onComputerConnected: () => void;
   onCreated: (agentId: string) => void;
   onSubmittingChange?: (submitting: boolean) => void;
   presentation?: "dialog" | "page";
@@ -1111,13 +1143,9 @@ function AgentCreationContent({
         const selectedComputerId = computer?.id ?? "";
         const readiness = computer?.providerReadiness?.find((entry) => entry.provider === runtimeProvider);
         return value.computers.length === 0 ? (
-          <EmptyState title="Connect a Local Computer first">
-            Open the{" "}
-            <Link to="/agents#agent-runtime" onClick={onCancel}>
-              Agent runtime
-            </Link>{" "}
-            section to generate a connection command.
-          </EmptyState>
+          <div className="agent-create-runtime-setup">
+            <ComputerSetup teamId={teamId} onConnected={onComputerConnected} />
+          </div>
         ) : (
           <form className="form-card agent-create-form" onSubmit={submit}>
             <Field
@@ -1562,8 +1590,17 @@ function RuntimeTab({ agent }: { agent: AgentDetailView }) {
         <>
           <DefinitionList
             rows={[
-              ["Provider", agent.runtimeProvider],
+              ["Provider", providerLabel(agent.runtimeProvider)],
               ["Computer", agent.computer.displayName],
+              ["System", platformLabel(agent.computer.platform)],
+              [
+                "Connection",
+                agent.availability.dependencies.computer.state === "ready"
+                  ? "Online"
+                  : agent.availability.dependencies.computer.state === "action_required"
+                    ? "Offline"
+                    : "Unable to confirm",
+              ],
             ]}
           />
           {config ? (
@@ -2318,7 +2355,7 @@ function InvitationSettings({
               </div>
             </>
           ) : (
-            <div className="actions">
+            <div className="actions settings-invitation-create">
               <Button disabled={busy} onClick={() => void createInvitation()}>
                 {busy ? "Creating…" : "Create invite link"}
               </Button>
@@ -2333,82 +2370,6 @@ function InvitationSettings({
         </p>
       ) : null}
     </section>
-  );
-}
-
-function ComputersSettings({ canManage, teamId }: { canManage: boolean; teamId: string }) {
-  const [reload, setReload] = useState(0);
-  const state = useResource(() => browserApi.computers(teamId), `${teamId}:${reload}`);
-  return (
-    <>
-      {canManage ? <ComputerSetup teamId={teamId} onConnected={() => setReload((current) => current + 1)} /> : null}
-      <AsyncState state={state}>
-        {(value) => (
-          <section className="settings-list-section">
-            <header className="settings-subheader">
-              <div>
-                <h2>Computers</h2>
-                <p>
-                  {value.computers.length} {value.computers.length === 1 ? "computer" : "computers"} ·{" "}
-                  {
-                    value.computers.filter((computer: TeamComputerSummary) => computer.connectionStatus === "online")
-                      .length
-                  }{" "}
-                  online
-                </p>
-              </div>
-              {!canManage ? <span className="settings-role-badge">Read only</span> : null}
-            </header>
-            {value.computers.length === 0 ? (
-              <div className="settings-compact-empty">
-                <strong>No computers connected</strong>
-                <p>{canManage ? "Use the connection flow above to add one." : "An Admin must connect a computer."}</p>
-              </div>
-            ) : (
-              <table className="settings-computer-table" aria-label="Computers">
-                <thead>
-                  <tr className="settings-table-header">
-                    <th scope="col">Computer</th>
-                    <th scope="col">Owner &amp; system</th>
-                    <th scope="col">Status</th>
-                    <th scope="col">Last seen</th>
-                    <th scope="col">Agents</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {value.computers.map((computer: TeamComputerSummary) => (
-                    <tr className="settings-computer-row" key={computer.id}>
-                      <th className="settings-computer-identity" scope="row">
-                        <span className="settings-computer-icon" aria-hidden="true" />
-                        <strong>{computer.displayName}</strong>
-                      </th>
-                      <td data-label="Owner & system">
-                        <strong>{computer.ownerDisplayName}</strong>
-                        <small>
-                          {computer.platform === "darwin"
-                            ? "macOS"
-                            : computer.platform === "win32"
-                              ? "Windows"
-                              : "Linux"}
-                        </small>
-                      </td>
-                      <td data-label="Status">
-                        <StatusIndicator
-                          label={titleCase(computer.connectionStatus)}
-                          tone={computer.connectionStatus === "online" ? "success" : "neutral"}
-                        />
-                      </td>
-                      <td data-label="Last seen">{formatDate(computer.lastSeenAt)}</td>
-                      <td data-label="Agents">{computer.agentIds.length}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-          </section>
-        )}
-      </AsyncState>
-    </>
   );
 }
 
@@ -2501,6 +2462,12 @@ function titleCase(value: string) {
 
 function providerLabel(provider: AgentSummary["runtimeProvider"]): string {
   return provider === "claude-code" ? "Claude Code" : "Codex";
+}
+
+function platformLabel(platform: AgentSummary["computer"]["platform"]): string {
+  if (platform === "darwin") return "macOS";
+  if (platform === "win32") return "Windows";
+  return "Linux";
 }
 
 function receiveModeLabel(receiveMode: AgentSummary["receiveMode"]): string {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -360,10 +360,11 @@ export function AppRouter() {
           <Route path="/resources" element={<Navigate replace to="/skills" />} />
           <Route path="/usage" element={<UsagePage />} />
           <Route path="/members" element={<MembersPage />} />
-          <Route path="/account" element={<AccountPage />} />
+          <Route path="/account" element={<AccountPage section="profile" />} />
+          <Route path="/account/workspace" element={<AccountPage section="workspace" />} />
           <Route path="/settings" element={<Navigate replace to="/members" />} />
           <Route path="/settings/account" element={<Navigate replace to="/account" />} />
-          <Route path="/settings/team" element={<Navigate replace to="/account#workspace-management" />} />
+          <Route path="/settings/team" element={<Navigate replace to="/account/workspace" />} />
           <Route path="/settings/members" element={<Navigate replace to="/members" />} />
           <Route path="/settings/access" element={<Navigate replace to="/members" />} />
           <Route path="/settings/security" element={<Navigate replace to="/members" />} />
@@ -747,56 +748,51 @@ function AppShell() {
                 role="menu"
                 onKeyDown={handleAccountMenuKeyDown}
               >
-                {me.memberships.length > 1 ? (
-                  <fieldset className="account-workspace-group">
-                    <legend className="menu-label">Switch Workspace</legend>
-                    {me.memberships.map((item: MeMembership) => {
-                      const current = item.teamId === membership.teamId;
-                      return (
-                        <button
-                          aria-current={current ? "true" : undefined}
-                          className="account-workspace-option"
-                          key={item.teamId}
-                          role="menuitem"
-                          type="button"
-                          onClick={() => {
-                            setOpenMenu(undefined);
-                            setNavigationOpen(false);
-                            if (!current) {
-                              navigate("/agents");
-                              selectTeam(item.teamId);
-                            }
-                          }}
-                        >
-                          <span className="team-avatar" aria-hidden="true">
-                            {initials(item.teamDisplayName)}
+                <fieldset className="account-workspace-group">
+                  <legend className="menu-label">Workspaces</legend>
+                  {me.memberships.map((item: MeMembership) => {
+                    const current = item.teamId === membership.teamId;
+                    const content = (
+                      <>
+                        <span className="team-avatar" aria-hidden="true">
+                          {initials(item.teamDisplayName)}
+                        </span>
+                        <span className="team-option-copy">
+                          <strong>{item.teamDisplayName}</strong>
+                          <small>{titleCase(item.role)}</small>
+                        </span>
+                        {current ? (
+                          <span className="team-option-check" aria-hidden="true">
+                            <Icon name="check" />
                           </span>
-                          <span className="team-option-copy">
-                            <strong>{item.teamDisplayName}</strong>
-                            <small>{titleCase(item.role)}</small>
-                          </span>
-                          {current ? (
-                            <span className="team-option-check" aria-hidden="true">
-                              <Icon name="check" />
-                            </span>
-                          ) : null}
-                        </button>
-                      );
-                    })}
-                    <Link
-                      className="account-workspace-manage"
-                      role="menuitem"
-                      to="/account#workspace-management"
-                      onClick={() => {
-                        setOpenMenu(undefined);
-                        setNavigationOpen(false);
-                      }}
-                    >
-                      <span>Manage Workspaces</span>
-                      <Icon name="chevron-right" />
-                    </Link>
-                  </fieldset>
-                ) : null}
+                        ) : null}
+                      </>
+                    );
+                    return me.memberships.length > 1 ? (
+                      <button
+                        aria-current={current ? "true" : undefined}
+                        className="account-workspace-option"
+                        key={item.teamId}
+                        role="menuitem"
+                        type="button"
+                        onClick={() => {
+                          setOpenMenu(undefined);
+                          setNavigationOpen(false);
+                          if (!current) {
+                            navigate("/agents");
+                            selectTeam(item.teamId);
+                          }
+                        }}
+                      >
+                        {content}
+                      </button>
+                    ) : (
+                      <div aria-current="true" className="account-workspace-option is-static" key={item.teamId}>
+                        {content}
+                      </div>
+                    );
+                  })}
+                </fieldset>
                 <div className="account-menu-actions">
                   <Link
                     role="menuitem"
@@ -806,7 +802,17 @@ function AppShell() {
                       setNavigationOpen(false);
                     }}
                   >
-                    Account settings
+                    Profile
+                  </Link>
+                  <Link
+                    role="menuitem"
+                    to="/account/workspace"
+                    onClick={() => {
+                      setOpenMenu(undefined);
+                      setNavigationOpen(false);
+                    }}
+                  >
+                    Workspace
                   </Link>
                   <button disabled={loggingOut} role="menuitem" type="button" onClick={() => void logout()}>
                     {loggingOut ? "Signing out…" : "Sign out"}
@@ -1354,40 +1360,56 @@ function AgentDetailPage() {
   );
 }
 
-function AccountPage() {
+function AccountPage({ section }: { section: "profile" | "workspace" }) {
   const { me, membership, refreshMe } = useTeam();
   const location = useLocation();
+  if (section === "profile" && location.hash === "#workspace-management") {
+    return <Navigate replace to="/account/workspace" />;
+  }
   return (
-    <Page title="Account" description="Manage your profile and advanced account options.">
-      <div className="account-settings-stack">
-        <AccountSettings refreshMe={refreshMe} user={me.user} />
-        <details
-          className="account-advanced"
-          id="workspace-management"
-          open={location.hash === "#workspace-management"}
-        >
-          <summary>Advanced</summary>
-          <div className="account-advanced-content">
-            <header className="settings-subheader">
-              <div>
-                <h2>Workspace management</h2>
-                <p>For people who operate more than one organization.</p>
-              </div>
-            </header>
-            <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
-            <div className="account-workspace-create">
-              <div>
-                <strong>Additional Workspace</strong>
-                <p>Create another isolated organization for a separate client or team.</p>
-              </div>
-              <Link className={buttonClassName({ variant: "secondary" })} to="/workspaces/new">
-                Create another Workspace
-              </Link>
-            </div>
-          </div>
-        </details>
+    <Page title="Account" description="Manage your profile and Workspace settings.">
+      <nav aria-label="Account settings" className="object-tabs account-tabs">
+        <NavLink end to="/account">
+          Profile
+        </NavLink>
+        <NavLink to="/account/workspace">Workspace</NavLink>
+      </nav>
+      <div className="account-settings-content">
+        {section === "profile" ? (
+          <AccountSettings refreshMe={refreshMe} user={me.user} />
+        ) : (
+          <WorkspaceSettings membership={membership} refreshMe={refreshMe} />
+        )}
       </div>
     </Page>
+  );
+}
+
+function WorkspaceSettings({ membership, refreshMe }: { membership: MeMembership; refreshMe: () => void }) {
+  return (
+    <div className="account-workspace-stack">
+      <section aria-labelledby="workspace-profile-heading" className="account-workspace-profile">
+        <header className="settings-subheader">
+          <div>
+            <h2 id="workspace-profile-heading">Workspace profile</h2>
+            <p>Manage the name and CLI identity of the current Workspace.</p>
+          </div>
+          {membership.role !== "admin" ? (
+            <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
+          ) : null}
+        </header>
+        <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
+      </section>
+      <section aria-labelledby="additional-workspace-heading" className="account-workspace-create">
+        <div>
+          <h2 id="additional-workspace-heading">Additional Workspace</h2>
+          <p>Create an isolated Workspace for another client or team.</p>
+        </div>
+        <Link className={buttonClassName({ variant: "secondary" })} to="/workspaces/new">
+          Create Workspace
+        </Link>
+      </section>
+    </div>
   );
 }
 
@@ -2042,21 +2064,14 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
 
   if (membership.role !== "admin") {
     return (
-      <section className="settings-readonly-panel">
-        <div className="settings-readonly-heading">
-          <div>
-            <h2>Workspace profile</h2>
-            <p>Only Workspace Admins can change these fields.</p>
-          </div>
-          <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
-        </div>
+      <div className="settings-readonly-panel">
         <DefinitionList
           rows={[
             ["Workspace name", membership.teamDisplayName],
             ["CLI identifier", membership.teamName],
           ]}
         />
-      </section>
+      </div>
     );
   }
   async function submit(event: FormEvent<HTMLFormElement>) {
@@ -2077,8 +2092,7 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
     }
   }
   return (
-    <form className="settings-profile-form" onSubmit={submit}>
-      <h2 className="visually-hidden">Workspace profile fields</h2>
+    <form aria-labelledby="workspace-profile-heading" className="settings-profile-form" onSubmit={submit}>
       <div className="settings-field-list">
         <div className="settings-field-row">
           <div className="settings-field-copy">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -33,7 +33,18 @@ import { UsagePage } from "./features/usage-page.js";
 import { FeishuSetup } from "./im/feishu-setup.js";
 import { OnboardingPage } from "./onboarding/page.js";
 import { RuntimeConfigurationForm } from "./runtime-configuration.js";
-import { Button, buttonClassName, Dialog, Field, Icon, StatusIndicator, type StatusTone } from "./ui/design-system.js";
+import {
+  Button,
+  buttonClassName,
+  Dialog,
+  Field,
+  Icon,
+  SettingsList,
+  SettingsRow,
+  StatusIndicator,
+  type StatusTone,
+  Tabs,
+} from "./ui/design-system.js";
 
 type LoadState<T> = { kind: "loading" } | { kind: "error"; error: Error } | { kind: "ready"; value: T };
 
@@ -1339,13 +1350,13 @@ function AgentDetailPage() {
             </select>
           </label>
           <div className="object-layout">
-            <nav className="object-tabs" aria-label="Agent settings">
+            <Tabs collapseOnMobile label="Agent settings">
               {agentSections.map((section) => (
                 <NavLink to={`/agents/${agentId}/${section.key}`} key={section.key}>
                   {section.label}
                 </NavLink>
               ))}
-            </nav>
+            </Tabs>
             <div className="object-content">
               <header className="section-header">
                 <h2>{currentSection.label}</h2>
@@ -1368,12 +1379,12 @@ function AccountPage({ section }: { section: "profile" | "workspace" }) {
   }
   return (
     <Page title="Account" description="Manage your profile and Workspace settings.">
-      <nav aria-label="Account settings" className="object-tabs account-tabs">
+      <Tabs className="account-tabs" label="Account settings">
         <NavLink end to="/account">
           Profile
         </NavLink>
         <NavLink to="/account/workspace">Workspace</NavLink>
-      </nav>
+      </Tabs>
       <div className="account-settings-content">
         {section === "profile" ? (
           <AccountSettings refreshMe={refreshMe} user={me.user} />
@@ -1969,12 +1980,8 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
   return (
     <form className="settings-profile-form" onSubmit={submit}>
       <h2>Account profile</h2>
-      <div className="settings-field-list">
-        <div className="settings-field-row">
-          <div className="settings-field-copy">
-            <strong>Email</strong>
-            <p>Your sign-in email cannot be changed here.</p>
-          </div>
+      <SettingsList>
+        <SettingsRow label="Email" description="Your sign-in email cannot be changed here.">
           <Field
             className="settings-profile-field"
             hint="Read only"
@@ -1992,12 +1999,8 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
               value={user.email}
             />
           </Field>
-        </div>
-        <div className="settings-field-row">
-          <div className="settings-field-copy">
-            <strong>Display name</strong>
-            <p>This identity is used throughout OpenTag.</p>
-          </div>
+        </SettingsRow>
+        <SettingsRow label="Display name" description="This identity is used throughout OpenTag.">
           <Field className="settings-profile-field" htmlFor="account-display-name" label="Display name">
             <input
               autoComplete="name"
@@ -2014,8 +2017,8 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
               value={displayName}
             />
           </Field>
-        </div>
-      </div>
+        </SettingsRow>
+      </SettingsList>
       {dirty ? (
         <div className="dirty-bar">
           <span>Unsaved changes</span>
@@ -2093,12 +2096,8 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
   }
   return (
     <form aria-labelledby="workspace-profile-heading" className="settings-profile-form" onSubmit={submit}>
-      <div className="settings-field-list">
-        <div className="settings-field-row">
-          <div className="settings-field-copy">
-            <strong>Workspace name</strong>
-            <p>What people see in navigation and invitations.</p>
-          </div>
+      <SettingsList>
+        <SettingsRow label="Workspace name" description="What people see in navigation and invitations.">
           <Field className="settings-profile-field" htmlFor="workspace-profile-name" label="Workspace name">
             <input
               className="ds-control"
@@ -2113,12 +2112,11 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
               }}
             />
           </Field>
-        </div>
-        <div className="settings-field-row">
-          <div className="settings-field-copy">
-            <strong>CLI identifier</strong>
-            <p>Created automatically for CLI commands. It stays the same when you rename the Workspace.</p>
-          </div>
+        </SettingsRow>
+        <SettingsRow
+          label="CLI identifier"
+          description="Created automatically for CLI commands. It stays the same when you rename the Workspace."
+        >
           <dl className="settings-readonly-value">
             <div>
               <dt className="visually-hidden">CLI identifier</dt>
@@ -2135,8 +2133,8 @@ function TeamProfileSettings({ membership, refreshMe }: { membership: MeMembersh
               </dd>
             </div>
           </dl>
-        </div>
-      </div>
+        </SettingsRow>
+      </SettingsList>
       {dirty ? (
         <div className="dirty-bar">
           <span>Unsaved changes</span>

--- a/apps/web/src/runtime-configuration.test.tsx
+++ b/apps/web/src/runtime-configuration.test.tsx
@@ -71,7 +71,10 @@ describe("RuntimeConfigurationForm", () => {
     fireEvent.change(screen.getByLabelText("Reasoning effort"), { target: { value: "high" } });
     fireEvent.change(screen.getByLabelText("Maximum Turn duration"), { target: { value: "45.5" } });
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Updated instructions." } });
-    fireEvent.click(screen.getByRole("button", { name: "Save Runtime settings" }));
+    const saveButton = screen.getByRole("button", { name: "Save Runtime settings" });
+    expect(saveButton.className).toContain("ds-button--primary");
+    expect(screen.getByLabelText("Model").closest(".ds-field")).toBeTruthy();
+    fireEvent.click(saveButton);
 
     await waitFor(() => expect(save).toHaveBeenCalledOnce());
     expect(save).toHaveBeenCalledWith({

--- a/apps/web/src/runtime-configuration.tsx
+++ b/apps/web/src/runtime-configuration.tsx
@@ -6,6 +6,7 @@ import {
   type UpdateAgentRuntimeConfig,
 } from "@opentag/shared/browser";
 import { type FormEvent, useState } from "react";
+import { Button, Field } from "./ui/design-system.js";
 
 const CODEX_REASONING_EFFORT_SUGGESTIONS = ["minimal", "low", "medium", "high", "xhigh"] as const;
 
@@ -62,8 +63,12 @@ function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigura
   return (
     <form className="form-card" key={config.revision} onSubmit={submit}>
       <h2>Execution choices</h2>
-      <div className="form-field">
-        <label htmlFor={fieldId("model")}>Model</label>
+      <Field
+        hint="Enter an exact Codex model ID. Leave blank to let Codex manage the selection."
+        hintId={fieldId("model-help")}
+        htmlFor={fieldId("model")}
+        label="Model"
+      >
         <input
           aria-describedby={fieldId("model-help")}
           autoComplete="off"
@@ -72,12 +77,13 @@ function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigura
           name="model"
           placeholder="Managed by provider"
         />
-        <small className="field-help" id={fieldId("model-help")}>
-          Enter an exact Codex model ID. Leave blank to let Codex manage the selection.
-        </small>
-      </div>
-      <div className="form-field">
-        <label htmlFor={fieldId("reasoning-effort")}>Reasoning effort</label>
+      </Field>
+      <Field
+        hint="These are common Codex values, not a compatibility guarantee. The bound Computer performs the authoritative runtime check."
+        hintId={fieldId("reasoning-help")}
+        htmlFor={fieldId("reasoning-effort")}
+        label="Reasoning effort"
+      >
         <input
           aria-describedby={fieldId("reasoning-help")}
           autoComplete="off"
@@ -92,13 +98,18 @@ function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigura
             <option value={effort} key={effort} />
           ))}
         </datalist>
-        <small className="field-help" id={fieldId("reasoning-help")}>
-          These are common Codex values, not a compatibility guarantee. The bound Computer performs the authoritative
-          runtime check.
-        </small>
-      </div>
-      <div className="form-field">
-        <label htmlFor={fieldId("max-duration")}>Maximum Turn duration</label>
+      </Field>
+      <Field
+        hint={
+          <>
+            Seconds. Leave blank to use OpenTag's {formatMinutes(RUNTIME_DEFAULT_MAX_DURATION_MS)} default. A timeout
+            stops the Turn, but external effects may already have occurred.
+          </>
+        }
+        hintId={fieldId("duration-help")}
+        htmlFor={fieldId("max-duration")}
+        label="Maximum Turn duration"
+      >
         <input
           aria-describedby={fieldId("duration-help")}
           defaultValue={millisecondsToSeconds(config.runtimeConfig.maxDurationMs)}
@@ -110,23 +121,18 @@ function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigura
           step="0.001"
           type="number"
         />
-        <small className="field-help" id={fieldId("duration-help")}>
-          Seconds. Leave blank to use OpenTag's {formatMinutes(RUNTIME_DEFAULT_MAX_DURATION_MS)} default. A timeout
-          stops the Turn, but external effects may already have occurred.
-        </small>
-      </div>
-      <div className="form-field">
-        <label htmlFor={fieldId("instructions")}>Instructions</label>
+      </Field>
+      <Field htmlFor={fieldId("instructions")} label="Instructions">
         <textarea
           defaultValue={config.runtimeConfig.instructions}
           id={fieldId("instructions")}
           name="instructions"
           rows={10}
         />
-      </div>
-      <button className="button" disabled={saving} type="submit">
+      </Field>
+      <Button disabled={saving} type="submit">
         {saving ? "Saving…" : "Save Runtime settings"}
-      </button>
+      </Button>
       {message ? (
         <p
           className={message.kind === "error" ? "error" : undefined}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -78,6 +78,7 @@
   --radius: 13px;
   --sidebar-width: 232px;
   --local-nav-width: 170px;
+  --workspace-page-width: 960px;
   --layer-sidebar: 30;
   --layer-backdrop: 20;
 }
@@ -903,7 +904,11 @@ pre {
   }
 }
 
-.page,
+.page {
+  width: min(100%, var(--workspace-page-width));
+  margin: 0 auto;
+}
+
 .object-page,
 .settings-page {
   width: min(100%, 1200px);
@@ -945,7 +950,7 @@ pre {
 
 .agent-runtime-section {
   display: grid;
-  width: min(100%, 860px);
+  width: 100%;
   gap: 24px;
   margin-top: 64px;
   border-top: 1px solid var(--border);
@@ -1429,6 +1434,10 @@ dd {
   padding: 28px;
 }
 
+.page > .empty-state {
+  width: 100%;
+}
+
 .empty-state h2 {
   margin-bottom: 8px;
   font-size: var(--text-subsection);
@@ -1534,6 +1543,10 @@ code {
   align-items: center;
   gap: 12px;
   margin-top: 12px;
+}
+
+.connect-command-primary {
+  justify-self: start;
 }
 
 .connect-command-meta {
@@ -2924,6 +2937,10 @@ textarea:focus {
   gap: 18px;
 }
 
+.settings-members-section {
+  width: 100%;
+}
+
 .agent-runtime-section > .panel,
 .agent-runtime-section > .settings-list-section {
   width: 100%;
@@ -2963,6 +2980,10 @@ textarea:focus {
   border-radius: var(--radius);
   background: var(--surface-soft);
   padding: 22px;
+}
+
+.settings-members-section .settings-invitation-panel {
+  width: 100%;
 }
 
 .settings-invitation-panel:focus-visible {
@@ -3513,6 +3534,11 @@ textarea:focus {
 
   .onboarding-action .ds-button,
   .onboarding-feedback > .ds-button {
+    width: 100%;
+  }
+
+  .connect-command-primary {
+    justify-self: stretch;
     width: 100%;
   }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2909,6 +2909,7 @@ textarea:focus {
 
 .settings-members-section {
   width: 100%;
+  gap: 32px;
 }
 
 .settings-readonly-heading,
@@ -2941,20 +2942,14 @@ textarea:focus {
 .settings-invitation-panel {
   display: grid;
   width: 100%;
-  gap: 16px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  padding: 24px;
+  gap: 14px;
+  border-top: 1px solid var(--strong-border);
+  background: transparent;
+  padding: 28px 0 0;
 }
 
 .settings-members-section .settings-invitation-panel {
   width: 100%;
-}
-
-.settings-invitation-panel:focus-visible {
-  outline: 3px solid var(--brand-ink);
-  outline-offset: 3px;
 }
 
 .settings-invitation-panel h3 {
@@ -3001,13 +2996,32 @@ textarea:focus {
   justify-content: flex-end;
 }
 
+.settings-member-list {
+  display: grid;
+  gap: 12px;
+}
+
+.settings-member-summary {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.settings-member-summary p {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--text-meta);
+  font-variant-numeric: tabular-nums;
+}
+
 .settings-member-table {
   display: block;
   width: 100%;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
+  border-top: 1px solid var(--strong-border);
+  border-bottom: 1px solid var(--border);
+  background: transparent;
   border-collapse: collapse;
 }
 
@@ -3029,11 +3043,10 @@ textarea:focus {
   align-items: center;
   border-bottom: 1px solid var(--border);
   gap: 16px;
-  padding-inline: 16px;
 }
 
 .settings-table-header {
-  min-height: 40px;
+  min-height: 38px;
   color: var(--muted);
   font-size: var(--text-micro);
   font-weight: var(--fw-semibold);
@@ -3041,12 +3054,12 @@ textarea:focus {
 
 .settings-member-table .settings-table-header,
 .settings-member-row {
-  grid-template-columns: minmax(0, 1fr) 132px;
+  grid-template-columns: minmax(0, 1fr) 112px;
 }
 
 .settings-member-row {
-  min-height: 64px;
-  padding-block: 8px;
+  min-height: 56px;
+  padding-block: 7px;
 }
 
 .settings-member-row:last-child {
@@ -3079,8 +3092,8 @@ textarea:focus {
 
 .settings-member-avatar {
   display: inline-flex;
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
@@ -3092,9 +3105,7 @@ textarea:focus {
 }
 
 .settings-member-row select {
-  min-height: 36px;
-  font-size: var(--text-ui);
-  padding-block: 0.35rem;
+  width: 100%;
 }
 
 .settings-status {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1155,45 +1155,6 @@ pre {
   padding-top: 32px;
 }
 
-.object-tabs {
-  display: flex;
-  gap: 32px;
-  overflow-x: auto;
-  border-bottom: 1px solid var(--border);
-  scrollbar-width: none;
-}
-
-.object-tabs::-webkit-scrollbar {
-  display: none;
-}
-
-.object-tabs a {
-  position: relative;
-  display: inline-flex;
-  min-height: 44px;
-  align-items: center;
-  color: var(--muted);
-  font-size: var(--text-ui);
-  font-weight: var(--fw-semibold);
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.object-tabs a:hover,
-.object-tabs a.active {
-  color: var(--brand-ink);
-}
-
-.object-tabs a.active::after {
-  position: absolute;
-  right: 0;
-  bottom: -1px;
-  left: 0;
-  height: 2px;
-  background: var(--brand);
-  content: "";
-}
-
 .local-nav-select {
   display: none;
 }
@@ -2321,7 +2282,7 @@ code {
   padding-top: 32px;
 }
 
-.object-tabs + .object-content {
+.ds-tabs + .object-content {
   padding-top: 32px;
 }
 
@@ -2797,46 +2758,6 @@ textarea:focus {
   font-weight: var(--fw-semibold);
 }
 
-.settings-field-list {
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-}
-
-.settings-field-row {
-  display: grid;
-  align-items: start;
-  border-bottom: 1px solid var(--border);
-  grid-template-columns: minmax(180px, 0.7fr) minmax(260px, 1.3fr);
-  gap: 32px;
-  padding: 24px;
-}
-
-.settings-field-row:last-child {
-  border-bottom: 0;
-}
-
-.settings-field-row .ds-field__label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.settings-field-copy strong,
-.settings-field-row label {
-  color: var(--secondary-foreground);
-  font-size: var(--text-ui);
-  font-weight: var(--fw-semibold);
-}
-
-.settings-field-copy p,
 .settings-field-hint,
 .settings-readonly-value small,
 .settings-subheader p,
@@ -2848,11 +2769,6 @@ textarea:focus {
   font-size: var(--text-meta);
   font-weight: var(--fw-regular);
   line-height: var(--lh-prose);
-}
-
-.settings-field-row label {
-  display: grid;
-  gap: 7px;
 }
 
 .settings-field-hint code {
@@ -3314,15 +3230,7 @@ textarea:focus {
     padding-top: 22px;
   }
 
-  .object-tabs {
-    display: none;
-  }
-
-  .account-tabs {
-    display: flex;
-  }
-
-  .object-tabs + .object-content {
+  .ds-tabs + .object-content {
     padding-top: 0;
   }
 
@@ -3555,11 +3463,6 @@ textarea:focus {
   .dirty-bar {
     align-items: flex-start;
     flex-direction: column;
-  }
-
-  .settings-field-row {
-    grid-template-columns: 1fr;
-    gap: 12px;
   }
 
   .settings-invitation-panel:has(.settings-invitation-create) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -64,8 +64,8 @@
   --foreground: #16211b;
   --secondary-foreground: #3a453e;
   --muted: #616b62;
-  --border: #d6d9ca;
-  --strong-border: #c9ccbb;
+  --border: #ddded4;
+  --strong-border: #cdd0c3;
   --brand: #4e7a06;
   --brand-light: #edf3df;
   --brand-ink: #385a04;
@@ -247,12 +247,10 @@ pre {
 
 /* Counts, timestamps and identifiers sit in columns or update in place;
    proportional digits make them jitter. */
-.agent-row,
-.agent-summary-strip,
+.agent-card,
 .definition-list,
 .row,
 .settings-member-row,
-.settings-computer-row,
 .timestamp,
 .mono,
 code,
@@ -919,7 +917,7 @@ pre {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 28px;
+  gap: 24px;
   margin-bottom: 24px;
 }
 
@@ -944,135 +942,100 @@ pre {
 
 .agent-list-section {
   display: grid;
-  gap: 24px;
-}
-
-.agent-runtime-section {
-  display: grid;
   width: 100%;
-  gap: 24px;
-  margin-top: 32px;
-  border-top: 1px solid var(--border);
-  padding-top: 32px;
-  scroll-margin-top: 28px;
 }
 
-.agent-summary-strip {
-  display: flex;
-  min-height: 56px;
-  align-items: center;
-  border: 1px solid var(--strong-border);
-  border-radius: 10px;
-  background: rgb(253 252 246 / 58%);
-}
-
-.agent-summary-strip > span {
-  display: inline-flex;
-  min-height: 0;
-  align-items: center;
-  gap: 8px;
-  border-right: 0;
-  color: var(--muted);
-  font-size: var(--text-meta);
-  padding: 0 12px 0 0;
-}
-
-.agent-summary-strip > span:last-child {
-  border-right: 0;
-}
-
-.agent-summary-strip strong {
-  color: var(--foreground);
-}
-
-.agent-table-header,
-.agent-row {
+.agent-card-grid {
   display: grid;
-  grid-template-columns: minmax(205px, 1fr) minmax(185px, 0.45fr) minmax(76px, auto);
-  gap: 20px;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.agent-table-header {
-  min-height: 34px;
-  align-items: center;
-  border-bottom: 1px solid var(--border);
-  color: var(--muted);
-  font-size: var(--text-micro);
-  font-weight: var(--fw-semibold);
-  padding: 0 15px;
-}
-
-.agent-row {
-  position: relative;
-  min-height: 72px;
-  align-items: center;
-  border-bottom: 1px solid var(--border);
-  color: var(--secondary-foreground);
-  font-size: var(--text-ui);
-  transition: background-color 130ms ease;
-}
-
-.agent-row-link {
-  position: absolute;
-  z-index: 1;
-  inset: 0;
-  border-radius: 6px;
-}
-
-.agent-row > span {
-  position: relative;
-  pointer-events: none;
-}
-
-.agent-row:hover {
-  background: var(--brand-light);
-}
-
-.agent-row:active {
-  transform: none;
-}
-
-.agent-row-action {
-  position: relative;
-  z-index: 2;
-  justify-self: end;
-  color: var(--brand-ink);
-  font-size: var(--text-ui);
-  font-weight: var(--fw-semibold);
+.agent-card {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: inherit;
   text-decoration: none;
+  transition:
+    border-color 130ms ease,
+    background-color 130ms ease;
 }
 
-.agent-row-action.prominent {
-  border: 1px solid #d9a04c;
-  border-radius: 8px;
-  color: #975a13;
-  font-size: var(--text-meta);
-  font-weight: var(--fw-semibold);
-  padding: 0.48rem 0.65rem;
+.agent-card:hover {
+  border-color: var(--strong-border);
+  background: var(--surface-soft);
 }
 
-.agent-row-action.prominent:hover {
-  background: #fff7e8;
+.agent-card:focus-visible {
+  outline: 3px solid rgb(78 122 6 / 18%);
+  outline-offset: 3px;
+}
+
+.agent-card article {
+  display: grid;
+  min-height: 224px;
+  gap: 20px;
+  padding: 24px;
+}
+
+.agent-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
 }
 
 .agent-identity {
   display: grid;
   min-width: 0;
   align-items: center;
-  grid-template-columns: 34px minmax(0, 1fr);
+  grid-template-columns: 40px minmax(0, 1fr);
   gap: 11px;
 }
 
 .agent-avatar {
-  width: 34px;
-  height: 34px;
-  background: var(--surface);
+  width: 40px;
+  height: 40px;
+  border: 0;
+  border-radius: 10px;
+  background: #dfe9cb;
 }
 
 .agent-avatar.large {
   width: 46px;
   height: 46px;
   font-size: var(--text-ui);
+}
+
+.agent-card-facts {
+  display: grid;
+  margin: 0;
+  border-top: 1px solid var(--border);
+  gap: 16px 24px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding-top: 18px;
+}
+
+.agent-card-facts div {
+  min-width: 0;
+}
+
+.agent-card-action {
+  display: inline-flex;
+  align-items: center;
+  align-self: end;
+  justify-self: end;
+  gap: 6px;
+  color: var(--brand-ink);
+  font-size: var(--text-meta);
+  font-weight: var(--fw-semibold);
+}
+
+.agent-card-action .ds-icon {
+  width: 16px;
+  height: 16px;
 }
 
 .agent-identity strong,
@@ -1202,7 +1165,7 @@ pre {
 
 .object-tabs {
   display: flex;
-  gap: 28px;
+  gap: 32px;
   overflow-x: auto;
   border-bottom: 1px solid var(--border);
   scrollbar-width: none;
@@ -1271,7 +1234,7 @@ pre {
 
 .overview-stack {
   display: grid;
-  gap: 34px;
+  gap: 32px;
 }
 
 .overview-section {
@@ -1439,6 +1402,22 @@ dd {
   overflow-wrap: anywhere;
 }
 
+.agent-card-facts dt {
+  margin-bottom: 4px;
+  color: var(--muted);
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
+}
+
+.agent-card-facts dd {
+  overflow: hidden;
+  margin: 0;
+  color: var(--secondary-foreground);
+  font-size: var(--text-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .empty-state {
   position: relative;
   width: 100%;
@@ -1446,7 +1425,7 @@ dd {
   border: 1px dashed var(--border);
   border-radius: var(--radius);
   background: var(--surface);
-  padding: 28px;
+  padding: 24px;
 }
 
 .page > .empty-state {
@@ -2302,72 +2281,6 @@ code {
   margin-bottom: 24px;
 }
 
-.agent-list-section {
-  gap: 18px;
-}
-
-.agent-summary-strip {
-  width: fit-content;
-  min-height: 0;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  padding: 11px 14px;
-}
-
-.agent-summary-strip > span + span {
-  padding-left: 10px;
-}
-
-.agent-table-body {
-  display: grid;
-  gap: 0;
-}
-
-.agent-table {
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-}
-
-.agent-row {
-  min-height: 73px;
-  border-bottom: 1px solid var(--border);
-  border-radius: 0;
-  background: transparent;
-  padding: 10px 16px;
-}
-
-.agent-row:last-child {
-  border-bottom: 0;
-}
-
-.agent-row-link {
-  border-radius: 0;
-}
-
-.agent-row:hover {
-  background: var(--brand-light);
-}
-
-.agent-row-action.prominent {
-  border: 0;
-  background: var(--warning-surface);
-  color: var(--warning);
-  padding: 0.58rem 0.7rem;
-}
-
-.agent-row-action.prominent:hover {
-  background: #f8e6c3;
-}
-
-.agent-avatar {
-  border: 0;
-  border-radius: 10px;
-  background: #dfe9cb;
-}
-
 .agent-avatar.large {
   border-radius: 13px;
 }
@@ -2427,7 +2340,7 @@ code {
 }
 
 .overview-stack {
-  gap: 31px;
+  gap: 32px;
 }
 
 .agent-use-panel {
@@ -2501,7 +2414,7 @@ code {
   border-radius: var(--radius);
   background: var(--surface-soft);
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  padding: 20px 22px;
+  padding: 24px;
 }
 
 .overview-section .definition-list div {
@@ -2532,7 +2445,7 @@ code {
 
 .form-card,
 .panel {
-  gap: 18px;
+  gap: 16px;
   border-top: 0;
   padding: 0 0 32px;
 }
@@ -2541,7 +2454,7 @@ code {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface);
-  padding: 22px;
+  padding: 24px;
 }
 
 .form-card:first-child,
@@ -2553,7 +2466,7 @@ code {
 
 .section-header + .form-card,
 .form-card:first-child {
-  padding: 22px;
+  padding: 24px;
 }
 
 input,
@@ -2582,8 +2495,15 @@ textarea:focus {
   background: transparent;
 }
 
+.agent-create-runtime-setup > .panel {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 24px;
+}
+
 .agent-create-form {
-  gap: 18px;
+  gap: 16px;
 }
 
 .agent-create-field {
@@ -2686,7 +2606,7 @@ textarea:focus {
 
 .im-stack {
   width: 100%;
-  gap: 30px;
+  gap: 32px;
 }
 
 .im-section h3 {
@@ -2709,7 +2629,7 @@ textarea:focus {
   border: 1px solid #d7dfc6;
   border-radius: var(--radius);
   background: var(--brand-light);
-  padding: 20px 22px;
+  padding: 24px;
 }
 
 .binding-status > small {
@@ -2724,8 +2644,8 @@ textarea:focus {
   border-radius: var(--radius);
   background: var(--surface);
   grid-template-columns: 210px minmax(0, 1fr);
-  gap: 28px;
-  padding: 22px;
+  gap: 32px;
+  padding: 24px;
 }
 
 .message-policy-copy strong {
@@ -2862,7 +2782,7 @@ textarea:focus {
 .settings-policy-stack {
   display: grid;
   width: 100%;
-  gap: 18px;
+  gap: 24px;
 }
 
 .settings-team-stack {
@@ -2897,8 +2817,8 @@ textarea:focus {
   align-items: start;
   border-bottom: 1px solid var(--border);
   grid-template-columns: minmax(180px, 0.7fr) minmax(260px, 1.3fr);
-  gap: 34px;
-  padding: 20px;
+  gap: 32px;
+  padding: 24px;
 }
 
 .settings-field-row:last-child {
@@ -2996,23 +2916,11 @@ textarea:focus {
 .settings-list-section {
   display: grid;
   width: 100%;
-  gap: 18px;
+  gap: 24px;
 }
 
 .settings-members-section {
   width: 100%;
-}
-
-.agent-runtime-section > .panel,
-.agent-runtime-section > .settings-list-section {
-  width: 100%;
-}
-
-.agent-runtime-section > .panel {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  padding: 20px;
 }
 
 .settings-readonly-heading,
@@ -3045,11 +2953,11 @@ textarea:focus {
 .settings-invitation-panel {
   display: grid;
   width: 100%;
-  gap: 14px;
+  gap: 16px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface);
-  padding: 22px;
+  padding: 24px;
 }
 
 .settings-members-section .settings-invitation-panel {
@@ -3074,6 +2982,29 @@ textarea:focus {
   font-size: var(--text-meta);
 }
 
+.settings-invitation-panel:has(.settings-invitation-create) {
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.settings-invitation-panel:has(.settings-invitation-create) h3,
+.settings-invitation-panel:has(.settings-invitation-create) > p {
+  grid-column: 1;
+}
+
+.settings-invitation-panel:has(.settings-invitation-create) h3 {
+  grid-row: 1;
+}
+
+.settings-invitation-panel:has(.settings-invitation-create) > p {
+  grid-row: 2;
+}
+
+.settings-invitation-panel .settings-invitation-create {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
 .settings-invitation-panel .invite-link {
   grid-template-columns: minmax(0, 1fr);
 }
@@ -3082,8 +3013,7 @@ textarea:focus {
   justify-content: flex-end;
 }
 
-.settings-member-table,
-.settings-computer-table {
+.settings-member-table {
   display: block;
   width: 100%;
   overflow: hidden;
@@ -3094,33 +3024,28 @@ textarea:focus {
 }
 
 .settings-member-table thead,
-.settings-member-table tbody,
-.settings-computer-table thead,
-.settings-computer-table tbody {
+.settings-member-table tbody {
   display: block;
 }
 
 .settings-member-table th,
-.settings-member-table td,
-.settings-computer-table th,
-.settings-computer-table td {
+.settings-member-table td {
   min-width: 0;
   padding: 0;
   text-align: left;
 }
 
 .settings-table-header,
-.settings-member-row,
-.settings-computer-row {
+.settings-member-row {
   display: grid;
   align-items: center;
   border-bottom: 1px solid var(--border);
-  gap: 18px;
+  gap: 16px;
   padding-inline: 16px;
 }
 
 .settings-table-header {
-  min-height: 38px;
+  min-height: 40px;
   color: var(--muted);
   font-size: var(--text-micro);
   font-weight: var(--fw-semibold);
@@ -3132,17 +3057,15 @@ textarea:focus {
 }
 
 .settings-member-row {
-  min-height: 66px;
-  padding-block: 9px;
+  min-height: 64px;
+  padding-block: 8px;
 }
 
-.settings-member-row:last-child,
-.settings-computer-row:last-child {
+.settings-member-row:last-child {
   border-bottom: 0;
 }
 
-.settings-member-identity,
-.settings-computer-identity {
+.settings-member-identity {
   display: flex;
   min-width: 0;
   align-items: center;
@@ -3154,14 +3077,12 @@ textarea:focus {
   display: block;
 }
 
-.settings-member-identity strong,
-.settings-computer-row strong {
+.settings-member-identity strong {
   font-size: var(--text-ui);
   font-weight: var(--fw-semibold);
 }
 
-.settings-member-identity small,
-.settings-computer-row small {
+.settings-member-identity small {
   display: block;
   margin-top: 3px;
   color: var(--muted);
@@ -3188,38 +3109,6 @@ textarea:focus {
   padding-block: 0.35rem;
 }
 
-.settings-computer-table .settings-table-header,
-.settings-computer-row {
-  grid-template-columns: minmax(160px, 1.35fr) minmax(128px, 0.9fr) 90px minmax(130px, 0.85fr) 46px;
-}
-
-.settings-computer-row {
-  min-height: 70px;
-  color: var(--secondary-foreground);
-  font-size: var(--text-ui);
-  padding-block: 10px;
-}
-
-.settings-computer-icon {
-  position: relative;
-  width: 24px;
-  height: 17px;
-  flex: 0 0 auto;
-  border: 1.5px solid var(--secondary-foreground);
-  border-radius: 3px;
-}
-
-.settings-computer-icon::after {
-  position: absolute;
-  right: -3px;
-  bottom: -5px;
-  left: -3px;
-  height: 2px;
-  border-radius: 2px;
-  background: var(--secondary-foreground);
-  content: "";
-}
-
 .settings-status {
   display: inline-flex;
   align-items: center;
@@ -3242,7 +3131,7 @@ textarea:focus {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-soft);
-  padding: 28px;
+  padding: 24px;
 }
 
 .settings-state-label {
@@ -3308,11 +3197,11 @@ textarea:focus {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 28px;
+  gap: 24px;
   border: 1px solid #cdd4bb;
   border-radius: var(--radius);
   background: var(--brand-light);
-  padding: 22px;
+  padding: 24px;
 }
 
 .settings-policy-banner .settings-state-label {
@@ -3354,31 +3243,6 @@ textarea:focus {
 
   .settings-page .section-header {
     margin-top: 24px;
-  }
-}
-
-@media (max-width: 820px) {
-  .settings-computer-table .settings-table-header {
-    display: none;
-  }
-
-  .settings-computer-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 15px 20px;
-    padding: 16px 0;
-  }
-
-  .settings-computer-identity {
-    grid-column: 1 / -1;
-  }
-
-  .settings-computer-row [data-label]::before {
-    display: block;
-    margin-bottom: 5px;
-    color: var(--muted);
-    content: attr(data-label);
-    font-size: var(--text-micro);
-    font-weight: var(--fw-semibold);
   }
 }
 
@@ -3662,37 +3526,8 @@ textarea:focus {
     align-self: flex-start;
   }
 
-  .agent-table-header {
-    display: none;
-  }
-
-  .agent-summary-strip {
-    width: 100%;
-    min-height: 0;
-    align-items: stretch;
-    flex-direction: column;
-    padding: 8px;
-  }
-
-  .agent-summary-strip > span {
-    min-height: 34px;
-    border-right: 0;
-    padding: 0 14px;
-  }
-
-  .agent-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 16px 20px;
-    padding: 16px;
-  }
-
-  .agent-identity {
-    grid-column: 1 / -1;
-  }
-
-  .agent-row-action {
-    align-self: end;
-    justify-self: end;
+  .agent-card-grid {
+    grid-template-columns: 1fr;
   }
 
   .agent-use-panel {
@@ -3731,6 +3566,21 @@ textarea:focus {
     gap: 12px;
   }
 
+  .settings-invitation-panel:has(.settings-invitation-create) {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-invitation-panel:has(.settings-invitation-create) h3,
+  .settings-invitation-panel:has(.settings-invitation-create) > p,
+  .settings-invitation-panel .settings-invitation-create {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .settings-invitation-panel .settings-invitation-create {
+    justify-content: flex-start;
+  }
+
   .settings-table-header {
     display: none;
   }
@@ -3739,17 +3589,6 @@ textarea:focus {
     grid-template-columns: minmax(0, 1fr) 112px;
   }
 
-  .settings-computer-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 15px 20px;
-    padding: 16px 0;
-  }
-
-  .settings-computer-identity {
-    grid-column: 1 / -1;
-  }
-
-  .settings-computer-row [data-label]::before,
   .settings-member-row [data-label]::before {
     display: block;
     margin-bottom: 5px;
@@ -3766,15 +3605,6 @@ textarea:focus {
   .dirty-actions {
     width: 100%;
     justify-content: flex-end;
-  }
-
-  .agent-row [data-label]::before {
-    display: block;
-    margin-bottom: 5px;
-    color: var(--muted);
-    content: attr(data-label);
-    font-size: var(--text-micro);
-    font-weight: var(--fw-semibold);
   }
 
   .definition-list div {
@@ -3811,7 +3641,7 @@ textarea:focus {
   .sidebar,
   .sidebar-backdrop,
   button,
-  .agent-row {
+  .agent-card {
     transition: none;
   }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -75,9 +75,11 @@
   --dark-surface: #0b101d;
   --error: #862b24;
   --error-surface: #fff0ec;
-  --radius: 13px;
-  --sidebar-width: 232px;
+  --radius: 12px;
+  --sidebar-width: 220px;
   --local-nav-width: 170px;
+  --workspace-page-frame: 1024px;
+  --workspace-page-gutter: 32px;
   --workspace-page-width: 960px;
   --layer-sidebar: 30;
   --layer-backdrop: 20;
@@ -157,23 +159,23 @@ textarea {
 
 button {
   display: inline-flex;
-  min-height: 42px;
+  min-height: 40px;
   align-items: center;
   justify-content: center;
   border: 0;
-  border-radius: 9px;
+  border-radius: 8px;
   background: var(--brand);
   color: #fff;
   cursor: pointer;
   font-size: var(--text-ui);
   font-weight: var(--fw-semibold);
-  padding: 0.58rem 0.95rem;
+  padding: 0.5rem 1rem;
   text-decoration: none;
   transition:
-    background-color 140ms ease,
-    border-color 140ms ease,
-    color 140ms ease,
-    transform 140ms ease;
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
   white-space: nowrap;
 }
 
@@ -182,7 +184,7 @@ button:hover {
 }
 
 button:active {
-  transform: translateY(1px);
+  transform: scale(0.96);
 }
 
 button:disabled {
@@ -219,7 +221,7 @@ h1,
 
 h1 {
   margin-bottom: 0.45rem;
-  font-size: var(--text-title);
+  font-size: var(--text-display);
   font-weight: var(--fw-semibold);
   letter-spacing: var(--track-tight);
   line-height: var(--lh-tight);
@@ -300,7 +302,7 @@ pre {
   height: 100dvh;
   flex-direction: column;
   justify-content: space-between;
-  border-right: 0;
+  border-right: 1px solid var(--border);
   background: var(--sidebar);
   padding: 24px 15px 16px;
 }
@@ -868,7 +870,7 @@ pre {
 }
 .content {
   min-width: 0;
-  padding: 42px clamp(24px, 4.2vw, 64px) 72px;
+  padding: 32px 20px 64px;
 }
 
 .loading-state {
@@ -904,15 +906,12 @@ pre {
   }
 }
 
-.page {
-  width: min(100%, var(--workspace-page-width));
-  margin: 0 auto;
-}
-
+.page,
 .object-page,
 .settings-page {
-  width: min(100%, 1200px);
+  width: min(100%, var(--workspace-page-frame));
   margin: 0 auto;
+  padding-inline: var(--workspace-page-gutter);
 }
 
 .page-header,
@@ -921,7 +920,7 @@ pre {
   align-items: flex-start;
   justify-content: space-between;
   gap: 28px;
-  margin-bottom: 30px;
+  margin-bottom: 24px;
 }
 
 .page-header p,
@@ -952,9 +951,9 @@ pre {
   display: grid;
   width: 100%;
   gap: 24px;
-  margin-top: 64px;
+  margin-top: 32px;
   border-top: 1px solid var(--border);
-  padding-top: 36px;
+  padding-top: 32px;
   scroll-margin-top: 28px;
 }
 
@@ -996,7 +995,7 @@ pre {
 .agent-table-header {
   min-height: 34px;
   align-items: center;
-  border-bottom: 0;
+  border-bottom: 1px solid var(--border);
   color: var(--muted);
   font-size: var(--text-micro);
   font-weight: var(--fw-semibold);
@@ -1178,7 +1177,7 @@ pre {
 
 .object-identity h1 {
   margin-bottom: 5px;
-  font-size: var(--text-title);
+  font-size: var(--text-display);
 }
 
 .object-identity p {
@@ -1190,38 +1189,54 @@ pre {
   font-size: var(--text-meta);
 }
 
-.object-layout,
+.object-layout {
+  padding-top: 32px;
+}
+
 .settings-layout {
   display: grid;
   grid-template-columns: var(--local-nav-width) minmax(0, 1fr);
-  gap: 44px;
-  padding-top: 30px;
+  gap: 32px;
+  padding-top: 32px;
 }
 
-.local-nav {
-  display: grid;
-  align-content: start;
-  gap: 3px;
-}
-
-.local-nav a {
+.object-tabs {
   display: flex;
-  min-height: 38px;
+  gap: 28px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+  scrollbar-width: none;
+}
+
+.object-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.object-tabs a {
+  position: relative;
+  display: inline-flex;
+  min-height: 44px;
   align-items: center;
-  border-left: 0;
-  border-radius: 9px;
   color: var(--muted);
   font-size: var(--text-ui);
-  font-weight: var(--fw-medium);
-  padding: 0 11px;
+  font-weight: var(--fw-semibold);
   text-decoration: none;
+  white-space: nowrap;
 }
 
-.local-nav a:hover,
-.local-nav a.active {
-  background: var(--brand-light);
+.object-tabs a:hover,
+.object-tabs a.active {
   color: var(--brand-ink);
-  font-weight: var(--fw-semibold);
+}
+
+.object-tabs a.active::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: var(--brand);
+  content: "";
 }
 
 .local-nav-select {
@@ -1230,7 +1245,7 @@ pre {
 
 .object-content,
 .settings-content {
-  width: min(100%, 840px);
+  width: 100%;
   min-width: 0;
 }
 
@@ -1260,7 +1275,7 @@ pre {
 }
 
 .overview-section {
-  width: min(100%, 760px);
+  width: 100%;
 }
 
 .overview-section > h3,
@@ -1284,7 +1299,7 @@ pre {
 }
 
 .admin-controls {
-  width: min(100%, 760px);
+  width: 100%;
   border-top: 1px solid var(--border);
   padding-top: 18px;
 }
@@ -1322,7 +1337,7 @@ pre {
 .form-card,
 .panel {
   display: grid;
-  width: min(100%, 760px);
+  width: 100%;
   gap: 16px;
   margin: 0;
   border: 0;
@@ -1365,9 +1380,9 @@ select,
 textarea {
   width: 100%;
   max-width: 100%;
-  min-height: 42px;
+  min-height: 40px;
   border: 1px solid var(--strong-border);
-  border-radius: 9px;
+  border-radius: 8px;
   background: var(--surface);
   color: var(--foreground);
   padding: 0.62rem 0.72rem;
@@ -1391,7 +1406,7 @@ textarea::placeholder {
 }
 
 .definition-list {
-  width: min(100%, 760px);
+  width: 100%;
   margin: 0 0 32px;
   border-top: 1px solid var(--strong-border);
 }
@@ -1426,11 +1441,11 @@ dd {
 
 .empty-state {
   position: relative;
-  width: min(100%, 760px);
+  width: 100%;
   overflow: hidden;
-  border: 0;
+  border: 1px dashed var(--border);
   border-radius: var(--radius);
-  background: var(--surface-soft);
+  background: var(--surface);
   padding: 28px;
 }
 
@@ -1451,7 +1466,7 @@ dd {
 }
 
 .notice {
-  width: min(100%, 760px);
+  width: 100%;
   margin-top: 16px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -2284,7 +2299,7 @@ code {
 /* Product surfaces use spacing and tonal grouping instead of repeated rules. */
 .page-header,
 .settings-title {
-  margin-bottom: 34px;
+  margin-bottom: 24px;
 }
 
 .agent-list-section {
@@ -2294,9 +2309,9 @@ code {
 .agent-summary-strip {
   width: fit-content;
   min-height: 0;
-  border: 0;
-  border-radius: 9px;
-  background: var(--surface-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
   padding: 11px 14px;
 }
 
@@ -2306,23 +2321,30 @@ code {
 
 .agent-table-body {
   display: grid;
-  gap: 7px;
+  gap: 0;
+}
+
+.agent-table {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
 }
 
 .agent-row {
   min-height: 73px;
-  border-bottom: 0;
-  border-radius: 11px;
-  background: rgb(239 240 230 / 66%);
-  padding: 10px 15px;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 10px 16px;
 }
 
-.agent-row:nth-child(even) {
-  background: rgb(245 244 236 / 72%);
+.agent-row:last-child {
+  border-bottom: 0;
 }
 
 .agent-row-link {
-  border-radius: 11px;
+  border-radius: 0;
 }
 
 .agent-row:hover {
@@ -2385,10 +2407,17 @@ code {
   text-underline-offset: 3px;
 }
 
-.object-layout,
+.object-layout {
+  padding-top: 32px;
+}
+
 .settings-layout {
-  gap: 50px;
-  padding-top: 38px;
+  gap: 32px;
+  padding-top: 32px;
+}
+
+.object-tabs + .object-content {
+  padding-top: 32px;
 }
 
 .section-header {
@@ -2406,12 +2435,14 @@ code {
   align-items: flex-start;
   justify-content: space-between;
   gap: 32px;
+  border: 1px solid #d7dfc6;
   border-radius: var(--radius);
   background: var(--brand-light);
   padding: 24px;
 }
 
 .agent-use-panel.empty {
+  border-color: var(--border);
   background: var(--surface-soft);
 }
 
@@ -2466,7 +2497,7 @@ code {
 .overview-section .definition-list {
   display: grid;
   margin-bottom: 0;
-  border: 0;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-soft);
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -2507,8 +2538,9 @@ code {
 }
 
 .form-card {
+  border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--surface-soft);
+  background: var(--surface);
   padding: 22px;
 }
 
@@ -2616,7 +2648,7 @@ textarea:focus {
 .definition-list {
   display: grid;
   gap: 0;
-  border-top: 0;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-soft);
   padding: 5px 20px;
@@ -2628,15 +2660,22 @@ textarea:focus {
 }
 
 .list {
-  gap: 7px;
-  border-top: 0;
+  overflow: hidden;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
 }
 
 .row {
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--surface);
+  padding: 11px 16px;
+}
+
+.row:last-child {
   border-bottom: 0;
-  border-radius: 10px;
-  background: var(--surface-soft);
-  padding: 11px 14px;
 }
 
 .im-stack,
@@ -2646,7 +2685,7 @@ textarea:focus {
 }
 
 .im-stack {
-  width: min(100%, 760px);
+  width: 100%;
   gap: 30px;
 }
 
@@ -2667,6 +2706,7 @@ textarea:focus {
   align-items: center;
   justify-content: space-between;
   gap: 20px;
+  border: 1px solid #d7dfc6;
   border-radius: var(--radius);
   background: var(--brand-light);
   padding: 20px 22px;
@@ -2680,8 +2720,9 @@ textarea:focus {
 
 .message-policy {
   display: grid;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--surface-soft);
+  background: var(--surface);
   grid-template-columns: 210px minmax(0, 1fr);
   gap: 28px;
   padding: 22px;
@@ -2745,8 +2786,9 @@ textarea:focus {
 .team-profile-fields {
   display: grid;
   gap: 23px;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--surface-soft);
+  background: var(--surface);
   padding: 23px;
 }
 
@@ -2778,7 +2820,8 @@ textarea:focus {
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  border-radius: 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   background: #e7e9df;
   padding: 8px 10px 8px 15px;
 }
@@ -2818,13 +2861,13 @@ textarea:focus {
 .settings-profile-form,
 .settings-policy-stack {
   display: grid;
-  width: min(100%, 760px);
+  width: 100%;
   gap: 18px;
 }
 
 .settings-team-stack {
   display: grid;
-  gap: 52px;
+  gap: 32px;
 }
 
 .settings-team-stack #members {
@@ -2843,7 +2886,10 @@ textarea:focus {
 }
 
 .settings-field-list {
-  border-top: 1px solid var(--strong-border);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
 }
 
 .settings-field-row {
@@ -2852,7 +2898,23 @@ textarea:focus {
   border-bottom: 1px solid var(--border);
   grid-template-columns: minmax(180px, 0.7fr) minmax(260px, 1.3fr);
   gap: 34px;
-  padding: 21px 0;
+  padding: 20px;
+}
+
+.settings-field-row:last-child {
+  border-bottom: 0;
+}
+
+.settings-field-row .ds-field__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .settings-field-copy strong,
@@ -2888,12 +2950,12 @@ textarea:focus {
 
 .settings-readonly-value {
   display: flex;
-  min-height: 42px;
+  min-height: 40px;
   align-items: center;
   justify-content: space-between;
   gap: 18px;
   border: 1px solid var(--border);
-  border-radius: 9px;
+  border-radius: 8px;
   background: rgb(253 252 247 / 58%);
   color: var(--secondary-foreground);
   font-size: var(--text-ui);
@@ -2933,7 +2995,7 @@ textarea:focus {
 .settings-readonly-panel,
 .settings-list-section {
   display: grid;
-  width: min(100%, 760px);
+  width: 100%;
   gap: 18px;
 }
 
@@ -2944,6 +3006,13 @@ textarea:focus {
 .agent-runtime-section > .panel,
 .agent-runtime-section > .settings-list-section {
   width: 100%;
+}
+
+.agent-runtime-section > .panel {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 20px;
 }
 
 .settings-readonly-heading,
@@ -2975,10 +3044,11 @@ textarea:focus {
 
 .settings-invitation-panel {
   display: grid;
-  width: min(100%, 760px);
+  width: 100%;
   gap: 14px;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--surface-soft);
+  background: var(--surface);
   padding: 22px;
 }
 
@@ -3016,7 +3086,10 @@ textarea:focus {
 .settings-computer-table {
   display: block;
   width: 100%;
-  border-top: 1px solid var(--strong-border);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
   border-collapse: collapse;
 }
 
@@ -3043,6 +3116,7 @@ textarea:focus {
   align-items: center;
   border-bottom: 1px solid var(--border);
   gap: 18px;
+  padding-inline: 16px;
 }
 
 .settings-table-header {
@@ -3059,7 +3133,12 @@ textarea:focus {
 
 .settings-member-row {
   min-height: 66px;
-  padding: 9px 0;
+  padding-block: 9px;
+}
+
+.settings-member-row:last-child,
+.settings-computer-row:last-child {
+  border-bottom: 0;
 }
 
 .settings-member-identity,
@@ -3118,7 +3197,7 @@ textarea:focus {
   min-height: 70px;
   color: var(--secondary-foreground);
   font-size: var(--text-ui);
-  padding: 10px 0;
+  padding-block: 10px;
 }
 
 .settings-computer-icon {
@@ -3148,9 +3227,10 @@ textarea:focus {
 }
 
 .settings-compact-empty {
-  border-top: 1px solid var(--strong-border);
-  border-bottom: 1px solid var(--border);
-  padding: 24px 0;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 24px;
 }
 
 .settings-compact-empty strong {
@@ -3158,7 +3238,8 @@ textarea:focus {
 }
 
 .settings-unavailable {
-  width: min(100%, 760px);
+  width: 100%;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-soft);
   padding: 28px;
@@ -3365,14 +3446,24 @@ textarea:focus {
     padding: 28px 20px 56px;
   }
 
+  .page,
+  .object-page,
+  .settings-page {
+    padding-inline: 0;
+  }
+
   .object-layout,
   .settings-layout {
     display: block;
     padding-top: 22px;
   }
 
-  .local-nav {
+  .object-tabs {
     display: none;
+  }
+
+  .object-tabs + .object-content {
+    padding-top: 0;
   }
 
   .local-nav-select {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -154,8 +154,7 @@ textarea {
   font: inherit;
 }
 
-button,
-.button {
+button {
   display: inline-flex;
   min-height: 42px;
   align-items: center;
@@ -177,71 +176,17 @@ button,
   white-space: nowrap;
 }
 
-button:hover,
-.button:hover {
+button:hover {
   background: var(--brand-ink);
 }
 
-button:active,
-.button:active {
+button:active {
   transform: translateY(1px);
 }
 
-button:disabled,
-.button[aria-disabled="true"] {
+button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
-}
-
-.secondary {
-  border: 0;
-  background: #e7e9df;
-  color: var(--foreground);
-}
-
-.secondary:hover {
-  background: #dde1d3;
-  color: var(--foreground);
-}
-
-.commit {
-  background: var(--foreground);
-  color: #fff;
-}
-
-.commit:hover {
-  background: #26332c;
-}
-
-.tertiary,
-.danger-text {
-  min-height: 34px;
-  border: 0;
-  background: transparent;
-  padding: 0 0.45rem;
-}
-
-.tertiary {
-  color: var(--muted);
-}
-
-.tertiary:hover {
-  background: #e7e9df;
-  color: var(--foreground);
-}
-
-.danger-text {
-  color: var(--error);
-}
-
-.danger-text:hover {
-  background: var(--error-surface);
-  color: var(--error);
-}
-
-.compact-button {
-  min-height: 36px;
-  padding: 0.42rem 0.75rem;
 }
 
 button:focus-visible,
@@ -341,18 +286,6 @@ pre {
   color: #7b4510;
 }
 
-button.danger {
-  min-height: 34px;
-  border: 0;
-  background: transparent;
-  color: var(--error);
-  padding: 0 0.45rem;
-}
-
-button.danger:hover {
-  background: var(--error-surface);
-  color: var(--error);
-}
 .shell {
   display: grid;
   min-height: 100dvh;
@@ -1172,33 +1105,6 @@ button.danger:hover {
   gap: 8px;
 }
 
-.availability-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  flex: 0 0 auto;
-  border-radius: 999px;
-  background: #8a9188;
-}
-
-.availability-dot.ready {
-  background: var(--brand);
-}
-
-.availability-dot.action-required {
-  background: #d97706;
-}
-
-.availability-dot.setting-up {
-  background: #2e6fa7;
-}
-
-.availability-dot.not-connected,
-.availability-dot.suspended,
-.availability-dot.unconfirmed {
-  background: #848b82;
-}
-
 .muted,
 .timestamp {
   color: var(--muted);
@@ -1447,18 +1353,6 @@ button.danger:hover {
   color: var(--error);
   font-size: var(--text-meta);
   font-weight: var(--fw-regular);
-}
-
-.form-field {
-  display: grid;
-  gap: 7px;
-}
-
-.field-help {
-  color: var(--muted);
-  font-size: var(--text-meta);
-  font-weight: var(--fw-regular);
-  line-height: var(--lh-ui);
 }
 
 input,
@@ -2230,7 +2124,7 @@ code {
   gap: 14px;
 }
 
-.onboarding-action .button:not(.compact-button) {
+.onboarding-action .ds-button:not(.ds-button--compact) {
   min-height: 46px;
   min-width: 190px;
   border-radius: 10px;
@@ -2765,22 +2659,6 @@ textarea:focus {
   padding: 20px 22px;
 }
 
-.binding-status-main {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.binding-status-main strong,
-.binding-status-main small {
-  display: block;
-}
-
-.binding-status-main strong {
-  font-size: var(--text-ui);
-}
-
-.binding-status-main small,
 .binding-status > small {
   margin-top: 4px;
   color: var(--muted);
@@ -3051,10 +2929,6 @@ textarea:focus {
   width: 100%;
 }
 
-.settings-content > .panel .button {
-  justify-self: start;
-}
-
 .settings-readonly-heading,
 .settings-subheader {
   display: flex;
@@ -3252,21 +3126,6 @@ textarea:focus {
   gap: 7px;
 }
 
-.settings-status-dot {
-  width: 7px;
-  height: 7px;
-  flex: 0 0 auto;
-  border-radius: 50%;
-}
-
-.settings-status-dot.online {
-  background: var(--brand);
-}
-
-.settings-status-dot.offline {
-  background: var(--warning);
-}
-
 .settings-compact-empty {
   border-top: 1px solid var(--strong-border);
   border-bottom: 1px solid var(--border);
@@ -3329,6 +3188,9 @@ textarea:focus {
 }
 
 .settings-state-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   color: var(--brand-ink);
   font-size: var(--text-ui);
   font-weight: var(--fw-semibold);
@@ -3517,7 +3379,7 @@ textarea:focus {
     flex-direction: column;
   }
 
-  .account-workspace-create .secondary {
+  .account-workspace-create .ds-button {
     justify-content: center;
     width: 100%;
   }
@@ -3649,8 +3511,8 @@ textarea:focus {
     gap: 5px;
   }
 
-  .onboarding-action .button,
-  .onboarding-feedback > .button {
+  .onboarding-action .ds-button,
+  .onboarding-feedback > .ds-button {
     width: 100%;
   }
 
@@ -3679,7 +3541,7 @@ textarea:focus {
     flex-direction: column;
   }
 
-  .page-header .button {
+  .page-header .ds-button {
     align-self: flex-start;
   }
 
@@ -3818,7 +3680,7 @@ textarea:focus {
   }
 
   .actions > button,
-  .actions > .button,
+  .actions > .ds-button,
   .actions > a {
     width: 100%;
   }
@@ -3832,7 +3694,6 @@ textarea:focus {
   .sidebar,
   .sidebar-backdrop,
   button,
-  .button,
   .agent-row {
     transition: none;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -635,7 +635,7 @@ pre {
 }
 
 .account-menu-popover {
-  right: 0;
+  right: auto;
   bottom: calc(100% + 7px);
   left: 0;
   display: grid;
@@ -643,6 +643,7 @@ pre {
   max-height: min(560px, calc(100dvh - 32px));
   overflow-y: auto;
   padding: 7px;
+  width: min(240px, calc(100vw - 32px));
 }
 
 .account-workspace-group {
@@ -667,7 +668,7 @@ pre {
 }
 
 .account-menu-popover .account-workspace-option[aria-current="true"] {
-  background: var(--brand-light);
+  background: transparent;
   color: var(--foreground);
 }
 
@@ -704,6 +705,27 @@ pre {
   color: var(--brand-ink);
 }
 
+.account-menu-actions a[aria-current="page"] {
+  background: var(--brand-light);
+  color: var(--brand-ink);
+}
+
+.account-menu-actions .account-signout {
+  position: relative;
+  margin-top: 8px;
+}
+
+.account-menu-actions .account-signout::before {
+  position: absolute;
+  top: -5px;
+  right: 0;
+  left: 0;
+  height: 1px;
+  background: var(--border);
+  content: "";
+  pointer-events: none;
+}
+
 .account-menu-error {
   color: var(--error);
   font-size: var(--text-meta);
@@ -711,11 +733,6 @@ pre {
   padding: 6px 9px;
 }
 
-.account-tabs {
-  margin-bottom: 32px;
-}
-
-.account-settings-content,
 .account-workspace-profile {
   width: 100%;
 }
@@ -963,6 +980,69 @@ pre {
 .agent-card:focus-visible {
   outline: 3px solid rgb(78 122 6 / 18%);
   outline-offset: 3px;
+}
+
+.agent-create-card {
+  display: grid;
+  min-width: 0;
+  min-height: 224px;
+  align-content: center;
+  justify-items: center;
+  gap: 10px;
+  padding: 24px;
+  border: 1px dashed var(--strong-border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--foreground);
+  text-align: center;
+  cursor: pointer;
+  transition:
+    border-color 130ms ease,
+    background-color 130ms ease,
+    transform 130ms ease;
+}
+
+.agent-create-card:hover {
+  border-color: var(--brand);
+  background: var(--surface-soft);
+}
+
+.agent-create-card:focus-visible {
+  outline: 3px solid rgb(78 122 6 / 18%);
+  outline-offset: 3px;
+}
+
+.agent-create-card:active {
+  transform: translateY(1px);
+}
+
+.agent-create-card-icon {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  margin-bottom: 2px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--brand-ink);
+}
+
+.agent-create-card-icon .ds-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.agent-create-card strong {
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+}
+
+.agent-create-card small {
+  max-width: 220px;
+  color: var(--muted);
+  font-size: var(--text-meta);
+  line-height: var(--lh-prose);
 }
 
 .agent-card article {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -671,13 +671,8 @@ pre {
   color: var(--foreground);
 }
 
-.account-menu-popover .account-workspace-manage {
-  justify-content: space-between;
-  min-height: 40px;
-  margin-top: 4px;
-  border-top: 1px solid var(--border);
-  border-radius: 0 0 7px 7px;
-  padding-top: 4px;
+.account-menu-popover .account-workspace-option.is-static {
+  cursor: default;
 }
 
 .account-menu-actions {
@@ -716,32 +711,23 @@ pre {
   padding: 6px 9px;
 }
 
-.account-settings-stack {
+.account-tabs {
+  margin-bottom: 32px;
+}
+
+.account-settings-content,
+.account-workspace-profile {
+  width: 100%;
+}
+
+.account-workspace-stack,
+.account-workspace-profile {
   display: grid;
+  gap: 24px;
+}
+
+.account-workspace-stack {
   gap: 32px;
-}
-
-.account-advanced {
-  border-top: 1px solid var(--border);
-  padding-top: 18px;
-}
-
-.account-advanced > summary {
-  width: fit-content;
-  cursor: pointer;
-  color: var(--muted);
-  font-size: var(--text-ui);
-  font-weight: var(--fw-semibold);
-}
-
-.account-advanced[open] > summary {
-  color: var(--foreground);
-}
-
-.account-advanced-content {
-  display: grid;
-  gap: 22px;
-  margin-top: 22px;
 }
 
 .account-workspace-create {
@@ -751,6 +737,12 @@ pre {
   gap: 24px;
   border-top: 1px solid var(--border);
   padding-top: 20px;
+}
+
+.account-workspace-create h2 {
+  margin: 0;
+  font-size: var(--text-subsection);
+  font-weight: var(--fw-semibold);
 }
 
 .account-workspace-create p {
@@ -3324,6 +3316,10 @@ textarea:focus {
 
   .object-tabs {
     display: none;
+  }
+
+  .account-tabs {
+    display: flex;
   }
 
   .object-tabs + .object-content {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2909,7 +2909,7 @@ textarea:focus {
 
 .settings-members-section {
   width: 100%;
-  gap: 36px;
+  gap: 32px;
 }
 
 .settings-readonly-heading,
@@ -2942,12 +2942,9 @@ textarea:focus {
 .settings-invitation-panel {
   display: grid;
   width: 100%;
-  align-items: start;
-  column-gap: 40px;
+  gap: 14px;
   border-top: 1px solid var(--strong-border);
   background: transparent;
-  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
-  row-gap: 10px;
   padding: 28px 0 0;
 }
 
@@ -2956,21 +2953,16 @@ textarea:focus {
 }
 
 .settings-invitation-panel h3 {
-  grid-column: 1;
-  grid-row: 1;
   margin: 0;
   font-size: var(--text-subsection);
   font-weight: var(--fw-semibold);
 }
 
 .settings-invitation-panel > p {
-  grid-column: 1;
-  grid-row: 2 / span 2;
   max-width: 590px;
-  margin: 0;
+  margin: -7px 0 1px;
   color: var(--muted);
   font-size: var(--text-meta);
-  line-height: var(--lh-ui);
 }
 
 .settings-invitation-panel:has(.settings-invitation-create) {
@@ -2997,23 +2989,16 @@ textarea:focus {
 }
 
 .settings-invitation-panel .invite-link {
-  grid-column: 2;
-  grid-row: 1;
   grid-template-columns: minmax(0, 1fr);
 }
 
 .settings-invitation-panel .invite-link + .muted {
-  grid-column: 2;
-  grid-row: 2;
   margin: 0;
   font-size: var(--text-meta);
 }
 
 .settings-invitation-panel .actions {
-  grid-column: 2;
-  grid-row: 3;
   justify-content: flex-end;
-  margin-top: 4px;
 }
 
 .settings-member-list {
@@ -3074,12 +3059,12 @@ textarea:focus {
 
 .settings-member-table .settings-table-header,
 .settings-member-row {
-  grid-template-columns: minmax(240px, 390px) 104px;
+  grid-template-columns: minmax(0, 1fr) 112px;
 }
 
 .settings-member-row {
-  min-height: 52px;
-  padding-block: 6px;
+  min-height: 56px;
+  padding-block: 7px;
 }
 
 .settings-member-row:last-child {
@@ -3095,7 +3080,7 @@ textarea:focus {
 
 .settings-member-identity strong,
 .settings-member-identity small {
-  display: inline;
+  display: block;
 }
 
 .settings-member-identity strong {
@@ -3104,15 +3089,15 @@ textarea:focus {
 }
 
 .settings-member-identity small {
-  margin-left: 8px;
+  margin-top: 3px;
   color: var(--muted);
   font-size: var(--text-meta);
 }
 
 .settings-member-avatar {
   display: inline-flex;
-  width: 30px;
-  height: 30px;
+  width: 32px;
+  height: 32px;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2909,7 +2909,7 @@ textarea:focus {
 
 .settings-members-section {
   width: 100%;
-  gap: 32px;
+  gap: 36px;
 }
 
 .settings-readonly-heading,
@@ -2942,9 +2942,12 @@ textarea:focus {
 .settings-invitation-panel {
   display: grid;
   width: 100%;
-  gap: 14px;
+  align-items: start;
+  column-gap: 40px;
   border-top: 1px solid var(--strong-border);
   background: transparent;
+  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
+  row-gap: 10px;
   padding: 28px 0 0;
 }
 
@@ -2953,16 +2956,21 @@ textarea:focus {
 }
 
 .settings-invitation-panel h3 {
+  grid-column: 1;
+  grid-row: 1;
   margin: 0;
   font-size: var(--text-subsection);
   font-weight: var(--fw-semibold);
 }
 
 .settings-invitation-panel > p {
+  grid-column: 1;
+  grid-row: 2 / span 2;
   max-width: 590px;
-  margin: -7px 0 1px;
+  margin: 0;
   color: var(--muted);
   font-size: var(--text-meta);
+  line-height: var(--lh-ui);
 }
 
 .settings-invitation-panel:has(.settings-invitation-create) {
@@ -2989,11 +2997,23 @@ textarea:focus {
 }
 
 .settings-invitation-panel .invite-link {
+  grid-column: 2;
+  grid-row: 1;
   grid-template-columns: minmax(0, 1fr);
 }
 
+.settings-invitation-panel .invite-link + .muted {
+  grid-column: 2;
+  grid-row: 2;
+  margin: 0;
+  font-size: var(--text-meta);
+}
+
 .settings-invitation-panel .actions {
+  grid-column: 2;
+  grid-row: 3;
   justify-content: flex-end;
+  margin-top: 4px;
 }
 
 .settings-member-list {
@@ -3054,12 +3074,12 @@ textarea:focus {
 
 .settings-member-table .settings-table-header,
 .settings-member-row {
-  grid-template-columns: minmax(0, 1fr) 112px;
+  grid-template-columns: minmax(240px, 390px) 104px;
 }
 
 .settings-member-row {
-  min-height: 56px;
-  padding-block: 7px;
+  min-height: 52px;
+  padding-block: 6px;
 }
 
 .settings-member-row:last-child {
@@ -3075,7 +3095,7 @@ textarea:focus {
 
 .settings-member-identity strong,
 .settings-member-identity small {
-  display: block;
+  display: inline;
 }
 
 .settings-member-identity strong {
@@ -3084,16 +3104,15 @@ textarea:focus {
 }
 
 .settings-member-identity small {
-  display: block;
-  margin-top: 3px;
+  margin-left: 8px;
   color: var(--muted);
   font-size: var(--text-meta);
 }
 
 .settings-member-avatar {
   display: inline-flex;
-  width: 32px;
-  height: 32px;
+  width: 30px;
+  height: 30px;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
@@ -3556,10 +3575,16 @@ textarea:focus {
     flex-direction: column;
   }
 
+  .settings-invitation-panel,
   .settings-invitation-panel:has(.settings-invitation-create) {
     grid-template-columns: 1fr;
   }
 
+  .settings-invitation-panel h3,
+  .settings-invitation-panel > p,
+  .settings-invitation-panel .invite-link,
+  .settings-invitation-panel .invite-link + .muted,
+  .settings-invitation-panel .actions,
   .settings-invitation-panel:has(.settings-invitation-create) h3,
   .settings-invitation-panel:has(.settings-invitation-create) > p,
   .settings-invitation-panel .settings-invitation-create {
@@ -3576,7 +3601,7 @@ textarea:focus {
   }
 
   .settings-member-row {
-    grid-template-columns: minmax(0, 1fr) 112px;
+    grid-template-columns: minmax(0, 1fr) 104px;
   }
 
   .settings-member-row [data-label]::before {

--- a/apps/web/src/ui/DESIGN_SYSTEM.md
+++ b/apps/web/src/ui/DESIGN_SYSTEM.md
@@ -29,5 +29,6 @@ This module is intentionally small. It owns repeated interaction and layout rule
 
 - Reuse a module when its semantic contract matches; do not add a variant only to reproduce one page.
 - Keep simple table selects as `ds-control` without wrapping them in `Field` or `SettingsRow`.
+- Keep top-level destinations as separate pages; do not repeat the app-shell navigation as page-level `Tabs`.
 - Keep domain modules such as Agent cards, messaging panels, runtime configuration, and invitation flows local to their page until at least two real call sites share the same behavior.
 - New pages should compose these modules and existing page shells before adding CSS. If a new pattern is genuinely repeated, deepen the existing module instead of creating a parallel one.

--- a/apps/web/src/ui/DESIGN_SYSTEM.md
+++ b/apps/web/src/ui/DESIGN_SYSTEM.md
@@ -1,0 +1,33 @@
+# OpenTag Web Design System
+
+This module is intentionally small. It owns repeated interaction and layout rules; product-specific cards and workflows stay with their pages.
+
+## Page contract
+
+- Workspace pages use one `1024px` outer frame with `32px` inline gutters, leaving `960px` of visible content.
+- Only page shells own page-level width. Sections, lists, forms, and panels use `width: 100%` and do not introduce another max-width.
+- Product pages keep the warm neutral canvas and olive brand treatment. Operational status uses the status palette, not the brand color.
+
+## Geometry
+
+- Dividers and surface borders are `1px`.
+- Controls use `8px` radius and a `40px` minimum height.
+- Panels and grouped settings use `12px` radius.
+- Repeated spacing uses the semantic `--space-*` tokens in `design-system.css`; new one-off spacing steps should not be added.
+
+## Modules
+
+- `Button` / `buttonClassName`: button hierarchy and link-as-button styling.
+- `Field`: accessible label, hint, and error relationships.
+- `Tabs`: labelled top navigation with optional mobile collapse when a select fallback exists.
+- `SettingsList` / `SettingsRow`: two-column settings geometry that collapses to one column on small screens.
+- `StatusIndicator`: operational state, visually separate from brand intent.
+- `Icon`: formal interaction icons instead of Unicode controls.
+- `Dialog`: focus trapping, Escape handling, busy state, and focus return.
+
+## Usage rules
+
+- Reuse a module when its semantic contract matches; do not add a variant only to reproduce one page.
+- Keep simple table selects as `ds-control` without wrapping them in `Field` or `SettingsRow`.
+- Keep domain modules such as Agent cards, messaging panels, runtime configuration, and invitation flows local to their page until at least two real call sites share the same behavior.
+- New pages should compose these modules and existing page shells before adding CSS. If a new pattern is genuinely repeated, deepen the existing module instead of creating a parallel one.

--- a/apps/web/src/ui/design-system.css
+++ b/apps/web/src/ui/design-system.css
@@ -269,25 +269,6 @@ textarea.ds-control--compact {
   padding: 0.4rem 0.65rem;
 }
 
-select.ds-control--quiet {
-  border-color: transparent;
-  background-color: transparent;
-  box-shadow: none;
-  color: var(--color-text-secondary);
-  font-weight: var(--fw-medium);
-}
-
-select.ds-control--quiet:hover:not(:disabled) {
-  border-color: var(--color-border-divider);
-  background-color: var(--color-bg-hover);
-  color: var(--color-text-primary);
-}
-
-select.ds-control--quiet:focus {
-  border-color: var(--color-brand);
-  background-color: var(--color-bg-surface);
-}
-
 .ds-field textarea,
 textarea.ds-control {
   min-height: 150px;

--- a/apps/web/src/ui/design-system.css
+++ b/apps/web/src/ui/design-system.css
@@ -269,6 +269,25 @@ textarea.ds-control--compact {
   padding: 0.4rem 0.65rem;
 }
 
+select.ds-control--quiet {
+  border-color: transparent;
+  background-color: transparent;
+  box-shadow: none;
+  color: var(--color-text-secondary);
+  font-weight: var(--fw-medium);
+}
+
+select.ds-control--quiet:hover:not(:disabled) {
+  border-color: var(--color-border-divider);
+  background-color: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+select.ds-control--quiet:focus {
+  border-color: var(--color-brand);
+  background-color: var(--color-bg-surface);
+}
+
 .ds-field textarea,
 textarea.ds-control {
   min-height: 150px;

--- a/apps/web/src/ui/design-system.css
+++ b/apps/web/src/ui/design-system.css
@@ -149,6 +149,83 @@
   opacity: 0.55;
 }
 
+.ds-tabs {
+  display: flex;
+  gap: var(--space-8);
+  overflow-x: auto;
+  border-bottom: 1px solid var(--color-border-divider);
+  scrollbar-width: none;
+}
+
+.ds-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.ds-tabs a {
+  position: relative;
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  color: var(--color-text-muted);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.ds-tabs a:hover,
+.ds-tabs a.active {
+  color: var(--color-brand-hover);
+}
+
+.ds-tabs a.active::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: var(--color-brand);
+  content: "";
+}
+
+.ds-settings-list {
+  overflow: hidden;
+  border: 1px solid var(--color-border-divider);
+  border-radius: var(--radius-panel);
+  background: var(--color-bg-surface);
+}
+
+.ds-settings-row {
+  display: grid;
+  align-items: start;
+  border-bottom: 1px solid var(--color-border-divider);
+  grid-template-columns: minmax(180px, 0.7fr) minmax(260px, 1.3fr);
+  gap: var(--space-8);
+  padding: var(--space-6);
+}
+
+.ds-settings-row:last-child {
+  border-bottom: 0;
+}
+
+.ds-settings-row__copy strong {
+  color: var(--color-text-secondary);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+}
+
+.ds-settings-row__copy p {
+  margin: 5px 0 0;
+  color: var(--color-text-muted);
+  font-size: var(--text-meta);
+  font-weight: var(--fw-regular);
+  line-height: var(--lh-prose);
+}
+
+.ds-settings-row__control {
+  min-width: 0;
+}
+
 .ds-field {
   display: grid;
   gap: 7px;
@@ -158,6 +235,18 @@
   color: var(--color-text-secondary);
   font-size: var(--text-ui);
   font-weight: var(--fw-semibold);
+}
+
+.ds-settings-row .ds-field__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .ds-field input,
@@ -321,5 +410,18 @@ textarea.ds-control:focus {
 @media (prefers-reduced-motion: reduce) {
   .ds-button {
     transition: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .ds-settings-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
+  }
+}
+
+@media (max-width: 900px) {
+  .ds-tabs--collapsible {
+    display: none;
   }
 }

--- a/apps/web/src/ui/design-system.css
+++ b/apps/web/src/ui/design-system.css
@@ -262,6 +262,13 @@ textarea.ds-control {
   padding: 0.55rem 0.75rem;
 }
 
+input.ds-control--compact,
+select.ds-control--compact,
+textarea.ds-control--compact {
+  min-height: 36px;
+  padding: 0.4rem 0.65rem;
+}
+
 .ds-field textarea,
 textarea.ds-control {
   min-height: 150px;
@@ -401,10 +408,6 @@ textarea.ds-control:focus {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-}
-
-.settings-member-row select.ds-control {
-  min-height: 40px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/ui/design-system.css
+++ b/apps/web/src/ui/design-system.css
@@ -287,11 +287,6 @@ textarea.ds-control:focus {
   height: 18px;
 }
 
-.agent-row-action .ds-icon {
-  width: 18px;
-  height: 18px;
-}
-
 .availability-action .ds-status {
   display: inline-flex;
   flex: 1;

--- a/apps/web/src/ui/design-system.css
+++ b/apps/web/src/ui/design-system.css
@@ -35,14 +35,14 @@
   --space-4: 16px;
   --space-6: 24px;
   --space-8: 32px;
-  --radius-control: 9px;
-  --radius-panel: 13px;
+  --radius-control: 8px;
+  --radius-panel: 12px;
   --radius-overlay: 16px;
 }
 
 .ds-button {
   display: inline-flex;
-  min-height: 42px;
+  min-height: 40px;
   align-items: center;
   justify-content: center;
   gap: var(--space-2);
@@ -51,13 +51,13 @@
   cursor: pointer;
   font-size: var(--text-ui);
   font-weight: var(--fw-semibold);
-  padding: 0.58rem 0.95rem;
+  padding: 0.5rem 1rem;
   text-decoration: none;
   transition:
-    background-color 140ms ease,
-    border-color 140ms ease,
-    color 140ms ease,
-    transform 140ms ease;
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
   white-space: nowrap;
 }
 
@@ -71,7 +71,7 @@
 }
 
 .ds-button--secondary {
-  background: var(--color-bg-hover);
+  background: var(--color-bg-subtle);
   color: var(--color-text-primary);
 }
 
@@ -80,47 +80,68 @@
   color: var(--color-text-primary);
 }
 
-.ds-button--commit {
-  background: var(--color-text-primary);
-  color: var(--color-on-accent);
-}
-
-.ds-button--commit:hover {
-  background: var(--color-text-primary-hover);
-}
-
-.ds-button--tertiary,
-.ds-button--danger {
-  min-height: 34px;
+.ds-button--outline {
+  border-color: var(--color-border-divider);
   background: transparent;
-  padding: 0 0.45rem;
+  color: var(--color-text-primary);
 }
 
-.ds-button--tertiary {
+.ds-button--outline:hover {
+  border-color: var(--color-border-control);
+  background: var(--color-bg-hover);
+}
+
+.ds-button--ghost,
+.ds-button--inline {
+  background: transparent;
+}
+
+.ds-button--ghost {
   color: var(--color-text-muted);
 }
 
-.ds-button--tertiary:hover {
+.ds-button--ghost:hover {
   background: var(--color-bg-hover);
   color: var(--color-text-primary);
 }
 
 .ds-button--danger {
-  color: var(--color-status-danger);
+  background: var(--color-status-danger);
+  color: var(--color-on-accent);
 }
 
 .ds-button--danger:hover {
-  background: var(--color-status-danger-surface);
-  color: var(--color-status-danger);
+  background: #6f211c;
+  color: var(--color-on-accent);
+}
+
+.ds-button--inline {
+  min-height: 0;
+  border-radius: 4px;
+  color: var(--color-brand-hover);
+  padding: 0;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 3px;
+}
+
+.ds-button--inline:hover {
+  color: var(--color-brand);
+  text-decoration-color: currentColor;
 }
 
 .ds-button--compact {
-  min-height: 36px;
-  padding: 0.42rem 0.75rem;
+  min-height: 32px;
+  padding: 0.375rem 0.75rem;
 }
 
 .ds-button:active {
-  transform: translateY(1px);
+  transform: scale(0.96);
+}
+
+.ds-button:focus-visible {
+  outline: 2px solid var(--color-brand-hover);
+  outline-offset: 2px;
 }
 
 .ds-button:disabled {
@@ -145,9 +166,16 @@
 input.ds-control,
 select.ds-control,
 textarea.ds-control {
+  min-height: 40px;
   border-color: var(--color-border-control);
   border-radius: var(--radius-control);
   background: var(--color-bg-surface);
+  padding: 0.55rem 0.75rem;
+}
+
+.ds-field textarea,
+textarea.ds-control {
+  min-height: 150px;
 }
 
 .ds-field input:focus,
@@ -207,13 +235,13 @@ textarea.ds-control:focus {
 }
 
 .ds-status__dot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   flex: 0 0 auto;
   margin-top: 0.42em;
   border-radius: 999px;
   background: var(--status-color);
-  box-shadow: 0 0 0 3px var(--status-surface);
+  box-shadow: 0 0 0 2px var(--status-surface);
 }
 
 .ds-status__copy,
@@ -250,7 +278,7 @@ textarea.ds-control:focus {
 }
 
 .dialog-close.ds-button {
-  width: 34px;
+  width: 40px;
   padding: 0;
 }
 
@@ -292,7 +320,7 @@ textarea.ds-control:focus {
 }
 
 .settings-member-row select.ds-control {
-  min-height: 36px;
+  min-height: 40px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/ui/design-system.test.tsx
+++ b/apps/web/src/ui/design-system.test.tsx
@@ -9,6 +9,19 @@ describe("design system primitives", () => {
     expect(screen.getByRole("button", { name: "Cancel" }).className).toContain("ds-button--secondary");
   });
 
+  it("exposes the Viktor-aligned button hierarchy without a separate save color", () => {
+    render(
+      <>
+        <Button variant="outline">Review</Button>
+        <Button variant="ghost">Dismiss</Button>
+        <Button variant="inline">Details</Button>
+      </>,
+    );
+    expect(screen.getByRole("button", { name: "Review" }).className).toContain("ds-button--outline");
+    expect(screen.getByRole("button", { name: "Dismiss" }).className).toContain("ds-button--ghost");
+    expect(screen.getByRole("button", { name: "Details" }).className).toContain("ds-button--inline");
+  });
+
   it("shares button styling with semantic links", () => {
     render(
       <a className={buttonClassName({ variant: "secondary" })} href="/continue">

--- a/apps/web/src/ui/design-system.test.tsx
+++ b/apps/web/src/ui/design-system.test.tsx
@@ -1,12 +1,21 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { createRef, useState } from "react";
 import { describe, expect, it } from "vitest";
-import { Button, Dialog, Field, Icon, StatusIndicator } from "./design-system.js";
+import { Button, buttonClassName, Dialog, Field, Icon, StatusIndicator } from "./design-system.js";
 
 describe("design system primitives", () => {
   it("maps button intent to an explicit visual variant", () => {
     render(<Button variant="secondary">Cancel</Button>);
     expect(screen.getByRole("button", { name: "Cancel" }).className).toContain("ds-button--secondary");
+  });
+
+  it("shares button styling with semantic links", () => {
+    render(
+      <a className={buttonClassName({ variant: "secondary" })} href="/continue">
+        Continue
+      </a>,
+    );
+    expect(screen.getByText("Continue").className).toContain("ds-button--secondary");
   });
 
   it("keeps field labels, help and errors associated with the control", () => {
@@ -33,7 +42,7 @@ describe("design system primitives", () => {
   });
 
   it("provides consistent vector icons", () => {
-    const { container } = render(<Icon name="chevron-right" />);
+    const { container } = render(<Icon name="check" />);
     expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
     expect(container.querySelector("path")).toBeTruthy();
   });

--- a/apps/web/src/ui/design-system.test.tsx
+++ b/apps/web/src/ui/design-system.test.tsx
@@ -1,7 +1,17 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { createRef, useState } from "react";
 import { describe, expect, it } from "vitest";
-import { Button, buttonClassName, Dialog, Field, Icon, StatusIndicator } from "./design-system.js";
+import {
+  Button,
+  buttonClassName,
+  Dialog,
+  Field,
+  Icon,
+  SettingsList,
+  SettingsRow,
+  StatusIndicator,
+  Tabs,
+} from "./design-system.js";
 
 describe("design system primitives", () => {
   it("maps button intent to an explicit visual variant", () => {
@@ -29,6 +39,35 @@ describe("design system primitives", () => {
       </a>,
     );
     expect(screen.getByText("Continue").className).toContain("ds-button--secondary");
+  });
+
+  it("provides labelled tabs with an explicit mobile-collapse contract", () => {
+    render(
+      <Tabs collapseOnMobile label="Example settings">
+        <a href="/general">General</a>
+        <a href="/runtime">Runtime</a>
+      </Tabs>,
+    );
+    const navigation = screen.getByRole("navigation", { name: "Example settings" });
+    expect(navigation.className).toContain("ds-tabs");
+    expect(navigation.className).toContain("ds-tabs--collapsible");
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+  });
+
+  it("keeps setting copy and controls in one consistent row", () => {
+    render(
+      <SettingsList>
+        <SettingsRow label="Display name" description="Visible throughout the product.">
+          <Field htmlFor="display-name" label="Display name">
+            <input id="display-name" />
+          </Field>
+        </SettingsRow>
+      </SettingsList>,
+    );
+    const row = screen.getByText("Visible throughout the product.").closest(".ds-settings-row");
+    expect(row).toBeTruthy();
+    expect(screen.getByLabelText("Display name")).toBeTruthy();
+    expect(row?.querySelector(".ds-settings-row__control")).toBeTruthy();
   });
 
   it("keeps field labels, help and errors associated with the control", () => {

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -40,6 +40,48 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   return <button className={buttonClassName({ className, size, variant })} ref={ref} type={type} {...props} />;
 });
 
+export function Tabs({
+  children,
+  className,
+  collapseOnMobile = false,
+  label,
+}: {
+  children: ReactNode;
+  className?: string;
+  collapseOnMobile?: boolean;
+  label: string;
+}) {
+  return (
+    <nav aria-label={label} className={classes("ds-tabs", collapseOnMobile && "ds-tabs--collapsible", className)}>
+      {children}
+    </nav>
+  );
+}
+
+export function SettingsList({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={classes("ds-settings-list", className)}>{children}</div>;
+}
+
+export function SettingsRow({
+  children,
+  description,
+  label,
+}: {
+  children: ReactNode;
+  description?: ReactNode;
+  label: ReactNode;
+}) {
+  return (
+    <div className="ds-settings-row">
+      <div className="ds-settings-row__copy">
+        <strong>{label}</strong>
+        {description ? <p>{description}</p> : null}
+      </div>
+      <div className="ds-settings-row__control">{children}</div>
+    </div>
+  );
+}
+
 export function Field({
   children,
   className,

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -145,7 +145,7 @@ export function StatusIndicator({
   );
 }
 
-export type IconName = "arrow-left" | "arrow-right" | "check" | "chevron-right" | "close" | "more-vertical";
+export type IconName = "arrow-left" | "arrow-right" | "check" | "chevron-right" | "close" | "more-vertical" | "plus";
 
 export function Icon({ className, name, ...props }: SVGAttributes<SVGSVGElement> & { name: IconName }) {
   return (
@@ -161,6 +161,7 @@ export function Icon({ className, name, ...props }: SVGAttributes<SVGSVGElement>
       {name === "check" ? <path d="m4.5 10.5 3.5 3.5 7.5-8" /> : null}
       {name === "more-vertical" ? <path d="M10 5.5h.01M10 10h.01M10 14.5h.01" /> : null}
       {name === "chevron-right" ? <path d="m7.5 4.5 5.5 5.5-5.5 5.5" /> : null}
+      {name === "plus" ? <path d="M10 4v12M4 10h12" /> : null}
       {name === "arrow-right" ? <path d="M3.5 10h13m-5-5 5 5-5 5" /> : null}
       {name === "arrow-left" ? <path d="M16.5 10h-13m5-5-5 5 5 5" /> : null}
     </svg>

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -21,18 +21,23 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: ButtonVariant;
 };
 
+export function buttonClassName({
+  className,
+  size = "default",
+  variant = "primary",
+}: {
+  className?: string;
+  size?: ButtonProps["size"];
+  variant?: ButtonVariant;
+} = {}): string {
+  return classes("ds-button", `ds-button--${variant}`, size === "compact" && "ds-button--compact", className);
+}
+
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   { className, size = "default", variant = "primary", type = "button", ...props },
   ref,
 ) {
-  return (
-    <button
-      className={classes("ds-button", `ds-button--${variant}`, size === "compact" && "ds-button--compact", className)}
-      ref={ref}
-      type={type}
-      {...props}
-    />
-  );
+  return <button className={buttonClassName({ className, size, variant })} ref={ref} type={type} {...props} />;
 });
 
 export function Field({
@@ -98,7 +103,7 @@ export function StatusIndicator({
   );
 }
 
-export type IconName = "arrow-left" | "arrow-right" | "chevron-right" | "close";
+export type IconName = "arrow-left" | "arrow-right" | "check" | "chevron-right" | "close" | "more-vertical";
 
 export function Icon({ className, name, ...props }: SVGAttributes<SVGSVGElement> & { name: IconName }) {
   return (
@@ -111,6 +116,8 @@ export function Icon({ className, name, ...props }: SVGAttributes<SVGSVGElement>
       {...props}
     >
       {name === "close" ? <path d="m5 5 10 10M15 5 5 15" /> : null}
+      {name === "check" ? <path d="m4.5 10.5 3.5 3.5 7.5-8" /> : null}
+      {name === "more-vertical" ? <path d="M10 5.5h.01M10 10h.01M10 14.5h.01" /> : null}
       {name === "chevron-right" ? <path d="m7.5 4.5 5.5 5.5-5.5 5.5" /> : null}
       {name === "arrow-right" ? <path d="M3.5 10h13m-5-5 5 5-5 5" /> : null}
       {name === "arrow-left" ? <path d="M16.5 10h-13m5-5-5 5 5 5" /> : null}

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -14,7 +14,7 @@ function classes(...values: Array<string | false | null | undefined>): string {
   return values.filter(Boolean).join(" ");
 }
 
-export type ButtonVariant = "primary" | "secondary" | "commit" | "tertiary" | "danger";
+export type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "danger" | "inline";
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: "default" | "compact";
@@ -238,7 +238,7 @@ export function Dialog({
             className="dialog-close"
             disabled={busy}
             ref={closeButtonRef}
-            variant="tertiary"
+            variant="ghost"
             onClick={onClose}
           >
             <Icon name="close" />

--- a/docs/design/web-design-system-migration.md
+++ b/docs/design/web-design-system-migration.md
@@ -1,0 +1,32 @@
+# Web design system migration inventory
+
+This inventory records the legacy UI implementations found at the start of the incremental site migration from baseline
+`17077fd`. It is intentionally scoped to the requested pages and avoids treating specialized controls as generic buttons.
+
+| Page group | Legacy implementation found | Migration target |
+| --- | --- | --- |
+| Login, invitation, Workspace creation | `.button` links/buttons; native Workspace label/input | `Button` styling for links, `Button`, `Field` |
+| Account and Workspace profile | `.tertiary`, `.button.commit`; native labels and help copy | `Button`, `Field` |
+| Onboarding | `.button`, `.secondary`, `.tertiary`; native Agent field; action links using button classes | `Button`, `Field`, design-system button-link classes |
+| Computer setup | `.button` and `.button.secondary` | `Button` |
+| Runtime configuration | four `.form-field`/`.field-help` groups and `.button` submit | `Field`, `Button` |
+| Feishu setup and Agent messaging | legacy primary/secondary/danger buttons; ad hoc binding status presentation | `Button`, `StatusIndicator` |
+| Integrations, Resources, Usage | legacy Connect/Add buttons; native range label/select | `Button`, `Field`; keep the resource filter as a specialized pressed-button group |
+| Shared navigation/action affordances | Unicode right arrow and current-Workspace check mark | `Icon` |
+| Legacy CSS | `.button` variants, compact modifier, old field helpers, unused availability/settings dots | Remove only after their migrated call sites are gone |
+
+## Intentionally specialized controls
+
+- Account-menu items remain native menu buttons because their menu layout and keyboard behavior are purpose-specific.
+- Messaging receive-mode buttons remain native buttons inside the existing segmented control.
+- Onboarding Computer/Agent choices remain native buttons with the existing choice-card interaction.
+- Resource filters remain native pressed buttons; replacing them with generic action buttons would weaken their selected-state
+  semantics.
+- Simple table role selects continue to use `ds-control` without an extra `Field` wrapper.
+
+## Completion status
+
+All legacy variant-class call sites in the scoped pages have been migrated. The shared base `button` rules remain because
+the specialized native controls above still use them; removing that base would be a separate, broader control-system
+rewrite. No `.button`, `.secondary`, `.tertiary`, `.danger`, `.danger-text`, `.commit`, or `.compact-button` call sites
+remain in the web TSX source.


### PR DESCRIPTION
## Summary

- Migrate the remaining scoped legacy buttons, form fields, status indicators, and interaction icons to the shared web design system.
- Establish a consistent 1024px page frame with 960px visible content across workspace pages.
- Refine Agents, Agent detail, Members, Usage, Account, Workspace, Integrations, Skills, onboarding, runtime, computer, and Feishu setup surfaces without changing API behavior.
- Document the page-layout contract and incremental migration inventory.

## UX changes

- Present Agents as information-rich cards and keep Computer and runtime configuration within Agent detail.
- Move Agent detail navigation to top tabs.
- Separate Account and Workspace settings into /account and /workspace.
- Remove duplicate invitation actions and the unused Usage time-range control.
- Align Members and other workspace pages with the shared spacing, border, control, and content-width rules.

## Validation

- pnpm --filter @opentag/web typecheck
- pnpm --filter @opentag/web test — 12 files, 264 tests passed
- pnpm --filter @opentag/web build
- pnpm exec biome check . — passed with 8 pre-existing E2E environment-variable warnings
- git diff --check origin/main...HEAD

## Notes

- Purpose-specific native controls such as menus, segmented receive-mode controls, onboarding choice cards, and resource filters remain specialized.
- The expanded New Agent dialog flow is intentionally excluded and remains on its separate branch.