### PR TITLE
test: canonicalize temporary directories in test helpers

### DIFF
--- a/apps/cli/src/__tests__/computer-connect.test.ts
+++ b/apps/cli/src/__tests__/computer-connect.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readCredentials, readMachineCredentials, writeCredentialsAtomically } from "@opentag/client";
@@ -131,7 +131,8 @@ describe("computer connect", () => {
 });
 
 async function temporaryHome(): Promise<string> {
-  const home = await mkdtemp(join(tmpdir(), "opentag-computer-connect-"));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const home = await realpath(await mkdtemp(join(tmpdir(), "opentag-computer-connect-")));
   homes.push(home);
   return home;
 }

--- a/apps/cli/src/__tests__/daemon-owner.test.ts
+++ b/apps/cli/src/__tests__/daemon-owner.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -90,7 +90,8 @@ describe("daemon owner inspection", () => {
 });
 
 async function temporaryDirectory(): Promise<string> {
-  const path = await mkdtemp(join(tmpdir(), "opentag-owner-"));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const path = await realpath(await mkdtemp(join(tmpdir(), "opentag-owner-")));
   directories.push(path);
   return path;
 }

--- a/apps/cli/src/__tests__/daemon-service-renderers.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-renderers.test.ts
@@ -832,7 +832,8 @@ function fakeRunner(handler: (program: string, args: readonly string[]) => Comma
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {
-  const path = await mkdtemp(join(tmpdir(), prefix));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const path = await realpath(await mkdtemp(join(tmpdir(), prefix)));
   directories.push(path);
   return path;
 }

--- a/apps/cli/src/__tests__/daemon-service-shared.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-shared.test.ts
@@ -428,7 +428,8 @@ function parseTestLease(value: unknown): TestLeaseRecord {
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {
-  const path = await mkdtemp(join(tmpdir(), prefix));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const path = await realpath(await mkdtemp(join(tmpdir(), prefix)));
   directories.push(path);
   return path;
 }

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -269,6 +269,7 @@ resolved path.
 On 2026-08-27 that change measured locally on macOS, through
 `turbo run test --continue`, as `@opentag/shared` 67/67, `@opentag/web`
 322/322, `apps/cli` 124/124 and `@opentag/client` 463/463, with
-`@opentag/server` at 256/257: its `observability` tracing case fails there for
-unrelated reasons and is tracked separately. The same commit ran green across
-all five packages in CI, where that case did not reproduce.
+`@opentag/server` at 256/257: its `observability` tracing case raced the
+server close there, which #187 has since fixed on `main` in `22001a6`, so
+that case passes from that commit onward. That same change ran green across
+all five packages in CI, where the case did not reproduce.

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -257,8 +257,18 @@ preserved, and the Runs produced 53 and 95 ordered events respectively. The
 Client manifests contain no Pi package, SDK, CLI, or bundled-binary dependency.
 
 The two macOS CLI failures this command used to retain, caused solely by `/tmp`
-versus `/private/tmp` path spelling, no longer occur. Every temporary-directory
-test helper canonicalizes its directory with `realpath`, so fixture paths match
-the canonical paths the code under test resolves, on every platform and under
-Turborepo's strict environment mode. No `TMPDIR` override is required. All
-package tests passed; the Pi and Client suites are green.
+versus `/private/tmp` path spelling, no longer occur. The 13 reusable
+temporary-directory helpers across the CLI and Client suites now canonicalize
+with `realpath`, so the fixture paths they hand out match the canonical paths
+the code under test resolves, on every platform and under Turborepo's strict
+environment mode. No `TMPDIR` override is required. Tests that call `mkdtemp`
+inline still receive raw paths, which is harmless where the directory serves
+only as a filesystem location rather than as a string compared against a
+resolved path.
+
+On 2026-08-27 that change measured locally on macOS, through
+`turbo run test --continue`, as `@opentag/shared` 67/67, `@opentag/web`
+322/322, `apps/cli` 124/124 and `@opentag/client` 463/463, with
+`@opentag/server` at 256/257: its `observability` tracing case fails there for
+unrelated reasons and is tracked separately. The same commit ran green across
+all five packages in CI, where that case did not reproduce.

--- a/docs/design/agent-runtime-test-plan.md
+++ b/docs/design/agent-runtime-test-plan.md
@@ -256,6 +256,9 @@ both create and resumed Runs completed, the materialized opaque binding was
 preserved, and the Runs produced 53 and 95 ordered events respectively. The
 Client manifests contain no Pi package, SDK, CLI, or bundled-binary dependency.
 
-The monorepo test command retains two unrelated existing macOS CLI failures
-caused solely by `/tmp` versus `/private/tmp` path spelling. All other package
-tests passed; the Pi and Client suites are green.
+The two macOS CLI failures this command used to retain, caused solely by `/tmp`
+versus `/private/tmp` path spelling, no longer occur. Every temporary-directory
+test helper canonicalizes its directory with `realpath`, so fixture paths match
+the canonical paths the code under test resolves, on every platform and under
+Turborepo's strict environment mode. No `TMPDIR` override is required. All
+package tests passed; the Pi and Client suites are green.

--- a/packages/client/src/__tests__/agent-workspace.test.ts
+++ b/packages/client/src/__tests__/agent-workspace.test.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { chmod, mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import {
@@ -624,13 +624,14 @@ async function readWorkspaceState(workspace: AgentWorkspaceManager, agentId: str
 }
 
 async function temporaryHome(): Promise<string> {
-  const home = await mkdtemp(resolve(tmpdir(), "opentag-client-test-"));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const home = await realpath(await mkdtemp(resolve(tmpdir(), "opentag-client-test-")));
   homes.push(home);
   return home;
 }
 
 async function realpathForTest(path: string): Promise<string> {
-  return (await import("node:fs/promises")).realpath(path);
+  return await realpath(path);
 }
 
 function sha256(value: string): string {

--- a/packages/client/src/__tests__/auth.test.ts
+++ b/packages/client/src/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, realpath, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -20,7 +20,8 @@ afterEach(async () => {
 });
 
 async function temporaryHome(): Promise<string> {
-  const path = await mkdtemp(join(tmpdir(), "opentag-auth-"));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const path = await realpath(await mkdtemp(join(tmpdir(), "opentag-auth-")));
   temporaryDirectories.push(path);
   return path;
 }

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -893,7 +893,8 @@ function argumentAfter(args: readonly string[], flag: string): string | undefine
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), prefix));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const directory = await realpath(await mkdtemp(join(tmpdir(), prefix)));
   directories.push(directory);
   return directory;
 }

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -1850,7 +1850,8 @@ async function runtimeServer(): Promise<{ close(): Promise<void>; url: string; w
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {
-  const directory = await mkdtemp(resolve(tmpdir(), prefix));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const directory = await realpath(await mkdtemp(resolve(tmpdir(), prefix)));
   directories.push(directory);
   return directory;
 }

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1675,7 +1675,8 @@ async function interact(
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), prefix));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const directory = await realpath(await mkdtemp(join(tmpdir(), prefix)));
   directories.push(directory);
   return directory;
 }

