### PR TITLE
fix(web): make a Workspace readable by the Admin who has one

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1195,14 +1195,26 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Ada")).toBeTruthy();
   });
 
-  it("hides Workspace management in the single-Workspace shell", async () => {
+  it("keeps Workspace identity and its Admins reachable in the single-Workspace shell", async () => {
     installApi();
     window.history.replaceState({}, "", "/workspace");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Admins" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/admins");
-    expect(screen.queryByLabelText("Workspace name")).toBeNull();
+    expect(await screen.findByRole("heading", { name: "Workspace" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/workspace");
+    expect(screen.getByRole("heading", { name: "Admins" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Invite Admin" })).toBeTruthy();
+    // The name reaches every invitation recipient and the identifier is required by the CLI, so a
+    // solo Admin has to be able to read and change them.
+    expect(screen.getByLabelText("Workspace name")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Save account profile" })).toBeNull();
+  });
+
+  it("redirects the retired Admins route onto the Workspace surface", async () => {
+    installApi();
+    window.history.replaceState({}, "", "/admins");
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "Workspace" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/workspace");
   });
 
   it("keeps the Agent home focused on status, current work, and contact", async () => {
@@ -1975,7 +1987,7 @@ describe("OpenTag Web App Shell", () => {
     installApi();
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, "clipboard", { configurable: true, value: { writeText } });
-    window.history.replaceState({}, "", "/admins");
+    window.history.replaceState({}, "", "/workspace");
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Admins" })).toBeTruthy();
@@ -1987,15 +1999,16 @@ describe("OpenTag Web App Shell", () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(link.value));
   });
 
-  it("hides Workspace selection and management for a single Workspace", async () => {
+  it("hides only the selector for a single Workspace, not the Workspace itself", async () => {
     installApi();
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
 
+    // Choosing between scopes is meaningless with one; reading your own Workspace is not.
     expect(screen.queryByRole("group", { name: "Workspaces" })).toBeNull();
-    expect(screen.queryByRole("menuitem", { name: "Workspace management" })).toBeNull();
-    expect(screen.getByRole("menuitem", { name: "Admins" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Workspace" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Account" })).toBeTruthy();
+    expect(screen.queryByRole("menuitem", { name: "Admins" })).toBeNull();
   });
 
   it("does not create an IM setup attempt while rendering Agent detail", async () => {
@@ -2544,17 +2557,17 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     const trigger = await screen.findByRole("button", { name: "Account menu" });
     fireEvent.click(trigger);
-    const admins = screen.getByRole("menuitem", { name: "Admins" });
+    const workspace = screen.getByRole("menuitem", { name: "Workspace" });
     const account = screen.getByRole("menuitem", { name: "Account" });
     const signOut = screen.getByRole("menuitem", { name: "Sign out" });
-    expect(document.activeElement).toBe(admins);
-    fireEvent.keyDown(admins, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(workspace);
+    fireEvent.keyDown(workspace, { key: "ArrowDown" });
     expect(document.activeElement).toBe(account);
     fireEvent.keyDown(account, { key: "ArrowDown" });
     expect(document.activeElement).toBe(signOut);
     fireEvent.keyDown(signOut, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(admins);
-    fireEvent.keyDown(admins, { key: "End" });
+    expect(document.activeElement).toBe(workspace);
+    fireEvent.keyDown(workspace, { key: "End" });
     expect(document.activeElement).toBe(signOut);
     fireEvent.keyDown(signOut, { key: "Escape" });
     expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -464,7 +464,7 @@ export function AppRouter() {
             <Route path="/integrations" element={<IntegrationsPage />} />
             <Route path="/resources" element={<Navigate replace to="/skills" />} />
             <Route path="/usage" element={<Navigate replace to="/agents" />} />
-            <Route path="/admins" element={<AdminsPage />} />
+            <Route path="/admins" element={<Navigate replace to="/workspace" />} />
             <Route path="/account" element={<AccountPage />} />
             <Route path="/workspace" element={<WorkspacePage />} />
           </Route>
@@ -903,26 +903,14 @@ function AppShell() {
                 <div className="account-menu-actions">
                   <NavLink
                     role="menuitem"
-                    to="/admins"
+                    to="/workspace"
                     onClick={() => {
                       setOpenMenu(undefined);
                       setNavigationOpen(false);
                     }}
                   >
-                    Admins
+                    Workspace
                   </NavLink>
-                  {me.workspaces.length > 1 ? (
-                    <NavLink
-                      role="menuitem"
-                      to="/workspace"
-                      onClick={() => {
-                        setOpenMenu(undefined);
-                        setNavigationOpen(false);
-                      }}
-                    >
-                      Workspace management
-                    </NavLink>
-                  ) : null}
                   <NavLink
                     end
                     role="menuitem"
@@ -1786,20 +1774,16 @@ function AccountPage() {
   );
 }
 
+/**
+ * One surface, reachable at any Workspace count. A Workspace is the scope its Admins share, and being
+ * an Admin is the product's only access decision, so who may administer it belongs with what it is
+ * called and how the CLI addresses it. Only the selector above this page is conditional: choosing
+ * between scopes is meaningless with one, while reading and changing your own Workspace is not.
+ */
 function WorkspacePage() {
-  const { me, membership, refreshMe } = useWorkspace();
-  if (me.workspaces.length <= 1) return <Navigate replace to="/admins" />;
-
+  const { membership, refreshMe } = useWorkspace();
   return (
-    <Page
-      action={
-        <Link className={buttonClassName({ variant: "secondary" })} to="/workspaces/new">
-          Create Workspace
-        </Link>
-      }
-      title="Workspace"
-      description="Manage the current Workspace identity."
-    >
+    <Page title="Workspace" description="Who can administer this Workspace, and how it is identified.">
       <WorkspaceSettings membership={membership} refreshMe={refreshMe} />
     </Page>
   );
@@ -1808,14 +1792,26 @@ function WorkspacePage() {
 function WorkspaceSettings({ membership, refreshMe }: { membership: MeWorkspace; refreshMe: () => void }) {
   return (
     <div className="settings-workspace-stack">
+      <WorkspaceAdminSettings membership={membership} />
       <section aria-labelledby="workspace-profile-heading" className="account-workspace-profile">
         <header className="settings-subheader">
           <div>
             <h2 id="workspace-profile-heading">Workspace profile</h2>
-            <p>Manage the name and CLI identity of the current Workspace.</p>
+            <p>The name people see in invitations, and the identifier CLI commands use.</p>
           </div>
         </header>
         <WorkspaceProfileSettings membership={membership} refreshMe={refreshMe} />
+      </section>
+      <section aria-labelledby="workspace-scope-heading" className="account-workspace-profile">
+        <header className="settings-subheader">
+          <div>
+            <h2 id="workspace-scope-heading">Separate scope</h2>
+            <p>Create another Workspace when some Agents must stay invisible to the Admins here.</p>
+          </div>
+          <Link className={buttonClassName({ variant: "secondary" })} to="/workspaces/new">
+            Create Workspace
+          </Link>
+        </header>
       </section>
     </div>
   );
@@ -2910,8 +2906,8 @@ function ComputersPage() {
   );
 }
 
-function AdminsPage() {
-  const { me, membership, refreshMe } = useWorkspace();
+function WorkspaceAdminSettings({ membership }: { membership: MeWorkspace }) {
+  const { me, refreshMe } = useWorkspace();
   const [revision, setRevision] = useState(0);
   const [invitation, setInvitation] = useState<Awaited<ReturnType<typeof browserApi.createAdminInvitation>>>();
   const [busy, setBusy] = useState(false);
@@ -2946,15 +2942,16 @@ function AdminsPage() {
   }
 
   return (
-    <Page
-      title="Admins"
-      description="Every Admin has complete management authority over this Workspace."
-      action={
+    <section aria-labelledby="workspace-admins-heading" className="account-workspace-profile">
+      <header className="settings-subheader">
+        <div>
+          <h2 id="workspace-admins-heading">Admins</h2>
+          <p>Every Admin has complete management authority over this Workspace.</p>
+        </div>
         <Button disabled={busy} onClick={() => void createInvitation()}>
           {busy ? "Creating…" : "Invite Admin"}
         </Button>
-      }
-    >
+      </header>
       {invitation ? (
         <section className="settings-invitation-panel">
           <h2>Single-use invitation</h2>
@@ -2988,7 +2985,7 @@ function AdminsPage() {
           {error}
         </p>
       ) : null}
-    </Page>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #161 on one rule from #125: that the Workspace concept should stay out of the single-Workspace path.

`WorkspacePage` redirected to `/admins` whenever an Account administered one Workspace, and the account menu showed the Workspace entry only above two. The concept returned regardless. The Admin list has to be reachable — otherwise a solo Admin can never invite a colleague — so it became its own page, and that page then had to open with "Every Admin has complete management authority over **this Workspace**" to explain itself. The word was hidden from the menu and reintroduced in the page.

Hiding also withheld two facts other people could already see:

- **The Workspace name is the first line of every invitation.** An auto-created Workspace is named after whoever signed up, so a colleague opens the invite and reads "Join hao xiong's Workspace" — which is usually the company's Workspace. The person who sent it could not read or change that name.
- **The CLI identifier is required by anyone running a CLI command**, and lived only on the hidden page.

The concept-reduction argument in #125 is about IM Users: they should not have to register, join anything, or learn what a Workspace is, and that is settled by giving them no Account and no Workspace membership at all. An Admin is a different person — someone who deliberately signed in to a management surface to run Agents on machines they operate, already holding Agent, Computer, Runtime, Provider, Skill, Integration, and IM binding. Workspace is the container the other seven live in.

So this narrows the rule to what it was protecting:

**Only the selector stays conditional.** Choosing between scopes is meaningless with one scope, so a single-Workspace Account still sees no `Workspaces` group in the account menu. Reading and changing your own Workspace is not selection.

**`/workspace` is one surface at any Workspace count**, in this order:

1. **Admins** — the list, `Invite Admin`, `Revoke`, and the single-use invitation panel
2. **Workspace profile** — name and CLI identifier
3. **Separate scope** — `Create Workspace`, which also moves out of the page action slot; it creates a *different* Workspace and does not belong to the page that manages this one

Being an Admin is the product's only access decision, and a Workspace is the scope its Admins share, so who may administer it belongs with what it is called. That is one list, not two pages. `/admins` redirects so existing links keep working.

No behaviour changes for an Account administering more than one Workspace, beyond the two entries becoming one.

## Testing

- `pnpm check` passes
- `pnpm build` passes
- `pnpm typecheck` passes
- `pnpm --filter @opentag/web test` passes: 304 tests, 17 files

Three tests asserted the behaviour this reverses and were rewritten to assert the new rule; one covers the `/admins` redirect. `pnpm test` cannot pass cleanly on `main` right now — `@opentag/server`'s `observability.test.ts > traces real RuntimeSession failure, overload, and dropped-queue terminal paths`, and two `open-tag` daemon-service tests ending "…before a stale PATH shim", fail on a clean tree. None are touched here.

## Breaking changes

None. Web presentation and client-side routing only; no contract, schema, or route changes on the server.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. — all pass except the three pre-existing failures described above.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable. — no documentation changes required.

Refs #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
