### PR TITLE
feat(web): add Task tab mock UI

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1414,14 +1414,19 @@ describe("OpenTag Web App Shell", () => {
     confirm.mockRestore();
   });
 
-  it("shows an honest Tasks unavailable state without synthetic records", async () => {
+  it("shows the Tasks demo and opens a Task detail", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/tasks");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Tasks" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Tasks are not available yet" })).toBeTruthy();
-    expect(screen.getByText("The current server does not expose a Tasks API.")).toBeTruthy();
-    expect(screen.getByText("No sample, inferred, or locally generated Task records are shown.")).toBeTruthy();
+    expect(screen.getByText("Demo data")).toBeTruthy();
+    const task = screen.getByRole("link", {
+      name: "Review the Q3 launch plan, identify unresolved owners, and flag every item without a confirmed date.",
+    });
+    fireEvent.click(task);
+    expect(await screen.findByRole("heading", { name: "Launch plan reviewed" })).toBeTruthy();
+    expect(screen.getByLabelText("Task source").textContent).toContain("Product Launch");
+    expect(window.location.pathname).toBe("/tasks/q3-launch-readiness");
   });
 
   it("groups invitations with Members", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1429,6 +1429,15 @@ describe("OpenTag Web App Shell", () => {
     expect(window.location.pathname).toBe("/tasks/q3-launch-readiness");
   });
 
+  it("labels a directly opened Task detail as demo data", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", "/tasks/q3-launch-readiness");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Launch plan reviewed" })).toBeTruthy();
+    expect(screen.getByText("Demo data")).toBeTruthy();
+  });
+
   it("groups invitations with Members", async () => {
     installApi("admin");
     window.history.replaceState({}, "", "/members");

--- a/apps/web/src/features/tasks-page.css
+++ b/apps/web/src/features/tasks-page.css
@@ -1,0 +1,683 @@
+.tasks-page,
+.task-not-found {
+  width: min(100%, var(--workspace-page-frame));
+  margin: 0 auto;
+  padding-inline: var(--workspace-page-gutter);
+}
+
+.task-conversation-page {
+  width: min(100%, 920px);
+  margin: 0 auto;
+  padding-inline: var(--workspace-page-gutter);
+}
+
+.tasks-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
+}
+
+.tasks-page-header h1 {
+  margin: 0 0 7px;
+}
+
+.tasks-page-header p {
+  max-width: 620px;
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
+}
+
+.tasks-demo-note {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: var(--text-meta);
+  line-height: 40px;
+}
+
+.task-toolbar {
+  display: grid;
+  align-items: center;
+  grid-template-columns: minmax(260px, 1fr) repeat(3, minmax(140px, 164px));
+  gap: var(--space-3);
+  margin-bottom: var(--space-8);
+}
+
+.task-toolbar label {
+  min-width: 0;
+}
+
+.task-toolbar input,
+.task-toolbar select {
+  background: var(--surface);
+}
+
+.task-toolbar input[type="search"]::-webkit-search-cancel-button {
+  cursor: pointer;
+}
+
+.task-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.task-table thead,
+.task-table tbody {
+  display: block;
+}
+
+.task-table th,
+.task-table td {
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.task-table-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(190px, 236px) minmax(160px, 180px);
+  column-gap: var(--space-8);
+}
+
+.task-table-header {
+  min-height: 36px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font-size: var(--text-micro);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+}
+
+.task-table-row {
+  min-height: 92px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  color: var(--secondary-foreground);
+  padding: var(--space-4) 0;
+}
+
+.task-table-row:last-child {
+  border-bottom: 0;
+}
+
+.task-work-cell a {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: var(--text-body);
+  font-weight: var(--fw-semibold);
+  line-height: 1.45;
+  text-decoration: none;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.task-work-cell a:hover {
+  color: var(--brand-ink);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.task-work-cell small {
+  display: block;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
+.task-source-identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.task-source-identity > span:last-child {
+  min-width: 0;
+}
+
+.task-source-identity strong,
+.task-source-identity small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-source-identity strong {
+  color: var(--foreground);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+}
+
+.task-source-identity small {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
+.task-source-mark {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--surface);
+  color: var(--secondary-foreground);
+  font-size: 10px;
+  font-weight: var(--fw-bold);
+  letter-spacing: -0.01em;
+}
+
+.task-source-mark--feishu {
+  border-color: #b8d9d5;
+  background: #edf7f5;
+  color: #176f6a;
+}
+
+.task-source-mark--github {
+  border-color: #c9ccd0;
+  background: #f1f2f3;
+  color: #28313a;
+}
+
+.task-source-mark--jira {
+  border-color: #b9c9e8;
+  background: #eef3fc;
+  color: #315caa;
+}
+
+.task-table-row .ds-status {
+  align-items: flex-start;
+}
+
+.task-empty-state,
+.task-not-found {
+  padding-top: var(--space-8);
+}
+
+.task-empty-state {
+  border-top: 1px solid var(--border);
+}
+
+.task-empty-state h2,
+.task-not-found h1 {
+  margin-bottom: var(--space-2);
+  font-size: var(--text-section);
+}
+
+.task-empty-state p,
+.task-not-found p {
+  color: var(--muted);
+  font-size: var(--text-body);
+}
+
+.task-not-found a,
+.task-breadcrumb a {
+  color: var(--brand-ink);
+  font-weight: var(--fw-semibold);
+  text-underline-offset: 3px;
+}
+
+.task-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+  color: var(--muted);
+  font-size: var(--text-ui);
+}
+
+.task-breadcrumb a {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  text-decoration: none;
+}
+
+.task-breadcrumb .ds-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.task-breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.task-conversation-header {
+  padding-bottom: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.task-conversation-header h1 {
+  max-width: 800px;
+  margin-bottom: var(--space-6);
+  font-size: var(--text-title);
+  line-height: 1.28;
+}
+
+.task-conversation-context {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+}
+
+.task-conversation-context .ds-status {
+  flex: 0 0 auto;
+  align-items: flex-end;
+}
+
+.task-thread {
+  padding: 40px 0 var(--space-8);
+}
+
+.task-turn + .task-turn {
+  margin-top: 64px;
+}
+
+.task-message + .task-message {
+  margin-top: 48px;
+}
+
+.task-message-author {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.task-message-author > span:last-child {
+  min-width: 0;
+}
+
+.task-message-author strong,
+.task-message-author small {
+  display: block;
+}
+
+.task-message-author strong {
+  color: var(--foreground);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+}
+
+.task-message-author small {
+  margin-top: 2px;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: var(--text-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-person-mark,
+.task-agent-mark {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-bold);
+}
+
+.task-person-mark {
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--secondary-foreground);
+}
+
+.task-agent-mark {
+  border-radius: var(--radius-control);
+  background: var(--brand-light);
+  color: var(--brand-ink);
+}
+
+.task-request-bubble {
+  width: fit-content;
+  max-width: 760px;
+  margin-left: 44px;
+  border-radius: 12px;
+  background: var(--surface-soft);
+  padding: var(--space-4) var(--space-5);
+}
+
+.task-request-bubble p {
+  margin: 0;
+  color: var(--foreground);
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
+}
+
+.task-work-summary,
+.task-agent-response,
+.task-agent-update,
+.task-delivery-receipt {
+  margin-left: 44px;
+}
+
+.task-agent-update {
+  max-width: 720px;
+  margin-top: 0;
+  margin-bottom: var(--space-5);
+  color: var(--secondary-foreground);
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
+}
+
+.task-work-summary {
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.task-agent-response + .task-work-summary {
+  margin-top: var(--space-5);
+}
+
+.task-work-summary summary,
+.task-record-details summary {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-medium);
+  list-style: none;
+}
+
+.task-work-summary summary::-webkit-details-marker,
+.task-record-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.task-work-summary summary .ds-icon,
+.task-record-details summary .ds-icon {
+  width: 16px;
+  height: 16px;
+  transition: transform 160ms ease;
+}
+
+.task-work-summary[open] summary .ds-icon,
+.task-record-details[open] summary .ds-icon {
+  transform: rotate(90deg);
+}
+
+.task-work-summary ol {
+  margin: 0;
+  padding: 0 0 var(--space-3);
+  list-style: none;
+}
+
+.task-work-summary li {
+  display: grid;
+  align-items: center;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  min-height: 48px;
+  color: var(--secondary-foreground);
+  font-size: var(--text-meta);
+}
+
+.task-action-mark {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: var(--fw-bold);
+}
+
+.task-action-mark .ds-icon {
+  width: 12px;
+  height: 12px;
+}
+
+.task-action-copy strong,
+.task-action-copy small {
+  display: block;
+}
+
+.task-action-copy strong {
+  color: var(--secondary-foreground);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-medium);
+}
+
+.task-action-copy small {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
+.task-work-summary time {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.task-agent-response {
+  max-width: 720px;
+  padding-top: 0;
+}
+
+.task-agent-response h2 {
+  margin-bottom: var(--space-3);
+  color: var(--foreground);
+  font-size: var(--text-section);
+}
+
+.task-agent-response > p {
+  margin: 0;
+  color: var(--secondary-foreground);
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
+}
+
+.task-agent-response ul {
+  margin: var(--space-5) 0 0;
+  padding-left: 18px;
+  list-style: disc;
+}
+
+.task-agent-response li {
+  padding: 4px 0;
+  font-size: var(--text-ui);
+}
+
+.task-agent-response li::marker {
+  color: var(--muted);
+}
+
+.task-agent-response li span {
+  color: var(--foreground);
+}
+
+.task-agent-response li small {
+  margin-left: 4px;
+  color: var(--muted);
+  font-size: inherit;
+}
+
+.task-delivery-receipt {
+  display: flex;
+  max-width: 720px;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-5);
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
+.task-delivery-receipt .ds-icon {
+  width: 14px;
+  height: 14px;
+  color: var(--success);
+}
+
+.task-delivery-receipt time {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.task-record-details {
+  margin: 0 0 var(--space-8) 44px;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.task-record-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-8);
+  padding: var(--space-2) 0 var(--space-5);
+}
+
+.task-record-grid dl {
+  margin: 0;
+}
+
+.task-record-grid dl > div {
+  display: grid;
+  grid-template-columns: minmax(92px, 116px) minmax(0, 1fr);
+  gap: var(--space-4);
+  min-height: 30px;
+  align-items: baseline;
+}
+
+.task-record-grid dt,
+.task-record-grid dd {
+  font-size: var(--text-meta);
+}
+
+.task-record-grid dt {
+  color: var(--muted);
+}
+
+.task-record-grid dd {
+  overflow-wrap: anywhere;
+  color: var(--secondary-foreground);
+}
+
+@media (max-width: 900px) {
+  .tasks-page,
+  .task-conversation-page,
+  .task-not-found {
+    padding-inline: 0;
+  }
+}
+
+@media (max-width: 820px) {
+  .task-toolbar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .task-search {
+    grid-column: 1 / -1;
+  }
+
+  .task-table-grid {
+    grid-template-columns: minmax(280px, 1fr) minmax(176px, 210px) minmax(150px, 170px);
+    column-gap: var(--space-6);
+  }
+}
+
+@media (max-width: 720px) {
+  .tasks-page-header {
+    margin-bottom: var(--space-6);
+  }
+
+  .task-table thead {
+    display: none;
+  }
+
+  .task-table-row {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+    padding: var(--space-6) 0;
+  }
+
+  .task-table-row td[data-label]::before {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--muted);
+    content: attr(data-label);
+    font-size: var(--text-micro);
+    font-weight: var(--fw-semibold);
+    text-transform: uppercase;
+  }
+
+  .task-record-grid {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .tasks-page-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .tasks-demo-note {
+    line-height: var(--lh-ui);
+  }
+
+  .task-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .task-search {
+    grid-column: auto;
+  }
+
+  .task-conversation-context {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .task-conversation-context .ds-status {
+    align-items: flex-start;
+  }
+
+  .task-conversation-header h1 {
+    font-size: var(--text-section);
+  }
+
+  .task-thread {
+    padding-top: var(--space-8);
+  }
+
+  .task-request-bubble,
+  .task-work-summary,
+  .task-agent-response,
+  .task-agent-update,
+  .task-delivery-receipt,
+  .task-record-details {
+    margin-left: 0;
+  }
+
+  .task-record-grid dl > div {
+    grid-template-columns: 100px minmax(0, 1fr);
+  }
+}

--- a/apps/web/src/features/tasks-page.css
+++ b/apps/web/src/features/tasks-page.css
@@ -368,7 +368,7 @@
 .task-work-summary,
 .task-agent-response,
 .task-agent-update,
-.task-delivery-receipt {
+.task-result-observation {
   margin-left: 44px;
 }
 
@@ -520,7 +520,7 @@
   font-size: inherit;
 }
 
-.task-delivery-receipt {
+.task-result-observation {
   display: flex;
   max-width: 720px;
   align-items: center;
@@ -531,13 +531,7 @@
   font-size: var(--text-meta);
 }
 
-.task-delivery-receipt .ds-icon {
-  width: 14px;
-  height: 14px;
-  color: var(--success);
-}
-
-.task-delivery-receipt time {
+.task-result-observation time {
   margin-left: auto;
   font-variant-numeric: tabular-nums;
 }
@@ -677,7 +671,7 @@
   .task-work-summary,
   .task-agent-response,
   .task-agent-update,
-  .task-delivery-receipt,
+  .task-result-observation,
   .task-record-details {
     margin-left: 0;
   }

--- a/apps/web/src/features/tasks-page.css
+++ b/apps/web/src/features/tasks-page.css
@@ -230,10 +230,15 @@
 .task-breadcrumb {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-2);
   margin-bottom: var(--space-6);
   color: var(--muted);
   font-size: var(--text-ui);
+}
+
+.task-breadcrumb .tasks-demo-note {
+  line-height: inherit;
 }
 
 .task-breadcrumb a {

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { TaskDetailPage, TasksPage } from "./tasks-page.js";
+
+describe("Tasks demo", () => {
+  it("renders the minimal Work, Source, and Activity list in English", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <TasksPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByRole("columnheader").map((header) => header.textContent)).toEqual([
+      "Work",
+      "Source",
+      "Activity",
+    ]);
+    expect(screen.getAllByRole("row")).toHaveLength(7);
+    expect(screen.getAllByText(/^Feishu ·/)).toHaveLength(3);
+    expect(screen.getByText(/^Email ·/)).toBeTruthy();
+    expect(screen.getByText(/^GitHub ·/)).toBeTruthy();
+    expect(screen.getByText(/^Jira ·/)).toBeTruthy();
+    expect(container.textContent).not.toMatch(/[\u3400-\u9fff]/u);
+  });
+
+  it("filters demo Tasks by source and search text", () => {
+    render(
+      <MemoryRouter>
+        <TasksPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter by source"), { target: { value: "github" } });
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+    expect(screen.getByText("opentag/web #123")).toBeTruthy();
+    expect(screen.queryByText("Product Launch")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Filter by source"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Search Tasks"), { target: { value: "security questionnaire" } });
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+    expect(screen.getByText("security@northstar.example")).toBeTruthy();
+  });
+
+  it("shows a compact empty result state", () => {
+    render(
+      <MemoryRouter>
+        <TasksPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText("Search Tasks"), { target: { value: "no matching task" } });
+    expect(screen.getByRole("heading", { name: "No Tasks found" })).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("renders the request and Agent response as a conversation", () => {
+    render(
+      <MemoryRouter initialEntries={["/tasks/q3-launch-readiness"]}>
+        <Routes>
+          <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Launch plan reviewed" })).toBeTruthy();
+    expect(screen.getByLabelText("Task source").textContent).toContain("Product Launch");
+    const conversation = screen.getByLabelText("Task conversation");
+    expect(within(conversation).getAllByText("Mia Zhang")).toHaveLength(2);
+    expect(
+      within(conversation).getByText(
+        "Please review the Q3 launch plan and call out anything that is still unowned or missing a confirmed date.",
+      ),
+    ).toBeTruthy();
+    expect(within(conversation).getByText("Opened the launch brief")).toBeTruthy();
+    expect(
+      within(conversation).getByText(
+        "Please turn the three unresolved items into follow-ups and tag the likely owners.",
+      ),
+    ).toBeTruthy();
+    expect(within(conversation).getByRole("heading", { name: "Follow-ups drafted" })).toBeTruthy();
+    expect(within(conversation).getAllByText("Delivered to Product Launch")).toHaveLength(2);
+    const work = screen.getByText("2 actions · Feishu · Google Drive · 8m 12s").closest("details");
+    const taskDetails = screen.getByText("Task details").closest("details");
+    expect(work?.hasAttribute("open")).toBe(false);
+    expect(taskDetails?.hasAttribute("open")).toBe(false);
+    expect(screen.queryByRole("complementary")).toBeNull();
+  });
+
+  it("does not turn unavailable provider tokens into zero", () => {
+    render(
+      <MemoryRouter initialEntries={["/tasks/jira-onboarding-coverage"]}>
+        <Routes>
+          <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const details = screen.getByText("Task details").closest("details");
+    expect(details).toBeTruthy();
+    const tokens = within(details as HTMLElement).getByText("Tokens").parentElement;
+    expect(tokens?.textContent).toBe("TokensUnavailable");
+    expect(
+      screen.getByText("The Task record is incomplete because the final provider response was not received."),
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -80,7 +80,10 @@ describe("Tasks demo", () => {
       ),
     ).toBeTruthy();
     expect(within(conversation).getByRole("heading", { name: "Follow-ups drafted" })).toBeTruthy();
-    expect(within(conversation).getAllByText("Delivered to Product Launch")).toHaveLength(2);
+    expect(
+      within(conversation).getAllByText("Agent result recorded locally · Outbound delivery unconfirmed"),
+    ).toHaveLength(2);
+    expect(within(conversation).queryByText(/^Delivered to /)).toBeNull();
     const work = screen.getByText("2 actions · Feishu · Google Drive · 8m 12s").closest("details");
     const taskDetails = screen.getByText("Task details").closest("details");
     expect(work?.hasAttribute("open")).toBe(false);

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -64,6 +64,7 @@ describe("Tasks demo", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Launch plan reviewed" })).toBeTruthy();
+    expect(screen.getByText("Demo data")).toBeTruthy();
     expect(screen.getByLabelText("Task source").textContent).toContain("Product Launch");
     const conversation = screen.getByLabelText("Task conversation");
     expect(within(conversation).getAllByText("Mia Zhang")).toHaveLength(2);

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -104,8 +104,26 @@ describe("Tasks demo", () => {
     expect(details).toBeTruthy();
     const tokens = within(details as HTMLElement).getByText("Tokens").parentElement;
     expect(tokens?.textContent).toBe("TokensUnavailable");
+    expect(screen.getByText("Time unavailable")).toBeTruthy();
     expect(
       screen.getByText("The Task record is incomplete because the final provider response was not received."),
     ).toBeTruthy();
+  });
+
+  it("shows the local result observation time instead of the request time", () => {
+    render(
+      <MemoryRouter initialEntries={["/tasks/security-questionnaire"]}>
+        <Routes>
+          <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const response = screen
+      .getByRole("heading", { name: "Questionnaire draft completed" })
+      .closest(".task-message--agent");
+    expect(response).toBeTruthy();
+    expect(within(response as HTMLElement).getAllByText("10:10 AM")).toHaveLength(2);
+    expect(within(response as HTMLElement).queryByText("9:56 AM")).toBeNull();
   });
 });

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -1,0 +1,408 @@
+import { type ChangeEventHandler, type ReactNode, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  findTaskPreview,
+  type TaskActivity,
+  type TaskPreview,
+  type TaskResult,
+  type TaskSourceKind,
+  type TaskStatus,
+  taskPreviews,
+} from "../mock/task-data.js";
+import { Icon, StatusIndicator, type StatusTone } from "../ui/design-system.js";
+import "./tasks-page.css";
+
+type TaskFilter = "all" | TaskStatus;
+type SourceFilter = "all" | TaskSourceKind;
+type AgentFilter = "all" | TaskPreview["agent"];
+
+type ConversationTurn = {
+  readonly actions: readonly TaskActivity[];
+  readonly assistantUpdate?: string;
+  readonly delivery?: { readonly label: string; readonly time: string };
+  readonly duration: string;
+  readonly id: string;
+  readonly request: string;
+  readonly requestTime: string;
+  readonly result: TaskResult;
+};
+
+const statusPresentation: Record<TaskStatus, { readonly label: string; readonly tone: StatusTone }> = {
+  needs_attention: { label: "Needs attention", tone: "warning" },
+  processing: { label: "In progress", tone: "info" },
+  recently_completed: { label: "Recently completed", tone: "success" },
+  unable_to_confirm: { label: "Unable to confirm", tone: "neutral" },
+};
+
+const sourcePresentation: Record<TaskSourceKind, { readonly abbreviation: string; readonly label: string }> = {
+  email: { abbreviation: "@", label: "Email" },
+  feishu: { abbreviation: "FS", label: "Feishu" },
+  github: { abbreviation: "GH", label: "GitHub" },
+  jira: { abbreviation: "J", label: "Jira" },
+};
+
+const toolPresentation: Readonly<Record<string, string>> = {
+  FS: "Feishu",
+  GD: "Google Drive",
+};
+
+export function TasksPage() {
+  const [query, setQuery] = useState("");
+  const [agent, setAgent] = useState<AgentFilter>("all");
+  const [source, setSource] = useState<SourceFilter>("all");
+  const [status, setStatus] = useState<TaskFilter>("all");
+  const tasks = useMemo(() => {
+    const normalizedQuery = query.trim().toLocaleLowerCase();
+    return taskPreviews.filter((task) => {
+      const matchesQuery =
+        normalizedQuery.length === 0 ||
+        [task.title, task.agent, task.source.context, task.source.detail, sourcePresentation[task.source.kind].label]
+          .join(" ")
+          .toLocaleLowerCase()
+          .includes(normalizedQuery);
+      return (
+        matchesQuery &&
+        (agent === "all" || task.agent === agent) &&
+        (source === "all" || task.source.kind === source) &&
+        (status === "all" || task.status === status)
+      );
+    });
+  }, [agent, query, source, status]);
+
+  return (
+    <section className="tasks-page" aria-labelledby="tasks-page-title">
+      <header className="tasks-page-header">
+        <div>
+          <h1 id="tasks-page-title">Tasks</h1>
+          <p>Track work Agents handle across connected sources.</p>
+        </div>
+        <span className="tasks-demo-note">Demo data</span>
+      </header>
+
+      <form className="task-toolbar" aria-label="Filter Tasks" onSubmit={(event) => event.preventDefault()}>
+        <label className="task-search">
+          <span className="visually-hidden">Search Tasks</span>
+          <input
+            value={query}
+            type="search"
+            placeholder="Search Tasks"
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </label>
+        <TaskSelect
+          label="Filter by Agent"
+          value={agent}
+          onChange={(event) => setAgent(event.target.value as AgentFilter)}
+        >
+          <option value="all">All Agents</option>
+          <option value="Atlas">Atlas</option>
+          <option value="Scout">Scout</option>
+        </TaskSelect>
+        <TaskSelect
+          label="Filter by source"
+          value={source}
+          onChange={(event) => setSource(event.target.value as SourceFilter)}
+        >
+          <option value="all">All sources</option>
+          <option value="feishu">Feishu</option>
+          <option value="email">Email</option>
+          <option value="github">GitHub</option>
+          <option value="jira">Jira</option>
+        </TaskSelect>
+        <TaskSelect
+          label="Filter by status"
+          value={status}
+          onChange={(event) => setStatus(event.target.value as TaskFilter)}
+        >
+          <option value="all">All statuses</option>
+          <option value="processing">In progress</option>
+          <option value="recently_completed">Recently completed</option>
+          <option value="needs_attention">Needs attention</option>
+          <option value="unable_to_confirm">Unable to confirm</option>
+        </TaskSelect>
+      </form>
+
+      {tasks.length > 0 ? (
+        <table className="task-table" aria-label="Demo Tasks">
+          <thead>
+            <tr className="task-table-grid task-table-header">
+              <th scope="col">Work</th>
+              <th scope="col">Source</th>
+              <th scope="col">Activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tasks.map((task) => (
+              <TaskRow key={task.id} task={task} />
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <section className="task-empty-state" aria-live="polite">
+          <h2>No Tasks found</h2>
+          <p>Try a different search or filter.</p>
+        </section>
+      )}
+    </section>
+  );
+}
+
+export function TaskDetailPage() {
+  const { taskId } = useParams();
+  const task = findTaskPreview(taskId);
+  if (!task) {
+    return (
+      <section className="task-not-found">
+        <h1>Task not found</h1>
+        <p>This demo Task does not exist.</p>
+        <Link to="/tasks">Back to Tasks</Link>
+      </section>
+    );
+  }
+
+  const status = statusPresentation[task.status];
+  const source = sourcePresentation[task.source.kind];
+  const request = task.activity.find((item) => item.quote);
+  const progress = task.activity.filter((item) => !item.quote);
+  const turns: readonly ConversationTurn[] = [
+    {
+      id: "initial",
+      request: request?.quote ?? task.title,
+      requestTime: request?.time ?? task.startedAt,
+      assistantUpdate: task.assistantUpdate,
+      duration: task.duration,
+      actions: progress.filter((item) => item.tool),
+      result: task.result,
+      delivery: task.delivery,
+    },
+    ...(task.followUps ?? []).map((followUp, index) => ({
+      id: `follow-up-${index + 1}`,
+      request: followUp.request,
+      requestTime: followUp.requestTime,
+      assistantUpdate: followUp.assistantUpdate,
+      duration: followUp.duration,
+      actions: followUp.activity,
+      result: followUp.result,
+      delivery: followUp.delivery,
+    })),
+  ];
+  const details = [
+    ["Source", source.label],
+    [task.source.locationLabel, task.source.context],
+    ["Initiated by", task.initiatedBy],
+    ["Agent", task.agent],
+    ["Started", task.startedAt],
+    ["Duration", task.duration],
+    ["Tokens", task.tokens ?? "Unavailable"],
+  ] as const;
+
+  return (
+    <article className="task-conversation-page">
+      <nav className="task-breadcrumb" aria-label="Breadcrumb">
+        <Link to="/tasks">
+          <Icon name="arrow-left" />
+          Tasks
+        </Link>
+      </nav>
+
+      <header className="task-conversation-header">
+        <h1>{task.title}</h1>
+        <section className="task-conversation-context" aria-label="Task source">
+          <SourceIdentity task={task} />
+          <StatusIndicator
+            aria-label={`${status.label}, updated ${task.relativeUpdatedAt}`}
+            detail={task.relativeUpdatedAt}
+            label={status.label}
+            tone={status.tone}
+          />
+        </section>
+      </header>
+
+      <section className="task-thread" aria-label="Task conversation">
+        {turns.map((turn) => (
+          <TaskConversationTurn key={turn.id} task={task} turn={turn} />
+        ))}
+      </section>
+
+      <details className="task-record-details">
+        <summary>
+          <span>Task details</span>
+          <Icon name="chevron-right" />
+        </summary>
+        <div className="task-record-grid">
+          <dl>
+            {details.map(([label, value]) => (
+              <div key={label}>
+                <dt>{label}</dt>
+                <dd>{value}</dd>
+              </div>
+            ))}
+          </dl>
+          <dl>
+            {task.execution.map((item) => (
+              <div key={item.label}>
+                <dt>{item.label}</dt>
+                <dd>{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </details>
+    </article>
+  );
+}
+
+function TaskConversationTurn({ task, turn }: { task: TaskPreview; turn: ConversationTurn }) {
+  const resultId = `${task.id}-${turn.id}-result`;
+  const toolLabels = [
+    ...new Set(turn.actions.flatMap((action) => (action.tool ? [toolPresentation[action.tool] ?? action.tool] : []))),
+  ];
+  const actionCount = `${turn.actions.length} ${turn.actions.length === 1 ? "action" : "actions"}`;
+  const duration = turn.duration === "In progress" ? "In progress" : turn.duration;
+  const workLabel = [actionCount, ...toolLabels, duration].join(" · ");
+  const responseTime = turn.delivery?.time ?? turn.actions.at(-1)?.time ?? turn.requestTime;
+
+  return (
+    <section className="task-turn" aria-label={`Conversation turn at ${turn.requestTime}`}>
+      <article className="task-message task-message--request">
+        <header className="task-message-author">
+          <span className="task-person-mark" aria-hidden="true">
+            {task.initiatedBy.charAt(0)}
+          </span>
+          <span>
+            <strong>{task.initiatedBy}</strong>
+            <small>
+              {task.source.context} · {turn.requestTime}
+            </small>
+          </span>
+        </header>
+        <div className="task-request-bubble">
+          <p>{turn.request}</p>
+        </div>
+      </article>
+
+      <article className="task-message task-message--agent">
+        <header className="task-message-author">
+          <span className="task-agent-mark" aria-hidden="true">
+            {task.agent.charAt(0)}
+          </span>
+          <span>
+            <strong>{task.agent}</strong>
+            <small>{responseTime}</small>
+          </span>
+        </header>
+
+        {task.status === "processing" && turn.assistantUpdate ? (
+          <p className="task-agent-update">{turn.assistantUpdate}</p>
+        ) : null}
+
+        <section className="task-agent-response" aria-labelledby={resultId}>
+          <h2 id={resultId}>{turn.result.title}</h2>
+          <p>{turn.result.summary}</p>
+          {turn.result.items ? (
+            <ul>
+              {turn.result.items.map((item) => (
+                <li key={`${item.label}-${item.value}`}>
+                  <span>{item.value}</span>
+                  <small>— {item.label}</small>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+
+        {turn.actions.length > 0 ? (
+          <details className="task-work-summary" open={task.status === "processing"}>
+            <summary>
+              <span>{workLabel}</span>
+              <Icon name="chevron-right" />
+            </summary>
+            <ol>
+              {turn.actions.map((item) => (
+                <li key={`${item.time}-${item.label}`}>
+                  <span className="task-action-mark" aria-hidden="true">
+                    {item.tool}
+                  </span>
+                  <span className="task-action-copy">
+                    <strong>{item.label}</strong>
+                    {item.detail ? <small>{item.detail}</small> : null}
+                  </span>
+                  <time>{item.time}</time>
+                </li>
+              ))}
+            </ol>
+          </details>
+        ) : null}
+
+        {turn.delivery ? (
+          <p className="task-delivery-receipt">
+            <Icon name="check" />
+            <span>{turn.delivery.label}</span>
+            <time>{turn.delivery.time}</time>
+          </p>
+        ) : null}
+      </article>
+    </section>
+  );
+}
+
+function TaskSelect({
+  children,
+  label,
+  onChange,
+  value,
+}: {
+  children: ReactNode;
+  label: string;
+  onChange: ChangeEventHandler<HTMLSelectElement>;
+  value: string;
+}) {
+  return (
+    <label>
+      <span className="visually-hidden">{label}</span>
+      <select aria-label={label} value={value} onChange={onChange}>
+        {children}
+      </select>
+    </label>
+  );
+}
+
+function TaskRow({ task }: { task: TaskPreview }) {
+  const status = statusPresentation[task.status];
+  return (
+    <tr className="task-table-grid task-table-row">
+      <td className="task-work-cell" data-label="Work">
+        <Link to={`/tasks/${task.id}`}>{task.title}</Link>
+        <small>{task.agent}</small>
+      </td>
+      <td data-label="Source">
+        <SourceIdentity task={task} />
+      </td>
+      <td data-label="Activity">
+        <StatusIndicator
+          aria-label={`${status.label}, updated ${task.relativeUpdatedAt}`}
+          detail={task.relativeUpdatedAt}
+          label={status.label}
+          tone={status.tone}
+        />
+      </td>
+    </tr>
+  );
+}
+
+function SourceIdentity({ task }: { task: TaskPreview }) {
+  const source = sourcePresentation[task.source.kind];
+  return (
+    <span className="task-source-identity">
+      <span className={`task-source-mark task-source-mark--${task.source.kind}`} aria-hidden="true">
+        {source.abbreviation}
+      </span>
+      <span>
+        <strong>{task.source.context}</strong>
+        <small>
+          {source.label} · {task.source.detail}
+        </small>
+      </span>
+    </span>
+  );
+}

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -19,12 +19,12 @@ type AgentFilter = "all" | TaskPreview["agent"];
 type ConversationTurn = {
   readonly actions: readonly TaskActivity[];
   readonly assistantUpdate?: string;
-  readonly delivery?: { readonly label: string; readonly time: string };
   readonly duration: string;
   readonly id: string;
   readonly request: string;
   readonly requestTime: string;
   readonly result: TaskResult;
+  readonly resultObservedAt?: string;
 };
 
 const statusPresentation: Record<TaskStatus, { readonly label: string; readonly tone: StatusTone }> = {
@@ -173,7 +173,7 @@ export function TaskDetailPage() {
       duration: task.duration,
       actions: progress.filter((item) => item.tool),
       result: task.result,
-      delivery: task.delivery,
+      resultObservedAt: task.resultObservedAt,
     },
     ...(task.followUps ?? []).map((followUp, index) => ({
       id: `follow-up-${index + 1}`,
@@ -183,7 +183,7 @@ export function TaskDetailPage() {
       duration: followUp.duration,
       actions: followUp.activity,
       result: followUp.result,
-      delivery: followUp.delivery,
+      resultObservedAt: followUp.resultObservedAt,
     })),
   ];
   const details = [
@@ -261,7 +261,7 @@ function TaskConversationTurn({ task, turn }: { task: TaskPreview; turn: Convers
   const actionCount = `${turn.actions.length} ${turn.actions.length === 1 ? "action" : "actions"}`;
   const duration = turn.duration === "In progress" ? "In progress" : turn.duration;
   const workLabel = [actionCount, ...toolLabels, duration].join(" · ");
-  const responseTime = turn.delivery?.time ?? turn.actions.at(-1)?.time ?? turn.requestTime;
+  const responseTime = turn.resultObservedAt ?? turn.actions.at(-1)?.time ?? turn.requestTime;
 
   return (
     <section className="task-turn" aria-label={`Conversation turn at ${turn.requestTime}`}>
@@ -335,11 +335,10 @@ function TaskConversationTurn({ task, turn }: { task: TaskPreview; turn: Convers
           </details>
         ) : null}
 
-        {turn.delivery ? (
-          <p className="task-delivery-receipt">
-            <Icon name="check" />
-            <span>{turn.delivery.label}</span>
-            <time>{turn.delivery.time}</time>
+        {turn.resultObservedAt ? (
+          <p className="task-result-observation">
+            <span>Agent result recorded locally · Outbound delivery unconfirmed</span>
+            <time>{turn.resultObservedAt}</time>
           </p>
         ) : null}
       </article>

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -203,6 +203,7 @@ export function TaskDetailPage() {
           <Icon name="arrow-left" />
           Tasks
         </Link>
+        <span className="tasks-demo-note">Demo data</span>
       </nav>
 
       <header className="task-conversation-header">

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -261,7 +261,7 @@ function TaskConversationTurn({ task, turn }: { task: TaskPreview; turn: Convers
   const actionCount = `${turn.actions.length} ${turn.actions.length === 1 ? "action" : "actions"}`;
   const duration = turn.duration === "In progress" ? "In progress" : turn.duration;
   const workLabel = [actionCount, ...toolLabels, duration].join(" · ");
-  const responseTime = turn.resultObservedAt ?? turn.actions.at(-1)?.time ?? turn.requestTime;
+  const responseTime = turn.resultObservedAt ?? "Time unavailable";
 
   return (
     <section className="task-turn" aria-label={`Conversation turn at ${turn.requestTime}`}>

--- a/apps/web/src/mock/task-data.ts
+++ b/apps/web/src/mock/task-data.ts
@@ -1,0 +1,361 @@
+export type TaskSourceKind = "email" | "feishu" | "github" | "jira";
+
+export type TaskStatus = "needs_attention" | "processing" | "recently_completed" | "unable_to_confirm";
+
+export type TaskActivity = {
+  readonly detail?: string;
+  readonly label: string;
+  readonly quote?: string;
+  readonly time: string;
+  readonly tone?: "default" | "warning";
+  readonly tool?: string;
+};
+
+export type TaskResult = {
+  readonly items?: readonly { readonly label: string; readonly value: string }[];
+  readonly summary: string;
+  readonly title: string;
+};
+
+export type TaskFollowUp = {
+  readonly activity: readonly TaskActivity[];
+  readonly assistantUpdate?: string;
+  readonly delivery?: { readonly label: string; readonly time: string };
+  readonly duration: string;
+  readonly request: string;
+  readonly requestTime: string;
+  readonly result: TaskResult;
+};
+
+export type TaskPreview = {
+  readonly activity: readonly TaskActivity[];
+  readonly agent: "Atlas" | "Scout";
+  readonly assistantUpdate?: string;
+  readonly delivery?: { readonly label: string; readonly time: string };
+  readonly duration: string;
+  readonly execution: readonly { readonly label: string; readonly value: string }[];
+  readonly followUps?: readonly TaskFollowUp[];
+  readonly id: string;
+  readonly initiatedBy: string;
+  readonly relativeUpdatedAt: string;
+  readonly result: TaskResult;
+  readonly source: {
+    readonly context: string;
+    readonly detail: string;
+    readonly kind: TaskSourceKind;
+    readonly locationLabel: "Channel" | "Issue" | "Mailbox" | "Repository";
+  };
+  readonly startedAt: string;
+  readonly status: TaskStatus;
+  readonly title: string;
+  readonly tokens: string | null;
+};
+
+export const taskPreviews: readonly TaskPreview[] = [
+  {
+    id: "q3-launch-readiness",
+    title: "Review the Q3 launch plan, identify unresolved owners, and flag every item without a confirmed date.",
+    agent: "Atlas",
+    source: {
+      kind: "feishu",
+      context: "Product Launch",
+      detail: "Q3 launch readiness",
+      locationLabel: "Channel",
+    },
+    status: "recently_completed",
+    relativeUpdatedAt: "12 min ago",
+    initiatedBy: "Mia Zhang",
+    startedAt: "Aug 24, 11:04 AM",
+    duration: "8m 12s",
+    tokens: "14.2K",
+    assistantUpdate:
+      "I’ll compare the launch checklist with the latest plan and call out anything that still needs a decision.",
+    delivery: { label: "Delivered to Product Launch", time: "11:12 AM" },
+    result: {
+      title: "Launch plan reviewed",
+      summary: "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
+      items: [
+        { label: "Needs owner", value: "Partner announcement copy" },
+        { label: "Needs owner", value: "Customer migration email" },
+        { label: "Date unconfirmed", value: "Security review sign-off" },
+      ],
+    },
+    activity: [
+      {
+        time: "11:04 AM",
+        label: "Request received",
+        detail: "From Mia Zhang in Product Launch",
+        quote:
+          "Please review the Q3 launch plan and call out anything that is still unowned or missing a confirmed date.",
+      },
+      {
+        time: "11:05 AM",
+        label: "Read Q3 launch checklist",
+        detail: "Feishu · Product Launch",
+        tool: "FS",
+      },
+      {
+        time: "11:07 AM",
+        label: "Opened the launch brief",
+        detail: "Google Drive · Q3 launch plan",
+        tool: "GD",
+      },
+    ],
+    followUps: [
+      {
+        requestTime: "11:18 AM",
+        request: "Please turn the three unresolved items into follow-ups and tag the likely owners.",
+        duration: "2m 41s",
+        assistantUpdate:
+          "I’ll draft the follow-ups in Feishu without assigning anyone who has not confirmed ownership.",
+        activity: [
+          {
+            time: "11:19 AM",
+            label: "Drafted 3 follow-up messages",
+            detail: "Feishu · Product Launch",
+            tool: "FS",
+          },
+        ],
+        result: {
+          title: "Follow-ups drafted",
+          summary:
+            "Three follow-up messages were posted with suggested owners. Ownership remains unassigned until each person confirms.",
+          items: [
+            { label: "Partner announcement", value: "Suggested owner: Jordan Lee" },
+            { label: "Migration email", value: "Suggested owner: Priya Nair" },
+            { label: "Security sign-off", value: "Date confirmation requested" },
+          ],
+        },
+        delivery: { label: "Delivered to Product Launch", time: "11:21 AM" },
+      },
+    ],
+    execution: [
+      { label: "Session", value: "Q3 launch readiness" },
+      { label: "Turns", value: "5" },
+      { label: "Provider", value: "OpenAI" },
+      { label: "Retries", value: "0" },
+      { label: "Record quality", value: "Complete" },
+    ],
+  },
+  {
+    id: "customer-visit-feedback",
+    title: "Summarize the recurring issues from yesterday's three customer visits and group them by account and team.",
+    agent: "Scout",
+    source: {
+      kind: "feishu",
+      context: "Customer Feedback",
+      detail: "Enterprise visit notes",
+      locationLabel: "Channel",
+    },
+    status: "processing",
+    relativeUpdatedAt: "2 min ago",
+    initiatedBy: "Noah Liu",
+    startedAt: "Aug 24, 10:42 AM",
+    duration: "In progress",
+    tokens: "6.4K",
+    result: {
+      title: "Customer feedback analysis in progress",
+      summary: "Three visit summaries are loaded. Scout is grouping recurring issues by account and owner.",
+      items: [
+        { label: "Most frequent", value: "Slow permission setup" },
+        { label: "Follow-up", value: "Clarify audit log retention" },
+      ],
+    },
+    activity: [
+      {
+        time: "10:42 AM",
+        label: "Request received",
+        detail: "From Noah Liu in Customer Feedback",
+        quote: "Please group yesterday's customer visit notes by account, issue, and the team that should follow up.",
+      },
+      { time: "10:43 AM", label: "Scout started" },
+      { time: "10:46 AM", label: "Read three visit summaries" },
+      { time: "10:47 AM", label: "Grouping recurring issues" },
+    ],
+    execution: [
+      { label: "Session", value: "Enterprise visit notes" },
+      { label: "Turns", value: "3" },
+      { label: "Provider", value: "Anthropic" },
+      { label: "Retries", value: "0" },
+      { label: "Record quality", value: "In progress" },
+    ],
+  },
+  {
+    id: "onboarding-document-review",
+    title: "Compare the new employee onboarding document with the actual process, then list missing steps and owners.",
+    agent: "Atlas",
+    source: {
+      kind: "feishu",
+      context: "Engineering Collaboration",
+      detail: "Onboarding process review",
+      locationLabel: "Channel",
+    },
+    status: "needs_attention",
+    relativeUpdatedAt: "25 min ago",
+    initiatedBy: "Olivia Sun",
+    startedAt: "Aug 24, 10:18 AM",
+    duration: "11m 03s",
+    tokens: "18.6K",
+    result: {
+      title: "Two source documents are missing",
+      summary: "The review is paused because the access checklist and security orientation steps are not available.",
+      items: [
+        { label: "Missing input", value: "Access provisioning checklist" },
+        { label: "Missing input", value: "Security orientation guide" },
+      ],
+    },
+    activity: [
+      {
+        time: "10:18 AM",
+        label: "Request received",
+        detail: "From Olivia Sun in Engineering Collaboration",
+        quote:
+          "Compare the onboarding document with what new engineers actually do, then call out missing steps and owners.",
+      },
+      { time: "10:19 AM", label: "Atlas started" },
+      { time: "10:24 AM", label: "Reviewed the onboarding document" },
+      { time: "10:29 AM", label: "Requested two missing inputs" },
+    ],
+    execution: [
+      { label: "Session", value: "Onboarding process review" },
+      { label: "Turns", value: "4" },
+      { label: "Provider", value: "OpenAI" },
+      { label: "Retries", value: "1" },
+      { label: "Record quality", value: "Complete" },
+    ],
+  },
+  {
+    id: "security-questionnaire",
+    title:
+      "Complete the attached enterprise security questionnaire and flag every answer that still needs legal review.",
+    agent: "Scout",
+    source: {
+      kind: "email",
+      context: "security@northstar.example",
+      detail: "Enterprise security questionnaire",
+      locationLabel: "Mailbox",
+    },
+    status: "recently_completed",
+    relativeUpdatedAt: "32 min ago",
+    initiatedBy: "Priya Nair",
+    startedAt: "Aug 24, 9:56 AM",
+    duration: "14m 21s",
+    tokens: "22.1K",
+    result: {
+      title: "Questionnaire draft completed",
+      summary: "Thirty-four answers were drafted and four policy questions were flagged for legal review.",
+      items: [
+        { label: "Legal review", value: "Data residency commitments" },
+        { label: "Legal review", value: "Subprocessor notification period" },
+      ],
+    },
+    activity: [
+      {
+        time: "9:56 AM",
+        label: "Email received",
+        detail: "From Priya Nair",
+        quote: "Please complete the attached security questionnaire and flag anything that requires a legal decision.",
+      },
+      { time: "9:58 AM", label: "Scout started" },
+      { time: "10:05 AM", label: "Drafted thirty-four answers" },
+      { time: "10:10 AM", label: "Flagged four policy questions" },
+      { time: "10:10 AM", label: "Completed" },
+    ],
+    execution: [
+      { label: "Session", value: "Enterprise security questionnaire" },
+      { label: "Turns", value: "6" },
+      { label: "Provider", value: "Anthropic" },
+      { label: "Retries", value: "0" },
+      { label: "Record quality", value: "Complete" },
+    ],
+  },
+  {
+    id: "github-oauth-regression",
+    title:
+      "Investigate why the OAuth callback intermittently drops the session cookie in staging and propose a safe fix.",
+    agent: "Atlas",
+    source: {
+      kind: "github",
+      context: "opentag/web #123",
+      detail: "OAuth callback regression",
+      locationLabel: "Repository",
+    },
+    status: "needs_attention",
+    relativeUpdatedAt: "46 min ago",
+    initiatedBy: "Ethan Brooks",
+    startedAt: "Aug 24, 9:31 AM",
+    duration: "17m 44s",
+    tokens: "27.3K",
+    result: {
+      title: "Likely proxy header mismatch",
+      summary:
+        "The staging proxy appears to drop the secure cookie on one callback path. Production behavior remains unconfirmed.",
+      items: [
+        { label: "Needs confirmation", value: "Production proxy header policy" },
+        { label: "Proposed fix", value: "Normalize forwarded protocol handling" },
+      ],
+    },
+    activity: [
+      {
+        time: "9:31 AM",
+        label: "Issue assigned",
+        detail: "From opentag/web #123",
+        quote: "Please isolate the intermittent staging cookie loss and propose the smallest safe fix.",
+      },
+      { time: "9:33 AM", label: "Atlas started" },
+      { time: "9:39 AM", label: "Compared callback request headers" },
+      { time: "9:49 AM", label: "Requested production proxy confirmation" },
+    ],
+    execution: [
+      { label: "Session", value: "OAuth callback regression" },
+      { label: "Turns", value: "7" },
+      { label: "Provider", value: "OpenAI" },
+      { label: "Retries", value: "1" },
+      { label: "Record quality", value: "Complete" },
+    ],
+  },
+  {
+    id: "jira-onboarding-coverage",
+    title: "Review onboarding event coverage before the next experiment and identify any missing analytics events.",
+    agent: "Scout",
+    source: {
+      kind: "jira",
+      context: "PROJ-342",
+      detail: "Onboarding event coverage",
+      locationLabel: "Issue",
+    },
+    status: "unable_to_confirm",
+    relativeUpdatedAt: "3 hr ago",
+    initiatedBy: "Avery Morgan",
+    startedAt: "Aug 24, 8:12 AM",
+    duration: "Unavailable",
+    tokens: null,
+    result: {
+      title: "Unable to confirm the latest execution",
+      summary: "The Task record is incomplete because the final provider response was not received.",
+      items: [{ label: "Last confirmed", value: "Event inventory loaded" }],
+    },
+    activity: [
+      {
+        time: "8:12 AM",
+        label: "Issue assigned",
+        detail: "From PROJ-342",
+        quote: "Review onboarding event coverage before the experiment and identify any missing analytics events.",
+      },
+      { time: "8:13 AM", label: "Scout started" },
+      { time: "8:17 AM", label: "Loaded the event inventory" },
+      { time: "Unknown", label: "Final provider response not received" },
+    ],
+    execution: [
+      { label: "Session", value: "Onboarding event coverage" },
+      { label: "Turns", value: "Unavailable" },
+      { label: "Provider", value: "Anthropic" },
+      { label: "Retries", value: "Unavailable" },
+      { label: "Record quality", value: "Incomplete" },
+    ],
+  },
+];
+
+export function findTaskPreview(taskId: string | undefined): TaskPreview | undefined {
+  return taskPreviews.find((task) => task.id === taskId);
+}

--- a/apps/web/src/mock/task-data.ts
+++ b/apps/web/src/mock/task-data.ts
@@ -153,6 +153,7 @@ export const taskPreviews: readonly TaskPreview[] = [
     startedAt: "Aug 24, 10:42 AM",
     duration: "In progress",
     tokens: "6.4K",
+    resultObservedAt: "10:47 AM",
     result: {
       title: "Customer feedback analysis in progress",
       summary: "Three visit summaries are loaded. Scout is grouping recurring issues by account and owner.",
@@ -196,6 +197,7 @@ export const taskPreviews: readonly TaskPreview[] = [
     startedAt: "Aug 24, 10:18 AM",
     duration: "11m 03s",
     tokens: "18.6K",
+    resultObservedAt: "10:29 AM",
     result: {
       title: "Two source documents are missing",
       summary: "The review is paused because the access checklist and security orientation steps are not available.",
@@ -241,6 +243,7 @@ export const taskPreviews: readonly TaskPreview[] = [
     startedAt: "Aug 24, 9:56 AM",
     duration: "14m 21s",
     tokens: "22.1K",
+    resultObservedAt: "10:10 AM",
     result: {
       title: "Questionnaire draft completed",
       summary: "Thirty-four answers were drafted and four policy questions were flagged for legal review.",
@@ -286,6 +289,7 @@ export const taskPreviews: readonly TaskPreview[] = [
     startedAt: "Aug 24, 9:31 AM",
     duration: "17m 44s",
     tokens: "27.3K",
+    resultObservedAt: "9:49 AM",
     result: {
       title: "Likely proxy header mismatch",
       summary:

--- a/apps/web/src/mock/task-data.ts
+++ b/apps/web/src/mock/task-data.ts
@@ -20,10 +20,10 @@ export type TaskResult = {
 export type TaskFollowUp = {
   readonly activity: readonly TaskActivity[];
   readonly assistantUpdate?: string;
-  readonly delivery?: { readonly label: string; readonly time: string };
   readonly duration: string;
   readonly request: string;
   readonly requestTime: string;
+  readonly resultObservedAt?: string;
   readonly result: TaskResult;
 };
 
@@ -31,7 +31,6 @@ export type TaskPreview = {
   readonly activity: readonly TaskActivity[];
   readonly agent: "Atlas" | "Scout";
   readonly assistantUpdate?: string;
-  readonly delivery?: { readonly label: string; readonly time: string };
   readonly duration: string;
   readonly execution: readonly { readonly label: string; readonly value: string }[];
   readonly followUps?: readonly TaskFollowUp[];
@@ -39,6 +38,7 @@ export type TaskPreview = {
   readonly initiatedBy: string;
   readonly relativeUpdatedAt: string;
   readonly result: TaskResult;
+  readonly resultObservedAt?: string;
   readonly source: {
     readonly context: string;
     readonly detail: string;
@@ -70,7 +70,7 @@ export const taskPreviews: readonly TaskPreview[] = [
     tokens: "14.2K",
     assistantUpdate:
       "I’ll compare the launch checklist with the latest plan and call out anything that still needs a decision.",
-    delivery: { label: "Delivered to Product Launch", time: "11:12 AM" },
+    resultObservedAt: "11:12 AM",
     result: {
       title: "Launch plan reviewed",
       summary: "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
@@ -119,14 +119,14 @@ export const taskPreviews: readonly TaskPreview[] = [
         result: {
           title: "Follow-ups drafted",
           summary:
-            "Three follow-up messages were posted with suggested owners. Ownership remains unassigned until each person confirms.",
+            "Three follow-up messages were drafted with suggested owners. Ownership remains unassigned until each person confirms.",
           items: [
             { label: "Partner announcement", value: "Suggested owner: Jordan Lee" },
             { label: "Migration email", value: "Suggested owner: Priya Nair" },
             { label: "Security sign-off", value: "Date confirmation requested" },
           ],
         },
-        delivery: { label: "Delivered to Product Launch", time: "11:21 AM" },
+        resultObservedAt: "11:21 AM",
       },
     ],
     execution: [
@@ -134,7 +134,7 @@ export const taskPreviews: readonly TaskPreview[] = [
       { label: "Turns", value: "5" },
       { label: "Provider", value: "OpenAI" },
       { label: "Retries", value: "0" },
-      { label: "Record quality", value: "Complete" },
+      { label: "Record quality", value: "Local result captured" },
     ],
   },
   {
@@ -221,7 +221,7 @@ export const taskPreviews: readonly TaskPreview[] = [
       { label: "Turns", value: "4" },
       { label: "Provider", value: "OpenAI" },
       { label: "Retries", value: "1" },
-      { label: "Record quality", value: "Complete" },
+      { label: "Record quality", value: "Local result captured" },
     ],
   },
   {
@@ -266,7 +266,7 @@ export const taskPreviews: readonly TaskPreview[] = [
       { label: "Turns", value: "6" },
       { label: "Provider", value: "Anthropic" },
       { label: "Retries", value: "0" },
-      { label: "Record quality", value: "Complete" },
+      { label: "Record quality", value: "Local result captured" },
     ],
   },
   {
@@ -311,7 +311,7 @@ export const taskPreviews: readonly TaskPreview[] = [
       { label: "Turns", value: "7" },
       { label: "Provider", value: "OpenAI" },
       { label: "Retries", value: "1" },
-      { label: "Record quality", value: "Complete" },
+      { label: "Record quality", value: "Local result captured" },
     ],
   },
   {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -44,6 +44,7 @@ import googleSignInButton from "./assets/google-sign-in-light@2x.png";
 import { CreateTeamForm } from "./create-team-form.js";
 import { IntegrationsPage } from "./features/integrations-page.js";
 import { SkillsPage } from "./features/skills-page.js";
+import { TaskDetailPage, TasksPage } from "./features/tasks-page.js";
 import { UsagePage } from "./features/usage-page.js";
 import { FeishuSetup } from "./im/feishu-setup.js";
 import { OnboardingPage } from "./onboarding/page.js";
@@ -384,6 +385,7 @@ export function AppRouter() {
             <Route path="/agents/:agentId/access" element={<LegacyAgentAccessRedirect />} />
             <Route path="/agents/:agentId/:tab" element={<AgentDetailPage />} />
             <Route path="/tasks" element={<TasksPage />} />
+            <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
             <Route path="/integrations" element={<IntegrationsPage />} />
             <Route path="/skills" element={<SkillsPage />} />
             <Route path="/resources" element={<Navigate replace to="/skills" />} />
@@ -2028,55 +2030,6 @@ function MembersPage() {
         teamId={membership.teamId}
       />
     </Page>
-  );
-}
-
-function TasksPage() {
-  return (
-    <Page title="Tasks" description="Track work assigned to Agents.">
-      <CapabilityUnavailable
-        details={[
-          "The current server does not expose a Tasks API.",
-          "No sample, inferred, or locally generated Task records are shown.",
-        ]}
-        status="Coming later"
-        title="Tasks are not available yet"
-      >
-        Tasks will appear here after OpenTag can load authoritative Task records from the server.
-      </CapabilityUnavailable>
-    </Page>
-  );
-}
-
-function CapabilityUnavailable({
-  action,
-  children,
-  details,
-  status = "Not enabled",
-  title,
-}: {
-  action?: { label: string; to: string };
-  children: ReactNode;
-  details: readonly string[];
-  status?: string;
-  title: string;
-}) {
-  return (
-    <section className="settings-unavailable">
-      <span className="settings-state-label">{status}</span>
-      <h2>{title}</h2>
-      <p>{children}</p>
-      <ul>
-        {details.map((detail) => (
-          <li key={detail}>{detail}</li>
-        ))}
-      </ul>
-      {action ? (
-        <Link className="settings-state-action" to={action.to}>
-          {action.label} <Icon name="arrow-right" />
-        </Link>
-      ) : null}
-    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

- Replace the unavailable Tasks placeholder with an English-only Task list and read-only conversation detail mock UI.
- Keep the list minimal with Work, Source, and Activity columns plus search and filters for Feishu, Email, GitHub, and Jira examples.
- Present Task details as a multi-turn source conversation: completed turns show results first, observable tool actions stay collapsed by default, and delivery receipts and Task metadata remain available.
- Label all records as demo data. This PR does not add a Tasks API, persistence, or a separate Task lifecycle.

## Testing

- `pnpm check` — passes with 8 existing undeclared E2E environment-variable warnings.
- `pnpm build` — passes.
- `pnpm typecheck` — passes.
- `pnpm --filter @opentag/web test` — 293 tests pass.
- Manual desktop and mobile browser review — passes.
- `pnpm test` — the changed Web suite and all Server/Client tests pass; the command remains red on macOS because two existing CLI assertions expect `/tmp` while the filesystem resolves `/private/tmp`:
  - `daemon-service-renderers.test.ts:162`
  - `daemon-service-shared.test.ts:80`

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` all pass. Two unrelated macOS path assertions remain red as documented above.
- [x] No credentials, private data, or generated build output are included.
- [x] No canonical documentation or Chinese mirror changes are required.
