### PR TITLE
feat(web): refine Agent detail settings UX

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1419,7 +1419,8 @@ describe("OpenTag Web App Shell", () => {
 
     fireEvent.click(within(dialog).getByRole("button", { name: "Pause Agent" }));
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Pause Reviewer?" })).toBeNull());
-    expect(await screen.findByRole("button", { name: "Reactivate" })).toBeTruthy();
+    const reactivateButton = await screen.findByRole("button", { name: "Reactivate" });
+    await waitFor(() => expect(document.activeElement).toBe(reactivateButton));
   });
 
   it("keeps delete failures visible inside the confirmation dialog and clears them after retry", async () => {
@@ -1757,6 +1758,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Allow all conversation messages?" })).toBeNull());
     expect(screen.queryByText("Unable to update message access")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("heading", { name: "Trigger rules" })));
   });
 
   it("keeps disconnect failures inside the active dialog and allows retry", async () => {
@@ -1794,6 +1796,7 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Disconnect" }));
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Disconnect messaging?" })).toBeNull());
     expect(screen.queryByText("Unable to disconnect messaging")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("heading", { name: "Messaging" })));
   });
 
   it("resumes a provisioning Slack setup after a refresh before credentials were submitted", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1392,6 +1392,65 @@ describe("OpenTag Web App Shell", () => {
     await waitFor(() => expect(window.location.pathname).toBe("/agents"));
   });
 
+  it("keeps lifecycle failures visible inside the confirmation dialog and allows retry", async () => {
+    installApi("admin", {
+      agentActivity: { state: "working", startedAt: "2026-08-24T12:00:00.000Z" },
+    });
+    const baseFetch = vi.mocked(fetch).getMockImplementation();
+    if (!baseFetch) throw new Error("Expected the test API to be installed");
+    let failSuspend = true;
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (String(input) === `/api/v1/agents/${agentId}/suspend` && init?.method === "POST" && failSuspend) {
+        failSuspend = false;
+        return json(
+          { error: { code: "SERVICE_UNAVAILABLE", category: "transient", message: "Unable to pause right now" } },
+          503,
+        );
+      }
+      return baseFetch(input, init);
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/manage`);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Pause" }));
+    const dialog = await screen.findByRole("dialog", { name: "Pause Reviewer?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Pause Agent" }));
+    expect((await within(dialog).findByRole("alert")).textContent).toContain("Unable to pause right now");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Pause Agent" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Pause Reviewer?" })).toBeNull());
+    expect(await screen.findByRole("button", { name: "Reactivate" })).toBeTruthy();
+  });
+
+  it("keeps delete failures visible inside the confirmation dialog and clears them after retry", async () => {
+    installApi("admin", { initialStatus: "suspended" });
+    const baseFetch = vi.mocked(fetch).getMockImplementation();
+    if (!baseFetch) throw new Error("Expected the test API to be installed");
+    let failDelete = true;
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (String(input) === `/api/v1/agents/${agentId}` && init?.method === "DELETE" && failDelete) {
+        failDelete = false;
+        return json(
+          { error: { code: "SERVICE_UNAVAILABLE", category: "transient", message: "Unable to delete right now" } },
+          503,
+        );
+      }
+      return baseFetch(input, init);
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/manage`);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete permanently" }));
+    const dialog = await screen.findByRole("dialog", { name: "Delete Reviewer?" });
+    fireEvent.change(within(dialog).getByLabelText(/Type Reviewer to confirm/), { target: { value: "Reviewer" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete permanently" }));
+    expect((await within(dialog).findByRole("alert")).textContent).toContain("Unable to delete right now");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete permanently" }));
+    await waitFor(() => expect(window.location.pathname).toBe("/agents"));
+    expect(screen.queryByText("Unable to delete right now")).toBeNull();
+  });
+
   it("shows detailed Agent Token usage and changes the selected period", async () => {
     installApi("admin");
     window.history.replaceState({}, "", `/agents/${agentId}/usage`);
@@ -1664,6 +1723,77 @@ describe("OpenTag Web App Shell", () => {
           ),
       ).toHaveLength(2),
     );
+  });
+
+  it("keeps receive-mode failures inside the active dialog and clears them before retry", async () => {
+    installApi("admin", { bound: true });
+    const baseFetch = vi.mocked(fetch).getMockImplementation();
+    if (!baseFetch) throw new Error("Expected the test API to be installed");
+    let failReceiveMode = true;
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (String(input) === `/api/v1/agents/${agentId}` && init?.method === "PATCH" && failReceiveMode) {
+        failReceiveMode = false;
+        return json(
+          {
+            error: {
+              code: "SERVICE_UNAVAILABLE",
+              category: "transient",
+              message: "Unable to update message access",
+            },
+          },
+          503,
+        );
+      }
+      return baseFetch(input, init);
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "All messages" }));
+    const dialog = await screen.findByRole("dialog", { name: "Allow all conversation messages?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
+    expect((await within(dialog).findByRole("alert")).textContent).toContain("Unable to update message access");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Allow all conversation messages?" })).toBeNull());
+    expect(screen.queryByText("Unable to update message access")).toBeNull();
+  });
+
+  it("keeps disconnect failures inside the active dialog and allows retry", async () => {
+    installApi("admin", { bound: true });
+    const baseFetch = vi.mocked(fetch).getMockImplementation();
+    if (!baseFetch) throw new Error("Expected the test API to be installed");
+    let failDisconnect = true;
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/disable") && init?.method === "POST") {
+        if (failDisconnect) {
+          failDisconnect = false;
+          return json(
+            {
+              error: {
+                code: "SERVICE_UNAVAILABLE",
+                category: "transient",
+                message: "Unable to disconnect messaging",
+              },
+            },
+            503,
+          );
+        }
+        return new Response(null, { status: 204 });
+      }
+      return baseFetch(input, init);
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Disable IM binding" }));
+    const dialog = await screen.findByRole("dialog", { name: "Disconnect messaging?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Disconnect" }));
+    expect((await within(dialog).findByRole("alert")).textContent).toContain("Unable to disconnect messaging");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Disconnect" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Disconnect messaging?" })).toBeNull());
+    expect(screen.queryByText("Unable to disconnect messaging")).toBeNull();
   });
 
   it("resumes a provisioning Slack setup after a refresh before credentials were submitted", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1265,18 +1265,19 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("button", { name: "Delete Agent permanently" })).toBeNull();
   });
 
-  it("keeps the Agent home focused on status, current activity, and contact", async () => {
+  it("keeps the Agent home focused on status, current work, and contact", async () => {
     installApi("admin", { bound: true });
     window.history.replaceState({}, "", `/agents/${agentId}`);
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Current activity" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Current work" })).toBeTruthy();
     expect(screen.getByText("No active work")).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Contact" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Where to use this Agent" })).toBeTruthy();
     expect(screen.getByText("Send a direct message, or mention @reviewer in a Feishu conversation.")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Settings" }).getAttribute("href")).toBe(`/agents/${agentId}/settings`);
     expect(screen.getByRole("link", { name: "Usage" }).getAttribute("href")).toBe(`/agents/${agentId}/usage`);
+    expect(screen.queryByLabelText("More Agent actions")).toBeNull();
     expect(screen.queryByRole("navigation", { name: "Agent sections" })).toBeNull();
     expect(screen.queryByText("Runtime")).toBeNull();
   });
@@ -1295,45 +1296,100 @@ describe("OpenTag Web App Shell", () => {
     expect(document.body.textContent).not.toContain("Private conversation content");
   });
 
-  it("keeps all admin-only controls in six understandable Settings sections", async () => {
+  it("groups all admin-only controls in a lightweight Settings directory", async () => {
     installApi("admin");
     window.history.replaceState({}, "", `/agents/${agentId}/settings`);
     render(<App />);
 
-    const navigation = await screen.findByRole("navigation", { name: "Agent settings" });
-    expect(
-      within(navigation)
-        .getAllByRole("link")
-        .map((link) => link.textContent),
-    ).toEqual(["Settings", "Identity", "Instructions", "Execution", "Messaging", "Computer", "Manage"]);
-    expect(screen.getByText("Provider, model, and reasoning")).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Agent settings" })).toBeTruthy();
+    expect(screen.queryByRole("navigation", { name: "Agent settings" })).toBeNull();
+    expect(await screen.findByRole("heading", { name: "How it works" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Where it receives work" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Agent details" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Instructions & behavior/ })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Model & reasoning/ })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Messaging/ })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Name & identity/ })).toBeTruthy();
+    expect(screen.getByText("Connected computer")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /Connected computer/ })).toBeNull();
+    expect(screen.getByRole("link", { name: /Manage Agent/ })).toBeTruthy();
+    expect(screen.getByText("Not configured")).toBeTruthy();
+    expect(screen.getByText("Codex · Default model · Default reasoning")).toBeTruthy();
+    expect(screen.getByText("Reviewer · @reviewer")).toBeTruthy();
+    expect(screen.getByText("Ada's Mac · macOS · Online")).toBeTruthy();
     expect(screen.queryByText("Runtime")).toBeNull();
+  });
+
+  it("returns to the Agent home when Messaging was opened from its Manage shortcut", async () => {
+    installApi("admin", { bound: true });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("link", { name: "Manage" }));
+    expect(await screen.findByRole("heading", { name: "Messaging" })).toBeTruthy();
+    const backLink = screen.getByRole("link", { name: "Back to Reviewer" });
+    expect(backLink.getAttribute("href")).toBe(`/agents/${agentId}`);
+    fireEvent.click(backLink);
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+  });
+
+  it("opens Connected computer recovery only when the Computer needs attention", async () => {
+    installApi("admin", { computerStatus: () => "offline" });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings`);
+    render(<App />);
+
+    const computerLabel = await screen.findByText("Connected computer");
+    const computerLink = computerLabel.closest("a");
+    expect(screen.getByText("Ada's Mac · macOS · Offline")).toBeTruthy();
+    expect(screen.getByText("Review")).toBeTruthy();
+    if (!(computerLink instanceof HTMLAnchorElement)) {
+      throw new Error("Expected the Connected computer recovery row to be a link");
+    }
+    expect(computerLink.getAttribute("href")).toBe(`/agents/${agentId}/settings/computer`);
+  });
+
+  it("edits Agent identity directly and keeps the permanent handle readable", async () => {
+    installApi("admin");
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/identity`);
+    render(<App />);
+
+    const displayName = (await screen.findByLabelText("Display name")) as HTMLInputElement;
+    const handle = screen.getByLabelText("Handle") as HTMLInputElement;
+    expect(handle.readOnly).toBe(true);
+    expect(handle.disabled).toBe(false);
+    expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+
+    fireEvent.change(displayName, { target: { value: "Research Reviewer" } });
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    expect(displayName.value).toBe("Reviewer");
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
   });
 
   it("pauses and deletes an Agent from Manage with destructive confirmation", async () => {
     installApi("admin");
     window.history.replaceState({}, "", `/agents/${agentId}/settings/manage`);
-    const confirm = vi.spyOn(window, "confirm").mockReturnValueOnce(false).mockReturnValueOnce(true);
     render(<App />);
 
     const unavailableDeleteButton = await screen.findByRole("button", { name: "Delete permanently" });
     expect(unavailableDeleteButton.hasAttribute("disabled")).toBe(true);
     expect(screen.getByText("Pause this Agent before deleting it permanently.")).toBeTruthy();
     fireEvent.click(unavailableDeleteButton);
-    expect(confirm).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog", { name: "Delete Reviewer?" })).toBeNull();
 
     fireEvent.click(await screen.findByRole("button", { name: "Pause" }));
     expect(await screen.findByRole("button", { name: "Reactivate" })).toBeTruthy();
     const deleteButton = screen.getByRole("button", { name: "Delete permanently" });
     expect(deleteButton.hasAttribute("disabled")).toBe(false);
     fireEvent.click(deleteButton);
+    const dialog = await screen.findByRole("dialog", { name: "Delete Reviewer?" });
     expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
-    fireEvent.click(deleteButton);
+    const confirmedDeleteButton = within(dialog).getByRole("button", { name: "Delete permanently" });
+    expect(confirmedDeleteButton.hasAttribute("disabled")).toBe(true);
+    fireEvent.change(within(dialog).getByLabelText(/Type Reviewer to confirm/), { target: { value: "Reviewer" } });
+    expect(confirmedDeleteButton.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(confirmedDeleteButton);
     await waitFor(() => expect(window.location.pathname).toBe("/agents"));
-    expect(confirm).toHaveBeenLastCalledWith(
-      "Permanently delete Reviewer? This will end active Sessions, remove messaging credentials and execution settings, and retain Session and message history. This Agent cannot be restored.",
-    );
-    confirm.mockRestore();
   });
 
   it("shows detailed Agent Token usage and changes the selected period", async () => {
@@ -1364,7 +1420,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin");
     window.history.replaceState({}, "", `/agents/${agentId}/runtime`);
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Execution" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Model & reasoning" })).toBeTruthy();
     expect(window.location.pathname).toBe(`/agents/${agentId}/settings/execution`);
     expect(screen.queryByText("Runtime")).toBeNull();
   });
@@ -1397,10 +1453,10 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", `/agents/${agentId}/settings/computer`);
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Connected computer" })).toBeTruthy();
     expect(await screen.findByText("Ada's Mac · macOS")).toBeTruthy();
     expect(screen.getByText("Online")).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Computer" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Reviewer" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Execution" })).toBeNull();
     expect(screen.queryByText(/Turn timeout/i)).toBeNull();
     expect(screen.queryByText(/Last seen/i)).toBeNull();
