### PR TITLE
feat(web): simplify Task final answers

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1591,7 +1591,11 @@ describe("OpenTag Web App Shell", () => {
       name: "Review the Q3 launch plan, identify unresolved owners, and flag every item without a confirmed date.",
     });
     fireEvent.click(task);
-    expect(await screen.findByRole("heading", { name: "Launch plan reviewed" })).toBeTruthy();
+    expect(
+      await screen.findByText(
+        "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
+      ),
+    ).toBeTruthy();
     expect(screen.getByLabelText("Task source").textContent).toContain("Product Launch");
     expect(window.location.pathname).toBe("/tasks/q3-launch-readiness");
   });
@@ -1601,7 +1605,11 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/tasks/q3-launch-readiness");
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Launch plan reviewed" })).toBeTruthy();
+    expect(
+      await screen.findByText(
+        "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
+      ),
+    ).toBeTruthy();
     expect(screen.getByText("Demo data")).toBeTruthy();
   });
 

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -86,4 +86,9 @@ describe("workspace page layout", () => {
     expect(declarationValue(taskStyles, ".task-tool-target", "grid-row")).toBe("2");
     expect(declarationValue(taskStyles, ".task-tool-target", "white-space")).toBe("normal");
   });
+
+  it("keeps Task final answers in a single reading column", () => {
+    expect(topLevelDeclarationValue(taskStyles, ".task-agent-response li", "color")).toBe("var(--foreground)");
+    expect(topLevelDeclarationValue(taskStyles, ".task-agent-response li", "font-size")).toBe("var(--text-body)");
+  });
 });

--- a/apps/web/src/features/tasks-page.css
+++ b/apps/web/src/features/tasks-page.css
@@ -379,7 +379,7 @@
   margin-left: 44px;
   border-radius: 12px;
   background: var(--surface-soft);
-  padding: var(--space-4) var(--space-5);
+  padding: var(--space-2) var(--space-4);
 }
 
 .task-request-bubble p {
@@ -390,8 +390,7 @@
 }
 
 .task-agent-process,
-.task-agent-response,
-.task-result-observation {
+.task-agent-response {
   margin-left: 44px;
 }
 
@@ -400,8 +399,7 @@
   border-bottom: 1px solid var(--border);
 }
 
