### PR TITLE
fix(web): open an Agent from the whole row

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -729,6 +729,27 @@ describe("OpenTag Web App Shell", () => {
     expect(exit.classList.contains("ds-button--outline")).toBe(false);
   });
 
+  it("opens the Agent from the row rather than from a 36px chevron", async () => {
+    installApi("admin");
+    render(<App />);
+
+    const open = await screen.findByRole("link", { name: "Open Reviewer" });
+    expect(open.textContent).toBe("Reviewer");
+    expect(open.getAttribute("href")).toBe(`/agents/${agentId}`);
+    const card = open.closest(".agent-card");
+    expect(card).toBeTruthy();
+    expect((card as HTMLElement).querySelector(".agent-card-action")?.tagName).toBe("SPAN");
+    /*
+     * The failure exit is a second link inside the same row. It has to stay a sibling of the row
+     * link rather than a child of it: nesting would be invalid, and wrapping the row in one anchor
+     * is the shortcut that would produce it.
+     */
+    const exit = within(card as HTMLElement).getByRole("link", { name: "Connect messaging" });
+    expect(open.contains(exit)).toBe(false);
+    expect(exit.getAttribute("href")).toBe(`/agents/${agentId}/settings/messaging`);
+    expect(within(card as HTMLElement).getAllByRole("link")).toEqual([open, exit]);
+  });
+
   it.each(["/", "/agents"])("redirects unauthenticated protected path %s to login", async (path) => {
     installApi("member", { unauthenticated: true });
     window.history.replaceState({}, "", path);

--- a/apps/web/src/__tests__/page-layout.test.ts
+++ b/apps/web/src/__tests__/page-layout.test.ts
@@ -62,6 +62,19 @@ describe("workspace page layout", () => {
     expect(declarationValue(appStyles, ".settings-members-section .settings-invitation-panel", "width")).toBe("100%");
   });
 
+  it("stretches the Agent row link over the whole row without covering its inline action", () => {
+    expect(topLevelDeclarationValue(appStyles, ".agent-card", "position")).toBe("relative");
+    expect(declarationValue(appStyles, ".agent-card-open::after", "position")).toBe("absolute");
+    expect(declarationValue(appStyles, ".agent-card-open::after", "inset")).toBe("0");
+    expect(declarationValue(appStyles, ".agent-reconnect", "z-index")).toBe("1");
+  });
+
+  it("keeps the Agent usage figure subordinate to the Agent name", () => {
+    expect(declarationValue(appStyles, ".agent-card-identity-copy > strong", "font-size")).toBe("var(--text-body)");
+    expect(declarationValue(appStyles, ".agent-card-usage dd", "font-size")).toBe("var(--text-ui)");
+    expect(declarationValue(appStyles, ".agent-card-usage dd", "font-family")).toBe("var(--font-sans)");
+  });
+
   it("does not introduce nested page-level width contracts", () => {
     expect(declarationValue(appStyles, ".object-content", "width")).toBe("100%");
     expect(declarationValue(appStyles, ".settings-content", "width")).toBe("100%");

--- a/apps/web/src/features/agent-list-order.test.ts
+++ b/apps/web/src/features/agent-list-order.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { orderAgentIds } from "./agent-list-order.js";
+
+describe("Agent list order", () => {
+  it("takes the incoming priority order on the first render", () => {
+    expect(orderAgentIds(["c", "a", "b"], [])).toEqual(["c", "a", "b"]);
+  });
+
+  it("keeps the shown order when a status change would resort the list", () => {
+    expect(orderAgentIds(["c", "a", "b"], ["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("adds Agents created since the first render at the end", () => {
+    expect(orderAgentIds(["d", "a", "c", "b"], ["a", "b"])).toEqual(["a", "b", "d", "c"]);
+  });
+
+  it("drops Agents that have left the list", () => {
+    expect(orderAgentIds(["c", "a"], ["a", "b", "c"])).toEqual(["a", "c"]);
+  });
+
+  it("returns the same order when applied to its own result", () => {
+    const once = orderAgentIds(["c", "a", "b"], ["a", "b"]);
+    expect(orderAgentIds(["c", "a", "b"], once)).toEqual(once);
+  });
+});

--- a/apps/web/src/features/agent-list-order.ts
+++ b/apps/web/src/features/agent-list-order.ts
@@ -1,0 +1,18 @@
+/**
+ * Display order for the Agent list, held stable for as long as the list stays mounted.
+ *
+ * The list revalidates in the background every 30 seconds, and its status-first sort moves a
+ * row the moment an Agent's availability changes. Because the whole row is a link, a row that
+ * moves under the pointer opens a different Agent than the one that was pressed. Rows keep the
+ * position they were first shown in, and an Agent that changes state turns amber where it
+ * already is rather than jumping to the top unobserved. Agents added since the first render
+ * join at the end, in the incoming order.
+ *
+ * The result is stable under reapplication, so re-rendering with an unchanged list is a no-op.
+ */
+export function orderAgentIds(currentIds: readonly string[], previousOrder: readonly string[]): string[] {
+  const current = new Set(currentIds);
+  const kept = previousOrder.filter((id) => current.has(id));
+  const shown = new Set(kept);
+  return [...kept, ...currentIds.filter((id) => !shown.has(id))];
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -42,6 +42,7 @@ import { ApiError, browserApi } from "./api.js";
 // Google-provided, pre-approved button asset: https://developers.google.com/identity/branding-guidelines
 import googleSignInButton from "./assets/google-sign-in-light@2x.png";
 import { CreateTeamForm } from "./create-team-form.js";
+import { orderAgentIds } from "./features/agent-list-order.js";
 import { AgentUsageTab } from "./features/agent-usage.js";
 import { IntegrationsPage } from "./features/integrations-page.js";
 import { SkillsPage } from "./features/skills-page.js";
@@ -1122,15 +1123,28 @@ function AgentsContent({ agents, canCreate }: { agents: AgentListItem[]; canCrea
 }
 
 function AgentList({ agents }: { agents: AgentListItem[] }) {
-  const sortedAgents = [...agents].sort(
+  const shownOrder = useRef<readonly string[]>([]);
+  const byPriority = [...agents].sort(
     (left, right) => agentCardStatus(left).priority - agentCardStatus(right).priority,
   );
+  const byId = new Map(agents.map((agent) => [agent.id, agent]));
+  /*
+   * Written during render on purpose. `orderAgentIds` is stable under reapplication, so a
+   * repeated render of the same list produces the same order; deferring it to an effect would
+   * show one frame of the resorted list before restoring the order the viewer is pointing at.
+   */
+  const order = orderAgentIds(
+    byPriority.map((agent) => agent.id),
+    shownOrder.current,
+  );
+  shownOrder.current = order;
   return (
     <section className="agent-list-section" aria-label="Agents">
       <div className="agent-card-grid">
-        {sortedAgents.map((agent) => (
-          <AgentCard agent={agent} key={agent.id} />
-        ))}
+        {order.map((id) => {
+          const agent = byId.get(id);
+          return agent ? <AgentCard agent={agent} key={agent.id} /> : null;
+        })}
       </div>
     </section>
   );
@@ -1173,7 +1187,11 @@ function AgentCard({ agent }: { agent: AgentListItem }) {
           {initials(agent.displayName)}
         </span>
         <div className="agent-card-identity-copy">
-          <strong>{agent.displayName}</strong>
+          <strong>
+            <Link aria-label={`Open ${agent.displayName}`} className="agent-card-open" to={`/agents/${agent.id}`}>
+              {agent.displayName}
+            </Link>
+          </strong>
           <small>@{agent.name}</small>
         </div>
       </div>
@@ -1190,9 +1208,10 @@ function AgentCard({ agent }: { agent: AgentListItem }) {
           <dd>{formatUsageNumber(agent.usage.tokens)}</dd>
         </div>
       </dl>
-      <Link aria-label={`Open ${agent.displayName}`} className="agent-card-action" to={`/agents/${agent.id}`}>
+      {/* The row itself is the link; the chevron only signals where it goes. */}
+      <span aria-hidden="true" className="agent-card-action">
         <Icon name="chevron-right" />
-      </Link>
+      </span>
     </article>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -942,6 +942,7 @@ pre {
 }
 
 .agent-card {
+  position: relative;
   display: grid;
   min-width: 0;
   min-height: 88px;
@@ -1038,6 +1039,26 @@ pre {
   line-height: var(--lh-ui);
 }
 
+/*
+ * The Agent name carries the row's link, stretched over the whole row so the name -- the
+ * subject of the row -- is what a click lands on, rather than a 36px chevron at the far edge.
+ */
+.agent-card-open {
+  color: inherit;
+  text-decoration: none;
+}
+
+.agent-card-open::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+}
+
+.agent-card:hover .agent-card-open {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .agent-card-identity-copy > small {
   margin-top: 2px;
   color: var(--muted);
@@ -1092,8 +1113,10 @@ pre {
   color: color-mix(in srgb, var(--muted) 62%, transparent);
 }
 
+/* Sits above the stretched row link so the failure exit stays reachable. */
 .agent-reconnect {
   position: relative;
+  z-index: 1;
   display: inline;
   font-size: var(--text-meta);
   line-height: var(--lh-ui);
@@ -1139,11 +1162,11 @@ pre {
   transition: transform 180ms ease;
 }
 
-.agent-card-action:hover {
+.agent-card:hover .agent-card-action {
   color: var(--brand-ink);
 }
 
-.agent-card-action:hover .ds-icon {
+.agent-card:hover .agent-card-action .ds-icon {
   transform: translateX(1px);
 }
 
@@ -1474,14 +1497,17 @@ dd {
   line-height: var(--lh-ui);
 }
 
+/*
+ * Usage is supporting detail, not the headline. At display size it outranked the Agent name
+ * and drew the eye to the least actionable number in the row.
+ */
 .agent-card-usage dd {
   color: var(--foreground);
-  font-family: var(--font-display);
-  font-size: var(--text-section);
+  font-family: var(--font-sans);
+  font-size: var(--text-ui);
   font-variant-numeric: tabular-nums;
   font-weight: var(--fw-medium);
-  letter-spacing: var(--track-tight);
-  line-height: var(--lh-tight);
+  line-height: var(--lh-ui);
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Why

The Agents list gave a 958x88 row exactly one navigable target: a 36x36 `<a>` at the far right edge. That is below the 44px touch minimum, and it is nowhere near the Agent name — the thing a viewer actually points at. The other 95% of the row was dead. On mobile the row stacks to a ~200px block with the same 36px arrow floating at the top right, and no hover to hint at it.

Two smaller problems on the same screen, both surfaced by the same review:

- The token count rendered at 20px/500 in Bricolage Grotesque while the Agent name sat at 14px/600. The eye landed on `269.6K` before it landed on whose Agent that was — and the token count is the least actionable number in the row.
- The list revalidates every 30 seconds behind a status-first sort, so rows move on their own. Harmless when only a chevron is clickable; not harmless once the whole row is a link.

## What changed

**The Agent name carries the row link**, stretched over the row with `.agent-card-open::after { inset: 0 }`. The chevron becomes `aria-hidden` decoration.

A stretched link rather than a click handler on the row: `cmd`/middle-click, right-click → "Open in new tab", the status-bar URL preview, and keyboard focus all work natively. A JS handler has to reimplement each one.

No nested anchors — the stretched `::after` belongs to the name link, and #162's inline failure exit is a **sibling** anchor. It already had `position: relative`, and now carries an explicit `z-index: 1` rather than relying on DOM order.

**Display order is held stable while the list is mounted** (`apps/web/src/features/agent-list-order.ts`). Without this, a status change during a background refresh can slide a row under the pointer between press and release, sending the viewer to a different Agent than the one they pressed. Rows keep the position they were first shown in; an Agent that starts failing turns amber where it already sits — more noticeable than jumping to the top unobserved. Agents created since the first render join at the end. Order is recomputed on the next visit.

**Usage drops from display size to a supporting size** — `.agent-card-usage dd` goes from `--text-section`/`--font-display` to `--text-ui`/`--font-sans`. The Agent name is deliberately left at `--text-body`: once the number stops shouting, 14px/600 already wins, and enlarging every name turns an 8-row list into a stack of headings.

`tabular-nums` and the two-column usage alignment are untouched — they are what make the numbers comparable across rows.

## Verification

jsdom cannot prove a stretched link actually covers the row, or that `z-index` puts the failure exit back on top. Both were measured in a real browser against the real stylesheet, with `elementFromPoint`:

- **1440x900** (row 1390x88) — far-left edge, the name, the empty middle, the Tokens figure, the chevron, and the bottom-right corner all resolve to the row link.
- **375x812** (block 325x214) — four points across the stacked block all resolve to the row link.
- At both sizes, the point over `Connect messaging` resolves to the failure exit, not the row link.

Test coverage: row link wraps the visible name and points at the Agent; the chevron is no longer a link; the failure exit is a sibling of the row link, never nested; the stretch and stacking rules are asserted against the parsed stylesheet; and the order function is covered for first render, resort, insertion, removal, and stability under reapplication.

`pnpm check`, `pnpm typecheck`, `pnpm build` all clean. Web suite 338 passing.

Two failures on this branch are pre-existing and reproduce on clean `origin/main` (verified in a detached worktree): `@opentag/server` `observability.test.ts`, and two `open-tag` daemon-service tests ("…before a stale PATH shim").

## Notes for review

Rebased onto `main` after #162 merged as `54db7f4`; the rebase was conflict-free.

A stretched link makes row text non-selectable by drag. That is the standard trade-off of the pattern and is accepted here for a list row.

Three further items from the review were considered and dropped: group headings, status filtering, and surfacing `usage.failed`. Grouping would make a status change move a row between bordered blocks, which is more visible than the reorder it was meant to fix; `usage.failed` has no baseline, which was the exact complaint levelled at the token count. Cost, last-active time, and period-over-period deltas are not in the API — `AgentListItem` carries only `{ windowDays, tasks, failed, tokens }` and `activity: idle | working{startedAt}` — so they would need shared-schema and server work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)