@@ -1472,8 +1528,8 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
     expect(screen.getByText("Messages cannot currently be handed off to this Agent.")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Review messaging" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Current activity" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Contact" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Current work" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Where to use this Agent" })).toBeTruthy();
     expect(screen.queryByText("Handoff")).toBeNull();
     expect(screen.queryByText("Ada's Mac")).toBeNull();
     expect(screen.queryByText("Runtime")).toBeNull();
@@ -1485,7 +1541,6 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    expect(await screen.findByText("Status temporarily unavailable")).toBeTruthy();
     expect(screen.getByText("Unable to confirm messaging")).toBeTruthy();
     expect(screen.queryByText("No messaging connected")).toBeNull();
     expect(screen.queryByText("Handoff")).toBeNull();
@@ -1509,7 +1564,7 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Contact channel" })).toBeTruthy();
     expect(screen.getByText(/Feishu · Available/)).toBeTruthy();
-    expect(screen.getAllByText("@reviewer")).toHaveLength(2);
+    expect(screen.getByText("@reviewer")).toBeTruthy();
     expect(screen.getByText("Send a direct message, or mention @reviewer in a Feishu conversation.")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Trigger rules" })).toBeTruthy();
     expect(screen.getByText("A direct message can always start work.")).toBeTruthy();
@@ -1522,10 +1577,10 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", `/agents/${agentId}`);
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Contact" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Where to use this Agent" })).toBeTruthy();
     expect(screen.getByText("Send a direct message, or mention @reviewer in a Feishu conversation.")).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Settings" })).toBeNull();
