### PR TITLE
fix(web): streamline Agent settings and usage

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1493,7 +1493,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByText("Average per measured Task")).toBeNull();
     expect(screen.getByText("Partial data.")).toBeTruthy();
     expect(screen.getByRole("status").textContent).toBe(
-      "Partial data. Token data is available for 31 of 32 tasks. Totals and charts are partial.",
+      "Partial data. Token data is available for 31 of 32 tasks. Token totals and charts are partial.",
     );
     expect(screen.getByRole("heading", { name: "Token usage over time" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Token breakdown" })).toBeTruthy();
@@ -1510,6 +1510,48 @@ describe("OpenTag Web App Shell", () => {
       ).toBe(true),
     );
     expect(await screen.findByRole("img", { name: /428K Tokens used during the last 7 days/ })).toBeTruthy();
+  });
+
+  it("explains when no Tasks report Token usage", async () => {
+    installApi("admin", {
+      agentUsage: {
+        tasks: 4,
+        measuredTasks: 0,
+        failed: 0,
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        tokens: 0,
+        daily: [],
+      },
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}/usage`);
+    render(<App />);
+
+    expect((await screen.findByText("Token data unavailable.")).closest("[role='status']")?.textContent).toBe(
+      "Token data unavailable. None of the 4 tasks reported token usage. Token totals and charts may be empty.",
+    );
+  });
+
+  it("keeps the Usage loading skeleton aligned with the two summary metrics", async () => {
+    installApi("admin");
+    const baseFetch = vi.mocked(fetch).getMockImplementation();
+    let releaseUsage = () => {};
+    const pendingUsage = new Promise<void>((resolve) => {
+      releaseUsage = resolve;
+    });
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (String(input).startsWith(`/api/v1/agents/${agentId}/usage?`)) await pendingUsage;
+      if (!baseFetch) throw new Error("Expected the base fetch implementation");
+      return baseFetch(input, init);
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}/usage`);
+    render(<App />);
+
+    const loading = await screen.findByLabelText("Loading Agent usage");
+    expect(loading.children).toHaveLength(2);
+    releaseUsage();
+    expect(await screen.findByText("Partial data.")).toBeTruthy();
   });
 
   it("redirects legacy Agent URLs without keeping the old UI", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1274,7 +1274,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("heading", { name: "Current work" })).toBeTruthy();
     expect(screen.getByText("No active work")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Where to use this Agent" })).toBeTruthy();
-    expect(screen.getByText("Send a direct message, or mention @reviewer in a Feishu conversation.")).toBeTruthy();
+    expect(screen.getByText("Send @reviewer a direct message, or mention it in a Feishu group chat.")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Settings" }).getAttribute("href")).toBe(`/agents/${agentId}/settings`);
     expect(screen.getByRole("link", { name: "Usage" }).getAttribute("href")).toBe(`/agents/${agentId}/usage`);
     expect(screen.queryByLabelText("More Agent actions")).toBeNull();
@@ -1642,7 +1642,7 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Contact channel" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "No messaging channel" })).toBeTruthy();
-    expect(screen.getByText(/cannot contact this Agent/)).toBeTruthy();
+    expect(screen.getByText(/cannot contact this agent/)).toBeTruthy();
   });
 
   it("separates a connected contact channel from its trigger rules", async () => {
@@ -1651,13 +1651,16 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Contact channel" })).toBeTruthy();
-    expect(screen.getByText(/Feishu · Available/)).toBeTruthy();
+    expect(screen.getByText(/Feishu · Connected/)).toBeTruthy();
+    expect(screen.getByText(/Last checked/)).toBeTruthy();
     expect(screen.getByText("@reviewer")).toBeTruthy();
-    expect(screen.getByText("Send a direct message, or mention @reviewer in a Feishu conversation.")).toBeTruthy();
+    expect(screen.getByText("Send @reviewer a direct message, or mention it in a Feishu group chat.")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Trigger rules" })).toBeTruthy();
-    expect(screen.getByText("A direct message can always start work.")).toBeTruthy();
-    expect(screen.getByRole("group", { name: "Conversation trigger rule" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Replace Feishu Bot" })).toBeTruthy();
+    expect(screen.getByText("Every direct message starts a task.")).toBeTruthy();
+    expect(screen.getByText("Group chats")).toBeTruthy();
+    expect(screen.getByRole("group", { name: "Shared conversation trigger rule" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Change Feishu Bot" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Disconnect Feishu" })).toBeTruthy();
   });
 
   it("keeps the contact summary readable and Settings unavailable to regular members", async () => {
@@ -1666,7 +1669,7 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Where to use this Agent" })).toBeTruthy();
-    expect(screen.getByText("Send a direct message, or mention @reviewer in a Feishu conversation.")).toBeTruthy();
+    expect(screen.getByText("Send @reviewer a direct message, or mention it in a Feishu group chat.")).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Settings" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Manage" })).toBeNull();
   });
@@ -1740,9 +1743,9 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", { bound: true });
     window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "All messages" }));
