### PR TITLE
refactor(web): retire Workspace product surface

### DIFF
--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -70,43 +70,14 @@ describe("BrowserApi", () => {
     setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
   });
 
-  it("revokes a Workspace Admin with the browser mutation contract", async () => {
-    setDocumentCookie("opentag_csrf=member-csrf; Path=/");
-    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
-      expect(String(input)).toBe(`/api/v1/workspaces/${workspaceId}/admins/${userId}`);
-      expect(init?.method).toBe("DELETE");
-      expect(new Headers(init?.headers).get("X-OpenTag-CSRF")).toBe("member-csrf");
-      return new Response(null, { status: 204 });
-    });
-
-    await expect(new BrowserApi(fetchImpl).revokeWorkspaceAdmin(workspaceId, userId)).resolves.toBeUndefined();
-    setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
-  });
-
-  it("updates Workspace profile fields with the browser mutation contract", async () => {
-    setDocumentCookie("opentag_csrf=workspace-csrf; Path=/");
-    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
-      expect(String(input)).toBe(`/api/v1/workspaces/${workspaceId}`);
-      expect(init?.method).toBe("PATCH");
-      expect(init?.body).toBe(JSON.stringify({ name: "renamed-workspace", displayName: "Renamed Workspace" }));
-      expect(new Headers(init?.headers).get("X-OpenTag-CSRF")).toBe("workspace-csrf");
-      return new Response(
-        JSON.stringify({
-          id: workspaceId,
-          name: "renamed-workspace",
-          displayName: "Renamed Workspace",
-          updatedAt: "2030-01-01T00:00:00.000Z",
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    });
-    await expect(
-      new BrowserApi(fetchImpl).updateWorkspace(workspaceId, {
-        name: "renamed-workspace",
-        displayName: "Renamed Workspace",
-      }),
-    ).resolves.toMatchObject({ id: workspaceId, name: "renamed-workspace" });
-    setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
+  it("exposes no Workspace management or invitation API", () => {
+    const api = new BrowserApi();
+    expect("admins" in api).toBe(false);
+    expect("revokeWorkspaceAdmin" in api).toBe(false);
+    expect("updateWorkspace" in api).toBe(false);
+    expect("invitationPreview" in api).toBe(false);
+    expect("acceptAdminInvitation" in api).toBe(false);
+    expect("createAdminInvitation" in api).toBe(false);
   });
 
   it("loads strict browser provider availability without retrying as an authenticated request", async () => {
@@ -160,48 +131,6 @@ describe("BrowserApi", () => {
 
     await expect(new BrowserApi().me()).resolves.toMatchObject({ user: { email: "admin@example.com" } });
     expect(fetchImpl.mock.contexts).toEqual([globalThis]);
-  });
-
-  it("rebuilds mutation CSRF headers after refreshing an expired access token", async () => {
-    setDocumentCookie("opentag_csrf=old-token; Path=/");
-    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
-      const url = String(input);
-      const headers = new Headers(init?.headers);
-      if (fetchImpl.mock.calls.length === 1) {
-        expect(url).toContain("/accept");
-        expect(headers.get("X-OpenTag-CSRF")).toBe("old-token");
-        return new Response(null, { status: 401 });
-      }
-      if (fetchImpl.mock.calls.length === 2) {
-        expect(url).toBe("/api/v1/auth/browser/refresh");
-        setDocumentCookie("opentag_csrf=new-token; Path=/");
-        return new Response(null, { status: 204 });
-      }
-      expect(url).toContain("/accept");
-      expect(headers.get("X-OpenTag-CSRF")).toBe("new-token");
-      return new Response(
-        JSON.stringify({
-          workspace: {
-            id: workspaceId,
-            name: "example",
-            displayName: "Example",
-            setupCompletedAt: null,
-            grantedAt: "2030-01-01T00:00:00.000Z",
-          },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    });
-
-    await expect(new BrowserApi(fetchImpl).acceptAdminInvitation("A".repeat(32))).resolves.toMatchObject({
-      workspace: { id: workspaceId },
-    });
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
-    setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
-  });
-
-  it("exposes no browser mutation that issues an Admin invitation", () => {
-    expect("createAdminInvitation" in new BrowserApi()).toBe(false);
   });
 
   it("shares refresh behavior across optional and no-content requests", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -595,7 +595,7 @@ describe("OpenTag Web App Shell", () => {
     expect(signIn.classList.contains("login-provider-button--google")).toBe(true);
     expect(signIn.querySelector('img[alt="Sign in with Google"]')).toBeTruthy();
     expect(new URL(signIn.getAttribute("href") ?? "", window.location.origin).searchParams.get("next")).toBe("/agents");
-    expect(screen.getByText("Access is managed by your OpenTag operator.")).toBeTruthy();
+    expect(screen.getByText("Sign in to manage your Agents and Computers.")).toBeTruthy();
   });
 
   it("keeps authenticated invalid Agent tabs on the plain workspace canvas", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -5,13 +5,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app.js";
 
 const workspaceId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
-const invitedWorkspaceId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
+const secondaryWorkspaceId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const memberUserId = "63e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
-const otherMemberUserId = "73e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const computerId = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
-const invitationToken = "A".repeat(43);
 
 const agentSummary = {
   id: agentId,
@@ -50,7 +48,7 @@ function installApi(
     agentActivity?: { state: "idle" } | { state: "working"; startedAt: string };
     emptyAgents?: boolean;
     agentCreate?: (input: Record<string, unknown>) => Promise<void> | void;
-    alreadyJoinedInvitation?: boolean;
+    multipleMemberships?: boolean;
     agentCreateError?: "conflict" | "generic" | "name";
     authProviders?: readonly { enabled: boolean; id: string; startUrl: string | null }[];
     bindingReauth?: boolean;
@@ -70,7 +68,6 @@ function installApi(
     computerReadStatus?: (connected: boolean) => number | undefined;
     handoffReady?: boolean;
     initialStatus?: "active" | "suspended";
-    invitationAcceptFails?: boolean;
     provider?: "feishu" | "slack";
     runtimeProvider?: "codex" | "claude-code";
     profileUpdate?: (displayName: string) => Promise<Response> | Response;
@@ -81,7 +78,6 @@ function installApi(
     workspaceless?: boolean;
   } = {},
 ) {
-  const workspaceProfile = { name: "example", displayName: "Example" };
   let lifecycleStatus = options.initialStatus ?? "active";
   let revision = lifecycleStatus === "active" ? 1 : 2;
   const adminConfig = () => ({
@@ -107,7 +103,6 @@ function installApi(
   });
   let setupCompletedAt = options.setupCompletedAt === undefined ? "2026-08-20T00:00:00.000Z" : options.setupCompletedAt;
   let currentDisplayName = "Ada";
-  let joinedInvitation = options.alreadyJoinedInvitation ?? false;
   let computerConnectCodeIssued = false;
   vi.mocked(fetch).mockImplementation(async (input, init) => {
     const path = String(input);
@@ -142,8 +137,8 @@ function installApi(
         : [
             {
               id: workspaceId,
-              name: workspaceProfile.name,
-              displayName: workspaceProfile.displayName,
+              name: "example",
+              displayName: "Example",
               setupCompletedAt,
               grantedAt: "2026-08-20T00:00:00.000Z",
             },
@@ -152,12 +147,12 @@ function installApi(
         user: { id: userId, email: "ada@example.com", displayName: currentDisplayName },
         workspaces: [
           ...existing,
-          ...(joinedInvitation
+          ...(options.multipleMemberships
             ? [
                 {
-                  id: invitedWorkspaceId,
-                  name: "invited-workspace",
-                  displayName: "Invited Workspace",
+                  id: secondaryWorkspaceId,
+                  name: "secondary",
+                  displayName: "Secondary",
                   setupCompletedAt: "2026-08-20T00:00:00.000Z",
                   grantedAt: "2026-08-20T00:00:00.000Z",
                 },
@@ -169,26 +164,6 @@ function installApi(
     if (path === `/api/v1/workspaces/${workspaceId}/setup/complete` && init?.method === "POST") {
       setupCompletedAt = "2026-08-20T00:10:00.000Z";
       return json({ setupCompletedAt });
-    }
-    if (path === `/api/v1/workspaces/${workspaceId}` && init?.method === "PATCH") {
-      const body = JSON.parse(String(init.body)) as { displayName?: string; name?: string };
-      if (body.name !== undefined) workspaceProfile.name = body.name.trim().toLowerCase();
-      if (body.displayName !== undefined) workspaceProfile.displayName = body.displayName.trim();
-      return json({
-        id: workspaceId,
-        name: workspaceProfile.name,
-        displayName: workspaceProfile.displayName,
-        updatedAt: "2026-08-20T00:01:00.000Z",
-      });
-    }
-    if (path === `/api/v1/workspaces/${workspaceId}` && init?.method === undefined) {
-      return json({
-        id: workspaceId,
-        name: workspaceProfile.name,
-        displayName: workspaceProfile.displayName,
-        setupCompletedAt,
-        updatedAt: "2026-08-20T00:00:00.000Z",
-      });
     }
     if (/^\/api\/v1\/workspaces\/[^/]+\/agents$/.test(path) && init?.method === "POST") {
       if (options.agentCreateError) {
@@ -222,7 +197,6 @@ function installApi(
       await options.agentCreate?.(body);
       return json(adminConfig(), 201);
     }
-    // Any Workspace id, so a Workspace created during the test is served like the seeded and invited ones.
     if (/^\/api\/v1\/workspaces\/[^/]+\/agents$/.test(path) && init?.method === undefined) {
       const failureStatus = options.agentListStatus?.();
       if (failureStatus) return json({ error: { message: "Agent list unavailable" } }, failureStatus);
@@ -230,54 +204,14 @@ function installApi(
         agents: options.emptyAgents
           ? []
           : [
-              path.includes(invitedWorkspaceId)
-                ? {
-                    ...agentListItem,
-                    createdBy: options.agentCreator ?? agentListItem.createdBy,
-                    activity: options.agentActivity ?? agentListItem.activity,
-                    workspaceId: invitedWorkspaceId,
-                    status: lifecycleStatus,
-                    runtimeProvider: options.runtimeProvider ?? agentListItem.runtimeProvider,
-                  }
-                : {
-                    ...agentListItem,
-                    createdBy: options.agentCreator ?? agentListItem.createdBy,
-                    activity: options.agentActivity ?? agentListItem.activity,
-                    status: lifecycleStatus,
-                    runtimeProvider: options.runtimeProvider ?? agentListItem.runtimeProvider,
-                  },
+              {
+                ...agentListItem,
+                createdBy: options.agentCreator ?? agentListItem.createdBy,
+                activity: options.agentActivity ?? agentListItem.activity,
+                status: lifecycleStatus,
+                runtimeProvider: options.runtimeProvider ?? agentListItem.runtimeProvider,
+              },
             ],
-      });
-    }
-    if (path === `/api/v1/workspaces/${workspaceId}/admins`) {
-      return json({
-        admins: [
-          { userId, displayName: currentDisplayName, grantedAt: "2026-08-20T00:00:00.000Z" },
-          { userId: memberUserId, displayName: "Grace", grantedAt: "2026-08-20T00:01:00.000Z" },
-          { userId: otherMemberUserId, displayName: "Lin", grantedAt: "2026-08-20T00:02:00.000Z" },
-        ],
-      });
-    }
-    if (path.startsWith(`/api/v1/workspaces/${workspaceId}/admins/`) && init?.method === "DELETE") {
-      return new Response(null, { status: 204 });
-    }
-    if (path === `/api/v1/admin-invitations/${invitationToken}/preview`) {
-      return json({ workspaceDisplayName: "Invited Workspace", expiresAt: "2026-08-27T00:00:00.000Z" });
-    }
-    if (path === `/api/v1/admin-invitations/${invitationToken}/accept` && init?.method === "POST") {
-      if (options.unauthenticated) return json({ error: { message: "Sign in required" } }, 401);
-      if (options.invitationAcceptFails) {
-        return json({ error: { message: "The invitation is invalid or expired" } }, 404);
-      }
-      joinedInvitation = true;
-      return json({
-        workspace: {
-          id: invitedWorkspaceId,
-          name: "invited-workspace",
-          displayName: "Invited Workspace",
-          setupCompletedAt: "2026-08-20T00:00:00.000Z",
-          grantedAt: "2026-08-20T00:00:00.000Z",
-        },
       });
     }
     if (/^\/api\/v1\/workspaces\/[^/]+\/computers$/.test(path)) {
@@ -550,7 +484,7 @@ describe("OpenTag Web App Shell", () => {
     expect(createAgent.closest(".page-header")).toBeTruthy();
     const agentCard = agentLink.closest(".agent-card");
     expect(agentCard).toBeTruthy();
-    expect(screen.getByText("Monitor availability and 30-day usage across your AI workspacemates.")).toBeTruthy();
+    expect(screen.getByText("Monitor availability and 30-day usage across your AI teammates.")).toBeTruthy();
     expect(screen.queryByText("Usage · Last 30 days")).toBeNull();
     expect(within(agentCard as HTMLElement).getByText("Tasks")).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("Tokens")).toBeTruthy();
@@ -661,7 +595,7 @@ describe("OpenTag Web App Shell", () => {
     expect(signIn.classList.contains("login-provider-button--google")).toBe(true);
     expect(signIn.querySelector('img[alt="Sign in with Google"]')).toBeTruthy();
     expect(new URL(signIn.getAttribute("href") ?? "", window.location.origin).searchParams.get("next")).toBe("/agents");
-    expect(screen.getByText("Access is managed by your workspace.")).toBeTruthy();
+    expect(screen.getByText("Access is managed by your OpenTag operator.")).toBeTruthy();
   });
 
   it("keeps authenticated invalid Agent tabs on the plain workspace canvas", async () => {
@@ -1140,28 +1074,16 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Ada")).toBeTruthy();
   });
 
-  it("keeps Workspace identity and its Admins reachable in the single-Workspace shell", async () => {
-    installApi();
-    window.history.replaceState({}, "", "/workspace");
-    render(<App />);
-    expect(await screen.findByRole("heading", { name: "Workspace" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/workspace");
-    expect(screen.getByRole("heading", { name: "Admins" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Invite Admin" })).toBeNull();
-    expect(screen.getByText(/New invitations cannot be issued/)).toBeTruthy();
-    // The name reaches every invitation recipient and the identifier is required by the CLI, so a
-    // solo Admin has to be able to read and change them.
-    expect(screen.getByLabelText("Workspace name")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Save account profile" })).toBeNull();
-  });
-
-  it("redirects the retired Admins route onto the Workspace surface", async () => {
-    installApi();
-    window.history.replaceState({}, "", "/admins");
-    render(<App />);
-    expect(await screen.findByRole("heading", { name: "Workspace" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/workspace");
-  });
+  it.each(["/workspace", "/admins", `/invites/${"A".repeat(43)}`])(
+    "does not preserve retired Workspace product route %s",
+    async (path) => {
+      window.history.replaceState({}, "", path);
+      render(<App />);
+      expect(await screen.findByRole("heading", { name: "Page not found" })).toBeTruthy();
+      expect(window.location.pathname).toBe(path);
+      expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps the Agent home focused on status, current work, and contact", async () => {
     installApi({ bound: true });
@@ -1290,7 +1212,7 @@ describe("OpenTag Web App Shell", () => {
 
     const displayName = (await screen.findByLabelText("Display name")) as HTMLInputElement;
     expect(screen.getByRole("heading", { name: "Name" })).toBeTruthy();
-    expect(screen.getByText("Choose the name workspacemates see.")).toBeTruthy();
+    expect(screen.getByText("Choose the name teammates see.")).toBeTruthy();
     expect(screen.queryByLabelText("Handle")).toBeNull();
     expect(screen.queryByText(/handle cannot be changed/i)).toBeNull();
     expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
@@ -1471,8 +1393,8 @@ describe("OpenTag Web App Shell", () => {
   });
 
   it.each([
-    ["integrations", "Agent integrations are not available here", "Browse Workspace integrations"],
-    ["skills", "Agent skills are not available here", "Browse Workspace skills"],
+    ["integrations", "Agent integrations are not available here", "Browse integrations"],
+    ["skills", "Agent skills are not available here", "Browse skills"],
   ])("keeps legacy Agent %s URLs inside an explicit Agent-scoped boundary", async (section, heading, action) => {
     installApi();
     window.history.replaceState({}, "", `/agents/${agentId}/${section}`);
@@ -1480,7 +1402,7 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: heading })).toBeTruthy();
     expect(window.location.pathname).toBe(`/agents/${agentId}/${section}`);
-    expect(screen.getByText(/assigned to Reviewer.*Workspace catalog is separate/)).toBeTruthy();
+    expect(screen.getByText(/assigned to Reviewer.*shared catalog is separate/)).toBeTruthy();
     expect(screen.getByRole("link", { name: action }).getAttribute("href")).toBe(`/${section}`);
   });
 
@@ -1918,94 +1840,32 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("link", { name: "Settings" })).toBeNull();
   });
 
-  it("lets an Admin rename a Workspace only after multiple Workspaces disclose management", async () => {
-    installApi({ alreadyJoinedInvitation: true });
-    window.localStorage.setItem("opentag.lastExplicitWorkspaceId.v1", workspaceId);
-    window.history.replaceState({}, "", "/workspace");
+  it("uses the server-ordered first membership without a browser Workspace preference", async () => {
+    installApi({ multipleMemberships: true });
+    window.history.replaceState({}, "", `/agents?joinedWorkspaceId=${secondaryWorkspaceId}`);
+    const getItem = vi.spyOn(Storage.prototype, "getItem");
     render(<App />);
 
-    const displayName = await screen.findByLabelText("Workspace name");
-    fireEvent.change(displayName, { target: { value: "Renamed Workspace" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save Workspace profile" }));
-
-    await waitFor(() =>
-      expect(
-        vi
-          .mocked(fetch)
-          .mock.calls.some(
-            ([input, init]) => String(input) === `/api/v1/workspaces/${workspaceId}` && init?.method === "PATCH",
-          ),
-      ).toBe(true),
+    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
+    expect(getItem).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch).mock.calls.some(([path]) => path === `/api/v1/workspaces/${workspaceId}/agents`)).toBe(
+      true,
     );
-    expect(((await screen.findByLabelText("Workspace name")) as HTMLInputElement).value).toBe("Renamed Workspace");
-  });
-
-  it("accepts a single-use invitation without recording an implicit Workspace preference", async () => {
-    installApi();
-    window.history.replaceState({}, "", `/invites/${invitationToken}`);
-    render(<App />);
-
-    fireEvent.click(await screen.findByRole("button", { name: "Accept full Workspace Admin access" }));
-    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-    expect(window.localStorage.getItem("opentag.lastExplicitWorkspaceId.v1")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
-    expect(screen.getByRole("menuitem", { name: /Invited Workspace Workspace Admin/ })).toBeTruthy();
-  });
-
-  it("redirects an unauthenticated invitation acceptance back through sign-in", async () => {
-    installApi({ unauthenticated: true });
-    window.history.replaceState({}, "", `/invites/${invitationToken}`);
-    render(<App />);
-
-    fireEvent.click(await screen.findByRole("button", { name: "Accept full Workspace Admin access" }));
-    expect(await screen.findByRole("heading", { name: "Welcome back" })).toBeTruthy();
-    expect(window.location.search).toBe(`?next=${encodeURIComponent(`/invites/${invitationToken}`)}`);
-  });
-
-  it("selects the Workspace redeemed atomically during invitation sign-in", async () => {
-    installApi({ alreadyJoinedInvitation: true });
-    window.history.replaceState({}, "", `/agents?joinedWorkspaceId=${invitedWorkspaceId}`);
-    render(<App />);
-
-    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
     expect(
-      screen.getByRole("menuitem", { name: /Invited Workspace Workspace Admin/ }).getAttribute("aria-current"),
-    ).toBe("true");
-    expect(window.localStorage.getItem("opentag.lastExplicitWorkspaceId.v1")).toBeNull();
+      vi.mocked(fetch).mock.calls.some(([path]) => path === `/api/v1/workspaces/${secondaryWorkspaceId}/agents`),
+    ).toBe(false);
+    getItem.mockRestore();
   });
 
-  it("offers no invitation issuance while keeping Admin revocation reachable", async () => {
-    installApi();
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
-    window.history.replaceState({}, "", "/workspace");
-    render(<App />);
-
-    expect(await screen.findByRole("heading", { name: "Admins" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Invite Admin" })).toBeNull();
-    const revokeButtons = await screen.findAllByRole("button", { name: "Revoke" });
-    fireEvent.click(revokeButtons[1] as HTMLElement);
-    await waitFor(() =>
-      expect(
-        vi
-          .mocked(fetch)
-          .mock.calls.some(
-            ([path, init]) =>
-              path === `/api/v1/workspaces/${workspaceId}/admins/${memberUserId}` && init?.method === "DELETE",
-          ),
-      ).toBe(true),
-    );
-    confirm.mockRestore();
-  });
-
-  it("hides only the selector for a single Workspace, not the Workspace itself", async () => {
-    installApi();
+  it("keeps Workspace management and switching out of the account menu", async () => {
+    installApi({ multipleMemberships: true });
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
 
-    // Choosing between scopes is meaningless with one; reading your own Workspace is not.
     expect(screen.queryByRole("group", { name: "Workspaces" })).toBeNull();
-    expect(screen.getByRole("menuitem", { name: "Workspace" })).toBeTruthy();
+    expect(screen.queryByRole("menuitem", { name: "Workspace" })).toBeNull();
+    expect(screen.queryByText("Secondary")).toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Computers" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Account" })).toBeTruthy();
     expect(screen.queryByRole("menuitem", { name: "Admins" })).toBeNull();
   });
@@ -2360,16 +2220,17 @@ describe("OpenTag Web App Shell", () => {
     expect(within(dialog).queryByRole("button", { name: "Create Agent" })).toBeNull();
   });
 
-  it("keeps the Workspace-less authenticated gate read-only while the server finishes Workspace setup", async () => {
+  it("keeps an unprovisioned authenticated account read-only while the server finishes setup", async () => {
     installApi({ workspaceless: true });
     render(
       <StrictMode>
         <App />
       </StrictMode>,
     );
-    expect(await screen.findByRole("heading", { name: "No Workspace administration access" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "OpenTag is not ready for this account" })).toBeTruthy();
     expect(window.location.pathname).toBe("/agents");
-    expect(screen.getByRole("status").textContent).toContain("Access cannot be restored from this screen");
+    expect(screen.getByRole("status").textContent).toContain("Retry after provisioning finishes");
+    expect(screen.getByText(/contact an operator/)).toBeTruthy();
     expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
     const initialMeReads = vi.mocked(fetch).mock.calls.filter(([path]) => path === "/api/v1/me").length;
     fireEvent.click(screen.getByRole("button", { name: "Check again" }));
@@ -2383,7 +2244,7 @@ describe("OpenTag Web App Shell", () => {
     installApi({ workspaceless: true });
     window.history.replaceState({}, "", "/onboarding");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "No Workspace administration access" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "OpenTag is not ready for this account" })).toBeTruthy();
     expect(window.location.pathname).toBe("/onboarding");
     expect(
       vi.mocked(fetch).mock.calls.some(([path, init]) => path === "/api/v1/workspaces" && init?.method === "POST"),
@@ -2405,26 +2266,6 @@ describe("OpenTag Web App Shell", () => {
     expect(window.location.pathname).toBe("/agents");
   });
 
-  it("loads standalone onboarding when selected Workspace preference storage is unavailable", async () => {
-    installApi({ computerProviderReadiness: [], setupCompletedAt: null });
-    window.history.replaceState({}, "", "/onboarding");
-    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new Error("Storage unavailable");
-    });
-    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
-      throw new Error("Storage unavailable");
-    });
-    try {
-      render(<App />);
-      expect(await screen.findByRole("heading", { name: "Reviewer needs its runtime route" })).toBeTruthy();
-      expect(window.location.pathname).toBe("/onboarding");
-      expect(vi.mocked(fetch).mock.calls.filter(([path]) => path === "/api/v1/me")).toHaveLength(1);
-    } finally {
-      getItem.mockRestore();
-      setItem.mockRestore();
-    }
-  });
-
   it("does not preserve the retired self-serve Workspace creation route", async () => {
     installApi();
     window.history.replaceState({}, "", "/workspaces/new");
@@ -2434,60 +2275,6 @@ describe("OpenTag Web App Shell", () => {
       vi.mocked(fetch).mock.calls.some(([path, init]) => path === "/api/v1/workspaces" && init?.method === "POST"),
     ).toBe(false);
   });
-
-  it("switches Workspaces when Workspace preference storage is unavailable", async () => {
-    installApi({ alreadyJoinedInvitation: true });
-    window.localStorage.setItem("opentag.lastExplicitWorkspaceId.v1", workspaceId);
-    const setItem = vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
-      throw new Error("Storage unavailable");
-    });
-    try {
-      render(<App />);
-      fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
-      fireEvent.click(
-        within(screen.getByRole("group", { name: "Workspaces" })).getByRole("menuitem", {
-          name: /Invited Workspace Workspace Admin/,
-        }),
-      );
-      fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
-      expect(
-        within(screen.getByRole("group", { name: "Workspaces" }))
-          .getByRole("menuitem", { name: /Invited Workspace Workspace Admin/ })
-          .getAttribute("aria-current"),
-      ).toBe("true");
-      expect(window.location.pathname).toBe("/agents");
-      expect(window.localStorage.getItem("opentag.lastExplicitWorkspaceId.v1")).toBe(workspaceId);
-    } finally {
-      setItem.mockRestore();
-    }
-  });
-
-  it.each([`/agents/${agentId}`, "/agents/new"])(
-    "leaves Workspace-scoped Agent route %s when switching Workspaces",
-    async (path) => {
-      installApi({ alreadyJoinedInvitation: true });
-      window.history.replaceState({}, "", path);
-      render(<App />);
-
-      fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
-      const targetWorkspace = within(screen.getByRole("group", { name: "Workspaces" }))
-        .getAllByRole("menuitem")
-        .find(
-          (item) => item.classList.contains("account-workspace-option") && item.getAttribute("aria-current") !== "true",
-        );
-      if (!targetWorkspace) throw new Error("A second Workspace option was not rendered");
-      const targetWorkspaceName = targetWorkspace.querySelector("strong")?.textContent;
-      fireEvent.click(targetWorkspace);
-
-      expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-      expect(window.location.pathname).toBe("/agents");
-      fireEvent.click(screen.getByRole("button", { name: "Account menu" }));
-      const selectedWorkspace = screen
-        .getByRole("group", { name: "Workspaces" })
-        .querySelector<HTMLElement>('[aria-current="true"]');
-      expect(selectedWorkspace?.querySelector("strong")?.textContent).toBe(targetWorkspaceName);
-    },
-  );
 
   it("keeps account controls personal and signs out from the account menu", async () => {
     installApi();
@@ -2523,14 +2310,14 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();
   });
 
-  it("moves focus into multi-Workspace account options and returns it to the trigger on Escape", async () => {
-    installApi({ alreadyJoinedInvitation: true });
+  it("moves focus into account actions and returns it to the trigger on Escape", async () => {
+    installApi({ multipleMemberships: true });
     render(<App />);
     const trigger = await screen.findByRole("button", { name: "Account menu" });
     fireEvent.click(trigger);
-    const currentWorkspace = screen.getByRole("menuitem", { name: /Example Workspace Admin/ });
-    expect(document.activeElement).toBe(currentWorkspace);
-    fireEvent.keyDown(currentWorkspace, { key: "Escape" });
+    const computers = screen.getByRole("menuitem", { name: "Computers" });
+    expect(document.activeElement).toBe(computers);
+    fireEvent.keyDown(computers, { key: "Escape" });
     expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();
     expect(document.activeElement).toBe(trigger);
   });
@@ -2540,20 +2327,17 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
     const trigger = await screen.findByRole("button", { name: "Account menu" });
     fireEvent.click(trigger);
-    const workspace = screen.getByRole("menuitem", { name: "Workspace" });
     const computers = screen.getByRole("menuitem", { name: "Computers" });
     const account = screen.getByRole("menuitem", { name: "Account" });
     const signOut = screen.getByRole("menuitem", { name: "Sign out" });
-    expect(document.activeElement).toBe(workspace);
-    fireEvent.keyDown(workspace, { key: "ArrowDown" });
     expect(document.activeElement).toBe(computers);
     fireEvent.keyDown(computers, { key: "ArrowDown" });
     expect(document.activeElement).toBe(account);
     fireEvent.keyDown(account, { key: "ArrowDown" });
     expect(document.activeElement).toBe(signOut);
     fireEvent.keyDown(signOut, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(workspace);
-    fireEvent.keyDown(workspace, { key: "End" });
+    expect(document.activeElement).toBe(computers);
+    fireEvent.keyDown(computers, { key: "End" });
     expect(document.activeElement).toBe(signOut);
     fireEvent.keyDown(signOut, { key: "Escape" });
     expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1842,7 +1842,7 @@ describe("OpenTag Web App Shell", () => {
 
   it("uses the server-ordered first membership without a browser Workspace preference", async () => {
     installApi({ multipleMemberships: true });
-    window.history.replaceState({}, "", `/agents?joinedWorkspaceId=${secondaryWorkspaceId}`);
+    window.history.replaceState({}, "", "/agents");
     const getItem = vi.spyOn(Storage.prototype, "getItem");
     render(<App />);
 

--- a/apps/web/src/__tests__/typography-tokens.test.ts
+++ b/apps/web/src/__tests__/typography-tokens.test.ts
@@ -50,7 +50,7 @@ const EXCEPTIONS: { property: string; value: string; selectors: Set<string> }[] 
   {
     property: "line-height",
     value: "1",
-    selectors: new Set([".workspace-menu-chevron", ".account-menu-dots", ".dialog-close"]),
+    selectors: new Set([".account-menu-dots", ".dialog-close"]),
   },
   { property: "line-height", value: "38px", selectors: new Set([".center-card::before"]) },
   { property: "font", value: "inherit", selectors: new Set(["button", "input", "select", "textarea"]) },

--- a/apps/web/src/agent-detail-capabilities.test.tsx
+++ b/apps/web/src/agent-detail-capabilities.test.tsx
@@ -36,10 +36,10 @@ describe("Agent detail capability previews", () => {
     );
 
     expect(screen.getByText("Release notes writer")).toBeTruthy();
-    expect(screen.getAllByText("Workspace source")).toHaveLength(2);
+    expect(screen.getAllByText("Shared source")).toHaveLength(2);
     expect(screen.getAllByText("Assigned")).toHaveLength(2);
     expect(screen.getByText("Assignment unavailable")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "View Workspace Skills" }).getAttribute("href")).toBe("/skills");
+    expect(screen.getByRole("link", { name: "View Skills" }).getAttribute("href")).toBe("/skills");
     expect(screen.queryByRole("button")).toBeNull();
   });
 

--- a/apps/web/src/agent-detail-capabilities.tsx
+++ b/apps/web/src/agent-detail-capabilities.tsx
@@ -10,7 +10,7 @@ export function AgentIntegrationsPreview() {
   return (
     <div className="agent-capability-preview">
       <PreviewNotice>
-        These examples design the Agent-level connection view. They are not connections from your Workspace.
+        These examples design the Agent-level connection view. They are not live connections.
       </PreviewNotice>
       <ul aria-label="Preview Agent integrations" className="agent-integration-list">
         {agentIntegrationPreviews.map((integration) => (
@@ -56,11 +56,11 @@ export function AgentSkillsPreview() {
   return (
     <div className="agent-capability-preview">
       <PreviewNotice>
-        These example assignments show how Agent skills relate to the Workspace Skills list. No assignments are saved.
+        These example assignments show how Agent skills relate to the shared Skills list. No assignments are saved.
       </PreviewNotice>
       <div className="agent-capability-list-heading">
         <p>Skill assignments</p>
-        <Link to="/skills">View Workspace Skills</Link>
+        <Link to="/skills">View Skills</Link>
       </div>
       <ul aria-label="Preview Agent skills" className="agent-skill-list">
         {agentSkillPreviews.map((skill) => (

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -35,18 +35,10 @@ import {
   ImBindingHandoffStatusSchema,
   type ImBindingSummary,
   ImBindingSummarySchema,
-  type InvitationAcceptanceResponse,
-  InvitationAcceptanceResponseSchema,
-  type InvitationPreview,
-  InvitationPreviewSchema,
   imBindingDiagnosticsPath,
   imBindingDisablePath,
-  invitationAcceptPath,
-  invitationPreviewPath,
   type ListAgentsResponse,
   ListAgentsResponseSchema,
-  type ListWorkspaceAdminsResponse,
-  ListWorkspaceAdminsResponseSchema,
   type ListWorkspaceComputersResponse,
   ListWorkspaceComputersResponseSchema,
   type MeResponse,
@@ -58,18 +50,12 @@ import {
   SlackConfigurationResultSchema,
   type UpdateAgentRequest,
   type UpdateUserProfileRequest,
-  type UpdateWorkspaceProfileRequest,
   type UserProfile,
   UserProfileSchema,
   type ValidationIssue,
-  type WorkspaceProfile,
-  WorkspaceProfileSchema,
   type WorkspaceSetupCompletion,
   WorkspaceSetupCompletionSchema,
-  workspaceAdminPath,
-  workspaceAdminsPath,
   workspaceAgentsPath,
-  workspaceByIdPath,
   workspaceComputerConnectCodesPath,
   workspaceComputersPath,
   workspaceSetupCompletePath,
@@ -109,25 +95,6 @@ export class BrowserApi {
 
   authProviders(): Promise<AuthProvidersResponse> {
     return this.request(HTTP_PATHS.authProviders, AuthProvidersResponseSchema, undefined, false);
-  }
-
-  admins(workspaceId: string): Promise<ListWorkspaceAdminsResponse> {
-    return this.request(workspaceAdminsPath(workspaceId), ListWorkspaceAdminsResponseSchema);
-  }
-
-  revokeWorkspaceAdmin(workspaceId: string, accountId: string): Promise<void> {
-    return this.requestNoContent(workspaceAdminPath(workspaceId, accountId), {
-      method: "DELETE",
-      headers: this.csrfHeaders(),
-    });
-  }
-
-  updateWorkspace(workspaceId: string, input: UpdateWorkspaceProfileRequest): Promise<WorkspaceProfile> {
-    return this.request(workspaceByIdPath(workspaceId), WorkspaceProfileSchema, {
-      method: "PATCH",
-      body: JSON.stringify(input),
-      headers: { "content-type": "application/json", ...this.csrfHeaders() },
-    });
   }
 
   completeWorkspaceSetup(workspaceId: string, agentId: string): Promise<WorkspaceSetupCompletion> {
@@ -249,17 +216,6 @@ export class BrowserApi {
 
   issueComputerConnectCode(workspaceId: string): Promise<ComputerConnectCodeIssueResponse> {
     return this.request(workspaceComputerConnectCodesPath(workspaceId), ComputerConnectCodeIssueResponseSchema, {
-      method: "POST",
-      headers: this.csrfHeaders(),
-    });
-  }
-
-  invitationPreview(token: string): Promise<InvitationPreview> {
-    return this.request(invitationPreviewPath(token), InvitationPreviewSchema, undefined, false);
-  }
-
-  acceptAdminInvitation(token: string): Promise<InvitationAcceptanceResponse> {
-    return this.request(invitationAcceptPath(token), InvitationAcceptanceResponseSchema, {
       method: "POST",
       headers: this.csrfHeaders(),
     });

--- a/apps/web/src/mock/agent-detail-capability-data.ts
+++ b/apps/web/src/mock/agent-detail-capability-data.ts
@@ -18,9 +18,9 @@ export const agentIntegrationPreviews: readonly AgentIntegrationPreview[] = [
   },
   {
     name: "Linear",
-    identity: "OpenTag preview workspace",
+    identity: "OpenTag preview",
     purpose: "Read issue context while planning and reviewing work.",
-    scope: "Product workspace · read only",
+    scope: "Shared catalog · read only",
     connection: "Needs attention",
     availability: "Unavailable",
   },
@@ -29,15 +29,15 @@ export const agentIntegrationPreviews: readonly AgentIntegrationPreview[] = [
 export type AgentSkillPreview = {
   readonly name: string;
   readonly description: string;
-  readonly source: "OpenTag" | "Workspace";
+  readonly source: "OpenTag" | "Shared";
   readonly assignment: "Assigned" | "Assignment unavailable";
 };
 
 export const agentSkillPreviews: readonly AgentSkillPreview[] = [
   {
     name: "Release notes writer",
-    description: "Turns merged changes into concise release notes for workspacemates and customers.",
-    source: "Workspace",
+    description: "Turns merged changes into concise release notes for teammates and customers.",
+    source: "Shared",
     assignment: "Assigned",
   },
   {
@@ -49,7 +49,7 @@ export const agentSkillPreviews: readonly AgentSkillPreview[] = [
   {
     name: "Issue triage",
     description: "Classifies incoming issues and recommends a priority.",
-    source: "Workspace",
+    source: "Shared",
     assignment: "Assignment unavailable",
   },
 ];

--- a/apps/web/src/mock/capability-data.ts
+++ b/apps/web/src/mock/capability-data.ts
@@ -1,6 +1,6 @@
 export type SkillPreview = {
   name: string;
-  source: "OpenTag" | "Workspace";
+  source: "OpenTag" | "Shared";
   agentCount: number;
   status: "Demo";
   description: string;
@@ -10,7 +10,7 @@ export type SkillPreview = {
 export const skillPreviews: readonly SkillPreview[] = [
   {
     name: "Release notes writer",
-    source: "Workspace",
+    source: "Shared",
     agentCount: 3,
     status: "Demo",
     description: "Turns merged changes into clear release notes",
@@ -27,7 +27,7 @@ export const skillPreviews: readonly SkillPreview[] = [
   },
   {
     name: "Issue triage",
-    source: "Workspace",
+    source: "Shared",
     agentCount: 5,
     status: "Demo",
     description: "Classifies incoming issues and recommends priority",
@@ -59,7 +59,7 @@ export const integrationPreviews: readonly IntegrationPreview[] = [
     name: "Google Drive",
     abbreviation: "GD",
     category: "Knowledge",
-    description: "Find and reference workspace documents and folders.",
+    description: "Find and reference shared documents and folders.",
   },
   {
     id: "linear",

--- a/apps/web/src/mock/task-data.ts
+++ b/apps/web/src/mock/task-data.ts
@@ -205,8 +205,7 @@ export const taskPreviews: readonly TaskPreview[] = [
   },
   {
     id: "customer-visit-feedback",
-    title:
-      "Summarize the recurring issues from yesterday's three customer visits and group them by account and workspace.",
+    title: "Summarize the recurring issues from yesterday's three customer visits and group them by account and team.",
     agent: "Scout",
     source: {
       kind: "feishu",
@@ -220,8 +219,7 @@ export const taskPreviews: readonly TaskPreview[] = [
     exchanges: [
       {
         id: "group-feedback",
-        request:
-          "Please group yesterday's customer visit notes by account, issue, and the workspace that should follow up.",
+        request: "Please group yesterday's customer visit notes by account, issue, and the team that should follow up.",
         requestTime: "10:42 AM",
         duration: "In progress",
         status: "processing",

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -299,7 +299,7 @@ describe("OnboardingPage", () => {
     render(<OnboardingPage membership={admin} onSetupReady={onSetupReady} user={user} />);
 
     await waitFor(() => expect(onSetupReady).toHaveBeenCalledWith(agentId));
-    expect(screen.getByRole("heading", { name: "Finishing Workspace setup" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Finishing OpenTag setup" })).toBeTruthy();
   });
 
   it("hands a completed setup over to the Agent it created", async () => {

--- a/apps/web/src/onboarding/page.tsx
+++ b/apps/web/src/onboarding/page.tsx
@@ -193,7 +193,7 @@ export function OnboardingPage({
         completionInFlight.current = undefined;
         setCompletionState({
           kind: "error",
-          error: cause instanceof Error ? cause : new Error("Unable to finish Workspace setup"),
+          error: cause instanceof Error ? cause : new Error("Unable to finish OpenTag setup"),
         });
       });
     },
@@ -275,7 +275,7 @@ function OnboardingJourney({ journey }: { journey: OnboardingJourneyState }) {
       <div className="onboarding-journey-intro">
         <span className="eyebrow">Agent setup</span>
         <h1>Set up OpenTag</h1>
-        <p>Prepare one Agent, then bring it into your workspace conversation.</p>
+        <p>Prepare one Agent, then bring it into a shared conversation.</p>
       </div>
       <nav aria-label="Onboarding steps">
         <ol className="onboarding-steps">
@@ -286,7 +286,7 @@ function OnboardingJourney({ journey }: { journey: OnboardingJourneyState }) {
             title="Prepare your Agent"
           />
           <JourneyStep
-            description="Authorize your workspace bot"
+            description="Authorize your messaging bot"
             number="02"
             status={journey.messaging}
             title="Add to Feishu"
@@ -380,7 +380,7 @@ function OnboardingStageContext({ journey }: { journey: OnboardingJourneyState }
           FS
         </span>
         <span>
-          <small>Workspace chat</small>
+          <small>Team chat</small>
           <strong>Feishu</strong>
         </span>
       </div>
@@ -499,7 +499,7 @@ function onboardingJourney(
     stageDescription: prepareComplete
       ? setupReady
         ? "Your Agent is ready for the first conversation in Feishu."
-        : "Authorize the bot your workspace will mention in conversations."
+        : "Authorize the bot people will mention in conversations."
       : "Confirm where your Agent runs, then give it a clear identity.",
     stageStatus: onboardingStageStatus(current),
     stageTitle: prepareComplete
@@ -545,7 +545,7 @@ function journeyComputerRouteFact(
 }
 
 function onboardingStageStatus(current: OnboardingCurrentState): string {
-  if (current.kind === "workspace") return "Checking Workspace";
+  if (current.kind === "workspace") return "Checking OpenTag";
   if (current.kind === "computer") {
     if (current.availability === "none") return "Computer needed";
     if (current.availability === "offline") return "Computer offline";
@@ -770,7 +770,7 @@ function OnboardingContent({
       <ActionSection
         readonly={!canManage}
         title={handoffTitle(current)}
-        description="Authorize the Feishu Bot that your workspace will mention."
+        description="Authorize the Feishu Bot people will mention."
       >
         {canManage ? (
           <FeishuSetup agentId={current.agent.id} onSuccess={onReload}>
@@ -783,7 +783,7 @@ function OnboardingContent({
     );
   }
   if (completionState.kind === "pending") {
-    return <ActionSection title="Finishing Workspace setup" description="Saving the verified Agent handoff." pending />;
+    return <ActionSection title="Finishing OpenTag setup" description="Saving the verified Agent handoff." pending />;
   }
   if (completionState.kind === "error") {
     return (

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -9,7 +9,6 @@ import type {
   MeResponse,
   MeWorkspace,
   ProviderReadinessStatus,
-  WorkspaceAdminSummary,
   WorkspaceComputerSummary,
 } from "@opentag/shared/browser";
 import {
@@ -426,7 +425,6 @@ interface WorkspaceSession {
   me: MeResponse;
   membership: MeWorkspace;
   refreshMe: () => void;
-  selectWorkspace: (workspaceId: string) => void;
 }
 
 const workspaceContext = createContext<WorkspaceSession | undefined>(undefined);
@@ -442,7 +440,6 @@ export function AppRouter() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
-      <Route path="/invites/:token" element={<InvitePage />} />
       <Route element={<AuthenticatedWorkspaceGate />}>
         <Route element={<AppShell />}>
           <Route element={<WorkspaceSetupGate />}>
@@ -462,9 +459,7 @@ export function AppRouter() {
             <Route path="/integrations" element={<IntegrationsPage />} />
             <Route path="/resources" element={<Navigate replace to="/skills" />} />
             <Route path="/usage" element={<Navigate replace to="/agents" />} />
-            <Route path="/admins" element={<Navigate replace to="/workspace" />} />
             <Route path="/account" element={<AccountPage />} />
-            <Route path="/workspace" element={<WorkspacePage />} />
           </Route>
         </Route>
       </Route>
@@ -505,7 +500,7 @@ function LoginPage() {
             );
           }}
         </AsyncState>
-        <p className="login-access-note">Access is managed by your workspace.</p>
+        <p className="login-access-note">Access is managed by your OpenTag operator.</p>
       </section>
     </main>
   );
@@ -557,61 +552,9 @@ function LoginProviderLink({ next, provider }: { next: string; provider: AuthPro
   );
 }
 
-function InvitePage() {
-  const { token = "" } = useParams();
-  const navigate = useNavigate();
-  const preview = useResource(() => browserApi.invitationPreview(token), token);
-  const [error, setError] = useState<string>();
-  const [joining, setJoining] = useState(false);
-  async function join() {
-    setError(undefined);
-    setJoining(true);
-    try {
-      await browserApi.acceptAdminInvitation(token);
-      navigate("/agents", { replace: true });
-    } catch (cause) {
-      if (cause instanceof ApiError && cause.status === 401) {
-        navigate(`/login?next=${encodeURIComponent(`/invites/${token}`)}`);
-      } else {
-        setError(cause instanceof Error ? cause.message : "The invitation could not be accepted");
-      }
-    } finally {
-      setJoining(false);
-    }
-  }
-  return (
-    <main className="center-card decorative-page">
-      <AsyncState state={preview}>
-        {(value) => (
-          <>
-            <span className="eyebrow">Workspace invitation</span>
-            <h1>Join {value.workspaceDisplayName}</h1>
-            <p>This invitation grants complete Workspace Admin access and expires {formatDate(value.expiresAt)}.</p>
-            <Button disabled={joining} onClick={() => void join()}>
-              {joining ? "Accepting…" : "Accept full Workspace Admin access"}
-            </Button>
-          </>
-        )}
-      </AsyncState>
-      {error ? (
-        <div className="notice error" role="alert">
-          {error}
-        </div>
-      ) : null}
-    </main>
-  );
-}
-
-const SELECTED_WORKSPACE_STORAGE_KEY = "opentag.lastExplicitWorkspaceId.v1";
-let memoryWorkspacePreference: string | undefined;
-let memoryWorkspacePreferenceFallback = false;
-
 function AuthenticatedWorkspaceGate() {
   const location = useLocation();
   const [meRevision, setMeRevision] = useState(0);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(
-    () => new URLSearchParams(location.search).get("joinedWorkspaceId") ?? readWorkspacePreference(),
-  );
   const state = useResource(() => browserApi.me(), `me:${meRevision}`);
   if (state.kind === "error" && state.error instanceof ApiError && state.error.status === 401) {
     const requested = location.pathname === "/" ? "/agents" : `${location.pathname}${location.search}`;
@@ -620,20 +563,12 @@ function AuthenticatedWorkspaceGate() {
   return (
     <AsyncState state={state}>
       {(me) => {
-        const membership =
-          me.workspaces.find((item: MeWorkspace) => item.id === selectedWorkspaceId) ?? me.workspaces[0];
+        const membership = me.workspaces[0];
         if (!membership) {
           return <NoWorkspaceAccess onRetry={() => setMeRevision((value) => value + 1)} />;
         }
-        const selectWorkspace = (workspaceId: string) => {
-          if (!me.workspaces.some((item: MeWorkspace) => item.id === workspaceId)) return;
-          rememberWorkspacePreference(workspaceId);
-          setSelectedWorkspaceId(workspaceId);
-        };
         return (
-          <WorkspaceContext
-            value={{ me, membership, refreshMe: () => setMeRevision((value) => value + 1), selectWorkspace }}
-          >
+          <WorkspaceContext value={{ me, membership, refreshMe: () => setMeRevision((value) => value + 1) }}>
             <Outlet />
           </WorkspaceContext>
         );
@@ -645,12 +580,11 @@ function AuthenticatedWorkspaceGate() {
 function NoWorkspaceAccess({ onRetry }: { onRetry: () => void }) {
   return (
     <main className="center-card decorative-page">
-      <span className="eyebrow">Workspace access</span>
-      <h1>No Workspace administration access</h1>
-      <p>You no longer have Workspace administration access.</p>
+      <span className="eyebrow">Account access</span>
+      <h1>OpenTag is not ready for this account</h1>
+      <p>The server has not assigned the internal access needed to use OpenTag.</p>
       <div className="notice" role="status">
-        Access cannot be restored from this screen. Open an unexpired invitation issued before this transition, or
-        contact an operator.
+        Retry after provisioning finishes, or contact an operator if this continues.
       </div>
       <Button onClick={onRetry}>Check again</Button>
     </main>
@@ -687,33 +621,8 @@ function WorkspaceSetupGate() {
   return onboarding ? <Outlet /> : <Navigate replace to="/onboarding" />;
 }
 
-function readWorkspacePreference(): string | undefined {
-  if (memoryWorkspacePreferenceFallback) return memoryWorkspacePreference;
-  try {
-    const value = window.localStorage.getItem(SELECTED_WORKSPACE_STORAGE_KEY);
-    if (value && value.length <= 64) {
-      memoryWorkspacePreference = value;
-      return value;
-    }
-    return undefined;
-  } catch {
-    return memoryWorkspacePreference;
-  }
-}
-
-function rememberWorkspacePreference(workspaceId: string): void {
-  memoryWorkspacePreference = workspaceId;
-  try {
-    window.localStorage.setItem(SELECTED_WORKSPACE_STORAGE_KEY, workspaceId);
-    memoryWorkspacePreferenceFallback = false;
-  } catch {
-    memoryWorkspacePreferenceFallback = true;
-    // The authoritative membership still determines the available Workspace.
-  }
-}
-
 function AppShell() {
-  const { me, membership, selectWorkspace } = useWorkspace();
+  const { me } = useWorkspace();
   const navigate = useNavigate();
   const [navigationOpen, setNavigationOpen] = useState(false);
   const [openMenu, setOpenMenu] = useState<"account">();
@@ -838,60 +747,7 @@ function AppShell() {
                 role="menu"
                 onKeyDown={handleAccountMenuKeyDown}
               >
-                {me.workspaces.length > 1 ? (
-                  <fieldset className="account-workspace-group">
-                    <legend className="menu-label">Workspaces</legend>
-                    {me.workspaces.map((item: MeWorkspace) => {
-                      const current = item.id === membership.id;
-                      const content = (
-                        <>
-                          <span className="workspace-avatar" aria-hidden="true">
-                            {initials(item.displayName)}
-                          </span>
-                          <span className="workspace-option-copy">
-                            <strong>{item.displayName}</strong>
-                            <small>Workspace Admin</small>
-                          </span>
-                          {current ? (
-                            <span className="workspace-option-check" aria-hidden="true">
-                              <Icon name="check" />
-                            </span>
-                          ) : null}
-                        </>
-                      );
-                      return (
-                        <button
-                          aria-current={current ? "true" : undefined}
-                          className="account-workspace-option"
-                          key={item.id}
-                          role="menuitem"
-                          type="button"
-                          onClick={() => {
-                            setOpenMenu(undefined);
-                            setNavigationOpen(false);
-                            if (!current) {
-                              navigate("/agents");
-                              selectWorkspace(item.id);
-                            }
-                          }}
-                        >
-                          {content}
-                        </button>
-                      );
-                    })}
-                  </fieldset>
-                ) : null}
                 <div className="account-menu-actions">
-                  <NavLink
-                    role="menuitem"
-                    to="/workspace"
-                    onClick={() => {
-                      setOpenMenu(undefined);
-                      setNavigationOpen(false);
-                    }}
-                  >
-                    Workspace
-                  </NavLink>
                   <NavLink
                     role="menuitem"
                     to="/agents/computers"
@@ -1005,7 +861,7 @@ function AgentsPage() {
     <>
       <Page
         title="Agents"
-        description="Monitor availability and 30-day usage across your AI workspacemates."
+        description="Monitor availability and 30-day usage across your AI teammates."
         action={
           <Button ref={createTriggerRef} size="compact" variant="outline" onClick={() => setCreateOpen(true)}>
             New Agent <Icon name="plus" />
@@ -1023,7 +879,7 @@ function AgentsContent({ agents, canCreate }: { agents: AgentListItem[]; canCrea
   if (agents.length > 0) return <AgentList agents={agents} />;
   return (
     <EmptyState title="No Agents yet">
-      {canCreate ? "Create the first shared AI workspacemate with New Agent." : "An Admin can create the first Agent."}
+      {canCreate ? "Create the first shared AI teammate with New Agent." : "An Admin can create the first Agent."}
     </EmptyState>
   );
 }
@@ -1366,7 +1222,7 @@ function NewAgentMessagingStep({ agent, onFinish }: { agent: AgentAdminConfig; o
           <div>
             <span className="eyebrow">Agent created</span>
             <h2 id="agent-created-heading">Connect messaging</h2>
-            <p>Connect a Feishu Bot so workspacemates can mention {agent.displayName}.</p>
+            <p>Connect a Feishu Bot so teammates can mention {agent.displayName}.</p>
           </div>
           <div className="agent-create-actions">
             <Button onClick={() => void setup.start()}>Connect Feishu</Button>
@@ -1491,8 +1347,8 @@ function LegacyAgentCapabilityPage({ capability }: { capability: "integrations" 
             <header className="section-header">
               <h2>Agent {label} are not available here</h2>
               <p>
-                OpenTag does not currently show {label} assigned to {agent.displayName}. The Workspace catalog is
-                separate from this Agent.
+                OpenTag does not currently show {label} assigned to {agent.displayName}. The shared catalog is separate
+                from this Agent.
               </p>
             </header>
             <div className="actions">
@@ -1500,7 +1356,7 @@ function LegacyAgentCapabilityPage({ capability }: { capability: "integrations" 
                 Back to {agent.displayName}
               </Link>
               <Link className={buttonClassName({ variant: "secondary" })} to={`/${capability}`}>
-                Browse Workspace {label}
+                Browse {label}
               </Link>
             </div>
           </div>
@@ -1754,46 +1610,10 @@ function AgentSettingsPage() {
 
 function AccountPage() {
   const { me, refreshMe } = useWorkspace();
-  const location = useLocation();
-  if (location.hash === "#workspace-management") {
-    return <Navigate replace to="/workspace" />;
-  }
   return (
     <Page title="Account" description="Manage your personal account details.">
       <AccountSettings refreshMe={refreshMe} user={me.user} />
     </Page>
-  );
-}
-
-/**
- * One surface, reachable at any Workspace count. A Workspace is the scope its Admins share, and being
- * an Admin is the product's only access decision, so who may administer it belongs with what it is
- * called and how the CLI addresses it. Only the selector above this page is conditional: choosing
- * between scopes is meaningless with one, while reading and changing your own Workspace is not.
- */
-function WorkspacePage() {
-  const { membership, refreshMe } = useWorkspace();
-  return (
-    <Page title="Workspace" description="Who can administer this Workspace, and how it is identified.">
-      <WorkspaceSettings membership={membership} refreshMe={refreshMe} />
-    </Page>
-  );
-}
-
-function WorkspaceSettings({ membership, refreshMe }: { membership: MeWorkspace; refreshMe: () => void }) {
-  return (
-    <div className="settings-workspace-stack">
-      <WorkspaceAdminSettings membership={membership} />
-      <section aria-labelledby="workspace-profile-heading" className="account-workspace-profile">
-        <header className="settings-subheader">
-          <div>
-            <h2 id="workspace-profile-heading">Workspace profile</h2>
-            <p>The name people see in invitations, and the identifier CLI commands use.</p>
-          </div>
-        </header>
-        <WorkspaceProfileSettings membership={membership} refreshMe={refreshMe} />
-      </section>
-    </div>
   );
 }
 
@@ -2009,7 +1829,7 @@ function GeneralConfigForm({
     <form className="form-card agent-settings-form" onSubmit={submit}>
       <header className="agent-settings-page-title">
         <h1>Name</h1>
-        <p>Choose the name workspacemates see.</p>
+        <p>Choose the name teammates see.</p>
       </header>
       <Field htmlFor="agent-display-name" label="Display name">
         <input
@@ -2394,7 +2214,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
         <h1 ref={messagingHeadingRef} tabIndex={-1}>
           Messaging
         </h1>
-        <p>Choose how workspacemates can contact and assign work to {agent.displayName}.</p>
+        <p>Choose how teammates can contact and assign work to {agent.displayName}.</p>
       </header>
       <FeishuSetup
         agentId={agent.id}
@@ -2429,7 +2249,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                           <section className="im-section" aria-labelledby="contact-channel-heading">
                             <div className="im-section-heading">
                               <h3 id="contact-channel-heading">Contact channel</h3>
-                              <p>See how workspacemates can reach this agent and check its connection status.</p>
+                              <p>See how teammates can reach this agent and check its connection status.</p>
                             </div>
                             <div className="binding-status">
                               <StatusIndicator
@@ -2539,10 +2359,10 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                         <section className="im-section" aria-labelledby="contact-channel-heading">
                           <div className="im-section-heading">
                             <h3 id="contact-channel-heading">Contact channel</h3>
-                            <p>See how workspacemates can reach this agent.</p>
+                            <p>See how teammates can reach this agent.</p>
                           </div>
                           <EmptyState title="No messaging channel">
-                            Workspacemates cannot contact this agent until a supported bot is connected.
+                            Teammates cannot contact this agent until a supported bot is connected.
                           </EmptyState>
                           <div className="im-actions">
                             <Button onClick={() => void connectFeishu()}>Connect a Feishu Bot</Button>
@@ -2593,7 +2413,7 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
       {confirmation?.kind === "disable_binding" ? (
         <Dialog
           busy={confirmationBusy}
-          description="Workspacemates will no longer be able to assign new work to this agent until another messaging connection is added."
+          description="Teammates will no longer be able to assign new work to this agent until another messaging connection is added."
           returnFocusRef={disableBindingButtonRef}
           title="Disconnect messaging?"
           onClose={closeMessagingConfirmation}
@@ -2780,115 +2600,11 @@ function AccountSettings({ refreshMe, user }: { refreshMe: () => void; user: MeR
   );
 }
 
-function WorkspaceProfileSettings({ membership, refreshMe }: { membership: MeWorkspace; refreshMe: () => void }) {
-  const [message, setMessage] = useState<string>();
-  const [error, setError] = useState<string>();
-  const [saving, setSaving] = useState(false);
-  const [workspaceDisplayName, setWorkspaceDisplayName] = useState(membership.displayName);
-  const dirty = workspaceDisplayName !== membership.displayName;
-
-  useEffect(() => {
-    setWorkspaceDisplayName(membership.displayName);
-  }, [membership.displayName]);
-
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setSaving(true);
-    try {
-      setMessage(undefined);
-      setError(undefined);
-      await browserApi.updateWorkspace(membership.id, {
-        displayName: workspaceDisplayName,
-      });
-      refreshMe();
-      setMessage("Workspace profile saved.");
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Unable to save the Workspace profile");
-    } finally {
-      setSaving(false);
-    }
-  }
-  return (
-    <form aria-labelledby="workspace-profile-heading" className="settings-profile-form" onSubmit={submit}>
-      <SettingsList>
-        <SettingsRow label="Workspace name" description="What people see in navigation and invitations.">
-          <Field className="settings-profile-field" htmlFor="workspace-profile-name" label="Workspace name">
-            <input
-              className="ds-control"
-              id="workspace-profile-name"
-              name="displayName"
-              required
-              value={workspaceDisplayName}
-              onChange={(event) => {
-                setWorkspaceDisplayName(event.currentTarget.value);
-                setMessage(undefined);
-                setError(undefined);
-              }}
-            />
-          </Field>
-        </SettingsRow>
-        <SettingsRow
-          label="CLI identifier"
-          description="Created automatically for CLI commands. It stays the same when you rename the Workspace."
-        >
-          <dl className="settings-readonly-value">
-            <div>
-              <dt className="visually-hidden">CLI identifier</dt>
-              <dd>
-                <code>{membership.name}</code>
-              </dd>
-            </div>
-            <div>
-              <dt className="visually-hidden">CLI command</dt>
-              <dd>
-                <small>
-                  <code>--workspace {membership.name}</code>
-                </small>
-              </dd>
-            </div>
-          </dl>
-        </SettingsRow>
-      </SettingsList>
-      {dirty ? (
-        <div className="dirty-bar">
-          <span>Unsaved changes</span>
-          <div className="dirty-actions">
-            <Button
-              disabled={saving}
-              variant="ghost"
-              onClick={() => {
-                setWorkspaceDisplayName(membership.displayName);
-                setMessage(undefined);
-                setError(undefined);
-              }}
-            >
-              Discard
-            </Button>
-            <Button disabled={saving} type="submit">
-              {saving ? "Saving…" : "Save Workspace profile"}
-            </Button>
-          </div>
-        </div>
-      ) : null}
-      {message ? (
-        <p className="settings-inline-status success" role="status">
-          {message}
-        </p>
-      ) : null}
-      {error ? (
-        <p className="notice error" role="alert">
-          {error}
-        </p>
-      ) : null}
-    </form>
-  );
-}
-
 function ComputersPage() {
   const { membership } = useWorkspace();
   const state = useResource(() => browserApi.computers(membership.id), membership.id);
   return (
-    <Page title="Computers" description="Enroll and recover the Computers used by this Workspace's Agents.">
+    <Page title="Computers" description="Enroll and recover the Computers used by your Agents.">
       <AsyncState state={state}>
         {(value) => (
           <div className="settings-workspace-stack">
@@ -2915,66 +2631,6 @@ function ComputersPage() {
         )}
       </AsyncState>
     </Page>
-  );
-}
-
-function WorkspaceAdminSettings({ membership }: { membership: MeWorkspace }) {
-  const { me, refreshMe } = useWorkspace();
-  const [revision, setRevision] = useState(0);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string>();
-  const state = useResource(() => browserApi.admins(membership.id), `${membership.id}:${revision}`);
-
-  async function revoke(admin: WorkspaceAdminSummary) {
-    if (!window.confirm(`Revoke Workspace Admin access for ${admin.displayName}?`)) return;
-    setBusy(true);
-    setError(undefined);
-    try {
-      await browserApi.revokeWorkspaceAdmin(membership.id, admin.userId);
-      setRevision((value) => value + 1);
-      if (admin.userId === me.user.id) refreshMe();
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Unable to revoke Workspace Admin access");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <section aria-labelledby="workspace-admins-heading" className="account-workspace-profile">
-      <header className="settings-subheader">
-        <div>
-          <h2 id="workspace-admins-heading">Admins</h2>
-          <p>Every Admin has complete management authority over this Workspace.</p>
-          <p>
-            New invitations cannot be issued. An outstanding invitation can still be accepted while unconsumed,
-            unrevoked, unexpired, and issued by a current Admin.
-          </p>
-        </div>
-      </header>
-      <AsyncState state={state}>
-        {(value) => (
-          <ul className="settings-member-list" aria-label="Workspace Admins">
-            {value.admins.map((admin) => (
-              <li className="settings-member-row" key={admin.userId}>
-                <span>
-                  <strong>{admin.displayName}</strong>
-                  {admin.userId === me.user.id ? " (you)" : ""}
-                </span>
-                <Button disabled={busy} size="compact" variant="secondary" onClick={() => void revoke(admin)}>
-                  Revoke
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </AsyncState>
-      {error ? (
-        <p className="notice error" role="alert">
-          {error}
-        </p>
-      ) : null}
-    </section>
   );
 }
 
@@ -3124,7 +2780,7 @@ function agentRecoveryMessage(agent: AgentDetailView): string {
     computer_offline: "The assigned Computer is offline, so new requests cannot start.",
     runtime_unavailable: "The assigned Computer is not ready to run this Agent.",
     runtime_unconfirmed: "OpenTag could not confirm whether the assigned Computer is ready.",
-    im_not_connected: "Connect Feishu or Slack so workspacemates can assign work to this agent.",
+    im_not_connected: "Connect Feishu or Slack so teammates can assign work to this agent.",
     im_provisioning: "The messaging connection is still being set up.",
     im_reauthorization_required: "The messaging connection needs permission to continue receiving requests.",
     im_error: "The messaging connection needs attention before it can receive requests.",

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -500,7 +500,7 @@ function LoginPage() {
             );
           }}
         </AsyncState>
-        <p className="login-access-note">Access is managed by your OpenTag operator.</p>
+        <p className="login-access-note">Sign in to manage your Agents and Computers.</p>
       </section>
     </main>
   );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -322,54 +322,15 @@ pre {
   text-decoration: none;
 }
 
-.workspace-menu,
 .account-menu {
   position: relative;
 }
 
-.workspace-switcher {
-  display: grid;
-  width: 100%;
-  min-height: 43px;
-  align-items: center;
-  justify-content: initial;
-  grid-template-columns: 24px minmax(0, 1fr) 14px;
-  gap: 9px;
-  border: 0;
-  border-radius: 8px;
-  background: #e6e8dc;
-  color: var(--secondary-foreground);
-  font-size: var(--text-ui);
-  font-weight: var(--fw-medium);
-  padding: 5px 10px;
-  text-align: left;
-  transition:
-    background-color 140ms ease,
-    color 140ms ease;
-}
-
-.workspace-switcher:hover,
-.workspace-switcher[aria-expanded="true"] {
-  border-color: transparent;
-  background: var(--brand-light);
-  color: var(--brand-ink);
-}
-
-.workspace-switcher:active,
-.workspace-menu-option:active,
 .account-row:active,
 .account-menu-popover button:active {
   transform: none;
 }
 
-.workspace-menu-chevron {
-  color: var(--muted);
-  font-size: var(--text-meta);
-  line-height: 1;
-  text-align: right;
-}
-
-.workspace-avatar,
 .account-avatar,
 .agent-avatar {
   display: inline-grid;
@@ -383,12 +344,6 @@ pre {
   letter-spacing: var(--track-tight);
 }
 
-.workspace-avatar {
-  width: 24px;
-  height: 24px;
-  border-radius: 6px;
-}
-
 .account-avatar,
 .agent-avatar {
   border-radius: 50%;
@@ -399,7 +354,6 @@ pre {
   height: 28px;
 }
 
-.workspace-menu-popover,
 .account-menu-popover {
   position: absolute;
   z-index: calc(var(--layer-sidebar) + 1);
@@ -407,139 +361,6 @@ pre {
   border-radius: var(--radius);
   background: var(--surface);
   box-shadow: 0 16px 36px rgb(43 55 38 / 12%);
-}
-
-.workspace-menu-popover {
-  top: calc(100% + 6px);
-  left: 0;
-  display: flex;
-  max-height: calc(100dvh - 32px);
-  flex-direction: column;
-  overflow: hidden;
-  width: min(272px, calc(100vw - 32px));
-  padding: 8px;
-}
-
-.menu-label {
-  padding: 7px 8px 6px;
-  color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: var(--text-micro);
-  font-weight: var(--fw-semibold);
-  letter-spacing: var(--track-label);
-  text-transform: uppercase;
-}
-
-.workspace-search {
-  display: block;
-  padding: 4px 5px 7px;
-}
-
-.workspace-search input {
-  width: 100%;
-  min-height: 36px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--background);
-  padding: 0 10px;
-}
-
-.workspace-menu-list {
-  display: grid;
-  min-height: 0;
-  max-height: min(352px, 45dvh);
-  gap: 2px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
-}
-
-.workspace-menu-option {
-  display: grid;
-  width: 100%;
-  min-height: 44px;
-  align-items: center;
-  justify-content: initial;
-  grid-template-columns: 24px minmax(0, 1fr) 16px;
-  gap: 10px;
-  border: 0;
-  border-radius: 7px;
-  background: transparent;
-  color: var(--foreground);
-  padding: 6px 8px;
-  text-align: left;
-}
-
-.workspace-menu-option:hover,
-.workspace-menu-option[aria-current="true"] {
-  border-color: transparent;
-  background: var(--brand-light);
-  color: var(--foreground);
-}
-
-.workspace-option-copy,
-.workspace-option-copy strong,
-.workspace-option-copy small {
-  display: block;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.workspace-option-copy strong {
-  font-size: var(--text-ui);
-  font-weight: var(--fw-semibold);
-}
-
-.workspace-option-copy small {
-  margin-top: 2px;
-  color: var(--muted);
-  font-size: var(--text-meta);
-}
-
-.workspace-option-check {
-  color: var(--brand-ink);
-  font-size: var(--text-ui);
-  font-weight: var(--fw-bold);
-  text-align: right;
-}
-
-.workspace-menu-empty {
-  color: var(--muted);
-  font-size: var(--text-meta);
-  padding: 14px 8px;
-}
-
-.workspace-menu-actions {
-  display: grid;
-  gap: 2px;
-  margin-top: 7px;
-  border-top: 1px solid var(--border);
-  padding-top: 7px;
-}
-
-.workspace-menu-action {
-  display: flex;
-  width: 100%;
-  min-height: 39px;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 9px;
-  border: 0;
-  border-radius: 7px;
-  background: transparent;
-  color: var(--secondary-foreground);
-  font-size: var(--text-ui);
-  font-weight: var(--fw-medium);
-  padding: 0 8px;
-  text-decoration: none;
-}
-
-.workspace-menu-action:hover {
-  border-color: transparent;
-  background: var(--brand-light);
-  color: var(--brand-ink);
 }
 
 .primary-nav,
@@ -647,36 +468,6 @@ pre {
   width: min(240px, calc(100vw - 32px));
 }
 
-.account-workspace-group {
-  display: grid;
-  max-height: min(304px, 42dvh);
-  gap: 2px;
-  overflow-y: auto;
-  min-width: 0;
-  border: 0;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 5px;
-  padding: 0 0 7px;
-}
-
-.account-menu-popover .account-workspace-option {
-  display: grid;
-  min-height: 48px;
-  grid-template-columns: 24px minmax(0, 1fr) 16px;
-  gap: 10px;
-  padding: 6px 8px;
-  text-align: left;
-}
-
-.account-menu-popover .account-workspace-option[aria-current="true"] {
-  background: transparent;
-  color: var(--foreground);
-}
-
-.account-menu-popover .account-workspace-option.is-static {
-  cursor: default;
-}
-
 .account-menu-actions {
   display: grid;
   gap: 2px;
@@ -732,12 +523,6 @@ pre {
   font-size: var(--text-meta);
   line-height: var(--lh-ui);
   padding: 6px 9px;
-}
-
-.account-workspace-profile {
-  display: grid;
-  width: 100%;
-  gap: 24px;
 }
 
 .sidebar-backdrop,
@@ -833,21 +618,8 @@ pre {
   font-size: var(--text-body);
 }
 
-.invitation-dialog-content {
-  display: grid;
-  gap: 14px;
-}
-
 .dialog-actions {
   margin-top: 4px;
-}
-
-.workspace-profile-dialog {
-  width: min(100%, 760px);
-}
-
-.workspace-profile-dialog .dialog-header {
-  margin-bottom: 20px;
 }
 
 .app-main {
@@ -3411,42 +3183,6 @@ textarea:focus {
   line-height: var(--lh-prose);
 }
 
-.workspace-profile-form {
-  background: transparent;
-  padding: 0;
-}
-
-.workspace-profile-fields {
-  display: grid;
-  gap: 23px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  padding: 23px;
-}
-
-.workspace-profile-row {
-  display: grid;
-  grid-template-columns: 210px minmax(0, 1fr);
-  gap: 29px;
-}
-
-.workspace-profile-copy strong {
-  display: block;
-  margin: 2px 0 5px;
-  font-size: var(--text-ui);
-}
-
-.workspace-profile-copy p {
-  margin-bottom: 0;
-  color: var(--muted);
-  font-size: var(--text-meta);
-}
-
-.workspace-profile-row label {
-  align-content: start;
-}
-
 .dirty-bar {
   display: flex;
   min-height: 55px;
@@ -4208,8 +3944,7 @@ textarea:focus {
     grid-template-columns: 1fr;
   }
 
-  .messaging-contact-facts,
-  .workspace-profile-row {
+  .messaging-contact-facts {
     grid-template-columns: 1fr;
     gap: 12px;
   }

--- a/packages/server/src/__tests__/browser-auth.test.ts
+++ b/packages/server/src/__tests__/browser-auth.test.ts
@@ -32,7 +32,7 @@ function authService(): UserAuthService {
   };
 }
 
-function google(result: { next?: string; selectedWorkspaceId?: string } = {}) {
+function google(result: { next?: string } = {}) {
   return {
     start: vi
       .fn()
@@ -41,7 +41,6 @@ function google(result: { next?: string; selectedWorkspaceId?: string } = {}) {
       options.onVerified();
       return {
         next: result.next ?? "/agents",
-        ...(result.selectedWorkspaceId ? { selectedWorkspaceId: result.selectedWorkspaceId } : {}),
         tokens: {
           accessToken: "access-secret",
           refreshToken: "refresh-secret",
@@ -183,10 +182,9 @@ describe("browser authentication routes", () => {
     );
   });
 
-  it("sends a redeemed invitation sign-in to the selected Workspace", async () => {
-    const selectedWorkspaceId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
+  it("sends a redeemed invitation sign-in to Agents without a Workspace selection hint", async () => {
     const token = "A".repeat(43);
-    const googleService = google({ next: `/invites/${token}`, selectedWorkspaceId });
+    const googleService = google({ next: `/invites/${token}` });
     const { app } = createBrowserApp({ googleService });
     const response = await app.inject({
       method: "GET",
@@ -195,7 +193,7 @@ describe("browser authentication routes", () => {
     });
 
     expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe(`/agents?joinedWorkspaceId=${selectedWorkspaceId}`);
+    expect(response.headers.location).toBe("/agents");
   });
 
   it("accepts provider-owned callback fields but passes only supported values to the Google service", async () => {

--- a/packages/server/src/__tests__/google-auth.test.ts
+++ b/packages/server/src/__tests__/google-auth.test.ts
@@ -111,11 +111,10 @@ describe("GoogleBrowserAuthService", () => {
     expect(exchangeCode).toHaveBeenCalledOnce();
   });
 
-  it("returns the Workspace selected while redeeming an invitation in the callback transaction", async () => {
+  it("redeems an invitation in the callback transaction without exposing a Workspace selection", async () => {
     const token = "A".repeat(43);
-    const selectedWorkspaceId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
     const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
-    const completeInTransaction = vi.fn().mockResolvedValue({ selectedWorkspaceId, userId });
+    const completeInTransaction = vi.fn().mockResolvedValue({ userId });
     const issueTokensForUser = vi.fn().mockResolvedValue({
       accessToken: "access-secret",
       refreshToken: "refresh-secret",
@@ -134,17 +133,18 @@ describe("GoogleBrowserAuthService", () => {
       tokenIssuer: { issueTokensForUser } as never,
     });
 
-    await expect(
-      service.callback({ code: "code", state: "state" }, "signed-context", { onVerified: vi.fn() }),
-    ).resolves.toMatchObject({ next: `/invites/${token}`, selectedWorkspaceId });
+    const result = await service.callback({ code: "code", state: "state" }, "signed-context", {
+      onVerified: vi.fn(),
+    });
+    expect(result).toMatchObject({ next: `/invites/${token}` });
+    expect(Object.keys(result).sort()).toEqual(["next", "tokens"]);
     expect(completeInTransaction).toHaveBeenCalledWith(expect.anything(), userId, true, token);
     expect(issueTokensForUser).toHaveBeenCalledWith(userId);
   });
 
-  it("returns the personal Workspace established by a solo OAuth completion", async () => {
-    const selectedWorkspaceId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
+  it("completes default provisioning without exposing a Workspace selection", async () => {
     const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
-    const completeInTransaction = vi.fn().mockResolvedValue({ selectedWorkspaceId, userId });
+    const completeInTransaction = vi.fn().mockResolvedValue({ userId });
     const service = new GoogleBrowserAuthService({
       database: { transaction: (callback: (transaction: object) => unknown) => callback({}) } as never,
       flow: { verify: vi.fn().mockResolvedValue({ next: "/onboarding", oidcNonce: "oidc-nonce" }) } as never,
@@ -164,9 +164,11 @@ describe("GoogleBrowserAuthService", () => {
       } as never,
     });
 
-    await expect(
-      service.callback({ code: "code", state: "state" }, "signed-context", { onVerified: vi.fn() }),
-    ).resolves.toMatchObject({ next: "/onboarding", selectedWorkspaceId });
+    const result = await service.callback({ code: "code", state: "state" }, "signed-context", {
+      onVerified: vi.fn(),
+    });
+    expect(result).toMatchObject({ next: "/onboarding" });
+    expect(Object.keys(result).sort()).toEqual(["next", "tokens"]);
     expect(completeInTransaction).toHaveBeenCalledWith(expect.anything(), userId, true, undefined);
   });
 

--- a/packages/server/src/__tests__/integration/admin-invitations.test.ts
+++ b/packages/server/src/__tests__/integration/admin-invitations.test.ts
@@ -81,14 +81,13 @@ describe("Admin invitation lifecycle", () => {
     const value = await fixture();
     try {
       const accountId = await createAccount(value, "normal-signup@example.com");
-      const completion = await value.postAuthentication.complete(accountId, true);
+      await value.postAuthentication.complete(accountId, true);
       const grants = await value.database
         .select({ workspaceId: workspaceAdminGrants.workspaceId })
         .from(workspaceAdminGrants)
         .innerJoin(workspaces, eq(workspaces.id, workspaceAdminGrants.workspaceId))
         .where(and(eq(workspaceAdminGrants.userId, accountId), isNull(workspaceAdminGrants.revokedAt)));
 
-      expect(completion.selectedWorkspaceId).toBe(grants[0]?.workspaceId);
       expect(grants).toHaveLength(1);
     } finally {
       await value.sql.end();
@@ -100,13 +99,12 @@ describe("Admin invitation lifecycle", () => {
     try {
       const invitation = await seedOutstandingInvitation(value);
       const accountId = await createAccount(value, "invited-signup@example.com");
-      const completion = await value.postAuthentication.complete(accountId, true, invitation.token);
+      await value.postAuthentication.complete(accountId, true, invitation.token);
       const grants = await value.database
         .select({ workspaceId: workspaceAdminGrants.workspaceId })
         .from(workspaceAdminGrants)
         .where(and(eq(workspaceAdminGrants.userId, accountId), isNull(workspaceAdminGrants.revokedAt)));
 
-      expect(completion.selectedWorkspaceId).toBe(value.bootstrap.workspaceId);
       expect(grants).toEqual([{ workspaceId: value.bootstrap.workspaceId }]);
     } finally {
       await value.sql.end();

--- a/packages/server/src/api/browser-auth.ts
+++ b/packages/server/src/api/browser-auth.ts
@@ -77,15 +77,8 @@ class RouteRateLimiter {
   }
 }
 
-function withSelectedWorkspaceHint(
-  next: string,
-  selectedWorkspaceId: string | undefined,
-  publicOrigin: string,
-): string {
-  if (!selectedWorkspaceId) return next;
-  const destination = new URL(next.startsWith("/invites/") ? "/agents" : next, publicOrigin);
-  destination.searchParams.set("joinedWorkspaceId", selectedWorkspaceId);
-  return `${destination.pathname}${destination.search}${destination.hash}`;
+function browserAuthDestination(next: string): string {
+  return next.startsWith("/invites/") ? "/agents" : next;
 }
 
 export function registerBrowserAuthRoutes(
@@ -176,10 +169,7 @@ export function registerBrowserAuthRoutes(
       refreshTtlSeconds: options.refreshTokenTtlSeconds,
       secure: options.secureCookies,
     });
-    return reply.redirect(
-      withSelectedWorkspaceHint(result.next, result.selectedWorkspaceId, options.publicOrigin),
-      302,
-    );
+    return reply.redirect(browserAuthDestination(result.next), 302);
   });
 
   app.post(HTTP_PATHS.authBrowserRefresh, async (request, reply) => {

--- a/packages/server/src/services/auth/google-browser-auth.ts
+++ b/packages/server/src/services/auth/google-browser-auth.ts
@@ -14,7 +14,6 @@ export interface GoogleAuthStartResult {
 
 export interface GoogleAuthCallbackResult {
   next: string;
-  selectedWorkspaceId?: string;
   tokens: RefreshTokenResponse;
 }
 
@@ -91,20 +90,19 @@ export class GoogleBrowserAuthService {
       redirectUri: this.#redirectUri,
     });
     const invitationToken = invitationTokenFromNext(flow.next);
-    const completion = await this.#database.transaction(async (transaction) => {
+    const userId = await this.#database.transaction(async (transaction) => {
       const resolved = await this.#identities.resolveOrCreateInTransaction(transaction, identity);
-      const result = await this.#postAuthentication.completeInTransaction(
+      await this.#postAuthentication.completeInTransaction(
         transaction,
         resolved.userId,
         resolved.accountWasCreated,
         invitationToken,
       );
-      return { selectedWorkspaceId: result.selectedWorkspaceId, userId: resolved.userId };
+      return resolved.userId;
     });
     return {
       next: flow.next,
-      ...(completion.selectedWorkspaceId ? { selectedWorkspaceId: completion.selectedWorkspaceId } : {}),
-      tokens: await this.#tokenIssuer.issueTokensForUser(completion.userId),
+      tokens: await this.#tokenIssuer.issueTokensForUser(userId),
     };
   }
 }

--- a/packages/server/src/services/auth/post-authentication.ts
+++ b/packages/server/src/services/auth/post-authentication.ts
@@ -5,7 +5,6 @@ import type { WorkspaceAdminAccess } from "../workspace-admin-access/index.js";
 import { AuthServiceError } from "./errors.js";
 
 export interface PostAuthenticationResult {
-  selectedWorkspaceId?: string;
   userId: string;
 }
 
@@ -35,18 +34,10 @@ export class PostAuthenticationService {
       throw new AuthServiceError("AUTH_USER_SUSPENDED", "deterministic", "The user account is suspended", 403);
     }
     if (invitationToken) {
-      const acceptance = await this.#workspaceAdmins.acceptInvitationInTransaction(
-        transaction,
-        userId,
-        invitationToken,
-      );
-      return { userId, selectedWorkspaceId: acceptance.workspace.id };
+      await this.#workspaceAdmins.acceptInvitationInTransaction(transaction, userId, invitationToken);
+      return { userId };
     }
-    const selectedWorkspaceId = await this.#workspaceAdmins.establishDefaultWorkspaceForNewAccount(
-      transaction,
-      user,
-      accountWasCreated,
-    );
-    return { userId, ...(selectedWorkspaceId ? { selectedWorkspaceId } : {}) };
+    await this.#workspaceAdmins.establishDefaultWorkspaceForNewAccount(transaction, user, accountWasCreated);
+    return { userId };
   }
 }


### PR DESCRIPTION
Parent: #167
Depends on: #171

## Summary
- remove the `/workspace`, `/admins`, and `/invites/:token` product routes and their profile, Admin, revocation, invitation preview, and invitation acceptance UI
- remove Workspace switching and browser preference storage; the authenticated gate now uses the first server-ordered internal membership solely for compatible Agent and Computer API routing
- remove the dead Browser API methods and Workspace-only CSS while keeping Account, Computers, Agents, and onboarding available
- make the unprovisioned-account gate retry/contact-only and remove Workspace terminology from remaining Web-facing copy
- remove the retired `joinedWorkspaceId` OAuth callback hint and its now-unused selection result types; invitation redemption/default provisioning remain transactional, and a redeemed legacy callback still lands on `/agents`

## Merge constraints
- #171 must be deployed first
- do not merge until the #167 production data gate confirms the retired invitation and multi-membership surfaces are no longer needed
- CI must be green and a reviewer must approve; do not bypass review

## Validation
- `pnpm --filter @opentag/web test` (301 passed)
- focused Web app regression (101 passed)
- focused Browser/Google auth tests (19 passed)
- focused Admin invitation integration tests (8 passed)
- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (285 passed; 100% statements, branches, functions, and lines)
- `pnpm --filter @opentag/server test:integration` (146 passed on rerun; the first run had one unrelated lock-order fixture timing failure, and the focused retry passed)
- `pnpm test` (all affected and non-CLI suites passed; two existing macOS `/tmp` versus `/private/tmp` CLI path assertions failed)