-    expect(screen.queryByRole("link", { name: "Manage messaging" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Manage" })).toBeNull();
   });
 
   it("shows a Messaging error instead of inferring an empty channel", async () => {
@@ -1563,7 +1618,7 @@ describe("OpenTag Web App Shell", () => {
     expect(agentReads).toBe(2);
 
     releaseAgentRead();
-    expect(await screen.findByText("Cannot receive new work")).toBeTruthy();
+    expect(await screen.findByText("The assigned Computer is offline, so new requests cannot start.")).toBeTruthy();
   });
 
   it("invalidates a stale Agent detail after a background not-found response", async () => {
@@ -1595,10 +1650,11 @@ describe("OpenTag Web App Shell", () => {
 
   it("refreshes the parent Agent projection after an IM mutation", async () => {
     installApi("admin", { bound: true });
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
     window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "All messages" }));
+    const dialog = await screen.findByRole("dialog", { name: "Allow all conversation messages?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
     await waitFor(() =>
       expect(
         vi
@@ -1608,7 +1664,6 @@ describe("OpenTag Web App Shell", () => {
           ),
       ).toHaveLength(2),
     );
-    confirm.mockRestore();
   });
 
   it("resumes a provisioning Slack setup after a refresh before credentials were submitted", async () => {
@@ -2217,13 +2272,13 @@ describe("OpenTag Web App Shell", () => {
   ] as const)("offers provider-correct recovery when %s needs additional scopes", async (provider, recovery) => {
     installApi("admin", { bound: true, provider, scopeReauth: true });
     window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "All messages" }));
+    const dialog = await screen.findByRole("dialog", { name: "Allow all conversation messages?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
     expect(await screen.findByText("Additional IM scopes are required")).toBeTruthy();
     expect(await screen.findByText(recovery)).toBeTruthy();
     if (provider === "slack") expect(screen.queryByRole("button", { name: "Reauthorize Feishu" })).toBeNull();
-    confirm.mockRestore();
   });
 
   it("starts a dedicated customer-owned Slack App setup from the Agent IM tab", async () => {

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -13,7 +13,13 @@ import { describe, expect, it } from "vitest";
  * role. Anywhere else, a rebinding is component-local drift: the thing this
  * PR removed.
  */
-const READING_SURFACES = new Set([".settings-page", ".onboarding-shell", ".decorative-page", ".dialog-card"]);
+const READING_SURFACES = new Set([
+  ".settings-page",
+  ".onboarding-shell",
+  ".decorative-page",
+  ".dialog-card",
+  ".agent-profile-page",
+]);
 
 /*
  * Every check reads parsed declarations rather than raw text. Matching CSS

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2124,6 +2124,7 @@ function AgentManageSettings({
   const [config, setConfig] = useState(initialConfig);
   const [message, setMessage] = useState<string>();
   const [confirmation, setConfirmation] = useState<"delete" | "pause">();
+  const [confirmationError, setConfirmationError] = useState<string>();
   const [confirmationText, setConfirmationText] = useState("");
   const [busy, setBusy] = useState(false);
   const pauseButtonRef = useRef<HTMLButtonElement>(null);
@@ -2131,6 +2132,8 @@ function AgentManageSettings({
   async function changeLifecycle(action: "suspend" | "reactivate") {
     try {
       setBusy(true);
+      setMessage(undefined);
+      setConfirmationError(undefined);
       setConfig(
         action === "suspend" ? await browserApi.suspendAgent(config.id) : await browserApi.reactivateAgent(config.id),
       );
@@ -2138,7 +2141,9 @@ function AgentManageSettings({
       setConfirmation(undefined);
       onAgentChanged();
     } catch (cause) {
-      setMessage(cause instanceof Error ? cause.message : "Unable to change Agent status");
+      const error = cause instanceof Error ? cause.message : "Unable to change Agent status";
+      if (confirmation === "pause") setConfirmationError(error);
+      else setMessage(error);
     } finally {
       setBusy(false);
     }
@@ -2146,12 +2151,18 @@ function AgentManageSettings({
   async function deleteAgent() {
     try {
       setBusy(true);
+      setMessage(undefined);
+      setConfirmationError(undefined);
       await browserApi.deleteAgent(config.id);
       navigate("/agents");
     } catch (cause) {
-      setMessage(cause instanceof Error ? cause.message : "Unable to delete Agent");
+      setConfirmationError(cause instanceof Error ? cause.message : "Unable to delete Agent");
       setBusy(false);
     }
+  }
+  function closeConfirmation() {
+    setConfirmation(undefined);
+    setConfirmationError(undefined);
   }
   return (
     <section className="agent-manage-settings agent-settings-section-page">
@@ -2171,6 +2182,7 @@ function AgentManageSettings({
             variant="secondary"
             onClick={() => {
               if (config.status === "active" && agent.activity.state === "working") {
+                setConfirmationError(undefined);
                 setConfirmation("pause");
                 return;
               }
@@ -2194,6 +2206,7 @@ function AgentManageSettings({
             variant="danger"
             onClick={() => {
               setConfirmationText("");
+              setConfirmationError(undefined);
               setConfirmation("delete");
             }}
           >
@@ -2208,10 +2221,15 @@ function AgentManageSettings({
           description="This Agent is handling a request. Pausing it stops new requests, but the current request may continue until it reaches a safe stopping point."
           returnFocusRef={pauseButtonRef}
           title={`Pause ${config.displayName}?`}
-          onClose={() => setConfirmation(undefined)}
+          onClose={closeConfirmation}
         >
+          {confirmationError ? (
+            <div className="notice error" role="alert">
+              {confirmationError}
+            </div>
+          ) : null}
           <div className="dialog-actions actions">
-            <Button disabled={busy} variant="ghost" onClick={() => setConfirmation(undefined)}>
+            <Button disabled={busy} variant="ghost" onClick={closeConfirmation}>
               Keep active
             </Button>
             <Button disabled={busy} variant="primary" onClick={() => void changeLifecycle("suspend")}>
@@ -2226,7 +2244,7 @@ function AgentManageSettings({
           description="This permanently removes the Agent and its messaging connection. The Agent cannot be restored."
           returnFocusRef={deleteButtonRef}
           title={`Delete ${config.displayName}?`}
-          onClose={() => setConfirmation(undefined)}
+          onClose={closeConfirmation}
         >
           <div className="agent-delete-confirmation">
             <Field
@@ -2244,8 +2262,13 @@ function AgentManageSettings({
                 onChange={(event) => setConfirmationText(event.currentTarget.value)}
               />
             </Field>
+            {confirmationError ? (
+              <div className="notice error" role="alert">
+                {confirmationError}
+              </div>
+            ) : null}
             <div className="dialog-actions actions">
-              <Button disabled={busy} variant="ghost" onClick={() => setConfirmation(undefined)}>
+              <Button disabled={busy} variant="ghost" onClick={closeConfirmation}>
                 Cancel
               </Button>
               <Button
@@ -2270,6 +2293,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
   const [confirmation, setConfirmation] = useState<
     { kind: "all_messages" } | { bindingId: string; kind: "disable_binding" }
   >();
+  const [confirmationError, setConfirmationError] = useState<string>();
   const [confirmationBusy, setConfirmationBusy] = useState(false);
   const allMessagesButtonRef = useRef<HTMLButtonElement>(null);
   const disableBindingButtonRef = useRef<HTMLButtonElement>(null);
@@ -2277,6 +2301,8 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
   async function changeReceiveMode(receiveMode: "mention_only" | "all_message") {
     try {
       setConfirmationBusy(true);
+      setError(undefined);
+      setConfirmationError(undefined);
       const config = await browserApi.agentConfig(agent.id);
       await browserApi.updateAgent(agent.id, { expectedRevision: config.revision, receiveMode });
       setReload((value) => value + 1);
@@ -2286,7 +2312,9 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
       if (cause instanceof ApiError && cause.code === "IM_BINDING_SCOPE_REAUTH_REQUIRED") {
         setReauthorizationNeeded(true);
       }
-      setError(cause instanceof Error ? cause.message : "Unable to change receive mode");
+      const nextError = cause instanceof Error ? cause.message : "Unable to change receive mode";
+      if (confirmation?.kind === "all_messages") setConfirmationError(nextError);
+      else setError(nextError);
     } finally {
       setConfirmationBusy(false);
     }
@@ -2294,15 +2322,21 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
   async function disableBinding(bindingId: string) {
     try {
       setConfirmationBusy(true);
+      setError(undefined);
+      setConfirmationError(undefined);
       await browserApi.disableImBinding(bindingId);
       setReload((value) => value + 1);
       setConfirmation(undefined);
       onAgentChanged();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Unable to disable IM binding");
+      setConfirmationError(cause instanceof Error ? cause.message : "Unable to disable IM binding");
     } finally {
       setConfirmationBusy(false);
     }
+  }
+  function closeMessagingConfirmation() {
+    setConfirmation(undefined);
+    setConfirmationError(undefined);
   }
   return (
     <div className="agent-settings-section-page">
@@ -2409,7 +2443,10 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                                   ref={disableBindingButtonRef}
                                   size="compact"
                                   variant="danger"
-                                  onClick={() => setConfirmation({ bindingId: binding.id, kind: "disable_binding" })}
+                                  onClick={() => {
+                                    setConfirmationError(undefined);
+                                    setConfirmation({ bindingId: binding.id, kind: "disable_binding" });
+                                  }}
                                 >
                                   Disable IM binding
                                 </Button>
@@ -2446,7 +2483,10 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                                         <button
                                           ref={allMessagesButtonRef}
                                           type="button"
-                                          onClick={() => setConfirmation({ kind: "all_messages" })}
+                                          onClick={() => {
+                                            setConfirmationError(undefined);
+                                            setConfirmation({ kind: "all_messages" });
+                                          }}
                                         >
                                           All messages
                                         </button>
@@ -2515,10 +2555,15 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
           description="Every new conversation message could start Agent work. This can share more conversation content and increase token usage."
           returnFocusRef={allMessagesButtonRef}
           title="Allow all conversation messages?"
-          onClose={() => setConfirmation(undefined)}
+          onClose={closeMessagingConfirmation}
         >
+          {confirmationError ? (
+            <div className="notice error" role="alert">
+              {confirmationError}
+            </div>
+          ) : null}
           <div className="dialog-actions actions">
-            <Button disabled={confirmationBusy} variant="ghost" onClick={() => setConfirmation(undefined)}>
+            <Button disabled={confirmationBusy} variant="ghost" onClick={closeMessagingConfirmation}>
               Keep mentions only
             </Button>
             <Button disabled={confirmationBusy} onClick={() => void changeReceiveMode("all_message")}>
@@ -2533,10 +2578,15 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
           description="Teammates will no longer be able to send new work to this Agent until another messaging connection is added."
           returnFocusRef={disableBindingButtonRef}
           title="Disconnect messaging?"
-          onClose={() => setConfirmation(undefined)}
+          onClose={closeMessagingConfirmation}
         >
+          {confirmationError ? (
+            <div className="notice error" role="alert">
+              {confirmationError}
+            </div>
+          ) : null}
           <div className="dialog-actions actions">
-            <Button disabled={confirmationBusy} variant="ghost" onClick={() => setConfirmation(undefined)}>
+            <Button disabled={confirmationBusy} variant="ghost" onClick={closeMessagingConfirmation}>
               Keep connected
             </Button>
             <Button

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -301,6 +301,7 @@ function useResource<T>(
   loader: () => Promise<T>,
   key: string,
   options: {
+    keepPreviousData?: boolean;
     onBackgroundError?: (value: T, error: Error) => T;
     revalidateMs?: number;
     refreshOnFocus?: boolean;
@@ -351,7 +352,7 @@ function useResource<T>(
         });
     };
     const revalidate = () => load(false);
-    load(true);
+    load(!options.keepPreviousData);
     const interval = options.revalidateMs ? window.setInterval(revalidate, options.revalidateMs) : undefined;
     const refreshVisible = () => {
       if (document.visibilityState === "visible") revalidate();
@@ -366,7 +367,7 @@ function useResource<T>(
       window.removeEventListener("focus", revalidate);
       document.removeEventListener("visibilitychange", refreshVisible);
     };
-  }, [key, options.refreshOnFocus, options.revalidateMs]);
+  }, [key, options.keepPreviousData, options.refreshOnFocus, options.revalidateMs]);
   return state;
 }
 
@@ -1735,6 +1736,7 @@ function AgentSettingsPage() {
   const location = useLocation();
   const [refreshVersion, setRefreshVersion] = useState(0);
   const state = useResource(() => loadAgentDetail(agentId), `${agentId}:${refreshVersion}`, {
+    keepPreviousData: true,
     onBackgroundError: markAgentDetailUnconfirmed,
   });
   const selected = section as AgentSettingsSection | undefined;
@@ -2127,8 +2129,14 @@ function AgentManageSettings({
   const [confirmationError, setConfirmationError] = useState<string>();
   const [confirmationText, setConfirmationText] = useState("");
   const [busy, setBusy] = useState(false);
+  const [restorePauseFocus, setRestorePauseFocus] = useState(false);
   const pauseButtonRef = useRef<HTMLButtonElement>(null);
   const deleteButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (confirmation || !restorePauseFocus) return;
+    pauseButtonRef.current?.focus();
+    setRestorePauseFocus(false);
+  }, [confirmation, restorePauseFocus]);
   async function changeLifecycle(action: "suspend" | "reactivate") {
     try {
       setBusy(true);
@@ -2138,6 +2146,7 @@ function AgentManageSettings({
         action === "suspend" ? await browserApi.suspendAgent(config.id) : await browserApi.reactivateAgent(config.id),
       );
       setMessage(action === "suspend" ? "Agent paused." : "Agent reactivated.");
+      setRestorePauseFocus(confirmation === "pause");
       setConfirmation(undefined);
       onAgentChanged();
     } catch (cause) {
@@ -2295,9 +2304,20 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
   >();
   const [confirmationError, setConfirmationError] = useState<string>();
   const [confirmationBusy, setConfirmationBusy] = useState(false);
+  const [restoreFocusTarget, setRestoreFocusTarget] = useState<"messaging" | "trigger_rules">();
   const allMessagesButtonRef = useRef<HTMLButtonElement>(null);
   const disableBindingButtonRef = useRef<HTMLButtonElement>(null);
-  const state = useResource(() => browserApi.imBinding(agent.id), `${agent.id}:${reload}`);
+  const messagingHeadingRef = useRef<HTMLHeadingElement>(null);
+  const triggerRulesHeadingRef = useRef<HTMLHeadingElement>(null);
+  const state = useResource(() => browserApi.imBinding(agent.id), `${agent.id}:${reload}`, {
+    keepPreviousData: true,
+  });
+  useEffect(() => {
+    if (confirmation || !restoreFocusTarget) return;
+    const target = restoreFocusTarget === "messaging" ? messagingHeadingRef.current : triggerRulesHeadingRef.current;
+    target?.focus();
+    setRestoreFocusTarget(undefined);
+  }, [confirmation, restoreFocusTarget]);
   async function changeReceiveMode(receiveMode: "mention_only" | "all_message") {
     try {
       setConfirmationBusy(true);
@@ -2306,6 +2326,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
       const config = await browserApi.agentConfig(agent.id);
       await browserApi.updateAgent(agent.id, { expectedRevision: config.revision, receiveMode });
       setReload((value) => value + 1);
+      if (receiveMode === "all_message") setRestoreFocusTarget("trigger_rules");
       setConfirmation(undefined);
       onAgentChanged();
     } catch (cause) {
@@ -2326,6 +2347,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
       setConfirmationError(undefined);
       await browserApi.disableImBinding(bindingId);
       setReload((value) => value + 1);
+      setRestoreFocusTarget("messaging");
       setConfirmation(undefined);
       onAgentChanged();
     } catch (cause) {
@@ -2341,7 +2363,9 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
   return (
     <div className="agent-settings-section-page">
       <header className="agent-settings-page-title">
-        <h1>Messaging</h1>
+        <h1 ref={messagingHeadingRef} tabIndex={-1}>
+          Messaging
+        </h1>
         <p>Choose where teammates send work to {agent.displayName}.</p>
       </header>
       <FeishuSetup
@@ -2457,7 +2481,9 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                           </section>
                           <section className="im-section" aria-labelledby="trigger-rules-heading">
                             <div className="im-section-heading">
-                              <h3 id="trigger-rules-heading">Trigger rules</h3>
+                              <h3 id="trigger-rules-heading" ref={triggerRulesHeadingRef} tabIndex={-1}>
+                                Trigger rules
+                              </h3>
                               <p>Which incoming messages can start Agent work.</p>
                             </div>
                             <SettingsList className="agent-message-rules">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -55,6 +55,7 @@ import {
   Dialog,
   Field,
   Icon,
+  type IconName,
   SettingsList,
   SettingsRow,
   StatusIndicator,
@@ -1434,15 +1435,57 @@ function markOwnComputersUnconfirmed(value: { computers: Computer[] }): { comput
   };
 }
 
-const agentSettingsSections = [
-  { key: "identity", label: "Identity", description: "Name and handle" },
-  { key: "instructions", label: "Instructions", description: "Guidance for every request" },
-  { key: "execution", label: "Execution", description: "Provider, model, and reasoning" },
-  { key: "messaging", label: "Messaging", description: "Contact channel and trigger rules" },
-  { key: "computer", label: "Computer", description: "Assigned device and connection" },
-  { key: "manage", label: "Manage", description: "Pause or delete this Agent" },
+type AgentSettingsSection = "instructions" | "execution" | "messaging" | "identity" | "computer" | "manage";
+type AgentSettingsGroup = "work" | "contact" | "details";
+
+const agentSettingsSections: ReadonlyArray<{
+  key: AgentSettingsSection;
+  label: string;
+  group: AgentSettingsGroup;
+  icon: IconName;
+}> = [
+  {
+    key: "instructions",
+    label: "Instructions & behavior",
+    group: "work",
+    icon: "instructions",
+  },
+  {
+    key: "execution",
+    label: "Model & reasoning",
+    group: "work",
+    icon: "model",
+  },
+  {
+    key: "messaging",
+    label: "Messaging",
+    group: "contact",
+    icon: "message",
+  },
+  {
+    key: "identity",
+    label: "Name & identity",
+    group: "details",
+    icon: "user",
+  },
+  {
+    key: "computer",
+    label: "Connected computer",
+    group: "details",
+    icon: "laptop",
+  },
+  {
+    key: "manage",
+    label: "Manage Agent",
+    group: "details",
+    icon: "shield",
+  },
+];
+const agentSettingsGroups = [
+  { key: "work", label: "How it works" },
+  { key: "contact", label: "Where it receives work" },
+  { key: "details", label: "Agent details" },
 ] as const;
-type AgentSettingsSection = (typeof agentSettingsSections)[number]["key"];
 
 function LegacyAgentAccessRedirect() {
   return <Navigate replace to="/workspace#members" />;
@@ -1472,7 +1515,7 @@ function LegacyAgentCapabilityPage({ capability }: { capability: "integrations" 
   return (
     <AsyncState state={state}>
       {(agent) => (
-        <section className="object-page">
+        <section className="object-page agent-profile-page">
           <AgentObjectHeader agent={agent} />
           <div className="agent-secondary-page">
             <header className="section-header">
@@ -1507,16 +1550,12 @@ function AgentDetailPage() {
   return (
     <AsyncState state={state}>
       {(agent) => (
-        <section className="object-page">
+        <section className="object-page agent-profile-page">
           <AgentObjectHeader agent={agent} />
           <div className="agent-home">
             {agent.availability.state !== "ready" ? <AgentRecoveryBanner agent={agent} /> : null}
             <AgentCurrentActivity agent={agent} />
             <AgentContact agent={agent} />
-            <p className="agent-home-footnote">
-              OpenTag shows confirmed status and contact information. Detailed work remains in the original messaging
-              thread.
-            </p>
           </div>
         </section>
       )}
@@ -1525,6 +1564,8 @@ function AgentDetailPage() {
 }
 
 function AgentObjectHeader({ agent, backToSettings }: { agent: AgentDetailView; backToSettings?: boolean }) {
+  const { me } = useTeam();
+  const showManager = agent.manager.userId !== me.user.id;
   return (
     <header className="object-header">
       <Link className="breadcrumb" to={backToSettings ? `/agents/${agent.id}` : "/agents"}>
@@ -1536,26 +1577,27 @@ function AgentObjectHeader({ agent, backToSettings }: { agent: AgentDetailView; 
           <span className="agent-avatar large" aria-hidden="true">
             {initials(agent.displayName)}
           </span>
-          <div>
-            <h1>{agent.displayName}</h1>
+          <div className="object-identity-copy">
+            <div className="agent-name-line">
+              <h1>{agent.displayName}</h1>
+              <AgentAvailabilityAction agent={agent} />
+            </div>
             <p>
               <span>@{agent.name}</span>
-              <span>Managed by {agent.manager.displayName}</span>
+              {showManager ? <span>Managed by {agent.manager.displayName}</span> : null}
             </p>
           </div>
         </div>
         <div className="agent-header-actions">
-          <AgentAvailabilityAction agent={agent} />
-          {agent.viewerCapabilities.canManage && !backToSettings ? (
-            <Link className={buttonClassName({ variant: "secondary" })} to={`/agents/${agent.id}/settings`}>
-              Settings
+          {!backToSettings ? (
+            <Link className="agent-usage-link" to={`/agents/${agent.id}/usage`}>
+              Usage
             </Link>
           ) : null}
-          {!backToSettings ? (
-            <details className="agent-more-menu">
-              <summary aria-label="More Agent actions">More</summary>
-              <Link to={`/agents/${agent.id}/usage`}>Usage</Link>
-            </details>
+          {agent.viewerCapabilities.canManage && !backToSettings ? (
+            <Link className={buttonClassName({ variant: "secondary" })} to={`/agents/${agent.id}/settings`}>
+              <Icon name="settings" /> Settings
+            </Link>
           ) : null}
         </div>
       </div>
@@ -1583,8 +1625,8 @@ function AgentRecoveryBanner({ agent }: { agent: AgentDetailView }) {
 function AgentCurrentActivity({ agent }: { agent: AgentDetailView }) {
   return (
     <section className="agent-home-section" aria-labelledby="current-activity-heading">
-      <header>
-        <h2 id="current-activity-heading">Current activity</h2>
+      <header className="agent-home-section-heading">
+        <h2 id="current-activity-heading">Current work</h2>
       </header>
       {agent.activity.state === "working" ? (
         <div className="agent-current-work">
@@ -1593,12 +1635,10 @@ function AgentCurrentActivity({ agent }: { agent: AgentDetailView }) {
             <strong>Handling a request</strong>
             <p>Started {formatRelativeTime(agent.activity.startedAt)}</p>
           </div>
-          <span className="agent-state-label">Working</span>
         </div>
       ) : (
-        <p className="agent-empty-line">
+        <p className="agent-activity-empty">
           <strong>No active work</strong>
-          <span>{agent.availability.state === "ready" ? "Ready for a new request" : "No request is running"}</span>
         </p>
       )}
     </section>
@@ -1610,33 +1650,58 @@ function AgentContact({ agent }: { agent: AgentDetailView }) {
   return (
     <section className="agent-home-section" aria-labelledby="agent-contact-heading">
       <header className="agent-home-section-heading">
-        <div>
-          <h2 id="agent-contact-heading">Contact</h2>
-          <p>Where teammates can send this Agent work.</p>
-        </div>
-        {agent.viewerCapabilities.canManage ? (
-          <Link to={`/agents/${agent.id}/settings/messaging`}>Manage messaging</Link>
-        ) : null}
+        <h2 id="agent-contact-heading">Where to use this Agent</h2>
       </header>
       {agent.messaging.kind === "unconfirmed" ? (
-        <p className="agent-empty-line">
-          <strong>Unable to confirm messaging</strong>
-          <span>Try again shortly</span>
-        </p>
+        <div className="agent-contact-row is-unconfirmed">
+          <span className="agent-contact-mark" aria-hidden="true">
+            ?
+          </span>
+          <span className="agent-contact-copy">
+            <strong>Unable to confirm messaging</strong>
+            <small>Try again shortly</small>
+          </span>
+        </div>
       ) : binding ? (
-        <div className="agent-contact-body">
-          <StatusIndicator
-            detail={titleCase(binding.provider)}
-            label={binding.bot.displayName}
-            tone={messagingConnectionTone(binding, agent.availability.dependencies.handoff.state)}
-          />
-          <p>{agentUseInstruction(agent, titleCase(binding.provider))}</p>
+        <div className="agent-contact-row">
+          <span className="agent-contact-mark" aria-hidden="true">
+            {titleCase(binding.provider).charAt(0)}
+          </span>
+          <span className="agent-contact-copy">
+            <strong>
+              {titleCase(binding.provider)} · @{agent.name}
+            </strong>
+            <small>{agentUseInstruction(agent, titleCase(binding.provider))}</small>
+          </span>
+          {agent.viewerCapabilities.canManage ? (
+            <Link
+              className={buttonClassName({ size: "compact", variant: "outline" })}
+              state={{ returnLabel: agent.displayName, returnTo: `/agents/${agent.id}` }}
+              to={`/agents/${agent.id}/settings/messaging`}
+            >
+              Manage
+            </Link>
+          ) : null}
         </div>
       ) : (
-        <p className="agent-empty-line">
-          <strong>No messaging connected</strong>
-          <span>Connect Feishu or Slack to start sending work</span>
-        </p>
+        <div className="agent-contact-row is-empty">
+          <span className="agent-contact-mark" aria-hidden="true">
+            +
+          </span>
+          <span className="agent-contact-copy">
+            <strong>No messaging connected</strong>
+            <small>Connect Feishu or Slack to start sending work</small>
+          </span>
+          {agent.viewerCapabilities.canManage ? (
+            <Link
+              className={buttonClassName({ size: "compact", variant: "outline" })}
+              state={{ returnLabel: agent.displayName, returnTo: `/agents/${agent.id}` }}
+              to={`/agents/${agent.id}/settings/messaging`}
+            >
+              Connect
+            </Link>
+          ) : null}
+        </div>
       )}
     </section>
   );
@@ -1650,7 +1715,7 @@ function AgentUsagePage() {
   return (
     <AsyncState state={state}>
       {(agent) => (
-        <section className="object-page">
+        <section className="object-page agent-profile-page">
           <AgentObjectHeader agent={agent} backToSettings />
           <div className="agent-secondary-page">
             <header className="section-header">
@@ -1667,6 +1732,7 @@ function AgentUsagePage() {
 
 function AgentSettingsPage() {
   const { agentId = "", section } = useParams();
+  const location = useLocation();
   const [refreshVersion, setRefreshVersion] = useState(0);
   const state = useResource(() => loadAgentDetail(agentId), `${agentId}:${refreshVersion}`, {
     onBackgroundError: markAgentDetailUnconfirmed,
@@ -1677,20 +1743,16 @@ function AgentSettingsPage() {
     <AsyncState state={state}>
       {(agent) => {
         if (!agent.viewerCapabilities.canManage) return <Navigate replace to={`/agents/${agent.id}`} />;
+        const returnState = location.state as { returnLabel?: string; returnTo?: string } | null;
+        const backTo = selected ? (returnState?.returnTo ?? `/agents/${agent.id}/settings`) : `/agents/${agent.id}`;
+        const backLabel = selected ? (returnState?.returnLabel ?? "Agent settings") : agent.displayName;
         return (
-          <section className="object-page">
-            <AgentObjectHeader agent={agent} backToSettings />
-            <div className="agent-settings-layout">
-              <nav aria-label="Agent settings" className="agent-settings-nav">
-                <Link className={!selected ? "active" : undefined} to={`/agents/${agent.id}/settings`}>
-                  Settings
-                </Link>
-                {agentSettingsSections.map((item) => (
-                  <NavLink key={item.key} to={`/agents/${agent.id}/settings/${item.key}`}>
-                    {item.label}
-                  </NavLink>
-                ))}
-              </nav>
+          <section className="object-page agent-profile-page">
+            <div className="agent-settings-page">
+              <Link className="agent-page-back" to={backTo}>
+                <Icon name="arrow-left" />
+                Back to {backLabel}
+              </Link>
               <div className="agent-settings-content">
                 <AgentSettingsContent
                   agent={agent}
@@ -1780,9 +1842,8 @@ function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
   const tone = availabilityTone(agent.availability.state);
   const working = agent.availability.state === "ready" && agent.activity.state === "working";
   return (
-    <div className={`availability-action ${tone}`}>
+    <div className="agent-availability-line">
       <StatusIndicator
-        detail={working ? "Handling a request" : agentAvailabilitySummary(agent)}
         label={working ? "Working" : availabilityStateLabel(agent.availability.state)}
         tone={working ? "info" : tone}
       />
@@ -1830,32 +1891,103 @@ function AgentConfigSettingsContent({
             />
           );
         }
-        return <AgentManageSettings initialConfig={config} onAgentChanged={onAgentChanged} />;
+        return <AgentManageSettings agent={agent} initialConfig={config} onAgentChanged={onAgentChanged} />;
       }}
     </AsyncState>
   );
 }
 
 function AgentSettingsOverview({ agent }: { agent: AgentDetailView }) {
+  const configState = useResource(() => browserApi.agentConfig(agent.id), `${agent.id}:settings-overview`);
   return (
-    <div>
-      <header className="section-header">
-        <h2>Settings</h2>
-        <p>Change how {agent.displayName} appears, works, and receives requests.</p>
+    <div className="agent-settings-overview">
+      <header className="agent-settings-page-title">
+        <h1>Agent settings</h1>
+        <p>Change how {agent.displayName} works and receives requests.</p>
       </header>
-      <div className="agent-settings-grid">
-        {agentSettingsSections.map((item) => (
-          <Link key={item.key} to={`/agents/${agent.id}/settings/${item.key}`}>
-            <span>
-              <strong>{item.label}</strong>
-              <small>{item.description}</small>
-            </span>
-            <Icon name="chevron-right" />
-          </Link>
-        ))}
-      </div>
+      <AsyncState state={configState}>
+        {(config) => (
+          <div className="agent-settings-groups">
+            {agentSettingsGroups.map((group) => (
+              <section className="agent-settings-group" key={group.key} aria-labelledby={`agent-settings-${group.key}`}>
+                <h2 id={`agent-settings-${group.key}`}>{group.label}</h2>
+                <div className="agent-settings-grid">
+                  {agentSettingsSections
+                    .filter((item) => item.group === group.key)
+                    .map((item) => {
+                      const content = (
+                        <>
+                          <span className="agent-settings-icon" aria-hidden="true">
+                            <Icon name={item.icon} />
+                          </span>
+                          <span className="agent-settings-row-copy">
+                            <strong>{item.label}</strong>
+                            <small>{agentSettingsSummary(agent, config, item.key)}</small>
+                          </span>
+                        </>
+                      );
+                      const computerReady =
+                        item.key === "computer" && agent.availability.dependencies.computer.state === "ready";
+                      if (computerReady) {
+                        return (
+                          <div className="agent-settings-entry is-static" key={item.key}>
+                            {content}
+                          </div>
+                        );
+                      }
+                      return (
+                        <Link
+                          className="agent-settings-entry"
+                          key={item.key}
+                          to={`/agents/${agent.id}/settings/${item.key}`}
+                        >
+                          {content}
+                          <span className="agent-settings-row-value" aria-hidden="true">
+                            {item.key === "computer" ? <small>Review</small> : null}
+                            <Icon name="chevron-right" />
+                          </span>
+                        </Link>
+                      );
+                    })}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </AsyncState>
     </div>
   );
+}
+
+function agentSettingsSummary(agent: AgentDetailView, config: AgentAdminConfig, section: AgentSettingsSection): string {
+  if (section === "instructions") {
+    return config.runtimeConfig.instructions.trim() ? "Custom instructions" : "Not configured";
+  }
+  if (section === "execution") {
+    const provider = config.runtimeProvider === "codex" ? "Codex" : "Claude Code";
+    const model = config.runtimeConfig.model ?? "Default model";
+    const reasoning = config.runtimeConfig.reasoningEffort
+      ? titleCase(config.runtimeConfig.reasoningEffort)
+      : "Default reasoning";
+    return `${provider} · ${model} · ${reasoning}`;
+  }
+  if (section === "messaging") {
+    if (agent.messaging.kind === "unconfirmed") return "Messaging status is temporarily unavailable";
+    const binding = agent.messaging.value;
+    if (!binding) return "No messaging channel connected";
+    const status =
+      binding.bindingState === "active" && agent.availability.dependencies.handoff.state === "ready"
+        ? "Connected"
+        : messagingConnectionLabel(binding, agent.availability.dependencies.handoff.state);
+    return `${titleCase(binding.provider)} · @${agent.name} · ${status}`;
+  }
+  if (section === "identity") return `${config.displayName} · @${config.name}`;
+  if (section === "computer") {
+    const state = agent.availability.dependencies.computer.state;
+    const status = state === "ready" ? "Online" : state === "action_required" ? "Offline" : "Unconfirmed";
+    return `${agent.computer.displayName} · ${platformLabel(agent.computer.platform)} · ${status}`;
+  }
+  return config.status === "active" ? "Active" : "Paused";
 }
 
 function GeneralConfigForm({
@@ -1866,38 +1998,69 @@ function GeneralConfigForm({
   onAgentChanged: () => void;
 }) {
   const [config, setConfig] = useState(initialConfig);
+  const [displayName, setDisplayName] = useState(initialConfig.displayName);
   const [message, setMessage] = useState<string>();
+  const [saving, setSaving] = useState(false);
+  const dirty = displayName !== config.displayName;
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const displayName = String(new FormData(event.currentTarget).get("displayName") ?? "");
+    if (!dirty || saving) return;
+    setSaving(true);
+    setMessage(undefined);
     try {
-      setConfig(await browserApi.updateAgent(config.id, { expectedRevision: config.revision, displayName }));
+      const updated = await browserApi.updateAgent(config.id, { expectedRevision: config.revision, displayName });
+      setConfig(updated);
+      setDisplayName(updated.displayName);
       setMessage("Identity saved.");
       onAgentChanged();
     } catch (cause) {
       setMessage(cause instanceof Error ? cause.message : "Unable to save identity");
+    } finally {
+      setSaving(false);
     }
   }
   return (
-    <form className="form-card" onSubmit={submit}>
-      <header className="section-header">
-        <h2>Identity</h2>
+    <form className="form-card agent-settings-form" onSubmit={submit}>
+      <header className="agent-settings-page-title">
+        <h1>Name &amp; identity</h1>
         <p>Choose the name teammates see. The handle cannot be changed.</p>
       </header>
       <Field htmlFor="agent-display-name" label="Display name">
         <input
           className="ds-control"
-          defaultValue={config.displayName}
           id="agent-display-name"
-          key={config.revision}
           name="displayName"
           required
+          value={displayName}
+          onChange={(event) => {
+            setDisplayName(event.currentTarget.value);
+            setMessage(undefined);
+          }}
         />
       </Field>
-      <Field htmlFor="agent-handle" label="Handle">
-        <input className="ds-control" disabled id="agent-handle" value={`@${config.name}`} />
+      <Field hint="The handle cannot be changed." htmlFor="agent-handle" label="Handle">
+        <input className="ds-control" id="agent-handle" readOnly value={`@${config.name}`} />
       </Field>
-      <Button type="submit">Save identity</Button>
+      {dirty ? (
+        <div className="dirty-bar">
+          <span>Unsaved changes</span>
+          <div className="dirty-actions">
+            <Button
+              disabled={saving}
+              variant="ghost"
+              onClick={() => {
+                setDisplayName(config.displayName);
+                setMessage(undefined);
+              }}
+            >
+              Discard
+            </Button>
+            <Button disabled={saving} type="submit">
+              {saving ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </div>
+      ) : null}
       {message ? <p role="status">{message}</p> : null}
     </form>
   );
@@ -1914,12 +2077,12 @@ function AgentComputerSettings({ agent, onAgentChanged }: { agent: AgentDetailVi
   const computerTone: StatusTone =
     computerState.state === "ready" ? "success" : computerState.state === "action_required" ? "warning" : "neutral";
   return (
-    <div className="agent-runtime-stack">
+    <div className="agent-runtime-stack agent-settings-section-page">
       <section aria-labelledby="computer-heading" className="agent-runtime-section agent-runtime-computer">
         <header className="agent-runtime-section__header">
           <div>
-            <h2 id="computer-heading">Computer</h2>
-            <p>The device assigned to run this Agent.</p>
+            <h1 id="computer-heading">Connected computer</h1>
+            <p>The computer assigned to run {agent.displayName}.</p>
           </div>
           <StatusIndicator label={computerStatus} tone={computerTone} />
         </header>
@@ -1949,44 +2112,51 @@ function AgentComputerSettings({ agent, onAgentChanged }: { agent: AgentDetailVi
 }
 
 function AgentManageSettings({
+  agent,
   initialConfig,
   onAgentChanged,
 }: {
+  agent: AgentDetailView;
   initialConfig: AgentAdminConfig;
   onAgentChanged: () => void;
 }) {
   const navigate = useNavigate();
   const [config, setConfig] = useState(initialConfig);
   const [message, setMessage] = useState<string>();
+  const [confirmation, setConfirmation] = useState<"delete" | "pause">();
+  const [confirmationText, setConfirmationText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const pauseButtonRef = useRef<HTMLButtonElement>(null);
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
   async function changeLifecycle(action: "suspend" | "reactivate") {
     try {
+      setBusy(true);
       setConfig(
         action === "suspend" ? await browserApi.suspendAgent(config.id) : await browserApi.reactivateAgent(config.id),
       );
       setMessage(action === "suspend" ? "Agent paused." : "Agent reactivated.");
+      setConfirmation(undefined);
       onAgentChanged();
     } catch (cause) {
       setMessage(cause instanceof Error ? cause.message : "Unable to change Agent status");
+    } finally {
+      setBusy(false);
     }
   }
   async function deleteAgent() {
-    if (
-      !window.confirm(
-        `Permanently delete ${config.displayName}? This will end active Sessions, remove messaging credentials and execution settings, and retain Session and message history. This Agent cannot be restored.`,
-      )
-    )
-      return;
     try {
+      setBusy(true);
       await browserApi.deleteAgent(config.id);
       navigate("/agents");
     } catch (cause) {
       setMessage(cause instanceof Error ? cause.message : "Unable to delete Agent");
+      setBusy(false);
     }
   }
   return (
-    <section className="agent-manage-settings">
-      <header className="section-header">
-        <h2>Manage</h2>
+    <section className="agent-manage-settings agent-settings-section-page">
+      <header className="agent-settings-page-title">
+        <h1>Manage Agent</h1>
         <p>Pause this Agent temporarily or remove it permanently.</p>
       </header>
       <SettingsList>
@@ -1997,8 +2167,15 @@ function AgentManageSettings({
           label={config.status === "active" ? "Pause Agent" : "Reactivate Agent"}
         >
           <Button
+            ref={pauseButtonRef}
             variant="secondary"
-            onClick={() => void changeLifecycle(config.status === "active" ? "suspend" : "reactivate")}
+            onClick={() => {
+              if (config.status === "active" && agent.activity.state === "working") {
+                setConfirmation("pause");
+                return;
+              }
+              void changeLifecycle(config.status === "active" ? "suspend" : "reactivate");
+            }}
           >
             {config.status === "active" ? "Pause" : "Reactivate"}
           </Button>
@@ -2011,12 +2188,77 @@ function AgentManageSettings({
           }
           label="Delete Agent"
         >
-          <Button disabled={config.status === "active"} variant="danger" onClick={() => void deleteAgent()}>
+          <Button
+            disabled={config.status === "active"}
+            ref={deleteButtonRef}
+            variant="danger"
+            onClick={() => {
+              setConfirmationText("");
+              setConfirmation("delete");
+            }}
+          >
             Delete permanently
           </Button>
         </SettingsRow>
       </SettingsList>
       {message ? <p role="status">{message}</p> : null}
+      {confirmation === "pause" ? (
+        <Dialog
+          busy={busy}
+          description="This Agent is handling a request. Pausing it stops new requests, but the current request may continue until it reaches a safe stopping point."
+          returnFocusRef={pauseButtonRef}
+          title={`Pause ${config.displayName}?`}
+          onClose={() => setConfirmation(undefined)}
+        >
+          <div className="dialog-actions actions">
+            <Button disabled={busy} variant="ghost" onClick={() => setConfirmation(undefined)}>
+              Keep active
+            </Button>
+            <Button disabled={busy} variant="primary" onClick={() => void changeLifecycle("suspend")}>
+              {busy ? "Pausing…" : "Pause Agent"}
+            </Button>
+          </div>
+        </Dialog>
+      ) : null}
+      {confirmation === "delete" ? (
+        <Dialog
+          busy={busy}
+          description="This permanently removes the Agent and its messaging connection. The Agent cannot be restored."
+          returnFocusRef={deleteButtonRef}
+          title={`Delete ${config.displayName}?`}
+          onClose={() => setConfirmation(undefined)}
+        >
+          <div className="agent-delete-confirmation">
+            <Field
+              htmlFor="agent-delete-confirmation"
+              label={
+                <>
+                  Type <strong>{config.displayName}</strong> to confirm
+                </>
+              }
+            >
+              <input
+                autoComplete="off"
+                id="agent-delete-confirmation"
+                value={confirmationText}
+                onChange={(event) => setConfirmationText(event.currentTarget.value)}
+              />
+            </Field>
+            <div className="dialog-actions actions">
+              <Button disabled={busy} variant="ghost" onClick={() => setConfirmation(undefined)}>
+                Cancel
+              </Button>
+              <Button
+                disabled={busy || confirmationText !== config.displayName}
+                variant="danger"
+                onClick={() => void deleteAgent()}
+              >
+                {busy ? "Deleting…" : "Delete permanently"}
+              </Button>
+            </div>
+          </div>
+        </Dialog>
+      ) : null}
     </section>
   );
 }
@@ -2025,230 +2267,289 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
   const [reload, setReload] = useState(0);
   const [error, setError] = useState<string>();
   const [reauthorizationNeeded, setReauthorizationNeeded] = useState(false);
+  const [confirmation, setConfirmation] = useState<
+    { kind: "all_messages" } | { bindingId: string; kind: "disable_binding" }
+  >();
+  const [confirmationBusy, setConfirmationBusy] = useState(false);
+  const allMessagesButtonRef = useRef<HTMLButtonElement>(null);
+  const disableBindingButtonRef = useRef<HTMLButtonElement>(null);
   const state = useResource(() => browserApi.imBinding(agent.id), `${agent.id}:${reload}`);
   async function changeReceiveMode(receiveMode: "mention_only" | "all_message") {
-    if (
-      receiveMode === "all_message" &&
-      !window.confirm(
-        "All-message mode may expose more conversation content and increase token usage and cost. Continue?",
-      )
-    )
-      return;
     try {
+      setConfirmationBusy(true);
       const config = await browserApi.agentConfig(agent.id);
       await browserApi.updateAgent(agent.id, { expectedRevision: config.revision, receiveMode });
       setReload((value) => value + 1);
+      setConfirmation(undefined);
       onAgentChanged();
     } catch (cause) {
       if (cause instanceof ApiError && cause.code === "IM_BINDING_SCOPE_REAUTH_REQUIRED") {
         setReauthorizationNeeded(true);
       }
       setError(cause instanceof Error ? cause.message : "Unable to change receive mode");
+    } finally {
+      setConfirmationBusy(false);
+    }
+  }
+  async function disableBinding(bindingId: string) {
+    try {
+      setConfirmationBusy(true);
+      await browserApi.disableImBinding(bindingId);
+      setReload((value) => value + 1);
+      setConfirmation(undefined);
+      onAgentChanged();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Unable to disable IM binding");
+    } finally {
+      setConfirmationBusy(false);
     }
   }
   return (
-    <FeishuSetup
-      agentId={agent.id}
-      onSuccess={() => {
-        setReload((value) => value + 1);
-        onAgentChanged();
-      }}
-    >
-      {(feishuSetup) => (
-        <SlackSetup
-          agentId={agent.id}
-          onSuccess={() => {
-            setReload((value) => value + 1);
-            onAgentChanged();
-          }}
-        >
-          {(slackSetup) => {
-            const connectFeishu = async (intent: "create" | "reauthorize" | "replace" = "create") => {
-              setError(undefined);
-              if (await feishuSetup.start(intent)) setReauthorizationNeeded(false);
-            };
-            const connectSlack = async (intent: "create" | "reauthorize" | "replace" = "create") => {
-              setError(undefined);
-              if (await slackSetup.start(intent)) setReauthorizationNeeded(false);
-            };
-            return (
-              <AsyncState state={state}>
-                {(binding) => (
-                  <div className="im-stack">
-                    {binding ? (
-                      <>
+    <div className="agent-settings-section-page">
+      <header className="agent-settings-page-title">
+        <h1>Messaging</h1>
+        <p>Choose where teammates send work to {agent.displayName}.</p>
+      </header>
+      <FeishuSetup
+        agentId={agent.id}
+        onSuccess={() => {
+          setReload((value) => value + 1);
+          onAgentChanged();
+        }}
+      >
+        {(feishuSetup) => (
+          <SlackSetup
+            agentId={agent.id}
+            onSuccess={() => {
+              setReload((value) => value + 1);
+              onAgentChanged();
+            }}
+          >
+            {(slackSetup) => {
+              const connectFeishu = async (intent: "create" | "reauthorize" | "replace" = "create") => {
+                setError(undefined);
+                if (await feishuSetup.start(intent)) setReauthorizationNeeded(false);
+              };
+              const connectSlack = async (intent: "create" | "reauthorize" | "replace" = "create") => {
+                setError(undefined);
+                if (await slackSetup.start(intent)) setReauthorizationNeeded(false);
+              };
+              return (
+                <AsyncState state={state}>
+                  {(binding) => (
+                    <div className="im-stack">
+                      {binding ? (
+                        <>
+                          <section className="im-section" aria-labelledby="contact-channel-heading">
+                            <div className="im-section-heading">
+                              <h3 id="contact-channel-heading">Contact channel</h3>
+                              <p>Where teammates can reach this Agent and whether the connection is available.</p>
+                            </div>
+                            <div className="binding-status">
+                              <StatusIndicator
+                                detail={`${titleCase(binding.provider)} · ${messagingConnectionLabel(
+                                  binding,
+                                  agent.availability.dependencies.handoff.state,
+                                )}`}
+                                label={binding.bot.displayName}
+                                tone={messagingConnectionTone(binding, agent.availability.dependencies.handoff.state)}
+                              />
+                              <small>
+                                {binding.lastConfirmedAt
+                                  ? `Confirmed ${formatDate(binding.lastConfirmedAt)}`
+                                  : "Unable to confirm"}
+                              </small>
+                            </div>
+                            <dl className="messaging-contact-facts">
+                              <div>
+                                <dt>Contact</dt>
+                                <dd>@{agent.name}</dd>
+                              </div>
+                              <div>
+                                <dt>How to use</dt>
+                                <dd>{agentUseInstruction(agent, titleCase(binding.provider))}</dd>
+                              </div>
+                            </dl>
+                            {(binding.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
+                            binding.provider === "feishu" &&
+                            agent.viewerCapabilities.canManage ? (
+                              <div className="im-actions">
+                                <Button onClick={() => void connectFeishu("reauthorize")}>Reauthorize Feishu</Button>
+                              </div>
+                            ) : null}
+                            {(binding.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
+                            binding.provider === "slack" &&
+                            agent.viewerCapabilities.canManage ? (
+                              <div className="im-actions">
+                                <Button onClick={() => void connectSlack("reauthorize")}>Reauthorize Slack</Button>
+                              </div>
+                            ) : null}
+                            {binding.bindingState === "provisioning" &&
+                            binding.provider === "slack" &&
+                            agent.viewerCapabilities.canManage ? (
+                              <SlackProvisioningActions onResume={() => void connectSlack("create")} />
+                            ) : null}
+                            {agent.viewerCapabilities.canManage ? (
+                              <div className="im-actions messaging-connection-actions">
+                                {binding.provider === "feishu" ? (
+                                  <Button
+                                    size="compact"
+                                    variant="outline"
+                                    onClick={() => void connectFeishu("replace")}
+                                  >
+                                    Replace Feishu Bot
+                                  </Button>
+                                ) : null}
+                                {binding.provider === "slack" && binding.bindingState !== "provisioning" ? (
+                                  <Button size="compact" variant="outline" onClick={() => void connectSlack("replace")}>
+                                    Replace Slack App
+                                  </Button>
+                                ) : null}
+                                <Button
+                                  ref={disableBindingButtonRef}
+                                  size="compact"
+                                  variant="danger"
+                                  onClick={() => setConfirmation({ bindingId: binding.id, kind: "disable_binding" })}
+                                >
+                                  Disable IM binding
+                                </Button>
+                              </div>
+                            ) : (
+                              <p className="muted">Workspace admins manage this contact channel.</p>
+                            )}
+                          </section>
+                          <section className="im-section" aria-labelledby="trigger-rules-heading">
+                            <div className="im-section-heading">
+                              <h3 id="trigger-rules-heading">Trigger rules</h3>
+                              <p>Which incoming messages can start Agent work.</p>
+                            </div>
+                            <SettingsList className="agent-message-rules">
+                              <SettingsRow
+                                description="A direct message can always start work."
+                                label="Direct messages"
+                              >
+                                <strong>Always</strong>
+                              </SettingsRow>
+                              <SettingsRow
+                                description={
+                                  binding.receiveMode === "mention_only"
+                                    ? `Teammates must mention @${agent.name}.`
+                                    : "Every new conversation message can start work."
+                                }
+                                label={`${titleCase(binding.provider)} conversations`}
+                              >
+                                {agent.viewerCapabilities.canManage ? (
+                                  <fieldset aria-label="Conversation trigger rule" className="segmented-control">
+                                    {binding.receiveMode === "mention_only" ? (
+                                      <>
+                                        <span className="active">Mentions only</span>
+                                        <button
+                                          ref={allMessagesButtonRef}
+                                          type="button"
+                                          onClick={() => setConfirmation({ kind: "all_messages" })}
+                                        >
+                                          All messages
+                                        </button>
+                                      </>
+                                    ) : (
+                                      <>
+                                        <button type="button" onClick={() => void changeReceiveMode("mention_only")}>
+                                          Mentions only
+                                        </button>
+                                        <span className="active">All messages</span>
+                                      </>
+                                    )}
+                                  </fieldset>
+                                ) : (
+                                  <strong>{receiveModeLabel(binding.receiveMode)}</strong>
+                                )}
+                              </SettingsRow>
+                            </SettingsList>
+                            {binding.pendingReceiveMode ? (
+                              <p className="muted">
+                                Scope upgrade pending: {receiveModeLabel(binding.pendingReceiveMode)} takes effect once{" "}
+                                {titleCase(binding.provider)} grants the additional permissions through reauthorization.
+                              </p>
+                            ) : null}
+                          </section>
+                        </>
+                      ) : (
                         <section className="im-section" aria-labelledby="contact-channel-heading">
                           <div className="im-section-heading">
                             <h3 id="contact-channel-heading">Contact channel</h3>
-                            <p>Where teammates can reach this Agent and whether the connection is available.</p>
+                            <p>Where teammates can reach this Agent.</p>
                           </div>
-                          <div className="binding-status">
-                            <StatusIndicator
-                              detail={`${titleCase(binding.provider)} · ${messagingConnectionLabel(
-                                binding,
-                                agent.availability.dependencies.handoff.state,
-                              )}`}
-                              label={binding.bot.displayName}
-                              tone={messagingConnectionTone(binding, agent.availability.dependencies.handoff.state)}
-                            />
-                            <small>
-                              {binding.lastConfirmedAt
-                                ? `Confirmed ${formatDate(binding.lastConfirmedAt)}`
-                                : "Unable to confirm"}
-                            </small>
-                          </div>
-                          <dl className="messaging-contact-facts">
-                            <div>
-                              <dt>Contact</dt>
-                              <dd>@{agent.name}</dd>
-                            </div>
-                            <div>
-                              <dt>How to use</dt>
-                              <dd>{agentUseInstruction(agent, titleCase(binding.provider))}</dd>
-                            </div>
-                          </dl>
-                          {(binding.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
-                          binding.provider === "feishu" &&
-                          agent.viewerCapabilities.canManage ? (
-                            <div className="im-actions">
-                              <Button onClick={() => void connectFeishu("reauthorize")}>Reauthorize Feishu</Button>
-                            </div>
-                          ) : null}
-                          {(binding.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
-                          binding.provider === "slack" &&
-                          agent.viewerCapabilities.canManage ? (
-                            <div className="im-actions">
-                              <Button onClick={() => void connectSlack("reauthorize")}>Reauthorize Slack</Button>
-                            </div>
-                          ) : null}
-                          {binding.bindingState === "provisioning" &&
-                          binding.provider === "slack" &&
-                          agent.viewerCapabilities.canManage ? (
-                            <SlackProvisioningActions onResume={() => void connectSlack("create")} />
-                          ) : null}
+                          <EmptyState title="No messaging channel">
+                            Teammates cannot contact this Agent until a supported bot is connected.
+                          </EmptyState>
                           {agent.viewerCapabilities.canManage ? (
-                            <div className="im-actions messaging-connection-actions">
-                              {binding.provider === "feishu" ? (
-                                <Button size="compact" variant="outline" onClick={() => void connectFeishu("replace")}>
-                                  Replace Feishu Bot
-                                </Button>
-                              ) : null}
-                              {binding.provider === "slack" && binding.bindingState !== "provisioning" ? (
-                                <Button size="compact" variant="outline" onClick={() => void connectSlack("replace")}>
-                                  Replace Slack App
-                                </Button>
-                              ) : null}
-                              <Button
-                                size="compact"
-                                variant="danger"
-                                onClick={() => {
-                                  if (
-                                    !window.confirm(
-                                      "Disable this IM binding? New IM work will stop until another binding is connected.",
-                                    )
-                                  )
-                                    return;
-                                  void browserApi.disableImBinding(binding.id).then(
-                                    () => {
-                                      setReload((value) => value + 1);
-                                      onAgentChanged();
-                                    },
-                                    (cause: unknown) =>
-                                      setError(cause instanceof Error ? cause.message : "Unable to disable IM binding"),
-                                  );
-                                }}
-                              >
-                                Disable IM binding
+                            <div className="im-actions">
+                              <Button onClick={() => void connectFeishu()}>Connect a Feishu Bot</Button>
+                              <Button variant="secondary" onClick={() => void connectSlack()}>
+                                Connect Slack App
                               </Button>
                             </div>
                           ) : (
-                            <p className="muted">Workspace admins manage this contact channel.</p>
+                            <p className="muted">Workspace admins manage messaging setup.</p>
                           )}
                         </section>
-                        <section className="im-section" aria-labelledby="trigger-rules-heading">
-                          <div className="im-section-heading">
-                            <h3 id="trigger-rules-heading">Trigger rules</h3>
-                            <p>Which incoming messages can start Agent work.</p>
-                          </div>
-                          <SettingsList className="agent-message-rules">
-                            <SettingsRow description="A direct message can always start work." label="Direct messages">
-                              <strong>Always</strong>
-                            </SettingsRow>
-                            <SettingsRow
-                              description={
-                                binding.receiveMode === "mention_only"
-                                  ? `Teammates must mention @${agent.name}.`
-                                  : "Every new conversation message can start work."
-                              }
-                              label={`${titleCase(binding.provider)} conversations`}
-                            >
-                              {agent.viewerCapabilities.canManage ? (
-                                <fieldset aria-label="Conversation trigger rule" className="segmented-control">
-                                  {binding.receiveMode === "mention_only" ? (
-                                    <>
-                                      <span className="active">Mentions only</span>
-                                      <button type="button" onClick={() => void changeReceiveMode("all_message")}>
-                                        All messages
-                                      </button>
-                                    </>
-                                  ) : (
-                                    <>
-                                      <button type="button" onClick={() => void changeReceiveMode("mention_only")}>
-                                        Mentions only
-                                      </button>
-                                      <span className="active">All messages</span>
-                                    </>
-                                  )}
-                                </fieldset>
-                              ) : (
-                                <strong>{receiveModeLabel(binding.receiveMode)}</strong>
-                              )}
-                            </SettingsRow>
-                          </SettingsList>
-                          {binding.pendingReceiveMode ? (
-                            <p className="muted">
-                              Scope upgrade pending: {receiveModeLabel(binding.pendingReceiveMode)} takes effect once{" "}
-                              {titleCase(binding.provider)} grants the additional permissions through reauthorization.
-                            </p>
-                          ) : null}
-                        </section>
-                      </>
-                    ) : (
-                      <section className="im-section" aria-labelledby="contact-channel-heading">
-                        <div className="im-section-heading">
-                          <h3 id="contact-channel-heading">Contact channel</h3>
-                          <p>Where teammates can reach this Agent.</p>
+                      )}
+                      {feishuSetup.feedback}
+                      {slackSetup.feedback}
+                      {error ? (
+                        <div className="notice error" role="alert">
+                          {error}
                         </div>
-                        <EmptyState title="No messaging channel">
-                          Teammates cannot contact this Agent until a supported bot is connected.
-                        </EmptyState>
-                        {agent.viewerCapabilities.canManage ? (
-                          <div className="im-actions">
-                            <Button onClick={() => void connectFeishu()}>Connect a Feishu Bot</Button>
-                            <Button variant="secondary" onClick={() => void connectSlack()}>
-                              Connect Slack App
-                            </Button>
-                          </div>
-                        ) : (
-                          <p className="muted">Workspace admins manage messaging setup.</p>
-                        )}
-                      </section>
-                    )}
-                    {feishuSetup.feedback}
-                    {slackSetup.feedback}
-                    {error ? (
-                      <div className="notice error" role="alert">
-                        {error}
-                      </div>
-                    ) : null}
-                  </div>
-                )}
-              </AsyncState>
-            );
-          }}
-        </SlackSetup>
-      )}
-    </FeishuSetup>
+                      ) : null}
+                    </div>
+                  )}
+                </AsyncState>
+              );
+            }}
+          </SlackSetup>
+        )}
+      </FeishuSetup>
+      {confirmation?.kind === "all_messages" ? (
+        <Dialog
+          busy={confirmationBusy}
+          description="Every new conversation message could start Agent work. This can share more conversation content and increase token usage."
+          returnFocusRef={allMessagesButtonRef}
+          title="Allow all conversation messages?"
+          onClose={() => setConfirmation(undefined)}
+        >
+          <div className="dialog-actions actions">
+            <Button disabled={confirmationBusy} variant="ghost" onClick={() => setConfirmation(undefined)}>
+              Keep mentions only
+            </Button>
+            <Button disabled={confirmationBusy} onClick={() => void changeReceiveMode("all_message")}>
+              {confirmationBusy ? "Updating…" : "Allow all messages"}
+            </Button>
+          </div>
+        </Dialog>
+      ) : null}
+      {confirmation?.kind === "disable_binding" ? (
+        <Dialog
+          busy={confirmationBusy}
+          description="Teammates will no longer be able to send new work to this Agent until another messaging connection is added."
+          returnFocusRef={disableBindingButtonRef}
+          title="Disconnect messaging?"
+          onClose={() => setConfirmation(undefined)}
+        >
+          <div className="dialog-actions actions">
+            <Button disabled={confirmationBusy} variant="ghost" onClick={() => setConfirmation(undefined)}>
+              Keep connected
+            </Button>
+            <Button
+              disabled={confirmationBusy}
+              variant="danger"
+              onClick={() => void disableBinding(confirmation.bindingId)}
+            >
+              {confirmationBusy ? "Disconnecting…" : "Disconnect"}
+            </Button>
+          </div>
+        </Dialog>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/web/src/runtime-configuration.test.tsx
+++ b/apps/web/src/runtime-configuration.test.tsx
@@ -32,18 +32,20 @@ describe("RuntimeConfigurationForm", () => {
     render(<RuntimeConfigurationForm initialConfig={config} save={vi.fn()} />);
 
     expect(screen.getByRole("heading", { name: "Execution" })).toBeTruthy();
-    expect(screen.getByText("Codex")).toBeTruthy();
-    expect(screen.getAllByText("Provider default")).toHaveLength(2);
+    expect(screen.getByText("Provider: Codex")).toBeTruthy();
+    expect((screen.getByLabelText("Model") as HTMLInputElement).placeholder).toBe("Codex default");
+    expect((screen.getByLabelText("Reasoning level") as HTMLInputElement).placeholder).toBe("Provider default");
     expect(screen.getByRole("heading", { name: "Agent instructions" })).toBeTruthy();
     expect(screen.queryByText(/timeout/i)).toBeNull();
     expect(screen.queryByText("Execution choices")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit settings" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
   });
 
-  it("edits only the understandable Runtime choices", () => {
+  it("directly edits only the understandable Runtime choices", () => {
     render(<RuntimeConfigurationForm initialConfig={config} save={vi.fn()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
-    expect((screen.getByLabelText("Model") as HTMLInputElement).placeholder).toBe("Provider default");
+    expect((screen.getByLabelText("Model") as HTMLInputElement).placeholder).toBe("Codex default");
     const effort = screen.getByLabelText("Reasoning level") as HTMLInputElement;
     expect(effort.placeholder).toBe("Provider default");
     const suggestions = document.getElementById(effort.getAttribute("list") ?? "");
@@ -75,13 +77,11 @@ describe("RuntimeConfigurationForm", () => {
     }));
     render(<RuntimeConfigurationForm initialConfig={claudeConfig} save={save} />);
 
-    expect(screen.getByText("Claude Code")).toBeTruthy();
-    expect(screen.getByText("claude-opus-4-1")).toBeTruthy();
-    expect(screen.getByText("max")).toBeTruthy();
+    expect(screen.getByText("Provider: Claude Code")).toBeTruthy();
+    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("claude-opus-4-1");
+    expect((screen.getByLabelText("Reasoning level") as HTMLInputElement).value).toBe("max");
     expect((screen.getByLabelText("Instructions") as HTMLTextAreaElement).value).toBe("Use the repository guidelines.");
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
-    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("claude-opus-4-1");
     expect(screen.getAllByText("Leave blank to use the provider default.")).toHaveLength(2);
     const effort = screen.getByLabelText("Reasoning level") as HTMLInputElement;
     const suggestions = document.getElementById(effort.getAttribute("list") ?? "");
@@ -95,7 +95,7 @@ describe("RuntimeConfigurationForm", () => {
     ]);
 
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Updated Claude instructions." } });
-    fireEvent.click(screen.getByRole("button", { name: "Save instructions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
     await waitFor(() => expect(save).toHaveBeenCalledOnce());
     expect(save).toHaveBeenCalledWith({
       expectedRevision: 4,
@@ -116,10 +116,9 @@ describe("RuntimeConfigurationForm", () => {
     }));
     render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
     fireEvent.change(screen.getByLabelText("Model"), { target: { value: "  gpt-5.6-codex  " } });
     fireEvent.change(screen.getByLabelText("Reasoning level"), { target: { value: "high" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => expect(save).toHaveBeenCalledOnce());
     expect(save).toHaveBeenCalledWith({
@@ -130,7 +129,7 @@ describe("RuntimeConfigurationForm", () => {
       },
     });
     expect((await screen.findByRole("status")).textContent).toBe("Execution settings saved.");
-    expect(screen.getByText("gpt-5.6-codex")).toBeTruthy();
+    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("gpt-5.6-codex");
   });
 
   it("saves Agent instructions independently", async () => {
@@ -142,7 +141,7 @@ describe("RuntimeConfigurationForm", () => {
     render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
 
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Updated instructions." } });
-    fireEvent.click(screen.getByRole("button", { name: "Save instructions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => expect(save).toHaveBeenCalledOnce());
     expect(save).toHaveBeenCalledWith({
@@ -169,10 +168,23 @@ describe("RuntimeConfigurationForm", () => {
     });
     render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit settings" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5.6-codex" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     expect((await screen.findByRole("alert")).textContent).toBe("Revision changed");
     expect(screen.getByLabelText("Model")).toBeTruthy();
+  });
+
+  it("discards a draft without saving", () => {
+    const save = vi.fn();
+    render(<RuntimeConfigurationForm initialConfig={config} save={save} section="execution" />);
+
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5.6-codex" } });
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+
+    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("");
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
+    expect(save).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/runtime-configuration.tsx
+++ b/apps/web/src/runtime-configuration.tsx
@@ -17,7 +17,9 @@ export function RuntimeConfigurationForm({ initialConfig, save, section = "all" 
 
 function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: RuntimeConfigurationFormProps) {
   const [config, setConfig] = useState(initialConfig);
-  const [editingRuntime, setEditingRuntime] = useState(false);
+  const [modelDraft, setModelDraft] = useState(initialConfig.runtimeConfig.model ?? "");
+  const [reasoningDraft, setReasoningDraft] = useState(initialConfig.runtimeConfig.reasoningEffort ?? "");
+  const [instructionsDraft, setInstructionsDraft] = useState(initialConfig.runtimeConfig.instructions);
   const [message, setMessage] = useState<{
     kind: "error" | "success";
     section: "runtime" | "instructions";
@@ -27,8 +29,14 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
   const fieldId = (name: string) => `runtime-${name}-${config.id}`;
   const reasoningListId = `reasoning-effort-${config.id}`;
   const providerName = config.runtimeProvider === "codex" ? "Codex" : "Claude Code";
+  const ExecutionHeading = section === "execution" ? "h1" : "h3";
+  const InstructionsHeading = section === "instructions" ? "h1" : "h3";
   const reasoningSuggestions =
     config.runtimeProvider === "codex" ? CODEX_REASONING_EFFORT_SUGGESTIONS : CLAUDE_CODE_REASONING_EFFORT_SUGGESTIONS;
+  const runtimeDirty =
+    modelDraft !== (config.runtimeConfig.model ?? "") ||
+    reasoningDraft !== (config.runtimeConfig.reasoningEffort ?? "");
+  const instructionsDirty = instructionsDraft !== config.runtimeConfig.instructions;
 
   async function saveRuntime(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -39,7 +47,8 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
       const runtimeConfig = runtimeConfigurationFromForm(new FormData(event.currentTarget));
       const updated = await save({ expectedRevision: config.revision, runtimeConfig });
       setConfig(updated);
-      setEditingRuntime(false);
+      setModelDraft(updated.runtimeConfig.model ?? "");
+      setReasoningDraft(updated.runtimeConfig.reasoningEffort ?? "");
       setMessage({ kind: "success", section: "runtime", text: "Execution settings saved." });
     } catch (cause) {
       setMessage({
@@ -58,12 +67,12 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
     setSaving("instructions");
     setMessage(undefined);
     try {
-      const instructions = String(new FormData(event.currentTarget).get("instructions") ?? "");
       const updated = await save({
         expectedRevision: config.revision,
-        runtimeConfig: { instructions },
+        runtimeConfig: { instructions: instructionsDraft },
       });
       setConfig(updated);
+      setInstructionsDraft(updated.runtimeConfig.instructions);
       setMessage({ kind: "success", section: "instructions", text: "Agent instructions saved." });
     } catch (cause) {
       setMessage({
@@ -77,78 +86,91 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
   }
 
   return (
-    <div className="agent-runtime-settings">
+    <div className={`agent-runtime-settings${section === "all" ? "" : " agent-settings-section-page"}`}>
       {section !== "instructions" ? (
         <section aria-labelledby="execution-heading" className="agent-runtime-section">
           <header className="agent-runtime-section__header">
             <div>
-              <h3 id="execution-heading">Execution</h3>
-              <p>Choose the provider, model, and reasoning level used for new work.</p>
+              <ExecutionHeading id="execution-heading">
+                {section === "execution" ? "Model & reasoning" : "Execution"}
+              </ExecutionHeading>
+              <p>
+                {section === "execution"
+                  ? "Choose how this Agent handles new work."
+                  : "Choose the provider, model, and reasoning level used for new work."}
+              </p>
             </div>
-            {!editingRuntime ? (
-              <Button size="compact" variant="inline" onClick={() => setEditingRuntime(true)}>
-                Edit settings
-              </Button>
-            ) : null}
           </header>
-          {editingRuntime ? (
-            <form className="agent-runtime-edit-form" key={config.revision} onSubmit={saveRuntime}>
-              <div className="agent-runtime-field-grid">
-                <Field
-                  hint="Leave blank to use the provider default."
-                  hintId={fieldId("model-help")}
-                  htmlFor={fieldId("model")}
-                  label="Model"
-                >
-                  <input
-                    aria-describedby={fieldId("model-help")}
-                    autoComplete="off"
-                    defaultValue={config.runtimeConfig.model ?? ""}
-                    id={fieldId("model")}
-                    name="model"
-                    placeholder="Provider default"
-                  />
-                </Field>
-                <Field
-                  hint="Leave blank to use the provider default."
-                  hintId={fieldId("reasoning-help")}
-                  htmlFor={fieldId("reasoning-effort")}
-                  label="Reasoning level"
-                >
-                  <input
-                    aria-describedby={fieldId("reasoning-help")}
-                    autoComplete="off"
-                    defaultValue={config.runtimeConfig.reasoningEffort ?? ""}
-                    id={fieldId("reasoning-effort")}
-                    list={reasoningListId}
-                    name="reasoningEffort"
-                    placeholder="Provider default"
-                  />
-                  <datalist id={reasoningListId}>
-                    {reasoningSuggestions.map((effort) => (
-                      <option value={effort} key={effort} />
-                    ))}
-                  </datalist>
-                </Field>
+          {section !== "execution" ? <p className="agent-runtime-provider">Provider: {providerName}</p> : null}
+          <form className="agent-runtime-edit-form" onSubmit={saveRuntime}>
+            <div className="agent-runtime-field-grid">
+              <Field
+                hint="Leave blank to use the provider default."
+                hintId={fieldId("model-help")}
+                htmlFor={fieldId("model")}
+                label="Model"
+              >
+                <input
+                  aria-describedby={fieldId("model-help")}
+                  autoComplete="off"
+                  id={fieldId("model")}
+                  name="model"
+                  placeholder={`${providerName} default`}
+                  value={modelDraft}
+                  onChange={(event) => {
+                    setModelDraft(event.currentTarget.value);
+                    setMessage(undefined);
+                  }}
+                />
+              </Field>
+              <Field
+                hint="Leave blank to use the provider default."
+                hintId={fieldId("reasoning-help")}
+                htmlFor={fieldId("reasoning-effort")}
+                label="Reasoning level"
+              >
+                <input
+                  aria-describedby={fieldId("reasoning-help")}
+                  autoComplete="off"
+                  id={fieldId("reasoning-effort")}
+                  list={reasoningListId}
+                  name="reasoningEffort"
+                  placeholder="Provider default"
+                  value={reasoningDraft}
+                  onChange={(event) => {
+                    setReasoningDraft(event.currentTarget.value);
+                    setMessage(undefined);
+                  }}
+                />
+                <datalist id={reasoningListId}>
+                  {reasoningSuggestions.map((effort) => (
+                    <option value={effort} key={effort} />
+                  ))}
+                </datalist>
+              </Field>
+            </div>
+            {runtimeDirty ? (
+              <div className="dirty-bar">
+                <span>Unsaved changes</span>
+                <div className="dirty-actions">
+                  <Button
+                    disabled={Boolean(saving)}
+                    variant="ghost"
+                    onClick={() => {
+                      setModelDraft(config.runtimeConfig.model ?? "");
+                      setReasoningDraft(config.runtimeConfig.reasoningEffort ?? "");
+                      setMessage(undefined);
+                    }}
+                  >
+                    Discard
+                  </Button>
+                  <Button disabled={Boolean(saving)} type="submit">
+                    {saving === "runtime" ? "Saving…" : "Save changes"}
+                  </Button>
+                </div>
               </div>
-              <div className="agent-runtime-actions">
-                <Button disabled={Boolean(saving)} type="submit">
-                  {saving === "runtime" ? "Saving…" : "Save settings"}
-                </Button>
-                <Button disabled={Boolean(saving)} variant="ghost" onClick={() => setEditingRuntime(false)}>
-                  Cancel
-                </Button>
-              </div>
-            </form>
-          ) : (
-            <RuntimeFacts
-              rows={[
-                ["Provider", providerName],
-                ["Model", config.runtimeConfig.model ?? "Provider default"],
-                ["Reasoning level", config.runtimeConfig.reasoningEffort ?? "Provider default"],
-              ]}
-            />
-          )}
+            ) : null}
+          </form>
           {message?.section === "runtime" ? <SaveMessage message={message} /> : null}
         </section>
       ) : null}
@@ -157,11 +179,17 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
         <section aria-labelledby="agent-instructions-heading" className="agent-runtime-section">
           <header className="agent-runtime-section__header">
             <div>
-              <h3 id="agent-instructions-heading">Agent instructions</h3>
-              <p>Set the guidance applied to every request this Agent handles.</p>
+              <InstructionsHeading id="agent-instructions-heading">
+                {section === "instructions" ? "Instructions & behavior" : "Agent instructions"}
+              </InstructionsHeading>
+              <p>
+                {section === "instructions"
+                  ? "Tell this Agent how it should work in plain language."
+                  : "Set the guidance applied to every request this Agent handles."}
+              </p>
             </div>
           </header>
-          <form className="agent-instructions-form" key={config.runtimeConfig.revision} onSubmit={saveInstructions}>
+          <form className="agent-instructions-form" onSubmit={saveInstructions}>
             <Field
               hint="Be concise and specific. These instructions apply in addition to OpenTag's platform guidance."
               hintId={fieldId("instructions-help")}
@@ -170,33 +198,41 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
             >
               <textarea
                 aria-describedby={fieldId("instructions-help")}
-                defaultValue={config.runtimeConfig.instructions}
                 id={fieldId("instructions")}
                 name="instructions"
                 rows={8}
+                value={instructionsDraft}
+                onChange={(event) => {
+                  setInstructionsDraft(event.currentTarget.value);
+                  setMessage(undefined);
+                }}
               />
             </Field>
-            <Button disabled={Boolean(saving)} type="submit">
-              {saving === "instructions" ? "Saving…" : "Save instructions"}
-            </Button>
+            {instructionsDirty ? (
+              <div className="dirty-bar">
+                <span>Unsaved changes</span>
+                <div className="dirty-actions">
+                  <Button
+                    disabled={Boolean(saving)}
+                    variant="ghost"
+                    onClick={() => {
+                      setInstructionsDraft(config.runtimeConfig.instructions);
+                      setMessage(undefined);
+                    }}
+                  >
+                    Discard
+                  </Button>
+                  <Button disabled={Boolean(saving)} type="submit">
+                    {saving === "instructions" ? "Saving…" : "Save changes"}
+                  </Button>
+                </div>
+              </div>
+            ) : null}
           </form>
           {message?.section === "instructions" ? <SaveMessage message={message} /> : null}
         </section>
       ) : null}
     </div>
-  );
-}
-
-function RuntimeFacts({ rows }: { rows: ReadonlyArray<readonly [string, string]> }) {
-  return (
-    <dl className="agent-runtime-facts">
-      {rows.map(([label, value]) => (
-        <div key={label}>
-          <dt>{label}</dt>
-          <dd>{value}</dd>
-        </div>
-      ))}
-    </dl>
   );
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -56,6 +56,7 @@
      tracking crowds CJK, which has no side bearings to give back. */
   --track-tight: -0.02em;
   --track-label: 0.06em;
+  --track-normal: 0;
 
   --background: #f8f7f0;
   --surface: #fdfcf7;
@@ -3052,16 +3053,7 @@ textarea:focus {
   gap: 32px;
 }
 
-.agent-runtime-facts dt {
-  display: block;
-  margin-bottom: 5px;
-  color: var(--muted);
-  font-size: var(--text-micro);
-  font-weight: var(--fw-semibold);
-}
-
-.agent-runtime-computer__body strong,
-.agent-runtime-facts dd {
+.agent-runtime-computer__body strong {
   color: var(--foreground);
   font-size: var(--text-body);
   font-weight: var(--fw-medium);
@@ -3078,17 +3070,6 @@ textarea:focus {
   margin: 0;
 }
 
-.agent-runtime-facts {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 24px;
-  margin: 0;
-}
-
-.agent-runtime-facts dd {
-  margin: 0;
-}
-
 .agent-runtime-edit-form,
 .agent-instructions-form {
   display: grid;
@@ -3101,18 +3082,15 @@ textarea:focus {
   gap: 20px;
 }
 
-.agent-runtime-actions {
-  display: flex;
-  gap: 8px;
+.agent-runtime-provider {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--text-meta);
 }
 
 .agent-instructions-form textarea {
   min-height: 160px;
   resize: vertical;
-}
-
-.agent-instructions-form > .ds-button {
-  justify-self: start;
 }
 
 .list {
@@ -4318,7 +4296,6 @@ textarea:focus {
     flex-direction: column;
   }
 
-  .agent-runtime-facts,
   .agent-runtime-field-grid {
     grid-template-columns: 1fr;
   }
@@ -4344,53 +4321,126 @@ textarea:focus {
   }
 }
 
+.agent-profile-page {
+  --text-meta: var(--fs-14);
+  --text-ui: var(--fs-16);
+  --text-body: var(--fs-16);
+  --text-subsection: var(--fs-20);
+  --text-display: var(--fs-32);
+}
+
+.agent-profile-page .object-header {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.agent-profile-page .breadcrumb,
+.agent-page-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: var(--text-ui);
+  text-decoration: none;
+}
+
+.agent-profile-page .breadcrumb {
+  margin-bottom: 26px;
+}
+
+.agent-page-back {
+  margin-bottom: 30px;
+}
+
+.agent-profile-page .breadcrumb:hover,
+.agent-page-back:hover {
+  color: var(--foreground);
+}
+
+.agent-profile-page .object-title-row {
+  align-items: center;
+}
+
+.agent-profile-page .object-identity {
+  gap: 16px;
+}
+
+.agent-profile-page .agent-avatar.large {
+  width: 58px;
+  height: 58px;
+  border-radius: 16px;
+  font-size: var(--text-subsection);
+}
+
+.object-identity-copy {
+  min-width: 0;
+}
+
+.agent-name-line {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.agent-profile-page .object-identity h1 {
+  margin: 0 0 6px;
+}
+
+.agent-name-line .agent-availability-line {
+  margin-bottom: 4px;
+}
+
+.agent-availability-line .ds-status {
+  align-items: center;
+  gap: 7px;
+}
+
+.agent-availability-line .ds-status__copy strong {
+  color: var(--status-color);
+  font-size: var(--text-meta);
+}
+
 .agent-header-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 9px;
 }
 
-.agent-more-menu {
-  position: relative;
+.agent-header-actions .ds-button .ds-icon {
+  width: 16px;
+  height: 16px;
 }
 
-.agent-more-menu > summary {
-  min-height: 38px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-control);
+.agent-usage-link {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
   color: var(--secondary-foreground);
-  cursor: pointer;
   font-size: var(--text-ui);
-  font-weight: var(--fw-semibold);
-  list-style: none;
-  padding: 8px 12px;
+  font-weight: var(--fw-medium);
+  padding: 0 10px;
+  text-decoration: none;
+  transition: color 180ms ease;
 }
 
-.agent-more-menu > summary::-webkit-details-marker {
-  display: none;
+.agent-usage-link:hover {
+  color: var(--brand-ink);
 }
 
-.agent-more-menu > a {
-  position: absolute;
-  z-index: 2;
-  top: calc(100% + 6px);
-  right: 0;
-  min-width: 140px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-control);
-  background: var(--surface);
-  box-shadow: 0 8px 24px rgb(43 55 38 / 10%);
-  color: var(--foreground);
-  font-size: var(--text-ui);
-  padding: 10px 12px;
+.agent-home {
+  display: grid;
+  width: 100%;
+  gap: 34px;
+  margin: 42px 0 0;
 }
 
-.agent-home,
 .agent-secondary-page {
   display: grid;
   width: min(100%, 820px);
   gap: 28px;
-  margin: 36px auto 0;
+  margin: 42px auto 0;
 }
 
 .agent-recovery-banner {
@@ -4399,9 +4449,9 @@ textarea:focus {
   justify-content: space-between;
   gap: 24px;
   border: 1px solid #e8c48d;
-  border-radius: 12px;
+  border-radius: 16px;
   background: #fffaf1;
-  padding: 18px 20px;
+  padding: 20px 22px;
 }
 
 .agent-recovery-banner strong,
@@ -4410,183 +4460,337 @@ textarea:focus {
   font-size: var(--text-subsection);
 }
 
-.agent-recovery-banner p,
-.agent-home-section header p,
-.agent-contact-body p,
-.agent-home-footnote {
-  margin: 5px 0 0;
+.agent-recovery-banner p {
+  max-width: 62ch;
+  margin: 6px 0 0;
   color: var(--muted);
   font-size: var(--text-ui);
   line-height: var(--lh-prose);
 }
 
-.agent-home-section {
-  border-top: 1px solid var(--border);
-  padding-top: 24px;
-}
-
-.agent-home-section > header,
 .agent-home-section-heading {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 20px;
-  margin-bottom: 18px;
+  margin-bottom: 14px;
 }
 
 .agent-home-section h2 {
   margin: 0;
   font-family: var(--font-display);
+  letter-spacing: var(--track-tight);
 }
 
-.agent-home-section-heading a {
-  color: var(--brand-ink);
-  font-size: var(--text-ui);
-  font-weight: var(--fw-semibold);
-}
-
-.agent-current-work,
-.agent-empty-line,
-.agent-contact-body {
+.agent-current-work {
   display: flex;
-  min-height: 72px;
+  min-height: 104px;
   align-items: center;
-  gap: 14px;
-  border-radius: 10px;
-  background: var(--surface-soft);
-  padding: 16px 18px;
+  gap: 16px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+  padding: 20px 22px;
 }
 
 .agent-current-work > div {
   flex: 1;
 }
 
+.agent-current-work strong,
+.agent-activity-empty strong,
+.agent-contact-copy strong {
+  color: var(--foreground);
+  font-size: var(--text-body);
+  font-weight: var(--fw-semibold);
+}
+
 .agent-current-work p,
-.agent-empty-line,
-.agent-empty-line span {
+.agent-activity-empty,
+.agent-activity-empty span {
   margin: 0;
   color: var(--muted);
   font-size: var(--text-ui);
 }
 
-.agent-empty-line {
-  justify-content: space-between;
+.agent-current-work p {
+  margin-top: 6px;
 }
 
-.agent-empty-line strong,
-.agent-current-work strong {
-  color: var(--foreground);
-  font-size: var(--text-body);
+.agent-activity-empty {
+  display: flex;
+  min-height: 54px;
+  align-items: center;
+  gap: 20px;
+  border-block: 1px solid var(--border);
+  padding: 14px 2px;
 }
 
 .agent-activity-pulse {
-  width: 10px;
-  height: 10px;
+  width: 9px;
+  height: 9px;
   flex: 0 0 auto;
   border-radius: 999px;
   background: var(--color-status-info);
+  box-shadow: 0 0 0 4px var(--color-status-info-surface);
 }
 
-.agent-state-label {
-  color: var(--color-status-info);
-  font-size: var(--text-meta);
-  font-weight: var(--fw-semibold);
-}
-
-.agent-contact-body {
-  align-items: flex-start;
-  justify-content: space-between;
-}
-
-.agent-contact-body > p {
-  max-width: 440px;
-  margin: 0;
-}
-
-.agent-home-footnote {
-  border-top: 1px solid var(--border);
-  padding-top: 18px;
-}
-
-.agent-settings-layout {
+.agent-contact-row {
   display: grid;
-  grid-template-columns: 190px minmax(0, 1fr);
-  gap: 48px;
-  padding-top: 36px;
+  min-height: 78px;
+  align-items: center;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  gap: 15px;
+  border-block: 1px solid var(--border);
+  padding: 16px 0;
 }
 
-.agent-settings-nav {
+.agent-contact-mark,
+.agent-settings-icon {
   display: grid;
-  align-content: start;
-  gap: 4px;
-}
-
-.agent-settings-nav a {
-  border-radius: 8px;
-  color: var(--secondary-foreground);
-  font-size: var(--text-ui);
-  padding: 9px 11px;
-}
-
-.agent-settings-nav a.active {
+  place-items: center;
+  border-radius: 12px;
   background: var(--surface-soft);
-  color: var(--foreground);
+  color: var(--brand-ink);
   font-weight: var(--fw-semibold);
 }
 
-.agent-settings-content {
-  width: min(100%, 760px);
+.agent-contact-mark {
+  width: 42px;
+  height: 42px;
+}
+
+.agent-contact-copy {
   min-width: 0;
 }
 
-.agent-settings-grid {
-  display: grid;
-  border-top: 1px solid var(--border);
-}
-
-.agent-settings-grid > a {
-  display: flex;
-  min-height: 72px;
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: 1px solid var(--border);
-  color: var(--foreground);
-  padding: 14px 4px;
-}
-
-.agent-settings-grid span,
-.agent-settings-grid small {
+.agent-contact-copy strong,
+.agent-contact-copy small {
   display: block;
 }
 
-.agent-settings-grid small {
+.agent-contact-copy small {
+  max-width: 64ch;
   margin-top: 4px;
+  color: var(--muted);
+  font-size: var(--text-ui);
+  line-height: var(--lh-prose);
+}
+
+.agent-settings-page {
+  width: min(100%, 780px);
+  margin: 0 auto;
+  padding-top: 6px;
+}
+
+.agent-settings-content {
+  width: 100%;
+  min-width: 0;
+}
+
+.agent-settings-page-title {
+  margin-bottom: 30px;
+}
+
+.agent-settings-page-title h1,
+.agent-settings-section-page .agent-runtime-section__header h1 {
+  margin: 0;
+  color: var(--foreground);
+  font-family: var(--font-display);
+  font-size: var(--text-display);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--track-tight);
+  line-height: var(--lh-tight);
+}
+
+.agent-settings-page-title p,
+.agent-settings-section-page .agent-runtime-section__header p {
+  max-width: 62ch;
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: var(--text-body);
+  line-height: var(--lh-prose);
+}
+
+.agent-settings-groups {
+  display: grid;
+  gap: 28px;
+}
+
+.agent-settings-group h2 {
+  margin: 0 0 10px 2px;
+  color: var(--secondary-foreground);
+  font-size: var(--text-meta);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--track-normal);
+}
+
+.agent-settings-grid {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.agent-settings-entry {
+  display: grid;
+  min-height: 78px;
+  align-items: center;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 14px;
+  border-bottom: 1px solid var(--border);
+  color: var(--foreground);
+  padding: 16px 18px;
+  text-decoration: none;
+  transition: background-color 180ms ease;
+}
+
+.agent-settings-entry:last-child {
+  border-bottom: 0;
+}
+
+.agent-settings-entry:is(a):hover {
+  background: var(--surface-soft);
+}
+
+.agent-settings-entry:is(a):active {
+  background: color-mix(in srgb, var(--surface-soft) 80%, var(--border));
+}
+
+.agent-settings-entry.is-static {
+  cursor: default;
+}
+
+.agent-settings-icon {
+  width: 42px;
+  height: 42px;
+  color: var(--muted);
+}
+
+.agent-settings-icon .ds-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.agent-settings-row-copy,
+.agent-settings-row-copy strong,
+.agent-settings-row-copy small,
+.agent-settings-row-value {
+  display: block;
+  min-width: 0;
+}
+
+.agent-settings-row-copy strong {
+  font-size: var(--text-body);
+  font-weight: var(--fw-semibold);
+}
+
+.agent-settings-row-copy small {
   color: var(--muted);
   font-size: var(--text-meta);
 }
 
+.agent-settings-row-copy small {
+  margin-top: 4px;
+}
+
+.agent-settings-row-value {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  white-space: nowrap;
+}
+
+.agent-settings-row-value small {
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
+.agent-settings-row-value .ds-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.agent-settings-form.form-card {
+  gap: 22px;
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.agent-settings-section-page,
 .agent-manage-settings {
   display: grid;
-  gap: 20px;
+  gap: 24px;
+}
+
+.agent-settings-section-page .agent-runtime-section {
+  gap: 24px;
+  border-top: 0;
+  padding: 0;
+}
+
+.agent-settings-section-page .agent-runtime-computer__body {
+  min-height: 86px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+  padding: 20px;
+}
+
+.agent-settings-section-page .im-stack {
+  gap: 34px;
+}
+
+.agent-manage-settings .ds-settings-list {
+  border-radius: 16px;
+}
+
+.agent-delete-confirmation {
+  display: grid;
+  gap: 22px;
+}
+
+.agent-delete-confirmation .dialog-actions,
+.agent-manage-settings .dialog-actions {
+  justify-content: flex-end;
 }
 
 @media (max-width: 760px) {
-  .agent-header-actions,
-  .agent-recovery-banner,
-  .agent-contact-body,
-  .agent-empty-line {
+  .agent-profile-page .object-title-row,
+  .agent-recovery-banner {
     align-items: flex-start;
     flex-direction: column;
   }
 
-  .agent-settings-layout {
-    grid-template-columns: 1fr;
-    gap: 28px;
+  .agent-header-actions {
+    width: 100%;
   }
 
-  .agent-settings-nav {
-    overflow-x: auto;
-    display: flex;
+  .agent-contact-row {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+
+  .agent-contact-row > .ds-button {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .agent-settings-entry {
+    grid-template-columns: 38px minmax(0, 1fr) auto;
+    gap: 11px;
+    padding: 14px 13px;
+  }
+
+  .agent-settings-icon {
+    width: 38px;
+    height: 38px;
+  }
+
+  .agent-settings-section-page .agent-runtime-section__header,
+  .agent-settings-section-page .agent-runtime-computer__body {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }
 

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -145,7 +145,21 @@ export function StatusIndicator({
   );
 }
 
-export type IconName = "arrow-left" | "arrow-right" | "check" | "chevron-right" | "close" | "more-vertical" | "plus";
+export type IconName =
+  | "arrow-left"
+  | "arrow-right"
+  | "check"
+  | "chevron-right"
+  | "close"
+  | "instructions"
+  | "laptop"
+  | "message"
+  | "model"
+  | "more-vertical"
+  | "plus"
+  | "settings"
+  | "shield"
+  | "user";
 
 export function Icon({ className, name, ...props }: SVGAttributes<SVGSVGElement> & { name: IconName }) {
   return (
@@ -164,6 +178,28 @@ export function Icon({ className, name, ...props }: SVGAttributes<SVGSVGElement>
       {name === "plus" ? <path d="M10 4v12M4 10h12" /> : null}
       {name === "arrow-right" ? <path d="M3.5 10h13m-5-5 5 5-5 5" /> : null}
       {name === "arrow-left" ? <path d="M16.5 10h-13m5-5-5 5 5 5" /> : null}
+      {name === "settings" ? (
+        <>
+          <circle cx="10" cy="10" r="2.5" />
+          <path d="M10 2.8v2M10 15.2v2M2.8 10h2M15.2 10h2M4.9 4.9l1.4 1.4M13.7 13.7l1.4 1.4M15.1 4.9l-1.4 1.4M6.3 13.7l-1.4 1.4" />
+        </>
+      ) : null}
+      {name === "instructions" ? <path d="M4 5h12M4 10h9M4 15h12" /> : null}
+      {name === "model" ? (
+        <>
+          <rect x="4" y="4" width="12" height="12" rx="3" />
+          <path d="M8 2v3M12 2v3M8 15v3M12 15v3M2 8h3M15 8h3M2 12h3M15 12h3M8 8h4v4H8z" />
+        </>
+      ) : null}
+      {name === "message" ? <path d="M4 4.5h12v9H8l-4 3v-12Z" /> : null}
+      {name === "user" ? (
+        <>
+          <circle cx="10" cy="7" r="3" />
+          <path d="M4.5 17c.5-3.2 2.3-5 5.5-5s5 1.8 5.5 5" />
+        </>
+      ) : null}
+      {name === "laptop" ? <path d="M4.5 4.5h11v8h-11zM3 15.5h14M5.5 12.5l-1 3M14.5 12.5l1 3" /> : null}
+      {name === "shield" ? <path d="M10 2.8 16 5v4.8c0 3.5-2.1 6-6 7.4-3.9-1.4-6-3.9-6-7.4V5l6-2.2Z" /> : null}
     </svg>
   );
 }


### PR DESCRIPTION
## Summary

- simplify the Agent home around status, current work, contact, Usage, and Settings
- replace the settings side navigation with a lightweight grouped directory that shows current values
- make instructions, model/reasoning, and identity directly editable with explicit dirty, discard, and save states
- keep healthy computer information inline and expose recovery only when attention is needed
- preserve source-aware back navigation and product confirmation dialogs

## Verification

- `pnpm install`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- Web test suite: 326 passed
- `pnpm --filter @opentag/client test:agent-runtime:coverage`: 268 passed, 100% coverage
- browser regression of Agent home, Settings directory, direct edit, dirty, and discard states

## Local baseline note

Repository-wide `pnpm test` / `pnpm test:coverage` reproduce three failures outside this Web diff on macOS: two `/var` vs `/private/var` daemon path assertions and one RuntimeSession observability timing assertion. The exact base commit is green in GitHub CI.