### PR TITLE
feat: centralize runtime configuration options

### DIFF
--- a/apps/web/src/runtime-configuration.test.tsx
+++ b/apps/web/src/runtime-configuration.test.tsx
@@ -133,7 +133,7 @@ describe("RuntimeConfigurationForm", () => {
       "__custom_model__",
     ]);
     expect((screen.getByLabelText("Model") as HTMLSelectElement).value).toBe("claude-sonnet-5");
-    expect(optionValues("Reasoning level")).toEqual(["", "low", "medium", "high", "xhigh", "max", "ultracode"]);
+    expect(optionValues("Reasoning level")).toEqual(["", "low", "medium", "high", "xhigh", "max"]);
     expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).value).toBe("max");
   });
 
@@ -157,6 +157,41 @@ describe("RuntimeConfigurationForm", () => {
     expect(save).toHaveBeenCalledWith({
       expectedRevision: 4,
       runtimeConfig: { model: null, reasoningEffort: null },
+    });
+  });
+
+  it("preserves an unknown historical reasoning value during a model-only save", async () => {
+    const historicalConfig: AgentAdminConfig = {
+      ...config,
+      runtimeConfig: { ...config.runtimeConfig, reasoningEffort: "historical-effort" },
+    };
+    const save = vi.fn(async () => ({
+      ...historicalConfig,
+      revision: 5,
+      runtimeConfig: { ...historicalConfig.runtimeConfig, revision: 8, model: "gpt-5.6-sol" },
+    }));
+    render(<RuntimeConfigurationForm initialConfig={historicalConfig} save={save} section="execution" />);
+
+    expect(optionValues("Reasoning level")).toEqual([
+      "",
+      "historical-effort",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).selectedOptions[0]?.textContent).toBe(
+      "historical-effort (saved value)",
+    );
+
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5.6-sol" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledOnce());
+    expect(save).toHaveBeenCalledWith({
+      expectedRevision: 4,
+      runtimeConfig: { model: "gpt-5.6-sol", reasoningEffort: "historical-effort" },
     });
   });
 
@@ -187,22 +222,36 @@ describe("RuntimeConfigurationForm", () => {
   });
 
   it("reports save failures without losing drafts", async () => {
+    const historicalConfig: AgentAdminConfig = {
+      ...config,
+      runtimeConfig: { ...config.runtimeConfig, reasoningEffort: "historical-effort" },
+    };
     const save = vi.fn(async () => {
       throw new Error("Revision changed");
     });
-    render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
+    render(<RuntimeConfigurationForm initialConfig={historicalConfig} save={save} />);
 
     fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5.6-sol" } });
     fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     expect((await screen.findByRole("alert")).textContent).toBe("Revision changed");
+    expect(save).toHaveBeenCalledWith({
+      expectedRevision: 4,
+      runtimeConfig: { model: "gpt-5.6-sol", reasoningEffort: "historical-effort" },
+    });
     expect((screen.getByLabelText("Model") as HTMLSelectElement).value).toBe("gpt-5.6-sol");
+    expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).value).toBe("historical-effort");
+    expect(optionValues("Reasoning level")).toContain("historical-effort");
   });
 
   it("discards model and reasoning drafts without saving", () => {
     const initialConfig: AgentAdminConfig = {
       ...config,
-      runtimeConfig: { ...config.runtimeConfig, model: "gpt-historical-private", reasoningEffort: "medium" },
+      runtimeConfig: {
+        ...config.runtimeConfig,
+        model: "gpt-historical-private",
+        reasoningEffort: "historical-effort",
+      },
     };
     const save = vi.fn();
     render(<RuntimeConfigurationForm initialConfig={initialConfig} save={save} section="execution" />);
@@ -213,7 +262,16 @@ describe("RuntimeConfigurationForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "Discard" }));
 
     expect((screen.getByLabelText("Custom model ID") as HTMLInputElement).value).toBe("gpt-historical-private");
-    expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).value).toBe("medium");
+    expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).value).toBe("historical-effort");
+    expect(optionValues("Reasoning level")).toEqual([
+      "",
+      "historical-effort",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
     expect(screen.queryByText("Unsaved changes")).toBeNull();
     expect(save).not.toHaveBeenCalled();
   });

--- a/apps/web/src/runtime-configuration.test.tsx
+++ b/apps/web/src/runtime-configuration.test.tsx
@@ -27,109 +27,137 @@ const config: AgentAdminConfig = {
   updatedAt: "2026-08-20T00:00:00.000Z",
 };
 
