### PR TITLE
fix(web): move Workspace creation to page header

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -2110,7 +2110,11 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
     expect(window.location.pathname).toBe("/workspace");
     expect(window.location.hash).toBe("");
-    expect(screen.getByRole("link", { name: "Create Workspace" })).toBeTruthy();
+    const createWorkspaceLink = screen.getByRole("link", { name: "Create Workspace" });
+    expect(screen.getByRole("heading", { name: "Workspace" }).closest("header")?.contains(createWorkspaceLink)).toBe(
+      true,
+    );
+    expect(screen.queryByText("Additional Workspace")).toBeNull();
   });
 
   it("switches Teams when Team preference storage is unavailable", async () => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1418,7 +1418,15 @@ function AccountPage() {
 function WorkspacePage() {
   const { membership, refreshMe } = useTeam();
   return (
-    <Page title="Workspace" description="Manage the current Workspace and create additional Workspaces.">
+    <Page
+      action={
+        <Link className={buttonClassName({ variant: "secondary" })} to="/workspaces/new">
+          Create Workspace
+        </Link>
+      }
+      title="Workspace"
+      description="Manage the current Workspace and create additional Workspaces."
+    >
       <WorkspaceSettings membership={membership} refreshMe={refreshMe} />
     </Page>
   );
@@ -1426,29 +1434,18 @@ function WorkspacePage() {
 
 function WorkspaceSettings({ membership, refreshMe }: { membership: MeMembership; refreshMe: () => void }) {
   return (
-    <div className="account-workspace-stack">
-      <section aria-labelledby="workspace-profile-heading" className="account-workspace-profile">
-        <header className="settings-subheader">
-          <div>
-            <h2 id="workspace-profile-heading">Workspace profile</h2>
-            <p>Manage the name and CLI identity of the current Workspace.</p>
-          </div>
-          {membership.role !== "admin" ? (
-            <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
-          ) : null}
-        </header>
-        <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
-      </section>
-      <section aria-labelledby="additional-workspace-heading" className="account-workspace-create">
+    <section aria-labelledby="workspace-profile-heading" className="account-workspace-profile">
+      <header className="settings-subheader">
         <div>
-          <h2 id="additional-workspace-heading">Additional Workspace</h2>
-          <p>Create an isolated Workspace for another client or team.</p>
+          <h2 id="workspace-profile-heading">Workspace profile</h2>
+          <p>Manage the name and CLI identity of the current Workspace.</p>
         </div>
-        <Link className={buttonClassName({ variant: "secondary" })} to="/workspaces/new">
-          Create Workspace
-        </Link>
-      </section>
-    </div>
+        {membership.role !== "admin" ? (
+          <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
+        ) : null}
+      </header>
+      <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
+    </section>
   );
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -734,37 +734,9 @@ pre {
 }
 
 .account-workspace-profile {
-  width: 100%;
-}
-
-.account-workspace-stack,
-.account-workspace-profile {
   display: grid;
+  width: 100%;
   gap: 24px;
-}
-
-.account-workspace-stack {
-  gap: 32px;
-}
-
-.account-workspace-create {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  border-top: 1px solid var(--border);
-  padding-top: 20px;
-}
-
-.account-workspace-create h2 {
-  margin: 0;
-  font-size: var(--text-subsection);
-  font-weight: var(--fw-semibold);
-}
-
-.account-workspace-create p {
-  margin: 5px 0 0;
-  color: var(--muted);
 }
 
 .sidebar-backdrop,
@@ -3671,16 +3643,6 @@ textarea:focus {
 }
 
 @media (max-width: 720px) {
-  .account-workspace-create {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .account-workspace-create .ds-button {
-    justify-content: center;
-    width: 100%;
-  }
-
   .onboarding-header {
     min-height: 60px;
     padding: 10px 18px;


### PR DESCRIPTION
## Summary

- move the Create Workspace link into the Workspace page header as a low-emphasis secondary action
- remove the redundant Additional Workspace section and its unused responsive styles
- assert that the creation link stays in the page header

## Testing

- pnpm check (passes with 8 existing undeclared E2E environment-variable warnings)
- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/web test (274 tests passed)
- pnpm test (fails in the unrelated server observability test: expected stale_connection but received handled; the focused test reproduces the same baseline failure)

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] pnpm check, pnpm build, pnpm typecheck, and pnpm test pass. (The unrelated server observability failure is documented above.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.