### PR TITLE
feat(web): show provider-native Task execution events

### DIFF
--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -38,6 +38,7 @@ function topLevelDeclarationValue(stylesheet: Root, selector: string, property: 
 const appStyles = postcss.parse(readFileSync(locateStylesheet("src/styles.css"), "utf8"));
 const designSystemStyles = postcss.parse(readFileSync(locateStylesheet("src/ui/design-system.css"), "utf8"));
 const capabilityStyles = postcss.parse(readFileSync(locateStylesheet("src/mock-pages.css"), "utf8"));
+const taskStyles = postcss.parse(readFileSync(locateStylesheet("src/features/tasks-page.css"), "utf8"));
 
 describe("workspace page layout", () => {
   it("uses one 1024px frame with a 960px visible content contract", () => {
@@ -77,5 +78,12 @@ describe("workspace page layout", () => {
     expect(declarationValue(designSystemStyles, ".ds-settings-list", "border-radius")).toBe("var(--radius-panel)");
     expect(declarationValue(designSystemStyles, ".ds-settings-row", "padding")).toBe("var(--space-6)");
     expect(declarationValue(designSystemStyles, "select.ds-control--compact", "min-height")).toBe("36px");
+  });
+
+  it("keeps Task provenance and execution targets visible in the compact layout", () => {
+    expect(declarationValue(taskStyles, ".task-breadcrumb-actions .tasks-demo-note", "display")).toBe("inline");
+    expect(declarationValue(taskStyles, ".task-tool-target", "display")).toBe("block");
+    expect(declarationValue(taskStyles, ".task-tool-target", "grid-row")).toBe("2");
+    expect(declarationValue(taskStyles, ".task-tool-target", "white-space")).toBe("normal");
   });
 });

--- a/apps/web/src/features/tasks-page.css
+++ b/apps/web/src/features/tasks-page.css
@@ -665,11 +665,34 @@
   }
 
   .task-tool-call {
+    align-items: start;
     grid-template-columns: 24px minmax(0, 1fr) auto;
+    padding-block: var(--space-2);
+  }
+
+  .task-tool-call .task-action-mark {
+    grid-row: 1 / span 2;
+    margin-top: 1px;
+  }
+
+  .task-tool-action {
+    grid-column: 2;
+    grid-row: 1;
   }
 
   .task-tool-target {
-    display: none;
+    display: block;
+    grid-column: 2 / 4;
+    grid-row: 2;
+    margin-top: 2px;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  .task-tool-call .ds-status {
+    grid-column: 3;
+    grid-row: 1;
   }
 }
 
@@ -699,7 +722,7 @@
   }
 
   .task-breadcrumb-actions .tasks-demo-note {
-    display: none;
+    display: inline;
   }
 
   .task-thread-link {

--- a/apps/web/src/features/tasks-page.css
+++ b/apps/web/src/features/tasks-page.css
@@ -41,7 +41,7 @@
 .task-toolbar {
   display: grid;
   align-items: center;
-  grid-template-columns: minmax(260px, 1fr) repeat(3, minmax(140px, 164px));
+  grid-template-columns: minmax(260px, 1fr) repeat(2, minmax(140px, 164px));
   gap: var(--space-3);
   margin-bottom: var(--space-8);
 }
@@ -183,18 +183,6 @@
   color: #176f6a;
 }
 
-.task-source-mark--github {
-  border-color: #c9ccd0;
-  background: #f1f2f3;
-  color: #28313a;
-}
-
-.task-source-mark--jira {
-  border-color: #b9c9e8;
-  background: #eef3fc;
-  color: #315caa;
-}
-
 .task-table-row .ds-status {
   align-items: flex-start;
 }
@@ -241,6 +229,30 @@
   line-height: inherit;
 }
 
+.task-breadcrumb-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.task-thread-link {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  border: 1px solid var(--strong-border);
+  border-radius: var(--radius-control);
+  padding: 0 var(--space-4);
+  color: var(--foreground);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-medium);
+  text-decoration: none;
+}
+
+.task-thread-link:hover {
+  border-color: var(--brand-ink);
+  color: var(--brand-ink);
+}
+
 .task-breadcrumb a {
   display: inline-flex;
   align-items: center;
@@ -285,7 +297,7 @@
   padding: 40px 0 var(--space-8);
 }
 
