### PR TITLE
docs(deploying): record the Computer re-enrolment the cutover requires

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -132,31 +132,44 @@ The Agent's Connected computer page reports `OpenTag is not running on <name>. S
 back online.` That advice is correct for a Computer that is merely asleep and wrong here; starting the old daemon
 cannot succeed.
 
-#### Recovery
-
-Per machine, and it cannot be done centrally — the credential is written to the target machine's disk.
-
-1. A Workspace Admin opens the Computers page in the web app and generates a connection command. The command is
-   single-use and expires in 15 minutes, so generate it once the person is ready rather than in advance.
-2. That person runs the generated command on the machine. It upgrades the CLI and enrols in one line, which matters
-   because the installed CLI predates the `computer connect` subcommand.
-3. The command writes the machine credential and restarts the daemon service. The Computer reports Online within one
-   registration.
-
-Re-enrolling a machine that still has its `config/computer.json` keeps the same `computerId`, so the existing
-enrollment is reused and its Agents stay bound. Losing that file makes the machine a new one, and its previous
-enrollment stays offline with its Agents attached to it.
-
-#### Confirming the scope
+#### Finding the affected enrollments
 
 ```sql
-select w.name as workspace, wc.display_name, wc.platform, wc.last_seen_at
+select w.name as workspace, wc.display_name, wc.computer_id, wc.platform, wc.last_seen_at
 from workspace_computers wc
 join workspaces w on w.id = wc.workspace_id
 left join workspace_computer_credentials c
        on c.workspace_computer_id = wc.id and c.revoked_at is null
 where wc.revoked_at is null and c.id is null
-order by w.name, wc.display_name;
+order by wc.computer_id, w.name;
 ```
 
-Every row is a Computer that has not been re-enrolled. The list is empty once the fleet has recovered.
+Each row is one enrollment waiting to be recovered, not one host. A `computer_id` appearing on more than one row is a
+host enrolled in several Workspaces, and every one of those rows needs its own pass. The list is empty once the fleet
+has recovered.
+
+#### Recovery
+
+**The unit of recovery is one Workspace enrollment, not one physical machine.** A connect code carries the Workspace it
+was issued for and `computer connect` writes the credential for that Workspace alone, while the daemon runs one
+independent Runtime connection per stored enrollment. Running the procedure once on a host enrolled in several
+Workspaces leaves the other Workspaces' Agents offline on a machine that already looks recovered.
+
+It cannot be done centrally either — the credential is written to the target host's disk.
+
+For each row returned above:
+
+1. A Workspace Admin **of that Workspace** opens the Computers page in the web app and generates a connection command.
+   The command is single-use and expires in 15 minutes, so generate it once the person is ready rather than in advance.
+2. That person runs the generated command on the host. It upgrades the CLI and enrols in one line, which matters
+   because the installed CLI predates the `computer connect` subcommand.
+3. The command writes the machine credential and restarts the daemon service. That enrollment reports Online within
+   one registration.
+
+Repeating this on a host already recovered for another Workspace is safe. `computer-credentials.json` holds one entry
+per enrollment and enrolling replaces only the entry for the Workspace being enrolled, so earlier credentials survive
+and the daemon picks up every stored enrollment when it restarts.
+
+Re-enrolling a host that still has its `config/computer.json` keeps the same `computerId`, so existing enrollments are
+reused and their Agents stay bound. Losing that file makes the host a new Computer, and every previous enrollment stays
+offline with its Agents attached to it.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -99,3 +99,64 @@ CapRover side afterwards:
 - The App's Deployment tab shows the new image reference and a successful build log.
 - `https://<app>/healthz` returns success.
 - The App logs show the migration and listen lines for the expected revision.
