### PR TITLE
fix(server): repair completed staging Team setup

### DIFF
--- a/packages/server/drizzle/0011_staging_team_setup_repair.sql
+++ b/packages/server/drizzle/0011_staging_team_setup_repair.sql
@@ -1,0 +1,14 @@
+-- Repair the Team that completed onboarding before setup_completed_at existed.
+-- The Agent UUID scopes this to the verified Staging Team and is a no-op elsewhere.
+UPDATE "teams"
+SET
+	"setup_completed_at" = CURRENT_TIMESTAMP,
+	"updated_at" = CURRENT_TIMESTAMP
+WHERE
+	"setup_completed_at" IS NULL
+	AND "id" = (
+		SELECT "team_id"
+		FROM "agents"
+		WHERE "id" = '6eb89d85-0f12-4962-8465-518071f1d3e9'
+		LIMIT 1
+	);

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1787472158796,
       "tag": "0010_optimal_jazinda",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1787502703000,
+      "tag": "0011_staging_team_setup_repair",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/integration/auth-migrations.test.ts
+++ b/packages/server/src/__tests__/integration/auth-migrations.test.ts
@@ -285,7 +285,7 @@ describe("database migrations", () => {
             array(select status::text from agents order by name) as statuses
         `;
         expect(lifecycle).toEqual({
-          count: 11,
+          count: 12,
           creation_intents_null: true,
           deleted_at_exists: false,
           setup_completed_at_exists: true,
@@ -311,7 +311,7 @@ describe("database migrations", () => {
         const [rerun] = await sql<{ count: number }[]>`
           select count(*)::int as count from drizzle.__drizzle_migrations
         `;
-        expect(rerun?.count).toBe(11);
+        expect(rerun?.count).toBe(12);
       } finally {
         await sql.end();
       }

--- a/packages/server/src/__tests__/integration/auth-migrations.test.ts
+++ b/packages/server/src/__tests__/integration/auth-migrations.test.ts
@@ -230,11 +230,16 @@ describe("database migrations", () => {
 
         const userId = crypto.randomUUID();
         const teamId = crypto.randomUUID();
+        const controlTeamId = crypto.randomUUID();
         const computerId = crypto.randomUUID();
-        const activeAgentId = crypto.randomUUID();
+        const activeAgentId = "6eb89d85-0f12-4962-8465-518071f1d3e9";
         const deletedAgentId = crypto.randomUUID();
         await sql`insert into users (id, email, display_name) values (${userId}, 'migration@example.com', 'Migration')`;
         await sql`insert into teams (id, name, display_name) values (${teamId}, 'migration', 'Migration')`;
+        await sql`
+          insert into teams (id, name, display_name)
+          values (${controlTeamId}, 'migration-control', 'Migration Control')
+        `;
         await sql`insert into memberships (team_id, user_id, role) values (${teamId}, ${userId}, 'admin')`;
         await sql`
           insert into computers (id, owner_user_id, display_name, platform, arch, client_version)
@@ -292,6 +297,15 @@ describe("database migrations", () => {
           status_default: "'active'::agent_status",
           statuses: ["active", "deleted"],
         });
+        const repairedTeams = await sql<{ completed: boolean; name: string }[]>`
+          select name, setup_completed_at is not null as completed
+          from teams
+          order by name
+        `;
+        expect(repairedTeams).toEqual([
+          { completed: true, name: "migration" },
+          { completed: false, name: "migration-control" },
+        ]);
         const [agentStatusEnum] = await sql<{ values: string[] }[]>`
           select array_agg(enumlabel order by enumsortorder)::text[] as values
           from pg_enum join pg_type on pg_type.oid = pg_enum.enumtypid


### PR DESCRIPTION
## Summary
- add an idempotent data-repair migration for the verified historical Staging Team
- locate the Team through the exact pre-existing Agent UUID
- leave every other Team and environment unchanged
- update migration-count assertions

## Validation
- `vitest ... -t "upgrades deployed"` passed
- the full migration suite previously ran successfully except for the expected migration-count assertions, now updated

## Scope
The repair only updates a Team whose `setup_completed_at` is null and which owns Agent `6eb89d85-0f12-4962-8465-518071f1d3e9` (`baixiaohang的助理`). It is a no-op where that UUID does not exist.