### PR TITLE
feat(web): align Agent typography and loading states

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1282,6 +1282,34 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByText("Runtime")).toBeNull();
   });
 
+  it.each([
+    ["Usage", "Usage"],
+    ["Settings", "Agent settings"],
+  ])("keeps Agent context visible while opening %s", async (linkName, destinationHeading) => {
+    let agentReads = 0;
+    let releaseAgentRead = () => {};
+    const pendingAgentRead = new Promise<void>((resolve) => {
+      releaseAgentRead = resolve;
+    });
+    installApi("admin", {
+      agentRead: () => {
+        agentReads += 1;
+        return agentReads === 1 ? undefined : pendingAgentRead;
+      },
+      bound: true,
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: linkName }));
+
+    expect(await screen.findByRole("heading", { name: destinationHeading })).toBeTruthy();
+    await waitFor(() => expect(agentReads).toBe(2));
+    expect(screen.queryByLabelText("Loading current server state")).toBeNull();
+    await act(async () => releaseAgentRead());
+  });
+
   it("shows confirmed active work without exposing conversation content", async () => {
     installApi("admin", {
       bound: true,

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -13,13 +13,7 @@ import { describe, expect, it } from "vitest";
  * role. Anywhere else, a rebinding is component-local drift: the thing this
  * PR removed.
  */
-const READING_SURFACES = new Set([
-  ".settings-page",
-  ".onboarding-shell",
-  ".decorative-page",
-  ".dialog-card",
-  ".agent-profile-page",
-]);
+const READING_SURFACES = new Set([".settings-page", ".onboarding-shell", ".decorative-page", ".dialog-card"]);
 
 /*
  * Every check reads parsed declarations rather than raw text. Matching CSS

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -301,13 +301,16 @@ function useResource<T>(
   loader: () => Promise<T>,
   key: string,
   options: {
+    initialValue?: T;
     keepPreviousData?: boolean;
     onBackgroundError?: (value: T, error: Error) => T;
     revalidateMs?: number;
     refreshOnFocus?: boolean;
   } = {},
 ): LoadState<T> {
-  const [state, setState] = useState<LoadState<T>>({ kind: "loading" });
+  const [state, setState] = useState<LoadState<T>>(() =>
+    options.initialValue === undefined ? { kind: "loading" } : { kind: "ready", value: options.initialValue },
+  );
   const loaderRef = useRef(loader);
   const keyRef = useRef(key);
   const optionsRef = useRef(options);
@@ -352,7 +355,7 @@ function useResource<T>(
         });
     };
     const revalidate = () => load(false);
-    load(!options.keepPreviousData);
+    load(!options.keepPreviousData && options.initialValue === undefined);
     const interval = options.revalidateMs ? window.setInterval(revalidate, options.revalidateMs) : undefined;
     const refreshVisible = () => {
       if (document.visibilityState === "visible") revalidate();
@@ -367,7 +370,7 @@ function useResource<T>(
       window.removeEventListener("focus", revalidate);
       document.removeEventListener("visibilitychange", refreshVisible);
     };
-  }, [key, options.keepPreviousData, options.refreshOnFocus, options.revalidateMs]);
+  }, [key, options.initialValue, options.keepPreviousData, options.refreshOnFocus, options.revalidateMs]);
   return state;
 }
 
@@ -375,14 +378,24 @@ function isTerminalResourceError(error: Error): boolean {
   return error instanceof ApiError && [401, 403, 404, 410].includes(error.status);
 }
 
-function AsyncState<T>({ state, children }: { state: LoadState<T>; children: (value: T) => ReactNode }) {
+function AsyncState<T>({
+  state,
+  children,
+  loading,
+}: {
+  state: LoadState<T>;
+  children: (value: T) => ReactNode;
+  loading?: ReactNode;
+}) {
   if (state.kind === "loading")
     return (
-      <div aria-label="Loading current server state" className="loading-state" role="status">
-        <span />
-        <span />
-        <span />
-      </div>
+      loading ?? (
+        <div aria-label="Loading current server state" className="loading-state" role="status">
+          <span />
+          <span />
+          <span />
+        </div>
+      )
     );
   if (state.kind === "error")
     return (
@@ -1591,12 +1604,16 @@ function AgentObjectHeader({ agent, backToSettings }: { agent: AgentDetailView; 
         </div>
         <div className="agent-header-actions">
           {!backToSettings ? (
-            <Link className="agent-usage-link" to={`/agents/${agent.id}/usage`}>
+            <Link className="agent-usage-link" state={{ agent }} to={`/agents/${agent.id}/usage`}>
               Usage
             </Link>
           ) : null}
           {agent.viewerCapabilities.canManage && !backToSettings ? (
-            <Link className={buttonClassName({ variant: "secondary" })} to={`/agents/${agent.id}/settings`}>
+            <Link
+              className={buttonClassName({ variant: "secondary" })}
+              state={{ agent }}
+              to={`/agents/${agent.id}/settings`}
+            >
               <Icon name="settings" /> Settings
             </Link>
           ) : null}
@@ -1615,7 +1632,7 @@ function AgentRecoveryBanner({ agent }: { agent: AgentDetailView }) {
         <p>{agentRecoveryMessage(agent)}</p>
       </div>
       {recovery ? (
-        <Link className={buttonClassName({ size: "compact", variant: "secondary" })} to={recovery.to}>
+        <Link className={buttonClassName({ size: "compact", variant: "secondary" })} state={{ agent }} to={recovery.to}>
           {recovery.label}
         </Link>
       ) : null}
@@ -1677,7 +1694,7 @@ function AgentContact({ agent }: { agent: AgentDetailView }) {
           {agent.viewerCapabilities.canManage ? (
             <Link
               className={buttonClassName({ size: "compact", variant: "outline" })}
-              state={{ returnLabel: agent.displayName, returnTo: `/agents/${agent.id}` }}
+              state={{ agent, returnLabel: agent.displayName, returnTo: `/agents/${agent.id}` }}
               to={`/agents/${agent.id}/settings/messaging`}
             >
               Manage
@@ -1710,7 +1727,11 @@ function AgentContact({ agent }: { agent: AgentDetailView }) {
 
 function AgentUsagePage() {
   const { agentId = "" } = useParams();
+  const location = useLocation();
+  const routeState = location.state as { agent?: AgentDetailView } | null;
+  const initialAgent = routeState?.agent?.id === agentId ? routeState.agent : undefined;
   const state = useResource(() => loadAgentDetail(agentId), agentId, {
+    initialValue: initialAgent,
     onBackgroundError: markAgentDetailUnconfirmed,
   });
   return (
@@ -1734,8 +1755,15 @@ function AgentUsagePage() {
 function AgentSettingsPage() {
   const { agentId = "", section } = useParams();
   const location = useLocation();
+  const routeState = location.state as {
+    agent?: AgentDetailView;
+    returnLabel?: string;
+    returnTo?: string;
+  } | null;
+  const initialAgent = routeState?.agent?.id === agentId ? routeState.agent : undefined;
   const [refreshVersion, setRefreshVersion] = useState(0);
   const state = useResource(() => loadAgentDetail(agentId), `${agentId}:${refreshVersion}`, {
+    initialValue: initialAgent,
     keepPreviousData: true,
     onBackgroundError: markAgentDetailUnconfirmed,
   });
@@ -1745,9 +1773,8 @@ function AgentSettingsPage() {
     <AsyncState state={state}>
       {(agent) => {
         if (!agent.viewerCapabilities.canManage) return <Navigate replace to={`/agents/${agent.id}`} />;
-        const returnState = location.state as { returnLabel?: string; returnTo?: string } | null;
-        const backTo = selected ? (returnState?.returnTo ?? `/agents/${agent.id}/settings`) : `/agents/${agent.id}`;
-        const backLabel = selected ? (returnState?.returnLabel ?? "Agent settings") : agent.displayName;
+        const backTo = selected ? (routeState?.returnTo ?? `/agents/${agent.id}/settings`) : `/agents/${agent.id}`;
+        const backLabel = selected ? (routeState?.returnLabel ?? "Agent settings") : agent.displayName;
         return (
           <section className="object-page agent-profile-page">
             <div className="agent-settings-page">
@@ -1907,7 +1934,7 @@ function AgentSettingsOverview({ agent }: { agent: AgentDetailView }) {
         <h1>Agent settings</h1>
         <p>Change how {agent.displayName} works and receives requests.</p>
       </header>
-      <AsyncState state={configState}>
+      <AsyncState loading={<AgentSettingsDirectoryLoading />} state={configState}>
         {(config) => (
           <div className="agent-settings-groups">
             {agentSettingsGroups.map((group) => (
@@ -1957,6 +1984,33 @@ function AgentSettingsOverview({ agent }: { agent: AgentDetailView }) {
           </div>
         )}
       </AsyncState>
+    </div>
+  );
+}
+
+function AgentSettingsDirectoryLoading() {
+  return (
+    <div aria-label="Loading Agent settings" className="agent-settings-loading" role="status">
+      <div aria-hidden="true" className="agent-settings-groups">
+        {agentSettingsGroups.map((group) => (
+          <div className="agent-settings-group" key={group.key}>
+            <span className="agent-settings-loading-label" />
+            <div className="agent-settings-grid">
+              {agentSettingsSections
+                .filter((item) => item.group === group.key)
+                .map((item) => (
+                  <div className="agent-settings-entry is-static is-loading" key={item.key}>
+                    <span className="agent-settings-icon" />
+                    <span className="agent-settings-loading-copy">
+                      <span className="agent-settings-loading-title" />
+                      <span className="agent-settings-loading-summary" />
+                    </span>
+                  </div>
+                ))}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -929,41 +929,43 @@ pre {
 
 .agent-card-grid {
   display: grid;
-  gap: 14px;
+  overflow: hidden;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
 }
 
 .agent-card {
   display: grid;
   min-width: 0;
-  min-height: 112px;
+  min-height: 88px;
   align-items: center;
-  gap: 24px;
+  gap: 20px;
   grid-template-columns: minmax(240px, 0.8fr) minmax(210px, 0.7fr) 206px 36px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: var(--surface);
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
   color: inherit;
-  padding: 22px 26px 24px;
-  transition:
-    border-color 180ms ease,
-    background-color 180ms ease;
+  padding: 16px 20px;
+  transition: background-color 180ms ease;
+}
+
+.agent-card:last-child {
+  border-bottom: 0;
 }
 
 .agent-card:hover,
 .agent-card:focus-within {
-  border-color: var(--strong-border);
-  background: color-mix(in srgb, var(--surface) 92%, var(--surface-soft));
-}
-
-.agent-card[data-tone="warning"] {
-  border-color: color-mix(in srgb, var(--border) 70%, #d79744 30%);
+  background: var(--surface-soft);
 }
 
 .agent-card-identity {
   display: grid;
   min-width: 0;
   align-items: center;
-  grid-template-columns: 48px minmax(0, 1fr);
+  grid-template-columns: 40px minmax(0, 1fr);
   gap: 14px;
 }
 
@@ -980,9 +982,9 @@ pre {
 }
 
 .agent-card .agent-avatar {
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
   font-size: var(--text-ui);
 }
 
@@ -1026,7 +1028,7 @@ pre {
 
 .agent-card-identity-copy > strong {
   color: var(--foreground);
-  font-size: var(--text-subsection);
+  font-size: var(--text-body);
   font-weight: var(--fw-semibold);
   line-height: var(--lh-ui);
 }
@@ -1470,7 +1472,7 @@ dd {
 .agent-card-usage dd {
   color: var(--foreground);
   font-family: var(--font-display);
-  font-size: var(--text-title);
+  font-size: var(--text-section);
   font-variant-numeric: tabular-nums;
   font-weight: var(--fw-medium);
   letter-spacing: var(--track-tight);
@@ -3875,9 +3877,9 @@ textarea:focus {
   }
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1040px) {
   .agent-card {
-    min-height: 132px;
+    min-height: 104px;
     gap: 6px 24px;
     grid-template-columns: minmax(0, 1fr) 206px 36px;
     grid-template-rows: auto auto;
@@ -4321,14 +4323,6 @@ textarea:focus {
   }
 }
 
-.agent-profile-page {
-  --text-meta: var(--fs-14);
-  --text-ui: var(--fs-16);
-  --text-body: var(--fs-16);
-  --text-subsection: var(--fs-20);
-  --text-display: var(--fs-32);
-}
-
 .agent-profile-page .object-header {
   border-bottom: 0;
   padding-bottom: 0;
@@ -4619,7 +4613,7 @@ textarea:focus {
 
 .agent-settings-group h2 {
   margin: 0 0 10px 2px;
-  color: var(--secondary-foreground);
+  color: var(--muted);
   font-size: var(--text-meta);
   font-weight: var(--fw-semibold);
   letter-spacing: var(--track-normal);
@@ -4681,6 +4675,7 @@ textarea:focus {
 }
 
 .agent-settings-row-copy strong {
+  color: var(--secondary-foreground);
   font-size: var(--text-body);
   font-weight: var(--fw-semibold);
 }
@@ -4709,6 +4704,34 @@ textarea:focus {
 .agent-settings-row-value .ds-icon {
   width: 16px;
   height: 16px;
+}
+
+.agent-settings-loading-label,
+.agent-settings-loading-copy span {
+  display: block;
+  border-radius: 4px;
+  background: var(--surface-soft);
+}
+
+.agent-settings-loading-label {
+  width: 88px;
+  height: 12px;
+  margin: 0 0 10px 2px;
+}
+
+.agent-settings-loading-copy {
+  display: grid;
+  gap: 7px;
+}
+
+.agent-settings-loading-title {
+  width: min(44%, 164px);
+  height: 13px;
+}
+
+.agent-settings-loading-summary {
+  width: min(64%, 240px);
+  height: 10px;
 }
 
 .agent-settings-form.form-card {


### PR DESCRIPTION
## Summary
- remove the Agent-only typography scale override so detail, Usage, and Settings use the shared design-system roles
- reduce Agent list density and replace per-Agent warning card borders with a single scannable grouped list
- preserve confirmed Agent context when opening Usage or Settings and replace the stray generic skeleton with directory-shaped loading rows
- add slow-navigation coverage for Usage and Settings

## Validation
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/web test` (332 tests)
- browser review of Agent list, home, Usage, Settings directory, all Settings subpages, and a forced 2.5-second Settings loading state

## Known unrelated local failure
- `pnpm test` reaches an existing Server observability failure in `src/observability/__tests__/observability.test.ts`: the RuntimeSession terminal-path assertion expects `stale_connection` but receives `handled`. This branch does not modify Server code.