### PR TITLE
fix(client): recover capability refresh from hung probes

### DIFF
--- a/packages/client/src/__tests__/agent-runtime-provider-registry.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-provider-registry.test.ts
@@ -158,9 +158,14 @@ describe("AgentRuntimeProviderRegistry", () => {
     expect(probe).toHaveBeenCalledTimes(2);
     expect(providers.isReady("codex")).toBe(true);
 
+    providers.invalidate("codex");
+    expect(providers.isReady("codex")).toBe(false);
+    providers.invalidate("codex");
+    expect(providers.isReady("codex")).toBe(false);
+
     releaseFirst();
     await vi.waitFor(() => expect(firstSettled).toBe(true));
-    expect(providers.isReady("codex")).toBe(true);
+    expect(providers.isReady("codex")).toBe(false);
   });
 
   it("fails closed for missing registrations, artifact verification errors, and caller abort", async () => {

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -17,6 +17,7 @@ import type { AgentRuntime, AgentRuntimeFactory } from "../agent-runtime/types.j
 import { createLogger } from "../observability/logger.js";
 import { claudeCodeRuntimePolicy, validateClaudeCodeRuntimePolicy } from "../providers/claude-code/runtime-policy.js";
 import { CODEX_AGENT_RUNTIME_APP_SERVER_ARGS } from "../providers/codex/agent-runtime.js";
+import { AgentRuntimeProviderRegistry } from "../runtime/agent-runtime-provider-registry.js";
 import {
   ComposedClientRuntime,
   codexProviderReadiness,
@@ -1504,6 +1505,205 @@ describe("createClientRuntime production composition", () => {
     await sawProbe;
     ensureSignal.abort(new Error("stop ensure"));
     await expect(ensuring).rejects.toThrow("stop ensure");
+    runtime.stop();
+  });
+
+  it("does not let a cancelled sole waiter hand its draining owner to a later caller", async () => {
+    const home = await temporaryDirectory("opentag-client-owner-evict-");
+    const connection = runtimeConnection();
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    let releaseOldOwner!: () => void;
+    let oldOwnerReturned = false;
+    const oldOwnerDrain = new Promise<void>((resolveDrain) => {
+      releaseOldOwner = resolveDrain;
+    });
+    const refresh = vi.spyOn(AgentRuntimeProviderRegistry.prototype, "refresh");
+    refresh
+      .mockResolvedValueOnce(false)
+      .mockImplementationOnce(async () => {
+        await oldOwnerDrain;
+        oldOwnerReturned = true;
+        return true;
+      })
+      .mockResolvedValue(true);
+    cleanup.push(async () => {
+      releaseOldOwner();
+      refresh.mockRestore();
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 60_000,
+      providerProbeDeadlineMs: 5_000,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: readyFactory("codex"),
+      home,
+    });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    const firstSignal = new AbortController();
+    const first = runtime.runtimeManager.ensureRuntime("session-1", firstSignal.signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    expect(refresh).toHaveBeenCalledTimes(2);
+    firstSignal.abort(new Error("cancel sole waiter"));
+    await expect(first).resolves.toBe("cancel sole waiter");
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "checking" });
+
+    const second = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(3));
+    await expect(second).resolves.toContain("not used");
+    await expect(second).resolves.not.toContain("has no waiters");
+    await vi.waitFor(() => expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" }));
+    expect(oldOwnerReturned).toBe(false);
+    const published = readinessUpdates.mock.calls.length;
+    releaseOldOwner();
+    await vi.waitFor(() => expect(oldOwnerReturned).toBe(true));
+    await new Promise((resolveWait) => setTimeout(resolveWait, 0));
+    expect(readinessUpdates).toHaveBeenCalledTimes(published);
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" });
+    runtime.stop();
+  });
+
+  it("does not let cancelled-owner cleanup evict or publish over its live successor", async () => {
+    const home = await temporaryDirectory("opentag-client-owner-identity-");
+    const connection = runtimeConnection();
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    let releaseOldOwner!: () => void;
+    let releaseNewOwner!: () => void;
+    let oldOwnerReturned = false;
+    const oldOwnerDrain = new Promise<void>((resolveDrain) => {
+      releaseOldOwner = resolveDrain;
+    });
+    const newOwnerDrain = new Promise<void>((resolveDrain) => {
+      releaseNewOwner = resolveDrain;
+    });
+    const refresh = vi.spyOn(AgentRuntimeProviderRegistry.prototype, "refresh");
+    refresh
+      .mockResolvedValueOnce(false)
+      .mockImplementationOnce(async () => {
+        await oldOwnerDrain;
+        oldOwnerReturned = true;
+        return true;
+      })
+      .mockImplementationOnce(async () => {
+        await newOwnerDrain;
+        return true;
+      })
+      .mockResolvedValue(false);
+    cleanup.push(async () => {
+      releaseOldOwner();
+      releaseNewOwner();
+      refresh.mockRestore();
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 60_000,
+      providerProbeDeadlineMs: 5_000,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: readyFactory("codex"),
+      home,
+    });
+    for (const sessionId of ["session-1", "session-2", "session-3"]) {
+      expect(
+        await runtime.reconciler.reconcile({
+          ...reconcileRequest(connection.computerId, snapshot()),
+          requestId: randomUUID(),
+          sessionId,
+        }),
+      ).toMatchObject({ status: "ready" });
+    }
+
+    const firstSignal = new AbortController();
+    const first = runtime.runtimeManager.ensureRuntime("session-1", firstSignal.signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    expect(refresh).toHaveBeenCalledTimes(2);
+    firstSignal.abort(new Error("cancel old owner"));
+    await expect(first).resolves.toBe("cancel old owner");
+
+    const second = runtime.runtimeManager.ensureRuntime("session-2", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(3));
+    releaseOldOwner();
+    await vi.waitFor(() => expect(oldOwnerReturned).toBe(true));
+    await new Promise((resolveWait) => setTimeout(resolveWait, 0));
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "checking" });
+
+    const third = runtime.runtimeManager.ensureRuntime("session-3", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await new Promise((resolveWait) => setTimeout(resolveWait, 0));
+    expect(refresh).toHaveBeenCalledTimes(3);
+    releaseNewOwner();
+    await expect(Promise.all([second, third])).resolves.toEqual([
+      expect.stringContaining("not used"),
+      expect.stringContaining("not used"),
+    ]);
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" });
+    runtime.stop();
+  });
+
+  it("starts a fresh owner after the previous cancelled owner has already drained", async () => {
+    const home = await temporaryDirectory("opentag-client-owner-drained-");
+    const connection = runtimeConnection();
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    let releaseHung!: () => void;
+    const hung = new Promise<void>((resolveHung) => {
+      releaseHung = resolveHung;
+    });
+    const probe = vi.fn(async ({ signal }: { signal?: AbortSignal }) => {
+      if (probe.mock.calls.length === 1) {
+        return {
+          ready: false as const,
+          issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
+        };
+      }
+      if (probe.mock.calls.length === 2) {
+        await hung;
+        if (signal?.aborted) throw signal.reason ?? new Error("aborted");
+        return { ready: true as const, issues: [] };
+      }
+      return { ready: true as const, issues: [] };
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 60_000,
+      providerProbeDeadlineMs: 5_000,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: readyFactory("codex", probe),
+      home,
+    });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    const firstSignal = new AbortController();
+    const first = runtime.runtimeManager.ensureRuntime("session-1", firstSignal.signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2));
+    firstSignal.abort(new Error("cancel before drain"));
+    await expect(first).resolves.toBe("cancel before drain");
+    releaseHung();
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "checking" });
+
+    const second = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await expect(second).resolves.toContain("not used");
+    expect(probe).toHaveBeenCalledTimes(3);
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" });
     runtime.stop();
   });
 

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -1203,35 +1203,26 @@ describe("createClientRuntime production composition", () => {
     runtime.stop();
   });
 