-    const dialog = await screen.findByRole("dialog", { name: "Allow all conversation messages?" });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Every message" }));
+    const dialog = await screen.findByRole("dialog", { name: "Allow messages without mentions?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Allow every message" }));
     await waitFor(() =>
       expect(
         vi
@@ -1778,13 +1781,13 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "All messages" }));
-    const dialog = await screen.findByRole("dialog", { name: "Allow all conversation messages?" });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Every message" }));
+    const dialog = await screen.findByRole("dialog", { name: "Allow messages without mentions?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Allow every message" }));
     expect((await within(dialog).findByRole("alert")).textContent).toContain("Unable to update message access");
 
-    fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
-    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Allow all conversation messages?" })).toBeNull());
+    fireEvent.click(within(dialog).getByRole("button", { name: "Allow every message" }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Allow messages without mentions?" })).toBeNull());
     expect(screen.queryByText("Unable to update message access")).toBeNull();
     await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("heading", { name: "Trigger rules" })));
   });
@@ -1816,7 +1819,7 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Disable IM binding" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Disconnect Feishu" }));
     const dialog = await screen.findByRole("dialog", { name: "Disconnect messaging?" });
     fireEvent.click(within(dialog).getByRole("button", { name: "Disconnect" }));
     expect((await within(dialog).findByRole("alert")).textContent).toContain("Unable to disconnect messaging");
@@ -1833,7 +1836,7 @@ describe("OpenTag Web App Shell", () => {
     const view = render(<App />);
 
     expect(await screen.findByRole("button", { name: "Resume Slack setup" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Replace Slack App" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Change Slack App" })).toBeNull();
     expect(screen.queryByLabelText("Bot User OAuth Token")).toBeNull();
     expect(
       vi
@@ -1905,7 +1908,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText(/Signing Secret not yet verified/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Edit credentials" })).toBeTruthy();
     expect(screen.queryByLabelText("Bot User OAuth Token")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Replace Slack App" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Change Slack App" })).toBeNull();
   });
 
   it("shows the Tasks demo and opens a Task detail", async () => {
@@ -2384,7 +2387,7 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByText(/Permissions update required/)).toBeTruthy();
     expect(screen.queryByText(/Online/)).toBeNull();
     expect(screen.getByRole("button", { name: "Reauthorize Feishu" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Replace Feishu Bot" }));
+    fireEvent.click(screen.getByRole("button", { name: "Change Feishu Bot" }));
     expect(await screen.findByText(/Choose an existing Feishu Bot or create a new one/)).toBeTruthy();
     const request = vi
       .mocked(fetch)
@@ -2407,7 +2410,7 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", { bound: true, setupFailureCode: "FEISHU_APP_ALREADY_BOUND" });
     window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "Replace Feishu Bot" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Change Feishu Bot" }));
     const setupNotice = (await screen.findByText("Feishu setup started")).parentElement;
     expect(setupNotice?.textContent).toContain(
       "This Feishu Bot is already connected to another Agent. Choose a different Bot or disable its current binding first.",
@@ -2434,9 +2437,9 @@ describe("OpenTag Web App Shell", () => {
     installApi("admin", { bound: true, provider, scopeReauth: true });
     window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "All messages" }));
-    const dialog = await screen.findByRole("dialog", { name: "Allow all conversation messages?" });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Allow all messages" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Every message" }));
+    const dialog = await screen.findByRole("dialog", { name: "Allow messages without mentions?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Allow every message" }));
     expect(await screen.findByText("Additional IM scopes are required")).toBeTruthy();
     expect(await screen.findByText(recovery)).toBeTruthy();
     if (provider === "slack") expect(screen.queryByRole("button", { name: "Reauthorize Feishu" })).toBeNull();

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1488,8 +1488,8 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Usage" })).toBeTruthy();
     expect(await screen.findByRole("img", { name: /428K Tokens used during the last 30 days/ })).toBeTruthy();