--- a/packages/client/src/__tests__/im-credential-environment-manager.test.ts
+++ b/packages/client/src/__tests__/im-credential-environment-manager.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -364,7 +364,8 @@ describe("ImCredentialEnvironmentManager", () => {
 });
 
 async function temporaryHome(): Promise<string> {
-  const home = await mkdtemp(join(tmpdir(), "opentag-im-credentials-"));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const home = await realpath(await mkdtemp(join(tmpdir(), "opentag-im-credentials-")));
   homes.push(home);
   return home;
 }

--- a/packages/client/src/__tests__/pi-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/pi-agent-runtime-exhaustive.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -910,7 +910,8 @@ async function probeCli(body: string): Promise<string> {
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), prefix));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const directory = await realpath(await mkdtemp(join(tmpdir(), prefix)));
   directories.push(directory);
   return directory;
 }

--- a/packages/client/src/observability/__tests__/logger.test.ts
+++ b/packages/client/src/observability/__tests__/logger.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -82,7 +82,8 @@ describe("Client logger", () => {
 });
 
 async function temporaryDirectory(): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), "opentag-logger-"));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const directory = await realpath(await mkdtemp(join(tmpdir(), "opentag-logger-")));
   directories.push(directory);
   return directory;
 }

--- a/packages/client/src/observability/__tests__/rotating-file-stream.test.ts
+++ b/packages/client/src/observability/__tests__/rotating-file-stream.test.ts
@@ -1,5 +1,5 @@
 import { writeSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -146,7 +146,8 @@ describe("RotatingFileStream", () => {
 });
 
 async function temporaryDirectory(): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), "opentag-rotation-"));
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const directory = await realpath(await mkdtemp(join(tmpdir(), "opentag-rotation-")));
   directories.push(directory);
   return directory;
 }


