### PR TITLE
feat(web): refine Agent status cards

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -689,8 +689,31 @@ describe("OpenTag Web App Shell", () => {
 
     const agentCard = (await screen.findByRole("link", { name: "Open Reviewer" })).closest(".agent-card");
     expect(agentCard).toBeTruthy();
-    expect(within(agentCard as HTMLElement).getByText("Working")).toBeTruthy();
-    expect(within(agentCard as HTMLElement).getByText("Started 8m ago")).toBeTruthy();
+    const status = within(agentCard as HTMLElement)
+      .getByText("Working")
+      .closest(".ds-status");
+    expect(status).toBeTruthy();
+    expect(within(status as HTMLElement).getByText("Started 8m ago")).toBeTruthy();
+  });
+
+  it("keeps an offline reason and reconnect action together in the Agent status", async () => {
+    installApi("admin", {
+      bound: true,
+      computerStatus: () => "offline",
+      handoffReady: true,
+    });
+    render(<App />);
+
+    const agentCard = (await screen.findByRole("link", { name: "Open Reviewer" })).closest(".agent-card");
+    expect(agentCard).toBeTruthy();
+    const status = within(agentCard as HTMLElement)
+      .getByText("Needs attention")
+      .closest(".ds-status");
+    expect(status).toBeTruthy();
+    expect(within(status as HTMLElement).getByText("Computer offline")).toBeTruthy();
+    const reconnect = within(status as HTMLElement).getByRole("link", { name: "Reconnect" });
+    expect(reconnect.classList.contains("ds-button--inline")).toBe(true);
+    expect(reconnect.classList.contains("ds-button--outline")).toBe(false);
   });
 
   it.each(["/", "/agents"])("redirects unauthenticated protected path %s to login", async (path) => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1097,8 +1097,29 @@ function AgentList({ agents }: { agents: AgentListItem[] }) {
 
 function AgentCard({ agent }: { agent: AgentListItem }) {
   const status = agentCardStatus(agent);
+  const statusDetail: ReactNode =
+    agent.activity.state === "working" && status.label === "Working" ? (
+      <>Started {formatElapsedCompact(agent.activity.startedAt)} ago</>
+    ) : status.detail ? (
+      status.reconnect ? (
+        <>
+          <span className="agent-state-reason">{status.detail}</span>
+          <span className="agent-state-separator" aria-hidden="true">
+            {" · "}
+          </span>
+          <Link
+            className={buttonClassName({ className: "agent-reconnect", variant: "inline" })}
+            to={`/agents/${agent.id}/runtime`}
+          >
+            Reconnect
+          </Link>
+        </>
+      ) : (
+        status.detail
+      )
+    ) : undefined;
   return (
-    <article className="agent-card" data-tone={status.tone}>
+    <article className="agent-card" data-avatar-tone={agentAvatarTone(agent.id)} data-tone={status.tone}>
       <div className="agent-card-identity">
         <span className="agent-avatar" aria-hidden="true">
           {initials(agent.displayName)}
@@ -1109,22 +1130,7 @@ function AgentCard({ agent }: { agent: AgentListItem }) {
         </div>
       </div>
       <div className="agent-card-state">
-        <StatusIndicator label={status.label} tone={status.tone} />
-        {agent.activity.state === "working" && status.label === "Working" ? (
-          <div className="agent-current-work">
-            <span>Started {formatElapsedCompact(agent.activity.startedAt)} ago</span>
-          </div>
-        ) : status.detail ? (
-          <small className="agent-state-detail">{status.detail}</small>
-        ) : null}
-        {status.reconnect ? (
-          <Link
-            className={buttonClassName({ className: "agent-reconnect", size: "compact", variant: "outline" })}
-            to={`/agents/${agent.id}/runtime`}
-          >
-            Reconnect
-          </Link>
-        ) : null}
+        <StatusIndicator className="agent-card-status" detail={statusDetail} label={status.label} tone={status.tone} />
       </div>
       <dl className="agent-card-usage">
         <div>
@@ -1141,6 +1147,16 @@ function AgentCard({ agent }: { agent: AgentListItem }) {
       </Link>
     </article>
   );
+}
+
+const agentAvatarTones = ["brand", "amber", "blue", "neutral"] as const;
+
+function agentAvatarTone(agentId: string): (typeof agentAvatarTones)[number] {
+  let hash = 0;
+  for (let index = 0; index < agentId.length; index += 1) {
+    hash = (hash * 31 + agentId.charCodeAt(index)) >>> 0;
+  }
+  return agentAvatarTones[hash % agentAvatarTones.length] ?? "brand";
 }
 
 function agentCardStatus(agent: AgentListItem): {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -934,15 +934,15 @@ pre {
 .agent-card {
   display: grid;
   min-width: 0;
-  min-height: 126px;
+  min-height: 112px;
   align-items: center;
-  gap: 28px;
-  grid-template-columns: minmax(250px, 1.15fr) minmax(220px, 1fr) minmax(190px, 0.7fr) 24px;
+  gap: 24px;
+  grid-template-columns: minmax(260px, 1fr) 230px 206px 36px;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: var(--surface);
   color: inherit;
-  padding: 22px 24px;
+  padding: 22px 26px 24px;
   transition:
     border-color 180ms ease,
     background-color 180ms ease;
@@ -955,14 +955,14 @@ pre {
 }
 
 .agent-card[data-tone="warning"] {
-  border-color: #e8c48d;
+  border-color: color-mix(in srgb, var(--border) 70%, #d79744 30%);
 }
 
 .agent-card-identity {
   display: grid;
   min-width: 0;
   align-items: center;
-  grid-template-columns: 52px minmax(0, 1fr);
+  grid-template-columns: 48px minmax(0, 1fr);
   gap: 14px;
 }
 
@@ -979,20 +979,30 @@ pre {
 }
 
 .agent-card .agent-avatar {
-  width: 52px;
-  height: 52px;
-  border-radius: 13px;
-  font-size: var(--text-subsection);
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  font-size: var(--text-ui);
 }
 
-.agent-card[data-tone="warning"] .agent-avatar {
+.agent-card[data-avatar-tone="amber"] .agent-avatar {
   background: #f8e6c8;
   color: var(--warning);
 }
 
-.agent-card[data-tone="info"] .agent-avatar {
+.agent-card[data-avatar-tone="blue"] .agent-avatar {
   background: #e1edf4;
   color: #1f6294;
+}
+
+.agent-card[data-avatar-tone="neutral"] .agent-avatar {
+  background: #e7e8e1;
+  color: var(--secondary-foreground);
+}
+
+.agent-card[data-avatar-tone="brand"] .agent-avatar {
+  background: #dfe9cb;
+  color: var(--brand-ink);
 }
 
 .agent-avatar.large {
@@ -1017,92 +1027,93 @@ pre {
   color: var(--foreground);
   font-size: var(--text-subsection);
   font-weight: var(--fw-semibold);
+  line-height: var(--lh-ui);
 }
 
 .agent-card-identity-copy > small {
-  margin-top: 4px;
+  margin-top: 2px;
   color: var(--muted);
   font-size: var(--text-meta);
+  line-height: var(--lh-ui);
 }
 
 .agent-card-state {
-  display: grid;
-  min-width: 0;
-  align-items: center;
-  justify-items: start;
-  gap: 7px;
-}
-
-.agent-card-state .ds-status__dot {
-  margin-top: 0;
-}
-
-.agent-card-state .ds-status__copy strong {
-  font-size: var(--text-ui);
-}
-
-.agent-current-work,
-.agent-state-detail {
-  color: var(--muted);
-  font-size: var(--text-meta);
-  line-height: var(--lh-prose);
-}
-
-.agent-current-work span,
-.agent-current-work small {
   display: block;
+  min-width: 0;
 }
 
-.agent-current-work span {
-  overflow: hidden;
-  max-width: 32ch;
-  color: var(--secondary-foreground);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.agent-card-status {
+  display: grid;
+  width: 100%;
+  align-items: start;
+  grid-template-columns: 6px minmax(0, 1fr);
+  column-gap: 8px;
 }
 
-.agent-current-work small {
-  margin-top: 1px;
+.agent-card-status .ds-status__dot {
+  margin-top: 6px;
+  box-shadow: none;
+}
+
+.agent-card-status .ds-status__copy strong {
+  font-size: var(--text-ui);
+  line-height: var(--lh-ui);
+}
+
+.agent-card-status .ds-status__copy small {
   color: var(--muted);
   font-size: var(--text-meta);
+  line-height: var(--lh-ui);
+  margin-top: 3px;
+  overflow-wrap: anywhere;
 }
 
-.agent-card[data-tone="warning"] .ds-status__copy strong {
+.agent-card[data-tone="warning"] .agent-card-status .ds-status__copy strong {
   color: var(--warning);
 }
 
-.agent-card[data-tone="info"] .ds-status__copy strong {
+.agent-card[data-tone="info"] .agent-card-status .ds-status__copy strong {
   color: #1f6294;
 }
 
-.agent-card[data-tone="success"] .ds-status__copy strong {
+.agent-card[data-tone="success"] .agent-card-status .ds-status__copy strong {
   color: var(--brand-ink);
 }
 
+.agent-state-separator {
+  color: color-mix(in srgb, var(--muted) 62%, transparent);
+}
+
 .agent-reconnect {
-  width: fit-content;
-  margin-top: 2px;
+  position: relative;
+  display: inline;
+  font-size: var(--text-meta);
+  line-height: var(--lh-ui);
   text-decoration: none;
+  vertical-align: baseline;
+}
+
+.agent-reconnect::before {
+  position: absolute;
+  inset: -8px -6px;
+  content: "";
 }
 
 .agent-card-usage {
   display: grid;
   min-width: 0;
   margin: 0;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 90px 116px;
 }
 
 .agent-card-usage div {
   min-width: 0;
-  padding: 0 12px;
-}
-
-.agent-card-usage div:first-child {
-  padding-left: 0;
 }
 
 .agent-card-action {
   display: inline-flex;
+  width: 36px;
+  height: 36px;
   align-items: center;
   align-self: center;
   justify-self: center;
@@ -1110,12 +1121,22 @@ pre {
   font-size: var(--text-meta);
   font-weight: var(--fw-semibold);
   text-decoration: none;
+  transition: color 180ms ease;
   white-space: nowrap;
 }
 
 .agent-card-action .ds-icon {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
+  transition: transform 180ms ease;
+}
+
+.agent-card-action:hover {
+  color: var(--brand-ink);
+}
+
+.agent-card-action:hover .ds-icon {
+  transform: translateX(1px);
 }
 
 .cell-stack strong,
@@ -1440,8 +1461,9 @@ dd {
 }
 
 .agent-card-usage dt {
-  margin-bottom: 5px;
+  margin-bottom: 4px;
   font-size: var(--text-meta);
+  line-height: var(--lh-ui);
 }
 
 .agent-card-usage dd {
@@ -1451,6 +1473,7 @@ dd {
   font-variant-numeric: tabular-nums;
   font-weight: var(--fw-medium);
   letter-spacing: var(--track-tight);
+  line-height: var(--lh-tight);
   white-space: nowrap;
 }
 
@@ -3876,9 +3899,9 @@ textarea:focus {
 
 @media (max-width: 1180px) {
   .agent-card {
-    min-height: 140px;
-    gap: 10px 24px;
-    grid-template-columns: minmax(0, 1fr) minmax(190px, 0.6fr) 24px;
+    min-height: 132px;
+    gap: 6px 24px;
+    grid-template-columns: minmax(0, 1fr) 206px 36px;
     grid-template-rows: auto auto;
   }
 
@@ -4181,29 +4204,34 @@ textarea:focus {
 
   .agent-card {
     align-items: end;
+    gap: 16px;
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto;
+    grid-template-rows: auto auto auto;
+    padding: 20px;
   }
 
   .agent-card-identity {
     grid-column: 1;
-    grid-row: auto;
+    grid-row: 1;
+    padding-right: 44px;
   }
 
   .agent-card-state {
     grid-column: 1;
-    grid-row: auto;
+    grid-row: 2;
   }
 
   .agent-card-usage {
     width: 100%;
     grid-column: 1;
-    grid-row: auto;
+    grid-row: 3;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .agent-card-action {
     grid-column: 1;
-    grid-row: auto;
+    grid-row: 1;
+    justify-self: end;
   }
 
   .overview-section .definition-list {


### PR DESCRIPTION
## Summary

- refine Agent card spacing and fixed usage columns for a calmer 1–3 Agent workspace
- group status, reason, elapsed time, and inline recovery into one aligned status block
- keep avatar colors stable by Agent identity and improve compact/mobile card layout
- add coverage for Working elapsed time and inline offline recovery

## Validation

- pnpm check
- pnpm typecheck
- pnpm build
- pnpm --filter @opentag/web test (321 passed)
- pnpm --filter @opentag/client test:agent-runtime:coverage (268 passed, 100% coverage)
- Playwright visual checks at 1440px, 1180px, 700px, and 390px with no horizontal overflow

## Local baseline notes

- pnpm test reaches the existing Server observability timing race; all Web tests pass
- pnpm test:coverage reaches the same race plus existing macOS temporary-path/runtime-probe timing failures