+
+## Deployments that need action outside the rollout
+
+Most revisions need nothing beyond the checks above. A migration that invalidates credentials held outside the
+database is different: the rollout succeeds, `/healthz` passes, the logs look clean, and the Computer fleet goes dark
+anyway. Record each such migration here, because nothing in the deployment surfaces it.
+
+### Workspace and machine authority cutover — `0016_certain_revanche` (#161)
+
+This migration moved Runtime authentication from Account access tokens to enrollment-scoped machine credentials. It
+deliberately creates no credentials for existing Computers, and asserts that it created none:
+
+```sql
+IF EXISTS (SELECT 1 FROM "workspace_computer_credentials") THEN
+    RAISE EXCEPTION 'Workspace cutover must not synthesize machine credentials';
+```
+
+Synthesizing a credential nobody consented to would be a back door, so the assertion is correct. The cost is that
+**every Computer enrolled before the cutover must be enrolled again by hand**, and three separate effects hide the
+reason:
+
+- Every Computer reports Offline. `workspace_computers` rows are inserted without `current_instance_id`, and only a
+  Computer registration sets it.
+- A daemon on the pre-cutover CLI authenticates the Runtime WebSocket with an Account access token and is refused with
+  `AUTH_INVALID_TOKEN` and close code 4401.
+- Upgrading the CLI alone does not recover a Computer. The daemon exits with `This Computer is not enrolled; run
+  computer connect first`, because `computer-credentials.json` does not exist. The pre-cutover CLI has no
+  `computer connect` subcommand at all, so the upgrade is required before the enrolment can be run.
+
+The Agent's Connected computer page reports `OpenTag is not running on <name>. Start it there to bring this Computer
+back online.` That advice is correct for a Computer that is merely asleep and wrong here; starting the old daemon
+cannot succeed.
+
+#### Recovery
+
+Per machine, and it cannot be done centrally — the credential is written to the target machine's disk.
+
+1. A Workspace Admin opens the Computers page in the web app and generates a connection command. The command is
+   single-use and expires in 15 minutes, so generate it once the person is ready rather than in advance.
+2. That person runs the generated command on the machine. It upgrades the CLI and enrols in one line, which matters
+   because the installed CLI predates the `computer connect` subcommand.
+3. The command writes the machine credential and restarts the daemon service. The Computer reports Online within one
+   registration.
+
+Re-enrolling a machine that still has its `config/computer.json` keeps the same `computerId`, so the existing
+enrollment is reused and its Agents stay bound. Losing that file makes the machine a new one, and its previous
+enrollment stays offline with its Agents attached to it.
+
+#### Confirming the scope
+
+```sql
+select w.name as workspace, wc.display_name, wc.platform, wc.last_seen_at
+from workspace_computers wc
+join workspaces w on w.id = wc.workspace_id
+left join workspace_computer_credentials c
+       on c.workspace_computer_id = wc.id and c.revoked_at is null
+where wc.revoked_at is null and c.id is null
+order by w.name, wc.display_name;
+```
+
+Every row is a Computer that has not been re-enrolled. The list is empty once the fleet has recovered.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -132,7 +132,7 @@ The Agent's Connected computer page reports `OpenTag is not running on <name>. S
 back online.` That advice is correct for a Computer that is merely asleep and wrong here; starting the old daemon
 cannot succeed.
 
-#### Finding the affected enrollments
+#### Building the work list
 
 ```sql
 select w.name as workspace, wc.display_name, wc.computer_id, wc.platform, wc.last_seen_at
