### PR TITLE
feat(web): unify Agent creation flow

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -40,7 +40,7 @@ function installApi(
     emptyAgents?: boolean;
     agentCreate?: (input: Record<string, unknown>) => Promise<void> | void;
     alreadyJoinedInvitation?: boolean;
-    agentCreateError?: "generic" | "name";
+    agentCreateError?: "conflict" | "generic" | "name";
     authProviders?: readonly { enabled: boolean; id: string; startUrl: string | null }[];
     bindingReauth?: boolean;
     bindingEvidenceFails?: boolean;
@@ -205,6 +205,18 @@ function installApi(
     }
     if (/^\/api\/v1\/teams\/[^/]+\/agents$/.test(path) && init?.method === "POST") {
       if (options.agentCreateError) {
+        if (options.agentCreateError === "conflict") {
+          return json(
+            {
+              error: {
+                code: "AGENT_NAME_CONFLICT",
+                category: "deterministic",
+                message: "An active Agent with this name already exists in the Team",
+              },
+            },
+            409,
+          );
+        }
         return json(
           {
             error: {
@@ -356,6 +368,7 @@ function installApi(
                   arch: "arm64",
                   clientVersion: "0.0.1",
                   connectionStatus: "online",
+                  providerReadiness: [{ provider: "codex", status: "ready", observedAt: "2026-08-20T00:00:00.000Z" }],
                   connectedAt: "2026-08-20T00:00:00.000Z",
                   lastSeenAt: "2026-08-20T00:00:01.000Z",
                 },
@@ -574,11 +587,21 @@ describe("OpenTag Web App Shell", () => {
     expect(within(dialog).queryByText("Create")).toBeNull();
     expect(window.location.pathname).toBe("/agents");
     await waitFor(() => expect(within(dialog).getByLabelText("Display name")).toBe(document.activeElement));
-    expect(within(dialog).getByLabelText("Agent name")).toBeTruthy();
-    expect(within(dialog).getByLabelText("Provider")).toBeTruthy();
-    expect(within(dialog).getByLabelText("Computer")).toBeTruthy();
-    expect(within(dialog).getByRole("button", { name: "Connect another Computer" })).toBeTruthy();
+    expect(within(dialog).queryByLabelText("Agent name")).toBeNull();
+    expect(within(dialog).getByRole("button", { name: "Edit Agent name" })).toBeTruthy();
+    expect(within(dialog).getByRole("heading", { name: "Where it runs" })).toBeTruthy();
+    expect(within(dialog).getByText("Ready to run")).toBeTruthy();
     expect(within(dialog).getByRole("button", { name: "Create Agent" })).toBeTruthy();
+
+    fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "Research Assistant" } });
+    expect(within(dialog).getByText("@research-assistant")).toBeTruthy();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Edit Agent name" }));
+    const name = within(dialog).getByLabelText("Agent name") as HTMLInputElement;
+    expect(name.value).toBe("research-assistant");
+    await waitFor(() => expect(name).toBe(document.activeElement));
+    fireEvent.change(name, { target: { value: "custom-researcher" } });
+    fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "Research Partner" } });
+    expect(name.value).toBe("custom-researcher");
 
     fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
     expect(screen.queryByRole("dialog", { name: "New Agent" })).toBeNull();
@@ -601,7 +624,8 @@ describe("OpenTag Web App Shell", () => {
     expect(
       within(dialog).getByRole("button", { name: "Cancel Computer connection" }).getAttribute("aria-expanded"),
     ).toBe("true");
-    expect(within(dialog).getByLabelText("Computer")).toBeTruthy();
+    expect(within(dialog).getByRole("heading", { name: "Where it runs" })).toBeTruthy();
+    expect(within(dialog).getByText("Ready to run")).toBeTruthy();
   });
 
   it("refreshes and selects a newly connected Computer in New Agent", async () => {
@@ -614,6 +638,7 @@ describe("OpenTag Web App Shell", () => {
       arch: "arm64",
       clientVersion: "0.0.1",
       connectionStatus: "online",
+      providerReadiness: [{ provider: "codex", status: "ready", observedAt: "2026-08-20T00:00:00.000Z" }],
       connectedAt: "2026-08-20T00:00:00.000Z",
       lastSeenAt: "2026-08-20T00:00:01.000Z",
     };
@@ -642,6 +667,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.change(within(dialog).getByLabelText("Display name"), {
       target: { value: "Research Assistant" },
     });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Edit Agent name" }));
     fireEvent.change(within(dialog).getByLabelText("Agent name"), {
       target: { value: "research-assistant" },
     });
@@ -667,11 +693,63 @@ describe("OpenTag Web App Shell", () => {
         await Promise.resolve();
       });
 
-      expect((within(dialog).getByLabelText("Computer") as HTMLSelectElement).value).toBe(connectedComputerId);
+      expect(within(dialog).getByText("Codex · Ada's Linux Computer")).toBeTruthy();
       expect((within(dialog).getByLabelText("Display name") as HTMLInputElement).value).toBe("Research Assistant");
       expect((within(dialog).getByLabelText("Agent name") as HTMLInputElement).value).toBe("research-assistant");
       expect(within(dialog).queryByRole("heading", { name: "Connect a Local Computer" })).toBeNull();
       expect(within(dialog).getByRole("button", { name: "Connect another Computer" })).toBe(document.activeElement);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps dialog focus when a post-connection Computer refresh fails terminally", async () => {
+    const connectedComputer = {
+      id: "95fe9af3-d1c6-472b-b78c-8a7ccf512750",
+      ownerUserId: userId,
+      displayName: "Ada's Linux Computer",
+      platform: "linux",
+      arch: "arm64",
+      clientVersion: "0.0.1",
+      connectionStatus: "online",
+      providerReadiness: [{ provider: "codex", status: "ready", observedAt: "2026-08-20T00:00:02.000Z" }],
+      connectedAt: "2026-08-20T00:00:02.000Z",
+      lastSeenAt: "2026-08-20T00:00:02.000Z",
+    };
+    let ownComputerReads = 0;
+    installApi("admin", {
+      computers: () => (ownComputerReads >= 3 ? [connectedComputer] : []),
+      ownComputerReadStatus: () => {
+        ownComputerReads += 1;
+        return ownComputerReads >= 4 ? 404 : undefined;
+      },
+    });
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
+    const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-08-20T00:00:00.000Z");
+    try {
+      const generateButton = within(dialog).getByRole("button", { name: "Generate connection command" });
+      generateButton.focus();
+      await act(async () => {
+        fireEvent.click(generateButton);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_500);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(within(dialog).getByRole("alert").textContent).toContain("Request failed");
+      const refreshStatus = within(dialog).getByRole("status");
+      expect(refreshStatus.textContent).toContain("Computer refresh failed");
+      expect(refreshStatus).toBe(document.activeElement);
+      expect(dialog.contains(document.activeElement)).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -688,6 +766,7 @@ describe("OpenTag Web App Shell", () => {
       arch: "arm64",
       clientVersion: "0.0.1",
       connectionStatus: "online",
+      providerReadiness: [{ provider: "codex", status: "ready", observedAt: disconnectedAt }],
       connectedAt: disconnectedAt,
       lastSeenAt: "2026-08-20T00:00:01.000Z",
     };
@@ -704,6 +783,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.change(within(dialog).getByLabelText("Display name"), {
       target: { value: "Research Assistant" },
     });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Edit Agent name" }));
     fireEvent.change(within(dialog).getByLabelText("Agent name"), {
       target: { value: "research-assistant" },
     });
@@ -721,7 +801,7 @@ describe("OpenTag Web App Shell", () => {
         await vi.advanceTimersByTimeAsync(1_500);
       });
 
-      expect((within(dialog).getByLabelText("Computer") as HTMLSelectElement).value).toBe(computerId);
+      expect(within(dialog).getByText("Codex · Ada's Mac")).toBeTruthy();
       expect((within(dialog).getByLabelText("Display name") as HTMLInputElement).value).toBe("Research Assistant");
       expect((within(dialog).getByLabelText("Agent name") as HTMLInputElement).value).toBe("research-assistant");
       expect(within(dialog).queryByRole("heading", { name: "Connect a Local Computer" })).toBeNull();
@@ -740,6 +820,7 @@ describe("OpenTag Web App Shell", () => {
       arch: "arm64",
       clientVersion: "0.0.1",
       connectionStatus: "online",
+      providerReadiness: [{ provider: "codex", status: "ready", observedAt: "2026-08-20T00:00:02.000Z" }],
       connectedAt: "2026-08-20T00:00:02.000Z",
       lastSeenAt: "2026-08-20T00:00:02.000Z",
     };
@@ -785,7 +866,7 @@ describe("OpenTag Web App Shell", () => {
         await Promise.resolve();
       });
 
-      expect((within(dialog).getByLabelText("Computer") as HTMLSelectElement).value).toBe(computerId);
+      expect(within(dialog).getByText("Codex · Ada's Mac")).toBeTruthy();
       expect(within(dialog).getByRole("button", { name: "Connect another Computer" })).toBe(document.activeElement);
     } finally {
       vi.useRealTimers();
@@ -799,9 +880,11 @@ describe("OpenTag Web App Shell", () => {
     const dialog = await screen.findByRole("dialog", { name: "New Agent" });
 
     fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "Research Assistant" } });
-    fireEvent.change(within(dialog).getByLabelText("Agent name"), { target: { value: "research-assistant" } });
+    expect(within(dialog).queryByLabelText("Agent name")).toBeNull();
     fireEvent.click(within(dialog).getByRole("button", { name: "Create Agent" }));
 
+    expect(await within(dialog).findByRole("heading", { name: "Connect messaging" })).toBeTruthy();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Set up later" }));
     await waitFor(() => expect(window.location.pathname).toBe(`/agents/${agentId}/general`));
     const createCall = vi
       .mocked(fetch)
@@ -828,6 +911,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
     const dialog = await screen.findByRole("dialog", { name: "New Agent" });
     fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "Research Assistant" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Edit Agent name" }));
     fireEvent.change(within(dialog).getByLabelText("Agent name"), { target: { value: "research-assistant" } });
     const form = within(dialog).getByRole("button", { name: "Create Agent" }).closest("form");
     const submitButton = within(dialog).getByRole("button", { name: "Create Agent" });
@@ -849,8 +933,7 @@ describe("OpenTag Web App Shell", () => {
     await waitFor(() => expect(dialog).toBe(document.activeElement));
     expect((within(dialog).getByLabelText("Display name") as HTMLInputElement).disabled).toBe(true);
     expect((within(dialog).getByLabelText("Agent name") as HTMLInputElement).disabled).toBe(true);
-    expect((within(dialog).getByLabelText("Provider") as HTMLSelectElement).disabled).toBe(true);
-    expect((within(dialog).getByLabelText("Computer") as HTMLSelectElement).disabled).toBe(true);
+    expect(within(dialog).getByRole("status").textContent).toContain("Ready to run");
     expect(within(dialog).getByRole("button", { name: "Creating…" }).hasAttribute("disabled")).toBe(true);
     expect(within(dialog).getByRole("button", { name: "Cancel" }).hasAttribute("disabled")).toBe(true);
     expect(within(dialog).getByRole("button", { name: "Close new Agent dialog" }).hasAttribute("disabled")).toBe(true);
@@ -858,6 +941,8 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("dialog", { name: "New Agent" })).toBe(dialog);
 
     resolveCreate();
+    expect(await within(dialog).findByRole("heading", { name: "Connect messaging" })).toBeTruthy();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Set up later" }));
     await waitFor(() => expect(window.location.pathname).toBe(`/agents/${agentId}/general`));
   });
 
@@ -874,12 +959,15 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
     const dialog = await screen.findByRole("dialog", { name: "New Agent" });
     fireEvent.change(within(dialog).getByLabelText("Display name"), { target: { value: "Research Assistant" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Edit Agent name" }));
     fireEvent.change(within(dialog).getByLabelText("Agent name"), { target: { value: "research-assistant" } });
 
     fireEvent.click(within(dialog).getByRole("button", { name: "Create Agent" }));
     expect((await within(dialog).findByRole("alert")).textContent).toContain("Connection lost after creation");
     fireEvent.click(within(dialog).getByRole("button", { name: "Create Agent" }));
 
+    expect(await within(dialog).findByRole("heading", { name: "Connect messaging" })).toBeTruthy();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Set up later" }));
     await waitFor(() => expect(window.location.pathname).toBe(`/agents/${agentId}/general`));
     expect(attempts).toHaveLength(2);
     expect(attempts[0]?.creationIntentId).toMatch(/^[0-9a-f-]{36}$/i);
@@ -1692,7 +1780,9 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", { ownComputer: true });
     window.history.replaceState({}, "", "/agents/new");
     render(<App />);
-    const name = await screen.findByLabelText("Agent name");
+    await screen.findByLabelText("Display name");
+    fireEvent.click(screen.getByRole("button", { name: "Edit Agent name" }));
+    const name = screen.getByLabelText("Agent name");
     fireEvent.change(name, { target: { value: "Bestony" } });
     fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Bestony" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
@@ -1711,13 +1801,38 @@ describe("OpenTag Web App Shell", () => {
     ).toHaveLength(0);
   });
 
+  it("asks for an explicit Agent name when the display name cannot produce an ASCII name", async () => {
+    installApi("admin", { ownComputer: true });
+    window.history.replaceState({}, "", "/agents/new");
+    render(<App />);
+    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "研究助手" } });
+    expect(screen.getByRole("button", { name: "Edit Agent name" }).textContent).toBe("Set Agent name");
+    expect(screen.queryByLabelText("Agent name")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
+
+    const alert = await screen.findByRole("alert");
+    const name = screen.getByLabelText("Agent name");
+    expect(alert.textContent).toBe("Agent name is required");
+    await waitFor(() => expect(name).toBe(document.activeElement));
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.filter(
+          ([input, init]) => String(input) === `/api/v1/teams/${teamId}/agents` && init?.method === "POST",
+        ),
+    ).toHaveLength(0);
+  });
+
   it("creates an Agent with a valid canonical name and keeps the existing payload", async () => {
     installApi("admin", { ownComputer: true });
     window.history.replaceState({}, "", "/agents/new");
     render(<App />);
-    fireEvent.change(await screen.findByLabelText("Agent name"), { target: { value: "bestony" } });
-    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Bestony" } });
+    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "Bestony" } });
+    expect(screen.queryByLabelText("Agent name")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
+    expect(await screen.findByRole("heading", { name: "Connect messaging" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Set up later" }));
     await waitFor(() => expect(window.location.pathname).toBe(`/agents/${agentId}/general`));
     const createCall = vi
       .mocked(fetch)
@@ -1737,29 +1852,44 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", { agentCreateError: "name", ownComputer: true });
     window.history.replaceState({}, "", "/agents/new");
     render(<App />);
-    const name = await screen.findByLabelText("Agent name");
-    fireEvent.change(name, { target: { value: "bestony" } });
-    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Bestony" } });
+    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "Bestony" } });
+    expect(screen.queryByLabelText("Agent name")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
     const alert = await screen.findByRole("alert");
+    const name = screen.getByLabelText("Agent name");
     expect(alert.textContent).toBe("Use a lowercase Agent name");
     expect(name.getAttribute("aria-describedby")?.split(" ")).toContain(alert.id);
+    await waitFor(() => expect(name).toBe(document.activeElement));
     expect(window.location.pathname).toBe("/agents/new");
+  });
+
+  it("reveals the Agent name editor when the Server reports a Team name conflict", async () => {
+    installApi("admin", { agentCreateError: "conflict", ownComputer: true });
+    window.history.replaceState({}, "", "/agents/new");
+    render(<App />);
+    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "Bestony" } });
+    expect(screen.queryByLabelText("Agent name")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
+
+    const alert = await screen.findByRole("alert");
+    const name = screen.getByLabelText("Agent name");
+    expect(alert.textContent).toBe("An active Agent with this name already exists in the Team");
+    expect(name.getAttribute("aria-invalid")).toBe("true");
+    await waitFor(() => expect(name).toBe(document.activeElement));
   });
 
   it("keeps an unmapped Server validation error at form level", async () => {
     installApi("admin", { agentCreateError: "generic", ownComputer: true });
     window.history.replaceState({}, "", "/agents/new");
     render(<App />);
-    const name = await screen.findByLabelText("Agent name");
-    fireEvent.change(name, { target: { value: "bestony" } });
-    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Bestony" } });
+    fireEvent.change(await screen.findByLabelText("Display name"), { target: { value: "Bestony" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
     expect((await screen.findByRole("alert")).textContent).toBe("The request payload is invalid");
-    expect(name.getAttribute("aria-invalid")).toBeNull();
+    expect(screen.queryByLabelText("Agent name")).toBeNull();
   });
 
-  it("shows exact Computer and Provider readiness without blocking Agent creation or offering fallback", async () => {
+  it("uses only a confirmed ready Computer and Provider route", async () => {
     installApi("admin", {
       computers: [
         {
@@ -1781,13 +1911,11 @@ describe("OpenTag Web App Shell", () => {
     });
     window.history.replaceState({}, "", "/agents/new");
     render(<App />);
-    expect(await screen.findByText("Codex is ready on Ada's Mac.")).toBeTruthy();
-    fireEvent.change(screen.getByLabelText("Provider"), { target: { value: "claude-code" } });
-    expect(await screen.findByText(/Claude Code requires sign-in/)).toBeTruthy();
-    expect(screen.getByText(/No other Provider will be substituted/)).toBeTruthy();
+    expect(await screen.findByText("Codex · Ada's Mac")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
+    expect(screen.queryByText(/Claude Code/)).toBeNull();
     expect(screen.getByRole("button", { name: "Create Agent" }).hasAttribute("disabled")).toBe(false);
-    fireEvent.change(screen.getByLabelText("Agent name"), { target: { value: "claude-reviewer" } });
-    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Claude Reviewer" } });
+    fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Codex Reviewer" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
     await waitFor(() => {
       const request = vi
@@ -1795,15 +1923,15 @@ describe("OpenTag Web App Shell", () => {
         .mock.calls.find(([path, init]) => path === `/api/v1/teams/${teamId}/agents` && init?.method === "POST");
       expect(JSON.parse(String(request?.[1]?.body))).toEqual({
         creationIntentId: expect.any(String),
-        name: "claude-reviewer",
-        displayName: "Claude Reviewer",
-        runtimeProvider: "claude-code",
+        name: "codex-reviewer",
+        displayName: "Codex Reviewer",
+        runtimeProvider: "codex",
         computerId,
       });
     });
   });
 
-  it("revalidates Agent creation readiness while preserving Provider and Computer selections", async () => {
+  it("revalidates ready routes and disables creation when readiness becomes unavailable", async () => {
     const claudeReadiness: {
       observedAt: string;
       provider: "claude-code";
@@ -1838,28 +1966,39 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
     const dialog = await screen.findByRole("dialog", { name: "New Agent" });
-    await within(dialog).findByText("Codex is ready on Ada's Mac.");
-    const provider = within(dialog).getByLabelText("Provider") as HTMLSelectElement;
-    const computer = within(dialog).getByLabelText("Computer") as HTMLSelectElement;
-    fireEvent.change(provider, { target: { value: "claude-code" } });
-    expect(await within(dialog).findByText(/Claude Code is currently unavailable/)).toBeTruthy();
+    await within(dialog).findByText("Codex · Ada's Mac");
+    expect(within(dialog).queryByRole("button", { name: "Change" })).toBeNull();
 
     claudeReadiness.status = "ready";
     window.dispatchEvent(new Event("focus"));
-    expect(await within(dialog).findByText("Claude Code is ready on Ada's Mac.")).toBeTruthy();
-    expect(provider.value).toBe("claude-code");
-    expect(computer.value).toBe(computerId);
+    const change = await within(dialog).findByRole("button", { name: "Change" });
+    fireEvent.click(change);
+    fireEvent.click(within(dialog).getByRole("button", { name: /Claude Code/ }));
+    expect(await within(dialog).findByText("Claude Code · Ada's Mac")).toBeTruthy();
 
     claudeReadiness.status = "unavailable";
     window.dispatchEvent(new Event("focus"));
-    expect(await within(dialog).findByText(/Claude Code is currently unavailable/)).toBeTruthy();
+    expect(await within(dialog).findByText("Codex · Ada's Mac")).toBeTruthy();
 
     ownComputerReadStatus = 503;
     window.dispatchEvent(new Event("focus"));
-    expect(await within(dialog).findByText(/Claude Code readiness has not been reported/)).toBeTruthy();
-    expect(provider.value).toBe("claude-code");
-    expect(computer.value).toBe(computerId);
-    expect(within(dialog).getByRole("button", { name: "Create Agent" }).hasAttribute("disabled")).toBe(false);
+    expect(await within(dialog).findByText("Readiness unconfirmed")).toBeTruthy();
+    expect(within(dialog).getByRole("button", { name: "Create Agent" }).hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes a retained creation route after a terminal Computer refresh error", async () => {
+    let ownComputerReadStatus: number | undefined;
+    installApi("admin", { ownComputer: true, ownComputerReadStatus: () => ownComputerReadStatus });
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
+    const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+    expect(await within(dialog).findByText("Ready to run")).toBeTruthy();
+
+    ownComputerReadStatus = 404;
+    window.dispatchEvent(new Event("focus"));
+
+    expect((await within(dialog).findByRole("alert")).textContent).toContain("Request failed");
+    expect(within(dialog).queryByRole("button", { name: "Create Agent" })).toBeNull();
   });
 
   it("keeps the Team-less authenticated gate read-only while the server finishes Workspace setup", async () => {

--- a/apps/web/src/agent-creation/agent-creation-flow.tsx
+++ b/apps/web/src/agent-creation/agent-creation-flow.tsx
@@ -1,0 +1,686 @@
+import type {
+  AgentAdminConfig,
+  AgentRuntimeProvider,
+  CreateAgentRequest,
+  ProviderReadinessStatus,
+} from "@opentag/shared/browser";
+import { AgentNameSchema } from "@opentag/shared/browser";
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ApiError, browserApi } from "../api.js";
+import { ComputerSetup } from "../computer-setup.js";
+import { Button, Field, StatusIndicator, type StatusTone } from "../ui/design-system.js";
+
+const CREATE_INTENT_VERSION = 2;
+
+export interface AgentCreationComputer {
+  readonly id: string;
+  readonly displayName: string;
+  readonly connectionStatus: "online" | "offline";
+}
+
+export interface AgentCreationProvider {
+  readonly computerId: string;
+  readonly provider: AgentRuntimeProvider;
+  readonly runtimeReady: boolean;
+  readonly status?: ProviderReadinessStatus;
+}
+
+export interface AgentCreationFacts {
+  readonly computers: readonly AgentCreationComputer[];
+  readonly providers: readonly AgentCreationProvider[];
+  readonly runtimeEvidenceAvailable: boolean;
+}
+
+export interface AgentCreationFlowProps {
+  readonly facts: AgentCreationFacts;
+  readonly initialDisplayName?: string;
+  readonly onCancel?: () => void;
+  readonly onComputerRefreshFocus?: () => void;
+  readonly onCreated: (agent: AgentAdminConfig) => void;
+  readonly onRefresh: () => void;
+  readonly onSubmittingChange?: (submitting: boolean) => void;
+  readonly refreshing?: boolean;
+  readonly teamId: string;
+}
+
+interface ReadyRoute {
+  readonly computer: AgentCreationComputer;
+  readonly provider: AgentRuntimeProvider;
+}
+
+interface CreationIntentRecord {
+  readonly version: typeof CREATE_INTENT_VERSION;
+  readonly teamId: string;
+  readonly creationIntentId: string;
+  readonly request: Omit<CreateAgentRequest, "creationIntentId">;
+}
+
+interface CreationIntentStore {
+  readonly version: typeof CREATE_INTENT_VERSION;
+  readonly teamId: string;
+  readonly records: readonly CreationIntentRecord[];
+}
+
+const memoryIntentRecords = new Map<string, readonly CreationIntentRecord[]>();
+const memoryIntentFallbackTeams = new Set<string>();
+const fallbackCreationLocks = new Map<string, Promise<void>>();
+const creationRequests = new Map<string, Promise<AgentAdminConfig>>();
+
+export function deriveAgentName(displayName: string): string {
+  return displayName
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+    .replace(/-+$/g, "");
+}
+
+export function AgentCreationFlow({
+  facts,
+  initialDisplayName = "",
+  onCancel,
+  onComputerRefreshFocus,
+  onCreated,
+  onRefresh,
+  onSubmittingChange,
+  refreshing = false,
+  teamId,
+}: AgentCreationFlowProps) {
+  const pendingIntent = useMemo(() => readCreationIntent(teamId), [teamId]);
+  const [displayName, setDisplayName] = useState(() => pendingIntent?.request.displayName ?? initialDisplayName);
+  const [name, setName] = useState(() => pendingIntent?.request.name ?? deriveAgentName(initialDisplayName));
+  const [nameDirty, setNameDirty] = useState(
+    () =>
+      pendingIntent !== undefined && pendingIntent.request.name !== deriveAgentName(pendingIntent.request.displayName),
+  );
+  const [editingName, setEditingName] = useState(false);
+  const [nameError, setNameError] = useState<string>();
+  const [error, setError] = useState<string>();
+  const [submitting, setSubmitting] = useState(false);
+  const [changingRoute, setChangingRoute] = useState(false);
+  const [connectingComputer, setConnectingComputer] = useState(false);
+  const [selectedRouteKey, setSelectedRouteKey] = useState(() =>
+    pendingIntent ? routeKey(pendingIntent.request.computerId, pendingIntent.request.runtimeProvider) : undefined,
+  );
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const nameFieldRef = useRef<HTMLInputElement>(null);
+  const computerSetupToggleRef = useRef<HTMLButtonElement>(null);
+  const inFlightRef = useRef(false);
+  const resumeAttemptedRef = useRef(false);
+  const connectedComputerIdRef = useRef<string | undefined>(undefined);
+  const restoreComputerSetupFocusRef = useRef(false);
+  const computerRefreshStartedRef = useRef(false);
+
+  const readyRoutes = useMemo(() => resolveReadyRoutes(facts), [facts]);
+  const selectedRoute =
+    readyRoutes.find((route) => routeKey(route.computer.id, route.provider) === selectedRouteKey) ?? readyRoutes[0];
+  const alternatives = readyRoutes.filter((route) => route !== selectedRoute);
+
+  useEffect(() => {
+    firstFieldRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (editingName) nameFieldRef.current?.focus();
+  }, [editingName]);
+
+  useEffect(() => {
+    if (nameError) nameFieldRef.current?.focus();
+  }, [nameError]);
+
+  useEffect(() => {
+    const connectedComputerId = connectedComputerIdRef.current;
+    if (!connectedComputerId) return;
+    const connectedRoute = readyRoutes.find((route) => route.computer.id === connectedComputerId);
+    if (!connectedRoute) return;
+    setSelectedRouteKey(routeKey(connectedRoute.computer.id, connectedRoute.provider));
+    connectedComputerIdRef.current = undefined;
+  }, [readyRoutes]);
+
+  useEffect(() => {
+    if (!restoreComputerSetupFocusRef.current) return;
+    if (refreshing) {
+      computerRefreshStartedRef.current = true;
+      return;
+    }
+    if (!computerRefreshStartedRef.current) return;
+    restoreComputerSetupFocusRef.current = false;
+    computerRefreshStartedRef.current = false;
+    (computerSetupToggleRef.current ?? firstFieldRef.current)?.focus();
+  }, [refreshing]);
+
+  const create = useCallback(
+    async (request: Omit<CreateAgentRequest, "creationIntentId">, intent?: CreationIntentRecord) => {
+      if (inFlightRef.current) return;
+      let record = intent;
+      inFlightRef.current = true;
+      setError(undefined);
+      setNameError(undefined);
+      setSubmitting(true);
+      onSubmittingChange?.(true);
+      try {
+        record ??= await getOrCreateCreationIntent(teamId, request);
+        const created = await createAgentOnce(record);
+        await clearCreationIntent(teamId, record.creationIntentId);
+        onCreated(created);
+      } catch (cause) {
+        if (cause instanceof ApiError) {
+          const issue = cause.issues?.find(({ path }) => path[0] === "name");
+          if (issue || cause.code === "AGENT_NAME_CONFLICT") {
+            if (record) await clearCreationIntent(teamId, record.creationIntentId);
+            setEditingName(true);
+            setNameError(issue?.message ?? cause.message);
+            return;
+          }
+          if (record && (cause.category === "validation" || cause.category === "deterministic")) {
+            await clearCreationIntent(teamId, record.creationIntentId);
+          }
+        }
+        setError(cause instanceof Error ? cause.message : "Agent creation failed");
+      } finally {
+        inFlightRef.current = false;
+        setSubmitting(false);
+        onSubmittingChange?.(false);
+      }
+    },
+    [onCreated, onSubmittingChange, teamId],
+  );
+
+  useEffect(() => {
+    if (!pendingIntent || resumeAttemptedRef.current) return;
+    const routeStillReady = readyRoutes.some(
+      (route) =>
+        route.computer.id === pendingIntent.request.computerId &&
+        route.provider === pendingIntent.request.runtimeProvider,
+    );
+    if (!routeStillReady) return;
+    resumeAttemptedRef.current = true;
+    void create(pendingIntent.request, pendingIntent);
+  }, [create, pendingIntent, readyRoutes]);
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (inFlightRef.current || !selectedRoute) return;
+    setError(undefined);
+    setNameError(undefined);
+    const parsedName = AgentNameSchema.safeParse(name);
+    if (!parsedName.success) {
+      setEditingName(true);
+      setNameError(parsedName.error.issues[0]?.message ?? "Agent name is invalid");
+      return;
+    }
+    void create({
+      name: parsedName.data,
+      displayName: displayName.trim(),
+      runtimeProvider: selectedRoute.provider,
+      computerId: selectedRoute.computer.id,
+    });
+  }
+
+  return (
+    <form className="form-card agent-create-form" onSubmit={submit}>
+      <div className="agent-create-identity">
+        <Field className="agent-create-field" htmlFor="new-agent-display-name" label="Display name">
+          <input
+            className="ds-control"
+            id="new-agent-display-name"
+            ref={firstFieldRef}
+            name="displayName"
+            placeholder="Research Assistant"
+            disabled={submitting}
+            required
+            value={displayName}
+            onChange={(event) => {
+              const nextDisplayName = event.currentTarget.value;
+              setDisplayName(nextDisplayName);
+              if (!nameDirty) {
+                setName(deriveAgentName(nextDisplayName));
+                setNameError(undefined);
+              }
+            }}
+          />
+        </Field>
+        {!editingName ? (
+          <div className="agent-name-summary">
+            <Button
+              aria-label="Edit Agent name"
+              aria-controls="agent-name-editor"
+              aria-expanded="false"
+              className="agent-name-handle"
+              disabled={submitting}
+              variant="inline"
+              onClick={() => setEditingName(true)}
+            >
+              {name ? `@${name}` : "Set Agent name"}
+            </Button>
+          </div>
+        ) : null}
+        {editingName ? (
+          <div id="agent-name-editor">
+            <Field
+              className="agent-create-field"
+              error={nameError}
+              errorId="agent-name-error"
+              hint="Used for mentions. Lowercase letters, numbers, and hyphens only."
+              hintId="new-agent-name-hint"
+              htmlFor="new-agent-name"
+              label="Agent name"
+            >
+              <span className="agent-name-input">
+                <span aria-hidden="true">@</span>
+                <input
+                  aria-describedby={nameError ? "new-agent-name-hint agent-name-error" : "new-agent-name-hint"}
+                  aria-invalid={nameError ? true : undefined}
+                  id="new-agent-name"
+                  ref={nameFieldRef}
+                  placeholder="research-assistant"
+                  disabled={submitting}
+                  aria-required="true"
+                  value={name}
+                  onChange={(event) => {
+                    setName(event.currentTarget.value);
+                    setNameDirty(true);
+                    setNameError(undefined);
+                  }}
+                />
+              </span>
+            </Field>
+          </div>
+        ) : null}
+      </div>
+
+      <RuntimeRouteSection
+        alternatives={alternatives}
+        changingRoute={changingRoute}
+        connectingComputer={connectingComputer}
+        computerSetupToggleRef={computerSetupToggleRef}
+        facts={facts}
+        refreshing={refreshing}
+        selectedRoute={selectedRoute}
+        submitting={submitting}
+        teamId={teamId}
+        onChangeRoute={(route) => {
+          setSelectedRouteKey(routeKey(route.computer.id, route.provider));
+          setChangingRoute(false);
+        }}
+        onConnected={(computer) => {
+          connectedComputerIdRef.current = computer.id;
+          restoreComputerSetupFocusRef.current = true;
+          computerRefreshStartedRef.current = false;
+          if (onCancel) onComputerRefreshFocus?.();
+          setConnectingComputer(false);
+          onRefresh();
+        }}
+        onRefresh={onRefresh}
+        onToggleComputerSetup={() => {
+          restoreComputerSetupFocusRef.current = false;
+          computerRefreshStartedRef.current = false;
+          setConnectingComputer((current) => !current);
+        }}
+        onToggleRoutes={() => setChangingRoute((value) => !value)}
+      />
+
+      {error ? (
+        <div className="notice error" role="alert">
+          {error}
+        </div>
+      ) : null}
+      <div className="agent-create-actions">
+        {onCancel ? (
+          <Button disabled={submitting} variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+        ) : null}
+        <Button disabled={submitting || refreshing || !selectedRoute} type="submit">
+          {submitting ? "Creating…" : "Create Agent"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function RuntimeRouteSection({
+  alternatives,
+  changingRoute,
+  connectingComputer,
+  computerSetupToggleRef,
+  facts,
+  onChangeRoute,
+  onConnected,
+  onRefresh,
+  onToggleComputerSetup,
+  onToggleRoutes,
+  refreshing,
+  selectedRoute,
+  submitting,
+  teamId,
+}: {
+  alternatives: readonly ReadyRoute[];
+  changingRoute: boolean;
+  connectingComputer: boolean;
+  computerSetupToggleRef: { current: HTMLButtonElement | null };
+  facts: AgentCreationFacts;
+  onChangeRoute: (route: ReadyRoute) => void;
+  onConnected: (computer: AgentCreationComputer) => void;
+  onRefresh: () => void;
+  onToggleComputerSetup: () => void;
+  onToggleRoutes: () => void;
+  refreshing: boolean;
+  selectedRoute: ReadyRoute | undefined;
+  submitting: boolean;
+  teamId: string;
+}) {
+  const onlineComputers = facts.computers.filter((computer) => computer.connectionStatus === "online");
+  const attention = providerAttention(facts, onlineComputers[0]);
+  return (
+    <section aria-labelledby="agent-runtime-heading" className="agent-create-runtime">
+      <header className="agent-create-runtime-header">
+        <div>
+          <h3 id="agent-runtime-heading">Where it runs</h3>
+          {selectedRoute ? (
+            <p>
+              {providerLabel(selectedRoute.provider)} · {selectedRoute.computer.displayName}
+            </p>
+          ) : null}
+        </div>
+        {selectedRoute && alternatives.length > 0 ? (
+          <Button
+            aria-expanded={changingRoute}
+            disabled={submitting || refreshing}
+            size="compact"
+            variant="ghost"
+            onClick={onToggleRoutes}
+          >
+            Change
+          </Button>
+        ) : null}
+      </header>
+
+      {facts.computers.length === 0 ? (
+        <div className="agent-create-runtime-setup">
+          <ComputerSetup teamId={teamId} onConnected={onConnected} />
+        </div>
+      ) : selectedRoute ? (
+        <>
+          <div aria-live="polite" className="agent-create-runtime-status" role="status">
+            <StatusIndicator label="Ready to run" tone="success" />
+          </div>
+          {changingRoute ? (
+            <div className="agent-create-route-list">
+              {[selectedRoute, ...alternatives].map((route) => (
+                <button
+                  className="agent-create-route-option"
+                  data-selected={route === selectedRoute ? "true" : undefined}
+                  disabled={submitting || refreshing}
+                  key={routeKey(route.computer.id, route.provider)}
+                  type="button"
+                  onClick={() => onChangeRoute(route)}
+                >
+                  <strong>{providerLabel(route.provider)}</strong>
+                  <span>{route.computer.displayName}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </>
+      ) : onlineComputers.length === 0 ? (
+        <RuntimeAttention
+          detail="Reconnect one of your Computers to continue."
+          label="Computer offline"
+          refreshing={refreshing}
+          tone="warning"
+          onRefresh={onRefresh}
+        />
+      ) : (
+        <RuntimeAttention
+          detail={attention.detail}
+          label={attention.label}
+          refreshing={refreshing}
+          tone={attention.tone}
+          onRefresh={onRefresh}
+        />
+      )}
+      {facts.computers.length > 0 ? (
+        <>
+          <div className="agent-create-computer-action">
+            <Button
+              aria-controls="new-agent-computer-setup"
+              aria-expanded={connectingComputer}
+              disabled={submitting}
+              ref={computerSetupToggleRef}
+              size="compact"
+              variant="inline"
+              onClick={onToggleComputerSetup}
+            >
+              {connectingComputer ? "Cancel Computer connection" : "Connect another Computer"}
+            </Button>
+          </div>
+          {connectingComputer ? (
+            <div className="agent-create-runtime-setup" id="new-agent-computer-setup">
+              <ComputerSetup teamId={teamId} onConnected={onConnected} />
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function RuntimeAttention({
+  detail,
+  label,
+  onRefresh,
+  refreshing,
+  tone,
+}: {
+  detail: string;
+  label: string;
+  onRefresh: () => void;
+  refreshing: boolean;
+  tone: StatusTone;
+}) {
+  return (
+    <div className="agent-create-runtime-attention">
+      <StatusIndicator detail={detail} label={label} tone={tone} />
+      <Button disabled={refreshing} size="compact" variant="secondary" onClick={onRefresh}>
+        {refreshing ? "Checking…" : "Check again"}
+      </Button>
+    </div>
+  );
+}
+
+function providerAttention(
+  facts: AgentCreationFacts,
+  computer: AgentCreationComputer | undefined,
+): { detail: string; label: string; tone: StatusTone } {
+  if (!facts.runtimeEvidenceAvailable) {
+    return {
+      label: "Readiness unconfirmed",
+      detail: "OpenTag cannot confirm a ready Provider on this Computer yet.",
+      tone: "neutral",
+    };
+  }
+  const provider = facts.providers.find((candidate) => candidate.computerId === computer?.id);
+  const providerName = providerLabel(provider?.provider ?? "codex");
+  if (provider?.status === "install") {
+    return {
+      label: `Install ${providerName}`,
+      detail: `Install ${providerName} on ${computer?.displayName}.`,
+      tone: "warning",
+    };
+  }
+  if (provider?.status === "sign-in") {
+    return {
+      label: `Sign in to ${providerName}`,
+      detail: `Finish sign-in on ${computer?.displayName}.`,
+      tone: "warning",
+    };
+  }
+  if (provider?.status === "checking") {
+    return { label: "Checking setup", detail: `${providerName} readiness is still being checked.`, tone: "neutral" };
+  }
+  return {
+    label: "Provider unavailable",
+    detail: `Prepare Codex or Claude Code on ${computer?.displayName ?? "this Computer"}.`,
+    tone: "warning",
+  };
+}
+
+function resolveReadyRoutes(facts: AgentCreationFacts): ReadyRoute[] {
+  const computers = new Map(
+    facts.computers
+      .filter((computer) => computer.connectionStatus === "online")
+      .map((computer) => [computer.id, computer]),
+  );
+  return facts.providers
+    .filter((provider) => provider.runtimeReady)
+    .map((provider) => ({ computer: computers.get(provider.computerId), provider: provider.provider }))
+    .filter((route): route is ReadyRoute => route.computer !== undefined)
+    .sort((left, right) => {
+      const computerOrder = left.computer.displayName.localeCompare(right.computer.displayName);
+      return computerOrder !== 0 ? computerOrder : providerRank(left.provider) - providerRank(right.provider);
+    });
+}
+
+function providerRank(provider: AgentRuntimeProvider): number {
+  return provider === "codex" ? 0 : 1;
+}
+
+function providerLabel(provider: AgentRuntimeProvider): string {
+  return provider === "claude-code" ? "Claude Code" : "Codex";
+}
+
+function routeKey(computerId: string, provider: AgentRuntimeProvider): string {
+  return `${computerId}:${provider}`;
+}
+
+function createAgentOnce(record: CreationIntentRecord): Promise<AgentAdminConfig> {
+  const existing = creationRequests.get(record.creationIntentId);
+  if (existing) return existing;
+  const request = browserApi.createAgent(record.teamId, {
+    ...record.request,
+    creationIntentId: record.creationIntentId,
+  });
+  creationRequests.set(record.creationIntentId, request);
+  void request.catch(() => creationRequests.delete(record.creationIntentId));
+  return request;
+}
+
+async function withCreationLock<T>(teamId: string, task: () => Promise<T> | T): Promise<T> {
+  const lockName = `opentag:create-agent:${teamId}`;
+  if (navigator.locks) return navigator.locks.request(lockName, task);
+  const prior = fallbackCreationLocks.get(lockName) ?? Promise.resolve();
+  let release: () => void = () => undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = prior.then(() => current);
+  fallbackCreationLocks.set(lockName, queued);
+  await prior;
+  try {
+    return await task();
+  } finally {
+    release();
+    if (fallbackCreationLocks.get(lockName) === queued) fallbackCreationLocks.delete(lockName);
+  }
+}
+
+async function getOrCreateCreationIntent(
+  teamId: string,
+  request: Omit<CreateAgentRequest, "creationIntentId">,
+): Promise<CreationIntentRecord> {
+  return withCreationLock(teamId, () => {
+    const records = readCreationIntents(teamId);
+    const fingerprint = JSON.stringify(request);
+    const existing = records.find((record) => JSON.stringify(record.request) === fingerprint);
+    if (existing) return existing;
+    const next: CreationIntentRecord = {
+      version: CREATE_INTENT_VERSION,
+      teamId,
+      creationIntentId: crypto.randomUUID(),
+      request,
+    };
+    writeCreationIntents(teamId, [...records, next]);
+    return next;
+  });
+}
+
+function readCreationIntent(teamId: string): CreationIntentRecord | undefined {
+  return readCreationIntents(teamId).at(-1);
+}
+
+function readCreationIntents(teamId: string): readonly CreationIntentRecord[] {
+  try {
+    const raw = window.localStorage.getItem(creationIntentKey(teamId));
+    if (!raw) {
+      if (memoryIntentFallbackTeams.has(teamId)) return memoryIntentRecords.get(teamId) ?? [];
+      memoryIntentRecords.delete(teamId);
+      return [];
+    }
+    const value = JSON.parse(raw) as Partial<CreationIntentStore>;
+    if (
+      value.version !== CREATE_INTENT_VERSION ||
+      value.teamId !== teamId ||
+      !Array.isArray(value.records) ||
+      !value.records.every((record) => validCreationIntentRecord(record, teamId))
+    ) {
+      return [];
+    }
+    const records = value.records as readonly CreationIntentRecord[];
+    memoryIntentRecords.set(teamId, records);
+    return records;
+  } catch {
+    return memoryIntentRecords.get(teamId) ?? [];
+  }
+}
+
+function writeCreationIntents(teamId: string, records: readonly CreationIntentRecord[]): void {
+  memoryIntentRecords.set(teamId, records);
+  try {
+    window.localStorage.setItem(
+      creationIntentKey(teamId),
+      JSON.stringify({ version: CREATE_INTENT_VERSION, teamId, records } satisfies CreationIntentStore),
+    );
+    memoryIntentFallbackTeams.delete(teamId);
+  } catch {
+    memoryIntentFallbackTeams.add(teamId);
+  }
+}
+
+async function clearCreationIntent(teamId: string, creationIntentId: string): Promise<void> {
+  await withCreationLock(teamId, () => {
+    const records = readCreationIntents(teamId).filter((record) => record.creationIntentId !== creationIntentId);
+    if (records.length > 0) {
+      writeCreationIntents(teamId, records);
+      return;
+    }
+    memoryIntentRecords.delete(teamId);
+    memoryIntentFallbackTeams.delete(teamId);
+    try {
+      window.localStorage.removeItem(creationIntentKey(teamId));
+    } catch {
+      // No durable record is available to clear.
+    }
+  });
+}
+
+function validCreationIntentRecord(value: unknown, teamId: string): value is CreationIntentRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Partial<CreationIntentRecord>;
+  return (
+    record.version === CREATE_INTENT_VERSION &&
+    record.teamId === teamId &&
+    typeof record.creationIntentId === "string" &&
+    record.request !== undefined &&
+    typeof record.request.name === "string" &&
+    typeof record.request.displayName === "string" &&
+    typeof record.request.computerId === "string" &&
+    (record.request.runtimeProvider === "codex" || record.request.runtimeProvider === "claude-code")
+  );
+}
+
+function creationIntentKey(teamId: string): string {
+  return `opentag.agent-creation.intent:${teamId}`;
+}

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@opentag/shared/browser";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentCreationFlow } from "../agent-creation/agent-creation-flow.js";
 import { browserApi } from "../api.js";
 import { OnboardingPage } from "./page.js";
 import type { RuntimeFactsAdapter, RuntimeFactsResult, RuntimeProviderStatus } from "./runtime-facts.js";
@@ -160,18 +161,20 @@ describe("OnboardingPage", () => {
     const summary = screen.getByRole("region", { name: "Agent preparation summary" });
     expect(summary.textContent).toContain("ComputerNot connected");
     expect(summary.textContent).toContain("RuntimeWaiting");
-    expect(summary.textContent).toContain("AgentNot created");
+    expect(summary.textContent).toContain("AgentName pending");
     expect(screen.queryByRole("img")).toBeNull();
   });
 
   it("asks for the existing Computer to be reconnected when every Computer is offline", async () => {
     installFacts({ computers: [{ ...computerA, connectionStatus: "offline" }] });
     renderPage();
-    expect(await screen.findByRole("heading", { name: "Reconnect your Computer" })).toBeTruthy();
-    expect(screen.getByText(/Ada's Mac/)).toBeTruthy();
+    const runtime = await screen.findByRole("region", { name: "Where it runs" });
+    expect(runtime.textContent).toContain("Computer offline");
+    expect(runtime.textContent).toContain("Reconnect one of your Computers to continue.");
+    expect(screen.getByRole("button", { name: "Create Agent" })).toHaveProperty("disabled", true);
   });
 
-  it("asks only for real Computer ambiguity", async () => {
+  it("selects a ready route by default and progressively reveals alternatives", async () => {
     installFacts({ computers: [computerA, computerB] });
     renderPage({
       runtime: runtimeFacts([
@@ -179,13 +182,14 @@ describe("OnboardingPage", () => {
         { computerId: computerBId, provider: "codex", runtimeReady: true },
       ]),
     });
-    expect(await screen.findByRole("heading", { name: "Choose a runnable Computer" })).toBeTruthy();
+    expect(await screen.findByText("Codex · Ada's Mac")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
     expect(screen.getByRole("button", { name: /Ada's Mac/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Studio Mac/ })).toBeTruthy();
     expect(vi.spyOn(browserApi, "createAgent")).not.toHaveBeenCalled();
   });
 
-  it("summarizes the explicitly selected Computer instead of the first online Computer", async () => {
+  it("updates the shared runtime summary when another ready Computer is selected", async () => {
     installFacts({ computers: [computerA, computerB] });
     renderPage({
       runtime: runtimeFacts([
@@ -194,26 +198,24 @@ describe("OnboardingPage", () => {
       ]),
     });
 
-    fireEvent.click(await screen.findByRole("button", { name: /Studio Mac/ }));
-
-    expect(await screen.findByRole("heading", { name: "Create your Agent" })).toBeTruthy();
-    const summary = screen.getByRole("region", { name: "Agent preparation summary" });
-    expect(summary.textContent).toContain("ComputerStudio Mac");
-    expect(summary.textContent).not.toContain("ComputerAda's Mac");
+    fireEvent.click(await screen.findByRole("button", { name: "Change" }));
+    fireEvent.click(screen.getByRole("button", { name: /Studio Mac/ }));
+    expect(await screen.findByText("Codex · Studio Mac")).toBeTruthy();
   });
 
-  it("keeps an ambiguous Computer choice actionable before runtime facts arrive", async () => {
+  it("does not offer an unconfirmed Computer route before runtime facts arrive", async () => {
     installFacts({ computers: [computerA, computerB] });
     renderPage();
-    fireEvent.click(await screen.findByRole("button", { name: /Ada's Mac/ }));
-    expect(await screen.findByRole("heading", { name: "Confirm the runtime route" })).toBeTruthy();
+    expect(await screen.findByText("Readiness unconfirmed")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Create Agent" })).toHaveProperty("disabled", true);
   });
 
   it("does not invent runtime readiness when the production fact seam is unavailable", async () => {
     installFacts({ computers: [computerA] });
     renderPage();
-    expect(await screen.findByRole("heading", { name: "Confirm the runtime route" })).toBeTruthy();
-    expect(screen.getByText(/cannot yet confirm an Agent-ready Provider/)).toBeTruthy();
+    expect(await screen.findByText("Readiness unconfirmed")).toBeTruthy();
+    expect(screen.getByText(/cannot confirm a ready Provider/)).toBeTruthy();
     expect(screen.queryByText("Preparing OpenTag")).toBeNull();
   });
 
@@ -227,8 +229,8 @@ describe("OnboardingPage", () => {
       ],
     });
     render(<OnboardingPage membership={admin} user={user} />);
-    expect(await screen.findByRole("heading", { name: "Install Codex" })).toBeTruthy();
-    expect(screen.getByText("Install Codex on Ada's Mac, then check again.")).toBeTruthy();
+    expect(await screen.findByText("Install Codex")).toBeTruthy();
+    expect(screen.getByText("Install Codex on Ada's Mac.")).toBeTruthy();
   });
 
   it("reaches Ready from production runtime and authoritative handoff facts", async () => {
@@ -277,7 +279,8 @@ describe("OnboardingPage", () => {
   it("shows Provider recovery when authoritative facts say no route is runnable", async () => {
     installFacts({ computers: [computerA] });
     renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: false }]) });
-    expect(await screen.findByRole("heading", { name: "Prepare Codex or Claude Code" })).toBeTruthy();
+    expect(await screen.findByText("Provider unavailable")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create Agent" })).toHaveProperty("disabled", true);
   });
 
   it("advances from Provider setup without asking the user to check again", async () => {
@@ -304,7 +307,7 @@ describe("OnboardingPage", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(screen.getByRole("heading", { name: "Install Codex" })).toBeTruthy();
+    expect(screen.getByText("Install Codex")).toBeTruthy();
     const loadsBeforePolling = computers.mock.calls.length;
 
     runtimeReady = true;
@@ -313,7 +316,7 @@ describe("OnboardingPage", () => {
     });
 
     expect(computers.mock.calls.length).toBeGreaterThan(loadsBeforePolling);
-    expect(screen.getByRole("heading", { name: "Create your Agent" })).toBeTruthy();
+    expect(screen.getByText("Ready to run")).toBeTruthy();
   });
 
   it("leaves a state that waits on this user alone", async () => {
@@ -324,7 +327,7 @@ describe("OnboardingPage", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(screen.getByRole("heading", { name: "Create your Agent" })).toBeTruthy();
+    expect(screen.getByText("Ready to run")).toBeTruthy();
     const loads = computers.mock.calls.length;
 
     await act(async () => {
@@ -342,7 +345,7 @@ describe("OnboardingPage", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(screen.getByRole("heading", { name: "Prepare Codex or Claude Code" })).toBeTruthy();
+    expect(screen.getByText("Provider unavailable")).toBeTruthy();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10 * 60 * 1_000);
@@ -390,17 +393,17 @@ describe("OnboardingPage", () => {
   });
 
   it.each([
-    ["checking", "Checking Codex", "OpenTag is checking Codex readiness on Ada's Mac."],
-    ["install", "Install Codex", "Install Codex on Ada's Mac, then check again."],
-    ["sign-in", "Sign in to Codex", "Sign in to Codex on Ada's Mac, then check again."],
-    ["unavailable", "Restore Codex", "Codex is currently unavailable on Ada's Mac. Restore it, then check again."],
+    ["checking", "Checking setup", "Codex readiness is still being checked."],
+    ["install", "Install Codex", "Install Codex on Ada's Mac."],
+    ["sign-in", "Sign in to Codex", "Finish sign-in on Ada's Mac."],
+    ["unavailable", "Provider unavailable", "Prepare Codex or Claude Code on Ada's Mac."],
   ] as const)("shows the current %s Provider action", async (status, heading, description) => {
     installFacts({ computers: [computerA] });
     renderPage({
       runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: false, status }]),
     });
-    expect(await screen.findByRole("heading", { name: heading })).toBeTruthy();
-    expect(screen.getByText(description)).toBeTruthy();
+    expect(await screen.findByText(heading)).toBeTruthy();
+    expect(await screen.findByText(description)).toBeTruthy();
   });
 
   it("preserves an existing Agent identity during runtime outage", async () => {
@@ -463,6 +466,28 @@ describe("OnboardingPage", () => {
     expect(screen.getByText("Read only")).toBeTruthy();
     expect(screen.getByText(/An admin can complete this action/)).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Feishu/ })).toBeNull();
+  });
+
+  it("shows members the Team-wide runnable route in both the action and preparation summary", async () => {
+    const ownerAdminId = "00000001-0000-4000-8000-000000000001";
+    const adminComputer = {
+      ...computerA,
+      ownerUserId: ownerAdminId,
+      ownerDisplayName: "Grace",
+      displayName: "Grace's Mac",
+    };
+    installFacts({ computers: [adminComputer], members: [teamAdmin("Grace", ownerAdminId)] });
+    renderPage({
+      membership: member,
+      runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]),
+    });
+
+    expect(await screen.findByRole("heading", { name: "Create the Agent" })).toBeTruthy();
+    expect(screen.getByText(/Codex on Grace's Mac/)).toBeTruthy();
+    const summary = screen.getByRole("region", { name: "Agent preparation summary" });
+    expect(summary.textContent).toContain("ComputerGrace's Mac");
+    expect(summary.textContent).toContain("RuntimeCodex");
+    expect(screen.getByText("Ready to create")).toBeTruthy();
   });
 
   it.each([
@@ -530,16 +555,16 @@ describe("OnboardingPage", () => {
     const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]) });
 
-    const name = await screen.findByLabelText("Agent display name");
+    const name = await screen.findByLabelText("Display name");
     expect(name).toHaveProperty("value", "OpenTag");
     expect(create).not.toHaveBeenCalled();
     fireEvent.change(name, { target: { value: "Research Partner" } });
-    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
 
     await waitFor(() =>
       expect(create).toHaveBeenCalledWith(
         teamId,
-        expect.objectContaining({ displayName: "Research Partner", name: "opentag" }),
+        expect.objectContaining({ displayName: "Research Partner", name: "research-partner" }),
       ),
     );
   });
@@ -554,14 +579,14 @@ describe("OnboardingPage", () => {
       ]),
     });
 
-    expect(await screen.findByText("OpenTag will run with Codex on Ada's Mac.")).toBeTruthy();
+    expect(await screen.findByText("Codex · Ada's Mac")).toBeTruthy();
     expect(create).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole("button", { name: "Change" }));
     fireEvent.click(screen.getByRole("button", { name: /Claude Code/ }));
-    expect(await screen.findByText("OpenTag will run with Claude Code on Ada's Mac.")).toBeTruthy();
+    expect(await screen.findByText("Claude Code · Ada's Mac")).toBeTruthy();
     expect(create).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
     await waitFor(() =>
       expect(create).toHaveBeenCalledWith(
         teamId,
@@ -570,13 +595,9 @@ describe("OnboardingPage", () => {
     );
   });
 
-  it("does not create on the stale route while an explicit Provider choice reloads", async () => {
+  it("changes a confirmed ready route locally without an intermediate reload", async () => {
     installFacts({ computers: [computerA] });
     const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
-    let finishReload: ((value: RuntimeFactsResult) => void) | undefined;
-    const pendingReload = new Promise<RuntimeFactsResult>((resolve) => {
-      finishReload = resolve;
-    });
     const available = {
       kind: "available" as const,
       providers: [
@@ -584,26 +605,15 @@ describe("OnboardingPage", () => {
         { computerId: computerAId, provider: "claude-code" as const, runtimeReady: true },
       ],
     };
-    const runtime: RuntimeFactsAdapter = {
-      load: vi.fn().mockResolvedValue(available).mockResolvedValueOnce(available).mockReturnValueOnce(pendingReload),
-    };
+    const runtime: RuntimeFactsAdapter = { load: vi.fn().mockResolvedValue(available) };
     renderPage({ runtime });
 
-    await screen.findByText("OpenTag will run with Codex on Ada's Mac.");
+    await screen.findByText("Codex · Ada's Mac");
     fireEvent.click(screen.getByRole("button", { name: "Change" }));
     fireEvent.click(screen.getByRole("button", { name: /Claude Code/ }));
-
-    const createButton = screen.getByRole("button", { name: "Updating route…" });
-    expect(createButton).toHaveProperty("disabled", true);
-    expect(screen.getByRole("status").textContent).toBe("Confirming the selected runtime route…");
-    fireEvent.click(createButton);
-    expect(create).not.toHaveBeenCalled();
-
-    await act(async () => {
-      finishReload?.(available);
-    });
-    expect(await screen.findByText("OpenTag will run with Claude Code on Ada's Mac.")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    expect(await screen.findByText("Claude Code · Ada's Mac")).toBeTruthy();
+    expect(runtime.load).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
     await waitFor(() =>
       expect(create).toHaveBeenCalledWith(
         teamId,
@@ -625,9 +635,9 @@ describe("OnboardingPage", () => {
       return adminConfig();
     });
     renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]) });
-    fireEvent.click(await screen.findByRole("button", { name: "Create agent" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Create Agent" }));
     expect((await screen.findByRole("alert")).textContent).toBe("Response was lost");
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
     expect(await screen.findByRole("heading", { name: "Connect OpenTag to Feishu" })).toBeTruthy();
     expect(requests).toHaveLength(2);
     expect(requests[0]?.creationIntentId).toBe(requests[1]?.creationIntentId);
@@ -649,9 +659,9 @@ describe("OnboardingPage", () => {
     });
     const runtime = runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]);
     const firstPage = renderPage({ runtime });
-    fireEvent.click(await screen.findByRole("button", { name: "Create agent" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Create Agent" }));
     expect((await screen.findByRole("alert")).textContent).toBe("Connection closed before the response");
-    const durableRecord = window.localStorage.getItem(`opentag.onboarding.creation-intent:${teamId}`);
+    const durableRecord = window.localStorage.getItem(`opentag.agent-creation.intent:${teamId}`);
     expect(durableRecord).toBeTruthy();
 
     firstPage.unmount();
@@ -659,7 +669,7 @@ describe("OnboardingPage", () => {
     expect(await screen.findByRole("heading", { name: "Connect OpenTag to Feishu" })).toBeTruthy();
     expect(create).toHaveBeenCalledTimes(2);
     expect(requests[0]?.creationIntentId).toBe(requests[1]?.creationIntentId);
-    expect(window.localStorage.getItem(`opentag.onboarding.creation-intent:${teamId}`)).toBeNull();
+    expect(window.localStorage.getItem(`opentag.agent-creation.intent:${teamId}`)).toBeNull();
   });
 
   it("uses one logical create across parallel page controllers", async () => {
@@ -674,11 +684,69 @@ describe("OnboardingPage", () => {
     const runtime = runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]);
     render(<OnboardingPage membership={admin} runtimeFacts={runtime} user={user} />);
     render(<OnboardingPage membership={admin} runtimeFacts={runtime} user={user} />);
-    await waitFor(() => expect(screen.getAllByRole("button", { name: "Create agent" })).toHaveLength(2));
-    const actions = screen.getAllByRole("button", { name: "Create agent" });
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "Create Agent" })).toHaveLength(2));
+    const actions = screen.getAllByRole("button", { name: "Create Agent" });
     fireEvent.click(actions[0] as HTMLButtonElement);
     fireEvent.click(actions[1] as HTMLButtonElement);
     await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps distinct concurrent creation intents isolated", async () => {
+    const requests: CreateAgentRequest[] = [];
+    let betaAttempts = 0;
+    vi.spyOn(browserApi, "createAgent").mockImplementation(async (_teamId, request) => {
+      requests.push(request);
+      if (request.displayName === "Beta" && betaAttempts++ === 0) throw new Error("Beta response was lost");
+      return adminConfig();
+    });
+    const facts = {
+      computers: [{ id: computerAId, displayName: computerA.displayName, connectionStatus: "online" as const }],
+      providers: [{ computerId: computerAId, provider: "codex" as const, runtimeReady: true }],
+      runtimeEvidenceAvailable: true,
+    };
+    const alphaCreated = vi.fn();
+    const betaCreated = vi.fn();
+    render(
+      <>
+        <AgentCreationFlow
+          facts={facts}
+          initialDisplayName="Alpha"
+          teamId={teamId}
+          onCreated={alphaCreated}
+          onRefresh={() => undefined}
+        />
+        <AgentCreationFlow
+          facts={facts}
+          initialDisplayName="Beta"
+          teamId={teamId}
+          onCreated={betaCreated}
+          onRefresh={() => undefined}
+        />
+      </>,
+    );
+
+    const actions = screen.getAllByRole("button", { name: "Create Agent" });
+    const alphaAction = actions[0];
+    const betaAction = actions[1];
+    if (!alphaAction || !betaAction) throw new Error("Expected two Agent creation actions");
+    fireEvent.click(alphaAction);
+    fireEvent.click(betaAction);
+
+    await waitFor(() => expect(alphaCreated).toHaveBeenCalledTimes(1));
+    expect((await screen.findByRole("alert")).textContent).toContain("Beta response was lost");
+    const betaRequest = requests.find((request) => request.displayName === "Beta");
+    const stored = JSON.parse(String(window.localStorage.getItem(`opentag.agent-creation.intent:${teamId}`))) as {
+      records: { creationIntentId: string }[];
+    };
+    expect(stored.records).toHaveLength(1);
+    expect(stored.records[0]?.creationIntentId).toBe(betaRequest?.creationIntentId);
+
+    fireEvent.click(betaAction);
+    await waitFor(() => expect(betaCreated).toHaveBeenCalledTimes(1));
+    const betaRequests = requests.filter((request) => request.displayName === "Beta");
+    expect(betaRequests).toHaveLength(2);
+    expect(betaRequests[1]?.creationIntentId).toBe(betaRequests[0]?.creationIntentId);
+    expect(window.localStorage.getItem(`opentag.agent-creation.intent:${teamId}`)).toBeNull();
   });
 
   it("reloads Server facts after Computer setup succeeds", async () => {
@@ -766,7 +834,6 @@ describe("OnboardingPage", () => {
     });
 
     expect(await screen.findByRole("button", { name: "Checking…" })).toHaveProperty("disabled", true);
-    expect(screen.getByRole("status").textContent).toBe("Refreshing Server facts…");
     expect(computers).toHaveBeenCalledTimes(2);
     expect(agents).toHaveBeenCalledTimes(2);
 
@@ -774,7 +841,7 @@ describe("OnboardingPage", () => {
     expect(await screen.findByRole("button", { name: "Check again" })).toHaveProperty("disabled", false);
   });
 
-  it("keeps an explicit Computer choice in memory when localStorage throws", async () => {
+  it("keeps ready route selection usable when localStorage throws", async () => {
     const storageTeamId = "a3fda800-7ce2-4338-aae8-3d2120401ed6";
     const storageAdmin = { ...admin, teamId: storageTeamId };
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
@@ -785,10 +852,17 @@ describe("OnboardingPage", () => {
     });
     installFacts({ computers: [computerA, computerB] });
 
-    renderPage({ membership: storageAdmin });
-    fireEvent.click(await screen.findByRole("button", { name: /Ada's Mac/ }));
+    renderPage({
+      membership: storageAdmin,
+      runtime: runtimeFacts([
+        { computerId: computerAId, provider: "codex", runtimeReady: true },
+        { computerId: computerBId, provider: "codex", runtimeReady: true },
+      ]),
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Change" }));
+    fireEvent.click(screen.getByRole("button", { name: /Studio Mac/ }));
 
-    expect(await screen.findByRole("heading", { name: "Confirm the runtime route" })).toBeTruthy();
+    expect(await screen.findByText("Codex · Studio Mac")).toBeTruthy();
   });
 
   it("keeps an explicit Agent choice in memory when localStorage throws", async () => {

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -1,16 +1,16 @@
 import type {
   AgentRuntimeProvider,
   AgentSummary,
-  CreateAgentRequest,
   MeMembership,
   TeamComputerSummary,
   UserProfile,
 } from "@opentag/shared/browser";
-import { type FormEvent, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type AgentCreationFacts, AgentCreationFlow } from "../agent-creation/agent-creation-flow.js";
 import { browserApi } from "../api.js";
 import { ComputerSetup } from "../computer-setup.js";
 import { FeishuSetup, type FeishuSetupControl } from "../im/feishu-setup.js";
-import { Button, buttonClassName, Field } from "../ui/design-system.js";
+import { Button, buttonClassName } from "../ui/design-system.js";
 import {
   deriveOnboardingState,
   type OnboardingAgent,
@@ -28,7 +28,6 @@ import {
 } from "./runtime-facts.js";
 
 const FEISHU_BOT_APP_LINK = "https://applink.feishu.cn/client/bot/open";
-const CREATE_INTENT_VERSION = 1;
 /** A Computer republishes Provider readiness about twice a minute, so a slower poll loses nothing. */
 const RUNTIME_POLL_INTERVAL_MS = 5_000;
 const RUNTIME_POLL_LIMIT_MS = 10 * 60 * 1_000;
@@ -55,23 +54,6 @@ interface OnboardingSnapshot {
   readonly runtime: RuntimeFactsResult;
   /** Team admins a member can ask; empty whenever the viewer manages the Team. */
   readonly admins: readonly string[];
-}
-
-interface RouteSelection {
-  readonly computerId: string;
-  readonly provider?: AgentRuntimeProvider;
-}
-
-interface CreationIntentRecord {
-  readonly version: typeof CREATE_INTENT_VERSION;
-  readonly teamId: string;
-  readonly creationIntentId: string;
-  readonly request: Omit<CreateAgentRequest, "creationIntentId">;
-}
-
-interface CreationState {
-  readonly kind: "pending" | "error";
-  readonly message?: string;
 }
 
 type JourneyStatus = "complete" | "current" | "upcoming";
@@ -112,13 +94,8 @@ export function OnboardingPage({
 }: OnboardingPageProps) {
   const [revision, setRevision] = useState(0);
   const [loadState, setLoadState] = useState<PageLoadState>({ kind: "loading" });
-  const [creation, setCreation] = useState<CreationState>();
-  const [agentDisplayName, setAgentDisplayName] = useState(
-    () => readCreationIntent(membership.teamId)?.request.displayName ?? "OpenTag",
-  );
   const [refreshPending, setRefreshPending] = useState(false);
   const [attendedWindow, setAttendedWindow] = useState(0);
-  const creationInFlight = useRef(false);
   const refreshInFlight = useRef(false);
   const reload = useCallback(() => {
     if (refreshInFlight.current) return;
@@ -181,6 +158,8 @@ export function OnboardingPage({
   const journey = onboardingJourney(
     resolved?.state.currentState,
     loadState.kind === "ready" ? loadState.snapshot : undefined,
+    user.id,
+    resolved?.state.canManage ?? membership.role === "admin",
   );
 
   const waitingForRuntime = resolved !== undefined && RUNTIME_WAIT_STATES.includes(resolved.state.currentState.kind);
@@ -200,44 +179,6 @@ export function OnboardingPage({
     return () => window.clearInterval(timer);
   }, [attendedWindow, reload, waitingForRuntime]);
 
-  const runAgentCreation = useCallback(
-    (request: Omit<CreateAgentRequest, "creationIntentId">) => {
-      if (refreshInFlight.current || creationInFlight.current) return;
-      creationInFlight.current = true;
-      setCreation({ kind: "pending" });
-      void createOnboardingAgent(membership.teamId, request).then(
-        (agent) => {
-          creationInFlight.current = false;
-          rememberTargetAgent(membership.teamId, agent.id);
-          setCreation(undefined);
-          reload();
-        },
-        (cause: unknown) => {
-          creationInFlight.current = false;
-          setCreation({
-            kind: "error",
-            message: cause instanceof Error ? cause.message : "Unable to prepare OpenTag",
-          });
-        },
-      );
-    },
-    [membership.teamId, reload],
-  );
-
-  useEffect(() => {
-    if (!resolved?.state.canManage || resolved.state.currentState.kind !== "agent") return;
-    const current = resolved.state.currentState;
-    const record = readCreationIntent(membership.teamId);
-    if (
-      !record ||
-      record.request.computerId !== current.computer.id ||
-      record.request.runtimeProvider !== current.provider.provider
-    )
-      return;
-    setAgentDisplayName(record.request.displayName);
-    runAgentCreation(record.request);
-  }, [membership.teamId, resolved, runAgentCreation]);
-
   return (
     <div className="onboarding-shell">
       <OnboardingHeader user={user} />
@@ -255,19 +196,16 @@ export function OnboardingPage({
               ) : null}
               {loadState.kind === "ready" && resolved ? (
                 <OnboardingContent
-                  agentDisplayName={agentDisplayName}
                   canManage={resolved.state.canManage}
-                  creation={creation}
+                  ownerUserId={user.id}
                   onChooseAgent={(agentId) => {
                     rememberTargetAgent(membership.teamId, agentId);
                     reload();
                   }}
-                  onChooseRoute={(selection) => {
-                    rememberRouteSelection(membership.teamId, selection);
+                  onAgentCreated={(agentId) => {
+                    rememberTargetAgent(membership.teamId, agentId);
                     reload();
                   }}
-                  onAgentDisplayNameChange={setAgentDisplayName}
-                  onCreateAgent={(current) => runAgentCreation(normalizedAgentRequest(current, agentDisplayName))}
                   onReload={attendedReload}
                   refreshPending={refreshPending}
                   snapshot={loadState.snapshot}
@@ -405,6 +343,8 @@ function OnboardingStageContext({ journey }: { journey: OnboardingJourneyState }
 function onboardingJourney(
   current: OnboardingCurrentState | undefined,
   snapshot: OnboardingSnapshot | undefined,
+  ownerUserId: string,
+  canManage: boolean,
 ): OnboardingJourneyState {
   if (!current) {
     return {
@@ -419,6 +359,59 @@ function onboardingJourney(
       prepare: "current",
       stageDescription: "We’re reading your Computer and runtime state.",
       stageStatus: "Checking setup",
+      stageTitle: "Prepare your Agent",
+    };
+  }
+
+  if (snapshot && !snapshot.targetAgent) {
+    const ownComputers = snapshot.computers.filter((computer) => computer.ownerUserId === ownerUserId);
+    const relevantComputers = canManage ? ownComputers : snapshot.computers;
+    const onlineComputers = relevantComputers
+      .filter((computer) => computer.connectionStatus === "online")
+      .sort((left, right) => left.displayName.localeCompare(right.displayName));
+    const computerById = new Map(onlineComputers.map((computer) => [computer.id, computer]));
+    const readyRoute =
+      snapshot.runtime.kind === "available"
+        ? snapshot.runtime.providers
+            .filter((provider) => provider.runtimeReady && computerById.has(provider.computerId))
+            .sort((left, right) => {
+              const computerOrder = (computerById.get(left.computerId)?.displayName ?? "").localeCompare(
+                computerById.get(right.computerId)?.displayName ?? "",
+              );
+              return computerOrder !== 0 ? computerOrder : compareProviderFacts(left, right);
+            })[0]
+        : undefined;
+    const readyComputer = readyRoute ? computerById.get(readyRoute.computerId) : undefined;
+    const computerFact = readyComputer
+      ? journeyComputerRouteFact(readyComputer)
+      : relevantComputers.length === 0
+        ? { label: "Computer", status: "current" as const, value: "Not connected" }
+        : onlineComputers.length === 0
+          ? { label: "Computer", status: "attention" as const, value: "Reconnect" }
+          : journeyComputerRouteFact(onlineComputers[0] as TeamComputerSummary);
+    const runtimeFact: JourneyFact = readyRoute
+      ? { label: "Runtime", status: "ready", value: providerLabel(readyRoute.provider) }
+      : relevantComputers.length === 0 || onlineComputers.length === 0
+        ? { label: "Runtime", status: "waiting", value: "Waiting" }
+        : snapshot.runtime.kind === "available"
+          ? { label: "Runtime", status: "current", value: "Setup required" }
+          : { label: "Runtime", status: "current", value: "Checking" };
+    return {
+      activeStep: 1,
+      agentName: "OpenTag",
+      messaging: "upcoming",
+      prepare: "current",
+      prepareFacts: [computerFact, runtimeFact, { label: "Agent", status: "current", value: "Name pending" }],
+      stageDescription: "Name your Agent, then confirm its ready runtime.",
+      stageStatus: readyRoute
+        ? "Ready to create"
+        : relevantComputers.length === 0
+          ? "Computer needed"
+          : onlineComputers.length === 0
+            ? "Computer offline"
+            : snapshot.runtime.kind === "available"
+              ? "Runtime needs setup"
+              : "Checking runtime",
       stageTitle: "Prepare your Agent",
     };
   }
@@ -557,33 +550,26 @@ function OnboardingLoading() {
 }
 
 function OnboardingContent({
-  agentDisplayName,
   canManage,
-  creation,
-  onAgentDisplayNameChange,
+  onAgentCreated,
   onChooseAgent,
-  onChooseRoute,
-  onCreateAgent,
   onReload,
+  ownerUserId,
   refreshPending,
   snapshot,
   state,
   teamId,
 }: {
-  agentDisplayName: string;
   canManage: boolean;
-  creation: CreationState | undefined;
-  onAgentDisplayNameChange: (value: string) => void;
+  onAgentCreated: (agentId: string) => void;
   onChooseAgent: (agentId: string) => void;
-  onChooseRoute: (selection: RouteSelection) => void;
-  onCreateAgent: (current: Extract<OnboardingCurrentState, { kind: "agent" }>) => void;
   onReload: () => void;
+  ownerUserId: string;
   refreshPending: boolean;
   snapshot: OnboardingSnapshot;
   state: OnboardingState;
   teamId: string;
 }) {
-  const [routeChangeOpen, setRouteChangeOpen] = useState(false);
   if (snapshot.targetCandidates.length > 1 && !snapshot.targetAgent) {
     return (
       <ActionSection
@@ -611,6 +597,20 @@ function OnboardingContent({
           <ReadOnlyCopy admins={snapshot.admins} />
         )}
       </ActionSection>
+    );
+  }
+  if (canManage && !snapshot.targetAgent) {
+    return (
+      <section className="onboarding-action">
+        <AgentCreationFlow
+          facts={onboardingAgentCreationFacts(snapshot, ownerUserId)}
+          initialDisplayName="OpenTag"
+          refreshing={refreshPending}
+          teamId={teamId}
+          onCreated={(agent) => onAgentCreated(agent.id)}
+          onRefresh={onReload}
+        />
+      </section>
     );
   }
 
@@ -658,31 +658,7 @@ function OnboardingContent({
         title="Choose a runnable Computer"
         description="OpenTag could not safely choose between these Computers."
       >
-        {canManage ? (
-          <div className="onboarding-choice-list">
-            {current.computers.map((computer) => {
-              const providers = runnableProviders(snapshot.runtime, computer.id);
-              const provider = providers.sort(compareProviderFacts)[0];
-              return (
-                <button
-                  className="onboarding-choice"
-                  key={computer.id}
-                  type="button"
-                  onClick={() =>
-                    onChooseRoute({ computerId: computer.id, ...(provider ? { provider: provider.provider } : {}) })
-                  }
-                >
-                  <strong>{computer.displayName}</strong>
-                  <span>
-                    {provider ? `${providerLabel(provider.provider)} ready` : "No runnable Provider confirmed"}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        ) : (
-          <ReadOnlyCopy admins={snapshot.admins} />
-        )}
+        <ReadOnlyCopy admins={snapshot.admins} />
       </ActionSection>
     );
   }
@@ -710,96 +686,13 @@ function OnboardingContent({
     );
   }
   if (current.kind === "agent") {
-    if (!canManage) {
-      return (
-        <ActionSection
-          readonly
-          title="Create the Agent"
-          description={`The runnable route is ${providerLabel(current.provider.provider)} on ${current.computer.displayName}.`}
-        >
-          <ReadOnlyCopy admins={snapshot.admins} />
-        </ActionSection>
-      );
-    }
-    const creationPending = creation?.kind === "pending";
-    const pending = creationPending || refreshPending;
     return (
       <ActionSection
-        title="Create your Agent"
-        description={`OpenTag will run with ${providerLabel(current.provider.provider)} on ${current.computer.displayName}.`}
+        readonly
+        title="Create the Agent"
+        description={`The runnable route is ${providerLabel(current.provider.provider)} on ${current.computer.displayName}.`}
       >
-        {current.alternatives.length > 0 ? (
-          <div className="onboarding-route-change">
-            <Button
-              aria-expanded={routeChangeOpen}
-              disabled={pending}
-              size="compact"
-              variant="ghost"
-              onClick={() => setRouteChangeOpen((open) => !open)}
-            >
-              Change
-            </Button>
-            {routeChangeOpen ? (
-              <div className="onboarding-choice-list">
-                {current.alternatives.map((alternative) => (
-                  <button
-                    className="onboarding-choice"
-                    disabled={pending}
-                    key={`${alternative.computerId}:${alternative.provider}`}
-                    type="button"
-                    onClick={() => {
-                      setRouteChangeOpen(false);
-                      onChooseRoute({ computerId: alternative.computerId, provider: alternative.provider });
-                    }}
-                  >
-                    <strong>{providerLabel(alternative.provider)}</strong>
-                    <span>
-                      {snapshot.computers.find((computer) => computer.id === alternative.computerId)?.displayName ??
-                        current.computer.displayName}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-        <form
-          className="onboarding-agent-form"
-          onSubmit={(event: FormEvent<HTMLFormElement>) => {
-            event.preventDefault();
-            onCreateAgent(current);
-          }}
-        >
-          <Field htmlFor="onboarding-agent-display-name" label="Agent display name">
-            <input
-              autoComplete="off"
-              disabled={pending}
-              id="onboarding-agent-display-name"
-              maxLength={120}
-              required
-              value={agentDisplayName}
-              onChange={(event) => onAgentDisplayNameChange(event.target.value)}
-            />
-          </Field>
-          <div className="onboarding-feedback">
-            {creation?.kind === "error" ? (
-              <div className="notice error" role="alert">
-                {creation.message}
-              </div>
-            ) : null}
-            <Button disabled={pending} type="submit">
-              {refreshPending
-                ? "Updating route…"
-                : creationPending
-                  ? "Creating agent…"
-                  : creation?.kind === "error"
-                    ? "Try again"
-                    : "Create agent"}
-            </Button>
-            {refreshPending ? <p role="status">Confirming the selected runtime route…</p> : null}
-            {creationPending ? <p role="status">Creating Agent identity and runtime binding…</p> : null}
-          </div>
-        </form>
+        <ReadOnlyCopy admins={snapshot.admins} />
       </ActionSection>
     );
   }
@@ -995,7 +888,6 @@ async function loadTeamAdmins(teamId: string): Promise<readonly string[]> {
 }
 
 function resolveSnapshot(membership: MeMembership, snapshot: OnboardingSnapshot): { state: OnboardingState } {
-  const route = readRouteSelection(membership.teamId);
   const providers = snapshot.runtime.kind === "available" ? snapshot.runtime.providers : [];
   const agent: OnboardingAgent | undefined = snapshot.targetAgent
     ? {
@@ -1013,165 +905,27 @@ function resolveSnapshot(membership: MeMembership, snapshot: OnboardingSnapshot)
         connectionStatus,
       })),
       providers,
-      ...(route ? { computerSelection: { computerId: route.computerId } } : {}),
-      ...(route?.provider ? { providerSelection: { computerId: route.computerId, provider: route.provider } } : {}),
       agent,
       handoff: snapshot.handoff,
     }),
   };
 }
 
-function normalizedAgentRequest(
-  current: Extract<OnboardingCurrentState, { kind: "agent" }>,
-  displayName: string,
-): Omit<CreateAgentRequest, "creationIntentId"> {
+function onboardingAgentCreationFacts(snapshot: OnboardingSnapshot, ownerUserId: string): AgentCreationFacts {
+  const computers = snapshot.computers.filter((computer) => computer.ownerUserId === ownerUserId);
+  const computerIds = new Set(computers.map((computer) => computer.id));
   return {
-    name: "opentag",
-    displayName: displayName.trim(),
-    computerId: current.computer.id,
-    runtimeProvider: current.provider.provider,
+    computers,
+    providers:
+      snapshot.runtime.kind === "available"
+        ? snapshot.runtime.providers.filter((provider) => computerIds.has(provider.computerId))
+        : [],
+    runtimeEvidenceAvailable: snapshot.runtime.kind === "available",
   };
 }
 
-async function createOnboardingAgent(
-  teamId: string,
-  request: Omit<CreateAgentRequest, "creationIntentId">,
-): Promise<{ id: string }> {
-  return withCreationLock(teamId, async () => {
-    const authoritative = (await browserApi.agents(teamId)).agents.filter((agent) => agent.status === "active");
-    if (authoritative.length === 1) {
-      clearCreationIntent(teamId);
-      return authoritative[0] as { id: string };
-    }
-    if (authoritative.length > 1) throw new Error("Choose the Agent to continue before creating another one.");
-    const record = getOrCreateCreationIntent(teamId, request);
-    const created = await browserApi.createAgent(teamId, {
-      ...record.request,
-      creationIntentId: record.creationIntentId,
-    });
-    clearCreationIntent(teamId);
-    return created;
-  });
-}
-
-const memoryIntentRecords = new Map<string, CreationIntentRecord>();
-const memoryRouteSelections = new Map<string, RouteSelection>();
 const memoryTargetAgents = new Map<string, string>();
-const memoryRouteFallbackTeams = new Set<string>();
 const memoryTargetFallbackTeams = new Set<string>();
-const fallbackCreationLocks = new Map<string, Promise<void>>();
-
-async function withCreationLock<T>(teamId: string, task: () => Promise<T>): Promise<T> {
-  const lockName = `opentag:onboarding:create-agent:${teamId}`;
-  if (navigator.locks) return navigator.locks.request(lockName, task);
-  const prior = fallbackCreationLocks.get(lockName) ?? Promise.resolve();
-  let release: () => void = () => {};
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = prior.then(() => current);
-  fallbackCreationLocks.set(lockName, queued);
-  await prior;
-  try {
-    return await task();
-  } finally {
-    release();
-    if (fallbackCreationLocks.get(lockName) === queued) fallbackCreationLocks.delete(lockName);
-  }
-}
-
-function getOrCreateCreationIntent(
-  teamId: string,
-  request: Omit<CreateAgentRequest, "creationIntentId">,
-): CreationIntentRecord {
-  const existing = readCreationIntent(teamId);
-  if (existing && requestsEqual(existing.request, request)) return existing;
-  // A different normalized route is the one intentional request change that replaces a pending replay record.
-  const next: CreationIntentRecord = {
-    version: CREATE_INTENT_VERSION,
-    teamId,
-    creationIntentId: crypto.randomUUID(),
-    request,
-  };
-  memoryIntentRecords.set(teamId, next);
-  try {
-    window.localStorage.setItem(creationIntentKey(teamId), JSON.stringify(next));
-  } catch {
-    // The in-memory record still protects retries in this page lifetime.
-  }
-  return next;
-}
-
-function readCreationIntent(teamId: string): CreationIntentRecord | undefined {
-  try {
-    const raw = window.localStorage.getItem(creationIntentKey(teamId));
-    if (!raw) return memoryIntentRecords.get(teamId);
-    const value = JSON.parse(raw) as Partial<CreationIntentRecord>;
-    if (
-      value.version !== CREATE_INTENT_VERSION ||
-      value.teamId !== teamId ||
-      typeof value.creationIntentId !== "string" ||
-      !value.request ||
-      typeof value.request.computerId !== "string" ||
-      (value.request.runtimeProvider !== "codex" && value.request.runtimeProvider !== "claude-code")
-    ) {
-      return undefined;
-    }
-    return value as CreationIntentRecord;
-  } catch {
-    return memoryIntentRecords.get(teamId);
-  }
-}
-
-function clearCreationIntent(teamId: string): void {
-  memoryIntentRecords.delete(teamId);
-  try {
-    window.localStorage.removeItem(creationIntentKey(teamId));
-  } catch {
-    // No durable record is available to clear.
-  }
-}
-
-function requestsEqual(
-  left: Omit<CreateAgentRequest, "creationIntentId">,
-  right: Omit<CreateAgentRequest, "creationIntentId">,
-): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
-}
-
-function creationIntentKey(teamId: string): string {
-  return `opentag.onboarding.creation-intent:${teamId}`;
-}
-
-function routeSelectionKey(teamId: string): string {
-  return `opentag.onboarding.route:${teamId}`;
-}
-
-function readRouteSelection(teamId: string): RouteSelection | undefined {
-  try {
-    const raw = window.localStorage.getItem(routeSelectionKey(teamId));
-    if (!raw) return memoryRouteFallbackTeams.has(teamId) ? memoryRouteSelections.get(teamId) : undefined;
-    const value = JSON.parse(raw) as Partial<RouteSelection> | null;
-    if (!value || typeof value.computerId !== "string") return undefined;
-    if (value.provider !== undefined && value.provider !== "codex" && value.provider !== "claude-code")
-      return undefined;
-    const selection = { computerId: value.computerId, ...(value.provider ? { provider: value.provider } : {}) };
-    memoryRouteSelections.set(teamId, selection);
-    return selection;
-  } catch {
-    return memoryRouteSelections.get(teamId);
-  }
-}
-
-function rememberRouteSelection(teamId: string, selection: RouteSelection): void {
-  memoryRouteSelections.set(teamId, selection);
-  try {
-    window.localStorage.setItem(routeSelectionKey(teamId), JSON.stringify(selection));
-    memoryRouteFallbackTeams.delete(teamId);
-  } catch {
-    memoryRouteFallbackTeams.add(teamId);
-  }
-}
 
 function targetAgentKey(teamId: string): string {
   return `opentag.onboarding.agent:${teamId}`;
@@ -1197,12 +951,6 @@ function rememberTargetAgent(teamId: string, agentId: string): void {
   } catch {
     memoryTargetFallbackTeams.add(teamId);
   }
-}
-
-function runnableProviders(runtime: RuntimeFactsResult, computerId: string): OnboardingProvider[] {
-  return runtime.kind === "available"
-    ? runtime.providers.filter((provider) => provider.computerId === computerId && provider.runtimeReady)
-    : [];
 }
 
 function runtimeAttention(

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -11,7 +11,7 @@ import type {
   TeamComputerSummary,
   TeamMemberSummary,
 } from "@opentag/shared/browser";
-import { AgentNameSchema, MembershipRoleSchema } from "@opentag/shared/browser";
+import { MembershipRoleSchema } from "@opentag/shared/browser";
 import {
   createContext,
   type FormEvent,
@@ -25,10 +25,10 @@ import {
   useState,
 } from "react";
 import { Link, Navigate, NavLink, Outlet, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
+import { type AgentCreationFacts, AgentCreationFlow } from "./agent-creation/agent-creation-flow.js";
 import { ApiError, browserApi } from "./api.js";
 // Google-provided, pre-approved button asset: https://developers.google.com/identity/branding-guidelines
 import googleSignInButton from "./assets/google-sign-in-light@2x.png";
-import { ComputerSetup } from "./computer-setup.js";
 import { CreateTeamForm } from "./create-team-form.js";
 import { IntegrationsPage } from "./features/integrations-page.js";
 import { SkillsPage } from "./features/skills-page.js";
@@ -1132,16 +1132,28 @@ function NewAgentPage() {
   const { membership } = useTeam();
   const navigate = useNavigate();
   const [computerRefreshVersion, setComputerRefreshVersion] = useState(0);
+  const [created, setCreated] = useState<AgentAdminConfig>();
   const computers = useOwnComputersResource(membership.teamId, computerRefreshVersion);
   if (membership.role !== "admin") return <UnavailablePage title="Admin access required" />;
   return (
-    <Page title="Create Agent" description="Create the identity first. Complete its setup from the Agent overview.">
-      <AgentCreationContent
-        computers={computers}
-        teamId={membership.teamId}
-        onComputerConnected={() => setComputerRefreshVersion((current) => current + 1)}
-        onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
-      />
+    <Page
+      title={created ? "Agent created" : "Create Agent"}
+      description={
+        created
+          ? "Connect messaging now or continue from the Agent overview."
+          : "Name the Agent and prepare where it runs."
+      }
+    >
+      {created ? (
+        <NewAgentMessagingStep agent={created} onFinish={() => navigate(`/agents/${created.id}/general`)} />
+      ) : (
+        <AgentCreationContent
+          computers={computers}
+          teamId={membership.teamId}
+          onCreated={setCreated}
+          onRefresh={() => setComputerRefreshVersion((current) => current + 1)}
+        />
+      )}
     </Page>
   );
 }
@@ -1158,26 +1170,36 @@ function NewAgentDialog({
   const [computerRefreshVersion, setComputerRefreshVersion] = useState(0);
   const computers = useOwnComputersResource(membership.teamId, computerRefreshVersion);
   const [submitting, setSubmitting] = useState(false);
+  const [created, setCreated] = useState<AgentAdminConfig>();
+  const finish = () => {
+    if (created) navigate(`/agents/${created.id}/general`);
+  };
+  const close = () => {
+    if (created) finish();
+    else onClose();
+  };
 
   return (
     <Dialog
       busy={submitting}
       className="new-agent-dialog"
       closeLabel="Close new Agent dialog"
-      description="Give the Agent an identity and choose where it runs. You can finish its setup from the overview."
       returnFocusRef={returnFocusRef}
       title="New Agent"
-      onClose={onClose}
+      onClose={close}
     >
-      <AgentCreationContent
-        computers={computers}
-        presentation="dialog"
-        teamId={membership.teamId}
-        onCancel={onClose}
-        onComputerConnected={() => setComputerRefreshVersion((current) => current + 1)}
-        onCreated={(agentId) => navigate(`/agents/${agentId}/general`)}
-        onSubmittingChange={setSubmitting}
-      />
+      {created ? (
+        <NewAgentMessagingStep agent={created} onFinish={finish} />
+      ) : (
+        <AgentCreationContent
+          computers={computers}
+          teamId={membership.teamId}
+          onCancel={onClose}
+          onCreated={setCreated}
+          onRefresh={() => setComputerRefreshVersion((current) => current + 1)}
+          onSubmittingChange={setSubmitting}
+        />
+      )}
     </Dialog>
   );
 }
@@ -1185,298 +1207,124 @@ function NewAgentDialog({
 function AgentCreationContent({
   computers,
   onCancel,
-  onComputerConnected,
   onCreated,
+  onRefresh,
   onSubmittingChange,
-  presentation = "page",
   teamId,
 }: {
   computers: LoadState<{ computers: Computer[] }>;
   onCancel?: () => void;
-  onComputerConnected: () => void;
-  onCreated: (agentId: string) => void;
+  onCreated: (agent: AgentAdminConfig) => void;
+  onRefresh: () => void;
   onSubmittingChange?: (submitting: boolean) => void;
-  presentation?: "dialog" | "page";
   teamId: string;
 }) {
-  const [error, setError] = useState<string>();
-  const [nameError, setNameError] = useState<string>();
-  const [submitting, setSubmitting] = useState(false);
-  const [displayName, setDisplayName] = useState("");
-  const [agentName, setAgentName] = useState("");
-  const [computerId, setComputerId] = useState("");
-  const [computerSetupOpen, setComputerSetupOpen] = useState(false);
-  const [runtimeProvider, setRuntimeProvider] = useState<"codex" | "claude-code">("codex");
-  const firstFieldRef = useRef<HTMLInputElement>(null);
+  const current = computers.kind === "ready" ? computers.value : undefined;
+  const [retained, setRetained] = useState(current);
+  const [computerRefreshFocusActive, setComputerRefreshFocusActive] = useState(false);
   const computerRefreshFocusRef = useRef<HTMLSpanElement>(null);
-  const computerSetupToggleRef = useRef<HTMLButtonElement>(null);
-  const initialDialogFocusSetRef = useRef(false);
-  const inFlightRef = useRef(false);
-  const creationIntentRef = useRef<{ fingerprint: string; id: string } | null>(null);
-  const restoreComputerSetupFocusRef = useRef(false);
-  const computerRefreshStartedRef = useRef(false);
 
   useEffect(() => {
-    if (presentation !== "dialog" || computers.kind !== "ready" || initialDialogFocusSetRef.current) return;
-    const firstField = firstFieldRef.current;
-    if (!firstField) return;
-    firstField.focus();
-    initialDialogFocusSetRef.current = true;
-  }, [computers.kind, presentation]);
+    if (computers.kind === "ready") setRetained(computers.value);
+  }, [computers]);
 
-  useEffect(() => {
-    if (!restoreComputerSetupFocusRef.current) return;
-    if (computers.kind === "loading") {
-      computerRefreshStartedRef.current = true;
-      return;
-    }
-    if (computers.kind !== "ready" || !computerRefreshStartedRef.current) return;
-    restoreComputerSetupFocusRef.current = false;
-    computerRefreshStartedRef.current = false;
-    computerSetupToggleRef.current?.focus();
-  }, [computers.kind]);
+  const refreshFocusTarget = onCancel ? (
+    <span
+      className="visually-hidden"
+      ref={computerRefreshFocusRef}
+      role={computerRefreshFocusActive ? "status" : undefined}
+      tabIndex={-1}
+    >
+      {computerRefreshFocusActive
+        ? computers.kind === "loading"
+          ? "Refreshing Computers"
+          : computers.kind === "error"
+            ? "Computer refresh failed"
+            : "Computer connection updated"
+        : null}
+    </span>
+  ) : null;
 
-  function toggleComputerSetup() {
-    setComputerSetupOpen((open) => !open);
+  if (computers.kind === "error") {
+    return (
+      <>
+        {refreshFocusTarget}
+        <AsyncState state={computers}>{() => null}</AsyncState>
+      </>
+    );
   }
-
-  function handleComputerConnected(computer: Computer) {
-    setComputerId(computer.id);
-    setComputerSetupOpen(false);
-    restoreComputerSetupFocusRef.current = presentation === "dialog";
-    computerRefreshStartedRef.current = false;
-    if (presentation === "dialog") computerRefreshFocusRef.current?.focus();
-    onComputerConnected();
+  const value = current ?? retained;
+  if (!value) {
+    return (
+      <>
+        {refreshFocusTarget}
+        <AsyncState state={computers}>{() => null}</AsyncState>
+      </>
+    );
   }
-
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (inFlightRef.current) return;
-    const data = new FormData(event.currentTarget);
-    setError(undefined);
-    setNameError(undefined);
-    const name = AgentNameSchema.safeParse(String(data.get("name") ?? ""));
-    if (!name.success) {
-      setNameError(name.error.issues[0]?.message ?? "Agent name is invalid");
-      return;
-    }
-    const input = {
-      name: name.data,
-      displayName: String(data.get("displayName") ?? ""),
-      runtimeProvider: String(data.get("runtimeProvider") ?? "codex") as "codex" | "claude-code",
-      computerId: String(data.get("computerId") ?? ""),
-    };
-    const fingerprint = JSON.stringify(input);
-    if (creationIntentRef.current?.fingerprint !== fingerprint) {
-      creationIntentRef.current = { fingerprint, id: crypto.randomUUID() };
-    }
-    inFlightRef.current = true;
-    setSubmitting(true);
-    onSubmittingChange?.(true);
-    try {
-      const created = await browserApi.createAgent(teamId, {
-        creationIntentId: creationIntentRef.current.id,
-        ...input,
-      });
-      onCreated(created.id);
-    } catch (cause) {
-      if (cause instanceof ApiError) {
-        const issue = cause.issues?.find(({ path }) => path[0] === "name");
-        if (issue) {
-          setNameError(issue.message);
-          return;
-        }
-      }
-      setError(cause instanceof Error ? cause.message : "Agent creation failed");
-    } finally {
-      inFlightRef.current = false;
-      setSubmitting(false);
-      onSubmittingChange?.(false);
-    }
-  }
-
-  const content = (
-    <AsyncState state={computers}>
-      {(value) => {
-        const computer = value.computers.find((candidate) => candidate.id === computerId) ?? value.computers[0];
-        const selectedComputerId = computer?.id ?? "";
-        const readiness = computer?.providerReadiness?.find((entry) => entry.provider === runtimeProvider);
-        return value.computers.length === 0 ? (
-          <div className="agent-create-runtime-setup">
-            <ComputerSetup teamId={teamId} onConnected={handleComputerConnected} />
-          </div>
-        ) : (
-          <form className="form-card agent-create-form" onSubmit={submit}>
-            <Field
-              className="agent-create-field"
-              hint="How teammates will see this Agent in lists and conversations."
-              hintId="new-agent-display-name-hint"
-              htmlFor="new-agent-display-name"
-              label="Display name"
-            >
-              <input
-                aria-describedby="new-agent-display-name-hint"
-                className="ds-control"
-                id="new-agent-display-name"
-                ref={firstFieldRef}
-                name="displayName"
-                value={displayName}
-                onChange={(event) => setDisplayName(event.currentTarget.value)}
-                placeholder="Research Assistant"
-                disabled={submitting}
-                required
-              />
-            </Field>
-            <Field
-              className="agent-create-field"
-              error={nameError}
-              errorId="agent-name-error"
-              hint="Used for mentions. Lowercase letters, numbers, and hyphens only."
-              hintId="new-agent-name-hint"
-              htmlFor="new-agent-name"
-              label="Agent name"
-            >
-              <span className="agent-name-input">
-                <span aria-hidden="true">@</span>
-                <input
-                  aria-describedby={nameError ? "new-agent-name-hint agent-name-error" : "new-agent-name-hint"}
-                  aria-invalid={nameError ? true : undefined}
-                  id="new-agent-name"
-                  name="name"
-                  value={agentName}
-                  onChange={(event) => {
-                    setAgentName(event.currentTarget.value);
-                    setNameError(undefined);
-                  }}
-                  placeholder="research-assistant"
-                  disabled={submitting}
-                  required
-                />
-              </span>
-            </Field>
-            <div className="agent-create-grid">
-              <Field className="agent-create-field" htmlFor="new-agent-provider" label="Provider">
-                <select
-                  className="ds-control"
-                  id="new-agent-provider"
-                  name="runtimeProvider"
-                  disabled={submitting}
-                  value={runtimeProvider}
-                  onChange={(event) => setRuntimeProvider(event.currentTarget.value as "codex" | "claude-code")}
-                >
-                  <option value="codex">Codex</option>
-                  <option value="claude-code">Claude Code</option>
-                </select>
-              </Field>
-              <Field className="agent-create-field" htmlFor="new-agent-computer" label="Computer">
-                <select
-                  className="ds-control"
-                  id="new-agent-computer"
-                  name="computerId"
-                  disabled={submitting}
-                  required
-                  value={selectedComputerId}
-                  onChange={(event) => setComputerId(event.currentTarget.value)}
-                >
-                  {value.computers.map((computer: Computer) => (
-                    <option value={computer.id} key={computer.id}>
-                      {computer.displayName}
-                    </option>
-                  ))}
-                </select>
-              </Field>
-            </div>
-            <div className="agent-create-computer-action">
-              <Button
-                aria-controls="new-agent-computer-setup"
-                aria-expanded={computerSetupOpen}
-                disabled={submitting}
-                ref={computerSetupToggleRef}
-                size="compact"
-                variant="inline"
-                onClick={toggleComputerSetup}
-              >
-                {computerSetupOpen ? "Cancel Computer connection" : "Connect another Computer"}
-              </Button>
-            </div>
-            {computerSetupOpen ? (
-              <div className="agent-create-runtime-setup" id="new-agent-computer-setup">
-                <ComputerSetup teamId={teamId} onConnected={handleComputerConnected} />
-              </div>
-            ) : null}
-            <div
-              className={`notice ${readiness?.status === "ready" && computer?.connectionStatus === "online" ? "" : "warning"}`}
-              role="status"
-            >
-              {providerReadinessMessage(computer, runtimeProvider, readiness?.status)}
-            </div>
-            <p className="agent-create-note">New Agents receive only direct mentions by default.</p>
-            {error ? (
-              <div className="notice error" role="alert">
-                {error}
-              </div>
-            ) : null}
-            <div className="agent-create-actions">
-              {presentation === "dialog" ? (
-                <Button disabled={submitting} variant="secondary" onClick={onCancel}>
-                  Cancel
-                </Button>
-              ) : null}
-              <Button disabled={submitting} type="submit">
-                {submitting ? "Creating…" : "Create Agent"}
-              </Button>
-            </div>
-          </form>
-        );
-      }}
-    </AsyncState>
-  );
-
   return (
     <>
-      {presentation === "dialog" ? (
-        <span className="visually-hidden" ref={computerRefreshFocusRef} role="status" tabIndex={-1}>
-          {restoreComputerSetupFocusRef.current
-            ? computers.kind === "loading"
-              ? "Refreshing Computers"
-              : computers.kind === "error"
-                ? "Computer refresh failed"
-                : "Computer connection updated"
-            : null}
-        </span>
-      ) : null}
-      {content}
+      {refreshFocusTarget}
+      <AgentCreationFlow
+        facts={agentCreationFactsFromOwnComputers(value.computers)}
+        refreshing={computers.kind === "loading"}
+        teamId={teamId}
+        onCancel={onCancel}
+        onComputerRefreshFocus={() => {
+          setComputerRefreshFocusActive(true);
+          computerRefreshFocusRef.current?.focus();
+        }}
+        onCreated={onCreated}
+        onRefresh={onRefresh}
+        onSubmittingChange={onSubmittingChange}
+      />
     </>
   );
+}
+
+function NewAgentMessagingStep({ agent, onFinish }: { agent: AgentAdminConfig; onFinish: () => void }) {
+  return (
+    <FeishuSetup agentId={agent.id} onSuccess={onFinish}>
+      {(setup) => (
+        <section className="agent-create-complete" aria-labelledby="agent-created-heading">
+          <div>
+            <span className="eyebrow">Agent created</span>
+            <h2 id="agent-created-heading">Connect messaging</h2>
+            <p>Connect a Feishu Bot so teammates can mention {agent.displayName}.</p>
+          </div>
+          <div className="agent-create-actions">
+            <Button onClick={() => void setup.start()}>Connect Feishu</Button>
+            <Button variant="secondary" onClick={onFinish}>
+              Set up later
+            </Button>
+          </div>
+          {setup.feedback}
+        </section>
+      )}
+    </FeishuSetup>
+  );
+}
+
+function agentCreationFactsFromOwnComputers(computers: readonly Computer[]): AgentCreationFacts {
+  return {
+    computers,
+    providers: computers.flatMap((computer) =>
+      (computer.providerReadiness ?? []).map((readiness) => ({
+        computerId: computer.id,
+        provider: readiness.provider,
+        runtimeReady: readiness.status === "ready",
+        status: readiness.status,
+      })),
+    ),
+    runtimeEvidenceAvailable:
+      computers.length === 0 || computers.some((computer) => computer.providerReadiness !== undefined),
+  };
 }
 
 function markOwnComputersUnconfirmed(value: { computers: Computer[] }): { computers: Computer[] } {
   return {
     computers: value.computers.map(({ providerReadiness: _providerReadiness, ...computer }) => computer),
   };
-}
-
-function providerReadinessMessage(
-  computer: Computer | undefined,
-  provider: "codex" | "claude-code",
-  status: "checking" | "install" | "sign-in" | "ready" | "unavailable" | undefined,
-): string {
-  const label = providerLabel(provider);
-  if (computer?.connectionStatus === "offline") {
-    return `${computer.displayName} is offline. You can still create this Agent; ${label} Turns will fail without starting and can be retried when this Computer reconnects. No other Provider will be substituted.`;
-  }
-  if (status === "ready") return `${label} is ready on ${computer?.displayName ?? "this Computer"}.`;
-  const action =
-    status === "checking"
-      ? "readiness is still being checked"
-      : status === "install"
-        ? "must be installed"
-        : status === "sign-in"
-          ? "requires sign-in"
-          : status === "unavailable"
-            ? "is currently unavailable"
-            : "readiness has not been reported by this Computer";
-  return `${label} ${action}. You can still create this Agent; its Turns will fail without starting and can be retried after readiness is restored. No other Provider will be substituted.`;
 }
 
 const agentSections = [

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2701,11 +2701,14 @@ textarea:focus {
 }
 
 .new-agent-dialog {
-  width: min(100%, 620px);
+  width: min(100%, 680px);
 }
 
 .new-agent-dialog .form-card {
   width: 100%;
+  max-width: none;
+  border: 0;
+  border-radius: 0;
   padding: 0;
   background: transparent;
 }
@@ -2718,7 +2721,8 @@ textarea:focus {
 }
 
 .agent-create-form {
-  gap: 16px;
+  max-width: 760px;
+  gap: 18px;
 }
 
 .agent-create-field {
@@ -2726,10 +2730,126 @@ textarea:focus {
   gap: 7px;
 }
 
+.agent-create-identity {
+  display: grid;
+  gap: 14px;
+}
+
+.agent-name-summary {
+  padding: 0 2px;
+}
+
+.agent-name-handle {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-meta);
+  font-weight: var(--fw-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-name-handle:hover {
+  color: var(--foreground);
+}
+
+#agent-name-editor {
+  border-left: 2px solid var(--brand);
+  padding-left: 14px;
+}
+
+.agent-create-runtime {
+  display: grid;
+  gap: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-soft);
+  padding: 18px;
+}
+
+.agent-create-runtime-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.agent-create-runtime-header h3 {
+  margin: 0;
+  font-size: var(--text-subsection);
+}
+
+.agent-create-runtime-header p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
 .agent-create-grid {
   display: grid;
   gap: 14px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+}
+
+.agent-create-runtime-status {
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.agent-create-runtime-status .ds-status {
+  width: 100%;
+}
+
+.agent-create-runtime-status .ds-status__copy small {
+  max-width: 70ch;
+  line-height: var(--lh-ui);
+}
+
+.agent-create-runtime-attention {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.agent-create-route-list {
+  display: grid;
+  gap: 8px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.agent-create-route-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--foreground);
+  cursor: pointer;
+  padding: 10px 12px;
+  text-align: left;
+}
+
+.agent-create-route-option:hover,
+.agent-create-route-option[data-selected="true"] {
+  border-color: var(--border);
+  background: var(--surface);
+}
+
+.agent-create-route-option:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.agent-create-route-option span {
+  color: var(--muted);
+  font-size: var(--text-meta);
 }
 
 .agent-create-computer-action {
@@ -2769,21 +2889,35 @@ textarea:focus {
 
 .agent-create-note {
   margin: 0;
-  border: 1px solid var(--border);
-  border-radius: 9px;
-  background: var(--background);
   color: var(--muted);
   font-size: var(--text-meta);
-  padding: 10px 12px;
+  padding: 0 2px;
 }
 
 .agent-create-actions {
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  margin-top: 2px;
+  margin-top: 4px;
   border-top: 1px solid var(--border);
-  padding-top: 18px;
+  padding-top: 20px;
+}
+
+.agent-create-complete {
+  display: grid;
+  max-width: 680px;
+  gap: 22px;
+}
+
+.agent-create-complete h2 {
+  margin: 6px 0 0;
+  font-size: var(--text-section);
+}
+
+.agent-create-complete p {
+  max-width: 56ch;
+  margin: 8px 0 0;
+  color: var(--muted);
 }
 
 .definition-list {


### PR DESCRIPTION
## Summary

- reuse one Agent creation flow across onboarding, `/agents/new`, and the New Agent dialog
- make Display name primary, derive Agent name automatically, and reveal its editor only on demand or validation conflict
- group confirmed Computer + Provider readiness under a compact **Where it runs** section while retaining new-Computer connection and existing-Computer reconnection
- continue to real Feishu setup after creation, with a clear **Set up later** path
- preserve focus trapping, Escape/focus restoration, in-flight close protection, inline errors, and creation-intent replay

## Capability audit

- **Visibility:** not present in the shared Agent schemas, create request, service, or database model, so no Visibility control is shown.
- **Agent name:** the API requires `name`; the service/database enforce a case-insensitive per-Team active-name constraint and return `AGENT_NAME_CONFLICT`. The Web derives a candidate and keeps an accessible editor.
- **Runtime readiness:** Computer projections expose online/offline plus Provider readiness. Creation itself only verifies Team admin authority and Computer ownership; it does not enforce online/readiness. To align this entry with onboarding, the Web only enables creation for a confirmed online + ready route.
- **Messaging:** Feishu setup is implemented and reused. Slack setup is not exposed because the creation flow has no equivalent supported setup UI.
- **Retries:** `creationIntentId` is supported end-to-end and uniquely constrained, so the shared flow durably resumes a lost response without creating a duplicate.

No API, permission, receive-mode, or backend creation behavior changes are included. No legacy storage migration is included because the product has not shipped.

## Verification

- `pnpm --filter @opentag/web typecheck`
- `pnpm --filter @opentag/web test` — 12 files, 274 tests
- `pnpm --filter @opentag/web build`
- `pnpm check` — passes; reports only the existing E2E environment-variable declaration warnings
- desktop and narrow-screen browser acceptance for progressive disclosure, ready/unavailable runtime states, Computer connection/reconnection, submit/error/post-create flow, Escape, close, and focus restoration


