### PR TITLE
feat(web): refine Skills demo

### DIFF
--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -24,6 +24,11 @@ describe("capability entry pages", () => {
     expect(screen.queryByText("Repositories")).toBeNull();
     expect(screen.queryByText("Tools")).toBeNull();
     expect(screen.queryByText("Prompts")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Skill file"), {
+      target: { files: [new File(["# Skill"], "release-notes.md", { type: "text/markdown" })] },
+    });
+    expect(screen.getByRole("status").textContent).toBe("release-notes.md selected · Demo only, not uploaded");
   });
 
   it("renders an explicitly labeled Integrations mock", () => {

--- a/apps/web/src/__tests__/mock-pages.test.tsx
+++ b/apps/web/src/__tests__/mock-pages.test.tsx
@@ -7,7 +7,7 @@ import { UsagePage } from "../features/usage-page.js";
 describe("capability entry pages", () => {
   afterEach(() => vi.unstubAllEnvs());
 
-  it("renders a minimal static Skills demo without unavailable controls", () => {
+  it("renders a minimal interactive Skills demo", () => {
     render(<SkillsPage />);
 
     expect(screen.getByRole("heading", { name: "Skills" })).toBeTruthy();
@@ -16,16 +16,14 @@ describe("capability entry pages", () => {
     expect(screen.getByText("Browser validation")).toBeTruthy();
     expect(screen.getByText("Issue triage")).toBeTruthy();
     expect(screen.getAllByText("Demo")).toHaveLength(3);
-    expect(screen.getAllByRole("columnheader").map((header) => header.textContent)).toEqual([
-      "Name",
-      "Source",
-      "Used by",
-      "Status",
-    ]);
+    expect(screen.getByRole("heading", { name: "All skills" })).toBeTruthy();
+    expect(screen.getAllByRole("article")).toHaveLength(3);
+    expect(screen.getByRole("button", { name: "Upload skill" })).toBeTruthy();
+    expect(screen.getByText("Built by OpenTag")).toBeTruthy();
+    expect(screen.queryByText("Workspace")).toBeNull();
     expect(screen.queryByText("Repositories")).toBeNull();
     expect(screen.queryByText("Tools")).toBeNull();
     expect(screen.queryByText("Prompts")).toBeNull();
-    expect(screen.queryByRole("button")).toBeNull();
   });
 
   it("renders an explicitly labeled Integrations mock", () => {

--- a/apps/web/src/features/skills-page.tsx
+++ b/apps/web/src/features/skills-page.tsx
@@ -1,44 +1,72 @@
+import { useRef } from "react";
 import { skillPreviews } from "../mock/capability-data.js";
 import "../mock-pages.css";
 
 export function SkillsPage() {
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+
   return (
-    <section className="capability-page" aria-labelledby="skills-page-title">
-      <header className="capability-page-header">
+    <section className="capability-page skills-page" aria-labelledby="skills-page-title">
+      <header className="skills-hero">
         <div>
-          <span className="capability-preview-label">Demo data</span>
           <h1 id="skills-page-title">Skills</h1>
-          <p>Reusable instructions and capability requirements that Agents use to complete Tasks.</p>
+          <p>Reusable playbooks that give Agents the context and methods they need to do specialized work.</p>
+        </div>
+        <div className="skills-header-actions">
+          <span className="skills-demo-note">Demo data</span>
+          <button
+            className="ds-button ds-button--secondary ds-button--compact"
+            type="button"
+            onClick={() => uploadInputRef.current?.click()}
+          >
+            Upload skill
+          </button>
+          <input ref={uploadInputRef} hidden accept=".md,.zip" aria-label="Skill file" type="file" />
         </div>
       </header>
 
-      <table className="capability-table" aria-label="Demo Skills">
-        <thead>
-          <tr className="capability-table-header capability-skill-grid">
-            <th scope="col">Name</th>
-            <th scope="col">Source</th>
-            <th scope="col">Used by</th>
-            <th scope="col">Status</th>
-          </tr>
-        </thead>
-        <tbody>
+      <section className="skills-catalog" aria-labelledby="skills-catalog-title">
+        <div className="skills-catalog-heading">
+          <h2 id="skills-catalog-title">All skills</h2>
+          <p>{skillPreviews.length} skills</p>
+        </div>
+
+        <ul className="skills-list" aria-label="Available skills">
           {skillPreviews.map((skill) => (
-            <tr className="capability-table-row capability-skill-grid" key={skill.name}>
-              <td className="capability-primary-cell">
-                <strong>{skill.name}</strong>
-                <small>{skill.description}</small>
-              </td>
-              <td data-label="Source">{skill.source}</td>
-              <td data-label="Used by">
-                {skill.agentCount} {skill.agentCount === 1 ? "Agent" : "Agents"}
-              </td>
-              <td data-label="Status">
-                <span className="capability-demo-status">{skill.status}</span>
-              </td>
-            </tr>
+            <li key={skill.name}>
+              <article className="skill-row">
+                <details>
+                  <summary className="skill-row-summary">
+                    <div className="skill-row-copy">
+                      <div className="skill-row-title">
+                        <h3>{skill.name}</h3>
+                        <span className="skill-row-status">{skill.status}</span>
+                        {skill.source === "OpenTag" ? (
+                          <span className="skill-row-provider">Built by OpenTag</span>
+                        ) : null}
+                      </div>
+                      <p>{skill.description}.</p>
+                    </div>
+                    <dl className="skill-row-meta">
+                      <div>
+                        <dt>Used by</dt>
+                        <dd>
+                          {skill.agentCount} {skill.agentCount === 1 ? "Agent" : "Agents"}
+                        </dd>
+                      </div>
+                    </dl>
+                    <span className="skill-row-preview-label">Preview</span>
+                  </summary>
+                  <div className="skill-preview-panel">
+                    <h4>Instructions preview</h4>
+                    <p>{skill.instructions}</p>
+                  </div>
+                </details>
+              </article>
+            </li>
           ))}
-        </tbody>
-      </table>
+        </ul>
+      </section>
     </section>
   );
 }

--- a/apps/web/src/features/skills-page.tsx
+++ b/apps/web/src/features/skills-page.tsx
@@ -1,9 +1,10 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { skillPreviews } from "../mock/capability-data.js";
 import "../mock-pages.css";
 
 export function SkillsPage() {
   const uploadInputRef = useRef<HTMLInputElement>(null);
+  const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
 
   return (
     <section className="capability-page skills-page" aria-labelledby="skills-page-title">
@@ -14,14 +15,28 @@ export function SkillsPage() {
         </div>
         <div className="skills-header-actions">
           <span className="skills-demo-note">Demo data</span>
-          <button
-            className="ds-button ds-button--secondary ds-button--compact"
-            type="button"
-            onClick={() => uploadInputRef.current?.click()}
-          >
-            Upload skill
-          </button>
-          <input ref={uploadInputRef} hidden accept=".md,.zip" aria-label="Skill file" type="file" />
+          <div className="skills-upload-entry">
+            <button
+              className="ds-button ds-button--secondary ds-button--compact"
+              type="button"
+              onClick={() => uploadInputRef.current?.click()}
+            >
+              Upload skill
+            </button>
+            <input
+              ref={uploadInputRef}
+              hidden
+              accept=".md,.zip"
+              aria-label="Skill file"
+              type="file"
+              onChange={(event) => setSelectedFileName(event.currentTarget.files?.[0]?.name ?? null)}
+            />
+            {selectedFileName ? (
+              <span className="skills-upload-status" role="status">
+                {selectedFileName} selected · Demo only, not uploaded
+              </span>
+            ) : null}
+          </div>
         </div>
       </header>
 

--- a/apps/web/src/mock-pages.css
+++ b/apps/web/src/mock-pages.css
@@ -163,8 +163,22 @@
 .skills-header-actions {
   display: flex;
   flex: 0 0 auto;
-  align-items: center;
+  align-items: flex-start;
   gap: 16px;
+}
+
+.skills-upload-entry {
+  display: grid;
+  justify-items: end;
+  gap: 6px;
+}
+
+.skills-upload-status {
+  max-width: 240px;
+  color: var(--muted, #616b62);
+  font-size: var(--text-micro, 0.75rem);
+  line-height: var(--lh-ui, 1.4);
+  text-align: right;
 }
 
 .skills-catalog-heading {

--- a/apps/web/src/mock-pages.css
+++ b/apps/web/src/mock-pages.css
@@ -129,6 +129,219 @@
   white-space: nowrap;
 }
 
+/* Skills use the same document-style hierarchy as the rest of the workspace.
+   Rows remain readable without imagery or decorative metadata. */
+.skills-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 36px;
+  border-bottom: 1px solid var(--border, #ddded4);
+  padding: 4px 0 28px;
+}
+
+.skills-hero h1 {
+  margin: 0 0 8px;
+}
+
+.skills-hero p {
+  max-width: 600px;
+  margin: 0;
+  color: var(--muted, #616b62);
+  font-size: var(--text-body, 0.875rem);
+  line-height: var(--lh-prose, 1.6);
+  text-wrap: pretty;
+}
+
+.skills-demo-note {
+  flex: 0 0 auto;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+}
+
+.skills-header-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 16px;
+}
+
+.skills-catalog-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  padding-bottom: 12px;
+}
+
+.skills-catalog-heading h2 {
+  margin: 0;
+  color: var(--foreground, #16211b);
+  font-size: var(--text-subsection, 1rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.skills-catalog-heading p {
+  margin: 0;
+  color: var(--muted, #616b62);
+  font-size: var(--text-meta, 0.75rem);
+  font-variant-numeric: tabular-nums;
+}
+
+.skills-list {
+  margin: 0;
+  border-top: 1px solid var(--strong-border, #cdd0c3);
+  padding: 0;
+  list-style: none;
+}
+
+.skills-list > li {
+  border-bottom: 1px solid var(--border, #ddded4);
+}
+
+.skill-row {
+  min-width: 0;
+}
+
+.skill-row details {
+  min-width: 0;
+}
+
+.skill-row-summary {
+  display: grid;
+  min-width: 0;
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) 104px auto;
+  gap: 32px;
+  padding: 22px 0 24px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.skill-row-summary::-webkit-details-marker {
+  display: none;
+}
+
+.skill-row-copy {
+  min-width: 0;
+}
+
+.skill-row-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 5px;
+}
+
+.skill-row h3 {
+  margin: 0;
+  color: var(--foreground, #16211b);
+  font-size: var(--text-subsection, 1rem);
+  font-weight: var(--fw-semibold, 600);
+  letter-spacing: -0.01em;
+}
+
+.skill-row-copy > p {
+  max-width: 54ch;
+  margin: 0;
+  color: var(--muted, #616b62);
+  font-size: var(--text-ui, 0.8125rem);
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+.skill-row-status {
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted, #616b62);
+  font-size: var(--text-micro, 0.75rem);
+  font-weight: var(--fw-medium, 500);
+}
+
+.skill-row-status::before {
+  width: 5px;
+  height: 5px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: var(--brand, #4e7a06);
+  content: "";
+}
+
+.skill-row-provider {
+  color: var(--brand-ink, #385a04);
+  font-size: var(--text-micro, 0.75rem);
+  font-weight: var(--fw-medium, 500);
+}
+
+.skill-row-meta {
+  margin: 0;
+}
+
+.skill-row-meta > div {
+  min-width: 0;
+}
+
+.skill-row-meta dt {
+  margin-bottom: 3px;
+  color: var(--muted, #616b62);
+  font-size: var(--text-micro, 0.75rem);
+}
+
+.skill-row-meta dd {
+  margin: 0;
+  color: var(--secondary-foreground, #3a453e);
+  font-size: var(--text-ui, 0.8125rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--fw-medium, 500);
+}
+
+.skill-row-preview-label {
+  display: inline-flex;
+  align-items: center;
+  justify-self: end;
+  color: var(--secondary-foreground, #3a453e);
+  font-size: var(--text-ui, 0.8125rem);
+  font-weight: var(--fw-medium, 500);
+}
+
+.skill-row-preview-label::after {
+  display: inline-block;
+  margin-left: 7px;
+  content: "›";
+  font-size: 1rem;
+  line-height: 1;
+  transition: transform 160ms ease;
+}
+
+.skill-row details[open] .skill-row-preview-label::after {
+  transform: rotate(90deg);
+}
+
+.skill-row-summary:hover .skill-row-preview-label {
+  color: var(--brand-ink, #385a04);
+}
+
+.skill-preview-panel {
+  max-width: 650px;
+  margin: -2px 0 22px;
+  border-left: 2px solid var(--brand, #4e7a06);
+  padding: 1px 0 1px 18px;
+}
+
+.skill-preview-panel h4 {
+  margin: 0 0 5px;
+  color: var(--foreground, #16211b);
+  font-size: var(--text-ui, 0.8125rem);
+  font-weight: var(--fw-semibold, 600);
+}
+
+.skill-preview-panel p {
+  margin: 0;
+  color: var(--muted, #616b62);
+  font-size: var(--text-ui, 0.8125rem);
+  line-height: 1.55;
+}
 .capability-section-stack {
   display: grid;
   gap: 42px;
@@ -624,6 +837,21 @@
 }
 
 @media (max-width: 720px) {
+  .skill-row-summary {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 16px;
+  }
+
+  .skill-row-meta {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .skill-row-preview-label {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
   .capability-page-header {
     display: grid;
     gap: 18px;
@@ -771,6 +999,35 @@
   .integration-dialog-actions {
     display: grid;
     grid-template-columns: 1fr;
+  }
+
+  .skills-hero {
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 34px;
+    padding-bottom: 28px;
+  }
+
+  .skills-demo-note {
+    line-height: var(--lh-ui, 1.45);
+  }
+
+  .skills-header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .skills-hero h1 {
+    font-size: var(--fs-32, 2rem);
+  }
+
+  .skills-catalog-heading {
+    align-items: flex-start;
+  }
+
+  .skills-catalog-heading > p {
+    max-width: 90px;
+    text-align: right;
   }
 
   .capability-table-header {

--- a/apps/web/src/mock/capability-data.ts
+++ b/apps/web/src/mock/capability-data.ts
@@ -4,6 +4,7 @@ export type SkillPreview = {
   agentCount: number;
   status: "Demo";
   description: string;
+  instructions: string;
 };
 
 export const skillPreviews: readonly SkillPreview[] = [
@@ -13,6 +14,7 @@ export const skillPreviews: readonly SkillPreview[] = [
     agentCount: 3,
     status: "Demo",
     description: "Turns merged changes into clear release notes",
+    instructions: "Review merged changes, group them by user impact, and write a concise summary for each group.",
   },
   {
     name: "Browser validation",
@@ -20,6 +22,8 @@ export const skillPreviews: readonly SkillPreview[] = [
     agentCount: 2,
     status: "Demo",
     description: "Checks key product flows and reports regressions",
+    instructions:
+      "Open each defined product flow, verify the expected outcome, and report any reproducible regression.",
   },
   {
     name: "Issue triage",
@@ -27,6 +31,8 @@ export const skillPreviews: readonly SkillPreview[] = [
     agentCount: 5,
     status: "Demo",
     description: "Classifies incoming issues and recommends priority",
+    instructions:
+      "Read the issue, identify the affected area and urgency, then recommend a priority with a short rationale.",
   },
 ];
 


### PR DESCRIPTION
## Summary

- replace the Skills table with a minimal, image-free catalogue
- add inline instruction previews and a compact upload file-picker entry
- keep demo labeling close to the page title and show OpenTag attribution only where useful
- preserve the current mock-only scope without introducing Workspace management concepts

## Testing

Passed locally:
- pnpm install --frozen-lockfile
- pnpm check (8 pre-existing E2E environment-variable warnings)
- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/web test
- pnpm --filter @opentag/client test (430/430)

Local full-suite notes:
- pnpm test reaches one pre-existing server observability timing failure in an unchanged file (expected stale_connection, observed handled)
- pnpm --filter @opentag/client test:agent-runtime:coverage reaches one temporary-file startup timing failure in an unchanged test; the same test passes in the normal client suite
- GitHub CI remains the merge gate

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [ ] The complete local test suite passes (see unchanged timing failures above; CI is the merge gate).
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.