+function optionValues(label: string): string[] {
+  const select = screen.getByLabelText(label) as HTMLSelectElement;
+  return Array.from(select.options, (option) => option.value);
+}
+
 describe("RuntimeConfigurationForm", () => {
-  it("presents concise Execution choices without exposing the request timeout", () => {
+  it("presents model suggestions and the complete Codex reasoning list", () => {
     render(<RuntimeConfigurationForm initialConfig={config} save={vi.fn()} />);
 
     expect(screen.getByRole("heading", { name: "Execution" })).toBeTruthy();
     expect(screen.getByText("Provider: Codex")).toBeTruthy();
-    expect((screen.getByLabelText("Model") as HTMLInputElement).placeholder).toBe("Codex default");
-    expect((screen.getByLabelText("Reasoning level") as HTMLInputElement).placeholder).toBe("Provider default");
+    expect(optionValues("Model")).toEqual([
+      "",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.3-codex",
+      "__custom_model__",
+    ]);
+    expect(optionValues("Reasoning level")).toEqual(["", "minimal", "low", "medium", "high", "xhigh"]);
+    expect((screen.getByLabelText("Model") as HTMLSelectElement).selectedOptions[0]?.textContent).toBe(
+      "Provider default",
+    );
+    expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).selectedOptions[0]?.textContent).toBe(
+      "Provider default",
+    );
     expect(screen.getByRole("heading", { name: "Agent instructions" })).toBeTruthy();
     expect(screen.queryByText(/timeout/i)).toBeNull();
-    expect(screen.queryByText("Execution choices")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Edit settings" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
   });
 
-  it("directly edits only the understandable Runtime choices", () => {
+  it("keeps the complete reasoning list after a selection", () => {
     render(<RuntimeConfigurationForm initialConfig={config} save={vi.fn()} />);
 
-    expect((screen.getByLabelText("Model") as HTMLInputElement).placeholder).toBe("Codex default");
-    const effort = screen.getByLabelText("Reasoning level") as HTMLInputElement;
-    expect(effort.placeholder).toBe("Provider default");
-    const suggestions = document.getElementById(effort.getAttribute("list") ?? "");
-    expect(Array.from(suggestions?.querySelectorAll("option") ?? []).map((option) => option.value)).toEqual([
-      "minimal",
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-    ]);
-    expect(screen.queryByLabelText(/duration/i)).toBeNull();
+    fireEvent.change(screen.getByLabelText("Reasoning level"), { target: { value: "high" } });
+    expect(optionValues("Reasoning level")).toEqual(["", "minimal", "low", "medium", "high", "xhigh"]);
+    expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).value).toBe("high");
   });
 
-  it("shows and edits stored Claude Code configuration", async () => {
-    const claudeConfig: AgentAdminConfig = {
-      ...config,
-      runtimeProvider: "claude-code",
-      runtimeConfig: {
-        ...config.runtimeConfig,
-        model: "claude-opus-4-1",
-        reasoningEffort: "max",
-        instructions: "Use the repository guidelines.",
-      },
-    };
-    const save = vi.fn(async () => ({
-      ...claudeConfig,
-      revision: 5,
-      runtimeConfig: { ...claudeConfig.runtimeConfig, revision: 8, instructions: "Updated Claude instructions." },
-    }));
-    render(<RuntimeConfigurationForm initialConfig={claudeConfig} save={save} />);
-
-    expect(screen.getByText("Provider: Claude Code")).toBeTruthy();
-    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("claude-opus-4-1");
-    expect((screen.getByLabelText("Reasoning level") as HTMLInputElement).value).toBe("max");
-    expect((screen.getByLabelText("Instructions") as HTMLTextAreaElement).value).toBe("Use the repository guidelines.");
-
-    expect(screen.getAllByText("Leave blank to use the provider default.")).toHaveLength(2);
-    const effort = screen.getByLabelText("Reasoning level") as HTMLInputElement;
-    const suggestions = document.getElementById(effort.getAttribute("list") ?? "");
-    expect(Array.from(suggestions?.querySelectorAll("option") ?? []).map((option) => option.value)).toEqual([
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max",
-      "ultracode",
-    ]);
-
-    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Updated Claude instructions." } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
-    await waitFor(() => expect(save).toHaveBeenCalledOnce());
-    expect(save).toHaveBeenCalledWith({
-      expectedRevision: 4,
-      runtimeConfig: { instructions: "Updated Claude instructions." },
-    });
-  });
-
-  it("saves Runtime choices without rewriting hidden configuration", async () => {
+  it("accepts and saves a non-empty custom model ID", async () => {
     const save = vi.fn(async () => ({
       ...config,
       revision: 5,
-      runtimeConfig: {
-        ...config.runtimeConfig,
-        revision: 8,
-        model: "gpt-5.6-codex",
-        reasoningEffort: "high",
-      },
+      runtimeConfig: { ...config.runtimeConfig, revision: 8, model: "team/fine-tuned-model" },
     }));
     render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
 
-    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "  gpt-5.6-codex  " } });
-    fireEvent.change(screen.getByLabelText("Reasoning level"), { target: { value: "high" } });
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "__custom_model__" } });
+    const customModel = screen.getByLabelText("Custom model ID") as HTMLInputElement;
+    expect(customModel.required).toBe(true);
+    fireEvent.change(customModel, { target: { value: "  team/fine-tuned-model  " } });
     fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => expect(save).toHaveBeenCalledOnce());
     expect(save).toHaveBeenCalledWith({
       expectedRevision: 4,
-      runtimeConfig: {
-        model: "gpt-5.6-codex",
-        reasoningEffort: "high",
-      },
+      runtimeConfig: { model: "team/fine-tuned-model", reasoningEffort: null },
     });
     expect((await screen.findByRole("status")).textContent).toBe("Execution settings saved.");