@@ -144,9 +144,12 @@ where wc.revoked_at is null and c.id is null
 order by wc.computer_id, w.name;
 ```
 
-Each row is one enrollment waiting to be recovered, not one host. A `computer_id` appearing on more than one row is a
-host enrolled in several Workspaces, and every one of those rows needs its own pass. The list is empty once the fleet
-has recovered.
+Each row is one enrollment that has not been **issued** a machine credential yet, not one host. A `computer_id`
+appearing on more than one row is a host enrolled in several Workspaces, and every one of those rows needs its own
+pass.
+
+This measures issuance, not recovery. Use it to build the work list; do not use it to declare the work finished. The
+reason is under [Confirming recovery](#confirming-recovery).
 
 #### Recovery
 
@@ -157,14 +160,15 @@ Workspaces leaves the other Workspaces' Agents offline on a machine that already
 
 It cannot be done centrally either — the credential is written to the target host's disk.
 
-For each row returned above:
+For each row in the work list:
 
 1. A Workspace Admin **of that Workspace** opens the Computers page in the web app and generates a connection command.
    The command is single-use and expires in 15 minutes, so generate it once the person is ready rather than in advance.
 2. That person runs the generated command on the host. It upgrades the CLI and enrols in one line, which matters
    because the installed CLI predates the `computer connect` subcommand.
-3. The command writes the machine credential and restarts the daemon service. That enrollment reports Online within
-   one registration.
+3. The command writes the machine credential and restarts the daemon service.
+4. Confirm that the enrollment reports Online before moving on, using the check below. Do not treat its disappearance
+   from the work list as success.
 
 Repeating this on a host already recovered for another Workspace is safe. `computer-credentials.json` holds one entry
 per enrollment and enrolling replaces only the entry for the Workspace being enrolled, so earlier credentials survive
@@ -173,3 +177,25 @@ and the daemon picks up every stored enrollment when it restarts.
 Re-enrolling a host that still has its `config/computer.json` keeps the same `computerId`, so existing enrollments are
 reused and their Agents stay bound. Losing that file makes the host a new Computer, and every previous enrollment stays
 offline with its Agents attached to it.
+
+#### Confirming recovery
+
+The authoritative signal is a Runtime registration, which is what the Computers page reports as Online. The same rule
+in SQL — an enrollment counts as online only while it holds a current instance and was seen inside the presence window,
+90 seconds by default:
+
+```sql
+select w.name as workspace, wc.display_name, wc.computer_id, wc.last_seen_at
+from workspace_computers wc
+join workspaces w on w.id = wc.workspace_id
+where wc.revoked_at is null
+  and (wc.current_instance_id is null or wc.last_seen_at < now() - interval '90 seconds')
+order by wc.computer_id, w.name;
+```
+
+Prefer this over the work-list query, which cannot prove recovery. `runComputerConnect` exchanges the code and the
+Server creates the new credential — revoking the enrollment's previous one — before the CLI writes
+`computer-credentials.json` on the host. A local write that fails on disk space, permissions, or an interrupted
+process therefore leaves an enrollment holding an active Server-side credential that the daemon does not have, with
+the old secret already revoked. That enrollment drops out of the work list without having recovered, and is worse off
+than before the attempt. Generate a fresh command and run it again.

--- a/docs/zh-CN/deploying.md
+++ b/docs/zh-CN/deploying.md
@@ -92,3 +92,59 @@ Job summary 会记录部署的 revision、镜像 tag 和镜像 digest。之后�
 - App 的 Deployment 页显示新的镜像引用和成功的构建日志。
 - `https://<app>/healthz` 返回成功。
 - App 日志中出现预期 revision 的 migration 与监听日志。
