### PR TITLE
feat(web): move Members into Workspace settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Configure `OPENTAG_GOOGLE_CLIENT_ID` and `OPENTAG_GOOGLE_CLIENT_SECRET` to enabl
 `http://127.0.0.1:8000/`. Active Team members share the same App Shell and member-safe views; Team Admins additionally
 manage Agents, runtime configuration, IM bindings, and Local Computer setup. Computer setup is Agent-scoped: Admins can
 connect another Computer with a short-lived install/login command while creating an Agent, then inspect the bound
-Computer from that Agent's pages. The **Members** page lets Team
+Computer from that Agent's pages. **Workspace settings** groups the Workspace profile with member roles and lets Team
 Admins create, copy, and rotate the bearer invitation link. Invitees can preview the link before signing in; after
 redemption, the Web selects the joined Team. Membership role and lifecycle changes remain explicit CLI operations:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,8 +80,8 @@ Effective Runtime Snapshot 目前尚未支持。
 配置 `OPENTAG_GOOGLE_CLIENT_ID` 和 `OPENTAG_GOOGLE_CLIENT_SECRET` 后即可启用 Google 登录，然后打开
 `http://127.0.0.1:8000/`。active Team member 使用同一套 App Shell 和 member-safe 视图；Team Admin 额外管理
 Agent、runtime 配置、IM binding 与 Local Computer setup。Computer setup 归属于 Agent：Admin 可在创建 Agent 时
-通过短期有效的安装/login 命令连接另一台 Computer，随后从该 Agent 的页面查看已绑定的 Computer。Team Admin 可在
-**Members** 页面创建、复制和轮换 bearer
+通过短期有效的安装/login 命令连接另一台 Computer，随后从该 Agent 的页面查看已绑定的 Computer。**Workspace
+settings** 将 Workspace profile 与 member role 集中管理，Team Admin 可在其中创建、复制和轮换 bearer
 邀请链接；受邀者可在登录前预览邀请，兑换后 Web 会选中刚加入的 Team。membership role 与 lifecycle 变更仍通过
 显式 CLI 操作完成：
 

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -550,9 +550,9 @@ describe("OpenTag Web App Shell", () => {
       within(workspaceNavigation)
         .getAllByRole("link")
         .map((item) => item.textContent),
-    ).toEqual(["Agents", "Tasks", "Integrations", "Skills", "Usage", "Members"]);
+    ).toEqual(["Agents", "Tasks", "Integrations", "Skills", "Usage"]);
     const navigationIcons = workspaceNavigation.querySelectorAll(".primary-nav-icon");
-    expect(navigationIcons).toHaveLength(6);
+    expect(navigationIcons).toHaveLength(5);
     expect(Array.from(navigationIcons).every((icon) => icon.getAttribute("aria-hidden") === "true")).toBe(true);
   });
 
@@ -1087,12 +1087,12 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Ada")).toBeTruthy();
   });
 
-  it("keeps account and advanced Workspace editing out of Members", async () => {
+  it("keeps account editing separate from Workspace settings", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
-    expect(screen.queryByLabelText("Workspace name")).toBeNull();
+    expect(await screen.findByRole("heading", { name: "Workspace" })).toBeTruthy();
+    expect(screen.getByLabelText("Workspace name")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Save account profile" })).toBeNull();
   });
 
@@ -1438,13 +1438,13 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Demo data")).toBeTruthy();
   });
 