-.task-agent-process summary,
-.task-record-details summary {
+.task-agent-process summary {
   display: flex;
   min-height: 44px;
   align-items: center;
@@ -413,20 +411,17 @@
   list-style: none;
 }
 
-.task-agent-process summary::-webkit-details-marker,
-.task-record-details summary::-webkit-details-marker {
+.task-agent-process summary::-webkit-details-marker {
   display: none;
 }
 
-.task-agent-process summary .ds-icon,
-.task-record-details summary .ds-icon {
+.task-agent-process summary .ds-icon {
   width: 16px;
   height: 16px;
   transition: transform 160ms ease;
 }
 
-.task-agent-process[open] summary .ds-icon,
-.task-record-details[open] summary .ds-icon {
+.task-agent-process[open] summary .ds-icon {
   transform: rotate(90deg);
 }
 
@@ -520,94 +515,43 @@
 
 .task-agent-response {
   max-width: 720px;
-  padding-top: var(--space-5);
+  padding-top: var(--space-6);
 }
 
-.task-agent-response h2 {
-  margin-bottom: var(--space-3);
-  color: var(--foreground);
-  font-size: var(--text-section);
-}
-
-.task-agent-response > p {
+.task-answer-paragraph {
   margin: 0;
   color: var(--secondary-foreground);
   font-size: var(--text-body);
   line-height: var(--lh-prose);
 }
 
+.task-answer-paragraph + .task-answer-paragraph {
+  margin-top: var(--space-4);
+}
+
 .task-agent-response ul {
-  margin: var(--space-5) 0 0;
+  margin: var(--space-4) 0 0;
   padding-left: 18px;
   list-style: disc;
 }
 
 .task-agent-response li {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(180px, 0.75fr);
-  gap: var(--space-6);
   padding: 5px 0;
-  font-size: var(--text-ui);
+  color: var(--foreground);
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
 }
 
 .task-agent-response li::marker {
   color: var(--muted);
 }
 
-.task-agent-response li span {
-  color: var(--foreground);
-}
-
-.task-agent-response li small {
-  color: var(--muted);
-  font-size: inherit;
-}
-
 .task-result-observation {
   max-width: 720px;
-  margin-top: var(--space-5);
+  margin-top: var(--space-4);
   margin-bottom: 0;
   color: var(--muted);
   font-size: var(--text-meta);
-}
-
-.task-record-details {
-  margin: 0 0 var(--space-8) 44px;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.task-record-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--space-8);
-  padding: var(--space-2) 0 var(--space-5);
-}
-
-.task-record-grid dl {
-  margin: 0;
-}
-
-.task-record-grid dl > div {
-  display: grid;
-  grid-template-columns: minmax(92px, 116px) minmax(0, 1fr);
-  gap: var(--space-4);
-  min-height: 30px;
-  align-items: baseline;
-}
-
-.task-record-grid dt,
-.task-record-grid dd {
-  font-size: var(--text-meta);
-}
-
-.task-record-grid dt {
-  color: var(--muted);
-}
-
-.task-record-grid dd {
-  overflow-wrap: anywhere;
-  color: var(--secondary-foreground);
 }
 
 @media (max-width: 900px) {
@@ -657,11 +601,6 @@
     font-size: var(--text-micro);
     font-weight: var(--fw-semibold);
     text-transform: uppercase;
-  }
-
-  .task-record-grid {
-    grid-template-columns: 1fr;
-    gap: 0;
   }
 
   .task-tool-call {
@@ -744,18 +683,7 @@
 
   .task-request-bubble,
   .task-agent-process,
-  .task-agent-response,
-  .task-result-observation,
-  .task-record-details {
+  .task-agent-response {
     margin-left: 0;
-  }
-
-  .task-record-grid dl > div {
-    grid-template-columns: 100px minmax(0, 1fr);
-  }
-
-  .task-agent-response li {
-    grid-template-columns: 1fr;
-    gap: 1px;
   }
 }

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -85,7 +85,12 @@ describe("Tasks demo", () => {
         "The checklist and brief disagree on three items. I’m checking the recent thread before treating any owner or date as confirmed.",
       ),
     ).toBeTruthy();
-    expect(within(conversation).getByRole("heading", { name: "Follow-ups drafted" })).toBeTruthy();
+    expect(
+      within(conversation).getByText(
+        "Three follow-up messages were prepared with suggested owners. No ownership was recorded as confirmed.",
+      ),
+    ).toBeTruthy();
+    expect(within(conversation).getByText("Partner announcement — Suggested owner: Jordan Lee")).toBeTruthy();
     expect(
       within(conversation).getAllByText(/Recorded locally at .*Open Feishu for the authoritative thread/),
     ).toHaveLength(2);
@@ -93,13 +98,19 @@ describe("Tasks demo", () => {
     expect(within(conversation).queryByText(/Chain of Thought/i)).toBeNull();
 
     const process = within(conversation).getByText("Worked for 8m 12s").closest("details");
-    const result = within(conversation).getByRole("heading", { name: "Launch plan reviewed" });
+    const finalAnswer = within(conversation).getByText(
+      "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
+    );
     expect(process).toBeTruthy();
     if (!process) throw new Error("Expected the Agent process details");
-    expect(process.hasAttribute("open")).toBe(true);
-    expect(process.compareDocumentPosition(result) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(process.hasAttribute("open")).toBe(false);
+    expect(process.compareDocumentPosition(finalAnswer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(within(process).getByText("3 tool calls · 0 retries · 8.1K input · 6.1K output · 14.2K total")).toBeTruthy();
-    expect(screen.getByText("Task details").closest("details")?.hasAttribute("open")).toBe(false);
+    expect(within(conversation).getByText("Partner announcement copy — Needs owner")).toBeTruthy();
+    expect(within(conversation).getByText("Security review sign-off — Date unconfirmed")).toBeTruthy();
+    expect(within(conversation).queryByText("Launch plan reviewed")).toBeNull();
+    expect(within(conversation).queryByText("Follow-ups drafted")).toBeNull();
+    expect(screen.queryByText("Task details")).toBeNull();
     expect(screen.queryByRole("complementary")).toBeNull();
   });
 
@@ -134,6 +145,11 @@ describe("Tasks demo", () => {
     expect(
       within(process as HTMLElement).getByText("2 tool calls · 1 retry · 11.8K input · 6.8K output · 18.6K total"),
     ).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Two source documents are missing" })).toBeTruthy();
+    expect(
+      screen.getByText(
+        "The review is paused because the access checklist and security orientation steps are not available.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Access provisioning checklist — Missing input")).toBeTruthy();
   });
 });

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -129,13 +129,6 @@ export function TaskDetailPage() {
   }
 
   const status = statusPresentation[task.status];
-  const details = [
-    ["Source", "Feishu"],
-    [task.source.locationLabel, task.source.context],
-    ["Initiated by", task.initiatedBy],
-    ["Agent", task.agent],
-    ["Started", task.startedAt],
-  ] as const;
 
   return (
     <article className="task-conversation-page">
@@ -170,37 +163,11 @@ export function TaskDetailPage() {
           <TaskConversationExchange key={exchange.id} task={task} exchange={exchange} />
         ))}
       </section>
-
-      <details className="task-record-details">
-        <summary>
-          <span>Task details</span>
-          <Icon name="chevron-right" />
-        </summary>
-        <div className="task-record-grid">
-          <dl>
-            {details.map(([label, value]) => (
-              <div key={label}>
-                <dt>{label}</dt>
-                <dd>{value}</dd>
-              </div>
-            ))}
-          </dl>
-          <dl>
-            {task.execution.map((item) => (
-              <div key={item.label}>
-                <dt>{item.label}</dt>
-                <dd>{item.value}</dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-      </details>
     </article>
   );
 }
 
 function TaskConversationExchange({ task, exchange }: { task: TaskPreview; exchange: TaskExchange }) {
-  const resultId = `${task.id}-${exchange.id}-result`;
   const processId = `${task.id}-${exchange.id}-process`;
 
   return (
@@ -230,30 +197,35 @@ function TaskConversationExchange({ task, exchange }: { task: TaskPreview; excha
           <span>
             <strong>{task.agent}</strong>
             <small>
-              {exchange.resultObservedAt ?? (exchange.status === "processing" ? "In progress" : "Time unavailable")}
+              {exchange.finalAnswerObservedAt ??
+                (exchange.status === "processing" ? "In progress" : "Time unavailable")}
             </small>
           </span>
         </header>
 
         <TaskAgentProcess exchange={exchange} id={processId} />
 
-        {exchange.result ? (
-          <section className="task-agent-response" aria-labelledby={resultId}>
-            <h2 id={resultId}>{exchange.result.title}</h2>
-            <p>{exchange.result.summary}</p>
-            {exchange.result.items ? (
-              <ul>
-                {exchange.result.items.map((item) => (
-                  <li key={`${item.label}-${item.value}`}>
-                    <span>{item.value}</span>
-                    <small>{item.label}</small>
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-            {exchange.resultObservedAt ? (
+        {exchange.finalAnswer ? (
+          <section className="task-agent-response" aria-label="Agent final answer">
+            {exchange.finalAnswer.blocks.map((block) => {
+              if (block.kind === "paragraph") {
+                return (
+                  <p className="task-answer-paragraph" key={block.text}>
+                    {block.text}
+                  </p>
+                );
+              }
+              return (
+                <ul key={block.items.join("\n")}>
+                  {block.items.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              );
+            })}
+            {exchange.finalAnswerObservedAt ? (
               <p className="task-result-observation">
-                Recorded locally at {exchange.resultObservedAt} · Open Feishu for the authoritative thread
+                Recorded locally at {exchange.finalAnswerObservedAt} · Open Feishu for the authoritative thread
               </p>
             ) : null}
           </section>
@@ -278,7 +250,7 @@ function TaskAgentProcess({ exchange, id }: { exchange: TaskExchange; id: string
   ];
 
   return (
-    <details className="task-agent-process" open>
+    <details className="task-agent-process" open={exchange.status !== "completed"}>
       <summary id={id}>
         <span>{processSummary}</span>
         <Icon name="chevron-right" />

--- a/apps/web/src/mock/task-data.ts
+++ b/apps/web/src/mock/task-data.ts
@@ -19,10 +19,12 @@ export type TaskToolCall = {
 
 export type TaskAgentEvent = TaskReasoningSummary | TaskToolCall;
 
-export type TaskResult = {
-  readonly items?: readonly { readonly label: string; readonly value: string }[];
-  readonly summary: string;
-  readonly title: string;
+export type TaskFinalAnswerBlock =
+  | { readonly kind: "paragraph"; readonly text: string }
+  | { readonly items: readonly string[]; readonly kind: "unordered_list" };
+
+export type TaskFinalAnswer = {
+  readonly blocks: readonly TaskFinalAnswerBlock[];
 };
 
 export type TaskUsage = {
@@ -37,8 +39,8 @@ export type TaskExchange = {
   readonly id: string;
   readonly request: string;
   readonly requestTime: string;
-  readonly result: TaskResult | null;
-  readonly resultObservedAt?: string;
+  readonly finalAnswer: TaskFinalAnswer | null;
+  readonly finalAnswerObservedAt?: string;
   readonly retries: number;
   readonly status: "completed" | "needs_attention" | "processing";
   readonly usage: TaskUsage;
@@ -46,7 +48,6 @@ export type TaskExchange = {
 
 export type TaskPreview = {
   readonly agent: "Atlas" | "Scout";
-  readonly execution: readonly { readonly label: string; readonly value: string }[];
   readonly exchanges: readonly TaskExchange[];
   readonly id: string;
   readonly initiatedBy: string;
@@ -55,10 +56,8 @@ export type TaskPreview = {
     readonly context: string;
     readonly detail: string;
     readonly kind: "feishu";
-    readonly locationLabel: "Channel";
     readonly threadUrl: string;
   };
-  readonly startedAt: string;
   readonly status: TaskStatus;
   readonly title: string;
 };
@@ -72,13 +71,11 @@ export const taskPreviews: readonly TaskPreview[] = [
       kind: "feishu",
       context: "Product Launch",
       detail: "Q3 launch readiness",
-      locationLabel: "Channel",
       threadUrl: "https://www.feishu.cn/",
     },
     status: "recently_completed",
     relativeUpdatedAt: "12 min ago",
     initiatedBy: "Mia Zhang",
-    startedAt: "Aug 24, 11:04 AM",
     exchanges: [
       {
         id: "review-plan",
@@ -125,14 +122,21 @@ export const taskPreviews: readonly TaskPreview[] = [
             status: "completed",
           },
         ],
-        resultObservedAt: "11:12 AM",
-        result: {
-          title: "Launch plan reviewed",
-          summary: "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
-          items: [
-            { label: "Needs owner", value: "Partner announcement copy" },
-            { label: "Needs owner", value: "Customer migration email" },
-            { label: "Date unconfirmed", value: "Security review sign-off" },
+        finalAnswerObservedAt: "11:12 AM",
+        finalAnswer: {
+          blocks: [
+            {
+              kind: "paragraph",
+              text: "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
+            },
+            {
+              kind: "unordered_list",
+              items: [
+                "Partner announcement copy — Needs owner",
+                "Customer migration email — Needs owner",
+                "Security review sign-off — Date unconfirmed",
+              ],
+            },
           ],
         },
       },
@@ -159,23 +163,24 @@ export const taskPreviews: readonly TaskPreview[] = [
             status: "completed",
           },
         ],
-        resultObservedAt: "11:18 AM",
-        result: {
-          title: "Follow-ups drafted",
-          summary:
-            "Three follow-up messages were prepared with suggested owners. No ownership was recorded as confirmed.",
-          items: [
-            { label: "Suggested: Jordan Lee", value: "Partner announcement" },
-            { label: "Suggested: Priya Nair", value: "Migration email" },
-            { label: "Date confirmation requested", value: "Security sign-off" },
+        finalAnswerObservedAt: "11:18 AM",
+        finalAnswer: {
+          blocks: [
+            {
+              kind: "paragraph",
+              text: "Three follow-up messages were prepared with suggested owners. No ownership was recorded as confirmed.",
+            },
+            {
+              kind: "unordered_list",
+              items: [
+                "Partner announcement — Suggested owner: Jordan Lee",
+                "Migration email — Suggested owner: Priya Nair",
+                "Security sign-off — Date confirmation requested",
+              ],
+            },
           ],
         },
       },
-    ],
-    execution: [
-      { label: "Provider", value: "OpenAI" },
-      { label: "Session", value: "Q3 launch readiness" },
-      { label: "Event record", value: "Reasoning summaries and tool calls captured" },
     ],
   },
   {
@@ -186,13 +191,11 @@ export const taskPreviews: readonly TaskPreview[] = [
       kind: "feishu",
       context: "Customer Feedback",
       detail: "Enterprise visit notes",
-      locationLabel: "Channel",
       threadUrl: "https://www.feishu.cn/",
     },
     status: "processing",
     relativeUpdatedAt: "2 min ago",
     initiatedBy: "Noah Liu",
-    startedAt: "Aug 24, 10:42 AM",
     exchanges: [
       {
         id: "group-feedback",
@@ -225,13 +228,8 @@ export const taskPreviews: readonly TaskPreview[] = [
             status: "in_progress",
           },
         ],
-        result: null,
+        finalAnswer: null,
       },
-    ],
-    execution: [
-      { label: "Provider", value: "Anthropic" },
-      { label: "Session", value: "Enterprise visit notes" },
-      { label: "Event record", value: "Live provider events" },
     ],
   },
   {
@@ -242,13 +240,11 @@ export const taskPreviews: readonly TaskPreview[] = [
       kind: "feishu",
       context: "Engineering Collaboration",
       detail: "Onboarding process review",
-      locationLabel: "Channel",
       threadUrl: "https://www.feishu.cn/",
     },
     status: "needs_attention",
     relativeUpdatedAt: "25 min ago",
     initiatedBy: "Olivia Sun",
-    startedAt: "Aug 24, 10:18 AM",
     exchanges: [
       {
         id: "review-onboarding",
@@ -282,22 +278,20 @@ export const taskPreviews: readonly TaskPreview[] = [
             status: "requires_attention",
           },
         ],
-        resultObservedAt: "10:29 AM",
-        result: {
-          title: "Two source documents are missing",
-          summary:
-            "The review is paused because the access checklist and security orientation steps are not available.",
-          items: [
-            { label: "Missing input", value: "Access provisioning checklist" },
-            { label: "Missing input", value: "Security orientation guide" },
+        finalAnswerObservedAt: "10:29 AM",
+        finalAnswer: {
+          blocks: [
+            {
+              kind: "paragraph",
+              text: "The review is paused because the access checklist and security orientation steps are not available.",
+            },
+            {
+              kind: "unordered_list",
+              items: ["Access provisioning checklist — Missing input", "Security orientation guide — Missing input"],
+            },
           ],
         },
       },
-    ],
-    execution: [
-      { label: "Provider", value: "OpenAI" },
-      { label: "Session", value: "Onboarding process review" },
-      { label: "Event record", value: "Provider events captured; source access incomplete" },
     ],
   },
 ];


### PR DESCRIPTION
## Summary

- model Task final answers as ordered content blocks instead of synthetic title/summary/table fields
- render answers as a single reading column and remove the redundant Task details footer
- keep provider-native reasoning/tool events available behind compact disclosures, with completed runs collapsed by default
- preserve live and needs-attention process visibility, provenance, Feishu authority, and responsive layout

## Testing

- `pnpm check` (passes with 8 existing undeclared E2E environment warnings)
- `pnpm build`
- `pnpm typecheck`
- Task component, route, and layout Vitest suites
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (268 tests, 100% coverage)
- desktop and 390px mobile Playwright visual QA against the approved mock
- `pnpm test` (Task/Web tests pass; local run hits the existing RuntimeSession observability race)
- `pnpm test:coverage` (Task/Web tests pass; local macOS run also hits existing `/var` vs `/private/var` assertions and the same observability race)

## Breaking changes

None. Mock UI data only.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (`pnpm test` is blocked locally by the existing server observability race; CI will validate on Linux.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.