### PR TITLE
feat(web): reach Computers from the account menu

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -2540,6 +2540,18 @@ describe("OpenTag Web App Shell", () => {
     );
   });
 
+  it("opens the Computers page from the account menu", async () => {
+    installApi();
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
+    const computers = screen.getByRole("menuitem", { name: "Computers" });
+    expect(computers.getAttribute("href")).toBe("/agents/computers");
+    fireEvent.click(computers);
+    expect(await screen.findByRole("heading", { level: 1, name: "Computers" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/agents/computers");
+    expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();
+  });
+
   it("moves focus into multi-Workspace account options and returns it to the trigger on Escape", async () => {
     installApi({ alreadyJoinedInvitation: true });
     render(<App />);
@@ -2558,10 +2570,13 @@ describe("OpenTag Web App Shell", () => {
     const trigger = await screen.findByRole("button", { name: "Account menu" });
     fireEvent.click(trigger);
     const workspace = screen.getByRole("menuitem", { name: "Workspace" });
+    const computers = screen.getByRole("menuitem", { name: "Computers" });
     const account = screen.getByRole("menuitem", { name: "Account" });
     const signOut = screen.getByRole("menuitem", { name: "Sign out" });
     expect(document.activeElement).toBe(workspace);
     fireEvent.keyDown(workspace, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(computers);
+    fireEvent.keyDown(computers, { key: "ArrowDown" });
     expect(document.activeElement).toBe(account);
     fireEvent.keyDown(account, { key: "ArrowDown" });
     expect(document.activeElement).toBe(signOut);

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -912,6 +912,16 @@ function AppShell() {
                     Workspace
                   </NavLink>
                   <NavLink
+                    role="menuitem"
+                    to="/agents/computers"
+                    onClick={() => {
+                      setOpenMenu(undefined);
+                      setNavigationOpen(false);
+                    }}
+                  >
+                    Computers
+                  </NavLink>
+                  <NavLink
                     end
                     role="menuitem"
                     to="/account"


### PR DESCRIPTION
## What was missing

`/agents/computers` (the `ComputersPage`) already lists the Workspace's enrolled Computers and can generate a connect command, but nothing in the app linked to it — `grep -rn "agents/computers" apps/web/src` matched only the `<Route>` definition. The page was reachable only by typing the URL.

## What was added

A `Computers` `NavLink` in the account menu popover (bottom-left avatar), inside the existing `account-menu-actions` group alongside `Workspace` and `Account`. Computers belong to the account rather than the product navigation, so the sidebar was deliberately not used. The link follows the sibling entries exactly, closing the account menu and the mobile navigation on click.

## Scope

Web only. No server, contract, schema, or API change. `ComputersPage` itself is untouched; the only production change is ten lines in the account menu of `apps/web/src/router.tsx`.

## Tests

- New test in `apps/web/src/__tests__/app.test.tsx`: opens the account menu, asserts the `Computers` menu item points at `/agents/computers`, clicks it, and confirms the Computers page renders, the URL changes, and the menu closes. Written first and confirmed failing (`Unable to find an accessible element with the role "menuitem" and name "Computers"`) before the implementation.
- Updated the existing account-menu arrow-key test so the roving-focus sequence includes the new item (Workspace -> Computers -> Account -> Sign out).

Verified: `pnpm check`, `pnpm typecheck`, and `pnpm turbo run test --filter=@opentag/web` (17 files, 305 tests passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)