-    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("gpt-5.6-codex");
+    expect((screen.getByLabelText("Custom model ID") as HTMLInputElement).value).toBe("team/fine-tuned-model");
+  });
+
+  it("shows, edits, and saves an unknown historical model as custom", async () => {
+    const historicalConfig: AgentAdminConfig = {
+      ...config,
+      runtimeConfig: { ...config.runtimeConfig, model: "gpt-historical-private" },
+    };
+    const save = vi.fn(async () => ({
+      ...historicalConfig,
+      revision: 5,
+      runtimeConfig: { ...historicalConfig.runtimeConfig, revision: 8, model: "gpt-historical-updated" },
+    }));
+    render(<RuntimeConfigurationForm initialConfig={historicalConfig} save={save} section="execution" />);
+
+    expect((screen.getByLabelText("Model") as HTMLSelectElement).selectedOptions[0]?.textContent).toBe(
+      "Custom model ID…",
+    );
+    expect((screen.getByLabelText("Custom model ID") as HTMLInputElement).value).toBe("gpt-historical-private");
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Custom model ID"), { target: { value: "gpt-historical-updated" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(save).toHaveBeenCalledOnce());
+    expect(save).toHaveBeenCalledWith({
+      expectedRevision: 4,
+      runtimeConfig: { model: "gpt-historical-updated", reasoningEffort: null },
+    });
+  });
+
+  it("shows Claude Code model suggestions and the complete strict reasoning list", () => {
+    const claudeConfig: AgentAdminConfig = {
+      ...config,
+      runtimeProvider: "claude-code",
+      runtimeConfig: { ...config.runtimeConfig, model: "claude-sonnet-5", reasoningEffort: "max" },
+    };
+    render(<RuntimeConfigurationForm initialConfig={claudeConfig} save={vi.fn()} />);
+
+    expect(screen.getByText("Provider: Claude Code")).toBeTruthy();
+    expect(optionValues("Model")).toEqual([
+      "",
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "claude-haiku-4-5",
+      "__custom_model__",
+    ]);
+    expect((screen.getByLabelText("Model") as HTMLSelectElement).value).toBe("claude-sonnet-5");
+    expect(optionValues("Reasoning level")).toEqual(["", "low", "medium", "high", "xhigh", "max", "ultracode"]);
+    expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).value).toBe("max");
+  });
+
+  it("maps Provider default to null while preserving expectedRevision", async () => {
+    const configured: AgentAdminConfig = {
+      ...config,
+      runtimeConfig: { ...config.runtimeConfig, model: "gpt-5.6-sol", reasoningEffort: "high" },
+    };
+    const save = vi.fn(async () => ({
+      ...configured,
+      revision: 5,
+      runtimeConfig: { ...configured.runtimeConfig, revision: 8, model: null, reasoningEffort: null },
+    }));
+    render(<RuntimeConfigurationForm initialConfig={configured} save={save} section="execution" />);
+
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("Reasoning level"), { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledOnce());
+    expect(save).toHaveBeenCalledWith({
+      expectedRevision: 4,
+      runtimeConfig: { model: null, reasoningEffort: null },
+    });
   });
 
   it("saves Agent instructions independently", async () => {
@@ -148,42 +176,44 @@ describe("RuntimeConfigurationForm", () => {
       expectedRevision: 4,
       runtimeConfig: { instructions: "Updated instructions." },
     });
-    expect((await screen.findByRole("status")).textContent).toBe("Agent instructions saved.");
   });
 