### PR DESCRIPTION
## Summary

- Fixes, at the root cause, the failure class this repository has been recording as a "pre-existing macOS canonical-path baseline" in fourteen merged pull requests (most recently #178, #173, #171, #170).
- Every temporary-directory test helper returned the raw `mkdtemp` result. On macOS that path is unresolved — `/var/folders/…/T/…` from the ambient `TMPDIR`, or `/tmp/…` when `TMPDIR` is absent — while the code under test canonicalizes (`apps/cli/src/core/daemon/service/shared.ts:86` returns `program: await realpath(bin).catch(() => bin)`). A fixture path and the resolved path it was compared against could therefore never be equal.
- Two CLI assertions failed on **every** macOS run of `turbo run test`:
  - `daemon-service-renderers.test.ts` › `systemd service backend` › renders the service with the newly installed binary before a stale PATH shim
  - `daemon-service-shared.test.ts` › `daemon service primitives` › resolves the freshly installed dev binary before a stale PATH shim
- The documented `TMPDIR=/private/tmp` workaround is **silently ineffective through `pnpm test`**: `turbo.json` does not list `TMPDIR` in `globalPassThroughEnv`, and Turborepo's strict environment mode filters it out. That is why the failures survived as a permanent baseline rather than being fixed — the workaround only ever worked when a package's `vitest` was invoked directly.
- Each of the 13 helpers now returns `await realpath(await mkdtemp(…))`, matching the convention the Codex capability probe already uses (`packages/client/src/providers/codex/agent-runtime.ts:745`). Cleanup registration (`directories.push` / `homes.push`) and removal operate on the canonical path, which resolves to the same directory.
- Applied to all helpers of this shape, including the ones that currently pass, because the latent bug is identical in each. Beyond the nine known sites, the sweep found four more with the same body: the `temporaryHome()` helpers in `computer-connect.test.ts`, `auth.test.ts`, `im-credential-environment-manager.test.ts`, and `agent-workspace.test.ts`.
- `agent-workspace.test.ts` also had a `realpathForTest()` wrapper that dynamically imported `realpath`; now that the module is imported statically for the helper, the wrapper delegates to it rather than keeping two import mechanisms for one function in the same file. Its six call sites are unchanged.
- **No production source file was changed.** The production canonicalization is correct — it is what makes the systemd unit and launchd plist reference a real binary rather than a symlink that a later install can repoint.

### `turbo.json`: deliberately unchanged

I decided **not** to add `"TMPDIR"` to `globalPassThroughEnv`.

Passing it through would be harmless to the cache hash, and there is a real argument that a developer who deliberately sets `TMPDIR` should have it honored. But the decisive point runs the other way: today, under strict mode, every `turbo run test` on every machine uses the same `/tmp`, and that uniformity is a feature. Passing `TMPDIR` through would reintroduce a per-developer environment knob into the test path — which is precisely the class of environment-shape divergence this pull request exists to eliminate. After this fix nothing needs the variable, and an entry no task requires would falsely signal that `TMPDIR` is load-bearing here.

### Documentation

`docs/design/agent-runtime-test-plan.md` recorded that "the monorepo test command retains two unrelated existing macOS CLI failures caused solely by `/tmp` versus `/private/tmp` path spelling". That is now obsolete and is corrected in place, including an explicit note that no `TMPDIR` override is required.

**Revised in `53c979b` after review.** My first attempt at that paragraph traded an obsolete failure claim for an unearned acceptance claim — it ended "All package tests passed" while this very PR body records the same commit at `@opentag/server` 256/257 locally, and it claimed "Every temporary-directory test helper canonicalizes" while inline `mkdtemp` callers still receive raw paths. Both were caught in review and both are fixed. The paragraph now names the environment behind each result — the local macOS run reported per package including the unrelated `@opentag/server` observability failure, and the all-green result attributed to CI, where that case did not reproduce — and narrows the canonicalization claim to the 13 reusable helpers this change actually updated.

That was the only obsolete guidance found. `DEVELOPMENT.md`, `DEVELOPMENT.zh-CN.md`, `AGENTS.md`, `CONTRIBUTING.md` and the rest of `docs/**` contain no advice about `TMPDIR`, `/private/tmp`, `TURBO_ENV_MODE=loose`, or canonical-path baseline failures. The remaining `$TMPDIR` mentions in `DEVELOPMENT.md` and its Chinese mirror describe the default `OPENTAG_E2E_ARTIFACTS` location and are unaffected; the `"TMPDIR"` entries in the three provider runtimes are environment allowlists for spawned agent processes. `docs/design/` has no Chinese mirror (`docs/zh-CN/` mirrors only the non-design documents), so no mirror needed syncing.

## Validation

Run from a shell with **no** `TMPDIR` or `TURBO_ENV_MODE` override (ambient macOS `TMPDIR` = `/var/folders/…/T/`), on the exact committed tree.

**Before the change** — `turbo run test --filter open-tag --force`, three consecutive runs, all three identical:

```
Tests  2 failed | 122 passed (124)
FAIL src/__tests__/daemon-service-renderers.test.ts > … newly installed binary before a stale PATH shim
FAIL src/__tests__/daemon-service-shared.test.ts   > … freshly installed dev binary before a stale PATH shim
```

The diff proves the mechanism directly: `- "/tmp/opentag-invocation-path-9sqsou/current-dist.mjs"` versus `+ "/private/tmp/opentag-invocation-path-9sqsou/current-dist.mjs"`. Note the `/tmp` spelling — that is Turborepo having stripped the ambient `TMPDIR`.

**After the change** — 3/3 failures become 0/3, with no environment overrides:

| Command | Result |
| --- | --- |
| `pnpm check` | pass (434 files, no fixes; CLI third-party notices verified) |
| `pnpm build` | pass (5/5 tasks) |
| `pnpm typecheck` | pass (7/7 tasks) |
| `pnpm test` (full, forced, `--continue`) | `@opentag/shared` 67/67, `@opentag/web` 322/322, **`open-tag` 124/124**, `@opentag/client` 463/463, `@opentag/server` 256/257 |
| `pnpm --filter open-tag test` ×3 | 124/124 each time |
| `pnpm --filter @opentag/client test:agent-runtime:coverage` | 288/288, **100% statements, branches, functions, lines** |

`@opentag/server` was the one local failure: `src/observability/__tests__/observability.test.ts` › `background and WebSocket tracing` › traces real RuntimeSession failure, overload, and dropped-queue terminal paths. It failed 2/2 in isolated reruns on this machine. It is the separate high-failure-rate tracing race already being fixed in a sibling pull request and already documented as a known pre-existing case in #178. This branch touches no file under `packages/server/` (`git diff --name-only origin/main...HEAD` lists only `apps/cli` tests, `packages/client` tests, and one document), so it cannot be affected by this change, and it is **not** fixed here.

Note that a plain `pnpm test` aborts on that server failure before the CLI and Client tasks are scheduled, so the local full-suite row above was produced with `--continue` to get every package's result in one run.

**CI on this branch is fully green**, which is the authoritative result:

- `Checks` › `Test` — `Tasks: 7 successful, 7 total`, covering `@opentag/shared` 11 files, `@opentag/web` 19 files, `@opentag/server` **37 files**, `open-tag` **14 files (124/124)**, `@opentag/client` 39 files. The observability tracing race did not reproduce on the Linux runner, so `pnpm test` passed outright there.
- `Checks` › `Build`, `Type-check` — 5/5 and 7/7 tasks.
- `CLI Pack Smoke`, `Container Smoke`, `Node 22.13.0 Compatibility`, `Node 26 Compatibility` — pass.
- Full disclosure on the one red attempt: the first run of `Checks` › `Test PostgreSQL integration` failed on two cases in `packages/server/src/__tests__/integration/im-binding.test.ts` (`requires old-placement reconciliation before moving a pending dispatch` and `… an expired dispatch`), both with `Error: Old generation dispatch was not persisted`. That is a dispatch-persistence race in a package this branch does not touch, in a step whose suites need PostgreSQL. Attempt 2 was green and every check now passes.

**Sanity check that the fix is real and not accidental** — the CLI package passes under all three temp-root shapes:

| `TMPDIR` | Temp root shape | Result |
| --- | --- | --- |
| ambient `/var/folders/…/T/` | unresolved per-user | 124/124 |
| `/private/tmp` | already canonical | 124/124 |
| `/tmp` | symlink to `/private/tmp` (what strict mode yields) | 124/124 |
| ambient, restored | unresolved per-user | 124/124 |

Local runtime was Node v25.8.1, which is outside the declared engine range and produces a `WARN Unsupported engine` line on every pnpm invocation. It is a warning only, it predates this branch, and CI covers Node 22.13.0 and Node 26.

## Breaking changes

None. Test-only change plus one documentation correction; no production source, no public surface, no configuration.

## Non-goals

- **Not** changing `turbo.json` — reasoning above.
- **Not** fixing `packages/server` observability tracing — a separate race owned by a sibling pull request.
- **Not** sweeping the ~50 one-off inline `mkdtemp(join(tmpdir(), …))` calls that live directly inside individual `it()` bodies and composite fixture builders (`runtimeFixture`, `custodyFixture`, `unpreparedBindingFixture`). They currently pass, they are not the helper pattern this change fixes, and converting them would balloon the diff well past the fix. The helper pattern is now the canonical example for anything new.
- **Not** removing the existing `realpath()` calls at assertion sites (`daemon-service-renderers.test.ts:350`, `client-runtime-composition.test.ts:350`, `client-turn.integration.test.ts:85`, `daemon-service-shared.test.ts:61`). Some are genuine symlink-resolution semantics rather than temp-path workarounds; the rest are now no-ops but remain harmless and defensive. Untangling which is which is a separate cleanup with real risk.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
  - All four pass in CI on this branch, including `pnpm test` outright (`Tasks: 7 successful, 7 total`). Stated plainly so the box is not read as stronger than it is: locally `pnpm test` is red on `@opentag/server`'s observability tracing race, which failed 2/2 on this machine and did not reproduce on the Linux runner. It is pre-existing, unrelated, owned by a sibling pull request, and in a package this branch does not touch. The separate `test:integration` step also needed one re-run for two unrelated `im-binding` races; both are detailed under Validation.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable. (`docs/design/` has no Chinese mirror; the corrected document has no counterpart to sync.)