-    expect(screen.getByText("Tokens recorded")).toBeTruthy();
-    expect(screen.getByText("Failed Tasks")).toBeTruthy();
+    expect(screen.getByText("Tokens")).toBeTruthy();
+    expect(screen.queryByText("Failed Tasks")).toBeNull();
     expect(screen.queryByText("Average per measured Task")).toBeNull();
     expect(screen.getByText("Partial data.")).toBeTruthy();
     expect(screen.getByRole("status").textContent).toBe(

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1337,13 +1337,13 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("link", { name: /Instructions & behavior/ })).toBeTruthy();
     expect(screen.getByRole("link", { name: /Model & reasoning/ })).toBeTruthy();
     expect(screen.getByRole("link", { name: /Messaging/ })).toBeTruthy();
-    expect(screen.getByRole("link", { name: /Name & identity/ })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /^Name Reviewer$/ })).toBeTruthy();
     expect(screen.getByText("Connected computer")).toBeTruthy();
     expect(screen.queryByRole("link", { name: /Connected computer/ })).toBeNull();
     expect(screen.getByRole("link", { name: /Manage Agent/ })).toBeTruthy();
     expect(screen.getByText("Not configured")).toBeTruthy();
     expect(screen.getByText("Codex · Default model · Default reasoning")).toBeTruthy();
-    expect(screen.getByText("Reviewer · @reviewer")).toBeTruthy();
+    expect(screen.getByText("Reviewer")).toBeTruthy();
     expect(screen.getByText("Ada's Mac · macOS · Online")).toBeTruthy();
     expect(screen.queryByText("Runtime")).toBeNull();
   });
@@ -1376,15 +1376,16 @@ describe("OpenTag Web App Shell", () => {
     expect(computerLink.getAttribute("href")).toBe(`/agents/${agentId}/settings/computer`);
   });
 
