### PR TITLE
feat(web): clarify Agent runtime selection

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -614,6 +614,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
 
     const dialog = await screen.findByRole("dialog", { name: "New Agent" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Change Computer" }));
     const trigger = within(dialog).getByRole("button", { name: "Connect another Computer" });
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
 
@@ -671,6 +672,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.change(within(dialog).getByLabelText("Agent name"), {
       target: { value: "research-assistant" },
     });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Change Computer" }));
     fireEvent.click(within(dialog).getByRole("button", { name: "Connect another Computer" }));
 
     vi.useFakeTimers();
@@ -693,11 +695,12 @@ describe("OpenTag Web App Shell", () => {
         await Promise.resolve();
       });
 
-      expect(within(dialog).getByText("Codex · Ada's Linux Computer")).toBeTruthy();
+      expect(within(dialog).getByText("Ada's Linux Computer")).toBeTruthy();
+      expect(within(dialog).getByText("Codex")).toBeTruthy();
       expect((within(dialog).getByLabelText("Display name") as HTMLInputElement).value).toBe("Research Assistant");
       expect((within(dialog).getByLabelText("Agent name") as HTMLInputElement).value).toBe("research-assistant");
       expect(within(dialog).queryByRole("heading", { name: "Connect a Local Computer" })).toBeNull();
-      expect(within(dialog).getByRole("button", { name: "Connect another Computer" })).toBe(document.activeElement);
+      expect(within(dialog).getByRole("button", { name: "Change Computer" })).toBe(document.activeElement);
     } finally {
       vi.useRealTimers();
     }
@@ -787,6 +790,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.change(within(dialog).getByLabelText("Agent name"), {
       target: { value: "research-assistant" },
     });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Change Computer" }));
     fireEvent.click(within(dialog).getByRole("button", { name: "Connect another Computer" }));
 
     vi.useFakeTimers();
@@ -801,11 +805,12 @@ describe("OpenTag Web App Shell", () => {
         await vi.advanceTimersByTimeAsync(1_500);
       });
 
-      expect(within(dialog).getByText("Codex · Ada's Mac")).toBeTruthy();
+      expect(within(dialog).getByText("Ada's Mac")).toBeTruthy();
+      expect(within(dialog).getByText("Codex")).toBeTruthy();
       expect((within(dialog).getByLabelText("Display name") as HTMLInputElement).value).toBe("Research Assistant");
       expect((within(dialog).getByLabelText("Agent name") as HTMLInputElement).value).toBe("research-assistant");
       expect(within(dialog).queryByRole("heading", { name: "Connect a Local Computer" })).toBeNull();
-      expect(within(dialog).getByRole("button", { name: "Connect another Computer" })).toBe(document.activeElement);
+      expect(within(dialog).getByRole("button", { name: "Change Computer" })).toBe(document.activeElement);
     } finally {
       vi.useRealTimers();
     }
@@ -866,8 +871,9 @@ describe("OpenTag Web App Shell", () => {
         await Promise.resolve();
       });
 
-      expect(within(dialog).getByText("Codex · Ada's Mac")).toBeTruthy();
-      expect(within(dialog).getByRole("button", { name: "Connect another Computer" })).toBe(document.activeElement);
+      expect(within(dialog).getByText("Ada's Mac")).toBeTruthy();
+      expect(within(dialog).getByText("Codex")).toBeTruthy();
+      expect(within(dialog).getByRole("button", { name: "Change Computer" })).toBe(document.activeElement);
     } finally {
       vi.useRealTimers();
     }
@@ -1911,9 +1917,11 @@ describe("OpenTag Web App Shell", () => {
     });
     window.history.replaceState({}, "", "/agents/new");
     render(<App />);