+
+## 需要在上线之外补动作的部署
+
+绝大多数 revision 只需要上面那些检查。但如果一次 migration 让数据库之外持有的凭证失效，情况就不同：上线成功、
+`/healthz` 通过、日志干净，而 Computer 全都掉线。这类 migration 必须记录在这里，因为部署流程本身不会暴露它。
+
+### Workspace 与机器授权切换 —— `0016_certain_revanche`（#161）
+
+这次 migration 把 Runtime 认证从 Account access token 换成了作用域限定到单条入组记录的机器凭证。它刻意不为存量
+Computer 生成任何凭证，并且断言自己确实没有生成：
+
+```sql
+IF EXISTS (SELECT 1 FROM "workspace_computer_credentials") THEN
+    RAISE EXCEPTION 'Workspace cutover must not synthesize machine credentials';
+```
+
+凭空造出一份没有人同意过的机器凭证等于自开后门，所以这个断言是对的。代价是**切换前入组的每一台 Computer 都必须
+重新手工入组**，而且有三重效应会掩盖真正的原因：
+
+- 所有 Computer 显示 Offline。`workspace_computers` 的行在插入时没有 `current_instance_id`，只有 Computer 注册才会
+  写入它。
+- 使用切换前 CLI 的 daemon 会用 Account access token 认证 Runtime WebSocket，被以 `AUTH_INVALID_TOKEN` 和关闭码
+  4401 拒绝。
+- 只升级 CLI 无法恢复。daemon 会以 `This Computer is not enrolled; run computer connect first` 退出，因为
+  `computer-credentials.json` 并不存在。而切换前的 CLI 根本没有 `computer connect` 子命令，所以必须先升级才谈得上
+  重新入组。
+
+Agent 的 Connected computer 页会显示 `OpenTag is not running on <name>. Start it there to bring this Computer back
+online.`。这句话对"机器只是睡着了"是对的，在这里是错的——启动旧 daemon 不可能成功。
+
+#### 恢复方式
+
+逐台进行，无法集中完成——凭证要写到目标机器的磁盘上。
+
+1. Workspace Admin 在 Web 的 Computers 页生成连接命令。该命令一次性、15 分钟过期，所以要等使用者到位再生成，不要
+   提前批量生成。
+2. 由使用者在那台机器上执行生成的命令。它会在一行里完成 CLI 升级和入组——这一点很关键，因为已安装的 CLI 早于
+   `computer connect` 子命令。
+3. 命令写入机器凭证并重启 daemon 服务。Computer 会在一次注册后回到 Online。
+
+重新入组时，只要机器上的 `config/computer.json` 还在，`computerId` 就不变，原有的入组记录会被复用，绑在上面的
+Agent 不受影响。该文件丢失则会被认作一台新机器，原入组记录连同它的 Agent 一起留在离线状态。
+
+#### 确认影响范围
+
+```sql
+select w.name as workspace, wc.display_name, wc.platform, wc.last_seen_at
+from workspace_computers wc
+join workspaces w on w.id = wc.workspace_id
+left join workspace_computer_credentials c
+       on c.workspace_computer_id = wc.id and c.revoked_at is null
+where wc.revoked_at is null and c.id is null
+order by w.name, wc.display_name;
+```
+
+每一行都是一台尚未重新入组的 Computer。全部恢复后这个列表为空。

--- a/docs/zh-CN/deploying.md
+++ b/docs/zh-CN/deploying.md
@@ -1,7 +1,7 @@
 # OpenTag 部署指南
 
 > Canonical source: [../deploying.md](../deploying.md)
