### PR TITLE
feat(web): refine Agent availability cards

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1447,7 +1447,7 @@ describe("OpenTag Web App Shell", () => {
     );
   });
 
-  it("requires the selected runtime Provider to be ready before an Agent card is Ready", async () => {
+  it("requires the selected runtime Provider to be ready before an Agent card is Available", async () => {
     installApi("admin", {
       bound: true,
       runtimeProvider: "claude-code",
@@ -1461,7 +1461,7 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByText("Needs attention")).toBeTruthy();
     expect(screen.getByText("Computer not ready")).toBeTruthy();
-    expect(screen.queryByText("Ready")).toBeNull();
+    expect(screen.queryByText("Available")).toBeNull();
   });
 
   it("shows a user-facing recovery without readiness implementation details", async () => {
@@ -1584,7 +1584,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", { agentListStatus: () => agentListStatus, bound: true });
     window.history.replaceState({}, "", "/agents");
     render(<App />);
-    expect(await screen.findByText("Ready")).toBeTruthy();
+    expect(await screen.findByText("Available")).toBeTruthy();
 
     agentListStatus = 503;
     fireEvent(window, new Event("focus"));

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1209,7 +1209,7 @@ function agentCardStatus(agent: AgentListItem): {
       tone: "success",
     };
   }
-  return { label: "Ready", priority: 3, tone: "success" };
+  return { label: "Available", priority: 3, tone: "success" };
 }
 
 function formatElapsedCompact(value: string): string {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -937,7 +937,7 @@ pre {
   min-height: 112px;
   align-items: center;
   gap: 24px;
-  grid-template-columns: minmax(260px, 1fr) 230px 206px 36px;
+  grid-template-columns: minmax(240px, 0.8fr) minmax(210px, 0.7fr) 206px 36px;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: var(--surface);


### PR DESCRIPTION
## Summary

- rebalance Agent card identity and status columns so availability sits closer to the Agent identity
- rename the idle ready-state label from Ready to Available to clarify that the Agent can accept work
- keep onboarding and runtime readiness terminology unchanged

## Testing

- pnpm check (passes with 8 existing E2E environment-variable warnings)
- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/web test (322 tests passed)
- pnpm test (scripts, shared, client, and web pass; server reports one unrelated failure in src/observability/__tests__/observability.test.ts expecting stale_connection but receiving handled; reproduced in isolation with no server changes in this branch)

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] pnpm check, pnpm build, pnpm typecheck, and pnpm test pass. (See the unrelated server test failure above.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.