### PR TITLE
fix(web): stabilize dialog backdrop color

### DIFF
--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -80,6 +80,13 @@ describe("workspace page layout", () => {
     expect(declarationValue(designSystemStyles, "select.ds-control--compact", "min-height")).toBe("36px");
   });
 
+  it("keeps the dialog backdrop stable across inherited button states", () => {
+    const backdrop = "rgb(22 33 27 / 42%)";
+    expect(topLevelDeclarationValue(appStyles, ".dialog-backdrop", "background")).toBe(backdrop);
+    expect(topLevelDeclarationValue(appStyles, ".dialog-backdrop:hover", "background")).toBe(backdrop);
+    expect(topLevelDeclarationValue(appStyles, ".dialog-backdrop:disabled", "opacity")).toBe("1");
+  });
+
   it("keeps Task provenance and grouped execution readable in the compact layout", () => {
     expect(declarationValue(taskStyles, ".task-breadcrumb-actions .tasks-demo-note", "display")).toBe("inline");
     expect(topLevelDeclarationValue(taskStyles, ".task-tool-list", "border")).toBe("1px solid var(--border)");

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -755,7 +755,8 @@ pre {
   padding: 24px;
 }
 
-.dialog-backdrop {
+.dialog-backdrop,
+.dialog-backdrop:hover {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -764,6 +765,10 @@ pre {
   border-radius: 0;
   background: rgb(22 33 27 / 42%);
   padding: 0;
+}
+
+.dialog-backdrop:disabled {
+  opacity: 1;
 }
 
 .dialog-backdrop:active {


### PR DESCRIPTION
## Summary
- keep the dialog backdrop translucent when it inherits the global button hover state
- preserve backdrop opacity while the dialog is busy and the backdrop button is disabled
- add a CSS regression test for hover and disabled states

## Verification
- pnpm check (passes with existing undeclared E2E environment-variable warnings)
- pnpm build
- pnpm typecheck
- pnpm --filter @opentag/web test (333 tests passed)
- pnpm --filter @opentag/client test:agent-runtime:coverage
- browser reproduction confirmed the original hover state became solid brand green; the production CSS now compiles the stable translucent hover rule

## Baseline test note
- pnpm test and pnpm test:coverage reproduce unrelated failures outside apps/web, including the existing RuntimeSession stale-connection observability expectation and local CLI service-path assumptions. No server or CLI files are changed by this PR.