-.task-turn + .task-turn {
+.task-exchange + .task-exchange {
   margin-top: 64px;
 }
 
@@ -307,6 +319,18 @@
 .task-message-author strong,
 .task-message-author small {
   display: block;
+}
+
+.task-message-author--agent > span:last-child {
+  display: flex;
+  flex: 1;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.task-message-author--agent small {
+  margin-top: 0;
 }
 
 .task-message-author strong {
@@ -365,32 +389,18 @@
   line-height: var(--lh-prose);
 }
 
-.task-work-summary,
+.task-agent-process,
 .task-agent-response,
-.task-agent-update,
 .task-result-observation {
   margin-left: 44px;
 }
 
-.task-agent-update {
-  max-width: 720px;
-  margin-top: 0;
-  margin-bottom: var(--space-5);
-  color: var(--secondary-foreground);
-  font-size: var(--text-body);
-  line-height: var(--lh-prose);
-}
-
-.task-work-summary {
-  border-top: 1px solid var(--border);
+.task-agent-process {
+  max-width: 760px;
   border-bottom: 1px solid var(--border);
 }
 
-.task-agent-response + .task-work-summary {
-  margin-top: var(--space-5);
-}
-
-.task-work-summary summary,
+.task-agent-process summary,
 .task-record-details summary {
   display: flex;
   min-height: 44px;
@@ -403,37 +413,27 @@
   list-style: none;
 }
 
-.task-work-summary summary::-webkit-details-marker,
+.task-agent-process summary::-webkit-details-marker,
 .task-record-details summary::-webkit-details-marker {
   display: none;
 }
 
-.task-work-summary summary .ds-icon,
+.task-agent-process summary .ds-icon,
 .task-record-details summary .ds-icon {
   width: 16px;
   height: 16px;
   transition: transform 160ms ease;
 }
 
-.task-work-summary[open] summary .ds-icon,
+.task-agent-process[open] summary .ds-icon,
 .task-record-details[open] summary .ds-icon {
   transform: rotate(90deg);
 }
 
-.task-work-summary ol {
-  margin: 0;
-  padding: 0 0 var(--space-3);
-  list-style: none;
-}
-
-.task-work-summary li {
+.task-agent-events {
   display: grid;
-  align-items: center;
-  grid-template-columns: 24px minmax(0, 1fr) auto;
-  gap: var(--space-3);
-  min-height: 48px;
-  color: var(--secondary-foreground);
-  font-size: var(--text-meta);
+  gap: 2px;
+  padding: 0 0 var(--space-2);
 }
 
 .task-action-mark {
@@ -455,31 +455,72 @@
   height: 12px;
 }
 
-.task-action-copy strong,
-.task-action-copy small {
+.task-tool-call {
+  display: grid;
+  min-height: 48px;
+  align-items: center;
+  grid-template-columns: 24px minmax(120px, 0.7fr) minmax(140px, 1fr) auto;
+  gap: var(--space-3);
+  padding: 3px 0;
+}
+
+.task-tool-action strong,
+.task-tool-action small {
   display: block;
 }
 
-.task-action-copy strong {
+.task-tool-action strong {
   color: var(--secondary-foreground);
   font-size: var(--text-ui);
   font-weight: var(--fw-medium);
 }
 
-.task-action-copy small {
+.task-tool-action small {
   margin-top: 2px;
   color: var(--muted);
   font-size: var(--text-meta);
 }
 
-.task-work-summary time {
+.task-tool-target {
+  overflow: hidden;
   color: var(--muted);
+  font-size: var(--text-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-tool-call .ds-status {
+  align-items: center;
+}
+
+.task-tool-call .ds-status__copy small {
+  display: none;
+}
+
+.task-tool-call .ds-status__copy strong {
+  color: var(--muted);
+  font-size: var(--text-meta);
+  font-weight: var(--fw-medium);
+}
+
+.task-reasoning-summary {
+  max-width: 700px;
+  margin: var(--space-3) 0 var(--space-4);
+  color: var(--secondary-foreground);
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
+}
+
+.task-process-metadata {
+  margin: var(--space-1) 0 var(--space-3);
+  color: var(--muted);
+  font-size: var(--text-meta);
   font-variant-numeric: tabular-nums;
 }
 
 .task-agent-response {
   max-width: 720px;
-  padding-top: 0;
+  padding-top: var(--space-5);
 }
 
 .task-agent-response h2 {
@@ -502,7 +543,10 @@
 }
 
 .task-agent-response li {
-  padding: 4px 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 0.75fr);
+  gap: var(--space-6);
+  padding: 5px 0;
   font-size: var(--text-ui);
 }
 
@@ -515,25 +559,16 @@
 }
 
 .task-agent-response li small {
-  margin-left: 4px;
   color: var(--muted);
   font-size: inherit;
 }
 
 .task-result-observation {
-  display: flex;
   max-width: 720px;
-  align-items: center;
-  gap: var(--space-2);
   margin-top: var(--space-5);
   margin-bottom: 0;
   color: var(--muted);
   font-size: var(--text-meta);
-}
-
-.task-result-observation time {
-  margin-left: auto;
-  font-variant-numeric: tabular-nums;
 }
 
 .task-record-details {
@@ -628,6 +663,14 @@
     grid-template-columns: 1fr;
     gap: 0;
   }
+
+  .task-tool-call {
+    grid-template-columns: 24px minmax(0, 1fr) auto;
+  }
+
+  .task-tool-target {
+    display: none;
+  }
 }
 
 @media (max-width: 520px) {
@@ -655,6 +698,15 @@
     gap: var(--space-4);
   }
 
+  .task-breadcrumb-actions .tasks-demo-note {
+    display: none;
+  }
+
+  .task-thread-link {
+    min-height: 32px;
+    padding-inline: var(--space-3);
+  }
+
   .task-conversation-context .ds-status {
     align-items: flex-start;
   }
@@ -668,9 +720,8 @@
   }
 
   .task-request-bubble,
-  .task-work-summary,
+  .task-agent-process,
   .task-agent-response,
-  .task-agent-update,
   .task-result-observation,
   .task-record-details {
     margin-left: 0;
@@ -678,5 +729,10 @@
 
   .task-record-grid dl > div {
     grid-template-columns: 100px minmax(0, 1fr);
+  }
+
+  .task-agent-response li {
+    grid-template-columns: 1fr;
+    gap: 1px;
   }
 }

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { TaskDetailPage, TasksPage } from "./tasks-page.js";
 
 describe("Tasks demo", () => {
-  it("renders the minimal Work, Source, and Activity list in English", () => {
+  it("renders the minimal Feishu-only Task list in English", () => {
     const { container } = render(
       <MemoryRouter>
         <TasksPage />
@@ -16,30 +16,33 @@ describe("Tasks demo", () => {
       "Source",
       "Activity",
     ]);
-    expect(screen.getAllByRole("row")).toHaveLength(7);
+    expect(screen.getAllByRole("row")).toHaveLength(4);
     expect(screen.getAllByText(/^Feishu ·/)).toHaveLength(3);
-    expect(screen.getByText(/^Email ·/)).toBeTruthy();
-    expect(screen.getByText(/^GitHub ·/)).toBeTruthy();
-    expect(screen.getByText(/^Jira ·/)).toBeTruthy();
+    expect(screen.queryByLabelText("Filter by source")).toBeNull();
     expect(container.textContent).not.toMatch(/[\u3400-\u9fff]/u);
   });
 
-  it("filters demo Tasks by source and search text", () => {
+  it("filters demo Tasks by Agent, status, and search text", () => {
     render(
       <MemoryRouter>
         <TasksPage />
       </MemoryRouter>,
     );
 
-    fireEvent.change(screen.getByLabelText("Filter by source"), { target: { value: "github" } });
+    fireEvent.change(screen.getByLabelText("Filter by Agent"), { target: { value: "Scout" } });
     expect(screen.getAllByRole("row")).toHaveLength(2);
-    expect(screen.getByText("opentag/web #123")).toBeTruthy();
+    expect(screen.getByText("Customer Feedback")).toBeTruthy();
     expect(screen.queryByText("Product Launch")).toBeNull();
 
-    fireEvent.change(screen.getByLabelText("Filter by source"), { target: { value: "all" } });
-    fireEvent.change(screen.getByLabelText("Search Tasks"), { target: { value: "security questionnaire" } });
+    fireEvent.change(screen.getByLabelText("Filter by Agent"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "needs_attention" } });
     expect(screen.getAllByRole("row")).toHaveLength(2);
-    expect(screen.getByText("security@northstar.example")).toBeTruthy();
+    expect(screen.getByText("Engineering Collaboration")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Search Tasks"), { target: { value: "confirmed date" } });
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+    expect(screen.getByText("Product Launch")).toBeTruthy();
   });
 
   it("shows a compact empty result state", () => {
@@ -54,7 +57,7 @@ describe("Tasks demo", () => {
     expect(screen.queryByRole("table")).toBeNull();
   });
 
-  it("renders the request and Agent response as a conversation", () => {
+  it("renders each request, provider event stream, and final answer in order", () => {
     render(
       <MemoryRouter initialEntries={["/tasks/q3-launch-readiness"]}>
         <Routes>
@@ -63,9 +66,10 @@ describe("Tasks demo", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: "Launch plan reviewed" })).toBeTruthy();
     expect(screen.getByText("Demo data")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Open in Feishu" }).getAttribute("href")).toBe("https://www.feishu.cn/");
     expect(screen.getByLabelText("Task source").textContent).toContain("Product Launch");
+
     const conversation = screen.getByLabelText("Task conversation");
     expect(within(conversation).getAllByText("Mia Zhang")).toHaveLength(2);
     expect(
@@ -73,57 +77,63 @@ describe("Tasks demo", () => {
         "Please review the Q3 launch plan and call out anything that is still unowned or missing a confirmed date.",
       ),
     ).toBeTruthy();
-    expect(within(conversation).getByText("Opened the launch brief")).toBeTruthy();
+    expect(within(conversation).getByText("Read thread")).toBeTruthy();
+    expect(within(conversation).getByText("Open document")).toBeTruthy();
+    expect(within(conversation).getByText("Search messages")).toBeTruthy();
     expect(
       within(conversation).getByText(
-        "Please turn the three unresolved items into follow-ups and tag the likely owners.",
+        "The checklist and brief disagree on three items. I’m checking the recent thread before treating any owner or date as confirmed.",
       ),
     ).toBeTruthy();
     expect(within(conversation).getByRole("heading", { name: "Follow-ups drafted" })).toBeTruthy();
     expect(
-      within(conversation).getAllByText("Agent result recorded locally · Outbound delivery unconfirmed"),
+      within(conversation).getAllByText(/Recorded locally at .*Open Feishu for the authoritative thread/),
     ).toHaveLength(2);
-    expect(within(conversation).queryByText(/^Delivered to /)).toBeNull();
-    const work = screen.getByText("2 actions · Feishu · Google Drive · 8m 12s").closest("details");
-    const taskDetails = screen.getByText("Task details").closest("details");
-    expect(work?.hasAttribute("open")).toBe(false);
-    expect(taskDetails?.hasAttribute("open")).toBe(false);
+    expect(within(conversation).queryByText(/Turn \d/u)).toBeNull();
+    expect(within(conversation).queryByText(/Chain of Thought/i)).toBeNull();
+
+    const process = within(conversation).getByText("Worked for 8m 12s").closest("details");
+    const result = within(conversation).getByRole("heading", { name: "Launch plan reviewed" });
+    expect(process).toBeTruthy();
+    if (!process) throw new Error("Expected the Agent process details");
+    expect(process.hasAttribute("open")).toBe(true);
+    expect(process.compareDocumentPosition(result) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(within(process).getByText("3 tool calls · 0 retries · 8.1K input · 6.1K output · 14.2K total")).toBeTruthy();
+    expect(screen.getByText("Task details").closest("details")?.hasAttribute("open")).toBe(false);
     expect(screen.queryByRole("complementary")).toBeNull();
   });
 
-  it("does not turn unavailable provider tokens into zero", () => {
+  it("shows live provider events without inventing a final answer or zero usage", () => {
     render(
-      <MemoryRouter initialEntries={["/tasks/jira-onboarding-coverage"]}>
+      <MemoryRouter initialEntries={["/tasks/customer-visit-feedback"]}>
         <Routes>
           <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
         </Routes>
       </MemoryRouter>,
     );
 
-    const details = screen.getByText("Task details").closest("details");
-    expect(details).toBeTruthy();
-    const tokens = within(details as HTMLElement).getByText("Tokens").parentElement;
-    expect(tokens?.textContent).toBe("TokensUnavailable");
-    expect(screen.getByText("Time unavailable")).toBeTruthy();
-    expect(
-      screen.getByText("The Task record is incomplete because the final provider response was not received."),
-    ).toBeTruthy();
+    const process = screen.getByText("Working").closest("details");
+    expect(process?.hasAttribute("open")).toBe(true);
+    expect(within(process as HTMLElement).getByText("2 tool calls · 0 retries · 6.4K input")).toBeTruthy();
+    expect(within(process as HTMLElement).getByText("In progress")).toBeTruthy();
+    expect(screen.queryByText(/0 output/)).toBeNull();
+    expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
   });
 
-  it("shows the local result observation time instead of the request time", () => {
+  it("keeps provider attention and retry state attached to the execution that produced it", () => {
     render(
-      <MemoryRouter initialEntries={["/tasks/security-questionnaire"]}>
+      <MemoryRouter initialEntries={["/tasks/onboarding-document-review"]}>
         <Routes>
           <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
         </Routes>
       </MemoryRouter>,
     );
 
-    const response = screen
-      .getByRole("heading", { name: "Questionnaire draft completed" })
-      .closest(".task-message--agent");
-    expect(response).toBeTruthy();
-    expect(within(response as HTMLElement).getAllByText("10:10 AM")).toHaveLength(2);
-    expect(within(response as HTMLElement).queryByText("9:56 AM")).toBeNull();
+    const process = screen.getByText("Worked for 11m 03s").closest("details");
+    expect(within(process as HTMLElement).getByText("Needs attention")).toBeTruthy();
+    expect(
+      within(process as HTMLElement).getByText("2 tool calls · 1 retry · 11.8K input · 6.8K output · 18.6K total"),
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Two source documents are missing" })).toBeTruthy();
   });
 });

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -2,79 +2,59 @@ import { type ChangeEventHandler, type ReactNode, useMemo, useState } from "reac
 import { Link, useParams } from "react-router-dom";
 import {
   findTaskPreview,
-  type TaskActivity,
+  type TaskExchange,
   type TaskPreview,
-  type TaskResult,
-  type TaskSourceKind,
   type TaskStatus,
+  type TaskToolCall,
+  type TaskToolStatus,
   taskPreviews,
 } from "../mock/task-data.js";
 import { Icon, StatusIndicator, type StatusTone } from "../ui/design-system.js";
 import "./tasks-page.css";
 
 type TaskFilter = "all" | TaskStatus;
-type SourceFilter = "all" | TaskSourceKind;
 type AgentFilter = "all" | TaskPreview["agent"];
-
-type ConversationTurn = {
-  readonly actions: readonly TaskActivity[];
-  readonly assistantUpdate?: string;
-  readonly duration: string;
-  readonly id: string;
-  readonly request: string;
-  readonly requestTime: string;
-  readonly result: TaskResult;
-  readonly resultObservedAt?: string;
-};
 
 const statusPresentation: Record<TaskStatus, { readonly label: string; readonly tone: StatusTone }> = {
   needs_attention: { label: "Needs attention", tone: "warning" },
   processing: { label: "In progress", tone: "info" },
   recently_completed: { label: "Recently completed", tone: "success" },
-  unable_to_confirm: { label: "Unable to confirm", tone: "neutral" },
 };
 
-const sourcePresentation: Record<TaskSourceKind, { readonly abbreviation: string; readonly label: string }> = {
-  email: { abbreviation: "@", label: "Email" },
+const toolPresentation: Record<TaskToolCall["tool"], { readonly abbreviation: string; readonly label: string }> = {
   feishu: { abbreviation: "FS", label: "Feishu" },
-  github: { abbreviation: "GH", label: "GitHub" },
-  jira: { abbreviation: "J", label: "Jira" },
+  google_drive: { abbreviation: "GD", label: "Google Drive" },
 };
 
-const toolPresentation: Readonly<Record<string, string>> = {
-  FS: "Feishu",
-  GD: "Google Drive",
+const toolStatusPresentation: Record<TaskToolStatus, { readonly label: string; readonly tone: StatusTone }> = {
+  completed: { label: "Completed", tone: "success" },
+  in_progress: { label: "In progress", tone: "info" },
+  requires_attention: { label: "Needs attention", tone: "warning" },
 };
 
 export function TasksPage() {
   const [query, setQuery] = useState("");
   const [agent, setAgent] = useState<AgentFilter>("all");
-  const [source, setSource] = useState<SourceFilter>("all");
   const [status, setStatus] = useState<TaskFilter>("all");
   const tasks = useMemo(() => {
     const normalizedQuery = query.trim().toLocaleLowerCase();
     return taskPreviews.filter((task) => {
       const matchesQuery =
         normalizedQuery.length === 0 ||
-        [task.title, task.agent, task.source.context, task.source.detail, sourcePresentation[task.source.kind].label]
+        [task.title, task.agent, task.source.context, task.source.detail, "Feishu"]
           .join(" ")
           .toLocaleLowerCase()
           .includes(normalizedQuery);
-      return (
-        matchesQuery &&
-        (agent === "all" || task.agent === agent) &&
-        (source === "all" || task.source.kind === source) &&
-        (status === "all" || task.status === status)
-      );
+      return matchesQuery && (agent === "all" || task.agent === agent) && (status === "all" || task.status === status);
     });
-  }, [agent, query, source, status]);
+  }, [agent, query, status]);
 
   return (
     <section className="tasks-page" aria-labelledby="tasks-page-title">
       <header className="tasks-page-header">
         <div>
           <h1 id="tasks-page-title">Tasks</h1>
-          <p>Track work Agents handle across connected sources.</p>
+          <p>Track work Agents handle in Feishu threads.</p>
         </div>
         <span className="tasks-demo-note">Demo data</span>
       </header>
@@ -99,17 +79,6 @@ export function TasksPage() {
           <option value="Scout">Scout</option>
         </TaskSelect>
         <TaskSelect
-          label="Filter by source"
-          value={source}
-          onChange={(event) => setSource(event.target.value as SourceFilter)}
-        >
-          <option value="all">All sources</option>
-          <option value="feishu">Feishu</option>
-          <option value="email">Email</option>
-          <option value="github">GitHub</option>
-          <option value="jira">Jira</option>
-        </TaskSelect>
-        <TaskSelect
           label="Filter by status"
           value={status}
           onChange={(event) => setStatus(event.target.value as TaskFilter)}
@@ -118,7 +87,6 @@ export function TasksPage() {
           <option value="processing">In progress</option>
           <option value="recently_completed">Recently completed</option>
           <option value="needs_attention">Needs attention</option>
-          <option value="unable_to_confirm">Unable to confirm</option>
         </TaskSelect>
       </form>
 
@@ -161,39 +129,12 @@ export function TaskDetailPage() {
   }
 
   const status = statusPresentation[task.status];
-  const source = sourcePresentation[task.source.kind];
-  const request = task.activity.find((item) => item.quote);
-  const progress = task.activity.filter((item) => !item.quote);
-  const turns: readonly ConversationTurn[] = [
-    {
-      id: "initial",
-      request: request?.quote ?? task.title,
-      requestTime: request?.time ?? task.startedAt,
-      assistantUpdate: task.assistantUpdate,
-      duration: task.duration,
-      actions: progress.filter((item) => item.tool),
-      result: task.result,
-      resultObservedAt: task.resultObservedAt,
-    },
-    ...(task.followUps ?? []).map((followUp, index) => ({
-      id: `follow-up-${index + 1}`,
-      request: followUp.request,
-      requestTime: followUp.requestTime,
-      assistantUpdate: followUp.assistantUpdate,
-      duration: followUp.duration,
-      actions: followUp.activity,
-      result: followUp.result,
-      resultObservedAt: followUp.resultObservedAt,
-    })),
-  ];
   const details = [
-    ["Source", source.label],
+    ["Source", "Feishu"],
     [task.source.locationLabel, task.source.context],
     ["Initiated by", task.initiatedBy],
     ["Agent", task.agent],
     ["Started", task.startedAt],
-    ["Duration", task.duration],
-    ["Tokens", task.tokens ?? "Unavailable"],
   ] as const;
 
   return (
@@ -203,7 +144,12 @@ export function TaskDetailPage() {
           <Icon name="arrow-left" />
           Tasks
         </Link>
-        <span className="tasks-demo-note">Demo data</span>
+        <span className="task-breadcrumb-actions">
+          <span className="tasks-demo-note">Demo data</span>
+          <a className="task-thread-link" href={task.source.threadUrl} target="_blank" rel="noreferrer">
+            Open in Feishu
+          </a>
+        </span>
       </nav>
 
       <header className="task-conversation-header">
@@ -212,7 +158,7 @@ export function TaskDetailPage() {
           <SourceIdentity task={task} />
           <StatusIndicator
             aria-label={`${status.label}, updated ${task.relativeUpdatedAt}`}
-            detail={task.relativeUpdatedAt}
+            detail={`Updated ${task.relativeUpdatedAt}`}
             label={status.label}
             tone={status.tone}
           />
@@ -220,8 +166,8 @@ export function TaskDetailPage() {
       </header>
 
       <section className="task-thread" aria-label="Task conversation">
-        {turns.map((turn) => (
-          <TaskConversationTurn key={turn.id} task={task} turn={turn} />
+        {task.exchanges.map((exchange) => (
+          <TaskConversationExchange key={exchange.id} task={task} exchange={exchange} />
         ))}
       </section>
 
@@ -253,96 +199,122 @@ export function TaskDetailPage() {
   );
 }
 
-function TaskConversationTurn({ task, turn }: { task: TaskPreview; turn: ConversationTurn }) {
-  const resultId = `${task.id}-${turn.id}-result`;
-  const toolLabels = [
-    ...new Set(turn.actions.flatMap((action) => (action.tool ? [toolPresentation[action.tool] ?? action.tool] : []))),
-  ];
-  const actionCount = `${turn.actions.length} ${turn.actions.length === 1 ? "action" : "actions"}`;
-  const duration = turn.duration === "In progress" ? "In progress" : turn.duration;
-  const workLabel = [actionCount, ...toolLabels, duration].join(" · ");
-  const responseTime = turn.resultObservedAt ?? "Time unavailable";
+function TaskConversationExchange({ task, exchange }: { task: TaskPreview; exchange: TaskExchange }) {
+  const resultId = `${task.id}-${exchange.id}-result`;
+  const processId = `${task.id}-${exchange.id}-process`;
 
   return (
-    <section className="task-turn" aria-label={`Conversation turn at ${turn.requestTime}`}>
+    <section className="task-exchange" aria-label={`Message sent at ${exchange.requestTime}`}>
       <article className="task-message task-message--request">
         <header className="task-message-author">
           <span className="task-person-mark" aria-hidden="true">
-            {task.initiatedBy.charAt(0)}
+            {getInitials(task.initiatedBy)}
           </span>
           <span>
             <strong>{task.initiatedBy}</strong>
             <small>
-              {task.source.context} · {turn.requestTime}
+              {task.source.context} · {exchange.requestTime}
             </small>
           </span>
         </header>
         <div className="task-request-bubble">
-          <p>{turn.request}</p>
+          <p>{exchange.request}</p>
         </div>
       </article>
 
       <article className="task-message task-message--agent">
-        <header className="task-message-author">
+        <header className="task-message-author task-message-author--agent">
           <span className="task-agent-mark" aria-hidden="true">
             {task.agent.charAt(0)}
           </span>
           <span>
             <strong>{task.agent}</strong>
-            <small>{responseTime}</small>
+            <small>
+              {exchange.resultObservedAt ?? (exchange.status === "processing" ? "In progress" : "Time unavailable")}
+            </small>
           </span>
         </header>
 
-        {task.status === "processing" && turn.assistantUpdate ? (
-          <p className="task-agent-update">{turn.assistantUpdate}</p>
-        ) : null}
+        <TaskAgentProcess exchange={exchange} id={processId} />
 
-        <section className="task-agent-response" aria-labelledby={resultId}>
-          <h2 id={resultId}>{turn.result.title}</h2>
-          <p>{turn.result.summary}</p>
-          {turn.result.items ? (
-            <ul>
-              {turn.result.items.map((item) => (
-                <li key={`${item.label}-${item.value}`}>
-                  <span>{item.value}</span>
-                  <small>— {item.label}</small>
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </section>
-
-        {turn.actions.length > 0 ? (
-          <details className="task-work-summary" open={task.status === "processing"}>
-            <summary>
-              <span>{workLabel}</span>
-              <Icon name="chevron-right" />
-            </summary>
-            <ol>
-              {turn.actions.map((item) => (
-                <li key={`${item.time}-${item.label}`}>
-                  <span className="task-action-mark" aria-hidden="true">
-                    {item.tool}
-                  </span>
-                  <span className="task-action-copy">
-                    <strong>{item.label}</strong>
-                    {item.detail ? <small>{item.detail}</small> : null}
-                  </span>
-                  <time>{item.time}</time>
-                </li>
-              ))}
-            </ol>
-          </details>
-        ) : null}
-
-        {turn.resultObservedAt ? (
-          <p className="task-result-observation">
-            <span>Agent result recorded locally · Outbound delivery unconfirmed</span>
-            <time>{turn.resultObservedAt}</time>
-          </p>
+        {exchange.result ? (
+          <section className="task-agent-response" aria-labelledby={resultId}>
+            <h2 id={resultId}>{exchange.result.title}</h2>
+            <p>{exchange.result.summary}</p>
+            {exchange.result.items ? (
+              <ul>
+                {exchange.result.items.map((item) => (
+                  <li key={`${item.label}-${item.value}`}>
+                    <span>{item.value}</span>
+                    <small>{item.label}</small>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {exchange.resultObservedAt ? (
+              <p className="task-result-observation">
+                Recorded locally at {exchange.resultObservedAt} · Open Feishu for the authoritative thread
+              </p>
+            ) : null}
+          </section>
         ) : null}
       </article>
     </section>
+  );
+}
+
+function TaskAgentProcess({ exchange, id }: { exchange: TaskExchange; id: string }) {
+  const toolCalls = exchange.events.filter((event): event is TaskToolCall => event.kind === "tool_call");
+  const usage = [
+    exchange.usage.input ? `${exchange.usage.input} input` : null,
+    exchange.usage.output ? `${exchange.usage.output} output` : null,
+    exchange.usage.total ? `${exchange.usage.total} total` : null,
+  ].filter(Boolean);
+  const processSummary = exchange.status === "processing" ? "Working" : `Worked for ${exchange.duration}`;
+  const processMetadata = [
+    `${toolCalls.length} ${toolCalls.length === 1 ? "tool call" : "tool calls"}`,
+    `${exchange.retries} ${exchange.retries === 1 ? "retry" : "retries"}`,
+    ...usage,
+  ];
+
+  return (
+    <details className="task-agent-process" open>
+      <summary id={id}>
+        <span>{processSummary}</span>
+        <Icon name="chevron-right" />
+      </summary>
+      <section className="task-agent-events" aria-labelledby={id}>
+        {exchange.events.map((event) => {
+          if (event.kind === "reasoning_summary") {
+            return (
+              <p className="task-reasoning-summary" key={event.id}>
+                {event.text}
+              </p>
+            );
+          }
+          return <TaskToolCallRow call={event} key={event.id} />;
+        })}
+      </section>
+      <p className="task-process-metadata">{processMetadata.join(" · ")}</p>
+    </details>
+  );
+}
+
+function TaskToolCallRow({ call }: { call: TaskToolCall }) {
+  const tool = toolPresentation[call.tool];
+  const status = toolStatusPresentation[call.status];
+  return (
+    <article className="task-tool-call">
+      <span className="task-action-mark" aria-hidden="true">
+        {tool.abbreviation}
+      </span>
+      <span className="task-tool-action">
+        <strong>{call.action}</strong>
+        <small>{tool.label}</small>
+      </span>
+      <span className="task-tool-target">{call.target}</span>
+      <StatusIndicator label={status.label} tone={status.tone} />
+    </article>
   );
 }
 
@@ -391,18 +363,23 @@ function TaskRow({ task }: { task: TaskPreview }) {
 }
 
 function SourceIdentity({ task }: { task: TaskPreview }) {
-  const source = sourcePresentation[task.source.kind];
   return (
     <span className="task-source-identity">
-      <span className={`task-source-mark task-source-mark--${task.source.kind}`} aria-hidden="true">
-        {source.abbreviation}
+      <span className="task-source-mark task-source-mark--feishu" aria-hidden="true">
+        FS
       </span>
       <span>
         <strong>{task.source.context}</strong>
-        <small>
-          {source.label} · {task.source.detail}
-        </small>
+        <small>Feishu · {task.source.detail}</small>
       </span>
     </span>
   );
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/u)
+    .slice(0, 2)
+    .map((part) => part.charAt(0))
+    .join("");
 }

--- a/apps/web/src/mock/task-data.ts
+++ b/apps/web/src/mock/task-data.ts
@@ -1,15 +1,23 @@
-export type TaskSourceKind = "email" | "feishu" | "github" | "jira";
+export type TaskStatus = "needs_attention" | "processing" | "recently_completed";
 
-export type TaskStatus = "needs_attention" | "processing" | "recently_completed" | "unable_to_confirm";
+export type TaskToolStatus = "completed" | "in_progress" | "requires_attention";
 
-export type TaskActivity = {
-  readonly detail?: string;
-  readonly label: string;
-  readonly quote?: string;
-  readonly time: string;
-  readonly tone?: "default" | "warning";
-  readonly tool?: string;
+export type TaskReasoningSummary = {
+  readonly id: string;
+  readonly kind: "reasoning_summary";
+  readonly text: string;
 };
+
+export type TaskToolCall = {
+  readonly action: string;
+  readonly id: string;
+  readonly kind: "tool_call";
+  readonly status: TaskToolStatus;
+  readonly target: string;
+  readonly tool: "feishu" | "google_drive";
+};
+
+export type TaskAgentEvent = TaskReasoningSummary | TaskToolCall;
 
 export type TaskResult = {
   readonly items?: readonly { readonly label: string; readonly value: string }[];
@@ -17,38 +25,42 @@ export type TaskResult = {
   readonly title: string;
 };
 
-export type TaskFollowUp = {
-  readonly activity: readonly TaskActivity[];
-  readonly assistantUpdate?: string;
+export type TaskUsage = {
+  readonly input: string | null;
+  readonly output: string | null;
+  readonly total: string | null;
+};
+
+export type TaskExchange = {
   readonly duration: string;
+  readonly events: readonly TaskAgentEvent[];
+  readonly id: string;
   readonly request: string;
   readonly requestTime: string;
+  readonly result: TaskResult | null;
   readonly resultObservedAt?: string;
-  readonly result: TaskResult;
+  readonly retries: number;
+  readonly status: "completed" | "needs_attention" | "processing";
+  readonly usage: TaskUsage;
 };
 
 export type TaskPreview = {
-  readonly activity: readonly TaskActivity[];
   readonly agent: "Atlas" | "Scout";
-  readonly assistantUpdate?: string;
-  readonly duration: string;
   readonly execution: readonly { readonly label: string; readonly value: string }[];
-  readonly followUps?: readonly TaskFollowUp[];
+  readonly exchanges: readonly TaskExchange[];
   readonly id: string;
   readonly initiatedBy: string;
   readonly relativeUpdatedAt: string;
-  readonly result: TaskResult;
-  readonly resultObservedAt?: string;
   readonly source: {
     readonly context: string;
     readonly detail: string;
-    readonly kind: TaskSourceKind;
-    readonly locationLabel: "Channel" | "Issue" | "Mailbox" | "Repository";
+    readonly kind: "feishu";
+    readonly locationLabel: "Channel";
+    readonly threadUrl: string;
   };
   readonly startedAt: string;
   readonly status: TaskStatus;
   readonly title: string;
-  readonly tokens: string | null;
 };
 
 export const taskPreviews: readonly TaskPreview[] = [
@@ -61,80 +73,109 @@ export const taskPreviews: readonly TaskPreview[] = [
       context: "Product Launch",
       detail: "Q3 launch readiness",
       locationLabel: "Channel",
+      threadUrl: "https://www.feishu.cn/",
     },
     status: "recently_completed",
     relativeUpdatedAt: "12 min ago",
     initiatedBy: "Mia Zhang",
     startedAt: "Aug 24, 11:04 AM",
-    duration: "8m 12s",
-    tokens: "14.2K",
-    assistantUpdate:
-      "I’ll compare the launch checklist with the latest plan and call out anything that still needs a decision.",
-    resultObservedAt: "11:12 AM",
-    result: {
-      title: "Launch plan reviewed",
-      summary: "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
-      items: [
-        { label: "Needs owner", value: "Partner announcement copy" },
-        { label: "Needs owner", value: "Customer migration email" },
-        { label: "Date unconfirmed", value: "Security review sign-off" },
-      ],
-    },
-    activity: [
+    exchanges: [
       {
-        time: "11:04 AM",
-        label: "Request received",
-        detail: "From Mia Zhang in Product Launch",
-        quote:
+        id: "review-plan",
+        request:
           "Please review the Q3 launch plan and call out anything that is still unowned or missing a confirmed date.",
-      },
-      {
-        time: "11:05 AM",
-        label: "Read Q3 launch checklist",
-        detail: "Feishu · Product Launch",
-        tool: "FS",
-      },
-      {
-        time: "11:07 AM",
-        label: "Opened the launch brief",
-        detail: "Google Drive · Q3 launch plan",
-        tool: "GD",
-      },
-    ],
-    followUps: [
-      {
-        requestTime: "11:18 AM",
-        request: "Please turn the three unresolved items into follow-ups and tag the likely owners.",
-        duration: "2m 41s",
-        assistantUpdate:
-          "I’ll draft the follow-ups in Feishu without assigning anyone who has not confirmed ownership.",
-        activity: [
+        requestTime: "11:04 AM",
+        duration: "8m 12s",
+        status: "completed",
+        retries: 0,
+        usage: { input: "8.1K", output: "6.1K", total: "14.2K" },
+        events: [
           {
-            time: "11:19 AM",
-            label: "Drafted 3 follow-up messages",
-            detail: "Feishu · Product Launch",
-            tool: "FS",
+            id: "review-reasoning-1",
+            kind: "reasoning_summary",
+            text: "I’ll compare the launch checklist with the latest plan and trace each unresolved item back to the thread.",
+          },
+          {
+            id: "review-tool-1",
+            kind: "tool_call",
+            tool: "feishu",
+            action: "Read thread",
+            target: "Product Launch",
+            status: "completed",
+          },
+          {
+            id: "review-tool-2",
+            kind: "tool_call",
+            tool: "google_drive",
+            action: "Open document",
+            target: "Q3 launch brief",
+            status: "completed",
+          },
+          {
+            id: "review-reasoning-2",
+            kind: "reasoning_summary",
+            text: "The checklist and brief disagree on three items. I’m checking the recent thread before treating any owner or date as confirmed.",
+          },
+          {
+            id: "review-tool-3",
+            kind: "tool_call",
+            tool: "feishu",
+            action: "Search messages",
+            target: "Product Launch",
+            status: "completed",
           },
         ],
+        resultObservedAt: "11:12 AM",
+        result: {
+          title: "Launch plan reviewed",
+          summary: "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
+          items: [
+            { label: "Needs owner", value: "Partner announcement copy" },
+            { label: "Needs owner", value: "Customer migration email" },
+            { label: "Date unconfirmed", value: "Security review sign-off" },
+          ],
+        },
+      },
+      {
+        id: "draft-follow-ups",
+        request: "Please turn the three unresolved items into follow-ups and tag the likely owners.",
+        requestTime: "11:15 AM",
+        duration: "2m 41s",
+        status: "completed",
+        retries: 0,
+        usage: { input: "3.2K", output: "1.6K", total: "4.8K" },
+        events: [
+          {
+            id: "follow-up-reasoning-1",
+            kind: "reasoning_summary",
+            text: "I’ll draft the follow-ups from the confirmed context and keep suggested ownership distinct from assigned ownership.",
+          },
+          {
+            id: "follow-up-tool-1",
+            kind: "tool_call",
+            tool: "feishu",
+            action: "Draft messages",
+            target: "Product Launch",
+            status: "completed",
+          },
+        ],
+        resultObservedAt: "11:18 AM",
         result: {
           title: "Follow-ups drafted",
           summary:
-            "Three follow-up messages were drafted with suggested owners. Ownership remains unassigned until each person confirms.",
+            "Three follow-up messages were prepared with suggested owners. No ownership was recorded as confirmed.",
           items: [
-            { label: "Partner announcement", value: "Suggested owner: Jordan Lee" },
-            { label: "Migration email", value: "Suggested owner: Priya Nair" },
-            { label: "Security sign-off", value: "Date confirmation requested" },
+            { label: "Suggested: Jordan Lee", value: "Partner announcement" },
+            { label: "Suggested: Priya Nair", value: "Migration email" },
+            { label: "Date confirmation requested", value: "Security sign-off" },
           ],
         },
-        resultObservedAt: "11:21 AM",
       },
     ],
     execution: [
-      { label: "Session", value: "Q3 launch readiness" },
-      { label: "Turns", value: "5" },
       { label: "Provider", value: "OpenAI" },
-      { label: "Retries", value: "0" },
-      { label: "Record quality", value: "Local result captured" },
+      { label: "Session", value: "Q3 launch readiness" },
+      { label: "Event record", value: "Reasoning summaries and tool calls captured" },
     ],
   },
   {
@@ -146,39 +187,51 @@ export const taskPreviews: readonly TaskPreview[] = [
       context: "Customer Feedback",
       detail: "Enterprise visit notes",
       locationLabel: "Channel",
+      threadUrl: "https://www.feishu.cn/",
     },
     status: "processing",
     relativeUpdatedAt: "2 min ago",
     initiatedBy: "Noah Liu",
     startedAt: "Aug 24, 10:42 AM",
-    duration: "In progress",
-    tokens: "6.4K",
-    resultObservedAt: "10:47 AM",
-    result: {
-      title: "Customer feedback analysis in progress",
-      summary: "Three visit summaries are loaded. Scout is grouping recurring issues by account and owner.",
-      items: [
-        { label: "Most frequent", value: "Slow permission setup" },
-        { label: "Follow-up", value: "Clarify audit log retention" },
-      ],
-    },
-    activity: [
+    exchanges: [
       {
-        time: "10:42 AM",
-        label: "Request received",
-        detail: "From Noah Liu in Customer Feedback",
-        quote: "Please group yesterday's customer visit notes by account, issue, and the team that should follow up.",
+        id: "group-feedback",
+        request: "Please group yesterday's customer visit notes by account, issue, and the team that should follow up.",
+        requestTime: "10:42 AM",
+        duration: "In progress",
+        status: "processing",
+        retries: 0,
+        usage: { input: "6.4K", output: null, total: null },
+        events: [
+          {
+            id: "feedback-reasoning-1",
+            kind: "reasoning_summary",
+            text: "I’m collecting the three visit summaries first, then I’ll group repeated issues without merging account-specific context.",
+          },
+          {
+            id: "feedback-tool-1",
+            kind: "tool_call",
+            tool: "feishu",
+            action: "Read thread",
+            target: "Customer Feedback",
+            status: "completed",
+          },
+          {
+            id: "feedback-tool-2",
+            kind: "tool_call",
+            tool: "feishu",
+            action: "Search messages",
+            target: "Customer Feedback",
+            status: "in_progress",
+          },
+        ],
+        result: null,
       },
-      { time: "10:43 AM", label: "Scout started" },
-      { time: "10:46 AM", label: "Read three visit summaries" },
-      { time: "10:47 AM", label: "Grouping recurring issues" },
     ],
     execution: [
-      { label: "Session", value: "Enterprise visit notes" },
-      { label: "Turns", value: "3" },
       { label: "Provider", value: "Anthropic" },
-      { label: "Retries", value: "0" },
-      { label: "Record quality", value: "In progress" },
+      { label: "Session", value: "Enterprise visit notes" },
+      { label: "Event record", value: "Live provider events" },
     ],
   },
   {
@@ -190,172 +243,61 @@ export const taskPreviews: readonly TaskPreview[] = [
       context: "Engineering Collaboration",
       detail: "Onboarding process review",
       locationLabel: "Channel",
+      threadUrl: "https://www.feishu.cn/",
     },
     status: "needs_attention",
     relativeUpdatedAt: "25 min ago",
     initiatedBy: "Olivia Sun",
     startedAt: "Aug 24, 10:18 AM",
-    duration: "11m 03s",
-    tokens: "18.6K",
-    resultObservedAt: "10:29 AM",
-    result: {
-      title: "Two source documents are missing",
-      summary: "The review is paused because the access checklist and security orientation steps are not available.",
-      items: [
-        { label: "Missing input", value: "Access provisioning checklist" },
-        { label: "Missing input", value: "Security orientation guide" },
-      ],
-    },
-    activity: [
+    exchanges: [
       {
-        time: "10:18 AM",
-        label: "Request received",
-        detail: "From Olivia Sun in Engineering Collaboration",
-        quote:
+        id: "review-onboarding",
+        request:
           "Compare the onboarding document with what new engineers actually do, then call out missing steps and owners.",
+        requestTime: "10:18 AM",
+        duration: "11m 03s",
+        status: "needs_attention",
+        retries: 1,
+        usage: { input: "11.8K", output: "6.8K", total: "18.6K" },
+        events: [
+          {
+            id: "onboarding-reasoning-1",
+            kind: "reasoning_summary",
+            text: "I’ll compare the documented path with the recent onboarding thread and identify gaps only where the source record is available.",
+          },
+          {
+            id: "onboarding-tool-1",
+            kind: "tool_call",
+            tool: "feishu",
+            action: "Open document",
+            target: "Engineering onboarding",
+            status: "completed",
+          },
+          {
+            id: "onboarding-tool-2",
+            kind: "tool_call",
+            tool: "google_drive",
+            action: "Open document",
+            target: "Access provisioning checklist",
+            status: "requires_attention",
+          },
+        ],
+        resultObservedAt: "10:29 AM",
+        result: {
+          title: "Two source documents are missing",
+          summary:
+            "The review is paused because the access checklist and security orientation steps are not available.",
+          items: [
+            { label: "Missing input", value: "Access provisioning checklist" },
+            { label: "Missing input", value: "Security orientation guide" },
+          ],
+        },
       },
-      { time: "10:19 AM", label: "Atlas started" },
-      { time: "10:24 AM", label: "Reviewed the onboarding document" },
-      { time: "10:29 AM", label: "Requested two missing inputs" },
     ],
     execution: [
+      { label: "Provider", value: "OpenAI" },
       { label: "Session", value: "Onboarding process review" },
-      { label: "Turns", value: "4" },
-      { label: "Provider", value: "OpenAI" },
-      { label: "Retries", value: "1" },
-      { label: "Record quality", value: "Local result captured" },
-    ],
-  },
-  {
-    id: "security-questionnaire",
-    title:
-      "Complete the attached enterprise security questionnaire and flag every answer that still needs legal review.",
-    agent: "Scout",
-    source: {
-      kind: "email",
-      context: "security@northstar.example",
-      detail: "Enterprise security questionnaire",
-      locationLabel: "Mailbox",
-    },
-    status: "recently_completed",
-    relativeUpdatedAt: "32 min ago",
-    initiatedBy: "Priya Nair",
-    startedAt: "Aug 24, 9:56 AM",
-    duration: "14m 21s",
-    tokens: "22.1K",
-    resultObservedAt: "10:10 AM",
-    result: {
-      title: "Questionnaire draft completed",
-      summary: "Thirty-four answers were drafted and four policy questions were flagged for legal review.",
-      items: [
-        { label: "Legal review", value: "Data residency commitments" },
-        { label: "Legal review", value: "Subprocessor notification period" },
-      ],
-    },
-    activity: [
-      {
-        time: "9:56 AM",
-        label: "Email received",
-        detail: "From Priya Nair",
-        quote: "Please complete the attached security questionnaire and flag anything that requires a legal decision.",
-      },
-      { time: "9:58 AM", label: "Scout started" },
-      { time: "10:05 AM", label: "Drafted thirty-four answers" },
-      { time: "10:10 AM", label: "Flagged four policy questions" },
-      { time: "10:10 AM", label: "Completed" },
-    ],
-    execution: [
-      { label: "Session", value: "Enterprise security questionnaire" },
-      { label: "Turns", value: "6" },
-      { label: "Provider", value: "Anthropic" },
-      { label: "Retries", value: "0" },
-      { label: "Record quality", value: "Local result captured" },
-    ],
-  },
-  {
-    id: "github-oauth-regression",
-    title:
-      "Investigate why the OAuth callback intermittently drops the session cookie in staging and propose a safe fix.",
-    agent: "Atlas",
-    source: {
-      kind: "github",
-      context: "opentag/web #123",
-      detail: "OAuth callback regression",
-      locationLabel: "Repository",
-    },
-    status: "needs_attention",
-    relativeUpdatedAt: "46 min ago",
-    initiatedBy: "Ethan Brooks",
-    startedAt: "Aug 24, 9:31 AM",
-    duration: "17m 44s",
-    tokens: "27.3K",
-    resultObservedAt: "9:49 AM",
-    result: {
-      title: "Likely proxy header mismatch",
-      summary:
-        "The staging proxy appears to drop the secure cookie on one callback path. Production behavior remains unconfirmed.",
-      items: [
-        { label: "Needs confirmation", value: "Production proxy header policy" },
-        { label: "Proposed fix", value: "Normalize forwarded protocol handling" },
-      ],
-    },
-    activity: [
-      {
-        time: "9:31 AM",
-        label: "Issue assigned",
-        detail: "From opentag/web #123",
-        quote: "Please isolate the intermittent staging cookie loss and propose the smallest safe fix.",
-      },
-      { time: "9:33 AM", label: "Atlas started" },
-      { time: "9:39 AM", label: "Compared callback request headers" },
-      { time: "9:49 AM", label: "Requested production proxy confirmation" },
-    ],
-    execution: [
-      { label: "Session", value: "OAuth callback regression" },
-      { label: "Turns", value: "7" },
-      { label: "Provider", value: "OpenAI" },
-      { label: "Retries", value: "1" },
-      { label: "Record quality", value: "Local result captured" },
-    ],
-  },
-  {
-    id: "jira-onboarding-coverage",
-    title: "Review onboarding event coverage before the next experiment and identify any missing analytics events.",
-    agent: "Scout",
-    source: {
-      kind: "jira",
-      context: "PROJ-342",
-      detail: "Onboarding event coverage",
-      locationLabel: "Issue",
-    },
-    status: "unable_to_confirm",
-    relativeUpdatedAt: "3 hr ago",
-    initiatedBy: "Avery Morgan",
-    startedAt: "Aug 24, 8:12 AM",
-    duration: "Unavailable",
-    tokens: null,
-    result: {
-      title: "Unable to confirm the latest execution",
-      summary: "The Task record is incomplete because the final provider response was not received.",
-      items: [{ label: "Last confirmed", value: "Event inventory loaded" }],
-    },
-    activity: [
-      {
-        time: "8:12 AM",
-        label: "Issue assigned",
-        detail: "From PROJ-342",
-        quote: "Review onboarding event coverage before the experiment and identify any missing analytics events.",
-      },
-      { time: "8:13 AM", label: "Scout started" },
-      { time: "8:17 AM", label: "Loaded the event inventory" },
-      { time: "Unknown", label: "Final provider response not received" },
-    ],
-    execution: [
-      { label: "Session", value: "Onboarding event coverage" },
-      { label: "Turns", value: "Unavailable" },
-      { label: "Provider", value: "Anthropic" },
-      { label: "Retries", value: "Unavailable" },
-      { label: "Record quality", value: "Incomplete" },
+      { label: "Event record", value: "Provider events captured; source access incomplete" },
     ],
   },
 ];


### PR DESCRIPTION
## Summary

- simplify the Task list to a Feishu-only mock with Work, Source, and Activity
- model each message exchange as ordered reasoning summaries, provider tool calls, usage/retry metadata, and an optional final answer
- render the real Agent process before the final answer without exposing raw chain-of-thought or adding visible Turn labels
- keep the multi-message detail responsive and link back to the authoritative Feishu surface

## Testing

- `pnpm check` (passes; existing undeclared E2E env-var warnings remain)
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/web test` (295 tests)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (268 tests, 100% coverage)
- production-preview Playwright QA for Task list, desktop detail, and 390px detail
- `pnpm test` reaches 117/119 CLI tests; two existing macOS path-canonicalization assertions compare `/tmp` with `/private/tmp`
- `pnpm test:coverage` reaches 1133/1136 tests; it reproduces those two CLI assertions and one existing coverage-only RuntimeSession observability timing failure

## Breaking changes

None. This remains mock UI and demo data only.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [ ] All repository tests pass locally (blocked by the unrelated baseline failures listed above).
- [x] No credentials, private data, or generated build output are included.
- [x] No canonical documentation mirror changes are required.