-  it("does not let a stale periodic deadline overwrite a newer shared Provider probe", async () => {
-    const home = await temporaryDirectory("opentag-client-stale-deadline-");
+  it("publishes a shared probe success after a newer waiter cancels", async () => {
+    const home = await temporaryDirectory("opentag-client-shared-cancel-");
     const server = await runtimeServer();
     cleanup.push(server.close);
     const connection = runtimeConnection(server.url);
     const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
-    let probeStarted!: () => void;
-    const started = new Promise<void>((resolveStarted) => {
-      probeStarted = resolveStarted;
+    const heartbeats: Array<Record<string, unknown>> = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      release = resolveGate;
     });
-    let releaseProbe!: () => void;
-    const gate = new Promise<void>((resolveProbe) => {
-      releaseProbe = resolveProbe;
-    });
-    cleanup.push(async () => releaseProbe());
-    let probeCount = 0;
-    const factory = readyFactory("codex", async () => {
-      probeCount += 1;
-      if (probeCount === 1) {
+    const probe = vi.fn(async () => {
+      if (probe.mock.calls.length === 1) {
         return {
-          ready: false,
+          ready: false as const,
           issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
         };
       }
-      if (probeCount === 2) {
-        probeStarted();
-        await gate;
-      }
-      return { ready: true, issues: [] };
+      await gate;
+      return { ready: true as const, issues: [] };
     });
     server.wss.on("connection", (socket) => {
       socket.on("message", (data) => {
@@ -1245,6 +1236,7 @@ describe("createClientRuntime production composition", () => {
           return;
         }
         if (frame.type === "heartbeat") {
+          heartbeats.push(frame);
           socket.send(
             JSON.stringify({
               type: "heartbeat:result",
@@ -1257,36 +1249,198 @@ describe("createClientRuntime production composition", () => {
       });
     });
     const runtime = await createClientRuntime(connection, {
-      capabilityRefreshIntervalMs: 20,
+      capabilityRefreshIntervalMs: 60_000,
+      providerProbeDeadlineMs: 5_000,
       clientVersion: "0.0.1",
       environment: { HOME: home, PATH: process.env.PATH },
-      factory,
+      factory: readyFactory("codex", probe),
       home,
-      providerProbeDeadlineMs: 100,
+    });
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "unavailable" });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    expect(
+      await runtime.reconciler.reconcile({
+        ...reconcileRequest(connection.computerId, snapshot()),
+        requestId: randomUUID(),
+        sessionId: "session-2",
+      }),
+    ).toMatchObject({ status: "ready" });
+    const running = runtime.run();
+    await vi.waitFor(() => expect(heartbeats.length).toBeGreaterThan(0));
+    const ownerSignal = new AbortController();
+    const owner = runtime.runtimeManager.ensureRuntime("session-1", ownerSignal.signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2));
+    const joinedSignal = new AbortController();
+    const joined = runtime.runtimeManager.ensureRuntime("session-2", joinedSignal.signal);
+    const joinedResult = joined.then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    joinedSignal.abort(new Error("cancel joined waiter"));
+    await expect(joinedResult).resolves.toBe("cancel joined waiter");
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "checking" });
+    expect(probe).toHaveBeenCalledTimes(2);
+    const heartbeatsBeforeReady = heartbeats.length;
+    release();
+    await vi.waitFor(() => expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" }));
+    await expect(owner).resolves.toContain("not used");
+    await vi.waitFor(() => {
+      const afterReady = heartbeats.slice(heartbeatsBeforeReady);
+      expect(
+        afterReady.some((heartbeat) =>
+          ((heartbeat.providerReadiness as Array<{ provider: string; status: string }> | undefined) ?? []).some(
+            (observation) => observation.provider === "codex" && observation.status === "ready",
+          ),
+        ),
+      ).toBe(true);
+    });
+    const onDemand = runtime.runtimeManager.ensureRuntime("session-2", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await expect(onDemand).resolves.toContain("not used");
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" });
+    runtime.stop();
+    await expect(running).resolves.toBeUndefined();
+  });
+
+  it("keeps a completed shared ready publication if a waiter cancels afterwards", async () => {
+    const home = await temporaryDirectory("opentag-client-complete-before-cancel-");
+    const connection = runtimeConnection();
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    let release!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      release = resolveGate;
+    });
+    const probe = vi.fn(async () => {
+      if (probe.mock.calls.length === 1) {
+        return {
+          ready: false as const,
+          issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
+        };
+      }
+      await gate;
+      return { ready: true as const, issues: [] };
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 60_000,
+      providerProbeDeadlineMs: 5_000,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: readyFactory("codex", probe),
+      home,
     });
     expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
       status: "ready",
     });
-    readinessUpdates.mockClear();
-    const running = runtime.run();
-    await started;
-    await new Promise((resolveWait) => setTimeout(resolveWait, 60));
-    const ensuring = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal).then(
+    expect(
+      await runtime.reconciler.reconcile({
+        ...reconcileRequest(connection.computerId, snapshot()),
+        requestId: randomUUID(),
+        sessionId: "session-2",
+      }),
+    ).toMatchObject({ status: "ready" });
+    const owner = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal).then(
       () => "created",
       (error: unknown) => (error instanceof Error ? error.message : String(error)),
     );
-    await new Promise((resolveWait) => setTimeout(resolveWait, 60));
-
-    expect(readinessUpdates.mock.calls.map(([observation]) => observation)).not.toContainEqual({
-      provider: "codex",
-      status: "unavailable",
-    });
-    releaseProbe();
-    await expect(ensuring).resolves.toContain("not used");
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2));
+    const joinedSignal = new AbortController();
+    const joined = runtime.runtimeManager.ensureRuntime("session-2", joinedSignal.signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    release();
     await vi.waitFor(() => expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" }));
-
+    await expect(Promise.all([owner, joined])).resolves.toEqual([
+      expect.stringContaining("not used"),
+      expect.stringContaining("not used"),
+    ]);
+    const published = readinessUpdates.mock.calls.length;
+    joinedSignal.abort(new Error("cancel after completion"));
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+    expect(readinessUpdates).toHaveBeenCalledTimes(published);
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" });
     runtime.stop();
-    await expect(running).resolves.toBeUndefined();
+  });
+
+  it("does not let a joined waiter extend the shared owner deadline or a late probe overwrite a newer result", async () => {
+    const home = await temporaryDirectory("opentag-client-stale-deadline-");
+    const connection = runtimeConnection();
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    let releaseHung!: () => void;
+    const hung = new Promise<void>((resolveHung) => {
+      releaseHung = resolveHung;
+    });
+    cleanup.push(async () => releaseHung());
+    const probe = vi.fn(async () => {
+      if (probe.mock.calls.length === 1) {
+        return {
+          ready: false as const,
+          issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
+        };
+      }
+      if (probe.mock.calls.length === 2) {
+        await hung;
+        return { ready: true as const, issues: [] };
+      }
+      return { ready: true as const, issues: [] };
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 60_000,
+      providerProbeDeadlineMs: 40,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: readyFactory("codex", probe),
+      home,
+    });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    expect(
+      await runtime.reconciler.reconcile({
+        ...reconcileRequest(connection.computerId, snapshot()),
+        requestId: randomUUID(),
+        sessionId: "session-2",
+      }),
+    ).toMatchObject({ status: "ready" });
+    const first = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => error,
+    );
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2));
+    const second = runtime.runtimeManager.ensureRuntime("session-2", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => error,
+    );
+    await vi.waitFor(() =>
+      expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "unavailable" }),
+    );
+    expect(probe).toHaveBeenCalledTimes(2);
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ name: "AgentRuntimeProviderUnavailableError" }),
+      expect.objectContaining({ name: "AgentRuntimeProviderUnavailableError" }),
+    ]);
+
+    const fresh = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await vi.waitFor(() => expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" }));
+    await expect(fresh).resolves.toContain("not used");
+    expect(probe).toHaveBeenCalledTimes(3);
+    const published = readinessUpdates.mock.calls.length;
+    releaseHung();
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+    expect(readinessUpdates).toHaveBeenCalledTimes(published);
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" });
+    runtime.stop();
   });
 
   it("does not publish Provider readiness after the caller aborts the Client Runtime", async () => {

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -5,10 +5,11 @@ import type { AddressInfo } from "node:net";
 import { homedir, tmpdir } from "node:os";
 import { delimiter, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type {
-  DirectImMessageDeliveryRequest,
-  EffectiveRuntimeSnapshot,
-  SessionReconcileRequest,
+import {
+  type DirectImMessageDeliveryRequest,
+  type EffectiveRuntimeSnapshot,
+  RUNTIME_CLIENT_CAPABILITY_TTL_MS,
+  type SessionReconcileRequest,
 } from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type WebSocket, WebSocketServer } from "ws";
@@ -75,6 +76,43 @@ describe("createClientRuntime production composition", () => {
       { provider: "slack", status: "checking" },
       { provider: "slack", status: "install" },
     ]);
+
+    const abortedBeforeStart = new AbortController();
+    abortedBeforeStart.abort(new Error("stop before IM probe"));
+    await refreshImCliReadiness({ setImCliReadiness } as never, "feishu", lark, {}, abortedBeforeStart.signal);
+    expect(setImCliReadiness).toHaveBeenCalledTimes(8);
+
+    const abortAfterChecking = new AbortController();
+    const checkingUpdates = vi.fn((observation: { status: string }) => {
+      if (observation.status === "checking") abortAfterChecking.abort(new Error("stop after checking"));
+    });
+    await refreshImCliReadiness(
+      { setImCliReadiness: checkingUpdates } as never,
+      "feishu",
+      lark,
+      {},
+      abortAfterChecking.signal,
+    );
+    expect(checkingUpdates.mock.calls.map(([observation]) => observation)).toEqual([
+      { provider: "feishu", status: "checking" },
+    ]);
+
+    const slowLark = resolve(home, "slow-lark");
+    await writeFile(slowLark, "#!/bin/sh\nsleep 1\nexit 0\n", "utf8");
+    await chmod(slowLark, 0o700);
+    const abortDuringProbe = new AbortController();
+    const inFlightUpdates = vi.fn();
+    const inFlight = refreshImCliReadiness(
+      { setImCliReadiness: inFlightUpdates } as never,
+      "feishu",
+      slowLark,
+      {},
+      abortDuringProbe.signal,
+    );
+    await vi.waitFor(() => expect(inFlightUpdates).toHaveBeenCalledWith({ provider: "feishu", status: "checking" }));
+    abortDuringProbe.abort(new Error("stop during IM probe"));
+    await inFlight;
+    expect(inFlightUpdates).toHaveBeenCalledTimes(1);
   });
 
   it("projects Codex probe outcomes without exposing provider diagnostics", () => {
@@ -97,6 +135,46 @@ describe("createClientRuntime production composition", () => {
         issues: [{ code: "temporarily_unavailable", message: "secret" }],
       }),
     ).toEqual({ provider: "codex", status: "unavailable" });
+  });
+
+  it("rejects invalid Provider probe deadlines before probing", async () => {
+    const home = await temporaryDirectory("opentag-client-probe-deadline-");
+    const probe = vi.fn(async () => ({ ready: true as const, issues: [] }));
+    const factory = readyFactory("codex", probe);
+
+    for (const providerProbeDeadlineMs of [0, 1.5]) {
+      await expect(
+        createClientRuntime(runtimeConnection(), {
+          clientVersion: "0.0.1",
+          environment: { HOME: home, PATH: process.env.PATH },
+          factory,
+          home,
+          providerProbeDeadlineMs,
+        }),
+      ).rejects.toThrow("Agent Runtime provider probe deadline must be a positive safe integer");
+    }
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("propagates unexpected capability publication failures after the bounded refresh settles", async () => {
+    const home = await temporaryDirectory("opentag-client-capability-publication-");
+    const connection = runtimeConnection();
+    const publicationFailure = new Error("readiness publication failed");
+    vi.spyOn(connection, "setProviderReadiness").mockImplementationOnce(() => {
+      throw publicationFailure;
+    });
+
+    await expect(
+      createClientRuntime(connection, {
+        clientVersion: "0.0.1",
+        environment: { HOME: home, PATH: process.env.PATH },
+        factory: readyFactory("codex"),
+        home,
+      }),
+    ).rejects.toMatchObject({
+      name: "AggregateError",
+      errors: [publicationFailure],
+    });
   });
 
   it("runs readiness and Session creation through the resolved, hardened Codex Agent Runtime factory", async () => {
@@ -822,9 +900,508 @@ describe("createClientRuntime production composition", () => {
     expect(closeCalls).toBe(1);
     expect(() => runtime.runtimeManager.runtime("session-1")).toThrow("manager is closing");
   });
+
+  it("recovers other Provider and IM readiness when one periodic probe never settles", async () => {
+    const home = await temporaryDirectory("opentag-client-hung-probe-");
+    const { lark, slack } = await writeReadyImClis(home);
+    const server = await runtimeServer();
+    cleanup.push(server.close);
+    let currentTime = Date.now();
+    const connection = runtimeConnection(server.url, () => currentTime);
+    const capabilityUpdates = vi.spyOn(connection, "setVerifiedCapabilities");
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    const imUpdates = vi.spyOn(connection, "setImCliReadiness");
+    const heartbeats: Array<Record<string, unknown>> = [];
+    let releaseHung!: (result: { ready: true; issues: [] } | { ready: false; issues: [] }) => void;
+    const hung = new Promise<{ ready: true; issues: [] } | { ready: false; issues: [] }>((resolve) => {
+      releaseHung = resolve;
+    });
+    cleanup.push(async () => {
+      releaseHung({ ready: true, issues: [] });
+    });
+    const codexProbe = vi.fn(async ({ signal }: { signal?: AbortSignal }) => {
+      if (codexProbe.mock.calls.length === 1) {
+        return {
+          ready: false as const,
+          issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
+        };
+      }
+      if (codexProbe.mock.calls.length === 2) {
+        void signal;
+        return hung;
+      }
+      return {
+        ready: false as const,
+        issues: [{ code: "temporarily_unavailable" as const, message: "bounded retry" }],
+      };
+    });
+    const claudeProbe = vi.fn(async () => ({ ready: true as const, issues: [] }));
+    server.wss.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        const frame = JSON.parse(data.toString()) as Record<string, unknown>;
+        if (frame.type === "auth") {
+          completeLegacyAuth(socket, frame, ["codex", "claude-code"]);
+          return;
+        }
+        if (frame.type === "computer:register") {
+          socket.send(JSON.stringify({ type: "computer:register:result", requestId: frame.requestId, ok: true }));
+          return;
+        }
+        if (frame.type === "heartbeat") {
+          heartbeats.push(frame);
+          socket.send(
+            JSON.stringify({
+              type: "heartbeat:result",
+              requestId: frame.requestId,
+              ok: true,
+              serverTime: new Date().toISOString(),
+            }),
+          );
+        }
+      });
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 80,
+      providerProbeDeadlineMs: 25,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factories: [readyFactory("codex", codexProbe), readyFactory("claude-code", claudeProbe)],
+      home,
+      larkCliCommand: lark,
+      slackCliCommand: slack,
+    });
+    expect(codexProbe).toHaveBeenCalledOnce();
+    expect(claudeProbe).toHaveBeenCalledOnce();
+    expect(readinessUpdates.mock.calls.map(([observation]) => observation)).toEqual(
+      expect.arrayContaining([
+        { provider: "codex", status: "unavailable" },
+        { provider: "claude-code", status: "ready" },
+      ]),
+    );
+    expect(imUpdates.mock.calls.map(([observation]) => observation)).toEqual(
+      expect.arrayContaining([
+        { provider: "feishu", status: "ready" },
+        { provider: "slack", status: "ready" },
+      ]),
+    );
+    const codexUnavailableAtStart = readinessUpdates.mock.calls.filter(
+      ([observation]) => observation.provider === "codex" && observation.status === "unavailable",
+    ).length;
+    const running = runtime.run();
+    await vi.waitFor(() => expect(codexProbe).toHaveBeenCalledTimes(2));
+    const claudeAtHungRefresh = claudeProbe.mock.calls.length;
+    const imReadyAtHungRefresh = imUpdates.mock.calls.filter(([{ status }]) => status === "ready").length;
+    const capabilitiesAtHungRefresh = capabilityUpdates.mock.calls.length;
+    await vi.waitFor(() =>
+      expect(
+        readinessUpdates.mock.calls.filter(
+          ([observation]) => observation.provider === "codex" && observation.status === "unavailable",
+        ).length,
+      ).toBeGreaterThan(codexUnavailableAtStart),
+    );
+
+    const lateReadyCalls = readinessUpdates.mock.calls.filter(
+      ([observation]) => observation.provider === "codex" && observation.status === "ready",
+    ).length;
+    releaseHung({ ready: true, issues: [] });
+    await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+    expect(
+      readinessUpdates.mock.calls.filter(
+        ([observation]) => observation.provider === "codex" && observation.status === "ready",
+      ).length,
+    ).toBe(lateReadyCalls);
+    expect(
+      [...readinessUpdates.mock.calls].reverse().find(([observation]) => observation.provider === "codex")?.[0],
+    ).toEqual({ provider: "codex", status: "unavailable" });
+
+    await vi.waitFor(() => expect(claudeProbe.mock.calls.length).toBeGreaterThan(claudeAtHungRefresh));
+    await vi.waitFor(() =>
+      expect(imUpdates.mock.calls.filter(([{ status }]) => status === "ready").length).toBeGreaterThan(
+        imReadyAtHungRefresh,
+      ),
+    );
+    await vi.waitFor(() => expect(capabilityUpdates.mock.calls.length).toBeGreaterThan(capabilitiesAtHungRefresh));
+
+    currentTime += RUNTIME_CLIENT_CAPABILITY_TTL_MS + 1;
+    const heartbeatAfterTtl = heartbeats.length;
+    await vi.waitFor(() => expect(heartbeats.length).toBeGreaterThan(heartbeatAfterTtl));
+    await vi.waitFor(() => {
+      const latest = heartbeats.at(-1);
+      expect(latest).toMatchObject({
+        capabilities: { imCredentialGrant: 1 },
+        providerReadiness: expect.arrayContaining([
+          { provider: "codex", status: "unavailable" },
+          { provider: "claude-code", status: "ready" },
+        ]),
+        imCliReadiness: expect.arrayContaining([
+          { provider: "feishu", status: "ready" },
+          { provider: "slack", status: "ready" },
+        ]),
+      });
+    });
+
+    runtime.stop();
+    await expect(running).resolves.toBeUndefined();
+  });
+
+  it("settles shutdown without publishing late hung-probe results", async () => {
+    const home = await temporaryDirectory("opentag-client-hung-stop-");
+    const { lark, slack } = await writeReadyImClis(home);
+    const server = await runtimeServer();
+    cleanup.push(server.close);
+    const connection = runtimeConnection(server.url);
+    const capabilityUpdates = vi.spyOn(connection, "setVerifiedCapabilities");
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    const imUpdates = vi.spyOn(connection, "setImCliReadiness");
+    let refreshStarted!: () => void;
+    const started = new Promise<void>((resolveStarted) => {
+      refreshStarted = resolveStarted;
+    });
+    let releaseHung!: (result: { ready: true; issues: [] }) => void;
+    const hung = new Promise<{ ready: true; issues: [] }>((resolve) => {
+      releaseHung = resolve;
+    });
+    cleanup.push(async () => {
+      releaseHung({ ready: true, issues: [] });
+    });
+    let probeCount = 0;
+    const countingFactory = readyFactory("codex", async ({ signal }) => {
+      probeCount += 1;
+      if (probeCount === 1) return { ready: true, issues: [] };
+      refreshStarted();
+      void signal;
+      return hung;
+    });
+    server.wss.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        const frame = JSON.parse(data.toString()) as Record<string, unknown>;
+        if (frame.type === "auth") {
+          completeLegacyAuth(socket, frame, ["codex"]);
+          return;
+        }
+        if (frame.type === "computer:register") {
+          socket.send(JSON.stringify({ type: "computer:register:result", requestId: frame.requestId, ok: true }));
+          return;
+        }
+        if (frame.type === "heartbeat") {
+          socket.send(
+            JSON.stringify({
+              type: "heartbeat:result",
+              requestId: frame.requestId,
+              ok: true,
+              serverTime: new Date().toISOString(),
+            }),
+          );
+        }
+      });
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 20,
+      providerProbeDeadlineMs: 1_000,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: countingFactory,
+      home,
+      larkCliCommand: lark,
+      slackCliCommand: slack,
+    });
+    const running = runtime.run();
+    await started;
+
+    runtime.stop();
+    await expect(running).resolves.toBeUndefined();
+    const capabilitiesAfterStop = capabilityUpdates.mock.calls.length;
+    const readinessAfterStop = readinessUpdates.mock.calls.length;
+    const imAfterStop = imUpdates.mock.calls.length;
+    releaseHung({ ready: true, issues: [] });
+    await new Promise((resolveWait) => setTimeout(resolveWait, 30));
+    expect(capabilityUpdates).toHaveBeenCalledTimes(capabilitiesAfterStop);
+    expect(readinessUpdates).toHaveBeenCalledTimes(readinessAfterStop);
+    expect(imUpdates).toHaveBeenCalledTimes(imAfterStop);
+    expect(
+      [...readinessUpdates.mock.calls].reverse().find(([observation]) => observation.provider === "codex")?.[0],
+    ).toEqual({ provider: "codex", status: "ready" });
+  });
+
+  it("ignores a stale overlapping Provider probe once a newer refresh has started", async () => {
+    const home = await temporaryDirectory("opentag-client-stale-probe-");
+    const server = await runtimeServer();
+    cleanup.push(server.close);
+    const connection = runtimeConnection(server.url);
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    let release!: () => void;
+    const gate = new Promise<void>((resolveGate) => {
+      release = resolveGate;
+    });
+    const probe = vi.fn(async () => {
+      if (probe.mock.calls.length === 1) {
+        return {
+          ready: false as const,
+          issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
+        };
+      }
+      await gate;
+      return { ready: true as const, issues: [] };
+    });
+    server.wss.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        const frame = JSON.parse(data.toString()) as Record<string, unknown>;
+        if (frame.type === "auth") {
+          completeLegacyAuth(socket, frame, ["codex"]);
+          return;
+        }
+        if (frame.type === "computer:register") {
+          socket.send(JSON.stringify({ type: "computer:register:result", requestId: frame.requestId, ok: true }));
+          return;
+        }
+        if (frame.type === "heartbeat") {
+          socket.send(
+            JSON.stringify({
+              type: "heartbeat:result",
+              requestId: frame.requestId,
+              ok: true,
+              serverTime: new Date().toISOString(),
+            }),
+          );
+        }
+      });
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 20,
+      providerProbeDeadlineMs: 500,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: readyFactory("codex", probe),
+      home,
+    });
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "unavailable" });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    expect(
+      await runtime.reconciler.reconcile({
+        ...reconcileRequest(connection.computerId, snapshot()),
+        requestId: randomUUID(),
+        sessionId: "session-2",
+      }),
+    ).toMatchObject({ status: "ready" });
+    const first = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2));
+    const second = runtime.runtimeManager.ensureRuntime("session-2", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    release();
+    await vi.waitFor(() => expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" }));
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.stringContaining("not used"),
+      expect.stringContaining("not used"),
+    ]);
+    runtime.stop();
+  });
+
+  it("does not let a stale periodic deadline overwrite a newer shared Provider probe", async () => {
+    const home = await temporaryDirectory("opentag-client-stale-deadline-");
+    const server = await runtimeServer();
+    cleanup.push(server.close);
+    const connection = runtimeConnection(server.url);
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    let probeStarted!: () => void;
+    const started = new Promise<void>((resolveStarted) => {
+      probeStarted = resolveStarted;
+    });
+    let releaseProbe!: () => void;
+    const gate = new Promise<void>((resolveProbe) => {
+      releaseProbe = resolveProbe;
+    });
+    cleanup.push(async () => releaseProbe());
+    let probeCount = 0;
+    const factory = readyFactory("codex", async () => {
+      probeCount += 1;
+      if (probeCount === 1) {
+        return {
+          ready: false,
+          issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
+        };
+      }
+      if (probeCount === 2) {
+        probeStarted();
+        await gate;
+      }
+      return { ready: true, issues: [] };
+    });
+    server.wss.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        const frame = JSON.parse(data.toString()) as Record<string, unknown>;
+        if (frame.type === "auth") {
+          completeLegacyAuth(socket, frame, ["codex"]);
+          return;
+        }
+        if (frame.type === "computer:register") {
+          socket.send(JSON.stringify({ type: "computer:register:result", requestId: frame.requestId, ok: true }));
+          return;
+        }
+        if (frame.type === "heartbeat") {
+          socket.send(
+            JSON.stringify({
+              type: "heartbeat:result",
+              requestId: frame.requestId,
+              ok: true,
+              serverTime: new Date().toISOString(),
+            }),
+          );
+        }
+      });
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 20,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory,
+      home,
+      providerProbeDeadlineMs: 100,
+    });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    readinessUpdates.mockClear();
+    const running = runtime.run();
+    await started;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 60));
+    const ensuring = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal).then(
+      () => "created",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    await new Promise((resolveWait) => setTimeout(resolveWait, 60));
+
+    expect(readinessUpdates.mock.calls.map(([observation]) => observation)).not.toContainEqual({
+      provider: "codex",
+      status: "unavailable",
+    });
+    releaseProbe();
+    await expect(ensuring).resolves.toContain("not used");
+    await vi.waitFor(() => expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "ready" }));
+
+    runtime.stop();
+    await expect(running).resolves.toBeUndefined();
+  });
+
+  it("does not publish Provider readiness after the caller aborts the Client Runtime", async () => {
+    const home = await temporaryDirectory("opentag-client-abort-publish-");
+    const connection = runtimeConnection();
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    const caller = new AbortController();
+    const runtime = await createClientRuntime(connection, {
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: readyFactory("codex", async () => ({
+        ready: false,
+        issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
+      })),
+      home,
+      signal: caller.signal,
+    });
+    expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "unavailable" });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    const published = readinessUpdates.mock.calls.length;
+    caller.abort(new Error("stop caller"));
+    await expect(runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal)).rejects.toThrow();
+    expect(readinessUpdates).toHaveBeenCalledTimes(published);
+    runtime.stop();
+  });
+
+  it("propagates ensure-time cancellation without treating it as a probe deadline", async () => {
+    const home = await temporaryDirectory("opentag-client-ensure-cancel-");
+    const connection = runtimeConnection();
+    let started!: () => void;
+    const sawProbe = new Promise<void>((resolveStarted) => {
+      started = resolveStarted;
+    });
+    let probes = 0;
+    const factory = readyFactory("codex", async ({ signal }) => {
+      probes += 1;
+      if (probes === 1) {
+        return { ready: false, issues: [{ code: "temporarily_unavailable" as const, message: "cold" }] };
+      }
+      started();
+      return new Promise((_, reject) => {
+        const abort = () => reject(signal?.reason ?? new Error("aborted"));
+        if (signal?.aborted) abort();
+        else signal?.addEventListener("abort", abort, { once: true });
+      });
+    });
+    const runtime = await createClientRuntime(connection, {
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory,
+      home,
+      providerProbeDeadlineMs: 5_000,
+    });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    const ensureSignal = new AbortController();
+    const ensuring = runtime.runtimeManager.ensureRuntime("session-1", ensureSignal.signal);
+    await sawProbe;
+    ensureSignal.abort(new Error("stop ensure"));
+    await expect(ensuring).rejects.toThrow("stop ensure");
+    runtime.stop();
+  });
+
+  it("marks a never-resolving ensure probe unavailable when its deadline elapses", async () => {
+    const home = await temporaryDirectory("opentag-client-ensure-deadline-");
+    const connection = runtimeConnection();
+    const readinessUpdates = vi.spyOn(connection, "setProviderReadiness");
+    const probe = vi.fn(async () => {
+      if (probe.mock.calls.length === 1) {
+        return {
+          ready: false as const,
+          issues: [{ code: "temporarily_unavailable" as const, message: "cold" }],
+        };
+      }
+      return new Promise<never>(() => undefined);
+    });
+    const runtime = await createClientRuntime(connection, {
+      capabilityRefreshIntervalMs: 60_000,
+      providerProbeDeadlineMs: 20,
+      clientVersion: "0.0.1",
+      environment: { HOME: home, PATH: process.env.PATH },
+      factory: readyFactory("codex", probe),
+      home,
+    });
+    expect(await runtime.reconciler.reconcile(reconcileRequest(connection.computerId, snapshot()))).toMatchObject({
+      status: "ready",
+    });
+    const ensuring = runtime.runtimeManager.ensureRuntime("session-1", new AbortController().signal);
+    const ensured = ensuring.then(
+      () => "created",
+      (error: unknown) => error,
+    );
+    await vi.waitFor(() =>
+      expect(readinessUpdates).toHaveBeenLastCalledWith({ provider: "codex", status: "unavailable" }),
+    );
+    await expect(ensured).resolves.toMatchObject({
+      name: "AgentRuntimeProviderUnavailableError",
+      result: {
+        ready: false,
+        issues: [
+          {
+            code: "temporarily_unavailable",
+            message: "Provider readiness probe exceeded its deadline",
+          },
+        ],
+      },
+    });
+    runtime.stop();
+  });
 });
 
