### PR TITLE
test(server): synchronize the stale-connection trace case on the server close

### DIFF
--- a/packages/server/src/observability/__tests__/observability.test.ts
+++ b/packages/server/src/observability/__tests__/observability.test.ts
@@ -586,12 +586,13 @@ describe("background and WebSocket tracing", () => {
       workspaceId: randomUUID(),
       computerId: randomUUID(),
     };
+    const registry = new ConnectionRegistry();
     const app = createApp({
       authService: runtimeAuthService() as never,
       machineAuthService: { verifyMachineToken: vi.fn().mockResolvedValue(machine) } as never,
       computerService: runtimeComputerService() as never,
       runtime: {
-        registry: new ConnectionRegistry(),
+        registry,
         business: {
           parse: (value) => runtimeTestFrame(value),
           laneKey: (frame) => String(frame.key),
@@ -657,8 +658,16 @@ describe("background and WebSocket tracing", () => {
     const overloadedRequestId = randomUUID();
     socket.send(JSON.stringify({ type: "test:work", requestId: overloadedRequestId, key: "slow" }));
     expect(await frames.next()).toMatchObject({ type: "test:result", requestId: overloadedRequestId, status: "busy" });
+    expect(registry.currentInstanceId(machine.workspaceComputerId)).toBe(registration.instanceId);
     socket.close();
-    await new Promise<void>((resolve) => socket.once("close", () => resolve()));
+    // The client socket's own close event proves nothing about the server: the server observes the
+    // close on a separate socket object, and only that handler aborts the session, closes the
+    // scheduler, and drops the registry entry. Releasing the held work before then lets it complete
+    // against a connection the server still considers live, which is traced as "handled". Wait for
+    // the registry entry to disappear so the release always happens after the server-observed close.
+    await vi.waitFor(() => expect(registry.currentInstanceId(machine.workspaceComputerId)).toBeUndefined(), {
+      timeout: 5_000,
+    });
     releaseSlow?.();
     await vi.waitFor(() => {
       const outcomes = exporter


### PR DESCRIPTION
Fixes the flaky `background and WebSocket tracing > traces real RuntimeSession failure, overload, and dropped-queue terminal paths` case that has been sitting on the required CI path and getting waved through as a "pre-existing baseline failure" for the past ten days.

## Summary

- The failure is a defect in the test, not in the tracing code. `RuntimeSession` traces a frame that completes after a server-observed close as `stale_connection` exactly as intended; the test was releasing the held work before the server had observed anything.
- The case now synchronizes on a server-observed signal — the `ConnectionRegistry` no longer reporting a current instance for the Computer — instead of the client socket's own `close` event, before releasing the held `slow` promise.
- The registry instance is hoisted into a local so the test can read it. That is the only other change; `createApp` already accepts it through `runtime.registry`.
- A pre-condition assertion (`registry.currentInstanceId(...)` equals the registered `instanceId`) is added immediately before `socket.close()`. Without it, a wrong registry key would make the wait pass instantly and silently reintroduce the same race.
- No production source is touched. The diff is 11 insertions and 2 deletions in one test file.

## Root cause

The case saturates the scheduler (`maxConcurrent: 1`, `maxQueuedPerKey: 1`, `maxQueuedTotal: 1`), confirms the third frame is rejected as `busy`, closes the socket, and then releases the held `slow` work, expecting the frames that complete afterwards to be traced as `stale_connection`.

The synchronization between the close and the release was wrong. It awaited `socket.once("close")` on the **client** socket and then asserted on **server** state. Those are two different socket objects with two independent `close` events. Everything the assertion depends on happens only in the server's handler, `RuntimeSession.#onClose`:

```ts
this.#state = "closed";
this.#abort.abort();
this.#businessScheduler?.close();   // drops the queued frame -> onDrop -> stale_connection
... this.#registry.remove(...)      // last step
```

and `#canSendBusiness` — the predicate that decides `handled` versus `stale_connection` — is false only once those have run:

```ts
!context.signal.aborted && this.#state === "registered" &&
context.connectionId === this.#connectionId &&
this.#registry.isCurrent(context.workspaceComputerId, context.instanceId, this.#socket)
```

On loopback the client's `close` normally fires first, so the release landed while the server still held a live, registered, non-aborted connection. The in-flight frame then completed successfully, the queued frame was pumped and completed too, and both were traced `handled` — which is the honest outcome for a connection the server still considered live. Hence the observed `["failed", "failed", "overloaded", "handled", "handled"]`.

The fix waits on `registry.currentInstanceId(machine.workspaceComputerId)` becoming `undefined`. `registry.remove` is the **last** statement in `#onClose`, so that signal implies the abort and the scheduler close have already happened. After it, the queued frame has been dropped through `onDrop` and the in-flight frame observes a dead connection on resume. I confirmed the outcome sequence is now deterministically `["failed", "failed", "overloaded", "stale_connection", "stale_connection"]` by temporarily tightening the assertion to an exact `toEqual` and running it repeatedly; the committed assertion is left exactly as it was.

I checked the other cases in this file for the same client-versus-server mistake. There are none — this is the only case that drives a real WebSocket, and every other wait in the file is either on a server-side mock or on `vi.waitFor` over exported spans. For the record, `packages/server/src/__tests__/runtime.test.ts:214` also awaits the client `close`, but it then follows up with `vi.waitFor` on `computers.disconnect`, a genuine server-observed signal, so it is already correct and is left alone.

## Validation

Measured on this machine, Node v25.8.1, macOS.

| Command | Before | After |
| --- | --- | --- |
| `pnpm --filter @opentag/server exec vitest run src/observability/__tests__/observability.test.ts --maxWorkers=1` | **1 pass / 5 fail out of 6** | **15 pass / 0 fail out of 15** |

The before figure reproduces the reported rate exactly, and every failure was the reported one: `["failed", "failed", "overloaded", "handled", "handled"]` against `arrayContaining([..., "stale_connection"])`.

Full gates, all run on the committed tree:

- `pnpm --filter @opentag/server test` — 37 files, **257/257 pass**.
- `pnpm check` — passes (434 files, no fixes; third-party notices verified).
- `pnpm build` — passes.
- `pnpm typecheck` — passes.
- `pnpm test` — server, shared, and client pass. Two CLI cases fail: `apps/cli/src/__tests__/daemon-service-renderers.test.ts` and `apps/cli/src/__tests__/daemon-service-shared.test.ts`, both "stale PATH shim". These are pre-existing, unrelated to this change (this PR touches only `packages/server`), caused by a macOS temp-path issue, and are being fixed in a sibling PR. They are untouched here.
- `pnpm --filter @opentag/server test:integration` — 8 files, **156/156 pass** against Docker.

## Non-goals

- No production source change. If the tracing itself had been wrong this would have been a `fix(server)` PR instead; it is not, and papering over a production bug with a test change was explicitly off the table.
- The assertion is not weakened. `expect(outcomes).toEqual(expect.arrayContaining(["failed", "overloaded", "stale_connection"]))` and `expect(outcomes).toHaveLength(5)` are byte-for-byte unchanged, so the case still proves that work completing after the connection died is traced as `stale_connection`.
- No `setTimeout` sleep is introduced. The wait is `vi.waitFor` over a real condition; the explicit `timeout: 5_000` is only an upper bound for a loaded CI runner, not the synchronization mechanism.
- The two CLI "stale PATH shim" failures are deliberately not touched.
- No shared test helper was extracted. The synchronization is two lines and is specific to this case, so a helper would have been indirection without a second caller.

## Breaking changes

None. Test-only change.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. — `check`, `build`, and `typecheck` pass. `pnpm test` is green everywhere except the two pre-existing `apps/cli` "stale PATH shim" cases described under Validation, which fail on `main` too and are owned by a sibling PR. This box goes green once that lands.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable. (No documentation changed.)