-  it("groups invitations with Members", async () => {
+  it("groups members and invitations with Workspace settings", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace#members");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
-    expect(screen.getAllByRole("heading", { name: "Members" })).toHaveLength(1);
+    expect(await screen.findByRole("heading", { name: "Workspace" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Members & access" })).toBeTruthy();
     const membersSection = document.querySelector<HTMLElement>("#members");
     if (!membersSection) throw new Error("Members section was not rendered");
     const memberRows = await within(membersSection).findAllByRole("rowheader");
@@ -1455,25 +1455,27 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("button", { name: "Invite members" })).toBeNull();
   });
 
-  it.each(["/settings", "/settings/members", "/settings/access", "/settings/security"])(
+  it.each(["/settings/members", "/settings/access", "/settings/security"])(
     "redirects legacy member administration URL %s",
     async (path) => {
       installApi("member");
       window.history.replaceState({}, "", path);
       render(<App />);
 
-      expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
-      expect(window.location.pathname).toBe("/members");
+      expect(await screen.findByRole("heading", { name: "Members & access" })).toBeTruthy();
+      expect(window.location.pathname).toBe("/workspace");
+      expect(window.location.hash).toBe("#members");
     },
   );
 
-  it("redirects the legacy Members URL to the first-class Members page", async () => {
+  it("redirects the former Members page to Workspace member access", async () => {
     installApi("member");
-    window.history.replaceState({}, "", "/settings/members");
+    window.history.replaceState({}, "", "/members");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/members");
+    expect(await screen.findByRole("heading", { name: "Members & access" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/workspace");
+    expect(window.location.hash).toBe("#members");
   });
 
   it("redirects the legacy Settings account URL to the editable Account page", async () => {
@@ -1494,17 +1496,20 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("button", { name: "Save account profile" })).toBeTruthy();
   });
 
-  it("redirects the legacy Team profile URL to the first-class Workspace page", async () => {
-    installApi("admin");
-    window.history.replaceState({}, "", "/settings/team");
-    render(<App />);
+  it.each(["/settings", "/settings/team"])(
+    "redirects legacy Workspace settings URL %s to the first-class Workspace page",
+    async (path) => {
+      installApi("admin");
+      window.history.replaceState({}, "", path);
+      render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Workspace", level: 1 })).toBeTruthy();
-    expect(window.location.pathname).toBe("/workspace");
-    expect(window.location.hash).toBe("");
-    expect(screen.getByLabelText("Workspace name")).toBeTruthy();
-  });
+      expect(await screen.findByRole("heading", { name: "Workspace profile" })).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Workspace", level: 1 })).toBeTruthy();
+      expect(window.location.pathname).toBe("/workspace");
+      expect(window.location.hash).toBe("");
+      expect(screen.getByLabelText("Workspace name")).toBeTruthy();
+    },
+  );
 
   it("keeps the legacy Workspace management hash compatible with the Workspace page", async () => {
     installApi("admin");
@@ -1669,7 +1674,7 @@ describe("OpenTag Web App Shell", () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, "clipboard", { configurable: true, value: { writeText } });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace#members");
     render(<App />);
     expect(await screen.findByText("This link lets anyone join as a member until it expires.")).toBeTruthy();
     const createInviteLink = await screen.findByRole("button", { name: "Create invite link" });
@@ -1689,7 +1694,7 @@ describe("OpenTag Web App Shell", () => {
   it("replaces a locally rotated invitation with a newer successful server read", async () => {
     const api = installApi("admin", { invitationExists: true });
     const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace#members");
     render(<App />);
 
     expect(((await screen.findByLabelText("Invite link")) as HTMLInputElement).value).toContain("/invites/AAA");
@@ -1701,8 +1706,9 @@ describe("OpenTag Web App Shell", () => {
     api.setInvitationVersion("C");
     fireEvent.click(screen.getByRole("link", { name: "Agents" }));
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("link", { name: "Members" }));
-    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Workspace settings" }));
+    expect(await screen.findByRole("heading", { name: "Members & access" })).toBeTruthy();
 
     await waitFor(() =>
       expect((screen.getByLabelText("Invite link") as HTMLInputElement).value).toContain("/invites/CCC"),
@@ -1723,9 +1729,9 @@ describe("OpenTag Web App Shell", () => {
 
   it("keeps invitation-link management hidden from regular members", async () => {
     installApi("member");
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace#members");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Members" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Members & access" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Invite people" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Invite members" })).toBeNull();
     expect(screen.queryByLabelText("Role for Ada")).toBeNull();
@@ -1734,7 +1740,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("lets Team admins update another member role from the member list", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace#members");
     render(<App />);
     const role = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
     expect(within(role).getByRole("option", { name: "Admin" })).toBeTruthy();
@@ -1759,7 +1765,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", {
       roleUpdate: (targetUserId) => (targetUserId === memberUserId ? graceUpdate : linUpdate),
     });
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace#members");
     render(<App />);
     const graceRole = (await screen.findByLabelText("Role for Grace")) as HTMLSelectElement;
     const linRole = screen.getByLabelText("Role for Lin") as HTMLSelectElement;
@@ -1814,7 +1820,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("refreshes current membership authority after an admin demotes themself", async () => {
     installApi("admin");
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace#members");
     render(<App />);
     fireEvent.change(await screen.findByLabelText("Role for Ada"), { target: { value: "member" } });
     await waitFor(() =>
@@ -1826,7 +1832,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("keeps the confirmed role and displays the server error when an update is rejected", async () => {
     installApi("admin", { roleUpdateFails: true });
-    window.history.replaceState({}, "", "/members");
+    window.history.replaceState({}, "", "/workspace#members");
     render(<App />);
     const role = (await screen.findByLabelText("Role for Ada")) as HTMLSelectElement;
     fireEvent.change(role, { target: { value: "member" } });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -390,21 +390,21 @@ export function AppRouter() {
             <Route path="/skills" element={<SkillsPage />} />
             <Route path="/resources" element={<Navigate replace to="/skills" />} />
             <Route path="/usage" element={<UsagePage />} />
-            <Route path="/members" element={<MembersPage />} />
+            <Route path="/members" element={<Navigate replace to="/workspace#members" />} />
             <Route path="/account" element={<AccountPage />} />
             <Route path="/workspace" element={<WorkspacePage />} />
             <Route path="/account/workspace" element={<Navigate replace to="/workspace" />} />
-            <Route path="/settings" element={<Navigate replace to="/members" />} />
+            <Route path="/settings" element={<Navigate replace to="/workspace" />} />
             <Route path="/settings/account" element={<Navigate replace to="/account" />} />
             <Route path="/settings/team" element={<Navigate replace to="/workspace" />} />
-            <Route path="/settings/members" element={<Navigate replace to="/members" />} />
-            <Route path="/settings/access" element={<Navigate replace to="/members" />} />
-            <Route path="/settings/security" element={<Navigate replace to="/members" />} />
+            <Route path="/settings/members" element={<Navigate replace to="/workspace#members" />} />
+            <Route path="/settings/access" element={<Navigate replace to="/workspace#members" />} />
+            <Route path="/settings/security" element={<Navigate replace to="/workspace#members" />} />
             <Route path="/settings/computers" element={<Navigate replace to="/agents/new" />} />
             <Route path="/settings/resources" element={<Navigate replace to="/skills" />} />
             <Route path="/settings/integrations" element={<Navigate replace to="/integrations" />} />
             <Route path="/settings/usage" element={<Navigate replace to="/usage" />} />
-            <Route path="/settings/:section" element={<Navigate replace to="/members" />} />
+            <Route path="/settings/:section" element={<Navigate replace to="/workspace" />} />
           </Route>
         </Route>
       </Route>
@@ -826,10 +826,6 @@ function AppShell() {
               <WorkspaceNavIcon name="usage" />
               Usage
             </NavLink>
-            <NavLink to="/members" onClick={() => setNavigationOpen(false)}>
-              <WorkspaceNavIcon name="members" />
-              Members
-            </NavLink>
           </nav>
         </div>
         <div className="sidebar-bottom">
@@ -966,7 +962,7 @@ function AppShell() {
   );
 }
 
-function WorkspaceNavIcon({ name }: { name: "agents" | "integrations" | "members" | "skills" | "tasks" | "usage" }) {
+function WorkspaceNavIcon({ name }: { name: "agents" | "integrations" | "skills" | "tasks" | "usage" }) {
   return (
     <svg
       aria-hidden="true"
@@ -1008,14 +1004,6 @@ function WorkspaceNavIcon({ name }: { name: "agents" | "integrations" | "members
         <>
           <path d="M5 19V9M12 19V5M19 19v-7" />
           <path d="M3.5 19.5h17" />
-        </>
-      ) : null}
-      {name === "members" ? (
-        <>
-          <circle cx="9" cy="8" r="3" />
-          <path d="M3.5 19v-1.5A4.5 4.5 0 0 1 8 13h2a4.5 4.5 0 0 1 4.5 4.5V19" />
-          <circle cx="17" cy="10" r="2" />
-          <path d="M16 14.5h1.5a3 3 0 0 1 3 3V19" />
         </>
       ) : null}
     </svg>
@@ -1486,7 +1474,14 @@ function AccountPage() {
 }
 
 function WorkspacePage() {
-  const { membership, refreshMe } = useTeam();
+  const { me, membership, refreshMe } = useTeam();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.hash !== "#members") return;
+    document.getElementById("members")?.scrollIntoView({ block: "start" });
+  }, [location.hash]);
+
   return (
     <Page
       action={
@@ -1495,27 +1490,43 @@ function WorkspacePage() {
         </Link>
       }
       title="Workspace"
-      description="Manage the current Workspace and create additional Workspaces."
+      description="Manage the current Workspace, its members, and access."
     >
-      <WorkspaceSettings membership={membership} refreshMe={refreshMe} />
+      <WorkspaceSettings currentUserId={me.user.id} membership={membership} refreshMe={refreshMe} />
     </Page>
   );
 }
 
-function WorkspaceSettings({ membership, refreshMe }: { membership: MeMembership; refreshMe: () => void }) {
+function WorkspaceSettings({
+  currentUserId,
+  membership,
+  refreshMe,
+}: {
+  currentUserId: string;
+  membership: MeMembership;
+  refreshMe: () => void;
+}) {
   return (
-    <section aria-labelledby="workspace-profile-heading" className="account-workspace-profile">
-      <header className="settings-subheader">
-        <div>
-          <h2 id="workspace-profile-heading">Workspace profile</h2>
-          <p>Manage the name and CLI identity of the current Workspace.</p>
-        </div>
-        {membership.role !== "admin" ? (
-          <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
-        ) : null}
-      </header>
-      <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
-    </section>
+    <div className="settings-team-stack">
+      <section aria-labelledby="workspace-profile-heading" className="account-workspace-profile">
+        <header className="settings-subheader">
+          <div>
+            <h2 id="workspace-profile-heading">Workspace profile</h2>
+            <p>Manage the name and CLI identity of the current Workspace.</p>
+          </div>
+          {membership.role !== "admin" ? (
+            <span className="settings-role-badge">Your role: {titleCase(membership.role)}</span>
+          ) : null}
+        </header>
+        <TeamProfileSettings membership={membership} refreshMe={refreshMe} />
+      </section>
+      <MembersSettings
+        canManage={membership.role === "admin"}
+        currentUserId={currentUserId}
+        refreshMe={refreshMe}
+        teamId={membership.teamId}
+      />
+    </div>
   );
 }
 
@@ -2019,20 +2030,6 @@ function messagingConnectionTone(
   return "warning";
 }
 
-function MembersPage() {
-  const { me, membership, refreshMe } = useTeam();
-  return (
-    <Page title="Members" description="Manage members, invitations, and roles.">
-      <MembersSettings
-        canManage={membership.role === "admin"}
-        currentUserId={me.user.id}
-        refreshMe={refreshMe}
-        teamId={membership.teamId}
-      />
-    </Page>
-  );
-}
-
 function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeResponse["user"] }) {
   const saveInFlight = useRef(false);
   const confirmedDisplayNameRef = useRef(user.displayName);
@@ -2299,6 +2296,12 @@ function MembersSettings({
 
   return (
     <section className="settings-list-section settings-members-section" id="members">
+      <header className="settings-subheader">
+        <div>
+          <h2>Members &amp; access</h2>
+          <p>Review members, manage roles, and invite people to this Workspace.</p>
+        </div>
+      </header>
       <AsyncState state={state}>
         {(value) => {
           const adminCount = value.members.filter((member: TeamMemberSummary) => member.role === "admin").length;


### PR DESCRIPTION
## Summary

- remove Members from the primary product navigation
- group member roles and invitation management with the Workspace profile under Workspace settings
- preserve former Members and Settings deep links through redirects to the member access section
- update Web tests and keep the English and Chinese README copies synchronized

## Testing

- pnpm check
- pnpm build
- pnpm typecheck
- node --test --test-concurrency=1 scripts/__tests__/*.test.mjs && TMPDIR=/private/tmp pnpm exec turbo run test --concurrency=2 --env-mode=loose
- pnpm --filter @opentag/client test:agent-runtime:coverage
- TMPDIR=/private/tmp pnpm test:coverage

The canonical TMPDIR avoids an existing macOS /tmp versus /private/tmp alias mismatch in two CLI path assertions.

## Breaking changes

None. Former /members and legacy Settings URLs redirect to /workspace#members.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] pnpm check, pnpm build, pnpm typecheck, and the full test suite pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.