### PR TITLE
fix(web): clarify Agent runtime settings

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1111,10 +1111,26 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    expect(await screen.findByText("Ada's Mac")).toBeTruthy();
-    expect(screen.getByText("macOS")).toBeTruthy();
+    expect(await screen.findByText("Ada's Mac · macOS")).toBeTruthy();
     expect(screen.getByText("Online")).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Execution choices" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Computer" })).toBeTruthy();
+    expect(screen.getByRole("heading", { level: 3, name: "Runtime" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Agent instructions" })).toBeTruthy();
+    expect(screen.queryByText("Execution choices")).toBeNull();
+    expect(screen.queryByText(/Turn timeout/i)).toBeNull();
+    expect(screen.queryByText(/Last seen/i)).toBeNull();
+  });
+
+  it("shows Computer recovery details only when the assigned Computer is offline", async () => {
+    installApi("admin", { bound: true, computerStatus: () => "offline" });
+    window.history.replaceState({}, "", `/agents/${agentId}/runtime`);
+    render(<App />);
+
+    expect(await screen.findByText("Ada's Mac · macOS")).toBeTruthy();
+    expect(screen.getByText("Offline")).toBeTruthy();
+    expect(screen.getByText(/Last seen/)).toBeTruthy();
+    expect(screen.getByText("New Turns can start after this Computer reconnects.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
   });
 
   it("refreshes Agent availability when the page regains focus", async () => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1451,7 +1451,7 @@ function WorkspaceSettings({ membership, refreshMe }: { membership: MeMembership
 
 function AgentTab({ agent, tab, onAgentChanged }: { agent: AgentDetailView; tab: string; onAgentChanged: () => void }) {
   if (tab === "general") return <GeneralTab agent={agent} onAgentChanged={onAgentChanged} />;
-  if (tab === "runtime") return <RuntimeTab agent={agent} />;
+  if (tab === "runtime") return <RuntimeTab agent={agent} onAgentChanged={onAgentChanged} />;
   if (tab === "im") return <ImTab agent={agent} onAgentChanged={onAgentChanged} />;
   if (tab === "access") return <AccessTab agent={agent} />;
   return <NotFoundPage />;
@@ -1637,39 +1637,87 @@ function GeneralConfigForm({
   );
 }
 
-function RuntimeTab({ agent }: { agent: AgentDetailView }) {
+function RuntimeTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChanged: () => void }) {
   const state = useResource(
     () => (agent.viewerCapabilities.canManage ? browserApi.agentConfig(agent.id) : Promise.resolve(undefined)),
     `${agent.id}:${agent.viewerCapabilities.canManage}`,
   );
+  const computerState = agent.availability.dependencies.computer;
+  const computerStatus =
+    computerState.state === "ready"
+      ? "Online"
+      : computerState.state === "action_required"
+        ? "Offline"
+        : "Unable to confirm";
+  const computerTone: StatusTone =
+    computerState.state === "ready" ? "success" : computerState.state === "action_required" ? "warning" : "neutral";
   return (
     <AsyncState state={state}>
       {(config) => (
-        <>
-          <DefinitionList
-            rows={[
-              ["Provider", providerLabel(agent.runtimeProvider)],
-              ["Computer", agent.computer.displayName],
-              ["System", platformLabel(agent.computer.platform)],
-              [
-                "Connection",
-                agent.availability.dependencies.computer.state === "ready"
-                  ? "Online"
-                  : agent.availability.dependencies.computer.state === "action_required"
-                    ? "Offline"
-                    : "Unable to confirm",
-              ],
-            ]}
-          />
+        <div className="agent-runtime-stack">
+          <section aria-labelledby="computer-heading" className="agent-runtime-section agent-runtime-computer">
+            <header className="agent-runtime-section__header">
+              <div>
+                <h3 id="computer-heading">Computer</h3>
+                <p>The Computer assigned to run this Agent.</p>
+              </div>
+              <StatusIndicator label={computerStatus} tone={computerTone} />
+            </header>
+            <div className="agent-runtime-computer__body">
+              <div>
+                <strong>
+                  {agent.computer.displayName} · {platformLabel(agent.computer.platform)}
+                </strong>
+              </div>
+              {computerState.state !== "ready" ? (
+                <div className="agent-runtime-recovery">
+                  {computerState.lastConfirmedAt ? <p>Last seen {formatDate(computerState.lastConfirmedAt)}</p> : null}
+                  <p>
+                    {computerState.state === "action_required"
+                      ? "New Turns can start after this Computer reconnects."
+                      : "OpenTag could not confirm this Computer's current connection."}
+                  </p>
+                  <Button size="compact" variant="outline" onClick={onAgentChanged}>
+                    Check again
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          </section>
           {config ? (
             <RuntimeConfigurationForm
               initialConfig={config}
               save={(input) => browserApi.updateAgent(config.id, input)}
             />
           ) : (
-            <p className="muted">Runtime instructions and tuning are visible only to Admins.</p>
+            <div className="agent-runtime-settings">
+              <section aria-labelledby="runtime-heading" className="agent-runtime-section">
+                <header className="agent-runtime-section__header">
+                  <div>
+                    <h3 id="runtime-heading">Runtime</h3>
+                    <p>Choose how this Agent runs.</p>
+                  </div>
+                </header>
+                <dl className="agent-runtime-facts">
+                  <div>
+                    <dt>Provider</dt>
+                    <dd>{providerLabel(agent.runtimeProvider)}</dd>
+                  </div>
+                </dl>
+                <p className="agent-runtime-note">Model and reasoning settings are visible only to Admins.</p>
+              </section>
+              <section aria-labelledby="agent-instructions-heading" className="agent-runtime-section">
+                <header className="agent-runtime-section__header">
+                  <div>
+                    <h3 id="agent-instructions-heading">Agent instructions</h3>
+                    <p>Set the guidance applied to every Turn this Agent runs.</p>
+                  </div>
+                </header>
+                <p className="agent-runtime-note">Agent instructions are visible only to Admins.</p>
+              </section>
+            </div>
           )}
-        </>
+        </div>
       )}
     </AsyncState>
   );
@@ -2572,7 +2620,7 @@ function initials(value: string): string {
 function agentSectionDescription(section: (typeof agentSections)[number]["key"]): string {
   const descriptions = {
     general: "See how teammates use this Agent and who can access it.",
-    runtime: "Inspect the bound Computer, provider, model, instructions, and execution limits.",
+    runtime: "Review this Agent's Computer, runtime, and instructions.",
     im: "Manage the Agent's Feishu or Slack bot and message policy.",
     access: "Understand who can use, inspect, and manage this Agent.",
   } satisfies Record<(typeof agentSections)[number]["key"], string>;

--- a/apps/web/src/runtime-configuration.test.tsx
+++ b/apps/web/src/runtime-configuration.test.tsx
@@ -57,13 +57,49 @@ describe("RuntimeConfigurationForm", () => {
     expect(screen.queryByLabelText(/duration/i)).toBeNull();
   });
 
-  it("uses plain provider-managed copy for Claude Code", () => {
-    render(<RuntimeConfigurationForm initialConfig={{ ...config, runtimeProvider: "claude-code" }} save={vi.fn()} />);
+  it("shows and edits stored Claude Code configuration", async () => {
+    const claudeConfig: AgentAdminConfig = {
+      ...config,
+      runtimeProvider: "claude-code",
+      runtimeConfig: {
+        ...config.runtimeConfig,
+        model: "claude-opus-4-1",
+        reasoningEffort: "max",
+        instructions: "Use the repository guidelines.",
+      },
+    };
+    const save = vi.fn(async () => ({
+      ...claudeConfig,
+      revision: 5,
+      runtimeConfig: { ...claudeConfig.runtimeConfig, revision: 8, instructions: "Updated Claude instructions." },
+    }));
+    render(<RuntimeConfigurationForm initialConfig={claudeConfig} save={save} />);
 
-    expect(screen.getByText("Runtime settings are managed by Claude Code.")).toBeTruthy();
-    expect(screen.getByText("Agent instructions are not editable for this provider.")).toBeTruthy();
-    expect(screen.queryByText(/Effective Runtime Snapshot/)).toBeNull();
-    expect(screen.queryByRole("button", { name: "Edit settings" })).toBeNull();
+    expect(screen.getByText("Claude Code")).toBeTruthy();
+    expect(screen.getByText("claude-opus-4-1")).toBeTruthy();
+    expect(screen.getByText("max")).toBeTruthy();
+    expect((screen.getByLabelText("Instructions") as HTMLTextAreaElement).value).toBe("Use the repository guidelines.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
+    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("claude-opus-4-1");
+    const effort = screen.getByLabelText("Reasoning level") as HTMLInputElement;
+    const suggestions = document.getElementById(effort.getAttribute("list") ?? "");
+    expect(Array.from(suggestions?.querySelectorAll("option") ?? []).map((option) => option.value)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultracode",
+    ]);
+
+    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Updated Claude instructions." } });
+    fireEvent.click(screen.getByRole("button", { name: "Save instructions" }));
+    await waitFor(() => expect(save).toHaveBeenCalledOnce());
+    expect(save).toHaveBeenCalledWith({
+      expectedRevision: 4,
+      runtimeConfig: { instructions: "Updated Claude instructions." },
+    });
   });
 
   it("saves Runtime choices without rewriting hidden configuration", async () => {

--- a/apps/web/src/runtime-configuration.test.tsx
+++ b/apps/web/src/runtime-configuration.test.tsx
@@ -21,19 +21,31 @@ const config: AgentAdminConfig = {
     model: null,
     reasoningEffort: null,
     instructions: "Review carefully.",
-    maxDurationMs: null,
+    maxDurationMs: 45_500,
   },
   createdAt: "2026-08-20T00:00:00.000Z",
   updatedAt: "2026-08-20T00:00:00.000Z",
 };
 
 describe("RuntimeConfigurationForm", () => {
-  it("presents provider-managed choices and the shared Turn-duration default", () => {
+  it("presents a concise Runtime summary without exposing the Turn timeout", () => {
     render(<RuntimeConfigurationForm initialConfig={config} save={vi.fn()} />);
 
-    expect((screen.getByLabelText("Model") as HTMLInputElement).placeholder).toBe("Managed by provider");
-    const effort = screen.getByLabelText("Reasoning effort") as HTMLInputElement;
-    expect(effort.placeholder).toBe("Managed by provider");
+    expect(screen.getByRole("heading", { name: "Runtime" })).toBeTruthy();
+    expect(screen.getByText("Codex")).toBeTruthy();
+    expect(screen.getAllByText("Provider default")).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Agent instructions" })).toBeTruthy();
+    expect(screen.queryByText(/timeout/i)).toBeNull();
+    expect(screen.queryByText("Execution choices")).toBeNull();
+  });
+
+  it("edits only the understandable Runtime choices", () => {
+    render(<RuntimeConfigurationForm initialConfig={config} save={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
+    expect((screen.getByLabelText("Model") as HTMLInputElement).placeholder).toBe("Provider default");
+    const effort = screen.getByLabelText("Reasoning level") as HTMLInputElement;
+    expect(effort.placeholder).toBe("Provider default");
     const suggestions = document.getElementById(effort.getAttribute("list") ?? "");
     expect(Array.from(suggestions?.querySelectorAll("option") ?? []).map((option) => option.value)).toEqual([
       "minimal",
@@ -42,39 +54,35 @@ describe("RuntimeConfigurationForm", () => {
       "high",
       "xhigh",
     ]);
-    expect((screen.getByLabelText("Maximum Turn duration") as HTMLInputElement).placeholder).toBe("1800");
-    expect(screen.getByText(/OpenTag's 30-minute default/)).toBeTruthy();
+    expect(screen.queryByLabelText(/duration/i)).toBeNull();
   });
 
-  it("does not advertise configuration for unsupported Claude Code snapshots", () => {
+  it("uses plain provider-managed copy for Claude Code", () => {
     render(<RuntimeConfigurationForm initialConfig={{ ...config, runtimeProvider: "claude-code" }} save={vi.fn()} />);
 
-    expect(screen.getByText(/Effective Runtime Snapshots currently support Codex only/)).toBeTruthy();
-    expect(screen.queryByLabelText("Model")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Save Runtime settings" })).toBeNull();
+    expect(screen.getByText("Runtime settings are managed by Claude Code.")).toBeTruthy();
+    expect(screen.getByText("Agent instructions are not editable for this provider.")).toBeTruthy();
+    expect(screen.queryByText(/Effective Runtime Snapshot/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit settings" })).toBeNull();
   });
 
-  it("saves exact Provider values and converts seconds to API milliseconds", async () => {
+  it("saves Runtime choices without rewriting hidden configuration", async () => {
     const save = vi.fn(async () => ({
       ...config,
       revision: 5,
       runtimeConfig: {
         ...config.runtimeConfig,
+        revision: 8,
         model: "gpt-5.6-codex",
         reasoningEffort: "high",
-        maxDurationMs: 45_500,
       },
     }));
     render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
 
+    fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
     fireEvent.change(screen.getByLabelText("Model"), { target: { value: "  gpt-5.6-codex  " } });
-    fireEvent.change(screen.getByLabelText("Reasoning effort"), { target: { value: "high" } });
-    fireEvent.change(screen.getByLabelText("Maximum Turn duration"), { target: { value: "45.5" } });
-    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Updated instructions." } });
-    const saveButton = screen.getByRole("button", { name: "Save Runtime settings" });
-    expect(saveButton.className).toContain("ds-button--primary");
-    expect(screen.getByLabelText("Model").closest(".ds-field")).toBeTruthy();
-    fireEvent.click(saveButton);
+    fireEvent.change(screen.getByLabelText("Reasoning level"), { target: { value: "high" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
 
     await waitFor(() => expect(save).toHaveBeenCalledOnce());
     expect(save).toHaveBeenCalledWith({
@@ -82,41 +90,52 @@ describe("RuntimeConfigurationForm", () => {
       runtimeConfig: {
         model: "gpt-5.6-codex",
         reasoningEffort: "high",
-        instructions: "Updated instructions.",
-        maxDurationMs: 45_500,
       },
     });
-    expect((await screen.findByRole("status")).textContent).toBe("Runtime configuration saved.");
+    expect((await screen.findByRole("status")).textContent).toBe("Runtime settings saved.");
+    expect(screen.getByText("gpt-5.6-codex")).toBeTruthy();
   });
 
-  it("restores provider-managed choices and the OpenTag duration default with blank values", () => {
+  it("saves Agent instructions independently", async () => {
+    const save = vi.fn(async () => ({
+      ...config,
+      revision: 5,
+      runtimeConfig: { ...config.runtimeConfig, revision: 8, instructions: "Updated instructions." },
+    }));
+    render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
+
+    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Updated instructions." } });
+    fireEvent.click(screen.getByRole("button", { name: "Save instructions" }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledOnce());
+    expect(save).toHaveBeenCalledWith({
+      expectedRevision: 4,
+      runtimeConfig: { instructions: "Updated instructions." },
+    });
+    expect((await screen.findByRole("status")).textContent).toBe("Agent instructions saved.");
+  });
+
+  it("restores provider defaults with blank Runtime values", () => {
     const data = new FormData();
     data.set("model", " ");
     data.set("reasoningEffort", "");
-    data.set("instructions", "Keep this.");
-    data.set("maxDurationSeconds", "");
 
     expect(runtimeConfigurationFromForm(data)).toEqual({
       model: null,
       reasoningEffort: null,
-      instructions: "Keep this.",
-      maxDurationMs: null,
     });
   });
 
-  it.each(["0", "-1", "0.0001", "86400.001"])("rejects an invalid duration of %s before saving", async (duration) => {
-    const save = vi.fn();
+  it("reports save failures without closing the editor", async () => {
+    const save = vi.fn(async () => {
+      throw new Error("Revision changed");
+    });
     render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
-    fireEvent.change(screen.getByLabelText("Maximum Turn duration"), { target: { value: duration } });
-    fireEvent.submit(screen.getByRole("button", { name: "Save Runtime settings" }).closest("form") as HTMLFormElement);
 
-    expect((await screen.findByRole("alert")).textContent).toContain("between 0.001 and 86400 seconds");
-    expect(save).not.toHaveBeenCalled();
-  });
+    fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
 
-  it("rejects non-numeric duration input at the form-contract boundary", () => {
-    const data = new FormData();
-    data.set("maxDurationSeconds", "not-a-number");
-    expect(() => runtimeConfigurationFromForm(data)).toThrow("between 0.001 and 86400 seconds");
+    expect((await screen.findByRole("alert")).textContent).toBe("Revision changed");
+    expect(screen.getByLabelText("Model")).toBeTruthy();
   });
 });

--- a/apps/web/src/runtime-configuration.test.tsx
+++ b/apps/web/src/runtime-configuration.test.tsx
@@ -82,6 +82,7 @@ describe("RuntimeConfigurationForm", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
     expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("claude-opus-4-1");
+    expect(screen.getAllByText("Leave blank to use the provider default.")).toHaveLength(2);
     const effort = screen.getByLabelText("Reasoning level") as HTMLInputElement;
     const suggestions = document.getElementById(effort.getAttribute("list") ?? "");
     expect(Array.from(suggestions?.querySelectorAll("option") ?? []).map((option) => option.value)).toEqual([

--- a/apps/web/src/runtime-configuration.tsx
+++ b/apps/web/src/runtime-configuration.tsx
@@ -93,7 +93,7 @@ function RuntimeConfigurationEditor({ initialConfig, save }: RuntimeConfiguratio
           <form className="agent-runtime-edit-form" key={config.revision} onSubmit={saveRuntime}>
             <div className="agent-runtime-field-grid">
               <Field
-                hint="Leave blank to let Codex choose."
+                hint="Leave blank to use the provider default."
                 hintId={fieldId("model-help")}
                 htmlFor={fieldId("model")}
                 label="Model"

--- a/apps/web/src/runtime-configuration.tsx
+++ b/apps/web/src/runtime-configuration.tsx
@@ -1,17 +1,8 @@
-import {
-  type AgentAdminConfig,
-  RUNTIME_DEFAULT_MAX_DURATION_MS,
-  RUNTIME_MAX_DURATION_MS,
-  type UpdateAgentRequest,
-  type UpdateAgentRuntimeConfig,
-} from "@opentag/shared/browser";
+import type { AgentAdminConfig, UpdateAgentRequest, UpdateAgentRuntimeConfig } from "@opentag/shared/browser";
 import { type FormEvent, useState } from "react";
 import { Button, Field } from "./ui/design-system.js";
 
 const CODEX_REASONING_EFFORT_SUGGESTIONS = ["minimal", "low", "medium", "high", "xhigh"] as const;
-
-const DEFAULT_DURATION_SECONDS = RUNTIME_DEFAULT_MAX_DURATION_MS / 1_000;
-const MAX_DURATION_SECONDS = RUNTIME_MAX_DURATION_MS / 1_000;
 
 export interface RuntimeConfigurationFormProps {
   readonly initialConfig: AgentAdminConfig;
@@ -21,13 +12,33 @@ export interface RuntimeConfigurationFormProps {
 export function RuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigurationFormProps) {
   if (initialConfig.runtimeProvider !== "codex") {
     return (
-      <section className="form-card">
-        <h2>Execution choices</h2>
-        <p className="muted">
-          Runtime Configuration is not available for Claude Code Agents. Effective Runtime Snapshots currently support
-          Codex only.
-        </p>
-      </section>
+      <div className="agent-runtime-settings">
+        <section aria-labelledby="runtime-heading" className="agent-runtime-section">
+          <header className="agent-runtime-section__header">
+            <div>
+              <h3 id="runtime-heading">Runtime</h3>
+              <p>Choose how this Agent runs.</p>
+            </div>
+          </header>
+          <RuntimeFacts
+            rows={[
+              ["Provider", "Claude Code"],
+              ["Model", "Provider default"],
+              ["Reasoning level", "Provider default"],
+            ]}
+          />
+          <p className="agent-runtime-note">Runtime settings are managed by Claude Code.</p>
+        </section>
+        <section aria-labelledby="agent-instructions-heading" className="agent-runtime-section">
+          <header className="agent-runtime-section__header">
+            <div>
+              <h3 id="agent-instructions-heading">Agent instructions</h3>
+              <p>Set the guidance applied to every Turn this Agent runs.</p>
+            </div>
+          </header>
+          <p className="agent-runtime-note">Agent instructions are not editable for this provider.</p>
+        </section>
+      </div>
     );
   }
   return <CodexRuntimeConfigurationForm initialConfig={initialConfig} save={save} />;
@@ -35,113 +46,190 @@ export function RuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigu
 
 function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigurationFormProps) {
   const [config, setConfig] = useState(initialConfig);
-  const [message, setMessage] = useState<{ kind: "error" | "success"; text: string }>();
-  const [saving, setSaving] = useState(false);
+  const [editingRuntime, setEditingRuntime] = useState(false);
+  const [message, setMessage] = useState<{
+    kind: "error" | "success";
+    section: "runtime" | "instructions";
+    text: string;
+  }>();
+  const [saving, setSaving] = useState<"runtime" | "instructions">();
   const fieldId = (name: string) => `runtime-${name}-${config.id}`;
   const reasoningListId = `reasoning-effort-${config.id}`;
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
+  async function saveRuntime(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (saving) return;
-    setSaving(true);
+    setSaving("runtime");
     setMessage(undefined);
     try {
       const runtimeConfig = runtimeConfigurationFromForm(new FormData(event.currentTarget));
       const updated = await save({ expectedRevision: config.revision, runtimeConfig });
       setConfig(updated);
-      setMessage({ kind: "success", text: "Runtime configuration saved." });
+      setEditingRuntime(false);
+      setMessage({ kind: "success", section: "runtime", text: "Runtime settings saved." });
     } catch (cause) {
       setMessage({
         kind: "error",
-        text: cause instanceof Error ? cause.message : "Unable to save Runtime configuration",
+        section: "runtime",
+        text: cause instanceof Error ? cause.message : "Unable to save Runtime settings",
       });
     } finally {
-      setSaving(false);
+      setSaving(undefined);
+    }
+  }
+
+  async function saveInstructions(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (saving) return;
+    setSaving("instructions");
+    setMessage(undefined);
+    try {
+      const instructions = String(new FormData(event.currentTarget).get("instructions") ?? "");
+      const updated = await save({
+        expectedRevision: config.revision,
+        runtimeConfig: { instructions },
+      });
+      setConfig(updated);
+      setMessage({ kind: "success", section: "instructions", text: "Agent instructions saved." });
+    } catch (cause) {
+      setMessage({
+        kind: "error",
+        section: "instructions",
+        text: cause instanceof Error ? cause.message : "Unable to save Agent instructions",
+      });
+    } finally {
+      setSaving(undefined);
     }
   }
 
   return (
-    <form className="form-card" key={config.revision} onSubmit={submit}>
-      <h2>Execution choices</h2>
-      <Field
-        hint="Enter an exact Codex model ID. Leave blank to let Codex manage the selection."
-        hintId={fieldId("model-help")}
-        htmlFor={fieldId("model")}
-        label="Model"
-      >
-        <input
-          aria-describedby={fieldId("model-help")}
-          autoComplete="off"
-          defaultValue={config.runtimeConfig.model ?? ""}
-          id={fieldId("model")}
-          name="model"
-          placeholder="Managed by provider"
-        />
-      </Field>
-      <Field
-        hint="These are common Codex values, not a compatibility guarantee. The bound Computer performs the authoritative runtime check."
-        hintId={fieldId("reasoning-help")}
-        htmlFor={fieldId("reasoning-effort")}
-        label="Reasoning effort"
-      >
-        <input
-          aria-describedby={fieldId("reasoning-help")}
-          autoComplete="off"
-          defaultValue={config.runtimeConfig.reasoningEffort ?? ""}
-          id={fieldId("reasoning-effort")}
-          list={reasoningListId}
-          name="reasoningEffort"
-          placeholder="Managed by provider"
-        />
-        <datalist id={reasoningListId}>
-          {CODEX_REASONING_EFFORT_SUGGESTIONS.map((effort) => (
-            <option value={effort} key={effort} />
-          ))}
-        </datalist>
-      </Field>
-      <Field
-        hint={
-          <>
-            Seconds. Leave blank to use OpenTag's {formatMinutes(RUNTIME_DEFAULT_MAX_DURATION_MS)} default. A timeout
-            stops the Turn, but external effects may already have occurred.
-          </>
-        }
-        hintId={fieldId("duration-help")}
-        htmlFor={fieldId("max-duration")}
-        label="Maximum Turn duration"
-      >
-        <input
-          aria-describedby={fieldId("duration-help")}
-          defaultValue={millisecondsToSeconds(config.runtimeConfig.maxDurationMs)}
-          id={fieldId("max-duration")}
-          max={MAX_DURATION_SECONDS}
-          min="0.001"
-          name="maxDurationSeconds"
-          placeholder={String(DEFAULT_DURATION_SECONDS)}
-          step="0.001"
-          type="number"
-        />
-      </Field>
-      <Field htmlFor={fieldId("instructions")} label="Instructions">
-        <textarea
-          defaultValue={config.runtimeConfig.instructions}
-          id={fieldId("instructions")}
-          name="instructions"
-          rows={10}
-        />
-      </Field>
-      <Button disabled={saving} type="submit">
-        {saving ? "Saving…" : "Save Runtime settings"}
-      </Button>
-      {message ? (
-        <p
-          className={message.kind === "error" ? "error" : undefined}
-          role={message.kind === "error" ? "alert" : "status"}
-        >
-          {message.text}
-        </p>
-      ) : null}
-    </form>
+    <div className="agent-runtime-settings">
+      <section aria-labelledby="runtime-heading" className="agent-runtime-section">
+        <header className="agent-runtime-section__header">
+          <div>
+            <h3 id="runtime-heading">Runtime</h3>
+            <p>Choose how this Agent runs.</p>
+          </div>
+          {!editingRuntime ? (
+            <Button size="compact" variant="inline" onClick={() => setEditingRuntime(true)}>
+              Edit settings
+            </Button>
+          ) : null}
+        </header>
+        {editingRuntime ? (
+          <form className="agent-runtime-edit-form" key={config.revision} onSubmit={saveRuntime}>
+            <div className="agent-runtime-field-grid">
+              <Field
+                hint="Leave blank to let Codex choose."
+                hintId={fieldId("model-help")}
+                htmlFor={fieldId("model")}
+                label="Model"
+              >
+                <input
+                  aria-describedby={fieldId("model-help")}
+                  autoComplete="off"
+                  defaultValue={config.runtimeConfig.model ?? ""}
+                  id={fieldId("model")}
+                  name="model"
+                  placeholder="Provider default"
+                />
+              </Field>
+              <Field
+                hint="Leave blank to use the provider default."
+                hintId={fieldId("reasoning-help")}
+                htmlFor={fieldId("reasoning-effort")}
+                label="Reasoning level"
+              >
+                <input
+                  aria-describedby={fieldId("reasoning-help")}
+                  autoComplete="off"
+                  defaultValue={config.runtimeConfig.reasoningEffort ?? ""}
+                  id={fieldId("reasoning-effort")}
+                  list={reasoningListId}
+                  name="reasoningEffort"
+                  placeholder="Provider default"
+                />
+                <datalist id={reasoningListId}>
+                  {CODEX_REASONING_EFFORT_SUGGESTIONS.map((effort) => (
+                    <option value={effort} key={effort} />
+                  ))}
+                </datalist>
+              </Field>
+            </div>
+            <div className="agent-runtime-actions">
+              <Button disabled={Boolean(saving)} type="submit">
+                {saving === "runtime" ? "Saving…" : "Save settings"}
+              </Button>
+              <Button disabled={Boolean(saving)} variant="ghost" onClick={() => setEditingRuntime(false)}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <RuntimeFacts
+            rows={[
+              ["Provider", "Codex"],
+              ["Model", config.runtimeConfig.model ?? "Provider default"],
+              ["Reasoning level", config.runtimeConfig.reasoningEffort ?? "Provider default"],
+            ]}
+          />
+        )}
+        {message?.section === "runtime" ? <SaveMessage message={message} /> : null}
+      </section>
+
+      <section aria-labelledby="agent-instructions-heading" className="agent-runtime-section">
+        <header className="agent-runtime-section__header">
+          <div>
+            <h3 id="agent-instructions-heading">Agent instructions</h3>
+            <p>Set the guidance applied to every Turn this Agent runs.</p>
+          </div>
+        </header>
+        <form className="agent-instructions-form" key={config.runtimeConfig.revision} onSubmit={saveInstructions}>
+          <Field
+            hint="Be concise and specific. These instructions apply in addition to OpenTag's platform guidance."
+            hintId={fieldId("instructions-help")}
+            htmlFor={fieldId("instructions")}
+            label="Instructions"
+          >
+            <textarea
+              aria-describedby={fieldId("instructions-help")}
+              defaultValue={config.runtimeConfig.instructions}
+              id={fieldId("instructions")}
+              name="instructions"
+              rows={8}
+            />
+          </Field>
+          <Button disabled={Boolean(saving)} type="submit">
+            {saving === "instructions" ? "Saving…" : "Save instructions"}
+          </Button>
+        </form>
+        {message?.section === "instructions" ? <SaveMessage message={message} /> : null}
+      </section>
+    </div>
+  );
+}
+
+function RuntimeFacts({ rows }: { rows: ReadonlyArray<readonly [string, string]> }) {
+  return (
+    <dl className="agent-runtime-facts">
+      {rows.map(([label, value]) => (
+        <div key={label}>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function SaveMessage({ message }: { message: { kind: "error" | "success"; text: string } }) {
+  return (
+    <p
+      className={message.kind === "error" ? "error" : "agent-runtime-save-message"}
+      role={message.kind === "error" ? "alert" : "status"}
+    >
+      {message.text}
+    </p>
   );
 }
 
@@ -149,30 +237,10 @@ export function runtimeConfigurationFromForm(data: FormData): UpdateAgentRuntime
   return {
     model: nullableText(data.get("model")),
     reasoningEffort: nullableText(data.get("reasoningEffort")),
-    instructions: String(data.get("instructions") ?? ""),
-    maxDurationMs: durationMilliseconds(data.get("maxDurationSeconds")),
   };
-}
-
-function durationMilliseconds(value: FormDataEntryValue | null): number | null {
-  const text = String(value ?? "").trim();
-  if (!text) return null;
-  const milliseconds = Number(text) * 1_000;
-  if (!Number.isSafeInteger(milliseconds) || milliseconds < 1 || milliseconds > RUNTIME_MAX_DURATION_MS) {
-    throw new Error("Maximum Turn duration must be between 0.001 and 86400 seconds, in millisecond increments.");
-  }
-  return milliseconds;
-}
-
-function millisecondsToSeconds(value: number | null): string {
-  return value === null ? "" : String(value / 1_000);
 }
 
 function nullableText(value: FormDataEntryValue | null): string | null {
   const text = String(value ?? "").trim();
   return text || null;
-}
-
-function formatMinutes(milliseconds: number): string {
-  return `${milliseconds / 60_000}-minute`;
 }

--- a/apps/web/src/runtime-configuration.tsx
+++ b/apps/web/src/runtime-configuration.tsx
@@ -3,6 +3,7 @@ import { type FormEvent, useState } from "react";
 import { Button, Field } from "./ui/design-system.js";
 
 const CODEX_REASONING_EFFORT_SUGGESTIONS = ["minimal", "low", "medium", "high", "xhigh"] as const;
+const CLAUDE_CODE_REASONING_EFFORT_SUGGESTIONS = ["low", "medium", "high", "xhigh", "max", "ultracode"] as const;
 
 export interface RuntimeConfigurationFormProps {
   readonly initialConfig: AgentAdminConfig;
@@ -10,41 +11,10 @@ export interface RuntimeConfigurationFormProps {
 }
 
 export function RuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigurationFormProps) {
-  if (initialConfig.runtimeProvider !== "codex") {
-    return (
-      <div className="agent-runtime-settings">
-        <section aria-labelledby="runtime-heading" className="agent-runtime-section">
-          <header className="agent-runtime-section__header">
-            <div>
-              <h3 id="runtime-heading">Runtime</h3>
-              <p>Choose how this Agent runs.</p>
-            </div>
-          </header>
-          <RuntimeFacts
-            rows={[
-              ["Provider", "Claude Code"],
-              ["Model", "Provider default"],
-              ["Reasoning level", "Provider default"],
-            ]}
-          />
-          <p className="agent-runtime-note">Runtime settings are managed by Claude Code.</p>
-        </section>
-        <section aria-labelledby="agent-instructions-heading" className="agent-runtime-section">
-          <header className="agent-runtime-section__header">
-            <div>
-              <h3 id="agent-instructions-heading">Agent instructions</h3>
-              <p>Set the guidance applied to every Turn this Agent runs.</p>
-            </div>
-          </header>
-          <p className="agent-runtime-note">Agent instructions are not editable for this provider.</p>
-        </section>
-      </div>
-    );
-  }
-  return <CodexRuntimeConfigurationForm initialConfig={initialConfig} save={save} />;
+  return <RuntimeConfigurationEditor initialConfig={initialConfig} save={save} />;
 }
 
-function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigurationFormProps) {
+function RuntimeConfigurationEditor({ initialConfig, save }: RuntimeConfigurationFormProps) {
   const [config, setConfig] = useState(initialConfig);
   const [editingRuntime, setEditingRuntime] = useState(false);
   const [message, setMessage] = useState<{
@@ -55,6 +25,9 @@ function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigura
   const [saving, setSaving] = useState<"runtime" | "instructions">();
   const fieldId = (name: string) => `runtime-${name}-${config.id}`;
   const reasoningListId = `reasoning-effort-${config.id}`;
+  const providerName = config.runtimeProvider === "codex" ? "Codex" : "Claude Code";
+  const reasoningSuggestions =
+    config.runtimeProvider === "codex" ? CODEX_REASONING_EFFORT_SUGGESTIONS : CLAUDE_CODE_REASONING_EFFORT_SUGGESTIONS;
 
   async function saveRuntime(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -150,7 +123,7 @@ function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigura
                   placeholder="Provider default"
                 />
                 <datalist id={reasoningListId}>
-                  {CODEX_REASONING_EFFORT_SUGGESTIONS.map((effort) => (
+                  {reasoningSuggestions.map((effort) => (
                     <option value={effort} key={effort} />
                   ))}
                 </datalist>
@@ -168,7 +141,7 @@ function CodexRuntimeConfigurationForm({ initialConfig, save }: RuntimeConfigura
         ) : (
           <RuntimeFacts
             rows={[
-              ["Provider", "Codex"],
+              ["Provider", providerName],
               ["Model", config.runtimeConfig.model ?? "Provider default"],
               ["Reasoning level", config.runtimeConfig.reasoningEffort ?? "Provider default"],
             ]}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3002,6 +3002,111 @@ textarea:focus {
   padding: 12px 0;
 }
 
+.agent-runtime-stack,
+.agent-runtime-settings {
+  display: grid;
+}
+
+.agent-runtime-section {
+  display: grid;
+  gap: 20px;
+  border-top: 1px solid var(--border);
+  padding: 28px 0 32px;
+}
+
+.agent-runtime-section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.agent-runtime-section__header h3 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: var(--text-section);
+  font-weight: var(--fw-semibold);
+}
+
+.agent-runtime-section__header p,
+.agent-runtime-note,
+.agent-runtime-recovery p,
+.agent-runtime-save-message {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: var(--text-ui);
+}
+
+.agent-runtime-computer__body {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.agent-runtime-facts dt {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
+}
+
+.agent-runtime-computer__body strong,
+.agent-runtime-facts dd {
+  color: var(--foreground);
+  font-size: var(--text-body);
+  font-weight: var(--fw-medium);
+}
+
+.agent-runtime-recovery {
+  display: grid;
+  max-width: 360px;
+  justify-items: start;
+  gap: 8px;
+}
+
+.agent-runtime-recovery p {
+  margin: 0;
+}
+
+.agent-runtime-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+  margin: 0;
+}
+
+.agent-runtime-facts dd {
+  margin: 0;
+}
+
+.agent-runtime-edit-form,
+.agent-instructions-form {
+  display: grid;
+  gap: 20px;
+}
+
+.agent-runtime-field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.agent-runtime-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.agent-instructions-form textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.agent-instructions-form > .ds-button {
+  justify-self: start;
+}
+
 .list {
   overflow: hidden;
   gap: 0;
@@ -3996,6 +4101,17 @@ textarea:focus {
   .definition-list div {
     grid-template-columns: 1fr;
     gap: 5px;
+  }
+
+  .agent-runtime-section__header,
+  .agent-runtime-computer__body {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .agent-runtime-facts,
+  .agent-runtime-field-grid {
+    grid-template-columns: 1fr;
   }
 
   .row {


### PR DESCRIPTION
## Summary

- split the Agent Runtime view into distinct Computer, Runtime, and Agent instructions sections
- surface semantic Computer health and recovery guidance without adding Workspace-level Computer management
- remove advanced timeout and technical snapshot UI while preserving partial-update API behavior

## Testing

- `pnpm check` (passes with 8 existing Biome environment-variable warnings)
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/web exec vitest run src/runtime-configuration.test.tsx src/__tests__/app.test.tsx` (103 tests)
- `pnpm test` (Web: 274 tests pass; one unchanged Server observability terminal-state test fails both in the full run and isolated rerun)

## Breaking changes

None. No API or data-model changes.

## Checklist

- [x] Change is focused and minimal
- [x] Tests cover the updated behavior
- [x] Build and typecheck pass
- [x] No generated artifacts or credentials are included
- [x] No documentation mirror changes are required