### PR TITLE
fix(client): bind IM delivery to provider CLI

### DIFF
--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -44,6 +44,18 @@ describe("AgentTurnRunner", () => {
     expect(JSON.stringify(input)).not.toContain(request.runtime.instructions.platform);
     expect(JSON.stringify(input)).not.toContain(request.runtime.instructions.agent);
     expect(input.items[0]?.text).toContain("slack api");
+    expect(input.items[0]?.text).toContain('the "user" your underlying agent addresses');
+    expect(input.items[0]?.text).toContain("is the OpenTag runtime");
+    expect(input.items[0]?.text).toContain("including the text that closes this Turn");
+    expect(input.items[0]?.text).toContain("This is your runtime console");
+    expect(input.items[0]?.text).toContain("ordinary output is not delivered to the IM participant");
+    expect(input.items[0]?.text).not.toContain("as the Turn report");
+    expect(input.items[0]?.text).toContain("The IM participant is a separate audience");
+    expect(input.items[0]?.text).toContain("The official slack api CLI is your outbox and the only path");
+    expect(input.items[0]?.text).toContain("only records it in OpenTag; it does not deliver it");
+    expect(input.items[0]?.text).toContain("run the provider CLI command before ending this Turn");
+    expect(input.items[0]?.text).toContain("Choosing to take no provider action remains valid");
+    expect(input.items[0]?.text).not.toContain("Your final text is not sent to the IM provider automatically");
     expect(input.items[0]?.text).toContain("OpenTag has no message send, reply, or reaction interface");
     expect(input.items[0]?.text).toContain("query the provider before deciding whether to retry");
     expect(input.items[0]?.text).toContain("Attention: direct");
@@ -69,6 +81,7 @@ describe("AgentTurnRunner", () => {
         },
       },
     });
+    expect(feishuInput.items[0]?.text).toContain("The official lark-cli CLI is your outbox and the only path");
     expect(feishuInput.items[0]?.text).toContain("official lark-cli CLI");
     expect(feishuInput.items[0]?.text).toContain("lark-cli im --help");
   });

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -217,6 +217,8 @@ export function buildAgentInput(request: DirectImMessageDeliveryRequest, supplem
     request.attention === "direct"
       ? "A human explicitly addressed this Agent/Session. Handle the message normally, then choose whether to reply, react, send proactively, or take no provider action."
       : "This Agent overheard the message. Use the conversation context to choose whether to reply, react, send proactively, or take no action; by default avoid meaningless, duplicate, intrusive, or attention-seeking intervention.";
+  // Rebind the provider's native user-facing output to OpenTag's runtime console. Merely saying that
+  // final text is not auto-sent is too weak when the provider treats its final channel as the reply.
   const context = [
     '<opentag-im-context source="managed">',
     "OpenTag managed runtime context (not user-authored).",
@@ -224,7 +226,10 @@ export function buildAgentInput(request: DirectImMessageDeliveryRequest, supplem
     `Session: ${request.sessionId}`,
     `Agent revision: ${request.runtime.revision.agent.sequence}/${request.runtime.revision.agent.id}`,
     `Session revision: ${request.runtime.revision.session.sequence}/${request.runtime.revision.session.id}`,
-    "Your final text is not sent to the IM provider automatically.",
+    'Who reads your output: inside OpenTag, the "user" your underlying agent addresses — the reader of everything you produce apart from running a provider CLI command, including the text that closes this Turn — is the OpenTag runtime. This is your runtime console; ordinary output is not delivered to the IM participant.',
+    `The IM participant is a separate audience. The official ${providerCommand} CLI is your outbox and the only path from this Turn to that audience.`,
+    "The console addresses OpenTag; running the provider CLI performs the provider action. Describing a reply, reaction, or proactive message in your output only records it in OpenTag; it does not deliver it.",
+    "If you choose to reply, react, or send proactively, run the provider CLI command before ending this Turn. Choosing to take no provider action remains valid.",
     `To write to this ${provider} conversation, load the credentials from $OPENTAG_PROVIDER_ENV_FILE in your shell, then use the official ${providerCommand} CLI directly.`,
     "OpenTag has no message send, reply, or reaction interface, and you do not report provider send results to OpenTag.",
     "Use the provider-native identifiers below. Do not substitute an OpenTag Session or message ID.",


### PR DESCRIPTION
## Summary

- rebind native agent output, including the turn-closing text, to the OpenTag runtime console
- define the official provider CLI as the only outbox to the IM participant
- preserve the agent's choice to take no provider action and existing direct/ambient placement policy
- add regression assertions for the load-bearing user/runtime rebinding and both Slack and Feishu outboxes

## Why

Codex treats its native final answer as the user-facing reply. The previous negative instruction that final text was not sent automatically could be overridden by that native behavior, allowing a Turn to complete without ever invoking `lark-cli` or `slack api`.

The new contract follows the audience-rebinding pattern: the underlying agent's `user` is explicitly the OpenTag runtime, while the IM participant is a separate audience reached only through the provider CLI.

## Testing

- `pnpm --filter @opentag/shared build`
- `pnpm --filter @opentag/client exec vitest run src/__tests__/agent-turn-runner.test.ts --maxWorkers=1`
- `pnpm exec biome check packages/client/src/runtime/agent-turn-runner.ts packages/client/src/__tests__/agent-turn-runner.test.ts`
- `pnpm --filter @opentag/client typecheck`
