### PR TITLE
fix(web): let an offline Computer be reconnected from its Agent

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1573,6 +1573,39 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("button", { name: "Check again" })).toBeNull();
   });
 
+  it("offers machine recovery on the Connected computer page when the Computer is offline", async () => {
+    installApi({ bound: true, computerStatus: () => "offline" });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/computer`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Ada's Mac · macOS" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reconnect this Computer" })).toBeTruthy();
+  });
+
+  it("withholds machine recovery when the Computer is reachable but its Provider is not", async () => {
+    installApi({
+      bound: true,
+      computerProviderReadiness: [{ provider: "codex", status: "install", observedAt: "2026-08-20T00:00:00.000Z" }],
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/computer`);
+    render(<App />);
+
+    expect(await screen.findByText("Codex is not installed on Ada's Mac.")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Reconnect this Computer" })).toBeNull();
+  });
+
+  it("generates a command naming the assigned Computer without leaving the Agent", async () => {
+    installApi({ bound: true, computerStatus: () => "offline" });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/computer`);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Reconnect this Computer" }));
+
+    expect(screen.getByRole("heading", { name: "Reconnect Ada's Mac" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Generate connection command" })).toBeTruthy();
+    expect(window.location.pathname).toBe(`/agents/${agentId}/settings/computer`);
+  });
+
   it("observes a Computer coming back online from the recovery page itself", async () => {
     let computerStatus: "online" | "offline" = "offline";
     installApi({ bound: true, computerStatus: () => computerStatus });

--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -411,4 +411,81 @@ describe("ComputerSetup", () => {
     expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
     expect(vi.getTimerCount()).toBe(2);
   });
+  it("names the target Computer in its prompt and waiting status", async () => {
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer] });
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(
+      <ComputerSetup
+        workspaceId={workspaceId}
+        target={{ computerId: existingComputer.computerId, displayName: existingComputer.displayName }}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Reconnect Ada's Mac" })).toBeTruthy();
+    await clickGenerate();
+
+    expect(screen.getByRole("status").textContent).toBe("Waiting for Ada's Mac to connect…");
+  });
+
+  it("confirms the target Computer by name once it reconnects", async () => {
+    const onConnected = vi.fn();
+    vi.spyOn(browserApi, "computers")
+      .mockResolvedValueOnce({ computers: [existingComputer] })
+      .mockResolvedValue({ computers: [{ ...existingComputer, connectedAt: "2026-08-20T00:00:02.000Z" }] });
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(
+      <ComputerSetup
+        workspaceId={workspaceId}
+        onConnected={onConnected}
+        target={{ computerId: existingComputer.computerId, displayName: existingComputer.displayName }}
+      />,
+    );
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+
+    expect(screen.getByRole("status").textContent).toBe("Ada's Mac is connected.");
+    expect(onConnected).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports when another Computer consumed a command meant for the target", async () => {
+    const onConnected = vi.fn();
+    vi.spyOn(browserApi, "computers")
+      .mockResolvedValueOnce({ computers: [existingComputer] })
+      .mockResolvedValue({ computers: [existingComputer, newComputer] });
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+
+    render(
+      <ComputerSetup
+        workspaceId={workspaceId}
+        onConnected={onConnected}
+        target={{ computerId: existingComputer.computerId, displayName: existingComputer.displayName }}
+      />,
+    );
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+
+    expect(screen.getByRole("alert").textContent).toBe(
+      "This command was used on Ada's Linux Computer, not Ada's Mac. Generate a new command and run it on Ada's Mac.",
+    );
+    expect(onConnected).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -459,7 +459,7 @@ describe("ComputerSetup", () => {
     expect(onConnected).toHaveBeenCalledTimes(1);
   });
 
-  it("reports when another Computer consumed a command meant for the target", async () => {
+  it("keeps waiting for the target when an unrelated Computer reconnects", async () => {
     const onConnected = vi.fn();
     vi.spyOn(browserApi, "computers")
       .mockResolvedValueOnce({ computers: [existingComputer] })
@@ -479,13 +479,12 @@ describe("ComputerSetup", () => {
     );
     await clickGenerate();
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1_500);
+      await vi.advanceTimersByTimeAsync(3_000);
     });
 
-    expect(screen.getByRole("alert").textContent).toBe(
-      "This command was used on Ada's Linux Computer, not Ada's Mac. Generate a new command and run it on Ada's Mac.",
-    );
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Waiting for Ada's Mac to connect…");
     expect(onConnected).not.toHaveBeenCalled();
-    expect(vi.getTimerCount()).toBe(0);
+    expect(vi.getTimerCount()).toBe(2);
   });
 });

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -11,6 +11,8 @@ const COPY_FALLBACK_HINT = "Copying is unavailable here. The command is selected
 export interface ComputerSetupProps {
   workspaceId: string;
   onConnected?: (computer: WorkspaceComputerSummary) => void;
+  /** Scopes the panel to one enrollment so a recovery flow names the Computer it came from. */
+  target?: { computerId: string; displayName: string };
 }
 
 function errorMessage(cause: unknown, fallback: string): string {
@@ -33,11 +35,20 @@ function formatRemaining(remainingMs: number): string {
   return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
 }
 
-export function ComputerSetup({ workspaceId, onConnected }: ComputerSetupProps) {
-  return <ComputerSetupLifecycle key={workspaceId} workspaceId={workspaceId} onConnected={onConnected} />;
+export function ComputerSetup({ workspaceId, onConnected, target }: ComputerSetupProps) {
+  return (
+    <ComputerSetupLifecycle
+      key={`${workspaceId}:${target?.computerId ?? ""}`}
+      workspaceId={workspaceId}
+      onConnected={onConnected}
+      target={target}
+    />
+  );
 }
 
-function ComputerSetupLifecycle({ workspaceId, onConnected }: ComputerSetupProps) {
+function ComputerSetupLifecycle({ workspaceId, onConnected, target }: ComputerSetupProps) {
+  const targetComputerId = target?.computerId;
+  const targetName = target?.displayName;
   const [bootstrapCommand, setBootstrapCommand] = useState<string>();
   const [error, setError] = useState<string>();
   const [waitingForComputer, setWaitingForComputer] = useState(false);
@@ -141,7 +152,7 @@ function ComputerSetupLifecycle({ workspaceId, onConnected }: ComputerSetupProps
       void browserApi.computers(workspaceId).then(
         (value) => {
           if (!active || completed || activePollCycle.current !== pollCycle) return;
-          const connected = value.computers.find(
+          const reconnected = value.computers.filter(
             (computer) =>
               computer.connectionStatus === "online" &&
               ((!baseline.has(computer.computerId) && computer.connectedAt !== null) ||
@@ -149,13 +160,26 @@ function ComputerSetupLifecycle({ workspaceId, onConnected }: ComputerSetupProps
                   computer.connectedAt !== null &&
                   baseline.get(computer.computerId) !== computer.connectedAt)),
           );
+          // A targeted command still enrolls whichever Computer runs it, so prefer the target and
+          // report the substitution rather than announcing a recovery that did not happen.
+          const matched = targetComputerId
+            ? reconnected.find((computer) => computer.computerId === targetComputerId)
+            : reconnected[0];
+          const connected = matched ?? reconnected[0];
           if (!connected) return;
           completed = true;
           window.clearInterval(pollTimer);
           window.clearTimeout(expiryTimer);
           setWaitingForComputer(false);
-          setComputerConnected(true);
           setRemainingMs(undefined);
+          if (targetName && !matched) {
+            setComputerConnected(false);
+            setError(
+              `This command was used on ${connected.displayName}, not ${targetName}. Generate a new command and run it on ${targetName}.`,
+            );
+            return;
+          }
+          setComputerConnected(true);
           onConnectedRef.current?.(connected);
         },
         (cause: unknown) => {
@@ -170,12 +194,12 @@ function ComputerSetupLifecycle({ workspaceId, onConnected }: ComputerSetupProps
       window.clearInterval(pollTimer);
       window.clearTimeout(expiryTimer);
     };
-  }, [pollCycle, waitingForComputer, workspaceId]);
+  }, [pollCycle, targetComputerId, targetName, waitingForComputer, workspaceId]);
 
   return (
     <section className="panel">
-      <h2>Connect a Local Computer</h2>
-      <p>Generate a short-lived command, then run it in a terminal on the Computer.</p>
+      <h2>{targetName ? `Reconnect ${targetName}` : "Connect a Local Computer"}</h2>
+      <p>Generate a short-lived command, then run it in a terminal on {targetName ?? "the Computer"}.</p>
       <Button className="connect-command-primary" onClick={() => void connectComputer()}>
         Generate connection command
       </Button>
@@ -194,7 +218,13 @@ function ComputerSetupLifecycle({ workspaceId, onConnected }: ComputerSetupProps
           </div>
           {copyHint ? <p className="connect-command-meta">{copyHint}</p> : null}
           {waitingForComputer || computerConnected ? (
-            <p role="status">{waitingForComputer ? "Waiting for the Computer to connect…" : "Computer connected."}</p>
+            <p role="status">
+              {waitingForComputer
+                ? `Waiting for ${targetName ?? "the Computer"} to connect…`
+                : targetName
+                  ? `${targetName} is connected.`
+                  : "Computer connected."}
+            </p>
           ) : null}
         </>
       ) : null}

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -160,26 +160,19 @@ function ComputerSetupLifecycle({ workspaceId, onConnected, target }: ComputerSe
                   computer.connectedAt !== null &&
                   baseline.get(computer.computerId) !== computer.connectedAt)),
           );
-          // A targeted command still enrolls whichever Computer runs it, so prefer the target and
-          // report the substitution rather than announcing a recovery that did not happen.
-          const matched = targetComputerId
+          // The Computers response carries no link back to the issued code, so another Computer
+          // registering says nothing about this command. A targeted recovery waits for its own
+          // Computer and lets the code expire rather than reading a foreign reconnection as proof.
+          const connected = targetComputerId
             ? reconnected.find((computer) => computer.computerId === targetComputerId)
             : reconnected[0];
-          const connected = matched ?? reconnected[0];
           if (!connected) return;
           completed = true;
           window.clearInterval(pollTimer);
           window.clearTimeout(expiryTimer);
           setWaitingForComputer(false);
-          setRemainingMs(undefined);
-          if (targetName && !matched) {
-            setComputerConnected(false);
-            setError(
-              `This command was used on ${connected.displayName}, not ${targetName}. Generate a new command and run it on ${targetName}.`,
-            );
-            return;
-          }
           setComputerConnected(true);
+          setRemainingMs(undefined);
           onConnectedRef.current?.(connected);
         },
         (cause: unknown) => {
@@ -194,7 +187,7 @@ function ComputerSetupLifecycle({ workspaceId, onConnected, target }: ComputerSe
       window.clearInterval(pollTimer);
       window.clearTimeout(expiryTimer);
     };
-  }, [pollCycle, targetComputerId, targetName, waitingForComputer, workspaceId]);
+  }, [pollCycle, targetComputerId, waitingForComputer, workspaceId]);
 
   return (
     <section className="panel">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1841,7 +1841,7 @@ function AgentSettingsContent({
 }) {
   if (!section) return <AgentSettingsOverview agent={agent} />;
   if (section === "messaging") return <ImTab agent={agent} onAgentChanged={onAgentChanged} />;
-  if (section === "computer") return <AgentComputerSettings agent={agent} />;
+  if (section === "computer") return <AgentComputerSettings agent={agent} onAgentChanged={onAgentChanged} />;
   return <AgentConfigSettingsContent agent={agent} section={section} onAgentChanged={onAgentChanged} />;
 }
 
@@ -2090,7 +2090,9 @@ function computerRecoveryMessage(agent: AgentDetailView): string {
   return `OpenTag is not running on ${computerName}. Start it there to bring this Computer back online.`;
 }
 
-function AgentComputerSettings({ agent }: { agent: AgentDetailView }) {
+function AgentComputerSettings({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChanged: () => void }) {
+  const { membership } = useWorkspace();
+  const [reconnecting, setReconnecting] = useState(false);
   const computerState = agent.availability.dependencies.computer;
   const runtimeUnavailable = agent.availability.reason === "runtime_unavailable";
   // A reachable Computer that cannot run this Agent's Provider is not "Online" for this Agent.
@@ -2125,6 +2127,36 @@ function AgentComputerSettings({ agent }: { agent: AgentDetailView }) {
                 </p>
               ) : null}
               <p>{computerRecoveryMessage(agent)}</p>
+              {/* Re-enrolment only answers an unreachable Computer; a missing Provider needs the
+                  Provider installed, so offering it there would send an operator down a dead path. */}
+              {computerState.state === "action_required" ? (
+                <>
+                  <Button
+                    aria-controls="agent-computer-reconnect"
+                    aria-expanded={reconnecting}
+                    size="compact"
+                    variant={reconnecting ? "inline" : "secondary"}
+                    onClick={() => setReconnecting((value) => !value)}
+                  >
+                    {reconnecting ? "Cancel Computer connection" : "Reconnect this Computer"}
+                  </Button>
+                  {reconnecting ? (
+                    <div className="agent-runtime-reconnect" id="agent-computer-reconnect">
+                      <ComputerSetup
+                        workspaceId={membership.id}
+                        target={{
+                          computerId: agent.computer.computerId,
+                          displayName: agent.computer.displayName,
+                        }}
+                        onConnected={() => onAgentChanged()}
+                      />
+                      <p className="agent-runtime-reconnect__scope">
+                        Reconnecting restores this Computer for every Agent that runs on it.
+                      </p>
+                    </div>
+                  ) : null}
+                </>
+              ) : null}
             </div>
           </div>
         )}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3104,6 +3104,21 @@ textarea:focus {
   margin: 0;
 }
 
+.agent-runtime-reconnect {
+  width: 100%;
+  justify-self: stretch;
+}
+
+/* The shared connect panel is built for a full page; inside the recovery card only its top rule
+   still earns its place, so the page-level padding is dropped. */
+.agent-runtime-reconnect .panel {
+  padding: 16px 0 0;
+}
+
+.agent-runtime-reconnect .agent-runtime-reconnect__scope {
+  margin-top: 12px;
+}
+
 .agent-runtime-edit-form,
 .agent-instructions-form {
   display: grid;


### PR DESCRIPTION
## Summary

An Agent whose Computer is offline had no way to recover from the product. This gives the page the product already routes operators to the action it was missing.

The Connected computer row in Agent settings is inert while the Computer is healthy and becomes a link — labelled `Review` — only when it needs attention. That is a deliberate repair entry point. The page behind it rendered a status, a last-seen line, and one sentence of advice, with nothing to act on. Meanwhile the only surface that issues a connect command lives at `/agents/computers`, and nothing in the app links there.

## What changed

- The recovery block offers **Reconnect this Computer**, which expands `ComputerSetup` in place instead of navigating away. The journey ends where it started: the Agent's status flips to Online as soon as its Computer registers, via the `onAgentChanged` refresh the settings page already owns.
- The action is shown only when the Computer itself is unreachable. A reachable Computer with a missing Provider reports `ready` for the Computer dependency, so that branch keeps its install guidance rather than suggesting a re-enrolment that cannot help.
- `ComputerSetup` accepts an optional `target`. When present it names the machine in its heading, prompt, waiting status and success line, and waits for that machine specifically. Every existing caller omits `target` and is unchanged.

## Scope

No schema, contract, or server change. `ComputersPage` is untouched.

## Tests

Six tests, each watched failing first:

- `computer-setup.test.tsx` — target naming, targeted success, and that an unrelated reconnection leaves a targeted recovery waiting
- `app.test.tsx` — action present when offline, absent when the Provider is the blocker, generator opens in place without navigation

The guard for the Provider branch was verified to discriminate: removing the condition makes it fail.

```
pnpm check      pass
pnpm typecheck  pass
@opentag/web    310/310
```

Two suites fail on this branch independently of this change, confirmed by running the same suites with these edits stashed: one flaky observability test in `packages/server`, and two `apps/cli` daemon-service tests. Neither is touched here.

## Review round 2

@baixiaohang and @yuezengwu both found the same defect: the first revision inferred connect-code consumption from a workspace-wide connection delta. `connectedAt` moves on every ordinary Runtime registration and the Computers response carries no correlation to the issued code, so an unrelated daemon restart inside the fifteen-minute window falsely ended a recovery whose command was still valid.

Fixed in 31f8780. A targeted recovery now waits only for its own Computer; the substitution branch is gone. Detail on why a foreign registration is ignored rather than described is in the review reply below.

## Note for reviewers

Run web tests through `pnpm turbo run test`. Invoking `vitest` directly skips the dependency build and resolves a stale `packages/shared/dist`, which fails 95 of 104 tests with "The server returned an invalid response".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
