### PR TITLE
feat(web): refine Agent overview cards

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -42,6 +42,7 @@ function installApi(
     agentRead?: () => Promise<void> | void;
     agentReadStatus?: () => number | undefined;
     agentListStatus?: () => number | undefined;
+    agentActivity?: { state: "idle" } | { state: "working"; startedAt: string; summary: string };
     emptyAgents?: boolean;
     agentCreate?: (input: Record<string, unknown>) => Promise<void> | void;
     alreadyJoinedInvitation?: boolean;
@@ -281,12 +282,14 @@ function installApi(
               path.includes(invitedTeamId)
                 ? {
                     ...agentListItem,
+                    activity: options.agentActivity ?? agentListItem.activity,
                     teamId: invitedTeamId,
                     status: lifecycleStatus,
                     runtimeProvider: options.runtimeProvider ?? agentListItem.runtimeProvider,
                   }
                 : {
                     ...agentListItem,
+                    activity: options.agentActivity ?? agentListItem.activity,
                     status: lifecycleStatus,
                     runtimeProvider: options.runtimeProvider ?? agentListItem.runtimeProvider,
                   },
@@ -606,7 +609,8 @@ describe("OpenTag Web App Shell", () => {
     expect(createAgent.closest(".page-header")).toBeTruthy();
     const agentCard = agentLink.closest(".agent-card");
     expect(agentCard).toBeTruthy();
-    expect(screen.getByText("Usage · Last 30 days")).toBeTruthy();
+    expect(screen.getByText("Monitor availability and 30-day usage across your AI teammates.")).toBeTruthy();
+    expect(screen.queryByText("Usage · Last 30 days")).toBeNull();
     expect(within(agentCard as HTMLElement).getByText("Tasks")).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("Tokens")).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("428K")).toBeTruthy();
@@ -622,6 +626,25 @@ describe("OpenTag Web App Shell", () => {
     const navigationIcons = workspaceNavigation.querySelectorAll(".primary-nav-icon");
     expect(navigationIcons).toHaveLength(5);
     expect(Array.from(navigationIcons).every((icon) => icon.getAttribute("aria-hidden") === "true")).toBe(true);
+  });
+
+  it("shows the current task and elapsed time for a working Agent", async () => {
+    installApi("admin", {
+      agentActivity: {
+        state: "working",
+        startedAt: new Date(Date.now() - 8 * 60_000).toISOString(),
+        summary: "Review PR #127",
+      },
+      bound: true,
+      handoffReady: true,
+    });
+    render(<App />);
+
+    const agentCard = (await screen.findByRole("link", { name: "Open Reviewer" })).closest(".agent-card");
+    expect(agentCard).toBeTruthy();
+    expect(within(agentCard as HTMLElement).getByText("Working")).toBeTruthy();
+    expect(within(agentCard as HTMLElement).getByText("Review PR #127")).toBeTruthy();
+    expect(within(agentCard as HTMLElement).getByText("Started 8m ago")).toBeTruthy();
   });
 
   it.each(["/", "/agents"])("redirects unauthenticated protected path %s to login", async (path) => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -42,7 +42,7 @@ function installApi(
     agentRead?: () => Promise<void> | void;
     agentReadStatus?: () => number | undefined;
     agentListStatus?: () => number | undefined;
-    agentActivity?: { state: "idle" } | { state: "working"; startedAt: string; summary: string };
+    agentActivity?: { state: "idle" } | { state: "working"; startedAt: string };
     emptyAgents?: boolean;
     agentCreate?: (input: Record<string, unknown>) => Promise<void> | void;
     alreadyJoinedInvitation?: boolean;
@@ -628,12 +628,11 @@ describe("OpenTag Web App Shell", () => {
     expect(Array.from(navigationIcons).every((icon) => icon.getAttribute("aria-hidden") === "true")).toBe(true);
   });
 
-  it("shows the current task and elapsed time for a working Agent", async () => {
+  it("shows elapsed time without exposing conversation content for a working Agent", async () => {
     installApi("admin", {
       agentActivity: {
         state: "working",
         startedAt: new Date(Date.now() - 8 * 60_000).toISOString(),
-        summary: "Review PR #127",
       },
       bound: true,
       handoffReady: true,
@@ -643,7 +642,6 @@ describe("OpenTag Web App Shell", () => {
     const agentCard = (await screen.findByRole("link", { name: "Open Reviewer" })).closest(".agent-card");
     expect(agentCard).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("Working")).toBeTruthy();
-    expect(within(agentCard as HTMLElement).getByText("Review PR #127")).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("Started 8m ago")).toBeTruthy();
   });
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1058,7 +1058,7 @@ function AgentsPage() {
     <>
       <Page
         title="Agents"
-        description="Monitor availability, output, and usage across your AI teammates."
+        description="Monitor availability and 30-day usage across your AI teammates."
         action={
           membership.role === "admin" ? (
             <Button ref={createTriggerRef} size="compact" variant="outline" onClick={() => setCreateOpen(true)}>
@@ -1096,9 +1096,6 @@ function AgentList({ agents }: { agents: AgentListItem[] }) {
   );
   return (
     <section className="agent-list-section" aria-label="Agents">
-      <div className="agent-usage-caption">
-        <span>Usage · Last 30 days</span>
-      </div>
       <div className="agent-card-grid">
         {sortedAgents.map((agent) => (
           <AgentCard agent={agent} key={agent.id} />
@@ -1110,7 +1107,6 @@ function AgentList({ agents }: { agents: AgentListItem[] }) {
 
 function AgentCard({ agent }: { agent: AgentListItem }) {
   const status = agentCardStatus(agent);
-  const tokenAverage = agent.usage.tasks > 0 ? agent.usage.tokens / agent.usage.tasks : 0;
   return (
     <article className="agent-card" data-tone={status.tone}>
       <div className="agent-card-identity">
@@ -1120,31 +1116,39 @@ function AgentCard({ agent }: { agent: AgentListItem }) {
         <div className="agent-card-identity-copy">
           <strong>{agent.displayName}</strong>
           <small>@{agent.name}</small>
-          <StatusIndicator detail={status.detail} label={status.label} tone={status.tone} />
-          {status.reconnect ? (
-            <Link
-              className={buttonClassName({ className: "agent-reconnect", size: "compact", variant: "outline" })}
-              to={`/agents/${agent.id}/runtime`}
-            >
-              Reconnect
-            </Link>
-          ) : null}
         </div>
+      </div>
+      <div className="agent-card-state">
+        <StatusIndicator label={status.label} tone={status.tone} />
+        {agent.activity.state === "working" && status.label === "Working" ? (
+          <div className="agent-current-work">
+            <span>{agent.activity.summary}</span>
+            <small>Started {formatElapsedCompact(agent.activity.startedAt)} ago</small>
+          </div>
+        ) : status.detail ? (
+          <small className="agent-state-detail">{status.detail}</small>
+        ) : null}
+        {status.reconnect ? (
+          <Link
+            className={buttonClassName({ className: "agent-reconnect", size: "compact", variant: "outline" })}
+            to={`/agents/${agent.id}/runtime`}
+          >
+            Reconnect
+          </Link>
+        ) : null}
       </div>
       <dl className="agent-card-usage">
         <div>
           <dt>Tasks</dt>
           <dd>{formatUsageNumber(agent.usage.tasks)}</dd>
-          {agent.usage.failed > 0 ? <small className="agent-usage-failed">{agent.usage.failed} failed</small> : null}
         </div>
         <div>
           <dt>Tokens</dt>
           <dd>{formatUsageNumber(agent.usage.tokens)}</dd>
-          {tokenAverage > 0 ? <small>{formatUsageNumber(tokenAverage)} / task</small> : null}
         </div>
       </dl>
       <Link aria-label={`Open ${agent.displayName}`} className="agent-card-action" to={`/agents/${agent.id}/general`}>
-        View details <Icon name="chevron-right" />
+        <Icon name="chevron-right" />
       </Link>
     </article>
   );
@@ -1187,10 +1191,9 @@ function agentCardStatus(agent: AgentListItem): {
   }
   if (agent.activity.state === "working") {
     return {
-      detail: `Started ${formatElapsedCompact(agent.activity.startedAt)} ago`,
       label: "Working",
       priority: 2,
-      tone: "info",
+      tone: "success",
     };
   }
   return { label: "Ready", priority: 3, tone: "success" };

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1122,8 +1122,7 @@ function AgentCard({ agent }: { agent: AgentListItem }) {
         <StatusIndicator label={status.label} tone={status.tone} />
         {agent.activity.state === "working" && status.label === "Working" ? (
           <div className="agent-current-work">
-            <span>{agent.activity.summary}</span>
-            <small>Started {formatElapsedCompact(agent.activity.startedAt)} ago</small>
+            <span>Started {formatElapsedCompact(agent.activity.startedAt)} ago</span>
           </div>
         ) : status.detail ? (
           <small className="agent-state-detail">{status.detail}</small>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -924,19 +924,6 @@ pre {
 .agent-list-section {
   display: grid;
   width: 100%;
-  gap: 10px;
-}
-
-.agent-usage-caption {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 112px 142px 112px;
-  color: var(--muted);
-  font-size: var(--text-meta);
-}
-
-.agent-usage-caption span {
-  grid-column: 2 / 4;
-  justify-self: center;
 }
 
 .agent-card-grid {
@@ -947,28 +934,28 @@ pre {
 .agent-card {
   display: grid;
   min-width: 0;
-  min-height: 132px;
+  min-height: 126px;
   align-items: center;
-  gap: 20px;
-  grid-template-columns: minmax(0, 1fr) minmax(220px, 254px) 92px;
+  gap: 28px;
+  grid-template-columns: minmax(250px, 1.15fr) minmax(220px, 1fr) minmax(190px, 0.7fr) 24px;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-radius: 12px;
   background: var(--surface);
   color: inherit;
-  padding: 20px 22px;
+  padding: 22px 24px;
   transition:
-    border-color 130ms ease,
-    background-color 130ms ease;
+    border-color 180ms ease,
+    background-color 180ms ease;
 }
 
+.agent-card:hover,
 .agent-card:focus-within {
   border-color: var(--strong-border);
-  background: var(--surface-soft);
+  background: color-mix(in srgb, var(--surface) 92%, var(--surface-soft));
 }
 
 .agent-card[data-tone="warning"] {
   border-color: #e8c48d;
-  background: #fffaf0;
 }
 
 .agent-card-identity {
@@ -1033,39 +1020,54 @@ pre {
 }
 
 .agent-card-identity-copy > small {
-  margin-top: 2px;
+  margin-top: 4px;
   color: var(--muted);
   font-size: var(--text-meta);
 }
 
-.agent-card .ds-status {
-  margin-top: 9px;
-  align-items: center;
-}
-
-.agent-card .ds-status__dot {
-  margin-top: 0;
-}
-
-.agent-card .ds-status__copy {
-  display: flex;
+.agent-card-state {
+  display: grid;
   min-width: 0;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0 5px;
+  align-items: center;
+  justify-items: start;
+  gap: 7px;
 }
 
-.agent-card .ds-status__copy small {
+.agent-card-state .ds-status__dot {
   margin-top: 0;
 }
 
-.agent-card .ds-status__copy small::before {
-  margin-right: 5px;
-  content: "·";
+.agent-card-state .ds-status__copy strong {
+  font-size: var(--text-ui);
 }
 
-.agent-card[data-tone="warning"] .ds-status__copy strong,
-.agent-usage-failed {
+.agent-current-work,
+.agent-state-detail {
+  color: var(--muted);
+  font-size: var(--text-meta);
+  line-height: var(--lh-prose);
+}
+
+.agent-current-work span,
+.agent-current-work small {
+  display: block;
+}
+
+.agent-current-work span {
+  overflow: hidden;
+  max-width: 32ch;
+  color: var(--secondary-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-current-work small {
+  margin-top: 1px;
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
+.agent-card[data-tone="warning"] .ds-status__copy strong {
   color: var(--warning);
 }
 
@@ -1079,7 +1081,7 @@ pre {
 
 .agent-reconnect {
   width: fit-content;
-  margin-top: 9px;
+  margin-top: 2px;
   text-decoration: none;
 }
 
@@ -1087,33 +1089,24 @@ pre {
   display: grid;
   min-width: 0;
   margin: 0;
-  border-left: 1px solid var(--border);
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .agent-card-usage div {
   min-width: 0;
-  min-height: 76px;
-  padding: 4px 16px;
-  border-right: 1px solid var(--border);
+  padding: 0 12px;
 }
 
-.agent-card-usage small {
-  display: block;
-  min-height: 1.45em;
-  margin-top: 3px;
-  color: var(--muted);
-  font-size: var(--text-meta);
-  font-variant-numeric: tabular-nums;
+.agent-card-usage div:first-child {
+  padding-left: 0;
 }
 
 .agent-card-action {
   display: inline-flex;
   align-items: center;
-  align-self: end;
-  justify-self: end;
-  gap: 6px;
-  color: var(--brand-ink);
+  align-self: center;
+  justify-self: center;
+  color: var(--foreground);
   font-size: var(--text-meta);
   font-weight: var(--fw-semibold);
   text-decoration: none;
@@ -1121,8 +1114,8 @@ pre {
 }
 
 .agent-card-action .ds-icon {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
 }
 
 .cell-stack strong,
@@ -1458,6 +1451,7 @@ dd {
   font-variant-numeric: tabular-nums;
   font-weight: var(--fw-medium);
   letter-spacing: var(--track-tight);
+  white-space: nowrap;
 }
 
 .empty-state {
@@ -4156,17 +4150,16 @@ textarea:focus {
     grid-template-columns: 1fr;
   }
 
-  .agent-usage-caption {
-    display: block;
-    text-align: right;
-  }
-
   .agent-card {
     align-items: end;
     grid-template-columns: minmax(0, 1fr);
   }
 
   .agent-card-identity {
+    grid-column: 1;
+  }
+
+  .agent-card-state {
     grid-column: 1;
   }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3874,6 +3874,35 @@ textarea:focus {
   }
 }
 
+@media (max-width: 1180px) {
+  .agent-card {
+    min-height: 140px;
+    gap: 10px 24px;
+    grid-template-columns: minmax(0, 1fr) minmax(190px, 0.6fr) 24px;
+    grid-template-rows: auto auto;
+  }
+
+  .agent-card-identity {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .agent-card-state {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .agent-card-usage {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+  }
+
+  .agent-card-action {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+  }
+}
+
 @media (max-width: 900px) {
   .shell {
     grid-template-columns: minmax(0, 1fr);
@@ -4153,23 +4182,28 @@ textarea:focus {
   .agent-card {
     align-items: end;
     grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto;
   }
 
   .agent-card-identity {
     grid-column: 1;
+    grid-row: auto;
   }
 
   .agent-card-state {
     grid-column: 1;
+    grid-row: auto;
   }
 
   .agent-card-usage {
     width: 100%;
     grid-column: 1;
+    grid-row: auto;
   }
 
   .agent-card-action {
     grid-column: 1;
+    grid-row: auto;
   }
 
   .overview-section .definition-list {

--- a/packages/server/src/__tests__/integration/agents.test.ts
+++ b/packages/server/src/__tests__/integration/agents.test.ts
@@ -286,8 +286,8 @@ describe("Agent persistence and authorization", () => {
             authorExternalId: "U_HUMAN",
             content: {
               version: 1 as const,
-              fallbackText: suffix,
-              blocks: [{ type: "text" as const, text: suffix }],
+              fallbackText: suffix === "working" ? "Review PR #127" : suffix,
+              blocks: [{ type: "text" as const, text: suffix === "working" ? "Review PR #127" : suffix }],
               truncated: false,
             },
             occurredAt: new Date(now.getTime() - (index + 1) * 60_000),
@@ -353,7 +353,11 @@ describe("Agent persistence and authorization", () => {
         agents: [
           {
             id: created.id,
-            activity: { state: "working", startedAt: workingAcceptedAt.toISOString() },
+            activity: {
+              state: "working",
+              startedAt: workingAcceptedAt.toISOString(),
+              summary: "Review PR #127",
+            },
             usage: { windowDays: 30, tasks: 2, failed: 1, tokens },
           },
         ],

--- a/packages/server/src/__tests__/integration/agents.test.ts
+++ b/packages/server/src/__tests__/integration/agents.test.ts
@@ -349,19 +349,21 @@ describe("Agent persistence and authorization", () => {
       ]);
 
       const service = new AgentService(value.database, { now: () => now });
-      await expect(service.listForTeam(value.bootstrap.userId, value.bootstrap.teamId)).resolves.toMatchObject({
+      const projectedAgents = await service.listForTeam(value.bootstrap.userId, value.bootstrap.teamId);
+      expect(projectedAgents).toMatchObject({
         agents: [
           {
             id: created.id,
             activity: {
               state: "working",
               startedAt: workingAcceptedAt.toISOString(),
-              summary: "Review PR #127",
             },
             usage: { windowDays: 30, tasks: 2, failed: 1, tokens },
           },
         ],
       });
+      expect(projectedAgents.agents[0]?.activity).not.toHaveProperty("summary");
+      expect(JSON.stringify(projectedAgents)).not.toContain("Review PR #127");
 
       await value.database.update(sessions).set({ endedAt: now }).where(eq(sessions.id, session.id));
       await expect(service.listForTeam(value.bootstrap.userId, value.bootstrap.teamId)).resolves.toMatchObject({

--- a/packages/server/src/services/agents/agent-service.ts
+++ b/packages/server/src/services/agents/agent-service.ts
@@ -26,6 +26,7 @@ import {
   computers,
   imBindings,
   imMessageDeliveries,
+  imMessages,
   memberships,
   sessionPlacements,
   sessions,
@@ -61,6 +62,13 @@ interface AgentSafeRow {
   status: AgentRow["status"];
   createdAt: Date;
   updatedAt: Date;
+}
+
+function summarizeCurrentWork(value: string): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return "Task in progress";
+  const characters = Array.from(normalized);
+  return characters.length <= 160 ? normalized : `${characters.slice(0, 159).join("")}…`;
 }
 
 export interface AgentSessionStopTarget {
@@ -376,6 +384,7 @@ export class AgentService {
         agentId: imBindings.agentId,
         cachedInputTokens: sql<string | null>`${imMessageDeliveries.turnReport} #>> '{usage,cachedInputTokens}'`,
         inputTokens: sql<string | null>`${imMessageDeliveries.turnReport} #>> '{usage,inputTokens}'`,
+        messageContent: imMessages.content,
         outcome: sql<string | null>`${imMessageDeliveries.turnReport} ->> 'outcome'`,
         outputTokens: sql<string | null>`${imMessageDeliveries.turnReport} #>> '{usage,outputTokens}'`,
         reportedAt: imMessageDeliveries.reportedAt,
@@ -384,6 +393,7 @@ export class AgentService {
         state: imMessageDeliveries.state,
       })
       .from(imMessageDeliveries)
+      .innerJoin(imMessages, eq(imMessages.id, imMessageDeliveries.messageId))
       .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
       .innerJoin(imBindings, eq(imBindings.id, sessions.imBindingId))
       .where(
@@ -400,7 +410,7 @@ export class AgentService {
       );
 
     const usageByAgent = new Map<string, { failed: number; tasks: number; tokens: number }>();
-    const workingByAgent = new Map<string, Date>();
+    const workingByAgent = new Map<string, { startedAt: Date; summary: string }>();
     const runtimeProviderByAgent = new Map(summaries.map((agent) => [agent.id, agent.runtimeProvider]));
     for (const row of activityRows) {
       if (
@@ -411,7 +421,12 @@ export class AgentService {
         row.sessionEndedAt === null
       ) {
         const current = workingByAgent.get(row.agentId);
-        if (!current || row.acceptedAt > current) workingByAgent.set(row.agentId, row.acceptedAt);
+        if (!current || row.acceptedAt > current.startedAt) {
+          workingByAgent.set(row.agentId, {
+            startedAt: row.acceptedAt,
+            summary: summarizeCurrentWork(row.messageContent.fallbackText),
+          });
+        }
       }
       if (!row.acceptedAt || row.acceptedAt < usageStartedAt) continue;
       const usage = usageByAgent.get(row.agentId) ?? { failed: 0, tasks: 0, tokens: 0 };
@@ -428,10 +443,16 @@ export class AgentService {
     return {
       agents: summaries.map((agent): AgentListItem => {
         const usage = usageByAgent.get(agent.id) ?? { failed: 0, tasks: 0, tokens: 0 };
-        const startedAt = workingByAgent.get(agent.id);
+        const currentWork = workingByAgent.get(agent.id);
         return {
           ...agent,
-          activity: startedAt ? { state: "working", startedAt: startedAt.toISOString() } : { state: "idle" },
+          activity: currentWork
+            ? {
+                state: "working",
+                startedAt: currentWork.startedAt.toISOString(),
+                summary: currentWork.summary,
+              }
+            : { state: "idle" },
           usage: { windowDays: AGENT_USAGE_WINDOW_DAYS, ...usage },
         };
       }),

--- a/packages/server/src/services/agents/agent-service.ts
+++ b/packages/server/src/services/agents/agent-service.ts
@@ -26,7 +26,6 @@ import {
   computers,
   imBindings,
   imMessageDeliveries,
-  imMessages,
   memberships,
   sessionPlacements,
   sessions,
@@ -62,13 +61,6 @@ interface AgentSafeRow {
   status: AgentRow["status"];
   createdAt: Date;
   updatedAt: Date;
-}
-
-function summarizeCurrentWork(value: string): string {
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (!normalized) return "Task in progress";
-  const characters = Array.from(normalized);
-  return characters.length <= 160 ? normalized : `${characters.slice(0, 159).join("")}…`;
 }
 
 export interface AgentSessionStopTarget {
@@ -384,7 +376,6 @@ export class AgentService {
         agentId: imBindings.agentId,
         cachedInputTokens: sql<string | null>`${imMessageDeliveries.turnReport} #>> '{usage,cachedInputTokens}'`,
         inputTokens: sql<string | null>`${imMessageDeliveries.turnReport} #>> '{usage,inputTokens}'`,
-        messageContent: imMessages.content,
         outcome: sql<string | null>`${imMessageDeliveries.turnReport} ->> 'outcome'`,
         outputTokens: sql<string | null>`${imMessageDeliveries.turnReport} #>> '{usage,outputTokens}'`,
         reportedAt: imMessageDeliveries.reportedAt,
@@ -393,7 +384,6 @@ export class AgentService {
         state: imMessageDeliveries.state,
       })
       .from(imMessageDeliveries)
-      .innerJoin(imMessages, eq(imMessages.id, imMessageDeliveries.messageId))
       .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
       .innerJoin(imBindings, eq(imBindings.id, sessions.imBindingId))
       .where(
@@ -410,7 +400,7 @@ export class AgentService {
       );
 
     const usageByAgent = new Map<string, { failed: number; tasks: number; tokens: number }>();
-    const workingByAgent = new Map<string, { startedAt: Date; summary: string }>();
+    const workingByAgent = new Map<string, Date>();
     const runtimeProviderByAgent = new Map(summaries.map((agent) => [agent.id, agent.runtimeProvider]));
     for (const row of activityRows) {
       if (
@@ -420,13 +410,8 @@ export class AgentService {
         row.bindingStatus === "active" &&
         row.sessionEndedAt === null
       ) {
-        const current = workingByAgent.get(row.agentId);
-        if (!current || row.acceptedAt > current.startedAt) {
-          workingByAgent.set(row.agentId, {
-            startedAt: row.acceptedAt,
-            summary: summarizeCurrentWork(row.messageContent.fallbackText),
-          });
-        }
+        const currentStartedAt = workingByAgent.get(row.agentId);
+        if (!currentStartedAt || row.acceptedAt > currentStartedAt) workingByAgent.set(row.agentId, row.acceptedAt);
       }
       if (!row.acceptedAt || row.acceptedAt < usageStartedAt) continue;
       const usage = usageByAgent.get(row.agentId) ?? { failed: 0, tasks: 0, tokens: 0 };
@@ -443,14 +428,13 @@ export class AgentService {
     return {
       agents: summaries.map((agent): AgentListItem => {
         const usage = usageByAgent.get(agent.id) ?? { failed: 0, tasks: 0, tokens: 0 };
-        const currentWork = workingByAgent.get(agent.id);
+        const currentWorkStartedAt = workingByAgent.get(agent.id);
         return {
           ...agent,
-          activity: currentWork
+          activity: currentWorkStartedAt
             ? {
                 state: "working",
-                startedAt: currentWork.startedAt.toISOString(),
-                summary: currentWork.summary,
+                startedAt: currentWorkStartedAt.toISOString(),
               }
             : { state: "idle" },
           usage: { windowDays: AGENT_USAGE_WINDOW_DAYS, ...usage },

--- a/packages/shared/src/__tests__/agent.test.ts
+++ b/packages/shared/src/__tests__/agent.test.ts
@@ -150,12 +150,23 @@ describe("Agent contracts", () => {
         agents: [
           {
             ...summary,
-            activity: { state: "working", startedAt: agent.updatedAt, summary: "Review PR #127" },
+            activity: { state: "working", startedAt: agent.updatedAt },
             usage: { windowDays: 30, tasks: 1, failed: 0, tokens: 0 },
           },
         ],
       }),
-    ).toMatchObject({ agents: [{ activity: { state: "working", summary: "Review PR #127" } }] });
+    ).toMatchObject({ agents: [{ activity: { state: "working", startedAt: agent.updatedAt } }] });
+    expect(() =>
+      ListAgentsResponseSchema.parse({
+        agents: [
+          {
+            ...summary,
+            activity: { state: "working", startedAt: agent.updatedAt, summary: "Private conversation content" },
+            usage: { windowDays: 30, tasks: 1, failed: 0, tokens: 0 },
+          },
+        ],
+      }),
+    ).toThrow();
     expect(AgentDetailSchema.parse({ ...summary, viewerCapabilities: { canManage: false } })).toMatchObject({
       viewerCapabilities: { canManage: false },
     });

--- a/packages/shared/src/__tests__/agent.test.ts
+++ b/packages/shared/src/__tests__/agent.test.ts
@@ -145,6 +145,17 @@ describe("Agent contracts", () => {
       usage: { windowDays: 30, tasks: 3, failed: 1, tokens: 420 },
     };
     expect(ListAgentsResponseSchema.parse({ agents: [listItem] })).toEqual({ agents: [listItem] });
+    expect(
+      ListAgentsResponseSchema.parse({
+        agents: [
+          {
+            ...summary,
+            activity: { state: "working", startedAt: agent.updatedAt, summary: "Review PR #127" },
+            usage: { windowDays: 30, tasks: 1, failed: 0, tokens: 0 },
+          },
+        ],
+      }),
+    ).toMatchObject({ agents: [{ activity: { state: "working", summary: "Review PR #127" } }] });
     expect(AgentDetailSchema.parse({ ...summary, viewerCapabilities: { canManage: false } })).toMatchObject({
       viewerCapabilities: { canManage: false },
     });

--- a/packages/shared/src/agent.ts
+++ b/packages/shared/src/agent.ts
@@ -109,7 +109,6 @@ export const AgentListActivitySchema = z.discriminatedUnion("state", [
     .object({
       state: z.literal("working"),
       startedAt: z.string().datetime(),
-      summary: z.string().min(1).max(160),
     })
     .strict(),
 ]);

--- a/packages/shared/src/agent.ts
+++ b/packages/shared/src/agent.ts
@@ -105,7 +105,13 @@ export const AGENT_USAGE_WINDOW_DAYS = 30;
 
 export const AgentListActivitySchema = z.discriminatedUnion("state", [
   z.object({ state: z.literal("idle") }).strict(),
-  z.object({ state: z.literal("working"), startedAt: z.string().datetime() }).strict(),
+  z
+    .object({
+      state: z.literal("working"),
+      startedAt: z.string().datetime(),
+      summary: z.string().min(1).max(160),
+    })
+    .strict(),
 ]);
 
 export const AgentUsageSummarySchema = z


### PR DESCRIPTION
## Summary

- Rework the Agents overview around identity, actionable status/current work, and the two primary usage metrics: Tasks and Tokens.
- Move the fixed 30-day context into the page description and remove the detached usage caption and secondary per-task/failed statistics.
- Project a bounded current-work summary from the accepted inbound task so Working Agents show what they are doing and when they started.
- Keep recovery actions adjacent to the relevant failure and simplify detail navigation to a compact chevron.

## Testing

Passed:
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- Web suite: 316 tests passed during `pnpm test`
- Shared suite: 71 tests passed during `pnpm test`
- Production browser check at 1440px with Working, Needs attention, and Paused Agents

Attempted full required suites; failures reproduce outside this change:
- `pnpm test`: existing RuntimeSession observability timing assertion expected `stale_connection` but observed `handled`.
- `pnpm --filter @opentag/client test:agent-runtime:coverage`: existing readiness timing assertion observed `checking` before `ready` (the same test passed in the full coverage run).
- `pnpm test:coverage`: 1166/1168 passed; two existing macOS path canonicalization assertions expect `/var/...` while runtime returns `/private/var/...`.

## Breaking changes

The Working activity response adds a bounded `summary` field. Server and consumers using the strict shared response schema should be deployed from the same revision.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (`pnpm test` is blocked by the unrelated baseline failure documented above.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (not applicable).