### PR TITLE
test(server): pin the persisted instance fence on IM delivery

### DIFF
--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -3287,19 +3287,20 @@ describe("IM binding persistence", () => {
 
   /**
    * The dispatch guard is `!instanceId || row.computer.currentInstanceId !== instanceId`. The first
-   * disjunct — no runtime connected at all — is covered above. This pins the second: a runtime IS
-   * connected, but the persisted enrollment still names a superseded instance, so it is the persisted
-   * column that withholds the dispatch. De-persisting it would make this disjunct vacuous and silently
-   * let a superseded generation be served.
+   * disjunct — no runtime connected at all — is covered above. This pins the second, in the direction
+   * that actually costs something: the enrollment has advanced to a new generation, while a stale
+   * registry entry for the previous one is still held. `instanceId` comes from the registry, so
+   * dropping this disjunct would dispatch to that superseded generation; the persisted column is the
+   * only thing that recognises it as stale.
    */
-  it("withholds delivery when the persisted instance disagrees with the connected runtime", async () => {
+  it("withholds delivery when the connected runtime is behind the persisted instance", async () => {
     const value = await fixture();
     try {
-      const supersededInstanceId = crypto.randomUUID();
-      const liveInstanceId = crypto.randomUUID();
+      const currentInstanceId = crypto.randomUUID();
+      const staleInstanceId = crypto.randomUUID();
       await value.database
         .update(workspaceComputers)
-        .set({ currentInstanceId: supersededInstanceId })
+        .set({ currentInstanceId })
         .where(eq(workspaceComputers.id, value.workspaceComputer.id));
       const admission = await new ImMessageInbox(value.database).ingest(
         value.imBindingId,
@@ -3312,7 +3313,7 @@ describe("IM binding persistence", () => {
       const domain = { requestReconcile: vi.fn(), requestDelivery: vi.fn() };
       await imDeliveryWorker({
         database: value.database,
-        registry: { currentInstanceId: () => liveInstanceId } as never,
+        registry: { currentInstanceId: () => staleInstanceId } as never,
         domain: domain as never,
       }).runOnce();
 
@@ -3325,6 +3326,7 @@ describe("IM binding persistence", () => {
       await value.sql.end();
     }
   });
+
   it("does not let a pending delivery for an ended Session fence another active Session of the Agent", async () => {
     const value = await fixture();
     try {

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -3285,6 +3285,46 @@ describe("IM binding persistence", () => {
     }
   });
 
+  /**
+   * The dispatch guard is `!instanceId || row.computer.currentInstanceId !== instanceId`. The first
+   * disjunct — no runtime connected at all — is covered above. This pins the second: a runtime IS
+   * connected, but the persisted enrollment still names a superseded instance, so it is the persisted
+   * column that withholds the dispatch. De-persisting it would make this disjunct vacuous and silently
+   * let a superseded generation be served.
+   */
+  it("withholds delivery when the persisted instance disagrees with the connected runtime", async () => {
+    const value = await fixture();
+    try {
+      const supersededInstanceId = crypto.randomUUID();
+      const liveInstanceId = crypto.randomUUID();
+      await value.database
+        .update(workspaceComputers)
+        .set({ currentInstanceId: supersededInstanceId })
+        .where(eq(workspaceComputers.id, value.workspaceComputer.id));
+      const admission = await new ImMessageInbox(value.database).ingest(
+        value.imBindingId,
+        1,
+        inbound("Ev-persisted-instance-fence"),
+      );
+      const deliveryId = admission.deliveryIds[0];
+      if (!deliveryId) throw new Error("Persisted instance fence fixture was not admitted");
+
+      const domain = { requestReconcile: vi.fn(), requestDelivery: vi.fn() };
+      await imDeliveryWorker({
+        database: value.database,
+        registry: { currentInstanceId: () => liveInstanceId } as never,
+        domain: domain as never,
+      }).runOnce();
+
+      expect(domain.requestReconcile).not.toHaveBeenCalled();
+      expect(domain.requestDelivery).not.toHaveBeenCalled();
+      expect(
+        (await value.database.select().from(imMessageDeliveries).where(eq(imMessageDeliveries.id, deliveryId)))[0],
+      ).toMatchObject({ attemptCount: 1, lastErrorCode: "IM_DELIVERY_RUNTIME_UNAVAILABLE", state: "pending" });
+    } finally {
+      await value.sql.end();
+    }
+  });
   it("does not let a pending delivery for an ended Session fence another active Session of the Agent", async () => {
     const value = await fixture();
     try {


### PR DESCRIPTION
Test-only. Closes a coverage gap found while working the gate 3 question on #179 — see [the analysis there](https://github.com/first-tree-ai/opentag/issues/179#issuecomment-5433642362). No production code changes, no schema, no behaviour change.

## Summary

The IM dispatch guard is a two-part condition:

```ts
// packages/server/src/runtime/im-delivery-worker.ts:328-329
const instanceId = this.#registry.currentInstanceId(row.computer.id);
if (!instanceId || row.computer.currentInstanceId !== instanceId) {
  await this.#recordFailure(deliveryId, "IM_DELIVERY_RUNTIME_UNAVAILABLE", claimToken);
```

Only the **first** disjunct was covered. The existing `IM_DELIVERY_RUNTIME_UNAVAILABLE` case builds its worker with `registry: { currentInstanceId: () => undefined }`, so it exercises "no runtime connected at all". The **second** disjunct — a runtime *is* connected, but at a different generation than the enrollment — had no test: every other delivery case in the file sets `currentInstanceId` to the live instance first (`:866`, `:935`, `:1010`, `:1079`, `:1143`, `:1451`, `:1531`, `:1612`, `:2256`), so the file is entirely happy path with respect to that column.

This adds one case for the second disjunct, oriented the way that costs something: **the enrollment has advanced to a new generation while a stale registry entry for the previous one is still held.** `instanceId` is read from the registry and is what gets dispatched, so dropping the disjunct sends the message to that superseded generation. The persisted column is the only thing that recognises it as stale.

## Why it is worth a test rather than a comment

`workspace_computers.current_instance_id` is a durable fencing token, not a connectivity observation — the same column is also a compare-and-set guard on `heartbeat` and `disconnect` (`computer-service.ts:74`, `:92`, already covered by `computers.test.ts:98-100`). Its routing role is easy to mistake for reachability metadata when the enrollment tables are reshaped, and until now nothing would have objected.

## Testing

I mutated the guard to simulate the column being dropped from routing, rewriting the condition to `if (!instanceId)`, and ran the whole file:

- **before this PR**, under that mutation: all 77 cases pass — the regression is invisible;
- **with this PR**, under that mutation: the new case fails on `expect(domain.requestReconcile).not.toHaveBeenCalled()`, and the instance handed to `requestReconcile` is the stale generation — sourced only from the registry mock, so there is no ambiguity about which one was served;
- with the guard intact: 78 passed.

Commands run: `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test` all pass. The server integration suite was run against a local PostgreSQL 16 — 129 passed, no test failures. Two integration files (`auth-migrations.test.ts`, `session-collaboration.test.ts`) could not run in the authoring sandbox because they construct their own `PostgreSqlContainer` and Docker is unavailable here; they are untouched by this change and run normally in CI. One `@opentag/client` Codex process-group test fails in this sandbox on `main` as well and is unrelated.

### Correction between heads

The first head (`e166d13`) had the mismatch backwards — persisted as the superseded value, registry as the current one — so removing the guard would have dispatched to the *current* runtime. Its commit message and this body claimed the mutation showed "the superseded generation was served"; that was wrong, and it came from reading my own variable names rather than the dispatched argument. Caught in review by @baixiaohang and fixed in `b54a10b`. The equality check is symmetric, so the earlier orientation still caught removal of the guard; the fix is about the test demonstrating the failure it names.

## Breaking changes

None. Test-only.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable. (No documentation changed.)