### PR TITLE
chore(ci): stop measuring unit coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,17 +74,12 @@ jobs:
       - name: Enforce Agent Runtime coverage
         run: pnpm --filter @opentag/client test:agent-runtime:coverage
 
-      - name: Measure unit coverage
-        run: pnpm test:coverage
-
       - name: Upload coverage reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: unit-coverage-reports-${{ github.sha }}
-          path: |
-            packages/client/coverage/**
-            coverage/unit/**
+          name: agent-runtime-coverage-report-${{ github.sha }}
+          path: packages/client/coverage/**
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/unit-coverage.yml
+++ b/.github/workflows/unit-coverage.yml
@@ -1,0 +1,47 @@
+name: Unit Coverage
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: Measure Unit Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.12.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --config.engine-strict=true
+
+      - name: Measure unit coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unit-coverage-report-${{ github.sha }}
+          path: coverage/unit/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,13 @@ pnpm build
 pnpm typecheck
 pnpm test
 pnpm --filter @opentag/client test:agent-runtime:coverage
-pnpm test:coverage
+pnpm --filter @opentag/server test:integration
 ```
 
 Run directly affected tests during development and all commands above before opening a pull request. Unit tests must not
-depend on the public network, external providers, or a running PostgreSQL instance.
+depend on the public network, external providers, or a running PostgreSQL instance. Run `pnpm test:coverage` when changing
+the root coverage configuration or investigating repository-wide coverage gaps; the scheduled `Unit Coverage` workflow
+owns the recurring baseline measurement.
 
 ## Code and Git conventions
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,21 +25,24 @@ pnpm build
 pnpm typecheck
 pnpm test
 pnpm --filter @opentag/client test:agent-runtime:coverage
-pnpm test:coverage
 pnpm --filter @opentag/server test:integration
 ```
 
 Use `pnpm lint` for lint-only feedback. Use `pnpm format` to apply Biome formatting.
 
-`pnpm test:coverage` builds the workspaces and measures the offline unit tests for CLI, Web, Shared, Client, and Server.
-It includes production source files that tests do not import, but excludes root `scripts/`, Server PostgreSQL integration
-tests, and Provider end-to-end tests. The unified report is a measurement baseline for finding and prioritizing gaps; it
-does not yet enforce repository-wide or per-workspace coverage thresholds. Add regression thresholds only after the
-measurement is stable across repeated runs. Agent Runtime keeps its separate 100% gate in
+The separate `Unit Coverage` workflow runs `pnpm test:coverage` against `main` every Monday at 03:17 UTC and can also be
+started manually. It builds the workspaces and measures the offline unit tests for CLI, Web, Shared, Client, and Server,
+then retains the unified report for 14 days. Run the command locally when changing the root coverage configuration or
+investigating coverage gaps. The measurement includes production source files that tests do not import, but excludes
+root `scripts/`, Server PostgreSQL integration tests, and Provider end-to-end tests. It is a baseline for finding and
+prioritizing gaps, not a required pull request check, and does not yet enforce repository-wide or per-workspace coverage
+thresholds. Add regression thresholds only after the measurement is stable across repeated runs.
+
+Required pull request CI still runs all offline unit tests. Agent Runtime keeps its separate 100% gate in
 `packages/client/vitest.agent-runtime.config.ts`, enforced by
 `pnpm --filter @opentag/client test:agent-runtime:coverage`.
 
-The required pull request check is the stable `CI` fan-in job. It covers the commands above, source and staging CLI
+The required pull request check is the stable `CI` fan-in job. It covers the required commands above, source and staging CLI
 tarball installation, a production-container health smoke, and the supported Node.js lines. Full validation and releases
 run on Node.js 24. Compatibility jobs run `pnpm check:node-compat` on the exact Node.js 22.13.0 floor and the latest
 Node.js 26 release; that command builds, tests, and installs the packed CLI. Node.js 23 and 25 are end-of-life and are not

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -1,7 +1,7 @@
 # OpenTag 开发指南
 
 > Canonical source: [DEVELOPMENT.md](./DEVELOPMENT.md)
-> Last synced with: 2026-08-23
+> Last synced with: 2026-08-25
 
 ## 前置要求
 
@@ -26,20 +26,23 @@ pnpm build
 pnpm typecheck
 pnpm test
 pnpm --filter @opentag/client test:agent-runtime:coverage
-pnpm test:coverage
 pnpm --filter @opentag/server test:integration
 ```
 
 仅检查 lint 可运行 `pnpm lint`；应用 Biome 格式化可运行 `pnpm format`。
 
-`pnpm test:coverage` 会先构建 workspace，再统计 CLI、Web、Shared、Client 和 Server 的离线单测覆盖率。它会纳入
-未被测试 import 的生产源码，但排除根目录 `scripts/`、Server PostgreSQL integration tests 和 Provider E2E。
-统一报告目前用于测量基线、定位缺口和安排优先级，暂不设置全仓或分 workspace 覆盖率阈值。只有在重复运行的
-统计结果稳定后，才应增加回退阈值。Agent Runtime 继续使用 `packages/client/vitest.agent-runtime.config.ts` 中
-独立的 100% 门槛，并由
+独立的 `Unit Coverage` workflow 会在每周一 03:17 UTC 针对 `main` 运行 `pnpm test:coverage`，也支持手动触发。
+该命令会先构建 workspace，再统计 CLI、Web、Shared、Client 和 Server 的离线单测覆盖率，并将统一报告保留
+14 天。修改根 coverage 配置或调查覆盖率缺口时，应在本地运行该命令。统计会纳入未被测试 import 的生产源码，
+但排除根目录 `scripts/`、Server PostgreSQL integration tests 和 Provider E2E。该统计是用于定位缺口和安排
+优先级的测量基线，不属于 Pull Request 必过检查，暂不设置全仓或分 workspace 覆盖率阈值。只有在重复运行的
+统计结果稳定后，才应增加回退阈值。
+
+Pull Request 必过 CI 仍会运行全部离线单测。Agent Runtime 继续使用
+`packages/client/vitest.agent-runtime.config.ts` 中独立的 100% 门槛，并由
 `pnpm --filter @opentag/client test:agent-runtime:coverage` 执行。
 
-Pull Request 的必过检查是稳定的 `CI` fan-in job。它会覆盖上述命令、source/staging CLI tarball 安装、生产容器
+Pull Request 的必过检查是稳定的 `CI` fan-in job。它会覆盖上述必需命令、source/staging CLI tarball 安装、生产容器
 健康检查和受支持的 Node.js 版本。完整验证与发布使用 Node.js 24；兼容 job 会在精确下限 Node.js 22.13.0 和
 最新 Node.js 26 上运行 `pnpm check:node-compat`，完成构建、测试和 CLI tarball 安装。Node.js 23 与 25 已 EOL，
 不在支持范围内。构建后可在本地验证当前 source tarball：


### PR DESCRIPTION
## Summary

- stop running the full unit coverage measurement in every CI run
- keep the focused Agent Runtime coverage enforcement
- rename the uploaded artifact and remove the no-longer-produced unit coverage path

## Validation

- `git diff --check`
- parsed `.github/workflows/ci.yml` with Ruby's YAML parser

## Non-goals

- no changes to local coverage commands
- no changes to the Agent Runtime coverage threshold
