### PR TITLE
feat(web): add Integrations mock UI

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1549,8 +1549,9 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("heading", { name: "Skills" })).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: "Integrations" }));
     expect(await screen.findByRole("heading", { name: "Integrations" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Workspace Integrations are not available yet" })).toBeTruthy();
-    expect(screen.queryByText("GitHub")).toBeNull();
+    expect(screen.getByRole("heading", { name: "Workspace integrations" })).toBeTruthy();
+    expect(screen.getByText("Demo data")).toBeTruthy();
+    expect(screen.getByText("GitHub")).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: "Usage" }));
     expect(await screen.findByRole("heading", { name: "Usage" })).toBeTruthy();
     expect(screen.getByLabelText("Usage metrics")).toBeTruthy();

--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -1,10 +1,12 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { IntegrationsPage } from "../features/integrations-page.js";
 import { SkillsPage } from "../features/skills-page.js";
 import { UsagePage } from "../features/usage-page.js";
 
 describe("capability entry pages", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
   it("renders a minimal static Skills demo without unavailable controls", () => {
     render(<SkillsPage />);
 
@@ -27,6 +29,7 @@ describe("capability entry pages", () => {
   });
 
   it("renders an explicitly labeled Integrations mock", () => {
+    vi.stubEnv("DEV", true);
     render(<IntegrationsPage />);
 
     expect(screen.getByRole("heading", { name: "Integrations" })).toBeTruthy();
@@ -39,17 +42,34 @@ describe("capability entry pages", () => {
   });
 
   it("filters the Integrations mock and exposes preview-only connection details", () => {
+    vi.stubEnv("DEV", true);
     render(<IntegrationsPage />);
 
     fireEvent.change(screen.getByLabelText("Search integrations"), { target: { value: "errors" } });
     expect(screen.getByText("Sentry")).toBeTruthy();
     expect(screen.queryByText("GitHub")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    const trigger = screen.getByRole("button", { name: "Connect" });
+    trigger.focus();
+    fireEvent.click(trigger);
     expect(screen.getByRole("dialog")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Connect Sentry" })).toBeTruthy();
     expect(screen.getByText("Preview only")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("keeps the Integrations proposal behind the development preview gate", () => {
+    vi.stubEnv("DEV", false);
+    render(<IntegrationsPage />);
+
+    expect(screen.getByRole("heading", { name: "Workspace Integrations are not available yet" })).toBeTruthy();
+    expect(screen.getByText("No preview records are shown in production.")).toBeTruthy();
+    expect(screen.queryByText("GitHub")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
   });
 
   it("renders the fixed 30-day Usage overview without a range control", () => {

--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { IntegrationsPage } from "../features/integrations-page.js";
 import { SkillsPage } from "../features/skills-page.js";
@@ -26,16 +26,30 @@ describe("capability entry pages", () => {
     expect(screen.queryByRole("button")).toBeNull();
   });
 
-  it("keeps Integrations truthful until a Workspace Integration contract exists", () => {
+  it("renders an explicitly labeled Integrations mock", () => {
     render(<IntegrationsPage />);
 
     expect(screen.getByRole("heading", { name: "Integrations" })).toBeTruthy();
-    expect(screen.getByText("Coming later")).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Workspace Integrations are not available yet" })).toBeTruthy();
-    expect(screen.getByText(/Provider Bot connections remain managed/)).toBeTruthy();
+    expect(screen.getByText("Demo data")).toBeTruthy();
+    expect(screen.getByText("GitHub")).toBeTruthy();
+    expect(screen.getByText("Google Drive")).toBeTruthy();
+    expect(within(screen.getByRole("region", { name: "Connected" })).getAllByText("Connected")).toHaveLength(3);
+    expect(screen.getAllByRole("button", { name: "Manage" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Connect" })).toHaveLength(4);
+  });
+
+  it("filters the Integrations mock and exposes preview-only connection details", () => {
+    render(<IntegrationsPage />);
+
+    fireEvent.change(screen.getByLabelText("Search integrations"), { target: { value: "errors" } });
+    expect(screen.getByText("Sentry")).toBeTruthy();
     expect(screen.queryByText("GitHub")).toBeNull();
-    expect(screen.queryByText("Connected")).toBeNull();
-    expect(screen.queryByRole("button")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Connect Sentry" })).toBeTruthy();
+    expect(screen.getByText("Preview only")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
   });
 
   it("renders the fixed 30-day Usage overview without a range control", () => {

--- a/apps/web/src/features/integrations-page.tsx
+++ b/apps/web/src/features/integrations-page.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { type RefObject, useMemo, useRef, useState } from "react";
 import { type IntegrationCategory, type IntegrationPreview, integrationPreviews } from "../mock/capability-data.js";
 import { Button, Dialog, StatusIndicator } from "../ui/design-system.js";
 import "../mock-pages.css";
@@ -8,9 +8,14 @@ type CategoryFilter = "All categories" | IntegrationCategory;
 const categoryFilters: readonly CategoryFilter[] = ["All categories", "Developer tools", "Knowledge", "Productivity"];
 
 export function IntegrationsPage() {
+  return import.meta.env.DEV ? <IntegrationsPreview /> : <IntegrationsUnavailable />;
+}
+
+export function IntegrationsPreview() {
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState<CategoryFilter>("All categories");
   const [selectedIntegration, setSelectedIntegration] = useState<IntegrationPreview>();
+  const returnFocusRef = useRef<HTMLElement>(null);
   const normalizedQuery = query.trim().toLocaleLowerCase();
   const filteredIntegrations = useMemo(
     () =>
@@ -26,7 +31,7 @@ export function IntegrationsPage() {
   const available = filteredIntegrations.filter((integration) => integration.connection.state === "available");
 
   return (
-    <section className="capability-page" aria-labelledby="integrations-page-title">
+    <section aria-label="Preview Workspace integrations" className="capability-page">
       <header className="capability-page-header integration-page-header">
         <div>
           <h1 id="integrations-page-title">Integrations</h1>
@@ -91,13 +96,23 @@ export function IntegrationsPage() {
         {filteredIntegrations.length > 0 ? (
           <div className="integration-groups">
             {connected.length > 0 ? (
-              <IntegrationGroup integrations={connected} label="Connected" onSelect={setSelectedIntegration} />
+              <IntegrationGroup
+                integrations={connected}
+                label="Connected"
+                onSelect={(integration, trigger) => {
+                  returnFocusRef.current = trigger;
+                  setSelectedIntegration(integration);
+                }}
+              />
             ) : null}
             {available.length > 0 ? (
               <IntegrationGroup
                 integrations={available}
                 label="Available to connect"
-                onSelect={setSelectedIntegration}
+                onSelect={(integration, trigger) => {
+                  returnFocusRef.current = trigger;
+                  setSelectedIntegration(integration);
+                }}
               />
             ) : null}
           </div>
@@ -120,8 +135,36 @@ export function IntegrationsPage() {
       </section>
 
       {selectedIntegration ? (
-        <IntegrationPreviewDialog integration={selectedIntegration} onClose={() => setSelectedIntegration(undefined)} />
+        <IntegrationPreviewDialog
+          integration={selectedIntegration}
+          returnFocusRef={returnFocusRef}
+          onClose={() => setSelectedIntegration(undefined)}
+        />
       ) : null}
+    </section>
+  );
+}
+
+export function IntegrationsUnavailable() {
+  return (
+    <section className="capability-page" aria-labelledby="integrations-page-title">
+      <header className="capability-page-header">
+        <div>
+          <h1 id="integrations-page-title">Integrations</h1>
+          <p>Review Workspace-level service connections when OpenTag exposes an authoritative API.</p>
+        </div>
+      </header>
+
+      <section className="settings-unavailable">
+        <span className="settings-state-label">Coming later</span>
+        <h2>Workspace Integrations are not available yet</h2>
+        <p>The current server does not expose a Workspace Integration contract.</p>
+        <ul>
+          <li>No connection state or Agent assignment is inferred or generated here.</li>
+          <li>Provider Bot connections remain managed from each Agent&apos;s Messaging page.</li>
+        </ul>
+        <p>No preview records are shown in production.</p>
+      </section>
     </section>
   );
 }
@@ -133,7 +176,7 @@ function IntegrationGroup({
 }: {
   integrations: readonly IntegrationPreview[];
   label: string;
-  onSelect: (integration: IntegrationPreview) => void;
+  onSelect: (integration: IntegrationPreview, trigger: HTMLButtonElement) => void;
 }) {
   return (
     <section
@@ -172,7 +215,7 @@ function IntegrationGroup({
               <Button
                 size="compact"
                 variant={isConnected ? "outline" : "secondary"}
-                onClick={() => onSelect(integration)}
+                onClick={(event) => onSelect(integration, event.currentTarget)}
               >
                 {isConnected ? "Manage" : "Connect"}
               </Button>
@@ -184,7 +227,15 @@ function IntegrationGroup({
   );
 }
 
-function IntegrationPreviewDialog({ integration, onClose }: { integration: IntegrationPreview; onClose: () => void }) {
+function IntegrationPreviewDialog({
+  integration,
+  onClose,
+  returnFocusRef,
+}: {
+  integration: IntegrationPreview;
+  onClose: () => void;
+  returnFocusRef: RefObject<HTMLElement | null>;
+}) {
   const { connection } = integration;
   const isConnected = connection.state === "connected";
   return (
@@ -195,6 +246,7 @@ function IntegrationPreviewDialog({ integration, onClose }: { integration: Integ
           : `Preview the information shown before connecting ${integration.name} to this Workspace.`
       }
       eyebrow="Mock interaction"
+      returnFocusRef={returnFocusRef}
       title={isConnected ? `Manage ${integration.name}` : `Connect ${integration.name}`}
       onClose={onClose}
     >

--- a/apps/web/src/features/integrations-page.tsx
+++ b/apps/web/src/features/integrations-page.tsx
@@ -1,24 +1,238 @@
+import { useMemo, useState } from "react";
+import { type IntegrationCategory, type IntegrationPreview, integrationPreviews } from "../mock/capability-data.js";
+import { Button, Dialog, StatusIndicator } from "../ui/design-system.js";
 import "../mock-pages.css";
 
+type CategoryFilter = "All categories" | IntegrationCategory;
+
+const categoryFilters: readonly CategoryFilter[] = ["All categories", "Developer tools", "Knowledge", "Productivity"];
+
 export function IntegrationsPage() {
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState<CategoryFilter>("All categories");
+  const [selectedIntegration, setSelectedIntegration] = useState<IntegrationPreview>();
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const filteredIntegrations = useMemo(
+    () =>
+      integrationPreviews.filter(
+        (integration) =>
+          (category === "All categories" || integration.category === category) &&
+          (normalizedQuery.length === 0 ||
+            `${integration.name} ${integration.description}`.toLocaleLowerCase().includes(normalizedQuery)),
+      ),
+    [category, normalizedQuery],
+  );
+  const connected = filteredIntegrations.filter((integration) => integration.connection.state === "connected");
+  const available = filteredIntegrations.filter((integration) => integration.connection.state === "available");
+
   return (
     <section className="capability-page" aria-labelledby="integrations-page-title">
-      <header className="capability-page-header">
+      <header className="capability-page-header integration-page-header">
         <div>
           <h1 id="integrations-page-title">Integrations</h1>
-          <p>Review Workspace-level service connections when OpenTag exposes an authoritative API.</p>
+          <p>Connect the services Agents can use to find context and complete work.</p>
         </div>
+        <span className="capability-demo-note">Demo data</span>
       </header>
 
-      <section className="settings-unavailable">
-        <span className="settings-state-label">Coming later</span>
-        <h2>Workspace Integrations are not available yet</h2>
-        <p>The current server does not expose a Workspace Integration contract.</p>
-        <ul>
-          <li>No connection state or Agent assignment is inferred or generated here.</li>
-          <li>Provider Bot connections remain managed from each Agent&apos;s Messaging page.</li>
-        </ul>
+      <dl className="integration-summary" aria-label="Demo integration summary">
+        <div>
+          <dt>Connected</dt>
+          <dd>2</dd>
+        </div>
+        <div>
+          <dt>Available</dt>
+          <dd>4</dd>
+        </div>
+        <div>
+          <dt>Agents with access</dt>
+          <dd>6</dd>
+        </div>
+      </dl>
+
+      <section className="integration-directory" aria-labelledby="integration-directory-title">
+        <header className="integration-directory-header">
+          <div>
+            <h2 id="integration-directory-title">Workspace integrations</h2>
+            <p>Connections are shared at the Workspace level, then assigned to individual Agents.</p>
+          </div>
+          <div className="integration-filters">
+            <label className="integration-search">
+              <span className="visually-hidden">Search integrations</span>
+              <svg aria-hidden="true" fill="none" focusable="false" viewBox="0 0 20 20">
+                <circle cx="8.5" cy="8.5" r="5" />
+                <path d="m12.2 12.2 3.8 3.8" />
+              </svg>
+              <input
+                aria-label="Search integrations"
+                className="ds-control ds-control--compact"
+                placeholder="Search integrations"
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+              />
+            </label>
+            <label>
+              <span className="visually-hidden">Filter by category</span>
+              <select
+                aria-label="Filter by category"
+                className="ds-control ds-control--compact"
+                value={category}
+                onChange={(event) => setCategory(event.target.value as CategoryFilter)}
+              >
+                {categoryFilters.map((filter) => (
+                  <option key={filter}>{filter}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </header>
+
+        {filteredIntegrations.length > 0 ? (
+          <div className="integration-groups">
+            {connected.length > 0 ? (
+              <IntegrationGroup integrations={connected} label="Connected" onSelect={setSelectedIntegration} />
+            ) : null}
+            {available.length > 0 ? (
+              <IntegrationGroup
+                integrations={available}
+                label="Available to connect"
+                onSelect={setSelectedIntegration}
+              />
+            ) : null}
+          </div>
+        ) : (
+          <div className="integration-empty-state" role="status">
+            <strong>No matching integrations</strong>
+            <p>Try another search term or category.</p>
+            <Button
+              size="compact"
+              variant="outline"
+              onClick={() => {
+                setQuery("");
+                setCategory("All categories");
+              }}
+            >
+              Clear filters
+            </Button>
+          </div>
+        )}
       </section>
+
+      {selectedIntegration ? (
+        <IntegrationPreviewDialog integration={selectedIntegration} onClose={() => setSelectedIntegration(undefined)} />
+      ) : null}
     </section>
+  );
+}
+
+function IntegrationGroup({
+  integrations,
+  label,
+  onSelect,
+}: {
+  integrations: readonly IntegrationPreview[];
+  label: string;
+  onSelect: (integration: IntegrationPreview) => void;
+}) {
+  return (
+    <section
+      className="integration-group"
+      aria-labelledby={`integration-group-${label.replaceAll(" ", "-").toLowerCase()}`}
+    >
+      <div className="integration-group-heading">
+        <h3 id={`integration-group-${label.replaceAll(" ", "-").toLowerCase()}`}>{label}</h3>
+        <span>{integrations.length}</span>
+      </div>
+      <ul className="capability-integration-list">
+        {integrations.map((integration) => {
+          const { connection } = integration;
+          const isConnected = connection.state === "connected";
+          return (
+            <li key={integration.id}>
+              <div className="capability-integration-identity">
+                <span className={`capability-integration-mark is-${integration.id}`} aria-hidden="true">
+                  {integration.abbreviation}
+                </span>
+                <div>
+                  <strong>{integration.name}</strong>
+                  <small>{integration.description}</small>
+                </div>
+              </div>
+              <span className="integration-category">{integration.category}</span>
+              <StatusIndicator
+                className="capability-status"
+                detail={connection.state === "connected" ? connection.identity : undefined}
+                label={isConnected ? "Connected" : "Not connected"}
+                tone={isConnected ? "success" : "neutral"}
+              />
+              <span className="capability-agent-count">
+                {connection.state === "connected" ? `${connection.agentCount} Agents` : "No access"}
+              </span>
+              <Button
+                size="compact"
+                variant={isConnected ? "outline" : "secondary"}
+                onClick={() => onSelect(integration)}
+              >
+                {isConnected ? "Manage" : "Connect"}
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function IntegrationPreviewDialog({ integration, onClose }: { integration: IntegrationPreview; onClose: () => void }) {
+  const { connection } = integration;
+  const isConnected = connection.state === "connected";
+  return (
+    <Dialog
+      description={
+        isConnected
+          ? `Preview how administrators would manage the ${integration.name} connection and Agent access.`
+          : `Preview the information shown before connecting ${integration.name} to this Workspace.`
+      }
+      eyebrow="Mock interaction"
+      title={isConnected ? `Manage ${integration.name}` : `Connect ${integration.name}`}
+      onClose={onClose}
+    >
+      <div className="integration-dialog-body">
+        <div className="integration-dialog-identity">
+          <span className={`capability-integration-mark is-${integration.id}`} aria-hidden="true">
+            {integration.abbreviation}
+          </span>
+          <div>
+            <strong>{integration.name}</strong>
+            <small>{integration.category}</small>
+          </div>
+        </div>
+        <dl>
+          <div>
+            <dt>Workspace access</dt>
+            <dd>
+              {connection.state === "connected"
+                ? `${connection.agentCount} Agents assigned`
+                : "Assigned after connection"}
+            </dd>
+          </div>
+          <div>
+            <dt>Purpose</dt>
+            <dd>{integration.description}</dd>
+          </div>
+        </dl>
+        <aside>
+          <strong>Preview only</strong>
+          <p>The server does not expose a Workspace Integration contract yet.</p>
+        </aside>
+        <div className="integration-dialog-actions">
+          <Button variant="outline" onClick={onClose}>
+            Close preview
+          </Button>
+          <Button disabled>{isConnected ? "Save changes" : "Continue"}</Button>
+        </div>
+      </div>
+    </Dialog>
   );
 }

--- a/apps/web/src/mock-pages.css
+++ b/apps/web/src/mock-pages.css
@@ -31,6 +31,13 @@
   line-height: var(--lh-prose, 1.6);
 }
 
+.capability-demo-note {
+  flex: 0 0 auto;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+  line-height: 40px;
+}
+
 .capability-preview-label {
   display: inline-flex;
   align-items: center;
@@ -161,14 +168,142 @@
   list-style: none;
 }
 
+.integration-category {
+  flex: 0 0 auto;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+  font-weight: var(--fw-medium, 500);
+}
+
+.integration-summary {
+  display: grid;
+  margin: 0 0 40px;
+  border-top: 1px solid var(--strong-border, #c9ccbb);
+  border-bottom: 1px solid var(--border, #d6d9ca);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.integration-summary > div {
+  display: grid;
+  gap: 3px;
+  border-right: 1px solid var(--border, #d6d9ca);
+  padding: 17px 20px;
+}
+
+.integration-summary > div:first-child {
+  padding-left: 0;
+}
+
+.integration-summary > div:last-child {
+  border-right: 0;
+}
+
+.integration-summary dt {
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.integration-summary dd {
+  margin: 0;
+  color: var(--foreground, #16211b);
+  font-family: var(--font-display, sans-serif);
+  font-size: var(--text-section, 1.25rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--fw-semibold, 600);
+}
+
+.integration-directory-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 30px;
+}
+
+.integration-directory-header h2 {
+  margin: 0 0 5px;
+  font-size: var(--text-subsection, 1rem);
+}
+
+.integration-directory-header p {
+  max-width: 520px;
+  margin: 0;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.integration-filters {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.integration-filters select {
+  width: 148px;
+}
+
+.integration-search {
+  position: relative;
+  display: block;
+}
+
+.integration-search svg {
+  position: absolute;
+  top: 50%;
+  left: 11px;
+  width: 16px;
+  height: 16px;
+  color: var(--muted, #616b62);
+  pointer-events: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.6;
+  transform: translateY(-50%);
+}
+
+.integration-search input.ds-control {
+  width: 208px;
+  padding-left: 34px;
+}
+
+.integration-search input::placeholder {
+  color: var(--muted, #616b62);
+  opacity: 1;
+}
+
+.integration-groups {
+  display: grid;
+  gap: 36px;
+}
+
+.integration-group-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.integration-group-heading h3 {
+  margin: 0;
+  color: var(--secondary-foreground, #3a453e);
+  font-size: var(--text-ui, 0.8125rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.integration-group-heading span {
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+  font-variant-numeric: tabular-nums;
+}
+
 .capability-integration-list li {
   display: grid;
-  min-height: 72px;
+  min-height: 78px;
   align-items: center;
-  grid-template-columns: minmax(180px, 1.3fr) 100px 92px minmax(132px, auto);
-  gap: 18px;
+  grid-template-columns: minmax(250px, 1.5fr) 112px minmax(112px, 0.75fr) 74px 82px;
+  gap: 16px;
   border-bottom: 1px solid var(--border, #d6d9ca);
-  padding: 10px 0;
+  padding: 12px 0;
 }
 
 .capability-integration-list li:last-child {
@@ -196,6 +331,7 @@
   margin-top: 3px;
   color: var(--muted, #616b62);
   font-size: var(--text-meta, 0.75rem);
+  line-height: var(--lh-ui, 1.45);
 }
 
 .capability-integration-mark {
@@ -211,6 +347,43 @@
   color: var(--brand-ink, #385a04);
   font-size: var(--text-micro, 0.75rem);
   font-weight: var(--fw-bold, 700);
+  letter-spacing: 0.02em;
+}
+
+.capability-integration-mark.is-github {
+  border-color: #27322c;
+  background: #27322c;
+  color: #fdfcf7;
+}
+
+.capability-integration-mark.is-google-drive {
+  border-color: #b8c7a2;
+  background: #e9f1dd;
+  color: #3f6710;
+}
+
+.capability-integration-mark.is-linear {
+  border-color: #cbd0c6;
+  background: #eceee9;
+  color: #3f4a43;
+}
+
+.capability-integration-mark.is-notion {
+  border-color: #3a453e;
+  background: var(--surface, #fdfcf7);
+  color: #27322c;
+}
+
+.capability-integration-mark.is-sentry {
+  border-color: #c5baa7;
+  background: #f1ece4;
+  color: #5c4535;
+}
+
+.capability-integration-mark.is-figma {
+  border-color: #b8c7a2;
+  background: #f1f4ea;
+  color: #4e6e23;
 }
 
 .capability-status.is-connected {
@@ -229,12 +402,108 @@
   justify-self: end;
 }
 
-.capability-integration-list button:disabled,
-.capability-integration-list button:disabled:hover {
-  border: 1px solid var(--border, #d6d9ca);
-  background: var(--surface-soft, #eff0e6);
+.integration-empty-state {
+  display: grid;
+  min-height: 240px;
+  place-items: center;
+  align-content: center;
+  border: 1px dashed var(--strong-border, #c9ccbb);
+  border-radius: var(--radius-panel, 12px);
+  background: rgb(253 252 247 / 45%);
+  padding: 36px 20px;
+  text-align: center;
+}
+
+.integration-empty-state strong {
+  color: var(--foreground, #16211b);
+  font-size: var(--text-ui, 0.8125rem);
+}
+
+.integration-empty-state p {
+  margin: 5px 0 18px;
   color: var(--muted, #616b62);
-  opacity: 1;
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.integration-dialog-body {
+  display: grid;
+  gap: 22px;
+  margin-top: 24px;
+}
+
+.integration-dialog-identity {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.integration-dialog-identity strong,
+.integration-dialog-identity small {
+  display: block;
+}
+
+.integration-dialog-identity strong {
+  color: var(--foreground, #16211b);
+  font-size: var(--text-body, 0.875rem);
+}
+
+.integration-dialog-identity small {
+  margin-top: 2px;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.integration-dialog-body dl {
+  display: grid;
+  margin: 0;
+  border-top: 1px solid var(--border, #d6d9ca);
+  border-bottom: 1px solid var(--border, #d6d9ca);
+  grid-template-columns: 1fr 1fr;
+}
+
+.integration-dialog-body dl > div {
+  padding: 15px 16px;
+}
+
+.integration-dialog-body dl > div:first-child {
+  border-right: 1px solid var(--border, #d6d9ca);
+  padding-left: 0;
+}
+
+.integration-dialog-body dt {
+  margin-bottom: 5px;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.integration-dialog-body dd {
+  margin: 0;
+  color: var(--secondary-foreground, #3a453e);
+  font-size: var(--text-ui, 0.8125rem);
+  line-height: var(--lh-prose, 1.6);
+}
+
+.integration-dialog-body aside {
+  border-radius: var(--radius-control, 8px);
+  background: var(--surface-soft, #eff0e6);
+  padding: 13px 14px;
+}
+
+.integration-dialog-body aside strong {
+  color: var(--secondary-foreground, #3a453e);
+  font-size: var(--text-ui, 0.8125rem);
+}
+
+.integration-dialog-body aside p {
+  margin: 3px 0 0;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.integration-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 .capability-usage-summary {
@@ -344,12 +613,24 @@
   .capability-page {
     padding-inline: 0;
   }
+
+  .capability-integration-list li {
+    grid-template-columns: minmax(220px, 1.4fr) 100px minmax(108px, 0.7fr) 80px;
+  }
+
+  .integration-category {
+    display: none;
+  }
 }
 
 @media (max-width: 720px) {
   .capability-page-header {
     display: grid;
     gap: 18px;
+  }
+
+  .integration-page-header {
+    display: flex;
   }
 
   .capability-skill-grid {
@@ -361,6 +642,20 @@
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 9px 16px;
     padding: 14px 0;
+  }
+
+  .integration-directory-header {
+    display: grid;
+    align-items: initial;
+  }
+
+  .integration-filters {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 148px;
+  }
+
+  .integration-search input.ds-control {
+    width: 100%;
   }
 
   .capability-integration-identity {
@@ -392,6 +687,92 @@
 }
 
 @media (max-width: 520px) {
+  .integration-page-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .integration-page-header .capability-demo-note {
+    line-height: var(--lh-ui, 1.4);
+  }
+
+  .integration-summary {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .integration-summary > div,
+  .integration-summary > div:first-child {
+    border-right: 0;
+    border-bottom: 1px solid var(--border, #d6d9ca);
+    padding: 14px 0;
+  }
+
+  .integration-summary > div:first-child {
+    border-right: 1px solid var(--border, #d6d9ca);
+  }
+
+  .integration-summary > div:nth-child(2) {
+    padding-left: 16px;
+  }
+
+  .integration-summary > div:last-child {
+    grid-column: 1 / -1;
+    border-bottom: 0;
+  }
+
+  .integration-filters {
+    grid-template-columns: 1fr;
+  }
+
+  .integration-filters select {
+    width: 100%;
+  }
+
+  .capability-integration-list li {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .ds-status.capability-status {
+    display: none;
+  }
+
+  .capability-integration-identity {
+    grid-row: 1;
+  }
+
+  .capability-agent-count {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: start;
+    padding-left: 48px;
+  }
+
+  .capability-integration-list button {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    align-self: center;
+  }
+
+  .integration-dialog-body dl {
+    grid-template-columns: 1fr;
+  }
+
+  .integration-dialog-body dl > div,
+  .integration-dialog-body dl > div:first-child {
+    border-right: 0;
+    padding: 13px 0;
+  }
+
+  .integration-dialog-body dl > div:first-child {
+    border-bottom: 1px solid var(--border, #d6d9ca);
+  }
+
+  .integration-dialog-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
   .capability-table-header {
     display: none;
   }

--- a/apps/web/src/mock/capability-data.ts
+++ b/apps/web/src/mock/capability-data.ts
@@ -30,6 +30,84 @@ export const skillPreviews: readonly SkillPreview[] = [
   },
 ];
 
+export type IntegrationCategory = "Developer tools" | "Knowledge" | "Productivity";
+
+export type IntegrationPreview = {
+  id: string;
+  name: string;
+  abbreviation: string;
+  category: IntegrationCategory;
+  description: string;
+  connection:
+    | {
+        state: "connected";
+        identity: string;
+        agentCount: number;
+      }
+    | {
+        state: "available";
+      };
+};
+
+export const integrationPreviews: readonly IntegrationPreview[] = [
+  {
+    id: "github",
+    name: "GitHub",
+    abbreviation: "GH",
+    category: "Developer tools",
+    description: "Read repositories, issues, pull requests, and checks.",
+    connection: {
+      state: "connected",
+      identity: "opentag-labs",
+      agentCount: 6,
+    },
+  },
+  {
+    id: "google-drive",
+    name: "Google Drive",
+    abbreviation: "GD",
+    category: "Knowledge",
+    description: "Find and reference workspace documents and folders.",
+    connection: {
+      state: "connected",
+      identity: "Product workspace",
+      agentCount: 3,
+    },
+  },
+  {
+    id: "linear",
+    name: "Linear",
+    abbreviation: "LI",
+    category: "Productivity",
+    description: "Search issues, update status, and create project work.",
+    connection: { state: "available" },
+  },
+  {
+    id: "notion",
+    name: "Notion",
+    abbreviation: "NO",
+    category: "Knowledge",
+    description: "Use selected pages and databases as Agent context.",
+    connection: { state: "available" },
+  },
+  {
+    id: "sentry",
+    name: "Sentry",
+    abbreviation: "SE",
+    category: "Developer tools",
+    description: "Inspect errors, releases, and application health signals.",
+    connection: { state: "available" },
+  },
+  {
+    id: "figma",
+    name: "Figma",
+    abbreviation: "FI",
+    category: "Productivity",
+    description: "Reference files, components, and design comments.",
+    connection: { state: "available" },
+  },
+];
+
 export const usageRanges = ["7 days", "30 days", "90 days"] as const;
 
 export type UsageRange = (typeof usageRanges)[number];


### PR DESCRIPTION
## Summary

- Keep the production Integrations destination on the truthful no-contract unavailable state.
- Add a development-only responsive mock directory with search, filters, empty states, and preview-only Manage/Connect dialogs.
- Match the Tasks tab's restrained `Demo data` marker and restore focus to the exact trigger whenever a preview dialog closes.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm check` (passes with 8 pre-existing undeclared E2E environment-variable warnings)
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/web test` (297 tests passed)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (268 tests passed, 100% targeted coverage)
- Desktop and mobile visual QA, including search, empty, Manage, and Connect states
- `TMPDIR=/private/tmp pnpm test:coverage` (1,136 of 1,137 tests passed; the existing Server observability timing test below fails in isolation and has no code overlap with this Web-only change)
  - `packages/server/src/observability/__tests__/observability.test.ts > traces real RuntimeSession failure, overload, and dropped-queue terminal paths`
  - Expected `stale_connection`; observed `handled`. Reproduces with the Server test file alone.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior; no documentation changes are required.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (`pnpm test` is blocked by the unrelated existing Server timing assertion documented above.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (not applicable).