-  it("edits Agent identity directly and keeps the permanent handle readable", async () => {
+  it("edits the Agent display name without exposing its permanent handle", async () => {
     installApi("admin");
     window.history.replaceState({}, "", `/agents/${agentId}/settings/identity`);
     render(<App />);
 
     const displayName = (await screen.findByLabelText("Display name")) as HTMLInputElement;
-    const handle = screen.getByLabelText("Handle") as HTMLInputElement;
-    expect(handle.readOnly).toBe(true);
-    expect(handle.disabled).toBe(false);
+    expect(screen.getByRole("heading", { name: "Name" })).toBeTruthy();
+    expect(screen.getByText("Choose the name teammates see.")).toBeTruthy();
+    expect(screen.queryByLabelText("Handle")).toBeNull();
+    expect(screen.queryByText(/handle cannot be changed/i)).toBeNull();
     expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
 
     fireEvent.change(displayName, { target: { value: "Research Reviewer" } });

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1488,6 +1488,13 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Usage" })).toBeTruthy();
     expect(await screen.findByRole("img", { name: /428K Tokens used during the last 30 days/ })).toBeTruthy();
+    expect(screen.getByText("Tokens recorded")).toBeTruthy();
+    expect(screen.getByText("Failed Tasks")).toBeTruthy();
+    expect(screen.queryByText("Average per measured Task")).toBeNull();
+    expect(screen.getByText("Partial data.")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe(
+      "Partial data. Token data is available for 31 of 32 tasks. Totals and charts are partial.",
+    );
     expect(screen.getByRole("heading", { name: "Token usage over time" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Token breakdown" })).toBeTruthy();
     expect(screen.getAllByText(/0 Tokens$/).length).toBeGreaterThan(0);

--- a/apps/web/src/features/agent-usage.css
+++ b/apps/web/src/features/agent-usage.css
@@ -16,7 +16,7 @@
   margin: 0;
   border-top: 1px solid var(--strong-border);
   border-bottom: 1px solid var(--border);
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .agent-usage-metrics > div {
@@ -53,7 +53,7 @@
 
 .agent-usage-loading {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 24px;
   border-top: 1px solid var(--strong-border);
   border-bottom: 1px solid var(--border);

--- a/apps/web/src/features/agent-usage.css
+++ b/apps/web/src/features/agent-usage.css
@@ -104,8 +104,17 @@
 
 .agent-usage-coverage {
   margin: -12px 0 0;
-  color: var(--muted);
+  border-left: 3px solid var(--warning);
+  background: var(--warning-surface);
+  color: var(--secondary-foreground);
   font-size: var(--text-meta);
+  line-height: var(--lh-prose);
+  padding: 10px 14px;
+}
+
+.agent-usage-coverage strong {
+  color: var(--foreground);
+  font-weight: var(--fw-semibold);
 }
 
 .agent-usage-analysis {

--- a/apps/web/src/features/agent-usage.test.tsx
+++ b/apps/web/src/features/agent-usage.test.tsx
@@ -1,0 +1,39 @@
+import type { AgentUsageDetail } from "@opentag/shared/browser";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { browserApi } from "../api.js";
+import { AgentUsageOverview } from "./agent-usage.js";
+
+const usage: AgentUsageDetail = {
+  windowDays: 30,
+  startedAt: "2026-07-27T00:00:00.000Z",
+  endedAt: "2026-08-25T23:59:59.999Z",
+  tasks: 32,
+  measuredTasks: 31,
+  failed: 0,
+  inputTokens: 400_000,
+  cachedInputTokens: 350_000,
+  outputTokens: 28_000,
+  tokens: 428_000,
+  daily: [],
+};
+
+describe("AgentUsageOverview", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("describes partial totals without referring to charts that are not shown", async () => {
+    vi.spyOn(browserApi, "agentUsage").mockResolvedValue(usage);
+
+    render(
+      <MemoryRouter>
+        <AgentUsageOverview agentId="agent-1" />
+      </MemoryRouter>,
+    );
+
+    const coverage = await screen.findByText("Partial data.");
+    expect(coverage.closest("[role='status']")?.textContent).toBe(
+      "Partial data. Token data is available for 31 of 32 tasks. Token totals are partial.",
+    );
+  });
+});

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -101,12 +101,11 @@ function UsageSummaryState({ state, compact = false }: { state: UsageState; comp
 }
 
 function UsageMetrics({ usage }: { usage: AgentUsageDetail }) {
-  const average = usage.measuredTasks > 0 ? formatUsageNumber(usage.tokens / usage.measuredTasks) : "—";
   return (
     <dl className="agent-usage-metrics" aria-label={`Agent usage for the last ${usage.windowDays} days`}>
-      <Metric label="Tokens" value={formatUsageNumber(usage.tokens)} primary />
+      <Metric label="Tokens recorded" value={formatUsageNumber(usage.tokens)} primary />
       <Metric label="Tasks" value={formatUsageNumber(usage.tasks)} />
-      <Metric label="Average per measured Task" value={average} />
+      <Metric label="Failed Tasks" value={formatUsageNumber(usage.failed)} />
     </dl>
   );
 }
@@ -115,9 +114,10 @@ function UsageCoverage({ usage }: { usage: AgentUsageDetail }) {
   if (usage.tasks === usage.measuredTasks) return null;
   return (
     <p className="agent-usage-coverage" role="status">
+      <strong>{usage.measuredTasks === 0 ? "Token data unavailable." : "Partial data."}</strong>{" "}
       {usage.measuredTasks === 0
-        ? `Token totals are unavailable for ${usage.tasks.toLocaleString()} Tasks.`
-        : `Token totals are available for ${usage.measuredTasks.toLocaleString()} of ${usage.tasks.toLocaleString()} Tasks.`}
+        ? `None of the ${usage.tasks.toLocaleString()} tasks reported token usage. Totals and charts may be empty.`
+        : `Token data is available for ${usage.measuredTasks.toLocaleString()} of ${usage.tasks.toLocaleString()} tasks. Totals and charts are partial.`}
     </p>
   );
 }

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -79,7 +79,6 @@ function UsageSummaryState({ state, compact = false }: { state: UsageState; comp
       <div aria-label="Loading Agent usage" className="agent-usage-loading" role="status">
         <span />
         <span />
-        <span />
       </div>
     );
   }
@@ -109,14 +108,15 @@ function UsageMetrics({ usage }: { usage: AgentUsageDetail }) {
   );
 }
 
-function UsageCoverage({ usage }: { usage: AgentUsageDetail }) {
+function UsageCoverage({ usage, includesCharts = false }: { usage: AgentUsageDetail; includesCharts?: boolean }) {
   if (usage.tasks === usage.measuredTasks) return null;
+  const affectedContent = includesCharts ? "Token totals and charts" : "Token totals";
   return (
     <p className="agent-usage-coverage" role="status">
       <strong>{usage.measuredTasks === 0 ? "Token data unavailable." : "Partial data."}</strong>{" "}
       {usage.measuredTasks === 0
-        ? `None of the ${usage.tasks.toLocaleString()} tasks reported token usage. Totals and charts may be empty.`
-        : `Token data is available for ${usage.measuredTasks.toLocaleString()} of ${usage.tasks.toLocaleString()} tasks. Totals and charts are partial.`}
+        ? `None of the ${usage.tasks.toLocaleString()} tasks reported token usage. ${affectedContent} may be empty.`
+        : `Token data is available for ${usage.measuredTasks.toLocaleString()} of ${usage.tasks.toLocaleString()} tasks. ${affectedContent} are partial.`}
     </p>
   );
 }
@@ -134,7 +134,7 @@ function AgentUsageDetailContent({ usage }: { usage: AgentUsageDetail }) {
   return (
     <>
       <UsageMetrics usage={usage} />
-      <UsageCoverage usage={usage} />
+      <UsageCoverage usage={usage} includesCharts />
       <div className="agent-usage-analysis">
         <section aria-labelledby="agent-usage-trend-heading">
           <header className="agent-usage-subheading">

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -103,9 +103,8 @@ function UsageSummaryState({ state, compact = false }: { state: UsageState; comp
 function UsageMetrics({ usage }: { usage: AgentUsageDetail }) {
   return (
     <dl className="agent-usage-metrics" aria-label={`Agent usage for the last ${usage.windowDays} days`}>
-      <Metric label="Tokens recorded" value={formatUsageNumber(usage.tokens)} primary />
+      <Metric label="Tokens" value={formatUsageNumber(usage.tokens)} primary />
       <Metric label="Tasks" value={formatUsageNumber(usage.tasks)} />
-      <Metric label="Failed Tasks" value={formatUsageNumber(usage.failed)} />
     </dl>
   );
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3375,7 +3375,7 @@ function initials(value: string): string {
 }
 
 function formatDate(value: string) {
-  return new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
 }
 
 function formatRelativeTime(value: string): string {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1478,7 +1478,7 @@ const agentSettingsSections: ReadonlyArray<{
   },
   {
     key: "identity",
-    label: "Name & identity",
+    label: "Name",
     group: "details",
     icon: "user",
   },
@@ -2037,7 +2037,7 @@ function agentSettingsSummary(agent: AgentDetailView, config: AgentAdminConfig, 
         : messagingConnectionLabel(binding, agent.availability.dependencies.handoff.state);
     return `${titleCase(binding.provider)} · @${agent.name} · ${status}`;
   }
-  if (section === "identity") return `${config.displayName} · @${config.name}`;
+  if (section === "identity") return config.displayName;
   if (section === "computer") {
     const state = agent.availability.dependencies.computer.state;
     const status = state === "ready" ? "Online" : state === "action_required" ? "Offline" : "Unconfirmed";
@@ -2067,10 +2067,10 @@ function GeneralConfigForm({
       const updated = await browserApi.updateAgent(config.id, { expectedRevision: config.revision, displayName });
       setConfig(updated);
       setDisplayName(updated.displayName);
-      setMessage("Identity saved.");
+      setMessage("Name saved.");
       onAgentChanged();
     } catch (cause) {
-      setMessage(cause instanceof Error ? cause.message : "Unable to save identity");
+      setMessage(cause instanceof Error ? cause.message : "Unable to save name");
     } finally {
       setSaving(false);
     }
@@ -2078,8 +2078,8 @@ function GeneralConfigForm({
   return (
     <form className="form-card agent-settings-form" onSubmit={submit}>
       <header className="agent-settings-page-title">
-        <h1>Name &amp; identity</h1>
-        <p>Choose the name teammates see. The handle cannot be changed.</p>
+        <h1>Name</h1>
+        <p>Choose the name teammates see.</p>
       </header>
       <Field htmlFor="agent-display-name" label="Display name">
         <input
@@ -2093,9 +2093,6 @@ function GeneralConfigForm({
             setMessage(undefined);
           }}
         />
-      </Field>
-      <Field hint="The handle cannot be changed." htmlFor="agent-handle" label="Handle">
-        <input className="ds-control" id="agent-handle" readOnly value={`@${config.name}`} />
       </Field>
       {dirty ? (
         <div className="dirty-bar">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1689,7 +1689,7 @@ function AgentContact({ agent }: { agent: AgentDetailView }) {
             <strong>
               {titleCase(binding.provider)} · @{agent.name}
             </strong>
-            <small>{agentUseInstruction(agent, titleCase(binding.provider))}</small>
+            <small>{agentUseInstruction(agent, binding.provider)}</small>
           </span>
           {agent.viewerCapabilities.canManage ? (
             <Link
@@ -2405,7 +2405,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
       setConfirmation(undefined);
       onAgentChanged();
     } catch (cause) {
-      setConfirmationError(cause instanceof Error ? cause.message : "Unable to disable IM binding");
+      setConfirmationError(cause instanceof Error ? cause.message : "Unable to disconnect messaging");
     } finally {
       setConfirmationBusy(false);
     }
@@ -2420,7 +2420,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
         <h1 ref={messagingHeadingRef} tabIndex={-1}>
           Messaging
         </h1>
-        <p>Choose where teammates send work to {agent.displayName}.</p>
+        <p>Choose how teammates can contact and assign work to {agent.displayName}.</p>
       </header>
       <FeishuSetup
         agentId={agent.id}
@@ -2455,7 +2455,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                           <section className="im-section" aria-labelledby="contact-channel-heading">
                             <div className="im-section-heading">
                               <h3 id="contact-channel-heading">Contact channel</h3>
-                              <p>Where teammates can reach this Agent and whether the connection is available.</p>
+                              <p>See how teammates can reach this agent and check its connection status.</p>
                             </div>
                             <div className="binding-status">
                               <StatusIndicator
@@ -2468,7 +2468,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                               />
                               <small>
                                 {binding.lastConfirmedAt
-                                  ? `Confirmed ${formatDate(binding.lastConfirmedAt)}`
+                                  ? `Last checked ${formatDate(binding.lastConfirmedAt)}`
                                   : "Unable to confirm"}
                               </small>
                             </div>
@@ -2479,7 +2479,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                               </div>
                               <div>
                                 <dt>How to use</dt>
-                                <dd>{agentUseInstruction(agent, titleCase(binding.provider))}</dd>
+                                <dd>{agentUseInstruction(agent, binding.provider)}</dd>
                               </div>
                             </dl>
                             {(binding.bindingState === "reauthorization_required" || reauthorizationNeeded) &&
@@ -2509,12 +2509,12 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                                     variant="outline"
                                     onClick={() => void connectFeishu("replace")}
                                   >
-                                    Replace Feishu Bot
+                                    Change Feishu Bot
                                   </Button>
                                 ) : null}
                                 {binding.provider === "slack" && binding.bindingState !== "provisioning" ? (
                                   <Button size="compact" variant="outline" onClick={() => void connectSlack("replace")}>
-                                    Replace Slack App
+                                    Change Slack App
                                   </Button>
                                 ) : null}
                                 <Button
@@ -2526,7 +2526,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                                     setConfirmation({ bindingId: binding.id, kind: "disable_binding" });
                                   }}
                                 >
-                                  Disable IM binding
+                                  Disconnect {titleCase(binding.provider)}
                                 </Button>
                               </div>
                             ) : (
@@ -2538,25 +2538,18 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                               <h3 id="trigger-rules-heading" ref={triggerRulesHeadingRef} tabIndex={-1}>
                                 Trigger rules
                               </h3>
-                              <p>Which incoming messages can start Agent work.</p>
+                              <p>Choose which incoming messages can start a task.</p>
                             </div>
                             <SettingsList className="agent-message-rules">
-                              <SettingsRow
-                                description="A direct message can always start work."
-                                label="Direct messages"
-                              >
-                                <strong>Always</strong>
+                              <SettingsRow description="Every direct message starts a task." label="Direct messages">
+                                <strong>All messages</strong>
                               </SettingsRow>
                               <SettingsRow
-                                description={
-                                  binding.receiveMode === "mention_only"
-                                    ? `Teammates must mention @${agent.name}.`
-                                    : "Every new conversation message can start work."
-                                }
-                                label={`${titleCase(binding.provider)} conversations`}
+                                description="Choose whether the agent responds only to mentions or to every message."
+                                label={sharedConversationLabel(binding.provider)}
                               >
                                 {agent.viewerCapabilities.canManage ? (
-                                  <fieldset aria-label="Conversation trigger rule" className="segmented-control">
+                                  <fieldset aria-label="Shared conversation trigger rule" className="segmented-control">
                                     {binding.receiveMode === "mention_only" ? (
                                       <>
                                         <span className="active">Mentions only</span>
@@ -2568,7 +2561,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                                             setConfirmation({ kind: "all_messages" });
                                           }}
                                         >
-                                          All messages
+                                          Every message
                                         </button>
                                       </>
                                     ) : (
@@ -2576,7 +2569,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                                         <button type="button" onClick={() => void changeReceiveMode("mention_only")}>
                                           Mentions only
                                         </button>
-                                        <span className="active">All messages</span>
+                                        <span className="active">Every message</span>
                                       </>
                                     )}
                                   </fieldset>
@@ -2597,10 +2590,10 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                         <section className="im-section" aria-labelledby="contact-channel-heading">
                           <div className="im-section-heading">
                             <h3 id="contact-channel-heading">Contact channel</h3>
-                            <p>Where teammates can reach this Agent.</p>
+                            <p>See how teammates can reach this agent.</p>
                           </div>
                           <EmptyState title="No messaging channel">
-                            Teammates cannot contact this Agent until a supported bot is connected.
+                            Teammates cannot contact this agent until a supported bot is connected.
                           </EmptyState>
                           {agent.viewerCapabilities.canManage ? (
                             <div className="im-actions">
@@ -2632,9 +2625,9 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
       {confirmation?.kind === "all_messages" ? (
         <Dialog
           busy={confirmationBusy}
-          description="Every new conversation message could start Agent work. This can share more conversation content and increase token usage."
+          description="Every new conversation message could start a task. This can share more conversation content and increase token usage."
           returnFocusRef={allMessagesButtonRef}
-          title="Allow all conversation messages?"
+          title="Allow messages without mentions?"
           onClose={closeMessagingConfirmation}
         >
           {confirmationError ? (
@@ -2647,7 +2640,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
               Keep mentions only
             </Button>
             <Button disabled={confirmationBusy} onClick={() => void changeReceiveMode("all_message")}>
-              {confirmationBusy ? "Updating…" : "Allow all messages"}
+              {confirmationBusy ? "Updating…" : "Allow every message"}
             </Button>
           </div>
         </Dialog>
@@ -2655,7 +2648,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
       {confirmation?.kind === "disable_binding" ? (
         <Dialog
           busy={confirmationBusy}
-          description="Teammates will no longer be able to send new work to this Agent until another messaging connection is added."
+          description="Teammates will no longer be able to assign new work to this agent until another messaging connection is added."
           returnFocusRef={disableBindingButtonRef}
           title="Disconnect messaging?"
           onClose={closeMessagingConfirmation}
@@ -2724,7 +2717,7 @@ function messagingConnectionLabel(
   handoffState: AgentAvailability["dependencies"]["handoff"]["state"],
 ): string {
   if (binding.bindingState !== "active") return imBindingStateLabel(binding);
-  if (handoffState === "ready") return "Available";
+  if (handoffState === "ready") return "Connected";
   if (handoffState === "setting_up") return "Setting up";
   if (handoffState === "unconfirmed") return "Unable to confirm";
   return "Needs attention";
@@ -3285,7 +3278,7 @@ function platformLabel(platform: AgentSummary["computer"]["platform"]): string {
 }
 
 function receiveModeLabel(receiveMode: AgentSummary["receiveMode"]): string {
-  return receiveMode === "all_message" ? "All messages" : "Mentions only";
+  return receiveMode === "all_message" ? "Every message" : "Mentions only";
 }
 
 function availabilityTone(state: AgentAvailability["state"]): StatusTone {
@@ -3307,11 +3300,20 @@ function availabilityStateLabel(state: AgentAvailability["state"]): string {
   return labels[state];
 }
 
-function agentUseInstruction(agent: AgentDetailView, channelLabel: string): string {
+function sharedConversationLabel(provider: ImBindingSummary["provider"]): string {
+  return provider === "feishu" ? "Group chats" : "Channels";
+}
+
+function sharedConversationDestination(provider: ImBindingSummary["provider"], plural = false): string {
+  if (provider === "feishu") return plural ? "connected Feishu group chats" : "a Feishu group chat";
+  return plural ? "connected Slack channels" : "a Slack channel";
+}
+
+function agentUseInstruction(agent: AgentDetailView, provider: ImBindingSummary["provider"]): string {
   if (agent.receiveMode === "all_message") {
-    return `Send a direct message to @${agent.name}. In connected ${channelLabel} conversations, it can also receive messages without a mention.`;
+    return `Send @${agent.name} a direct message. It can also receive every message in ${sharedConversationDestination(provider, true)}.`;
   }
-  return `Send a direct message, or mention @${agent.name} in a ${channelLabel} conversation.`;
+  return `Send @${agent.name} a direct message, or mention it in ${sharedConversationDestination(provider)}.`;
 }
 
 function agentAvailabilitySummary(agent: AgentDetailView): string {
@@ -3355,7 +3357,7 @@ function agentRecoveryMessage(agent: AgentDetailView): string {
     computer_offline: "The assigned Computer is offline, so new requests cannot start.",
     runtime_unavailable: "The assigned Computer is not ready to run this Agent.",
     runtime_unconfirmed: "OpenTag could not confirm whether the assigned Computer is ready.",
-    im_not_connected: "Connect Feishu or Slack so teammates can send this Agent work.",
+    im_not_connected: "Connect Feishu or Slack so teammates can assign work to this agent.",
     im_provisioning: "The messaging connection is still being set up.",
     im_reauthorization_required: "The messaging connection needs permission to continue receiving requests.",
     im_error: "The messaging connection needs attention before it can receive requests.",
@@ -3376,7 +3378,7 @@ function initials(value: string): string {
 }
 
 function formatDate(value: string) {
-  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+  return new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
 }
 
 function formatRelativeTime(value: string): string {


### PR DESCRIPTION
## Summary

- clarify Messaging settings copy and simplify the Agent name editor to the editable display name
- focus Usage on actionable Tokens and Tasks metrics, with clearer partial and unavailable coverage states
- align the Usage loading skeleton with the two-metric layout and add regression coverage for compact and detailed states

## Testing

- `pnpm check` (passes; reports 8 existing Turborepo environment-variable warnings)
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/web test` (336 tests)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (268 tests, 100% coverage)
- `pnpm test:coverage` (1188/1190 tests pass; two unrelated macOS `/var` vs `/private/var` path-canonicalization assertions fail in existing CLI daemon tests; this PR does not change those files)

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (Repository-wide local coverage is blocked only by the two existing macOS path assertions documented above; GitHub CI is the merge gate.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