-  it("restores provider defaults with blank Runtime values", () => {
+  it("normalizes blank form values to provider defaults", () => {
     const data = new FormData();
     data.set("model", " ");
     data.set("reasoningEffort", "");
 
-    expect(runtimeConfigurationFromForm(data)).toEqual({
-      model: null,
-      reasoningEffort: null,
-    });
+    expect(runtimeConfigurationFromForm(data)).toEqual({ model: null, reasoningEffort: null });
   });
 
-  it("reports save failures without closing the editor", async () => {
+  it("reports save failures without losing drafts", async () => {
     const save = vi.fn(async () => {
       throw new Error("Revision changed");
     });
     render(<RuntimeConfigurationForm initialConfig={config} save={save} />);
 
-    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5.6-codex" } });
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5.6-sol" } });
     fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
     expect((await screen.findByRole("alert")).textContent).toBe("Revision changed");
-    expect(screen.getByLabelText("Model")).toBeTruthy();
+    expect((screen.getByLabelText("Model") as HTMLSelectElement).value).toBe("gpt-5.6-sol");
   });
 
-  it("discards a draft without saving", () => {
+  it("discards model and reasoning drafts without saving", () => {
+    const initialConfig: AgentAdminConfig = {
+      ...config,
+      runtimeConfig: { ...config.runtimeConfig, model: "gpt-historical-private", reasoningEffort: "medium" },
+    };
     const save = vi.fn();
-    render(<RuntimeConfigurationForm initialConfig={config} save={save} section="execution" />);
+    render(<RuntimeConfigurationForm initialConfig={initialConfig} save={save} section="execution" />);
 
-    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-5.6-codex" } });
+    fireEvent.change(screen.getByLabelText("Custom model ID"), { target: { value: "gpt-historical-updated" } });
+    fireEvent.change(screen.getByLabelText("Reasoning level"), { target: { value: "high" } });
     expect(screen.getByText("Unsaved changes")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Discard" }));
 
-    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("");
+    expect((screen.getByLabelText("Custom model ID") as HTMLInputElement).value).toBe("gpt-historical-private");
+    expect((screen.getByLabelText("Reasoning level") as HTMLSelectElement).value).toBe("medium");
     expect(screen.queryByText("Unsaved changes")).toBeNull();
     expect(save).not.toHaveBeenCalled();
   });

--- a/apps/web/src/runtime-configuration.tsx
+++ b/apps/web/src/runtime-configuration.tsx
@@ -1,9 +1,13 @@
-import type { AgentAdminConfig, UpdateAgentRequest, UpdateAgentRuntimeConfig } from "@opentag/shared/browser";
+import {
+  type AgentAdminConfig,
+  getRuntimeConfigurationOptions,
+  type UpdateAgentRequest,
+  type UpdateAgentRuntimeConfig,
+} from "@opentag/shared/browser";
 import { type FormEvent, useState } from "react";
 import { Button, Field } from "./ui/design-system.js";
 
-const CODEX_REASONING_EFFORT_SUGGESTIONS = ["minimal", "low", "medium", "high", "xhigh"] as const;
-const CLAUDE_CODE_REASONING_EFFORT_SUGGESTIONS = ["low", "medium", "high", "xhigh", "max", "ultracode"] as const;
+const CUSTOM_MODEL_OPTION = "__custom_model__";
 
 export interface RuntimeConfigurationFormProps {
   readonly initialConfig: AgentAdminConfig;
@@ -16,8 +20,12 @@ export function RuntimeConfigurationForm({ initialConfig, save, section = "all" 
 }
 
 function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: RuntimeConfigurationFormProps) {
+  const initialOptions = getRuntimeConfigurationOptions(initialConfig.runtimeProvider);
   const [config, setConfig] = useState(initialConfig);
   const [modelDraft, setModelDraft] = useState(initialConfig.runtimeConfig.model ?? "");
+  const [modelSelection, setModelSelection] = useState(() =>
+    modelSelectionFor(initialConfig.runtimeConfig.model, initialOptions.modelSuggestions),
+  );
   const [reasoningDraft, setReasoningDraft] = useState(initialConfig.runtimeConfig.reasoningEffort ?? "");
   const [instructionsDraft, setInstructionsDraft] = useState(initialConfig.runtimeConfig.instructions);
   const [message, setMessage] = useState<{
@@ -27,20 +35,19 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
   }>();
   const [saving, setSaving] = useState<"runtime" | "instructions">();
   const fieldId = (name: string) => `runtime-${name}-${config.id}`;
-  const reasoningListId = `reasoning-effort-${config.id}`;
   const providerName = config.runtimeProvider === "codex" ? "Codex" : "Claude Code";
   const ExecutionHeading = section === "execution" ? "h1" : "h3";
   const InstructionsHeading = section === "instructions" ? "h1" : "h3";
-  const reasoningSuggestions =
-    config.runtimeProvider === "codex" ? CODEX_REASONING_EFFORT_SUGGESTIONS : CLAUDE_CODE_REASONING_EFFORT_SUGGESTIONS;
+  const runtimeOptions = getRuntimeConfigurationOptions(config.runtimeProvider);
   const runtimeDirty =
     modelDraft !== (config.runtimeConfig.model ?? "") ||
     reasoningDraft !== (config.runtimeConfig.reasoningEffort ?? "");
+  const customModelInvalid = modelSelection === CUSTOM_MODEL_OPTION && modelDraft.trim().length === 0;
   const instructionsDirty = instructionsDraft !== config.runtimeConfig.instructions;
 
   async function saveRuntime(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (saving) return;
+    if (saving || customModelInvalid) return;
     setSaving("runtime");
     setMessage(undefined);
     try {
@@ -48,6 +55,12 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
       const updated = await save({ expectedRevision: config.revision, runtimeConfig });
       setConfig(updated);
       setModelDraft(updated.runtimeConfig.model ?? "");
+      setModelSelection(
+        modelSelectionFor(
+          updated.runtimeConfig.model,
+          getRuntimeConfigurationOptions(updated.runtimeProvider).modelSuggestions,
+        ),
+      );
       setReasoningDraft(updated.runtimeConfig.reasoningEffort ?? "");
       setMessage({ kind: "success", section: "runtime", text: "Execution settings saved." });
     } catch (cause) {
@@ -105,48 +118,77 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
           <form className="agent-runtime-edit-form" onSubmit={saveRuntime}>
             <div className="agent-runtime-field-grid">
               <Field
-                hint="Leave blank to use the provider default."
+                hint="Choose a common model or enter a custom model ID."
                 hintId={fieldId("model-help")}
                 htmlFor={fieldId("model")}
                 label="Model"
               >
-                <input
+                <select
                   aria-describedby={fieldId("model-help")}
-                  autoComplete="off"
                   id={fieldId("model")}
-                  name="model"
-                  placeholder={`${providerName} default`}
-                  value={modelDraft}
+                  value={modelSelection}
                   onChange={(event) => {
-                    setModelDraft(event.currentTarget.value);
+                    const selection = event.currentTarget.value;
+                    setModelSelection(selection);
+                    if (selection === CUSTOM_MODEL_OPTION) {
+                      if (modelSelection !== CUSTOM_MODEL_OPTION) setModelDraft("");
+                    } else {
+                      setModelDraft(selection);
+                    }
                     setMessage(undefined);
                   }}
-                />
+                >
+                  <option value="">Provider default</option>
+                  {runtimeOptions.modelSuggestions.map((model) => (
+                    <option value={model} key={model}>
+                      {model}
+                    </option>
+                  ))}
+                  <option value={CUSTOM_MODEL_OPTION}>Custom model ID…</option>
+                </select>
+                {modelSelection === CUSTOM_MODEL_OPTION ? (
+                  <div className="agent-runtime-custom-model">
+                    <label className="ds-field__label" htmlFor={fieldId("custom-model")}>
+                      Custom model ID
+                    </label>
+                    <input
+                      aria-describedby={fieldId("model-help")}
+                      autoComplete="off"
+                      id={fieldId("custom-model")}
+                      required
+                      value={modelDraft}
+                      onChange={(event) => {
+                        setModelDraft(event.currentTarget.value);
+                        setMessage(undefined);
+                      }}
+                    />
+                  </div>
+                ) : null}
+                <input name="model" readOnly type="hidden" value={modelDraft} />
               </Field>
               <Field
-                hint="Leave blank to use the provider default."
+                hint="Provider default lets the runtime choose."
                 hintId={fieldId("reasoning-help")}
                 htmlFor={fieldId("reasoning-effort")}
                 label="Reasoning level"
               >
-                <input
+                <select
                   aria-describedby={fieldId("reasoning-help")}
-                  autoComplete="off"
                   id={fieldId("reasoning-effort")}
-                  list={reasoningListId}
                   name="reasoningEffort"
-                  placeholder="Provider default"
                   value={reasoningDraft}
                   onChange={(event) => {
                     setReasoningDraft(event.currentTarget.value);
                     setMessage(undefined);
                   }}
-                />
-                <datalist id={reasoningListId}>
-                  {reasoningSuggestions.map((effort) => (
-                    <option value={effort} key={effort} />
+                >
+                  <option value="">Provider default</option>
+                  {runtimeOptions.reasoningEffortAllowedValues.map((effort) => (
+                    <option value={effort} key={effort}>
+                      {effort}
+                    </option>
                   ))}
-                </datalist>
+                </select>
               </Field>
             </div>
             {runtimeDirty ? (
@@ -158,13 +200,14 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
                     variant="ghost"
                     onClick={() => {
                       setModelDraft(config.runtimeConfig.model ?? "");
+                      setModelSelection(modelSelectionFor(config.runtimeConfig.model, runtimeOptions.modelSuggestions));
                       setReasoningDraft(config.runtimeConfig.reasoningEffort ?? "");
                       setMessage(undefined);
                     }}
                   >
                     Discard
                   </Button>
-                  <Button disabled={Boolean(saving)} type="submit">
+                  <Button disabled={Boolean(saving) || customModelInvalid} type="submit">
                     {saving === "runtime" ? "Saving…" : "Save changes"}
                   </Button>
                 </div>
@@ -234,6 +277,11 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
       ) : null}
     </div>
   );
+}
+
+function modelSelectionFor(model: string | null, suggestions: readonly string[]): string {
+  if (model === null) return "";
+  return suggestions.includes(model) ? model : CUSTOM_MODEL_OPTION;
 }
 
 function SaveMessage({ message }: { message: { kind: "error" | "success"; text: string } }) {

--- a/apps/web/src/runtime-configuration.tsx
+++ b/apps/web/src/runtime-configuration.tsx
@@ -39,6 +39,8 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
   const ExecutionHeading = section === "execution" ? "h1" : "h3";
   const InstructionsHeading = section === "instructions" ? "h1" : "h3";
   const runtimeOptions = getRuntimeConfigurationOptions(config.runtimeProvider);
+  const hasHistoricalReasoningDraft =
+    reasoningDraft !== "" && !runtimeOptions.reasoningEffortAllowedValues.includes(reasoningDraft);
   const runtimeDirty =
     modelDraft !== (config.runtimeConfig.model ?? "") ||
     reasoningDraft !== (config.runtimeConfig.reasoningEffort ?? "");
@@ -183,6 +185,9 @@ function RuntimeConfigurationEditor({ initialConfig, save, section = "all" }: Ru
                   }}
                 >
                   <option value="">Provider default</option>
+                  {hasHistoricalReasoningDraft ? (
+                    <option value={reasoningDraft}>{reasoningDraft} (saved value)</option>
+                  ) : null}
                   {runtimeOptions.reasoningEffortAllowedValues.map((effort) => (
                     <option value={effort} key={effort}>
                       {effort}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3089,6 +3089,12 @@ textarea:focus {
   gap: 20px;
 }
 
+.agent-runtime-custom-model {
+  display: grid;
+  gap: 7px;
+  margin-top: 4px;
+}
+
 .agent-runtime-provider {
   margin: 0;
   color: var(--muted);

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -745,7 +745,7 @@ function createRequest(eventSink: CreateAgentRuntimeRequest["eventSink"]): Creat
     },
     configuration: {
       model: "claude-test",
-      reasoningEffort: "high",
+      reasoningEffort: "ultracode",
       provider: { maxBudgetUsd: 1.5, maxTurns: 5 },
     },
   };

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -2,6 +2,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getRuntimeConfigurationOptions } from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentRunConfiguration,
@@ -475,6 +476,27 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
     }
   });
 
+  it("forwards every supported Claude Code effort to the controlled process", async () => {
+    const supportedEfforts = ["low", "medium", "high", "xhigh", "max"] as const;
+    expect(getRuntimeConfigurationOptions("claude-code").reasoningEffortAllowedValues).toEqual(supportedEfforts);
+
+    for (const reasoningEffort of supportedEfforts) {
+      const process = new ManualClaudeCodeProcess([successResult()]);
+      const runtime = await factory(process).create(withConfiguration({ reasoningEffort }));
+
+      await runtime.prompt({ runId: `effort-${reasoningEffort}`, input: input("args") });
+
+      expect(argumentAfter(process.args, "--effort")).toBe(reasoningEffort);
+      await runtime.close();
+    }
+
+    const rejectedProcess = new ManualClaudeCodeProcess([successResult()]);
+    await expect(factory(rejectedProcess).create(withConfiguration({ reasoningEffort: "ultracode" }))).rejects.toThrow(
+      "reasoning effort",
+    );
+    expect(rejectedProcess.args).toEqual([]);
+  });
+
   it.each([
     {
       scenario: "foreign-init",
@@ -745,7 +767,7 @@ function createRequest(eventSink: CreateAgentRuntimeRequest["eventSink"]): Creat
     },
     configuration: {
       model: "claude-test",
-      reasoningEffort: "ultracode",
+      reasoningEffort: "max",
       provider: { maxBudgetUsd: 1.5, maxTurns: 5 },
     },
   };

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -140,7 +140,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
       },
       configuration: {
         model: "base-model",
-        reasoningEffort: "high",
+        reasoningEffort: "xhigh",
         provider: { personality: "friendly", serviceName: "opentag", summary: "concise" },
       },
     });
@@ -185,7 +185,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
 
     const second = runtime.prompt({ runId: "base-only", input: input("again") });
     await vi.waitFor(() => expect(client.calls.filter((call) => call.method === "turn/start")).toHaveLength(2));
-    expect(client.lastCall("turn/start")?.params).toMatchObject({ model: "base-model", effort: "high" });
+    expect(client.lastCall("turn/start")?.params).toMatchObject({ model: "base-model", effort: "xhigh" });
     client.complete({ id: "turn-2", items: [] });
     await second;
     await runtime.close();

--- a/packages/client/src/providers/claude-code/agent-runtime.ts
+++ b/packages/client/src/providers/claude-code/agent-runtime.ts
@@ -2,6 +2,7 @@ import { type ChildProcessWithoutNullStreams, execFile } from "node:child_proces
 import { randomUUID } from "node:crypto";
 import { isAbsolute } from "node:path";
 import { promisify } from "node:util";
+import { getRuntimeConfigurationOptions } from "@opentag/shared";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
 import {
@@ -40,7 +41,6 @@ import {
 const execFileAsync = promisify(execFile);
 const CLAUDE_CODE_BINDING_SCHEMA_VERSION = 1;
 const CLAUDE_CODE_PROVIDER_ID = "claude-code";
-const CLAUDE_CODE_EFFORTS = new Set(["low", "medium", "high", "xhigh", "max", "ultracode"]);
 
 export const CLAUDE_CODE_AGENT_RUNTIME_MANIFEST: AgentRuntimeManifest = Object.freeze({
   providerId: CLAUDE_CODE_PROVIDER_ID,
@@ -831,7 +831,10 @@ function validateConfiguration(configuration: AgentRunConfiguration | undefined)
   if (configuration.model !== undefined && configuration.model.trim().length === 0) {
     throw new AgentRuntimeError("configuration_invalid", "model must be non-empty");
   }
-  if (configuration.reasoningEffort && !CLAUDE_CODE_EFFORTS.has(configuration.reasoningEffort)) {
+  if (
+    configuration.reasoningEffort &&
+    !getRuntimeConfigurationOptions("claude-code").reasoningEffortAllowedValues.includes(configuration.reasoningEffort)
+  ) {
     throw new AgentRuntimeError("configuration_invalid", "Claude Code reasoning effort is unsupported");
   }
   parseProviderConfiguration(configuration.provider);

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -3,6 +3,7 @@ import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
+import { getRuntimeConfigurationOptions } from "@opentag/shared";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
 import {
@@ -103,7 +104,6 @@ export const CODEX_AGENT_RUNTIME_APP_SERVER_ARGS = [
   "-c",
   'shell_environment_policy.filters={ PATH = "include", LANG = "include", LC_ALL = "include", OPENTAG_PROVIDER_ENV_FILE = "include" }',
 ] as const;
-const CODEX_REASONING_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh"]);
 const TOOL_ITEM_TYPES = new Set([
   "collabToolCall",
   "commandExecution",
@@ -1040,7 +1040,10 @@ function validateConfiguration(configuration: AgentRunConfiguration | undefined)
   if (configuration.model !== undefined && configuration.model.trim().length === 0) {
     throw new AgentRuntimeError("configuration_invalid", "model must be non-empty");
   }
-  if (configuration.reasoningEffort && !CODEX_REASONING_EFFORTS.has(configuration.reasoningEffort)) {
+  if (
+    configuration.reasoningEffort &&
+    !getRuntimeConfigurationOptions("codex").reasoningEffortAllowedValues.includes(configuration.reasoningEffort)
+  ) {
     throw new AgentRuntimeError("configuration_invalid", "Codex reasoning effort is unsupported");
   }
   parseProviderConfiguration(configuration.provider);

--- a/packages/shared/src/__tests__/runtime-configuration-options.test.ts
+++ b/packages/shared/src/__tests__/runtime-configuration-options.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_RUNTIME_PROVIDERS } from "../agent.js";
+import { getRuntimeConfigurationOptions } from "../runtime-configuration-options.js";
+
+describe("getRuntimeConfigurationOptions", () => {
+  it.each([
+    [
+      "codex",
+      ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex"],
+      ["minimal", "low", "medium", "high", "xhigh"],
+    ],
+    [
+      "claude-code",
+      ["claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"],
+      ["low", "medium", "high", "xhigh", "max", "ultracode"],
+    ],
+  ] as const)("returns the complete %s options", (provider, modelSuggestions, reasoningEffortAllowedValues) => {
+    expect(getRuntimeConfigurationOptions(provider)).toEqual({ modelSuggestions, reasoningEffortAllowedValues });
+  });
+
+  it("defines options for every Agent runtime provider", () => {
+    expect(AGENT_RUNTIME_PROVIDERS.map((provider) => getRuntimeConfigurationOptions(provider))).toHaveLength(
+      AGENT_RUNTIME_PROVIDERS.length,
+    );
+  });
+});

--- a/packages/shared/src/__tests__/runtime-configuration-options.test.ts
+++ b/packages/shared/src/__tests__/runtime-configuration-options.test.ts
@@ -12,7 +12,7 @@ describe("getRuntimeConfigurationOptions", () => {
     [
       "claude-code",
       ["claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"],
-      ["low", "medium", "high", "xhigh", "max", "ultracode"],
+      ["low", "medium", "high", "xhigh", "max"],
     ],
   ] as const)("returns the complete %s options", (provider, modelSuggestions, reasoningEffortAllowedValues) => {
     expect(getRuntimeConfigurationOptions(provider)).toEqual({ modelSuggestions, reasoningEffortAllowedValues });

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -7,5 +7,6 @@ export * from "./http-paths.js";
 export * from "./im-binding.js";
 export * from "./invitation.js";
 export { RUNTIME_DEFAULT_MAX_DURATION_MS, RUNTIME_MAX_DURATION_MS } from "./runtime-config.js";
+export * from "./runtime-configuration-options.js";
 export * from "./runtime-protocol.js";
 export * from "./team.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -201,6 +201,10 @@ export {
   TeamInvitationSchema,
 } from "./invitation.js";
 export {
+  getRuntimeConfigurationOptions,
+  type RuntimeConfigurationOptions,
+} from "./runtime-configuration-options.js";
+export {
   type AgentTraceBatch,
   AgentTraceBatchSchema,
   type AgentTraceEvent,

--- a/packages/shared/src/runtime-configuration-options.ts
+++ b/packages/shared/src/runtime-configuration-options.ts
@@ -1,0 +1,21 @@
+import type { AgentRuntimeProvider } from "./agent.js";
+
+export interface RuntimeConfigurationOptions {
+  readonly modelSuggestions: readonly string[];
+  readonly reasoningEffortAllowedValues: readonly string[];
+}
+
+const RUNTIME_CONFIGURATION_OPTIONS = {
+  codex: {
+    modelSuggestions: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex"],
+    reasoningEffortAllowedValues: ["minimal", "low", "medium", "high", "xhigh"],
+  },
+  "claude-code": {
+    modelSuggestions: ["claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"],
+    reasoningEffortAllowedValues: ["low", "medium", "high", "xhigh", "max", "ultracode"],
+  },
+} as const satisfies Record<AgentRuntimeProvider, RuntimeConfigurationOptions>;
+
+export function getRuntimeConfigurationOptions(provider: AgentRuntimeProvider): RuntimeConfigurationOptions {
+  return RUNTIME_CONFIGURATION_OPTIONS[provider];
+}

--- a/packages/shared/src/runtime-configuration-options.ts
+++ b/packages/shared/src/runtime-configuration-options.ts
@@ -12,7 +12,7 @@ const RUNTIME_CONFIGURATION_OPTIONS = {
   },
   "claude-code": {
     modelSuggestions: ["claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"],
-    reasoningEffortAllowedValues: ["low", "medium", "high", "xhigh", "max", "ultracode"],
+    reasoningEffortAllowedValues: ["low", "medium", "high", "xhigh", "max"],
   },
 } as const satisfies Record<AgentRuntimeProvider, RuntimeConfigurationOptions>;
 


### PR DESCRIPTION
## Summary

- add a browser-safe shared runtime configuration options catalog for model suggestions and strict Provider reasoning values
- reuse the shared reasoning values in the Codex and Claude Code runtimes
- replace free-form Web model/reasoning fields with native selects while preserving custom and historical model IDs
- retain staged save, discard, and expectedRevision behavior

## Testing

Passed:

- `pnpm check` (8 pre-existing undeclared E2E environment-variable warnings)
- `pnpm build`
- `pnpm typecheck`
- Shared tests: 75/75
- Web tests: 335/335
- Client tests: 430/430
- `pnpm --filter @opentag/client test:agent-runtime:coverage`: 268/268 and 100% statements/branches/functions/lines

Full-suite limitations unrelated to this diff:

- `pnpm test`: Server observability timing assertion expected `stale_connection` but received `handled`; 232/233 Server tests passed. The isolated test reproduced under Node 24, while the same test passed during the coverage run.
- `pnpm test:coverage`: two CLI daemon path assertions compare `/var/...` with macOS-normalized `/private/var/...`; 117/119 CLI tests passed. The new shared module has 100% coverage.

## Breaking changes

None. Model suggestions are not an allowlist, and unknown saved model IDs remain editable.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.