-> Last synced with: 2026-08-20
+> Last synced with: 2026-08-26
 
 OpenTag 的 Staging 环境运行在 [CapRover](https://caprover.com/) 上。每个合入 `main` 且通过 CI 的 revision，都会用
 `Docker` workflow 已经发布到 GHCR 的容器镜像自动部署。CapRover 主机上不构建任何内容，也不上传源码 tarball；一次部署
@@ -122,7 +122,7 @@ IF EXISTS (SELECT 1 FROM "workspace_computer_credentials") THEN
 Agent 的 Connected computer 页会显示 `OpenTag is not running on <name>. Start it there to bring this Computer back
 online.`。这句话对"机器只是睡着了"是对的，在这里是错的——启动旧 daemon 不可能成功。
 
-#### 找出受影响的入组记录
+#### 建立待办清单
 
 ```sql
 select w.name as workspace, wc.display_name, wc.computer_id, wc.platform, wc.last_seen_at
@@ -134,8 +134,11 @@ where wc.revoked_at is null and c.id is null
 order by wc.computer_id, w.name;
 ```
 
-每一行是一条待恢复的**入组记录**，不是一台主机。同一个 `computer_id` 出现在多行上，说明这台主机入组了多个
-Workspace，每一行都需要单独走一遍恢复。全部恢复后这个列表为空。
+每一行是一条**尚未被签发**机器凭证的入组记录，不是一台主机。同一个 `computer_id` 出现在多行上，说明这台主机入组了
+多个 Workspace，每一行都需要单独走一遍。
+
+这个查询衡量的是"是否签发"，不是"是否恢复"。用它建立待办清单，不要用它判断收工——原因见
+[确认恢复](#确认恢复)。
 
 #### 恢复方式
 
@@ -145,16 +148,36 @@ Workspace 的主机只跑一次，其余 Workspace 的 Agent 仍然离线，而�
 
 而且无法集中完成——凭证要写到目标主机的磁盘上。
 
-对上面查询返回的每一行：
+对待办清单里的每一行：
 
 1. **该 Workspace 的** Admin 在 Web 的 Computers 页生成连接命令。该命令一次性、15 分钟过期，所以要等使用者到位再
    生成，不要提前批量生成。
 2. 由使用者在那台主机上执行生成的命令。它会在一行里完成 CLI 升级和入组——这一点很关键，因为已安装的 CLI 早于
    `computer connect` 子命令。
-3. 命令写入机器凭证并重启 daemon 服务。该条入组记录会在一次注册后回到 Online。
+3. 命令写入机器凭证并重启 daemon 服务。
+4. 用下面的检查确认这条入组记录确实回到 Online 之后再处理下一条。**不要**把它从待办清单里消失当作成功。
 
 在一台已经为别的 Workspace 恢复过的主机上重复执行是安全的。`computer-credentials.json` 每条入组记录存一项，入组
 时只替换正在入组的那个 Workspace 对应的那一项，先前的凭证会保留，daemon 重启后会重新拾起全部已存储的入组记录。
 
 重新入组时，只要主机上的 `config/computer.json` 还在，`computerId` 就不变，已有的入组记录会被复用，绑在上面的
 Agent 不受影响。该文件丢失则会被认作一台新的 Computer，此前的每一条入组记录连同它们的 Agent 一起留在离线状态。
+
+#### 确认恢复
+
+权威信号是一次 Runtime 注册，也就是 Computers 页显示的 Online。用 SQL 表达同一条规则——只有当入组记录持有当前
+instance、且在存活窗口（默认 90 秒）内被看到过，才算在线：
+
+```sql
+select w.name as workspace, wc.display_name, wc.computer_id, wc.last_seen_at
+from workspace_computers wc
+join workspaces w on w.id = wc.workspace_id
+where wc.revoked_at is null
+  and (wc.current_instance_id is null or wc.last_seen_at < now() - interval '90 seconds')
+order by wc.computer_id, w.name;
+```
+
+优先用这条，而不是待办清单那条——后者无法证明恢复。`runComputerConnect` 先兑换连接码、由服务端创建新凭证并**吊销
+该入组记录原有的凭证**，之后 CLI 才把 `computer-credentials.json` 写到主机上。因此本地写入若因磁盘、权限或进程中断
+而失败，这条入组记录就处于"服务端有一份 daemon 拿不到的有效凭证、而旧凭证已被吊销"的状态。它会从待办清单里消失，
+却并没有恢复，而且比尝试之前更糟。遇到这种情况，重新生成一条命令再跑一次。

--- a/docs/zh-CN/deploying.md
+++ b/docs/zh-CN/deploying.md
@@ -122,29 +122,39 @@ IF EXISTS (SELECT 1 FROM "workspace_computer_credentials") THEN
 Agent 的 Connected computer 页会显示 `OpenTag is not running on <name>. Start it there to bring this Computer back
 online.`。这句话对"机器只是睡着了"是对的，在这里是错的——启动旧 daemon 不可能成功。
 
-#### 恢复方式
-
-逐台进行，无法集中完成——凭证要写到目标机器的磁盘上。
-
-1. Workspace Admin 在 Web 的 Computers 页生成连接命令。该命令一次性、15 分钟过期，所以要等使用者到位再生成，不要
-   提前批量生成。
-2. 由使用者在那台机器上执行生成的命令。它会在一行里完成 CLI 升级和入组——这一点很关键，因为已安装的 CLI 早于
-   `computer connect` 子命令。
-3. 命令写入机器凭证并重启 daemon 服务。Computer 会在一次注册后回到 Online。
-
-重新入组时，只要机器上的 `config/computer.json` 还在，`computerId` 就不变，原有的入组记录会被复用，绑在上面的
-Agent 不受影响。该文件丢失则会被认作一台新机器，原入组记录连同它的 Agent 一起留在离线状态。
-
-#### 确认影响范围
+#### 找出受影响的入组记录
 
 ```sql
-select w.name as workspace, wc.display_name, wc.platform, wc.last_seen_at
+select w.name as workspace, wc.display_name, wc.computer_id, wc.platform, wc.last_seen_at
 from workspace_computers wc
 join workspaces w on w.id = wc.workspace_id
 left join workspace_computer_credentials c
        on c.workspace_computer_id = wc.id and c.revoked_at is null
 where wc.revoked_at is null and c.id is null
-order by w.name, wc.display_name;
+order by wc.computer_id, w.name;
 ```
 
-每一行都是一台尚未重新入组的 Computer。全部恢复后这个列表为空。
+每一行是一条待恢复的**入组记录**，不是一台主机。同一个 `computer_id` 出现在多行上，说明这台主机入组了多个
+Workspace，每一行都需要单独走一遍恢复。全部恢复后这个列表为空。
+
+#### 恢复方式
+
+**恢复的单位是一条 Workspace 入组记录，不是一台物理机。** 连接码携带它被签发时所属的 Workspace，`computer connect`
+只写入该 Workspace 的凭证；而 daemon 会为每条已存储的入组记录各跑一条独立的 Runtime 连接。对一台入组了多个
+Workspace 的主机只跑一次，其余 Workspace 的 Agent 仍然离线，而这台机器看上去已经恢复了。
+
+而且无法集中完成——凭证要写到目标主机的磁盘上。
+
+对上面查询返回的每一行：
+
+1. **该 Workspace 的** Admin 在 Web 的 Computers 页生成连接命令。该命令一次性、15 分钟过期，所以要等使用者到位再
+   生成，不要提前批量生成。
+2. 由使用者在那台主机上执行生成的命令。它会在一行里完成 CLI 升级和入组——这一点很关键，因为已安装的 CLI 早于
+   `computer connect` 子命令。
+3. 命令写入机器凭证并重启 daemon 服务。该条入组记录会在一次注册后回到 Online。
+
+在一台已经为别的 Workspace 恢复过的主机上重复执行是安全的。`computer-credentials.json` 每条入组记录存一项，入组
+时只替换正在入组的那个 Workspace 对应的那一项，先前的凭证会保留，daemon 重启后会重新拾起全部已存储的入组记录。
+
+重新入组时，只要主机上的 `config/computer.json` 还在，`computerId` 就不变，已有的入组记录会被复用，绑在上面的
+Agent 不受影响。该文件丢失则会被认作一台新的 Computer，此前的每一条入组记录连同它们的 Agent 一起留在离线状态。


### PR DESCRIPTION
## Summary

The cutover in #161 replaced Account-token Runtime authentication with enrollment-scoped machine credentials, and deliberately synthesized no credentials for existing Computers — the migration raises an exception if it created any. That assertion is correct: a credential nobody consented to would be a back door.

Nothing in the deployment surfaces what it costs. The rollout succeeds, `/healthz` passes, the logs are clean, and every Computer goes offline with no discoverable way back.

Three effects hide the cause from whoever is looking:

- Migrated enrollments are inserted without `current_instance_id`, so everything reads Offline regardless of whether the machine is on.
- A daemon on the pre-cutover CLI presents an Account access token and is refused with `AUTH_INVALID_TOKEN` and close code 4401.
- Upgrading the CLI alone still fails, because `computer-credentials.json` does not exist — and the pre-cutover CLI has no `computer connect` subcommand to create it.

The Agent's Connected computer page compounds it, advising the operator to start OpenTag on the machine. Correct for a sleeping laptop; impossible when the credential is what is missing.

## What this adds

A section for deployments that need action outside the rollout, so this class of migration has somewhere to live, with the cutover documented under it:

- what breaks and why the assertion causing it is right
- the per-machine recovery, including why the CLI upgrade and the enrolment must happen in the single generated command
- that re-enrolling with `config/computer.json` intact preserves the `computerId`, the enrollment, and the Agent bindings — and what losing that file costs
- a query listing the Computers still waiting, which is empty once the fleet has recovered

Mirrored in `docs/zh-CN/deploying.md` per the repository convention.

Documentation only. `pnpm check` passes.

## Related

PR #166 gives the Agent's Computer page the recovery action it was missing, so this stops being the only route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