-    expect(await screen.findByText("Codex · Ada's Mac")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
-    expect(screen.queryByText(/Claude Code/)).toBeNull();
+    expect(await screen.findByText("Ada's Mac")).toBeTruthy();
+    expect(screen.getByText("Codex")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Change Runtime" }));
+    const claudeCode = screen.getByRole("button", { name: /Claude Code Sign-in required/ });
+    expect(claudeCode.hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Create Agent" }).hasAttribute("disabled")).toBe(false);
     fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Codex Reviewer" } });
     fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
@@ -1966,19 +1974,23 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
     const dialog = await screen.findByRole("dialog", { name: "New Agent" });
-    await within(dialog).findByText("Codex · Ada's Mac");
-    expect(within(dialog).queryByRole("button", { name: "Change" })).toBeNull();
+    await within(dialog).findByText("Ada's Mac");
+    expect(within(dialog).getByText("Codex")).toBeTruthy();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Change Runtime" }));
+    expect(
+      within(dialog)
+        .getByRole("button", { name: /Claude Code Unavailable/ })
+        .hasAttribute("disabled"),
+    ).toBe(true);
 
     claudeReadiness.status = "ready";
     window.dispatchEvent(new Event("focus"));
-    const change = await within(dialog).findByRole("button", { name: "Change" });
-    fireEvent.click(change);
-    fireEvent.click(within(dialog).getByRole("button", { name: /Claude Code/ }));
-    expect(await within(dialog).findByText("Claude Code · Ada's Mac")).toBeTruthy();
+    fireEvent.click(await within(dialog).findByRole("button", { name: /Claude Code Ready/ }));
+    expect(await within(dialog).findByText("Claude Code")).toBeTruthy();
 
     claudeReadiness.status = "unavailable";
     window.dispatchEvent(new Event("focus"));
-    expect(await within(dialog).findByText("Codex · Ada's Mac")).toBeTruthy();
+    expect(await within(dialog).findByText("Codex")).toBeTruthy();
 
     ownComputerReadStatus = 503;
     window.dispatchEvent(new Event("focus"));

--- a/apps/web/src/agent-creation/agent-creation-flow.tsx
+++ b/apps/web/src/agent-creation/agent-creation-flow.tsx
@@ -102,8 +102,9 @@ export function AgentCreationFlow({
   const [changingComputer, setChangingComputer] = useState(false);
   const [changingRuntime, setChangingRuntime] = useState(false);
   const [connectingComputer, setConnectingComputer] = useState(false);
-  const [selectedRouteKey, setSelectedRouteKey] = useState(() =>
-    pendingIntent ? routeKey(pendingIntent.request.computerId, pendingIntent.request.runtimeProvider) : undefined,
+  const [selectedComputerId, setSelectedComputerId] = useState(() => pendingIntent?.request.computerId);
+  const [selectedProvider, setSelectedProvider] = useState<AgentRuntimeProvider | undefined>(
+    () => pendingIntent?.request.runtimeProvider,
   );
   const firstFieldRef = useRef<HTMLInputElement>(null);
   const nameFieldRef = useRef<HTMLInputElement>(null);
@@ -115,8 +116,34 @@ export function AgentCreationFlow({
   const computerRefreshStartedRef = useRef(false);
 
   const readyRoutes = useMemo(() => resolveReadyRoutes(facts), [facts]);
-  const selectedRoute =
-    readyRoutes.find((route) => routeKey(route.computer.id, route.provider) === selectedRouteKey) ?? readyRoutes[0];
+  const defaultReadyRoute = readyRoutes[0];
+  const displayedComputer =
+    facts.computers.find((computer) => computer.id === selectedComputerId) ??
+    defaultReadyRoute?.computer ??
+    facts.computers.find((computer) => computer.connectionStatus === "online") ??
+    facts.computers[0];
+  const displayedProvider =
+    facts.providers.find(
+      (provider) => provider.computerId === displayedComputer?.id && provider.provider === selectedProvider,
+    ) ??
+    facts.providers.find(
+      (provider) =>
+        provider.computerId === displayedComputer?.id &&
+        displayedComputer.id === defaultReadyRoute?.computer.id &&
+        provider.provider === defaultReadyRoute.provider,
+    ) ??
+    [...facts.providers]
+      .filter((provider) => provider.computerId === displayedComputer?.id)
+      .sort((left, right) => providerRank(left.provider) - providerRank(right.provider))[0];
+  const selectedRoute = readyRoutes.find(
+    (route) => route.computer.id === displayedComputer?.id && route.provider === displayedProvider?.provider,
+  );
+
+  useEffect(() => {
+    if (!displayedComputer || !displayedProvider || selectedRoute) return;
+    const fallbackRoute = readyRoutes.find((route) => route.computer.id === displayedComputer.id);
+    if (fallbackRoute) setSelectedProvider(fallbackRoute.provider);
+  }, [displayedComputer, displayedProvider, readyRoutes, selectedRoute]);
 
   useEffect(() => {
     firstFieldRef.current?.focus();
@@ -133,11 +160,18 @@ export function AgentCreationFlow({
   useEffect(() => {
     const connectedComputerId = connectedComputerIdRef.current;
     if (!connectedComputerId) return;
+    const connectedComputer = facts.computers.find((computer) => computer.id === connectedComputerId);
+    if (!connectedComputer) return;
     const connectedRoute = readyRoutes.find((route) => route.computer.id === connectedComputerId);
-    if (!connectedRoute) return;
-    setSelectedRouteKey(routeKey(connectedRoute.computer.id, connectedRoute.provider));
+    const connectedProvider =
+      connectedRoute?.provider ??
+      [...facts.providers]
+        .filter((provider) => provider.computerId === connectedComputerId)
+        .sort((left, right) => providerRank(left.provider) - providerRank(right.provider))[0]?.provider;
+    setSelectedComputerId(connectedComputer.id);
+    setSelectedProvider(connectedProvider);
     connectedComputerIdRef.current = undefined;
-  }, [readyRoutes]);
+  }, [facts.computers, facts.providers, readyRoutes]);
 
   useEffect(() => {
     if (!restoreComputerSetupFocusRef.current) return;
@@ -296,14 +330,30 @@ export function AgentCreationFlow({
         changingRuntime={changingRuntime}
         connectingComputer={connectingComputer}
         computerChangeButtonRef={computerChangeButtonRef}
+        displayedComputer={displayedComputer}
+        displayedProvider={displayedProvider}
         facts={facts}
         readyRoutes={readyRoutes}
         refreshing={refreshing}
         selectedRoute={selectedRoute}
         submitting={submitting}
         teamId={teamId}
-        onChangeRoute={(route) => {
-          setSelectedRouteKey(routeKey(route.computer.id, route.provider));
+        onChangeComputer={(computer) => {
+          const providers = [...facts.providers]
+            .filter((provider) => provider.computerId === computer.id)
+            .sort((left, right) => providerRank(left.provider) - providerRank(right.provider));
+          const nextProvider =
+            providers.find((provider) => provider.provider === displayedProvider?.provider)?.provider ??
+            readyRoutes.find((route) => route.computer.id === computer.id)?.provider ??
+            providers[0]?.provider;
+          setSelectedComputerId(computer.id);
+          setSelectedProvider(nextProvider);
+          setChangingComputer(false);
+          setChangingRuntime(false);
+        }}
+        onChangeRuntime={(provider) => {
+          if (displayedComputer) setSelectedComputerId(displayedComputer.id);
+          setSelectedProvider(provider.provider);
           setChangingComputer(false);
           setChangingRuntime(false);
         }}
@@ -358,8 +408,11 @@ function RuntimeRouteSection({
   changingRuntime,
   connectingComputer,
   computerChangeButtonRef,
+  displayedComputer,
+  displayedProvider,
   facts,
-  onChangeRoute,
+  onChangeComputer,
+  onChangeRuntime,
   onConnected,
   onRefresh,
   onToggleComputerSetup,
@@ -375,8 +428,11 @@ function RuntimeRouteSection({
   changingRuntime: boolean;
   connectingComputer: boolean;
   computerChangeButtonRef: { current: HTMLButtonElement | null };
+  displayedComputer: AgentCreationComputer | undefined;
+  displayedProvider: AgentCreationProvider | undefined;
   facts: AgentCreationFacts;
-  onChangeRoute: (route: ReadyRoute) => void;
+  onChangeComputer: (computer: AgentCreationComputer) => void;
+  onChangeRuntime: (provider: AgentCreationProvider) => void;
   onConnected: (computer: AgentCreationComputer) => void;
   onRefresh: () => void;
   onToggleComputerSetup: () => void;
@@ -389,8 +445,7 @@ function RuntimeRouteSection({
   teamId: string;
 }) {
   const onlineComputers = facts.computers.filter((computer) => computer.connectionStatus === "online");
-  const displayedComputer = selectedRoute?.computer ?? onlineComputers[0] ?? facts.computers[0];
-  const attention = providerAttention(facts, displayedComputer);
+  const attention = providerAttention(facts, displayedComputer, displayedProvider);
   const providerOptions = [...facts.providers]
     .filter((provider) => provider.computerId === displayedComputer?.id)
     .sort((left, right) => providerRank(left.provider) - providerRank(right.provider));
@@ -438,12 +493,12 @@ function RuntimeRouteSection({
             <div className="agent-create-route-row">
               <div className="agent-create-route-copy">
                 <span>Runtime</span>
-                <strong>{selectedRoute ? providerLabel(selectedRoute.provider) : "No ready Runtime"}</strong>
+                <strong>{displayedProvider ? providerLabel(displayedProvider.provider) : "No Runtime detected"}</strong>
               </div>
               <div className="agent-create-route-controls">
                 <RouteState
-                  label={selectedRoute ? "Ready" : providerStatusLabel(providerOptions[0])}
-                  tone={selectedRoute ? "success" : providerStatusTone(providerOptions[0])}
+                  label={selectedRoute ? "Ready" : providerStatusLabel(displayedProvider)}
+                  tone={selectedRoute ? "success" : providerStatusTone(displayedProvider)}
                 />
                 {providerOptions.length > 0 ? (
                   <Button
@@ -468,17 +523,15 @@ function RuntimeRouteSection({
               <div className="agent-create-route-list">
                 {computerOptions.map((computer) => {
                   const routes = readyRoutes.filter((route) => route.computer.id === computer.id);
-                  const preferredRoute =
-                    routes.find((route) => route.provider === selectedRoute?.provider) ?? routes[0];
                   return (
                     <button
                       aria-pressed={computer.id === displayedComputer.id}
                       className="agent-create-route-option"
                       data-selected={computer.id === displayedComputer.id ? "true" : undefined}
-                      disabled={submitting || refreshing || preferredRoute === undefined}
+                      disabled={submitting || refreshing}
                       key={computer.id}
                       type="button"
-                      onClick={() => preferredRoute && onChangeRoute(preferredRoute)}
+                      onClick={() => onChangeComputer(computer)}
                     >
                       <span className="agent-create-route-option-copy">
                         <strong>{computer.displayName}</strong>
@@ -520,13 +573,13 @@ function RuntimeRouteSection({
                   );
                   return (
                     <button
-                      aria-pressed={provider.provider === selectedRoute?.provider}
+                      aria-pressed={provider.provider === displayedProvider?.provider}
                       className="agent-create-route-option"
-                      data-selected={provider.provider === selectedRoute?.provider ? "true" : undefined}
+                      data-selected={provider.provider === displayedProvider?.provider ? "true" : undefined}
                       disabled={submitting || refreshing || route === undefined}
                       key={provider.provider}
                       type="button"
-                      onClick={() => route && onChangeRoute(route)}
+                      onClick={() => onChangeRuntime(provider)}
                     >
                       <strong>{providerLabel(provider.provider)}</strong>
                       <span>{providerStatusLabel(provider)}</span>
@@ -541,9 +594,13 @@ function RuntimeRouteSection({
             <div aria-live="polite" className="agent-create-runtime-status" role="status">
               <StatusIndicator label="Ready to run" tone="success" />
             </div>
-          ) : onlineComputers.length === 0 ? (
+          ) : displayedComputer.connectionStatus === "offline" ? (
             <RuntimeAttention
-              detail="Reconnect one of your Computers to continue."
+              detail={
+                onlineComputers.length === 0
+                  ? "Reconnect one of your Computers to continue."
+                  : `Reconnect ${displayedComputer.displayName} or choose another Computer to continue.`
+              }
               label="Computer offline"
               refreshing={refreshing}
               tone="warning"
@@ -619,6 +676,7 @@ function RuntimeAttention({
 function providerAttention(
   facts: AgentCreationFacts,
   computer: AgentCreationComputer | undefined,
+  selectedProvider: AgentCreationProvider | undefined,
 ): { detail: string; label: string; tone: StatusTone } {
   if (!facts.runtimeEvidenceAvailable) {
     return {
@@ -627,7 +685,7 @@ function providerAttention(
       tone: "neutral",
     };
   }
-  const provider = facts.providers.find((candidate) => candidate.computerId === computer?.id);
+  const provider = selectedProvider;
   const providerName = providerLabel(provider?.provider ?? "codex");
   if (provider?.status === "install") {
     return {
@@ -675,10 +733,6 @@ function providerRank(provider: AgentRuntimeProvider): number {
 
 function providerLabel(provider: AgentRuntimeProvider): string {
   return provider === "claude-code" ? "Claude Code" : "Codex";
-}
-
-function routeKey(computerId: string, provider: AgentRuntimeProvider): string {
-  return `${computerId}:${provider}`;
 }
 
 function createAgentOnce(record: CreationIntentRecord): Promise<AgentAdminConfig> {

--- a/apps/web/src/agent-creation/agent-creation-flow.tsx
+++ b/apps/web/src/agent-creation/agent-creation-flow.tsx
@@ -99,14 +99,15 @@ export function AgentCreationFlow({
   const [nameError, setNameError] = useState<string>();
   const [error, setError] = useState<string>();
   const [submitting, setSubmitting] = useState(false);
-  const [changingRoute, setChangingRoute] = useState(false);
+  const [changingComputer, setChangingComputer] = useState(false);
+  const [changingRuntime, setChangingRuntime] = useState(false);
   const [connectingComputer, setConnectingComputer] = useState(false);
   const [selectedRouteKey, setSelectedRouteKey] = useState(() =>
     pendingIntent ? routeKey(pendingIntent.request.computerId, pendingIntent.request.runtimeProvider) : undefined,
   );
   const firstFieldRef = useRef<HTMLInputElement>(null);
   const nameFieldRef = useRef<HTMLInputElement>(null);
-  const computerSetupToggleRef = useRef<HTMLButtonElement>(null);
+  const computerChangeButtonRef = useRef<HTMLButtonElement>(null);
   const inFlightRef = useRef(false);
   const resumeAttemptedRef = useRef(false);
   const connectedComputerIdRef = useRef<string | undefined>(undefined);
@@ -116,7 +117,6 @@ export function AgentCreationFlow({
   const readyRoutes = useMemo(() => resolveReadyRoutes(facts), [facts]);
   const selectedRoute =
     readyRoutes.find((route) => routeKey(route.computer.id, route.provider) === selectedRouteKey) ?? readyRoutes[0];
-  const alternatives = readyRoutes.filter((route) => route !== selectedRoute);
 
   useEffect(() => {
     firstFieldRef.current?.focus();
@@ -148,7 +148,7 @@ export function AgentCreationFlow({
     if (!computerRefreshStartedRef.current) return;
     restoreComputerSetupFocusRef.current = false;
     computerRefreshStartedRef.current = false;
-    (computerSetupToggleRef.current ?? firstFieldRef.current)?.focus();
+    (computerChangeButtonRef.current ?? firstFieldRef.current)?.focus();
   }, [refreshing]);
 
   const create = useCallback(
@@ -292,18 +292,20 @@ export function AgentCreationFlow({
       </div>
 
       <RuntimeRouteSection
-        alternatives={alternatives}
-        changingRoute={changingRoute}
+        changingComputer={changingComputer}
+        changingRuntime={changingRuntime}
         connectingComputer={connectingComputer}
-        computerSetupToggleRef={computerSetupToggleRef}
+        computerChangeButtonRef={computerChangeButtonRef}
         facts={facts}
+        readyRoutes={readyRoutes}
         refreshing={refreshing}
         selectedRoute={selectedRoute}
         submitting={submitting}
         teamId={teamId}
         onChangeRoute={(route) => {
           setSelectedRouteKey(routeKey(route.computer.id, route.provider));
-          setChangingRoute(false);
+          setChangingComputer(false);
+          setChangingRuntime(false);
         }}
         onConnected={(computer) => {
           connectedComputerIdRef.current = computer.id;
@@ -311,6 +313,7 @@ export function AgentCreationFlow({
           computerRefreshStartedRef.current = false;
           if (onCancel) onComputerRefreshFocus?.();
           setConnectingComputer(false);
+          setChangingComputer(false);
           onRefresh();
         }}
         onRefresh={onRefresh}
@@ -319,7 +322,16 @@ export function AgentCreationFlow({
           computerRefreshStartedRef.current = false;
           setConnectingComputer((current) => !current);
         }}
-        onToggleRoutes={() => setChangingRoute((value) => !value)}
+        onToggleComputer={() => {
+          setChangingRuntime(false);
+          setConnectingComputer(false);
+          setChangingComputer((current) => !current);
+        }}
+        onToggleRuntime={() => {
+          setChangingComputer(false);
+          setConnectingComputer(false);
+          setChangingRuntime((current) => !current);
+        }}
       />
 
       {error ? (
@@ -342,130 +354,243 @@ export function AgentCreationFlow({
 }
 
 function RuntimeRouteSection({
-  alternatives,
-  changingRoute,
+  changingComputer,
+  changingRuntime,
   connectingComputer,
-  computerSetupToggleRef,
+  computerChangeButtonRef,
   facts,
   onChangeRoute,
   onConnected,
   onRefresh,
   onToggleComputerSetup,
-  onToggleRoutes,
+  onToggleComputer,
+  onToggleRuntime,
+  readyRoutes,
   refreshing,
   selectedRoute,
   submitting,
   teamId,
 }: {
-  alternatives: readonly ReadyRoute[];
-  changingRoute: boolean;
+  changingComputer: boolean;
+  changingRuntime: boolean;
   connectingComputer: boolean;
-  computerSetupToggleRef: { current: HTMLButtonElement | null };
+  computerChangeButtonRef: { current: HTMLButtonElement | null };
   facts: AgentCreationFacts;
   onChangeRoute: (route: ReadyRoute) => void;
   onConnected: (computer: AgentCreationComputer) => void;
   onRefresh: () => void;
   onToggleComputerSetup: () => void;
-  onToggleRoutes: () => void;
+  onToggleComputer: () => void;
+  onToggleRuntime: () => void;
+  readyRoutes: readonly ReadyRoute[];
   refreshing: boolean;
   selectedRoute: ReadyRoute | undefined;
   submitting: boolean;
   teamId: string;
 }) {
   const onlineComputers = facts.computers.filter((computer) => computer.connectionStatus === "online");
-  const attention = providerAttention(facts, onlineComputers[0]);
+  const displayedComputer = selectedRoute?.computer ?? onlineComputers[0] ?? facts.computers[0];
+  const attention = providerAttention(facts, displayedComputer);
+  const providerOptions = [...facts.providers]
+    .filter((provider) => provider.computerId === displayedComputer?.id)
+    .sort((left, right) => providerRank(left.provider) - providerRank(right.provider));
+  const computerOptions = [...facts.computers].sort((left, right) => left.displayName.localeCompare(right.displayName));
   return (
     <section aria-labelledby="agent-runtime-heading" className="agent-create-runtime">
       <header className="agent-create-runtime-header">
         <div>
           <h3 id="agent-runtime-heading">Where it runs</h3>
-          {selectedRoute ? (
-            <p>
-              {providerLabel(selectedRoute.provider)} · {selectedRoute.computer.displayName}
-            </p>
-          ) : null}
+          <p>Choose the Computer and Runtime for this Agent.</p>
         </div>
-        {selectedRoute && alternatives.length > 0 ? (
-          <Button
-            aria-expanded={changingRoute}
-            disabled={submitting || refreshing}
-            size="compact"
-            variant="ghost"
-            onClick={onToggleRoutes}
-          >
-            Change
-          </Button>
-        ) : null}
       </header>
 
       {facts.computers.length === 0 ? (
         <div className="agent-create-runtime-setup">
           <ComputerSetup teamId={teamId} onConnected={onConnected} />
         </div>
-      ) : selectedRoute ? (
+      ) : displayedComputer ? (
         <>
-          <div aria-live="polite" className="agent-create-runtime-status" role="status">
-            <StatusIndicator label="Ready to run" tone="success" />
-          </div>
-          {changingRoute ? (
-            <div className="agent-create-route-list">
-              {[selectedRoute, ...alternatives].map((route) => (
-                <button
-                  className="agent-create-route-option"
-                  data-selected={route === selectedRoute ? "true" : undefined}
+          <div className="agent-create-route-summary">
+            <div className="agent-create-route-row">
+              <div className="agent-create-route-copy">
+                <span>Computer</span>
+                <strong>{displayedComputer.displayName}</strong>
+              </div>
+              <div className="agent-create-route-controls">
+                <RouteState
+                  label={displayedComputer.connectionStatus === "online" ? "Online" : "Offline"}
+                  tone={displayedComputer.connectionStatus === "online" ? "success" : "warning"}
+                />
+                <Button
+                  aria-controls="new-agent-computer-picker"
+                  aria-expanded={changingComputer}
+                  aria-label="Change Computer"
                   disabled={submitting || refreshing}
-                  key={routeKey(route.computer.id, route.provider)}
-                  type="button"
-                  onClick={() => onChangeRoute(route)}
+                  ref={computerChangeButtonRef}
+                  size="compact"
+                  variant="inline"
+                  onClick={onToggleComputer}
                 >
-                  <strong>{providerLabel(route.provider)}</strong>
-                  <span>{route.computer.displayName}</span>
-                </button>
-              ))}
+                  Change
+                </Button>
+              </div>
             </div>
-          ) : null}
-        </>
-      ) : onlineComputers.length === 0 ? (
-        <RuntimeAttention
-          detail="Reconnect one of your Computers to continue."
-          label="Computer offline"
-          refreshing={refreshing}
-          tone="warning"
-          onRefresh={onRefresh}
-        />
-      ) : (
-        <RuntimeAttention
-          detail={attention.detail}
-          label={attention.label}
-          refreshing={refreshing}
-          tone={attention.tone}
-          onRefresh={onRefresh}
-        />
-      )}
-      {facts.computers.length > 0 ? (
-        <>
-          <div className="agent-create-computer-action">
-            <Button
-              aria-controls="new-agent-computer-setup"
-              aria-expanded={connectingComputer}
-              disabled={submitting}
-              ref={computerSetupToggleRef}
-              size="compact"
-              variant="inline"
-              onClick={onToggleComputerSetup}
-            >
-              {connectingComputer ? "Cancel Computer connection" : "Connect another Computer"}
-            </Button>
+            <div className="agent-create-route-row">
+              <div className="agent-create-route-copy">
+                <span>Runtime</span>
+                <strong>{selectedRoute ? providerLabel(selectedRoute.provider) : "No ready Runtime"}</strong>
+              </div>
+              <div className="agent-create-route-controls">
+                <RouteState
+                  label={selectedRoute ? "Ready" : providerStatusLabel(providerOptions[0])}
+                  tone={selectedRoute ? "success" : providerStatusTone(providerOptions[0])}
+                />
+                {providerOptions.length > 0 ? (
+                  <Button
+                    aria-controls="new-agent-runtime-picker"
+                    aria-expanded={changingRuntime}
+                    aria-label="Change Runtime"
+                    disabled={submitting || refreshing}
+                    size="compact"
+                    variant="inline"
+                    onClick={onToggleRuntime}
+                  >
+                    Change
+                  </Button>
+                ) : null}
+              </div>
+            </div>
           </div>
-          {connectingComputer ? (
-            <div className="agent-create-runtime-setup" id="new-agent-computer-setup">
-              <ComputerSetup teamId={teamId} onConnected={onConnected} />
+
+          {changingComputer ? (
+            <div className="agent-create-route-picker" id="new-agent-computer-picker">
+              <strong className="agent-create-route-picker-title">Choose Computer</strong>
+              <div className="agent-create-route-list">
+                {computerOptions.map((computer) => {
+                  const routes = readyRoutes.filter((route) => route.computer.id === computer.id);
+                  const preferredRoute =
+                    routes.find((route) => route.provider === selectedRoute?.provider) ?? routes[0];
+                  return (
+                    <button
+                      aria-pressed={computer.id === displayedComputer.id}
+                      className="agent-create-route-option"
+                      data-selected={computer.id === displayedComputer.id ? "true" : undefined}
+                      disabled={submitting || refreshing || preferredRoute === undefined}
+                      key={computer.id}
+                      type="button"
+                      onClick={() => preferredRoute && onChangeRoute(preferredRoute)}
+                    >
+                      <span className="agent-create-route-option-copy">
+                        <strong>{computer.displayName}</strong>
+                        <small>{computerRouteSummary(computer, routes.length)}</small>
+                      </span>
+                      <span>{computer.connectionStatus === "online" ? "Online" : "Offline"}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="agent-create-computer-action">
+                <Button
+                  aria-controls="new-agent-computer-setup"
+                  aria-expanded={connectingComputer}
+                  disabled={submitting}
+                  size="compact"
+                  variant="inline"
+                  onClick={onToggleComputerSetup}
+                >
+                  {connectingComputer ? "Cancel Computer connection" : "Connect another Computer"}
+                </Button>
+              </div>
+              {connectingComputer ? (
+                <div className="agent-create-runtime-setup" id="new-agent-computer-setup">
+                  <ComputerSetup teamId={teamId} onConnected={onConnected} />
+                </div>
+              ) : null}
             </div>
           ) : null}
+
+          {changingRuntime ? (
+            <div className="agent-create-route-picker" id="new-agent-runtime-picker">
+              <strong className="agent-create-route-picker-title">Choose Runtime</strong>
+              <div className="agent-create-route-list">
+                {providerOptions.map((provider) => {
+                  const route = readyRoutes.find(
+                    (candidate) =>
+                      candidate.computer.id === provider.computerId && candidate.provider === provider.provider,
+                  );
+                  return (
+                    <button
+                      aria-pressed={provider.provider === selectedRoute?.provider}
+                      className="agent-create-route-option"
+                      data-selected={provider.provider === selectedRoute?.provider ? "true" : undefined}
+                      disabled={submitting || refreshing || route === undefined}
+                      key={provider.provider}
+                      type="button"
+                      onClick={() => route && onChangeRoute(route)}
+                    >
+                      <strong>{providerLabel(provider.provider)}</strong>
+                      <span>{providerStatusLabel(provider)}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
+
+          {selectedRoute ? (
+            <div aria-live="polite" className="agent-create-runtime-status" role="status">
+              <StatusIndicator label="Ready to run" tone="success" />
+            </div>
+          ) : onlineComputers.length === 0 ? (
+            <RuntimeAttention
+              detail="Reconnect one of your Computers to continue."
+              label="Computer offline"
+              refreshing={refreshing}
+              tone="warning"
+              onRefresh={onRefresh}
+            />
+          ) : (
+            <RuntimeAttention
+              detail={attention.detail}
+              label={attention.label}
+              refreshing={refreshing}
+              tone={attention.tone}
+              onRefresh={onRefresh}
+            />
+          )}
         </>
       ) : null}
     </section>
   );
+}
+
+function RouteState({ label, tone }: { label: string; tone: "success" | "warning" | "neutral" }) {
+  return (
+    <span className="agent-create-route-state" data-tone={tone}>
+      <span aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+function computerRouteSummary(computer: AgentCreationComputer, readyRuntimeCount: number): string {
+  if (computer.connectionStatus === "offline") return "Computer offline";
+  if (readyRuntimeCount === 0) return "No Runtime ready";
+  return `${readyRuntimeCount} ${readyRuntimeCount === 1 ? "Runtime" : "Runtimes"} ready`;
+}
+
+function providerStatusLabel(provider: AgentCreationProvider | undefined): string {
+  if (provider?.runtimeReady || provider?.status === "ready") return "Ready";
+  if (provider?.status === "checking") return "Checking";
+  if (provider?.status === "install") return "Not installed";
+  if (provider?.status === "sign-in") return "Sign-in required";
+  if (provider?.status === "unavailable") return "Unavailable";
+  return "Unconfirmed";
+}
+
+function providerStatusTone(provider: AgentCreationProvider | undefined): "success" | "warning" | "neutral" {
+  if (provider?.runtimeReady || provider?.status === "ready") return "success";
+  return provider?.status === "checking" || provider === undefined ? "neutral" : "warning";
 }
 
 function RuntimeAttention({

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -207,14 +207,42 @@ describe("OnboardingPage", () => {
     expect(within(runtime).getByText("Codex")).toBeTruthy();
   });
 
-  it("does not offer an unconfirmed Computer route before runtime facts arrive", async () => {
+  it("shows unavailable Runtime states after selecting a Computer without a ready route", async () => {
+    installFacts({ computers: [computerA, computerB] });
+    renderPage({
+      runtime: runtimeFacts([
+        { computerId: computerAId, provider: "codex", runtimeReady: true, status: "ready" },
+        { computerId: computerBId, provider: "claude-code", runtimeReady: false, status: "sign-in" },
+      ]),
+    });
+
+    const runtime = await screen.findByRole("region", { name: "Where it runs" });
+    expect(within(runtime).getByText("Ada's Mac")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create Agent" })).toHaveProperty("disabled", false);
+
+    fireEvent.click(within(runtime).getByRole("button", { name: "Change Computer" }));
+    const unavailableComputer = within(runtime).getByRole("button", { name: /Studio Mac/ });
+    expect(unavailableComputer).toHaveProperty("disabled", false);
+    fireEvent.click(unavailableComputer);
+
+    expect(within(runtime).getByText("Studio Mac")).toBeTruthy();
+    expect(within(runtime).getByText("Claude Code")).toBeTruthy();
+    expect(within(runtime).getByText("Sign-in required")).toBeTruthy();
+    expect(within(runtime).getByText("Finish sign-in on Studio Mac.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create Agent" })).toHaveProperty("disabled", true);
+  });
+
+  it("allows inspecting an unconfirmed Computer before runtime facts arrive", async () => {
     installFacts({ computers: [computerA, computerB] });
     renderPage();
     const runtime = await screen.findByRole("region", { name: "Where it runs" });
     expect(within(runtime).getByText("Readiness unconfirmed")).toBeTruthy();
     fireEvent.click(within(runtime).getByRole("button", { name: "Change Computer" }));
-    expect(within(runtime).getByRole("button", { name: /Ada's Mac/ })).toHaveProperty("disabled", true);
-    expect(within(runtime).getByRole("button", { name: /Studio Mac/ })).toHaveProperty("disabled", true);
+    const studioMac = within(runtime).getByRole("button", { name: /Studio Mac/ });
+    expect(studioMac).toHaveProperty("disabled", false);
+    fireEvent.click(studioMac);
+    expect(within(runtime).getByText("Studio Mac")).toBeTruthy();
+    expect(within(runtime).getByText("Readiness unconfirmed")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Create Agent" })).toHaveProperty("disabled", true);
   });
 

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -9,7 +9,7 @@ import type {
   TeamMemberSummary,
   UserProfile,
 } from "@opentag/shared/browser";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentCreationFlow } from "../agent-creation/agent-creation-flow.js";
 import { browserApi } from "../api.js";
@@ -182,8 +182,10 @@ describe("OnboardingPage", () => {
         { computerId: computerBId, provider: "codex", runtimeReady: true },
       ]),
     });
-    expect(await screen.findByText("Codex · Ada's Mac")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+    const runtime = await screen.findByRole("region", { name: "Where it runs" });
+    expect(within(runtime).getByText("Ada's Mac")).toBeTruthy();
+    expect(within(runtime).getByText("Codex")).toBeTruthy();
+    fireEvent.click(within(runtime).getByRole("button", { name: "Change Computer" }));
     expect(screen.getByRole("button", { name: /Ada's Mac/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Studio Mac/ })).toBeTruthy();
     expect(vi.spyOn(browserApi, "createAgent")).not.toHaveBeenCalled();
@@ -198,16 +200,21 @@ describe("OnboardingPage", () => {
       ]),
     });
 
-    fireEvent.click(await screen.findByRole("button", { name: "Change" }));
+    const runtime = await screen.findByRole("region", { name: "Where it runs" });
+    fireEvent.click(within(runtime).getByRole("button", { name: "Change Computer" }));
     fireEvent.click(screen.getByRole("button", { name: /Studio Mac/ }));
-    expect(await screen.findByText("Codex · Studio Mac")).toBeTruthy();
+    expect(within(runtime).getByText("Studio Mac")).toBeTruthy();
+    expect(within(runtime).getByText("Codex")).toBeTruthy();
   });
 
   it("does not offer an unconfirmed Computer route before runtime facts arrive", async () => {
     installFacts({ computers: [computerA, computerB] });
     renderPage();
-    expect(await screen.findByText("Readiness unconfirmed")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
+    const runtime = await screen.findByRole("region", { name: "Where it runs" });
+    expect(within(runtime).getByText("Readiness unconfirmed")).toBeTruthy();
+    fireEvent.click(within(runtime).getByRole("button", { name: "Change Computer" }));
+    expect(within(runtime).getByRole("button", { name: /Ada's Mac/ })).toHaveProperty("disabled", true);
+    expect(within(runtime).getByRole("button", { name: /Studio Mac/ })).toHaveProperty("disabled", true);
     expect(screen.getByRole("button", { name: "Create Agent" })).toHaveProperty("disabled", true);
   });
 
@@ -579,11 +586,12 @@ describe("OnboardingPage", () => {
       ]),
     });
 
-    expect(await screen.findByText("Codex · Ada's Mac")).toBeTruthy();
+    const runtime = await screen.findByRole("region", { name: "Where it runs" });
+    expect(within(runtime).getByText("Codex")).toBeTruthy();
     expect(create).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole("button", { name: "Change" }));
-    fireEvent.click(screen.getByRole("button", { name: /Claude Code/ }));
-    expect(await screen.findByText("Claude Code · Ada's Mac")).toBeTruthy();
+    fireEvent.click(within(runtime).getByRole("button", { name: "Change Runtime" }));
+    fireEvent.click(within(runtime).getByRole("button", { name: /Claude Code/ }));
+    expect(within(runtime).getByText("Claude Code")).toBeTruthy();
     expect(create).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
@@ -608,10 +616,11 @@ describe("OnboardingPage", () => {
     const runtime: RuntimeFactsAdapter = { load: vi.fn().mockResolvedValue(available) };
     renderPage({ runtime });
 
-    await screen.findByText("Codex · Ada's Mac");
-    fireEvent.click(screen.getByRole("button", { name: "Change" }));
-    fireEvent.click(screen.getByRole("button", { name: /Claude Code/ }));
-    expect(await screen.findByText("Claude Code · Ada's Mac")).toBeTruthy();
+    const runtimeRegion = await screen.findByRole("region", { name: "Where it runs" });
+    expect(within(runtimeRegion).getByText("Codex")).toBeTruthy();
+    fireEvent.click(within(runtimeRegion).getByRole("button", { name: "Change Runtime" }));
+    fireEvent.click(within(runtimeRegion).getByRole("button", { name: /Claude Code/ }));
+    expect(within(runtimeRegion).getByText("Claude Code")).toBeTruthy();
     expect(runtime.load).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
     await waitFor(() =>
@@ -859,10 +868,12 @@ describe("OnboardingPage", () => {
         { computerId: computerBId, provider: "codex", runtimeReady: true },
       ]),
     });
-    fireEvent.click(await screen.findByRole("button", { name: "Change" }));
+    const runtime = await screen.findByRole("region", { name: "Where it runs" });
+    fireEvent.click(within(runtime).getByRole("button", { name: "Change Computer" }));
     fireEvent.click(screen.getByRole("button", { name: /Studio Mac/ }));
 
-    expect(await screen.findByText("Codex · Studio Mac")).toBeTruthy();
+    expect(within(runtime).getByText("Studio Mac")).toBeTruthy();
+    expect(within(runtime).getByText("Codex")).toBeTruthy();
   });
 
   it("keeps an explicit Agent choice in memory when localStorage throws", async () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2762,10 +2762,6 @@ textarea:focus {
 .agent-create-runtime {
   display: grid;
   gap: 16px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface-soft);
-  padding: 18px;
 }
 
 .agent-create-runtime-header {
@@ -2786,15 +2782,94 @@ textarea:focus {
   font-size: var(--text-meta);
 }
 
-.agent-create-grid {
+.agent-create-route-summary {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.agent-create-route-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 76px;
+  padding: 14px 16px;
+}
+
+.agent-create-route-row + .agent-create-route-row {
+  border-top: 1px solid var(--border);
+}
+
+.agent-create-route-copy {
   display: grid;
-  gap: 14px;
-  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+  min-width: 0;
+  gap: 4px;
+}
+
+.agent-create-route-copy > span,
+.agent-create-route-picker-title {
+  color: var(--muted);
+  font-size: var(--text-meta);
+  font-weight: var(--fw-medium);
+  letter-spacing: var(--track-label);
+  text-transform: uppercase;
+}
+
+.agent-create-route-copy strong {
+  overflow: hidden;
+  font-size: var(--text-ui);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-create-route-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.agent-create-route-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: var(--text-meta);
+  white-space: nowrap;
+}
+
+.agent-create-route-state > span {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--muted);
+}
+
+.agent-create-route-state[data-tone="success"] > span {
+  background: var(--success);
+}
+
+.agent-create-route-state[data-tone="warning"] > span {
+  background: var(--warning);
+}
+
+.agent-create-route-picker {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 10px;
+}
+
+.agent-create-route-picker-title {
+  padding: 4px 6px 2px;
 }
 
 .agent-create-runtime-status {
-  border-top: 1px solid var(--border);
-  padding-top: 14px;
+  padding: 0 2px;
 }
 
 .agent-create-runtime-status .ds-status {
@@ -2811,15 +2886,12 @@ textarea:focus {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-  border-top: 1px solid var(--border);
-  padding-top: 14px;
+  padding: 0 2px;
 }
 
 .agent-create-route-list {
   display: grid;
-  gap: 8px;
-  border-top: 1px solid var(--border);
-  padding-top: 14px;
+  gap: 4px;
 }
 
 .agent-create-route-option {
@@ -2839,7 +2911,12 @@ textarea:focus {
 .agent-create-route-option:hover,
 .agent-create-route-option[data-selected="true"] {
   border-color: var(--border);
-  background: var(--surface);
+  background: var(--surface-soft);
+}
+
+.agent-create-route-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.72;
 }
 
 .agent-create-route-option:focus-visible {
@@ -2852,10 +2929,29 @@ textarea:focus {
   font-size: var(--text-meta);
 }
 
+.agent-create-route-option-copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.agent-create-route-option-copy strong {
+  overflow: hidden;
+  color: var(--foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-create-route-option-copy small {
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
 .agent-create-computer-action {
   display: flex;
-  justify-content: flex-end;
-  margin-top: -8px;
+  justify-content: flex-start;
+  border-top: 1px solid var(--border);
+  padding: 8px 6px 0;
 }
 
 .field-hint {
@@ -3833,8 +3929,14 @@ textarea:focus {
     padding: 20px;
   }
 
-  .agent-create-grid {
-    grid-template-columns: 1fr;
+  .agent-create-route-row {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .agent-create-route-controls {
+    justify-content: space-between;
   }
 
   .page-header,


### PR DESCRIPTION
## Summary

- separate Computer and Runtime into explicit rows in the New Agent flow
- provide independent Computer and Runtime pickers while preserving only validated ready routes
- keep unavailable Runtimes visible with actionable readiness states instead of hiding them
- move Connect another Computer into the Computer picker and remove the outer runtime card chrome
- preserve responsive layout, focus restoration, and onboarding behavior

## Testing

- `pnpm --filter @opentag/web test` — passed, 274 tests
- `pnpm typecheck` — passed
- `pnpm build` — passed
- tracked-file Biome check plus `node scripts/third-party-notices.mjs --check` — passed; existing E2E environment declarations emit warnings
- `pnpm check` — local checkout is blocked before file checking by nested root configs under `.claude/worktrees/*/biome.json`
- `pnpm test` — Web and other completed suites pass; the unrelated Server observability test `traces real RuntimeSession failure, overload, and dropped-queue terminal paths` expects `stale_connection` but receives `handled`. A focused rerun reproduces the same baseline failure.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` all pass locally; see the two baseline issues documented above.
- [x] No credentials, private data, or generated build output are included.
- [x] No canonical documentation mirror update is required.