-function runtimeConnection(serverUrl = "http://127.0.0.1:3000"): RuntimeConnection {
+function runtimeConnection(serverUrl = "http://127.0.0.1:3000", now?: () => number): RuntimeConnection {
   return new RuntimeConnection({
     arch: "arm64",
     clientVersion: "0.0.1",
@@ -836,6 +1413,7 @@ function runtimeConnection(serverUrl = "http://127.0.0.1:3000"): RuntimeConnecti
     },
     displayName: "test",
     instanceId: randomUUID(),
+    now,
     platform: "darwin",
     tokenProvider: {
       getAccessTokenLease: async () => ({
@@ -846,7 +1424,11 @@ function runtimeConnection(serverUrl = "http://127.0.0.1:3000"): RuntimeConnecti
   });
 }
 
-function completeLegacyAuth(socket: WebSocket, frame: Record<string, unknown>, providerReadiness = false): void {
+function completeLegacyAuth(
+  socket: WebSocket,
+  frame: Record<string, unknown>,
+  providerReadiness: boolean | readonly string[] = false,
+): void {
   if (frame.protocolVersion !== 1) {
     socket.send(
       JSON.stringify({
@@ -868,16 +1450,34 @@ function completeLegacyAuth(socket: WebSocket, frame: Record<string, unknown>, p
       tokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
     }),
   );
+  const providers = Array.isArray(providerReadiness) ? providerReadiness : providerReadiness ? ["codex"] : undefined;
   socket.send(
     JSON.stringify({
       type: "server:welcome",
       protocolVersion: 1,
       capabilities: { sessionReconcile: 1, imDelivery: 1, turnReport: 1, agentTrace: 1, imCredentialGrant: 1 },
-      ...(providerReadiness ? { providerReadiness: { version: 1, providers: ["codex"] } } : {}),
+      ...(providers ? { providerReadiness: { version: 1, providers } } : {}),
       heartbeatIntervalMs: 10,
       heartbeatTimeoutMs: 100,
     }),
   );
+}
+
+async function writeReadyImClis(home: string): Promise<{ lark: string; slack: string }> {
+  const lark = resolve(home, "lark-cli");
+  const slack = resolve(home, "slack");
+  await writeFile(
+    lark,
+    '#!/bin/sh\nif [ "$1" = "--version" ] || { [ "$1" = "im" ] && [ "$2" = "--help" ]; }; then exit 0; fi\nexit 1\n',
+    "utf8",
+  );
+  await writeFile(
+    slack,
+    '#!/bin/sh\nif [ "$1" = "version" ] || { [ "$1" = "api" ] && [ "$2" = "--help" ]; }; then exit 0; fi\nexit 1\n',
+    "utf8",
+  );
+  await Promise.all([chmod(lark, 0o700), chmod(slack, 0o700)]);
+  return { lark, slack };
 }
 
 async function runtimeServer(): Promise<{ close(): Promise<void>; url: string; wss: WebSocketServer }> {

--- a/packages/client/src/runtime/agent-runtime-provider-registry.ts
+++ b/packages/client/src/runtime/agent-runtime-provider-registry.ts
@@ -74,6 +74,11 @@ export class AgentRuntimeProviderRegistry {
     return this.#ready.has(providerId);
   }
 
+  invalidate(providerId: string, result?: AgentRuntimeProbeResult): void {
+    this.#ready.delete(providerId);
+    if (result) this.#probeResults.set(providerId, result);
+  }
+
   probeResult(providerId: string): AgentRuntimeProbeResult | undefined {
     return this.#probeResults.get(providerId);
   }

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -54,11 +54,13 @@ import { TurnCustodyOwner } from "./turn-custody-owner.js";
 import { TurnReportOwner } from "./turn-report-owner.js";
 
 const DEFAULT_CAPABILITY_REFRESH_INTERVAL_MS = Math.floor(RUNTIME_CLIENT_CAPABILITY_TTL_MS / 2);
+const DEFAULT_PROVIDER_PROBE_DEADLINE_MS = 10_000;
 const execFileAsync = promisify(execFile);
 
 export interface CreateClientRuntimeOptions {
   readonly api?: Pick<OpenTagApi, "openImResource">;
   readonly capabilityRefreshIntervalMs?: number;
+  readonly providerProbeDeadlineMs?: number;
   readonly clientVersion: string;
   readonly codexCommand?: string;
   readonly codexHome?: string;
@@ -231,28 +233,80 @@ export async function createClientRuntime(
   const readinessSignal = options.signal
     ? AbortSignal.any([options.signal, capabilityAbort.signal])
     : capabilityAbort.signal;
+  const providerProbeDeadlineMs = options.providerProbeDeadlineMs ?? DEFAULT_PROVIDER_PROBE_DEADLINE_MS;
+  if (!Number.isSafeInteger(providerProbeDeadlineMs) || providerProbeDeadlineMs < 1) {
+    throw new Error("Agent Runtime provider probe deadline must be a positive safe integer");
+  }
+  const providerRefreshGenerations = new Map<string, number>();
+  const beginProviderRefresh = (providerId: string): number => {
+    const generation = (providerRefreshGenerations.get(providerId) ?? 0) + 1;
+    providerRefreshGenerations.set(providerId, generation);
+    return generation;
+  };
+  const publishProviderReadiness = (observation: RuntimeProviderReadinessObservation): void => {
+    if (readinessSignal.aborted) return;
+    connection.setProviderReadiness(observation);
+  };
   const refreshProviderReadiness = async (providerId: string, signal?: AbortSignal): Promise<boolean> => {
-    const refreshSignal = signal ? AbortSignal.any([readinessSignal, signal]) : readinessSignal;
+    const generation = beginProviderRefresh(providerId);
+    const deadline = new AbortController();
+    const deadlineTimer = setTimeout(() => {
+      deadline.abort(new Error(`Agent Runtime provider probe exceeded its deadline: ${providerId}`));
+    }, providerProbeDeadlineMs);
+    deadlineTimer.unref();
+    const refreshSignals = [readinessSignal, deadline.signal];
+    if (signal) refreshSignals.push(signal);
+    const refreshSignal = AbortSignal.any(refreshSignals);
     const provider = providerId as AgentRuntimeProvider;
     const releaseReadiness = providers.isReady(providerId)
       ? connection.leaseProviderReadiness({ provider, status: "ready" })
       : undefined;
-    if (!releaseReadiness) connection.setProviderReadiness({ provider, status: "checking" });
+    if (!releaseReadiness) publishProviderReadiness({ provider, status: "checking" });
+    let settled: { available: boolean } | { error: unknown };
     try {
-      const available = await providers.refresh(providerId, refreshSignal);
-      refreshSignal.throwIfAborted();
-      connection.setProviderReadiness(providerReadiness(provider, available, providers.probeResult(providerId)));
-      return available;
+      settled = { available: await providers.refresh(providerId, refreshSignal) };
+    } catch (error) {
+      settled = { error };
     } finally {
+      clearTimeout(deadlineTimer);
       releaseReadiness?.();
     }
+    if ("error" in settled) {
+      if (readinessSignal.aborted || signal?.aborted) throw settled.error;
+      if (providerRefreshGenerations.get(providerId) !== generation) return providers.isReady(providerId);
+      const result: AgentRuntimeProbeResult = {
+        ready: false,
+        issues: [{ code: "temporarily_unavailable", message: "Provider readiness probe exceeded its deadline" }],
+      };
+      providers.invalidate(providerId, result);
+      publishProviderReadiness(providerReadiness(provider, false, result));
+      return false;
+    }
+    if (providerRefreshGenerations.get(providerId) !== generation) return providers.isReady(providerId);
+    publishProviderReadiness(providerReadiness(provider, settled.available, providers.probeResult(providerId)));
+    return settled.available;
   };
   const refreshCapability = async (): Promise<void> => {
-    await Promise.all([
+    const results = await Promise.allSettled([
       ...providers.providerIds().map((providerId) => refreshProviderReadiness(providerId)),
-      refreshImCliReadiness(connection, "feishu", options.larkCliCommand ?? "lark-cli", sourceEnvironment),
-      refreshImCliReadiness(connection, "slack", options.slackCliCommand ?? "slack", sourceEnvironment),
+      refreshImCliReadiness(
+        connection,
+        "feishu",
+        options.larkCliCommand ?? "lark-cli",
+        sourceEnvironment,
+        readinessSignal,
+      ),
+      refreshImCliReadiness(
+        connection,
+        "slack",
+        options.slackCliCommand ?? "slack",
+        sourceEnvironment,
+        readinessSignal,
+      ),
     ]);
+    readinessSignal.throwIfAborted();
+    const failures = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+    if (failures.length > 0) throw new AggregateError(failures, "Client capability refresh failed");
     connection.setVerifiedCapabilities({ imCredentialGrant: 1 });
   };
   const ensureProviderReady = async (providerId: string, signal?: AbortSignal): Promise<void> => {
@@ -382,28 +436,49 @@ export async function refreshImCliReadiness(
   provider: RuntimeImCliReadinessObservation["provider"],
   configuredCommand: string,
   environment: NodeJS.ProcessEnv,
+  signal?: AbortSignal,
 ): Promise<void> {
+  if (signal?.aborted) return;
   connection.setImCliReadiness({ provider, status: "checking" });
-  let command: string;
-  try {
-    command = await resolveExecutable(configuredCommand, environment);
-  } catch {
-    connection.setImCliReadiness({ provider, status: "install" });
-    return;
-  }
-  const execution = { env: environment, timeout: 10_000, windowsHide: true } as const;
-  try {
-    if (provider === "feishu") {
-      await execFileAsync(command, ["--version"], execution);
-      await execFileAsync(command, ["im", "--help"], execution);
-    } else {
-      await execFileAsync(command, ["version"], execution);
-      await execFileAsync(command, ["api", "--help"], execution);
+  const probe = (async () => {
+    let command: string;
+    try {
+      command = await resolveExecutable(configuredCommand, environment);
+    } catch {
+      return "install" as const;
     }
-    connection.setImCliReadiness({ provider, status: "ready" });
-  } catch {
-    connection.setImCliReadiness({ provider, status: "unavailable" });
-  }
+    const execution = { env: environment, signal, timeout: 10_000, windowsHide: true } as const;
+    try {
+      if (provider === "feishu") {
+        await execFileAsync(command, ["--version"], execution);
+        await execFileAsync(command, ["im", "--help"], execution);
+      } else {
+        await execFileAsync(command, ["version"], execution);
+        await execFileAsync(command, ["api", "--help"], execution);
+      }
+      return "ready" as const;
+    } catch {
+      return "unavailable" as const;
+    }
+  })();
+  let onAbort: (() => void) | undefined;
+  const status = await (signal
+    ? Promise.race([
+        probe,
+        new Promise<"aborted">((resolve) => {
+          if (signal.aborted) {
+            resolve("aborted");
+            return;
+          }
+          onAbort = () => resolve("aborted");
+          signal.addEventListener("abort", onAbort, { once: true });
+        }),
+      ]).finally(() => {
+        if (onAbort) signal.removeEventListener("abort", onAbort);
+      })
+    : probe);
+  if (status === "aborted" || signal?.aborted) return;
+  connection.setImCliReadiness({ provider, status });
 }
 
 export interface ResolvedCodexFactoryOptions {

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -298,9 +298,16 @@ export async function createClientRuntime(
         } catch (error) {
           settled = { error };
         }
+        const isCurrentOwner = sharedProviderRefreshes.get(providerId) === owner;
+        if (!isCurrentOwner) {
+          if ("error" in settled) throw settled.error;
+          controller.signal.throwIfAborted();
+          return settled.available;
+        }
         if ("error" in settled) {
-          if (readinessSignal.aborted) throw settled.error;
-          if (controller.signal.reason !== deadlineError) throw settled.error;
+          if (readinessSignal.aborted || controller.signal.reason !== deadlineError) {
+            throw settled.error;
+          }
           const result: AgentRuntimeProbeResult = {
             ready: false,
             issues: [{ code: "temporarily_unavailable", message: "Provider readiness probe exceeded its deadline" }],
@@ -324,16 +331,22 @@ export async function createClientRuntime(
     void owner.promise.catch(() => undefined);
     return owner;
   };
+  const liveSharedProviderRefresh = (providerId: string): SharedProviderRefresh | undefined => {
+    const owner = sharedProviderRefreshes.get(providerId);
+    if (!owner || owner.settled || owner.controller.signal.aborted) return undefined;
+    return owner;
+  };
   const refreshProviderReadiness = async (providerId: string, signal?: AbortSignal): Promise<boolean> => {
     signal?.throwIfAborted();
     readinessSignal.throwIfAborted();
-    const owner = sharedProviderRefreshes.get(providerId) ?? startSharedProviderRefresh(providerId);
+    const owner = liveSharedProviderRefresh(providerId) ?? startSharedProviderRefresh(providerId);
     owner.waiters += 1;
     try {
       return await waitForSharedRefresh(owner.promise, signal);
     } finally {
       owner.waiters -= 1;
       if (owner.waiters === 0 && !owner.settled) {
+        if (sharedProviderRefreshes.get(providerId) === owner) sharedProviderRefreshes.delete(providerId);
         owner.controller.abort(new Error(`Agent Runtime provider probe has no waiters: ${providerId}`));
       }
     }

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -57,6 +57,31 @@ const DEFAULT_CAPABILITY_REFRESH_INTERVAL_MS = Math.floor(RUNTIME_CLIENT_CAPABIL
 const DEFAULT_PROVIDER_PROBE_DEADLINE_MS = 10_000;
 const execFileAsync = promisify(execFile);
 
+interface SharedProviderRefresh {
+  readonly controller: AbortController;
+  readonly promise: Promise<boolean>;
+  settled: boolean;
+  waiters: number;
+}
+
+async function waitForSharedRefresh(refresh: Promise<boolean>, signal?: AbortSignal): Promise<boolean> {
+  if (!signal) return refresh;
+  signal.throwIfAborted();
+  let rejectAborted!: (reason: unknown) => void;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAborted = reject;
+  });
+  const onAbort = () => rejectAborted(signal.reason);
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    const available = await Promise.race([refresh, aborted]);
+    signal.throwIfAborted();
+    return available;
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+}
+
 export interface CreateClientRuntimeOptions {
   readonly api?: Pick<OpenTagApi, "openImResource">;
   readonly capabilityRefreshIntervalMs?: number;
@@ -237,54 +262,81 @@ export async function createClientRuntime(
   if (!Number.isSafeInteger(providerProbeDeadlineMs) || providerProbeDeadlineMs < 1) {
     throw new Error("Agent Runtime provider probe deadline must be a positive safe integer");
   }
-  const providerRefreshGenerations = new Map<string, number>();
-  const beginProviderRefresh = (providerId: string): number => {
-    const generation = (providerRefreshGenerations.get(providerId) ?? 0) + 1;
-    providerRefreshGenerations.set(providerId, generation);
-    return generation;
-  };
-  const publishProviderReadiness = (observation: RuntimeProviderReadinessObservation): void => {
-    if (readinessSignal.aborted) return;
-    connection.setProviderReadiness(observation);
-  };
-  const refreshProviderReadiness = async (providerId: string, signal?: AbortSignal): Promise<boolean> => {
-    const generation = beginProviderRefresh(providerId);
-    const deadline = new AbortController();
+  const sharedProviderRefreshes = new Map<string, SharedProviderRefresh>();
+  const startSharedProviderRefresh = (providerId: string): SharedProviderRefresh => {
+    const controller = new AbortController();
+    let resolveOwner!: (available: boolean) => void;
+    let rejectOwner!: (reason: unknown) => void;
+    const promise = new Promise<boolean>((resolvePromise, rejectPromise) => {
+      resolveOwner = resolvePromise;
+      rejectOwner = rejectPromise;
+    });
+    const owner: SharedProviderRefresh = {
+      controller,
+      promise,
+      settled: false,
+      waiters: 0,
+    };
+    sharedProviderRefreshes.set(providerId, owner);
+    const deadlineError = new Error(`Agent Runtime provider probe exceeded its deadline: ${providerId}`);
     const deadlineTimer = setTimeout(() => {
-      deadline.abort(new Error(`Agent Runtime provider probe exceeded its deadline: ${providerId}`));
+      controller.abort(deadlineError);
     }, providerProbeDeadlineMs);
     deadlineTimer.unref();
-    const refreshSignals = [readinessSignal, deadline.signal];
-    if (signal) refreshSignals.push(signal);
-    const refreshSignal = AbortSignal.any(refreshSignals);
     const provider = providerId as AgentRuntimeProvider;
-    const releaseReadiness = providers.isReady(providerId)
-      ? connection.leaseProviderReadiness({ provider, status: "ready" })
-      : undefined;
-    if (!releaseReadiness) publishProviderReadiness({ provider, status: "checking" });
-    let settled: { available: boolean } | { error: unknown };
+    const operation = (async () => {
+      let releaseReadiness: (() => void) | undefined;
+      try {
+        releaseReadiness = providers.isReady(providerId)
+          ? connection.leaseProviderReadiness({ provider, status: "ready" })
+          : undefined;
+        if (!releaseReadiness) connection.setProviderReadiness({ provider, status: "checking" });
+        const ownerSignal = AbortSignal.any([readinessSignal, controller.signal]);
+        let settled: { available: boolean } | { error: unknown };
+        try {
+          settled = { available: await providers.refresh(providerId, ownerSignal) };
+        } catch (error) {
+          settled = { error };
+        }
+        if ("error" in settled) {
+          if (readinessSignal.aborted) throw settled.error;
+          if (controller.signal.reason !== deadlineError) throw settled.error;
+          const result: AgentRuntimeProbeResult = {
+            ready: false,
+            issues: [{ code: "temporarily_unavailable", message: "Provider readiness probe exceeded its deadline" }],
+          };
+          providers.invalidate(providerId, result);
+          connection.setProviderReadiness(providerReadiness(provider, false, result));
+          return false;
+        }
+        connection.setProviderReadiness(
+          providerReadiness(provider, settled.available, providers.probeResult(providerId)),
+        );
+        return settled.available;
+      } finally {
+        owner.settled = true;
+        clearTimeout(deadlineTimer);
+        releaseReadiness?.();
+        if (sharedProviderRefreshes.get(providerId) === owner) sharedProviderRefreshes.delete(providerId);
+      }
+    })();
+    void operation.then(resolveOwner, rejectOwner);
+    void owner.promise.catch(() => undefined);
+    return owner;
+  };
+  const refreshProviderReadiness = async (providerId: string, signal?: AbortSignal): Promise<boolean> => {
+    signal?.throwIfAborted();
+    readinessSignal.throwIfAborted();
+    const owner = sharedProviderRefreshes.get(providerId) ?? startSharedProviderRefresh(providerId);
+    owner.waiters += 1;
     try {
-      settled = { available: await providers.refresh(providerId, refreshSignal) };
-    } catch (error) {
-      settled = { error };
+      return await waitForSharedRefresh(owner.promise, signal);
     } finally {
-      clearTimeout(deadlineTimer);
-      releaseReadiness?.();
+      owner.waiters -= 1;
+      if (owner.waiters === 0 && !owner.settled) {
+        owner.controller.abort(new Error(`Agent Runtime provider probe has no waiters: ${providerId}`));
+      }
     }
-    if ("error" in settled) {
-      if (readinessSignal.aborted || signal?.aborted) throw settled.error;
-      if (providerRefreshGenerations.get(providerId) !== generation) return providers.isReady(providerId);
-      const result: AgentRuntimeProbeResult = {
-        ready: false,
-        issues: [{ code: "temporarily_unavailable", message: "Provider readiness probe exceeded its deadline" }],
-      };
-      providers.invalidate(providerId, result);
-      publishProviderReadiness(providerReadiness(provider, false, result));
-      return false;
-    }
-    if (providerRefreshGenerations.get(providerId) !== generation) return providers.isReady(providerId);
-    publishProviderReadiness(providerReadiness(provider, settled.available, providers.probeResult(providerId)));
-    return settled.available;
   };
   const refreshCapability = async (): Promise<void> => {
     const results = await Promise.allSettled([


### PR DESCRIPTION
## Summary

- bound every exact-provider readiness probe with a 10-second deadline so one non-settling probe cannot hold the capability monitor forever
- isolate provider and IM readiness work, keep the existing no-overlap monitor latch, and let later intervals recover after a bounded failure
- make one shared provider-refresh owner the only readiness publisher, with independent waiter cancellation and immediate zero-waiter owner eviction
- preserve registry-identity fencing, lifecycle/caller abort semantics, shutdown publication suppression, and cancellation of IM CLI probes

## Root cause

The initial capability refresh completed, but a later provider probe could return a promise that never settled and did not honor abort. `refreshCapability()` awaited all provider and IM work through one `Promise.all`, so that single promise kept `#capabilityRefreshInFlight` occupied forever. An unavailable provider had already published `checking`; other provider and IM probes could finish that one refresh, but could never run again. Once their observations crossed the capability TTL, the Server projected the missing readiness as `checking`, leaving handoff unavailable until the daemon restarted.

This reproduces deterministically with an initially unavailable provider whose periodic probe never resolves, controlled time advancement beyond the TTL, and otherwise healthy provider/Feishu/Slack probes.

## Review follow-up

The first implementation advanced a publication generation per caller even though the provider registry coalesces concurrent callers onto one underlying probe. A cancelled newer waiter could therefore suppress the older active waiter's successful publication, leaving the registry `ready` while the connection observation remained `checking`.

Commit `e46f625` replaced those caller generations with one composition-level owner for each shared provider refresh. Joiners wait on that owner with independent caller cancellation, while only the owner owns the deadline and publishes the result.

The second review identified a drain window in that owner lifecycle: the last waiter aborted an unsettled owner but left it discoverable until the asynchronous operation reached `finally`. Commit `ce14b71` now removes the exact zero-waiter owner from the map before aborting it, refuses aborted or settled owners during lookup, and fences both publication and cleanup by current owner identity. A later caller can therefore start a fresh owner while the cancelled operation drains, without inheriting its cancellation or being removed by its late `finally`.

## Boundaries and safety

- the provider deadline is per shared provider owner, not a global replacement timeout; a joiner inherits the owner's remaining deadline rather than extending it
- zero-waiter eviction checks exact owner identity and occurs before abort, closing synchronous and asynchronous reuse windows
- both success/failure publication and `finally` cleanup are owner-identity fenced; a draining owner cannot publish over or delete its successor
- the monitor still permits only one top-level capability refresh at a time
- provider registry record identity fences old timed-out work and late underlying completions
- a timed-out provider is invalidated with the existing `temporarily_unavailable` readiness semantics
- lifecycle and caller abort remain distinct from deadline failure; shutdown and all-waiter cancellation do not publish late state
- exact-provider dispatch is unchanged; there is no fallback or provider substitution
- no schema, database migration, or persistence semantics change

## Tests

- never-resolving periodic provider probe with explicit time advancement past the readiness TTL
- healthy second provider plus Feishu and Slack probes continue and recover on later intervals
- A starts a shared probe, B coalesces and cancels, then A succeeds: provider readiness and heartbeat/handoff observation publish `ready` immediately, and the on-demand fast path does not leave `checking`
- A is the sole waiter and cancels while its composition owner is deliberately held draining; B starts and completes a new live refresh before A returns, and A's late success cannot overwrite B
- A's old `finally` runs while B's successor owner remains pending; C still joins B instead of starting a third owner, proving old cleanup cannot delete the successor
- the previous owner can fully drain before B starts, and B still receives a fresh result
- opposite completion/cancellation order does not unpublish a completed `ready` result
- a joined waiter cannot extend the owner's deadline, and the old late handler cannot overwrite a newer successful probe
- ensure-time cancellation/deadline behavior, Client Runtime shutdown, IM abort, and post-stop publication suppression
- provider registry invalidation remains idempotent and stale draining probes cannot restore readiness

## Validation

- `pnpm check` — pass; 8 existing undeclared-environment warnings remain in untouched `scripts/e2e/onboarding-e2e.mjs`
- `pnpm build` — pass, 5/5 tasks
- `pnpm typecheck` — pass, 7/7 tasks
- focused Client composition + provider-registry regression — pass, 2 files / 35 tests
- `pnpm --filter @opentag/client test` — pass, 37 files / 444 tests
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — pass on final rerun, 20 files / 282 tests, 100% statements/branches/functions/lines; the immediately preceding run had one unrelated Pi probe fixture marker `ENOENT`
- `pnpm test` — Client, Server, Shared, and Web pass; local macOS run stops on 2 CLI path assertions that expect `/tmp/...` while canonical resolution returns `/private/tmp/...`
- exact-main baseline `39b5184011dfaf7fff50cdd7304423f7039d516d` — the same isolated CLI tests fail 2/53 with the same canonical-path diffs
- `pnpm test:coverage` — 1188/1190 pass; only those same two CLI path assertions fail, and changed Client Runtime composition coverage is 100%
- exact-main Server observability timing baseline — three repeated isolated runs produced one pass and two `handled` versus `stale_connection` failures; the final PR coverage run did not hit this flake
- GitHub CI for `ce14b71` — pass, 6/6 checks

## Remaining risk

If a provider implementation ignores its supplied `AbortSignal`, its underlying promise may continue consuming resources after the registry and composition owner detach it. Its result is fenced from shared readiness state, and the capability monitor can safely retry; production provider adapters should still terminate their owned process on abort. A waiter that joins a nearly expired shared owner receives only the remaining deadline; after that owner settles, a retry starts a fresh owner. Draft PR #114 changes the same composition area and will require an intentional conflict resolution whichever PR lands second.

Fixes #123
