### PR TITLE
test(server): speed up PostgreSQL integration tests

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
     "start": "node dist/index.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --maxWorkers=1 --exclude 'src/__tests__/integration/**'",
-    "test:integration": "vitest run src/__tests__/integration --maxWorkers=1"
+    "test:integration": "vitest run src/__tests__/integration --maxWorkers=2"
   },
   "dependencies": {
     "@autotelic/fastify-opentelemetry": "^0.23.0",

--- a/packages/server/src/__tests__/integration/account-team-foundation.test.ts
+++ b/packages/server/src/__tests__/integration/account-team-foundation.test.ts
@@ -1,11 +1,7 @@
-import { fileURLToPath } from "node:url";
-import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { and, asc, eq } from "drizzle-orm";
-import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient } from "../../db/client.js";
-import { migrateDatabase } from "../../db/migrate.js";
 import {
   agentRuntimeConfigs,
   agents,
@@ -29,32 +25,22 @@ import { ApplicationCipher } from "../../services/crypto.js";
 import { InvitationService } from "../../services/invitations/index.js";
 import { DEFAULT_AGENT_RUNTIME_CONFIG } from "../../services/runtime-config/index.js";
 import { TEAM_MEMBERSHIP_LIMIT, TeamMembershipService } from "../../services/teams/index.js";
+import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
 
-const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
 const now = new Date("2026-08-19T00:00:00.000Z");
-let container: StartedPostgreSqlContainer;
+let testDatabase: MigratedTestDatabase;
 let databaseUrl: string;
 
 beforeAll(async () => {
-  container = await new PostgreSqlContainer("postgres:17-alpine").start();
-  databaseUrl = container.getConnectionUri();
+  testDatabase = await startMigratedTestDatabase();
+  databaseUrl = testDatabase.databaseUrl;
 }, 120_000);
 
-afterAll(async () => container.stop());
+afterAll(async () => testDatabase.stop());
 
-beforeEach(async () => {
-  const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
-  try {
-    await sql.unsafe("drop schema if exists public cascade");
-    await sql.unsafe("drop schema if exists drizzle cascade");
-    await sql.unsafe("create schema public");
-  } finally {
-    await sql.end();
-  }
-});
+beforeEach(async () => testDatabase.reset());
 
 async function fixture() {
-  await migrateDatabase(databaseUrl, migrationsFolder);
   const client = createDatabaseClient(databaseUrl);
   const bootstrap = await bootstrapInitialAdmin(
     client.database,

--- a/packages/server/src/__tests__/integration/agents.test.ts
+++ b/packages/server/src/__tests__/integration/agents.test.ts
@@ -1,12 +1,9 @@
-import { fileURLToPath } from "node:url";
 import type { TurnReportRequest } from "@opentag/shared";
-import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { and, eq } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient, type DatabaseClient } from "../../db/client.js";
-import { migrateDatabase } from "../../db/migrate.js";
 import {
   agents,
   computers,
@@ -21,31 +18,21 @@ import {
 import { AgentService } from "../../services/agents/index.js";
 import { DEFAULT_AGENT_RUNTIME_CONFIG } from "../../services/runtime-config/index.js";
 import { TeamMembershipService } from "../../services/teams/index.js";
+import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
 
-const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
-let container: StartedPostgreSqlContainer;
+let testDatabase: MigratedTestDatabase;
 let databaseUrl: string;
 
 beforeAll(async () => {
-  container = await new PostgreSqlContainer("postgres:17-alpine").start();
-  databaseUrl = container.getConnectionUri();
+  testDatabase = await startMigratedTestDatabase();
+  databaseUrl = testDatabase.databaseUrl;
 }, 120_000);
 
-afterAll(async () => container.stop());
+afterAll(async () => testDatabase.stop());
 
-beforeEach(async () => {
-  const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
-  try {
-    await sql.unsafe("drop schema if exists public cascade");
-    await sql.unsafe("drop schema if exists drizzle cascade");
-    await sql.unsafe("create schema public");
-  } finally {
-    await sql.end();
-  }
-});
+beforeEach(async () => testDatabase.reset());
 
 async function fixture() {
-  await migrateDatabase(databaseUrl, migrationsFolder);
   const client = createDatabaseClient(databaseUrl);
   const bootstrap = await bootstrapInitialAdmin(client.database, {
     displayName: "Admin",
@@ -106,6 +93,44 @@ function deferred<T>() {
 }
 
 describe("Agent persistence and authorization", () => {
+  it("resets standalone sequences without changing the migration ledger", async () => {
+    const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+    try {
+      const migrationsBefore = await sql<{ createdAt: string; hash: string; id: number }[]>`
+        select id, hash, created_at::text as "createdAt"
+        from drizzle.__drizzle_migrations
+        order by id
+      `;
+      const [sequence] = await sql<{ startValue: string }[]>`
+        select start_value::text as "startValue"
+        from pg_sequences
+        where schemaname = 'public' and sequencename = 'runtime_config_revision_sequence'
+      `;
+      const [first] = await sql<{ value: string }[]>`
+        select nextval('public.runtime_config_revision_sequence')::text as value
+      `;
+      const [second] = await sql<{ value: string }[]>`
+        select nextval('public.runtime_config_revision_sequence')::text as value
+      `;
+      expect(BigInt(second?.value ?? "0")).toBe(BigInt(first?.value ?? "0") + 1n);
+
+      await testDatabase.reset();
+
+      const [afterReset] = await sql<{ value: string }[]>`
+        select nextval('public.runtime_config_revision_sequence')::text as value
+      `;
+      const migrationsAfter = await sql<{ createdAt: string; hash: string; id: number }[]>`
+        select id, hash, created_at::text as "createdAt"
+        from drizzle.__drizzle_migrations
+        order by id
+      `;
+      expect(afterReset?.value).toBe(sequence?.startValue);
+      expect(migrationsAfter).toEqual(migrationsBefore);
+    } finally {
+      await sql.end();
+    }
+  });
+
   it("installs Agent constraints, creation-intent uniqueness, and restrictive foreign keys", async () => {
     const value = await fixture();
     try {

--- a/packages/server/src/__tests__/integration/computers.test.ts
+++ b/packages/server/src/__tests__/integration/computers.test.ts
@@ -1,42 +1,28 @@
-import { fileURLToPath } from "node:url";
 import { ComputerSchema, HTTP_PATHS, PROVIDER_READINESS_V1_HEADER, RUNTIME_PROTOCOL_V2 } from "@opentag/shared";
-import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { eq } from "drizzle-orm";
-import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createApp } from "../../app.js";
 import { createDatabaseClient } from "../../db/client.js";
-import { migrateDatabase } from "../../db/migrate.js";
 import { computers, memberships, teams, users } from "../../db/schema/index.js";
 import { AuthService, AuthTokenService } from "../../services/auth/index.js";
 import { ComputerService } from "../../services/computers/index.js";
+import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
 
-const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
 const jwtSecret = "im-binding-test-secret-at-least-32-characters";
-let container: StartedPostgreSqlContainer;
+let testDatabase: MigratedTestDatabase;
 let databaseUrl: string;
 
 beforeAll(async () => {
-  container = await new PostgreSqlContainer("postgres:17-alpine").start();
-  databaseUrl = container.getConnectionUri();
+  testDatabase = await startMigratedTestDatabase();
+  databaseUrl = testDatabase.databaseUrl;
 }, 120_000);
 
-afterAll(async () => container.stop());
+afterAll(async () => testDatabase.stop());
 
-beforeEach(async () => {
-  const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
-  try {
-    await sql.unsafe("drop schema if exists public cascade");
-    await sql.unsafe("drop schema if exists drizzle cascade");
-    await sql.unsafe("create schema public");
-  } finally {
-    await sql.end();
-  }
-});
+beforeEach(async () => testDatabase.reset());
 
 async function fixture() {
-  await migrateDatabase(databaseUrl, migrationsFolder);
   const client = createDatabaseClient(databaseUrl);
   const bootstrap = await bootstrapInitialAdmin(client.database, {
     displayName: "Admin",

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { Readable } from "node:stream";
-import { fileURLToPath } from "node:url";
 import {
   computeDirectInputHash,
   computeRuntimeSnapshotHashes,
@@ -16,14 +15,11 @@ import {
   type TurnReportRequest,
   type UpdateAgentRequest,
 } from "@opentag/shared";
-import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { and, eq, inArray, isNull } from "drizzle-orm";
-import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient } from "../../db/client.js";
-import { migrateDatabase } from "../../db/migrate.js";
 import {
   agentRuntimeConfigs,
   agents,
@@ -57,29 +53,19 @@ import { SlackSetupService } from "../../services/im-bindings/slack/index.js";
 import { EffectiveRuntimeSnapshotAssembler } from "../../services/runtime-config/index.js";
 import { SessionService } from "../../services/sessions/index.js";
 import { TeamMembershipService, TeamSetupService } from "../../services/teams/index.js";
+import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
 
-const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
-
-let container: StartedPostgreSqlContainer;
+let testDatabase: MigratedTestDatabase;
 let databaseUrl: string;
 
 beforeAll(async () => {
-  container = await new PostgreSqlContainer("postgres:17-alpine").start();
-  databaseUrl = container.getConnectionUri();
+  testDatabase = await startMigratedTestDatabase();
+  databaseUrl = testDatabase.databaseUrl;
 }, 120_000);
 
-afterAll(async () => container.stop());
+afterAll(async () => testDatabase.stop());
 
-beforeEach(async () => {
-  const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
-  try {
-    await sql.unsafe("drop schema if exists public cascade");
-    await sql.unsafe("drop schema if exists drizzle cascade");
-    await sql.unsafe("create schema public");
-  } finally {
-    await sql.end();
-  }
-});
+beforeEach(async () => testDatabase.reset());
 
 async function validatingFeishuAttempt(
   database: ReturnType<typeof createDatabaseClient>["database"],
@@ -113,7 +99,6 @@ async function validatingFeishuAttempt(
 }
 
 async function fixture() {
-  await migrateDatabase(databaseUrl, migrationsFolder);
   const client = createDatabaseClient(databaseUrl);
   const bootstrap = await bootstrapInitialAdmin(client.database, {
     displayName: "Admin",
@@ -167,7 +152,6 @@ async function fixture() {
 }
 
 async function unboundFixture() {
-  await migrateDatabase(databaseUrl, migrationsFolder);
   const client = createDatabaseClient(databaseUrl);
   const bootstrap = await bootstrapInitialAdmin(client.database, {
     displayName: "Admin",

--- a/packages/server/src/__tests__/integration/migrated-test-database.ts
+++ b/packages/server/src/__tests__/integration/migrated-test-database.ts
@@ -1,0 +1,74 @@
+import { fileURLToPath } from "node:url";
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import postgres from "postgres";
+import { migrateDatabase } from "../../db/migrate.js";
+
+const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
+
+export interface MigratedTestDatabase {
+  databaseUrl: string;
+  reset(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+// Stable-schema suites can preserve the migration ledger and clear only application data.
+// Migration contract tests intentionally use their own empty-schema setup instead of this helper.
+export async function startMigratedTestDatabase(): Promise<MigratedTestDatabase> {
+  const container = await new PostgreSqlContainer("postgres:17-alpine").start();
+  const databaseUrl = container.getConnectionUri();
+
+  try {
+    await migrateDatabase(databaseUrl, migrationsFolder);
+  } catch (error) {
+    await container.stop();
+    throw error;
+  }
+
+  return {
+    databaseUrl,
+    reset: () => resetApplicationTables(databaseUrl),
+    stop: () => stopContainer(container),
+  };
+}
+
+async function resetApplicationTables(databaseUrl: string): Promise<void> {
+  const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+  try {
+    await sql.unsafe(`
+      do $$
+      declare
+        table_list text;
+        sequence_record record;
+      begin
+        select string_agg(format('%I.%I', schemaname, tablename), ', ')
+        into table_list
+        from pg_tables
+        where schemaname = 'public';
+
+        if table_list is not null then
+          execute 'truncate table ' || table_list || ' restart identity cascade';
+        end if;
+
+        for sequence_record in
+          select schemaname, sequencename, start_value
+          from pg_sequences
+          where schemaname = 'public'
+        loop
+          execute format(
+            'alter sequence %I.%I restart with %s',
+            sequence_record.schemaname,
+            sequence_record.sequencename,
+            sequence_record.start_value
+          );
+        end loop;
+      end
+      $$;
+    `);
+  } finally {
+    await sql.end();
+  }
+}
+
+async function stopContainer(container: StartedPostgreSqlContainer): Promise<void> {
+  await container.stop();
+}


### PR DESCRIPTION
## Summary

- migrate each stable-schema PostgreSQL integration suite once per test file
- reset application tables and standalone sequences between tests while preserving the migration ledger
- run at most two independent integration test files concurrently in the existing CI job
- keep the migration contract suite on its original empty-schema isolation path

## Performance

- baseline: 93.63 seconds in the referenced GitHub Actions run on `main`
- synthetic-merge CI: 40.27 seconds for 162/162 tests
- reduction: 53.36 seconds (57.0%) on the GitHub runner
- exact-head local runs: 38.33 seconds and 37.28 seconds wall time for 158/158 tests

## Validation

- `pnpm build`
- `pnpm --filter @opentag/server typecheck`
- `pnpm check` (passes with 8 pre-existing E2E environment warnings)
- two consecutive `pnpm --filter @opentag/server test:integration` runs: 158/158 tests passed
- all six GitHub checks passed
- `git diff --check`

## Non-goals

- no integration tests are removed or skipped
- no split into multiple GitHub Actions jobs
- no changes to production database or migration behavior
