### PR TITLE
feat(server): add the Account-native management facade

### DIFF
--- a/packages/server/src/__tests__/account-api.test.ts
+++ b/packages/server/src/__tests__/account-api.test.ts
@@ -234,23 +234,50 @@ describe("Account-native management collections", () => {
     expect(service.workspaceService.listComputers).toHaveBeenLastCalledWith(userId, workspaceId, false);
   });
 
-  it("rejects a client-selected scope in the request body", async () => {
+  it("rejects a client-selected scope on every creation route", async () => {
     const { app, service } = appWith();
 
-    for (const payload of [
-      { ...createAgentPayload, workspaceId },
-      { ...createAgentPayload, accountId: userId },
-    ]) {
+    const routes = [
+      { url: HTTP_PATHS.accountAgents, base: createAgentPayload },
+      { url: HTTP_PATHS.accountComputerConnectCodes, base: {} },
+      { url: HTTP_PATHS.accountSetupComplete, base: { agentId } },
+    ];
+    for (const route of routes) {
+      for (const selector of [{ workspaceId }, { accountId: userId }]) {
+        const response = await app.inject({
+          method: "POST",
+          url: route.url,
+          headers: authorization,
+          payload: { ...route.base, ...selector },
+        });
+        expect({ url: route.url, selector, status: response.statusCode }).toEqual({
+          url: route.url,
+          selector,
+          status: 400,
+        });
+        expect(response.json().error.code).toBe("VALIDATION_ERROR");
+      }
+    }
+
+    expect(service.agentService.createForWorkspace).not.toHaveBeenCalled();
+    expect(service.machineAuthService.issueForWorkspaceAdmin).not.toHaveBeenCalled();
+    expect(service.workspaceSetupService.complete).not.toHaveBeenCalled();
+    expect(service.accountScope.resolveCompatibilityWorkspaceId).not.toHaveBeenCalled();
+  });
+
+  it("still issues a connect code for an empty or absent body", async () => {
+    const { app, service } = appWith();
+
+    for (const payload of [undefined, {}]) {
       const response = await app.inject({
         method: "POST",
-        url: HTTP_PATHS.accountAgents,
+        url: HTTP_PATHS.accountComputerConnectCodes,
         headers: authorization,
-        payload,
+        ...(payload === undefined ? {} : { payload }),
       });
-      expect(response.statusCode).toBe(400);
-      expect(response.json().error.code).toBe("VALIDATION_ERROR");
+      expect(response.statusCode).toBe(201);
     }
-    expect(service.agentService.createForWorkspace).not.toHaveBeenCalled();
+    expect(service.machineAuthService.issueForWorkspaceAdmin).toHaveBeenCalledTimes(2);
   });
 
   it("does not disclose whether an Account has no compatibility scope", async () => {

--- a/packages/server/src/__tests__/account-api.test.ts
+++ b/packages/server/src/__tests__/account-api.test.ts
@@ -1,0 +1,314 @@
+import {
+  HTTP_PATHS,
+  PROVIDER_READINESS_V1_HEADER,
+  workspaceAgentsPath,
+  workspaceComputerConnectCodesPath,
+  workspaceComputersPath,
+  workspaceSetupCompletePath,
+} from "@opentag/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AccountScopeResolver } from "../api/account.js";
+import { createApp } from "../app.js";
+import type { AgentService } from "../services/agents/index.js";
+import { AuthServiceError, type UserAuthService } from "../services/auth/index.js";
+import type { ComputerService, MachineAuthService } from "../services/computers/index.js";
+import type { WorkspaceAdminService, WorkspaceSetupService } from "../services/workspaces/index.js";
+
+const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
+const workspaceId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
+const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
+const computerId = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
+const authorization = { authorization: "Bearer access" };
+
+const agent = {
+  id: agentId,
+  workspaceId,
+  createdByUserId: userId,
+  computerId,
+  name: "code-reviewer",
+  displayName: "Code Reviewer",
+  runtimeProvider: "codex" as const,
+  receiveMode: "all_message" as const,
+  status: "active" as const,
+  revision: 1,
+  runtimeConfig: {
+    revision: 1,
+    model: null,
+    reasoningEffort: null,
+    instructions: "Follow instructions.",
+    maxDurationMs: null,
+  },
+  createdAt: "2026-08-19T00:00:00.000Z",
+  updatedAt: "2026-08-19T00:00:00.000Z",
+};
+const agentListItem = {
+  id: agentId,
+  workspaceId,
+  name: agent.name,
+  displayName: agent.displayName,
+  runtimeProvider: agent.runtimeProvider,
+  receiveMode: agent.receiveMode,
+  status: agent.status,
+  createdAt: agent.createdAt,
+  updatedAt: agent.updatedAt,
+  createdBy: { userId, displayName: "Admin" },
+  computer: { computerId, displayName: "Laptop", platform: "linux" as const },
+  activity: { state: "idle" as const },
+  usage: { windowDays: 30 as const, tasks: 0, failed: 0, tokens: 0 },
+};
+const computerSummary = {
+  computerId,
+  displayName: "Laptop",
+  platform: "linux" as const,
+  connectionStatus: "online" as const,
+  connectedAt: "2026-08-19T00:00:00.000Z",
+  lastSeenAt: "2026-08-19T00:00:00.000Z",
+  observedAt: "2026-08-19T00:00:00.000Z",
+  enrolledAt: "2026-08-18T00:00:00.000Z",
+  agentIds: [agentId],
+};
+const createAgentPayload = {
+  name: "code-reviewer",
+  displayName: "Code Reviewer",
+  runtimeProvider: "codex" as const,
+  computerId,
+};
+
+const apps: ReturnType<typeof createApp>[] = [];
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.close()));
+});
+
+function authService(): UserAuthService {
+  return {
+    exchangeConnectCode: vi.fn(),
+    refresh: vi.fn(),
+    getActiveUserById: vi.fn(),
+    updateSelfProfile: vi.fn(),
+    getAuthenticatedUser: vi.fn().mockResolvedValue({
+      tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
+      me: {
+        user: { id: userId, email: "admin@example.com", displayName: "Admin" },
+        workspaces: [
+          {
+            id: workspaceId,
+            name: "example",
+            displayName: "Example",
+            setupCompletedAt: null,
+            grantedAt: "2026-08-20T00:00:00.000Z",
+          },
+        ],
+      },
+    }),
+  };
+}
+
+function services() {
+  return {
+    accountScope: { resolveCompatibilityWorkspaceId: vi.fn().mockResolvedValue(workspaceId) },
+    agentService: {
+      createForWorkspace: vi.fn().mockResolvedValue(agent),
+      listForWorkspace: vi.fn().mockResolvedValue({ agents: [agentListItem] }),
+      getById: vi.fn(),
+      getUsageById: vi.fn(),
+      getConfigById: vi.fn(),
+      updateById: vi.fn(),
+      suspendById: vi.fn(),
+      reactivateById: vi.fn(),
+      deleteById: vi.fn(),
+    },
+    machineAuthService: {
+      issueForWorkspaceAdmin: vi.fn().mockResolvedValue({
+        code: "connect-code-value",
+        expiresIn: 900,
+        issuedAt: new Date("2026-08-19T00:00:00.000Z"),
+      }),
+    },
+    workspaceService: {
+      listComputers: vi.fn().mockResolvedValue({ computers: [computerSummary] }),
+    },
+    workspaceSetupService: {
+      complete: vi.fn().mockResolvedValue({ setupCompletedAt: "2026-08-19T00:00:00.000Z" }),
+    },
+  };
+}
+
+function appWith(overrides: Partial<ReturnType<typeof services>> = {}) {
+  const service = { ...services(), ...overrides };
+  const app = createApp({
+    authService: authService(),
+    accountScope: service.accountScope as unknown as AccountScopeResolver,
+    agentService: service.agentService as unknown as AgentService,
+    machineAuthService: service.machineAuthService as unknown as MachineAuthService,
+    // The legacy connect-code route is gated behind the runtime Computer service; the Account-native
+    // route is not, so the equivalence comparison needs both registered.
+    computerService: {} as unknown as ComputerService,
+    workspaceService: service.workspaceService as unknown as WorkspaceAdminService,
+    workspaceSetupService: service.workspaceSetupService as unknown as WorkspaceSetupService,
+    computerConnectCode: { environment: "dev", publicUrl: "https://opentag.example" },
+  });
+  apps.push(app);
+  return { app, service };
+}
+
+describe("Account-native management collections", () => {
+  it("creates and lists Agents without a client-selected scope", async () => {
+    const { app, service } = appWith();
+
+    const create = await app.inject({
+      method: "POST",
+      url: HTTP_PATHS.accountAgents,
+      headers: authorization,
+      payload: createAgentPayload,
+    });
+    expect(create.statusCode).toBe(201);
+    expect(create.json()).toEqual(agent);
+    expect(service.agentService.createForWorkspace).toHaveBeenCalledWith(userId, workspaceId, createAgentPayload);
+    expect(service.accountScope.resolveCompatibilityWorkspaceId).toHaveBeenCalledWith(userId);
+
+    const list = await app.inject({ method: "GET", url: HTTP_PATHS.accountAgents, headers: authorization });
+    expect(list.statusCode).toBe(200);
+    expect(list.json()).toEqual({ agents: [agentListItem] });
+    expect(service.agentService.listForWorkspace).toHaveBeenCalledWith(userId, workspaceId);
+  });
+
+  it("returns the same resources as the legacy Workspace-scoped routes", async () => {
+    const { app } = appWith();
+
+    const [accountAgents, legacyAgents] = await Promise.all([
+      app.inject({ method: "GET", url: HTTP_PATHS.accountAgents, headers: authorization }),
+      app.inject({ method: "GET", url: workspaceAgentsPath(workspaceId), headers: authorization }),
+    ]);
+    expect(accountAgents.statusCode).toBe(legacyAgents.statusCode);
+    expect(accountAgents.json()).toEqual(legacyAgents.json());
+
+    const [accountComputers, legacyComputers] = await Promise.all([
+      app.inject({ method: "GET", url: HTTP_PATHS.accountComputers, headers: authorization }),
+      app.inject({ method: "GET", url: workspaceComputersPath(workspaceId), headers: authorization }),
+    ]);
+    expect(accountComputers.statusCode).toBe(legacyComputers.statusCode);
+    expect(accountComputers.json()).toEqual(legacyComputers.json());
+
+    const [accountSetup, legacySetup] = await Promise.all([
+      app.inject({
+        method: "POST",
+        url: HTTP_PATHS.accountSetupComplete,
+        headers: authorization,
+        payload: { agentId },
+      }),
+      app.inject({
+        method: "POST",
+        url: workspaceSetupCompletePath(workspaceId),
+        headers: authorization,
+        payload: { agentId },
+      }),
+    ]);
+    expect(accountSetup.statusCode).toBe(legacySetup.statusCode);
+    expect(accountSetup.json()).toEqual(legacySetup.json());
+
+    const [accountCode, legacyCode] = await Promise.all([
+      app.inject({ method: "POST", url: HTTP_PATHS.accountComputerConnectCodes, headers: authorization }),
+      app.inject({
+        method: "POST",
+        url: workspaceComputerConnectCodesPath(workspaceId),
+        headers: authorization,
+      }),
+    ]);
+    expect(accountCode.statusCode).toBe(201);
+    expect(accountCode.statusCode).toBe(legacyCode.statusCode);
+    expect(accountCode.json()).toEqual(legacyCode.json());
+    expect(accountCode.headers["cache-control"]).toBe("no-store");
+  });
+
+  it("forwards the provider readiness opt-in header", async () => {
+    const { app, service } = appWith();
+    await app.inject({
+      method: "GET",
+      url: HTTP_PATHS.accountComputers,
+      headers: { ...authorization, [PROVIDER_READINESS_V1_HEADER]: "1" },
+    });
+    expect(service.workspaceService.listComputers).toHaveBeenCalledWith(userId, workspaceId, true);
+
+    await app.inject({ method: "GET", url: HTTP_PATHS.accountComputers, headers: authorization });
+    expect(service.workspaceService.listComputers).toHaveBeenLastCalledWith(userId, workspaceId, false);
+  });
+
+  it("rejects a client-selected scope in the request body", async () => {
+    const { app, service } = appWith();
+
+    for (const payload of [
+      { ...createAgentPayload, workspaceId },
+      { ...createAgentPayload, accountId: userId },
+    ]) {
+      const response = await app.inject({
+        method: "POST",
+        url: HTTP_PATHS.accountAgents,
+        headers: authorization,
+        payload,
+      });
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error.code).toBe("VALIDATION_ERROR");
+    }
+    expect(service.agentService.createForWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("does not disclose whether an Account has no compatibility scope", async () => {
+    const { app, service } = appWith({
+      accountScope: {
+        resolveCompatibilityWorkspaceId: vi
+          .fn()
+          .mockRejectedValue(
+            new AuthServiceError("RESOURCE_NOT_FOUND", "deterministic", "The requested resource was not found", 404),
+          ),
+      },
+    });
+
+    for (const url of [HTTP_PATHS.accountAgents, HTTP_PATHS.accountComputers]) {
+      const response = await app.inject({ method: "GET", url, headers: authorization });
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error.code).toBe("RESOURCE_NOT_FOUND");
+    }
+    expect(service.agentService.listForWorkspace).not.toHaveBeenCalled();
+    expect(service.workspaceService.listComputers).not.toHaveBeenCalled();
+  });
+
+  it("keeps the legacy routes usable for older clients", async () => {
+    const { app, service } = appWith();
+    const response = await app.inject({
+      method: "POST",
+      url: workspaceAgentsPath(workspaceId),
+      headers: authorization,
+      payload: createAgentPayload,
+    });
+    expect(response.statusCode).toBe(201);
+    expect(service.agentService.createForWorkspace).toHaveBeenCalledWith(userId, workspaceId, createAgentPayload);
+    expect(service.accountScope.resolveCompatibilityWorkspaceId).not.toHaveBeenCalled();
+  });
+
+  it("requires an authenticated Account on every collection", async () => {
+    const { app, service } = appWith();
+
+    for (const [method, url] of [
+      ["GET", HTTP_PATHS.accountAgents],
+      ["POST", HTTP_PATHS.accountAgents],
+      ["GET", HTTP_PATHS.accountComputers],
+      ["POST", HTTP_PATHS.accountComputerConnectCodes],
+      ["POST", HTTP_PATHS.accountSetupComplete],
+    ] as const) {
+      const response = await app.inject({ method, url });
+      expect(response.statusCode).toBe(401);
+    }
+    expect(service.accountScope.resolveCompatibilityWorkspaceId).not.toHaveBeenCalled();
+  });
+
+  it("registers no Account-native collection without the compatibility resolver", async () => {
+    const app = createApp({
+      authService: authService(),
+      agentService: services().agentService as unknown as AgentService,
+    });
+    apps.push(app);
+    const response = await app.inject({ method: "GET", url: HTTP_PATHS.accountAgents, headers: authorization });
+    expect(response.statusCode).toBe(404);
+  });
+});

--- a/packages/server/src/__tests__/integration/account-scope-resolution.test.ts
+++ b/packages/server/src/__tests__/integration/account-scope-resolution.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createDatabaseClient } from "../../db/client.js";
+import { users, workspaceAdminGrants, workspaces } from "../../db/schema/index.js";
+import { WorkspaceAdminAccess } from "../../services/workspace-admin-access/index.js";
+import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
+
+let testDatabase: MigratedTestDatabase;
+let databaseUrl: string;
+
+beforeAll(async () => {
+  testDatabase = await startMigratedTestDatabase();
+  databaseUrl = testDatabase.databaseUrl;
+}, 120_000);
+
+afterAll(async () => testDatabase.stop());
+beforeEach(async () => testDatabase.reset());
+
+const EARLY = new Date("2026-08-01T00:00:00.000Z");
+const LATE = new Date("2026-08-20T00:00:00.000Z");
+const LOWER_UUID = "11111111-1111-4111-8111-111111111111";
+const HIGHER_UUID = "22222222-2222-4222-8222-222222222222";
+
+type Client = ReturnType<typeof createDatabaseClient>;
+
+async function withClient<T>(operation: (client: Client) => Promise<T>): Promise<T> {
+  const client = createDatabaseClient(databaseUrl);
+  try {
+    return await operation(client);
+  } finally {
+    await client.sql.end();
+  }
+}
+
+async function createAccount(client: Client, email: string, suspendedAt: Date | null = null): Promise<string> {
+  const [account] = await client.database
+    .insert(users)
+    .values({ displayName: "Account", email, suspendedAt })
+    .returning({ id: users.id });
+  if (!account) throw new Error("Account fixture was not created");
+  return account.id;
+}
+
+async function grantWorkspace(
+  client: Client,
+  input: { accountId: string; grantedAt: Date; id: string; name: string; revoked?: boolean; setupCompletedAt?: Date },
+): Promise<string> {
+  await client.database.insert(workspaces).values({
+    id: input.id,
+    name: input.name,
+    displayName: input.name,
+    setupCompletedAt: input.setupCompletedAt ?? null,
+  });
+  await client.database.insert(workspaceAdminGrants).values({
+    workspaceId: input.id,
+    userId: input.accountId,
+    grantedByUserId: input.accountId,
+    grantedAt: input.grantedAt,
+    ...(input.revoked ? { revokedByUserId: input.accountId, revokedAt: LATE } : {}),
+  });
+  return input.id;
+}
+
+/**
+ * The Account-native facade resolves every management call through this single compatibility fact, so the
+ * order is pinned here: setup-completed Workspace first, then earliest grant, then Workspace UUID.
+ */
+describe("Account compatibility scope resolution", () => {
+  it("prefers a setup-completed Workspace over an earlier grant", async () => {
+    await withClient(async (client) => {
+      const accountId = await createAccount(client, "ordering@example.com");
+      await grantWorkspace(client, { accountId, grantedAt: EARLY, id: LOWER_UUID, name: "incomplete-earlier" });
+      await grantWorkspace(client, {
+        accountId,
+        grantedAt: LATE,
+        id: HIGHER_UUID,
+        name: "completed-later",
+        setupCompletedAt: LATE,
+      });
+
+      const access = new WorkspaceAdminAccess(client.database);
+      expect(await access.resolveCompatibilityWorkspaceId(accountId)).toBe(HIGHER_UUID);
+    });
+  });
+
+  it("falls back to the earliest grant when no Workspace completed setup", async () => {
+    await withClient(async (client) => {
+      const accountId = await createAccount(client, "earliest@example.com");
+      await grantWorkspace(client, { accountId, grantedAt: LATE, id: LOWER_UUID, name: "granted-later" });
+      await grantWorkspace(client, { accountId, grantedAt: EARLY, id: HIGHER_UUID, name: "granted-earlier" });
+
+      const access = new WorkspaceAdminAccess(client.database);
+      expect(await access.resolveCompatibilityWorkspaceId(accountId)).toBe(HIGHER_UUID);
+    });
+  });
+
+  it("breaks a full tie on Workspace UUID", async () => {
+    await withClient(async (client) => {
+      const accountId = await createAccount(client, "tie@example.com");
+      await grantWorkspace(client, { accountId, grantedAt: EARLY, id: HIGHER_UUID, name: "higher" });
+      await grantWorkspace(client, { accountId, grantedAt: EARLY, id: LOWER_UUID, name: "lower" });
+
+      const access = new WorkspaceAdminAccess(client.database);
+      expect(await access.resolveCompatibilityWorkspaceId(accountId)).toBe(LOWER_UUID);
+    });
+  });
+
+  it("ignores revoked grants and other Accounts", async () => {
+    await withClient(async (client) => {
+      const accountId = await createAccount(client, "revoked@example.com");
+      const otherAccountId = await createAccount(client, "other@example.com");
+      await grantWorkspace(client, {
+        accountId,
+        grantedAt: EARLY,
+        id: LOWER_UUID,
+        name: "revoked-scope",
+        revoked: true,
+      });
+      await grantWorkspace(client, { accountId: otherAccountId, grantedAt: EARLY, id: HIGHER_UUID, name: "other" });
+
+      const access = new WorkspaceAdminAccess(client.database);
+      await expect(access.resolveCompatibilityWorkspaceId(accountId)).rejects.toMatchObject({
+        code: "RESOURCE_NOT_FOUND",
+        statusCode: 404,
+      });
+      expect(await access.resolveCompatibilityWorkspaceId(otherAccountId)).toBe(HIGHER_UUID);
+    });
+  });
+
+  it("does not disclose a scope to an Account with no grant or a suspended Account", async () => {
+    await withClient(async (client) => {
+      const withoutGrant = await createAccount(client, "no-grant@example.com");
+      const suspended = await createAccount(client, "suspended@example.com", LATE);
+      await grantWorkspace(client, { accountId: suspended, grantedAt: EARLY, id: LOWER_UUID, name: "suspended-scope" });
+
+      const access = new WorkspaceAdminAccess(client.database);
+      for (const accountId of [withoutGrant, suspended]) {
+        await expect(access.resolveCompatibilityWorkspaceId(accountId)).rejects.toMatchObject({
+          code: "RESOURCE_NOT_FOUND",
+          statusCode: 404,
+        });
+      }
+    });
+  });
+});

--- a/packages/server/src/api/account.ts
+++ b/packages/server/src/api/account.ts
@@ -1,4 +1,5 @@
 import {
+  AccountComputerConnectCodeIssueRequestSchema,
   AgentAdminConfigSchema,
   type ChannelName,
   CompleteWorkspaceSetupRequestSchema,
@@ -108,6 +109,7 @@ export function registerAccountRoutes(
     const { environment, publicUrl } = options.computerConnectCode;
 
     app.post(HTTP_PATHS.accountComputerConnectCodes, { preHandler }, async (request, reply) => {
+      parseRequest(AccountComputerConnectCodeIssueRequestSchema, request.body ?? {});
       const scope = await scopeOf(request);
       const issued = await machineAuthService.issueForWorkspaceAdmin(scope.accountId, scope.workspaceId);
       return reply

--- a/packages/server/src/api/account.ts
+++ b/packages/server/src/api/account.ts
@@ -1,0 +1,141 @@
+import {
+  AgentAdminConfigSchema,
+  type ChannelName,
+  CompleteWorkspaceSetupRequestSchema,
+  ComputerConnectCodeIssueResponseSchema,
+  CreateAgentRequestSchema,
+  HTTP_PATHS,
+  ListAgentsResponseSchema,
+  ListWorkspaceComputersResponseSchema,
+  PROVIDER_READINESS_V1_HEADER,
+  WorkspaceSetupCompletionSchema,
+} from "@opentag/shared";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import type { AgentService } from "../services/agents/index.js";
+import type { UserAuthService } from "../services/auth/index.js";
+import { buildComputerConnectCommand, type MachineAuthService } from "../services/computers/index.js";
+import type { WorkspaceAdminService, WorkspaceSetupService } from "../services/workspaces/index.js";
+import { parseRequest } from "./request-validation.js";
+
+/**
+ * Resolves the authenticated Account to the compatibility Workspace that still backs management storage.
+ * `WorkspaceAdminAccess` is the only implementation; the seam exists so that removing it is a single
+ * deletion once Agents and enrollments carry a direct Account owner.
+ */
+export interface AccountScopeResolver {
+  resolveCompatibilityWorkspaceId(accountId: string): Promise<string>;
+}
+
+export interface AccountRoutesOptions {
+  accountScope: AccountScopeResolver;
+  agentService?: AgentService;
+  computerConnectCode?: { environment: ChannelName; publicUrl: string };
+  machineAuthService?: MachineAuthService;
+  publicOrigin?: string;
+  workspaceService?: WorkspaceAdminService;
+  workspaceSetupService?: WorkspaceSetupService;
+}
+
+function accountId(request: FastifyRequest): string {
+  const value = request.authContext?.me.user.id;
+  if (!value) throw new Error("Authenticated Account context is missing");
+  return value;
+}
+
+/**
+ * Account-native management collections. Ownership comes only from the authenticated Account: these routes
+ * accept neither a management `workspaceId` nor a client-selected `accountId`, and the legacy
+ * Workspace-scoped routes stay registered alongside them for the compatibility window.
+ */
+export function registerAccountRoutes(
+  app: FastifyInstance,
+  authService: UserAuthService,
+  options: AccountRoutesOptions,
+): void {
+  const preHandler = createUserAuthPreHandler(authService, { publicOrigin: options.publicOrigin });
+  const { accountScope } = options;
+
+  async function scopeOf(request: FastifyRequest): Promise<{ accountId: string; workspaceId: string }> {
+    const account = accountId(request);
+    return { accountId: account, workspaceId: await accountScope.resolveCompatibilityWorkspaceId(account) };
+  }
+
+  if (options.agentService) {
+    const agentService = options.agentService;
+
+    app.post(HTTP_PATHS.accountAgents, { preHandler }, async (request, reply) => {
+      const input = parseRequest(CreateAgentRequestSchema, request.body);
+      const scope = await scopeOf(request);
+      return reply
+        .code(201)
+        .send(
+          AgentAdminConfigSchema.parse(
+            await agentService.createForWorkspace(scope.accountId, scope.workspaceId, input),
+          ),
+        );
+    });
+
+    app.get(HTTP_PATHS.accountAgents, { preHandler }, async (request, reply) => {
+      const scope = await scopeOf(request);
+      return reply
+        .code(200)
+        .send(ListAgentsResponseSchema.parse(await agentService.listForWorkspace(scope.accountId, scope.workspaceId)));
+    });
+  }
+
+  if (options.workspaceService) {
+    const workspaceService = options.workspaceService;
+
+    app.get(HTTP_PATHS.accountComputers, { preHandler }, async (request, reply) => {
+      const scope = await scopeOf(request);
+      return reply
+        .code(200)
+        .send(
+          ListWorkspaceComputersResponseSchema.parse(
+            await workspaceService.listComputers(
+              scope.accountId,
+              scope.workspaceId,
+              request.headers[PROVIDER_READINESS_V1_HEADER] === "1",
+            ),
+          ),
+        );
+    });
+  }
+
+  if (options.machineAuthService && options.computerConnectCode) {
+    const machineAuthService = options.machineAuthService;
+    const { environment, publicUrl } = options.computerConnectCode;
+
+    app.post(HTTP_PATHS.accountComputerConnectCodes, { preHandler }, async (request, reply) => {
+      const scope = await scopeOf(request);
+      const issued = await machineAuthService.issueForWorkspaceAdmin(scope.accountId, scope.workspaceId);
+      return reply
+        .header("Cache-Control", "no-store")
+        .code(201)
+        .send(
+          ComputerConnectCodeIssueResponseSchema.parse({
+            bootstrapCommand: buildComputerConnectCommand({ code: issued.code, environment, publicUrl }),
+            expiresIn: issued.expiresIn,
+            issuedAt: issued.issuedAt.toISOString(),
+          }),
+        );
+    });
+  }
+
+  if (options.workspaceSetupService) {
+    const workspaceSetupService = options.workspaceSetupService;
+
+    app.post(HTTP_PATHS.accountSetupComplete, { preHandler }, async (request, reply) => {
+      const { agentId } = parseRequest(CompleteWorkspaceSetupRequestSchema, request.body);
+      const scope = await scopeOf(request);
+      return reply
+        .code(200)
+        .send(
+          WorkspaceSetupCompletionSchema.parse(
+            await workspaceSetupService.complete(scope.accountId, scope.workspaceId, agentId),
+          ),
+        );
+    });
+  }
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -3,6 +3,7 @@ import websocket from "@fastify/websocket";
 import type { ChannelName } from "@opentag/shared";
 import { ErrorEnvelopeSchema, HTTP_PATHS, ServerHealthSchema } from "@opentag/shared";
 import Fastify, { type FastifyLoggerOptions } from "fastify";
+import { type AccountScopeResolver, registerAccountRoutes } from "./api/account.js";
 import { registerAgentRoutes } from "./api/agents.js";
 import { registerAuthRoutes } from "./api/auth.js";
 import { type BrowserAuthRoutesOptions, registerBrowserAuthRoutes } from "./api/browser-auth.js";
@@ -31,6 +32,8 @@ import {
 import { registerWebApp } from "./web-app.js";
 
 export interface CreateAppOptions {
+  /** Enables the Account-native management collections that back the Workspace-free client contracts. */
+  accountScope?: AccountScopeResolver;
   authService?: UserAuthService;
   webAppRoot?: string;
   agentService?: AgentService;
@@ -184,6 +187,17 @@ export function createApp(options: CreateAppOptions = {}) {
     }
     if (options.workspaceService) {
       registerWorkspaceRoutes(app, authService, options.workspaceService, publicOrigin, options.workspaceSetupService);
+    }
+    if (options.accountScope) {
+      registerAccountRoutes(app, authService, {
+        accountScope: options.accountScope,
+        ...(options.agentService ? { agentService: options.agentService } : {}),
+        ...(options.computerConnectCode ? { computerConnectCode: options.computerConnectCode } : {}),
+        ...(options.machineAuthService ? { machineAuthService: options.machineAuthService } : {}),
+        ...(options.workspaceService ? { workspaceService: options.workspaceService } : {}),
+        ...(options.workspaceSetupService ? { workspaceSetupService: options.workspaceSetupService } : {}),
+        publicOrigin,
+      });
     }
     if (options.imBindingService) {
       registerImBindingRoutes(

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -240,6 +240,7 @@ export async function startServer(): Promise<void> {
     const dev = config.devAuth ? new DevBrowserAuthService(database, authService, config.devAuth.email) : undefined;
     app = createApp({
       webAppRoot: defaultWebAppRoot,
+      accountScope: workspaceAdmins,
       agentService,
       authService,
       browserAuth: {

--- a/packages/server/src/services/workspace-admin-access/workspace-admin-access.ts
+++ b/packages/server/src/services/workspace-admin-access/workspace-admin-access.ts
@@ -154,6 +154,18 @@ export class WorkspaceAdminAccess {
       ) as Promise<AdminWorkspace[]>;
   }
 
+  /**
+   * Resolves the authenticated Account to the single compatibility Workspace that Account-native routes
+   * operate on, using the same deterministic order as `/me`: setup-completed first, then earliest grant,
+   * then Workspace UUID. This is the only transitional fact behind the Account-native facade and is
+   * removed once Agents and enrollments carry a direct Account owner.
+   */
+  async resolveCompatibilityWorkspaceId(accountId: string): Promise<string> {
+    const [workspace] = await this.listActiveAdminWorkspaces(accountId);
+    if (!workspace) throw workspaceNotFound();
+    return workspace.workspaceId;
+  }
+
   async establishDefaultWorkspaceForNewAccount(
     transaction: DatabaseTransaction,
     account: { displayName: string; id: string },

--- a/packages/shared/src/computer.ts
+++ b/packages/shared/src/computer.ts
@@ -31,6 +31,12 @@ export const ComputerConnectCodeExchangeResponseSchema = z
 
 export const ComputerConnectCodeIssueRequestSchema = z.object({ workspaceId: z.string().uuid() }).strict();
 
+/**
+ * The Account-native connect-code request carries no scope: the issuing Account comes from the access
+ * token alone, so any client-selected `workspaceId` or `accountId` is rejected rather than ignored.
+ */
+export const AccountComputerConnectCodeIssueRequestSchema = z.object({}).strict();
+
 export const ComputerConnectCodeIssueResponseSchema = z
   .object({
     bootstrapCommand: z.string().min(1),
@@ -108,6 +114,7 @@ export type ComputerConnectCodeExchangeRequest = z.infer<typeof ComputerConnectC
 export type ComputerConnectCodeExchangeResponse = z.infer<typeof ComputerConnectCodeExchangeResponseSchema>;
 export type ComputerConnectCodeIssueRequest = z.infer<typeof ComputerConnectCodeIssueRequestSchema>;
 export type ComputerConnectCodeIssueResponse = z.infer<typeof ComputerConnectCodeIssueResponseSchema>;
+export type AccountComputerConnectCodeIssueRequest = z.infer<typeof AccountComputerConnectCodeIssueRequestSchema>;
 export type ComputerConnectionStatus = z.infer<typeof ComputerConnectionStatusSchema>;
 export type ProviderReadinessStatus = z.infer<typeof ProviderReadinessStatusSchema>;
 export type ImCliReadinessStatus = z.infer<typeof ImCliReadinessStatusSchema>;

--- a/packages/shared/src/http-paths.ts
+++ b/packages/shared/src/http-paths.ts
@@ -21,7 +21,20 @@ export const RUNTIME_IM_RESOURCE_TEMPLATE = `${API_V1_PREFIX}/runtime/im-message
 export const WORKSPACE_COMPUTERS_TEMPLATE = `${API_V1_PREFIX}/workspaces/:workspaceId/computers`;
 export const WORKSPACE_COMPUTER_CONNECT_CODES_TEMPLATE = `${WORKSPACE_BY_ID_TEMPLATE}/computer-connect-codes`;
 
+/**
+ * Account-native management collections. Ownership comes only from the authenticated Account, so these
+ * paths accept neither a management `workspaceId` nor a client-selected `accountId`.
+ */
+export const ACCOUNT_AGENTS_PATH = `${API_V1_PREFIX}/agents`;
+export const ACCOUNT_COMPUTERS_PATH = `${API_V1_PREFIX}/computers`;
+export const ACCOUNT_COMPUTER_CONNECT_CODES_PATH = `${API_V1_PREFIX}/computer-connect-codes`;
+export const ACCOUNT_SETUP_COMPLETE_PATH = `${API_V1_PREFIX}/me/setup/complete`;
+
 export const HTTP_PATHS = {
+  accountAgents: ACCOUNT_AGENTS_PATH,
+  accountComputerConnectCodes: ACCOUNT_COMPUTER_CONNECT_CODES_PATH,
+  accountComputers: ACCOUNT_COMPUTERS_PATH,
+  accountSetupComplete: ACCOUNT_SETUP_COMPLETE_PATH,
   agentById: AGENT_BY_ID_TEMPLATE,
   slackEvents: SLACK_EVENTS_PATH,
   authConnectExchange: `${API_V1_PREFIX}/auth/connect/exchange`,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -81,6 +81,8 @@ export {
   ServiceIdSchema,
 } from "./channel.js";
 export {
+  type AccountComputerConnectCodeIssueRequest,
+  AccountComputerConnectCodeIssueRequestSchema,
   type ComputerConnectCodeExchangeRequest,
   ComputerConnectCodeExchangeRequestSchema,
   type ComputerConnectCodeExchangeResponse,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -124,6 +124,10 @@ export {
 } from "./errors.js";
 export { type ServerHealth, ServerHealthSchema } from "./health.js";
 export {
+  ACCOUNT_AGENTS_PATH,
+  ACCOUNT_COMPUTER_CONNECT_CODES_PATH,
+  ACCOUNT_COMPUTERS_PATH,
+  ACCOUNT_SETUP_COMPLETE_PATH,
   AGENT_BY_ID_TEMPLATE,
   AGENT_CONFIG_TEMPLATE,
   AGENT_FEISHU_SETUP_ATTEMPTS_TEMPLATE,


### PR DESCRIPTION
Phase 2 PR 2A for #179.

## Summary

Adds Account-native management collections that take ownership only from the authenticated Account, so clients stop selecting a management scope:

| New route | Delegates to |
| --- | --- |
| `GET` / `POST /api/v1/agents` | `AgentService.listForWorkspace` / `createForWorkspace` |
| `GET /api/v1/computers` | `WorkspaceAdminService.listComputers` |
| `POST /api/v1/computer-connect-codes` | `MachineAuthService.issueForWorkspaceAdmin` |
| `POST /api/v1/me/setup/complete` | `WorkspaceSetupService.complete` |

The whole compatibility window is concentrated in one method, `WorkspaceAdminAccess.resolveCompatibilityWorkspaceId`. It reuses `listActiveAdminWorkspaces`, so it is guaranteed to select the same Workspace that `/me` already publishes: setup-completed first, then earliest grant, then Workspace UUID. No active grant returns 404 without disclosing whether a scope exists. Removing that seam is a single deletion once Agents and enrollments carry a direct Account owner.

Every creation route refuses a client-selected scope rather than ignoring it: `workspaceId` and `accountId` are rejected with 400 on all three of `POST /agents`, `POST /computer-connect-codes`, and `POST /me/setup/complete`.

Everything else is unchanged on purpose:

- every legacy Workspace-scoped route stays registered for the compatibility window;
- the current strict DTOs are reused as-is, deprecated response `workspaceId` fields included;
- no schema, migration, owner column, dual write, mismatch diagnostic, or data mutation;
- the Agent execution workspace is untouched.

The facade lives in its own `packages/server/src/api/account.ts`, so the later cutover deletes `api/workspaces.ts` and the legacy handlers while this file survives.

### Note on an existing asymmetry

The legacy connect-code route is gated behind `options.computerService` (`app.ts`), which is really the gate for the runtime WebSocket route and unrelated to issuing connect codes. The Account-native route is gated on `machineAuthService` + `computerConnectCode` instead. Production wires both, so there is no behavioral difference; it only means the equivalence test has to register a `computerService` stub, which is called out in a comment there.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test` — all pass.
- `packages/server/src/__tests__/account-api.test.ts` (9 tests): facade-vs-legacy resource equivalence on all four collections, provider-readiness header forwarding, rejection of a client-supplied `workspaceId` / `accountId` on every creation route, an absent or empty connect-code body still issuing a code, non-disclosing 404 when no scope resolves, legacy routes still usable by older clients, authentication required on every collection, and no registration without the resolver.
- `packages/server/src/__tests__/integration/account-scope-resolution.test.ts` (5 tests): pins the deterministic selection order — setup-completed first, earliest grant, UUID tie-break — plus revoked-grant exclusion, cross-Account isolation, and no-grant / suspended-Account 404. That ordering had no test coverage before this PR, even though Phase 1 Web already depends on it.
- Server unit tests: 239 → 248.

The integration tests cannot run in the authoring sandbox (the testcontainers images are unreachable there), so CI is their first execution. The HTTP-level tests run locally and pass.

## Breaking changes

None. This PR is purely additive: no route, contract, field, or storage behavior is removed or altered, and old clients keep working against the legacy routes.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable. (No documentation changed; the routes stay internal until the Web and CLI consumers move.)