### PR TITLE
feat(web): show stored sessions in Tasks

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -10,6 +10,7 @@ const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const memberUserId = "63e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const computerId = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
+const taskSessionId = "11111111-1111-4111-8111-111111111111";
 
 const agentSummary = {
   id: agentId,
@@ -32,6 +33,17 @@ const agentListItem = {
   ...agentSummary,
   activity: { state: "idle" as const },
   usage: { windowDays: 30 as const, tasks: 32, failed: 0, tokens: 428_000 },
+};
+const taskSummary = {
+  id: taskSessionId,
+  agent: { id: agentId, name: "reviewer", displayName: "Reviewer", runtimeProvider: "codex" },
+  source: { provider: "feishu", conversationKind: "dm", channelId: "oc_debug", threadKey: null },
+  sessionKind: "channel",
+  title: "Investigate the failed deployment",
+  status: "completed",
+  createdAt: "2026-08-20T00:00:00.000Z",
+  endedAt: null,
+  lastActivityAt: "2026-08-20T00:02:00.000Z",
 };
 
 function json(value: unknown, status = 200) {
@@ -182,6 +194,51 @@ function installApi(
     if (path === "/api/v1/me/setup/complete" && init?.method === "POST") {
       setupCompletedAt = "2026-08-20T00:10:00.000Z";
       return json({ setupCompletedAt });
+    }
+    if (path === "/api/v1/sessions") {
+      return json({ tasks: [taskSummary], nextCursor: null });
+    }
+    if (path === `/api/v1/sessions/${taskSessionId}`) {
+      return json({
+        task: taskSummary,
+        turns: [
+          {
+            deliveryId: "33333333-3333-4333-8333-333333333333",
+            attention: "direct",
+            delivery: {
+              state: "accepted",
+              attemptCount: 1,
+              acceptedAt: "2026-08-20T00:01:00.000Z",
+              expiresAt: "2026-08-21T00:00:00.000Z",
+              reason: null,
+              lastErrorCode: null,
+            },
+            message: {
+              id: "44444444-4444-4444-8444-444444444444",
+              externalMessageId: "om_debug",
+              operation: "created",
+              authorKind: "human",
+              authorDisplayName: "Mia",
+              fallbackText: "Please investigate the failed deployment.",
+              truncated: false,
+              occurredAt: "2026-08-20T00:00:00.000Z",
+            },
+            report: {
+              turnId: "turn-debug",
+              outcome: "completed",
+              executionEffects: "completed",
+              finalText: "Stored runtime output",
+              errorReason: null,
+              usage: null,
+              traceSummary: { lastSequence: 2, droppedEvents: 0 },
+              reportedAt: "2026-08-20T00:02:00.000Z",
+            },
+          },
+        ],
+        internalSessions: [],
+        collaborationMessages: [],
+        nextCursor: null,
+      });
     }
     if (path === "/api/v1/agents" && init?.method === "POST") {
       if (options.agentCreateError) {
@@ -1923,36 +1980,28 @@ describe("OpenTag Web App Shell", () => {
     await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("heading", { name: "Messaging" })));
   });
 
-  it("shows the Tasks demo and opens a Task detail", async () => {
+  it("shows stored Tasks and opens a Task detail", async () => {
     installApi();
     window.history.replaceState({}, "", "/tasks");
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Tasks" })).toBeTruthy();
-    expect(screen.getByText("Demo data")).toBeTruthy();
-    const task = screen.getByRole("link", {
-      name: "Review the Q3 launch plan, identify unresolved owners, and flag every item without a confirmed date.",
+    expect(screen.getByText("Read-only debug view")).toBeTruthy();
+    const task = await screen.findByRole("link", {
+      name: "Investigate the failed deployment",
     });
     fireEvent.click(task);
-    expect(
-      await screen.findByText(
-        "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
-      ),
-    ).toBeTruthy();
-    expect(screen.getByLabelText("Task source").textContent).toContain("Product Launch");
-    expect(window.location.pathname).toBe("/tasks/q3-launch-readiness");
+    expect(await screen.findByText("Stored runtime output")).toBeTruthy();
+    expect(screen.getByLabelText("Task source").textContent).toContain("Reviewer");
+    expect(window.location.pathname).toBe(`/tasks/${taskSessionId}`);
   });
 
-  it("labels a directly opened Task detail as demo data", async () => {
+  it("labels a directly opened Task detail as a read-only debug view", async () => {
     installApi();
-    window.history.replaceState({}, "", "/tasks/q3-launch-readiness");
+    window.history.replaceState({}, "", `/tasks/${taskSessionId}`);
     render(<App />);
 
-    expect(
-      await screen.findByText(
-        "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
-      ),
-    ).toBeTruthy();
-    expect(screen.getByText("Demo data")).toBeTruthy();
+    expect(await screen.findByText("Stored runtime output")).toBeTruthy();
+    expect(screen.getByText("Read-only debug view")).toBeTruthy();
   });
 
   it.each(["/settings", "/settings/members", "/members", "/teams"])(
@@ -1987,7 +2036,9 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
     expect(getItem).not.toHaveBeenCalled();
-    expect(vi.mocked(fetch).mock.calls.some(([path]) => path === "/api/v1/agents")).toBe(true);
+    await waitFor(() =>
+      expect(vi.mocked(fetch).mock.calls.some(([path]) => String(path) === "/api/v1/agents")).toBe(true),
+    );
     expect(vi.mocked(fetch).mock.calls.some(([path]) => String(path).includes("/api/v1/workspaces/"))).toBe(false);
     getItem.mockRestore();
   });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -40,6 +40,8 @@ import {
   imBindingDisablePath,
   type ListAgentsResponse,
   ListAgentsResponseSchema,
+  type ListTasksResponse,
+  ListTasksResponseSchema,
   type ListWorkspaceComputersResponse,
   ListWorkspaceComputersResponseSchema,
   type MeResponse,
@@ -54,6 +56,9 @@ import {
   type StartSlackOAuthRequest,
   type StartSlackOAuthResponse,
   StartSlackOAuthResponseSchema,
+  type TaskDetail,
+  TaskDetailSchema,
+  taskByIdPath,
   type UpdateAgentRequest,
   type UpdateUserProfileRequest,
   type UserProfile,
@@ -109,6 +114,20 @@ export class BrowserApi {
 
   agents(): Promise<ListAgentsResponse> {
     return this.request(HTTP_PATHS.accountAgents, ListAgentsResponseSchema);
+  }
+
+  tasks(input: { cursor?: string; agentId?: string; kind?: "channel" | "thread" } = {}): Promise<ListTasksResponse> {
+    const query = new URLSearchParams();
+    if (input.cursor) query.set("cursor", input.cursor);
+    if (input.agentId) query.set("agentId", input.agentId);
+    if (input.kind) query.set("kind", input.kind);
+    const suffix = query.size > 0 ? `?${query.toString()}` : "";
+    return this.request(`${HTTP_PATHS.accountTasks}${suffix}`, ListTasksResponseSchema);
+  }
+
+  task(sessionId: string, cursor?: string): Promise<TaskDetail> {
+    const query = cursor ? `?${new URLSearchParams({ cursor }).toString()}` : "";
+    return this.request(`${taskByIdPath(sessionId)}${query}`, TaskDetailSchema);
   }
 
   agent(agentId: string): Promise<AgentDetail> {

--- a/apps/web/src/features/tasks-page.css
+++ b/apps/web/src/features/tasks-page.css
@@ -38,6 +38,106 @@
   line-height: 40px;
 }
 
+.tasks-debug-note {
+  color: var(--muted);
+  font-size: var(--text-meta);
+  white-space: nowrap;
+}
+
+.task-load-more {
+  display: block;
+  margin: var(--space-6) auto 0;
+  padding: var(--space-2) var(--space-4);
+}
+
+.task-provider-mark {
+  align-items: center;
+  background: var(--surface-soft);
+  border-radius: 4px;
+  display: inline-flex;
+  font-size: 10px;
+  font-weight: 700;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+
+.task-debug-facts {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin: var(--space-4) 0;
+}
+
+.task-debug-value {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.task-debug-value strong {
+  color: var(--muted);
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+}
+
+.task-debug-value code {
+  font-size: var(--text-micro);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.task-debug-value button {
+  background: transparent;
+  border: 0;
+  color: var(--brand-ink);
+  cursor: pointer;
+  font-size: var(--text-micro);
+  padding: 0;
+}
+
+.task-capture-boundary {
+  background: var(--surface-soft);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-size: var(--text-ui);
+  margin: var(--space-4) 0 var(--space-6);
+  padding: var(--space-3) var(--space-4);
+}
+
+.task-runtime-error {
+  color: var(--error);
+  font-family: var(--font-mono);
+  font-size: var(--text-ui);
+}
+
+.task-related-sessions {
+  border-top: 1px solid var(--border);
+  margin-top: var(--space-8);
+  padding-top: var(--space-4);
+}
+
+.task-related-sessions > summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.task-collaboration-message {
+  border-left: 2px solid var(--strong-border);
+  margin-top: var(--space-3);
+  padding-left: var(--space-3);
+}
+
+.task-collaboration-message p {
+  white-space: pre-wrap;
+}
+
+.task-collaboration-message small {
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
 .task-toolbar {
   display: grid;
   align-items: center;

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -1,172 +1,186 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { TaskDetail, TaskSummary } from "@opentag/shared/browser";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { browserApi } from "../api.js";
 import { TaskDetailPage, TasksPage } from "./tasks-page.js";
 
-describe("Tasks demo", () => {
-  it("renders the minimal Feishu-only Task list in English", () => {
-    const { container } = render(
-      <MemoryRouter>
-        <TasksPage />
-      </MemoryRouter>,
-    );
+const sessionId = "11111111-1111-4111-8111-111111111111";
+const agentId = "22222222-2222-4222-8222-222222222222";
+const task = {
+  id: sessionId,
+  agent: { id: agentId, name: "atlas", displayName: "Atlas", runtimeProvider: "codex" },
+  source: {
+    provider: "feishu",
+    conversationKind: "dm",
+    channelId: "oc_debug_channel",
+    threadKey: null,
+  },
+  sessionKind: "channel",
+  title: "Investigate the failed deployment",
+  status: "completed",
+  createdAt: "2026-08-27T01:00:00.000Z",
+  endedAt: null,
+  lastActivityAt: "2026-08-27T02:00:00.000Z",
+} satisfies TaskSummary;
 
-    expect(screen.getAllByRole("columnheader").map((header) => header.textContent)).toEqual(["Task", "Status"]);
-    expect(screen.getAllByRole("row")).toHaveLength(4);
-    expect(container.querySelectorAll(".task-feishu-icon")).toHaveLength(3);
-    expect(container.querySelector(".task-list-metadata")?.textContent).toBe(
-      "Atlas·Product Launch·Q3 launch readiness",
-    );
-    expect(within(screen.getByRole("table")).getByText("Completed")).toBeTruthy();
-    expect(screen.queryByText("Recently completed")).toBeNull();
-    expect(screen.queryByLabelText("Filter by source")).toBeNull();
-    expect(container.textContent).not.toMatch(/[\u3400-\u9fff]/u);
-  });
+const detail = {
+  task,
+  turns: [
+    {
+      deliveryId: "33333333-3333-4333-8333-333333333333",
+      attention: "direct",
+      delivery: {
+        state: "accepted",
+        attemptCount: 1,
+        acceptedAt: "2026-08-27T01:01:00.000Z",
+        expiresAt: "2026-08-28T01:00:00.000Z",
+        reason: null,
+        lastErrorCode: null,
+      },
+      message: {
+        id: "44444444-4444-4444-8444-444444444444",
+        externalMessageId: "om_debug",
+        operation: "created",
+        authorKind: "human",
+        authorDisplayName: "Mia Zhang",
+        fallbackText: "Please investigate the failed deployment.",
+        truncated: false,
+        occurredAt: "2026-08-27T01:00:00.000Z",
+      },
+      report: {
+        turnId: "turn-debug",
+        outcome: "completed",
+        executionEffects: "completed",
+        finalText: "The runtime finished and the provider reply was sent separately.",
+        errorReason: null,
+        usage: { inputTokens: 100, cachedInputTokens: null, outputTokens: 50 },
+        traceSummary: { lastSequence: 4, droppedEvents: 0 },
+        reportedAt: "2026-08-27T02:00:00.000Z",
+      },
+    },
+  ],
+  internalSessions: [
+    {
+      id: "55555555-5555-4555-8555-555555555555",
+      createdBySessionId: sessionId,
+      createdAt: "2026-08-27T01:10:00.000Z",
+      endedAt: null,
+      runtimeModel: "gpt-5",
+      runtimeReasoningEffort: null,
+    },
+  ],
+  collaborationMessages: [],
+  nextCursor: null,
+} satisfies TaskDetail;
 
-  it("filters demo Tasks by Agent, status, and search text", () => {
+afterEach(() => vi.restoreAllMocks());
+
+describe("Tasks debug view", () => {
+  it("loads stored Tasks and filters them locally", async () => {
+    const second = {
+      ...task,
+      id: "66666666-6666-4666-8666-666666666666",
+      title: "Review onboarding",
+      status: "failed",
+      agent: { ...task.agent, id: "77777777-7777-4777-8777-777777777777", displayName: "Scout" },
+    } satisfies TaskSummary;
+    vi.spyOn(browserApi, "tasks").mockResolvedValue({ tasks: [task, second], nextCursor: null });
+
     render(
       <MemoryRouter>
         <TasksPage />
       </MemoryRouter>,
     );
 
-    fireEvent.change(screen.getByLabelText("Filter by Agent"), { target: { value: "Scout" } });
-    expect(screen.getAllByRole("row")).toHaveLength(2);
-    expect(screen.getByText("Customer Feedback")).toBeTruthy();
-    expect(screen.queryByText("Product Launch")).toBeNull();
+    expect(await screen.findByRole("table", { name: "Tasks" })).toBeTruthy();
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+    expect(screen.getByText("Read-only debug view")).toBeTruthy();
+    expect(screen.queryByText("Demo data")).toBeNull();
 
-    fireEvent.change(screen.getByLabelText("Filter by Agent"), { target: { value: "all" } });
-    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "needs_attention" } });
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "failed" } });
     expect(screen.getAllByRole("row")).toHaveLength(2);
-    expect(screen.getByText("Engineering Collaboration")).toBeTruthy();
+    expect(screen.getByText("Review onboarding")).toBeTruthy();
+    expect(screen.queryByText("Investigate the failed deployment")).toBeNull();
 
     fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "all" } });
-    fireEvent.change(screen.getByLabelText("Search Tasks"), { target: { value: "confirmed date" } });
+    fireEvent.change(screen.getByLabelText("Search Tasks"), { target: { value: sessionId } });
     expect(screen.getAllByRole("row")).toHaveLength(2);
-    expect(screen.getByText("Product Launch")).toBeTruthy();
+    expect(screen.getByText("Investigate the failed deployment")).toBeTruthy();
   });
 
-  it("shows a compact empty result state", () => {
+  it("renders the stored inbound message and runtime report without claiming an outbound record", async () => {
+    vi.spyOn(browserApi, "task").mockResolvedValue(detail);
+    render(
+      <MemoryRouter initialEntries={[`/tasks/${sessionId}`]}>
+        <Routes>
+          <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const conversation = await screen.findByLabelText("Task conversation");
+    expect(within(conversation).getByText("Please investigate the failed deployment.")).toBeTruthy();
+    expect(
+      within(conversation).getByText("The runtime finished and the provider reply was sent separately."),
+    ).toBeTruthy();
+    expect(screen.getByText(/Provider outbound messages and detailed tool traces are not captured/)).toBeTruthy();
+    expect(screen.getByText(/Internal collaboration · 1 Sessions/)).toBeTruthy();
+
+    fireEvent.click(within(conversation).getByText("Runtime details"));
+    expect(
+      within(conversation).getByText("1 attempt · Outcome completed · Effects completed · 150 tokens · 4 trace events"),
+    ).toBeTruthy();
+    expect(screen.getByLabelText("Copy Session")).toBeTruthy();
+  });
+
+  it("loads older Turns from the detail cursor", async () => {
+    const firstPage = { ...detail, nextCursor: "older-turns" } satisfies TaskDetail;
+    const baseTurn = detail.turns[0];
+    if (!baseTurn) throw new Error("Expected the Task fixture to include a Turn");
+    const olderTurn = {
+      ...baseTurn,
+      deliveryId: "88888888-8888-4888-8888-888888888888",
+      message: {
+        ...baseTurn.message,
+        id: "99999999-9999-4999-8999-999999999999",
+        externalMessageId: "om_older",
+        fallbackText: "This is an older inbound message.",
+      },
+    } satisfies TaskDetail["turns"][number];
+    const taskRequest = vi
+      .spyOn(browserApi, "task")
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce({ ...detail, turns: [olderTurn], nextCursor: null });
+    render(
+      <MemoryRouter initialEntries={[`/tasks/${sessionId}`]}>
+        <Routes>
+          <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Load more Turns" }));
+    expect(await screen.findByText("This is an older inbound message.")).toBeTruthy();
+    expect(taskRequest).toHaveBeenLastCalledWith(sessionId, "older-turns");
+    expect(screen.queryByRole("button", { name: "Load more Turns" })).toBeNull();
+  });
+
+  it("shows loading and empty states from the API", async () => {
+    let resolve: (value: { tasks: []; nextCursor: null }) => void = () => undefined;
+    vi.spyOn(browserApi, "tasks").mockReturnValue(
+      new Promise((next) => {
+        resolve = next;
+      }),
+    );
     render(
       <MemoryRouter>
         <TasksPage />
       </MemoryRouter>,
     );
 
-    fireEvent.change(screen.getByLabelText("Search Tasks"), { target: { value: "no matching task" } });
-    expect(screen.getByRole("heading", { name: "No Tasks found" })).toBeTruthy();
-    expect(screen.queryByRole("table")).toBeNull();
-  });
-
-  it("renders each request, provider event stream, and final answer in order", () => {
-    render(
-      <MemoryRouter initialEntries={["/tasks/q3-launch-readiness"]}>
-        <Routes>
-          <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByText("Demo data")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Open in Feishu" }).getAttribute("href")).toBe("https://www.feishu.cn/");
-    expect(screen.getByLabelText("Task source").textContent).toContain("Product Launch");
-
-    const conversation = screen.getByLabelText("Task conversation");
-    expect(within(conversation).getAllByText("Mia Zhang")).toHaveLength(2);
-    expect(
-      within(conversation).getByText(
-        "Please review the Q3 launch plan and call out anything that is still unowned or missing a confirmed date.",
-      ),
-    ).toBeTruthy();
-    expect(within(conversation).getByText("Read 2 sources")).toBeTruthy();
-    expect(within(conversation).getByText("Read the Product Launch thread")).toBeTruthy();
-    expect(within(conversation).getByText("Opened the Q3 launch brief")).toBeTruthy();
-    expect(within(conversation).getByText("Searched 12 Feishu messages")).toBeTruthy();
-    expect(
-      within(conversation).getByText(
-        "The checklist and brief disagree on three items. I’m checking the recent thread before treating any owner or date as confirmed.",
-      ),
-    ).toBeTruthy();
-    expect(
-      within(conversation).getByText(
-        "Three follow-up messages were prepared with suggested owners. No ownership was recorded as confirmed.",
-      ),
-    ).toBeTruthy();
-    expect(within(conversation).getByText("Partner announcement — Suggested owner: Jordan Lee")).toBeTruthy();
-    expect(
-      within(conversation).getAllByText(/Recorded locally at .*Open Feishu for the authoritative thread/),
-    ).toHaveLength(2);
-    expect(within(conversation).queryByText(/Turn \d/u)).toBeNull();
-    expect(within(conversation).queryByText(/Chain of Thought/i)).toBeNull();
-
-    const process = within(conversation).getByText("Activity details · 8m 12s").closest("details");
-    const finalAnswer = within(conversation).getByText(
-      "Eight items were checked. Five are ready, two still need owners, and one has no confirmed date.",
-    );
-    expect(process).toBeTruthy();
-    if (!process) throw new Error("Expected the Agent process details");
-    expect(process.hasAttribute("open")).toBe(false);
-    expect(finalAnswer.compareDocumentPosition(process) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(within(process).getByText("3 tool calls · 0 retries · 14.2K tokens")).toBeTruthy();
-    const sourceGroup = within(process).getByText("Read 2 sources").closest("details");
-    expect(sourceGroup?.hasAttribute("open")).toBe(true);
-    const threadCall = within(process).getByText("Read the Product Launch thread").closest("details");
-    expect(threadCall?.hasAttribute("open")).toBe(false);
-    fireEvent.click(within(threadCall as HTMLElement).getByText("Read the Product Launch thread"));
-    expect(threadCall?.hasAttribute("open")).toBe(true);
-    expect(within(threadCall as HTMLElement).getByText("18 messages read")).toBeTruthy();
-    expect(within(conversation).getByText("Partner announcement copy — Needs owner")).toBeTruthy();
-    expect(within(conversation).getByText("Security review sign-off — Date unconfirmed")).toBeTruthy();
-    expect(within(conversation).queryByText("Launch plan reviewed")).toBeNull();
-    expect(within(conversation).queryByText("Follow-ups drafted")).toBeNull();
-    expect(screen.queryByText("Task details")).toBeNull();
-    expect(screen.queryByRole("complementary")).toBeNull();
-  });
-
-  it("shows live provider events without inventing a final answer or zero usage", () => {
-    render(
-      <MemoryRouter initialEntries={["/tasks/customer-visit-feedback"]}>
-        <Routes>
-          <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    const progress = screen.getByText(
-      "I’m collecting the three visit summaries first, then I’ll group repeated issues without merging account-specific context.",
-    );
-    expect(progress.className).toBe("task-progress-summary");
-    const process = screen.getByText("Activity details · In progress").closest("details");
-    expect(process?.hasAttribute("open")).toBe(false);
-    expect(
-      within(process as HTMLElement).queryByText(
-        "I’m collecting the three visit summaries first, then I’ll group repeated issues without merging account-specific context.",
-      ),
-    ).toBeNull();
-    expect(within(process as HTMLElement).getByText("2 tool calls · 0 retries · 6.4K input")).toBeTruthy();
-    expect(within(process as HTMLElement).getAllByText("In progress")).toHaveLength(1);
-    expect(screen.queryByText(/0 output/)).toBeNull();
-    expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
-  });
-
-  it("keeps provider attention and retry state attached to the execution that produced it", () => {
-    render(
-      <MemoryRouter initialEntries={["/tasks/onboarding-document-review"]}>
-        <Routes>
-          <Route path="/tasks/:taskId" element={<TaskDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    const process = screen.getByText("Activity details · 11m 03s").closest("details");
-    expect(process?.hasAttribute("open")).toBe(false);
-    expect(within(process as HTMLElement).getAllByText("Needs attention")).toHaveLength(1);
-    expect(within(process as HTMLElement).getByText("2 tool calls · 1 retry · 18.6K tokens")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "The review is paused because the access checklist and security orientation steps are not available.",
-      ),
-    ).toBeTruthy();
-    expect(screen.getByText("Access provisioning checklist — Missing input")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Loading Tasks" })).toBeTruthy();
+    resolve({ tasks: [], nextCursor: null });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "No Tasks found" })).toBeTruthy());
   });
 });

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -1,68 +1,92 @@
-import { type ChangeEventHandler, type ReactNode, useMemo, useState } from "react";
+import type { TaskDetail, TaskStatus, TaskSummary, TaskTurn } from "@opentag/shared/browser";
+import { type ChangeEventHandler, type ReactNode, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { ApiError, browserApi } from "../api.js";
 import feishuIconUrl from "../assets/feishu.svg";
-import {
-  findTaskPreview,
-  type TaskAgentEvent,
-  type TaskExchange,
-  type TaskPreview,
-  type TaskStatus,
-  type TaskToolCall,
-  type TaskToolStatus,
-  taskPreviews,
-} from "../mock/task-data.js";
 import { Icon, StatusIndicator, type StatusTone } from "../ui/design-system.js";
 import "./tasks-page.css";
 
 type TaskFilter = "all" | TaskStatus;
-type AgentFilter = "all" | TaskPreview["agent"];
+type LoadState<T> = { kind: "loading" } | { kind: "error"; error: Error } | { kind: "ready"; value: T };
 
 const statusPresentation: Record<TaskStatus, { readonly label: string; readonly tone: StatusTone }> = {
-  needs_attention: { label: "Needs attention", tone: "warning" },
-  processing: { label: "In progress", tone: "info" },
-  recently_completed: { label: "Completed", tone: "success" },
+  queued: { label: "Queued", tone: "info" },
+  running: { label: "Running", tone: "info" },
+  completed: { label: "Completed", tone: "success" },
+  failed: { label: "Failed", tone: "danger" },
+  expired: { label: "Expired", tone: "warning" },
+  ended: { label: "Ended", tone: "neutral" },
+  idle: { label: "Idle", tone: "neutral" },
 };
-
-const toolStatusPresentation: Record<TaskToolStatus, { readonly label: string }> = {
-  completed: { label: "Completed" },
-  in_progress: { label: "In progress" },
-  requires_attention: { label: "Needs attention" },
-};
-
-type TaskToolCallGroup = {
-  readonly calls: readonly TaskToolCall[];
-  readonly id: string;
-  readonly kind: "tool_call_group";
-  readonly label: string;
-};
-
-type TaskProcessItem = Exclude<TaskAgentEvent, TaskToolCall> | TaskToolCallGroup;
 
 export function TasksPage() {
+  const [state, setState] = useState<LoadState<{ tasks: TaskSummary[]; nextCursor: string | null }>>({
+    kind: "loading",
+  });
   const [query, setQuery] = useState("");
-  const [agent, setAgent] = useState<AgentFilter>("all");
+  const [agentId, setAgentId] = useState("all");
   const [status, setStatus] = useState<TaskFilter>("all");
+
+  useEffect(() => {
+    let active = true;
+    browserApi.tasks().then(
+      (value) =>
+        active && setState({ kind: "ready", value: { tasks: [...value.tasks], nextCursor: value.nextCursor } }),
+      (error: unknown) => active && setState({ kind: "error", error: asError(error) }),
+    );
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const agents = useMemo(() => {
+    if (state.kind !== "ready") return [];
+    return [...new Map(state.value.tasks.map((task) => [task.agent.id, task.agent])).values()].sort((left, right) =>
+      left.displayName.localeCompare(right.displayName),
+    );
+  }, [state]);
   const tasks = useMemo(() => {
+    if (state.kind !== "ready") return [];
     const normalizedQuery = query.trim().toLocaleLowerCase();
-    return taskPreviews.filter((task) => {
+    return state.value.tasks.filter((task) => {
       const matchesQuery =
         normalizedQuery.length === 0 ||
-        [task.title, task.agent, task.source.context, task.source.detail, "Feishu"]
+        [
+          task.title,
+          task.id,
+          task.agent.displayName,
+          task.agent.name,
+          task.source.provider,
+          task.source.channelId,
+          task.source.threadKey,
+        ]
           .join(" ")
           .toLocaleLowerCase()
           .includes(normalizedQuery);
-      return matchesQuery && (agent === "all" || task.agent === agent) && (status === "all" || task.status === status);
+      return (
+        matchesQuery && (agentId === "all" || task.agent.id === agentId) && (status === "all" || task.status === status)
+      );
     });
-  }, [agent, query, status]);
+  }, [agentId, query, state, status]);
+
+  async function loadMore(): Promise<void> {
+    if (state.kind !== "ready" || !state.value.nextCursor) return;
+    try {
+      const next = await browserApi.tasks({ cursor: state.value.nextCursor });
+      setState({ kind: "ready", value: { tasks: [...state.value.tasks, ...next.tasks], nextCursor: next.nextCursor } });
+    } catch (error) {
+      setState({ kind: "error", error: asError(error) });
+    }
+  }
 
   return (
     <section className="tasks-page" aria-labelledby="tasks-page-title">
       <header className="tasks-page-header">
         <div>
           <h1 id="tasks-page-title">Tasks</h1>
-          <p>Track work Agents handle in Feishu threads.</p>
+          <p>Inspect stored bot Sessions, inbound messages, and runtime Turn results.</p>
         </div>
-        <span className="tasks-demo-note">Demo data</span>
+        <span className="tasks-debug-note">Read-only debug view</span>
       </header>
 
       <form className="task-toolbar" aria-label="Filter Tasks" onSubmit={(event) => event.preventDefault()}>
@@ -75,14 +99,13 @@ export function TasksPage() {
             onChange={(event) => setQuery(event.target.value)}
           />
         </label>
-        <TaskSelect
-          label="Filter by Agent"
-          value={agent}
-          onChange={(event) => setAgent(event.target.value as AgentFilter)}
-        >
+        <TaskSelect label="Filter by Agent" value={agentId} onChange={(event) => setAgentId(event.target.value)}>
           <option value="all">All Agents</option>
-          <option value="Atlas">Atlas</option>
-          <option value="Scout">Scout</option>
+          {agents.map((agent) => (
+            <option key={agent.id} value={agent.id}>
+              {agent.displayName}
+            </option>
+          ))}
         </TaskSelect>
         <TaskSelect
           label="Filter by status"
@@ -90,51 +113,107 @@ export function TasksPage() {
           onChange={(event) => setStatus(event.target.value as TaskFilter)}
         >
           <option value="all">All statuses</option>
-          <option value="processing">In progress</option>
-          <option value="recently_completed">Completed</option>
-          <option value="needs_attention">Needs attention</option>
+          {Object.entries(statusPresentation).map(([value, presentation]) => (
+            <option key={value} value={value}>
+              {presentation.label}
+            </option>
+          ))}
         </TaskSelect>
       </form>
 
-      {tasks.length > 0 ? (
-        <table className="task-table" aria-label="Demo Tasks">
-          <thead>
-            <tr className="task-table-grid task-table-header">
-              <th scope="col">Task</th>
-              <th scope="col">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {tasks.map((task) => (
-              <TaskRow key={task.id} task={task} />
-            ))}
-          </tbody>
-        </table>
-      ) : (
-        <section className="task-empty-state" aria-live="polite">
-          <h2>No Tasks found</h2>
-          <p>Try a different search or filter.</p>
-        </section>
-      )}
+      {state.kind === "loading" ? (
+        <TaskNotice heading="Loading Tasks" detail="Reading stored Sessions and Turns." />
+      ) : null}
+      {state.kind === "error" ? <TaskNotice heading="Tasks unavailable" detail={state.error.message} /> : null}
+      {state.kind === "ready" && tasks.length > 0 ? (
+        <>
+          <table className="task-table" aria-label="Tasks">
+            <thead>
+              <tr className="task-table-grid task-table-header">
+                <th scope="col">Task</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tasks.map((task) => (
+                <TaskRow key={task.id} task={task} />
+              ))}
+            </tbody>
+          </table>
+          {state.value.nextCursor ? (
+            <button className="task-load-more" type="button" onClick={() => void loadMore()}>
+              Load more
+            </button>
+          ) : null}
+        </>
+      ) : null}
+      {state.kind === "ready" && tasks.length === 0 ? (
+        <TaskNotice heading="No Tasks found" detail="Try a different search or filter." />
+      ) : null}
     </section>
   );
 }
 
 export function TaskDetailPage() {
   const { taskId } = useParams();
-  const task = findTaskPreview(taskId);
-  if (!task) {
+  const [state, setState] = useState<LoadState<TaskDetail>>({ kind: "loading" });
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    if (!taskId) {
+      setState({ kind: "error", error: new Error("Task not found") });
+      return () => undefined;
+    }
+    browserApi.task(taskId).then(
+      (value) => active && setState({ kind: "ready", value }),
+      (error: unknown) => active && setState({ kind: "error", error: asError(error) }),
+    );
+    return () => {
+      active = false;
+    };
+  }, [taskId]);
+
+  async function loadMoreTurns(): Promise<void> {
+    if (!taskId || state.kind !== "ready" || !state.value.nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    setLoadMoreError(null);
+    try {
+      const next = await browserApi.task(taskId, state.value.nextCursor);
+      setState((current) =>
+        current.kind === "ready"
+          ? {
+              kind: "ready",
+              value: {
+                ...current.value,
+                turns: [...current.value.turns, ...next.turns],
+                nextCursor: next.nextCursor,
+              },
+            }
+          : current,
+      );
+    } catch (error) {
+      setLoadMoreError(asError(error));
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
+  if (state.kind === "loading") return <TaskNotice heading="Loading Task" detail="Reading stored Turn details." />;
+  if (state.kind === "error") {
+    const notFound = state.error instanceof ApiError && state.error.status === 404;
     return (
       <section className="task-not-found">
-        <h1>Task not found</h1>
-        <p>This demo Task does not exist.</p>
+        <h1>{notFound ? "Task not found" : "Task unavailable"}</h1>
+        <p>{notFound ? "This Task does not exist or is outside your Account." : state.error.message}</p>
         <Link to="/tasks">Back to Tasks</Link>
       </section>
     );
   }
 
+  const { task, turns, internalSessions, collaborationMessages } = state.value;
   const status = statusPresentation[task.status];
-
   return (
     <article className="task-conversation-page">
       <nav className="task-breadcrumb" aria-label="Breadcrumb">
@@ -142,12 +221,7 @@ export function TaskDetailPage() {
           <Icon name="arrow-left" />
           Tasks
         </Link>
-        <span className="task-breadcrumb-actions">
-          <span className="tasks-demo-note">Demo data</span>
-          <a className="task-thread-link" href={task.source.threadUrl} target="_blank" rel="noreferrer">
-            Open in Feishu
-          </a>
-        </span>
+        <span className="tasks-debug-note">Read-only debug view</span>
       </nav>
 
       <header className="task-conversation-header">
@@ -155,235 +229,149 @@ export function TaskDetailPage() {
         <section className="task-conversation-context" aria-label="Task source">
           <SourceIdentity task={task} />
           <StatusIndicator
-            aria-label={`${status.label}, updated ${task.relativeUpdatedAt}`}
-            detail={`Updated ${task.relativeUpdatedAt}`}
+            aria-label={`${status.label}, updated ${formatRelativeTime(task.lastActivityAt)}`}
+            detail={`Updated ${formatRelativeTime(task.lastActivityAt)}`}
             label={status.label}
             tone={status.tone}
           />
         </section>
       </header>
 
-      <section className="task-thread" aria-label="Task conversation">
-        {task.exchanges.map((exchange) => (
-          <TaskConversationExchange key={exchange.id} task={task} exchange={exchange} />
-        ))}
+      <section className="task-debug-facts" aria-label="Task debug identifiers">
+        <DebugValue label="Session" value={task.id} />
+        <DebugValue label="Channel" value={task.source.channelId} />
+        {task.source.threadKey ? <DebugValue label="Thread" value={task.source.threadKey} /> : null}
+        <DebugValue label="Agent" value={task.agent.id} />
       </section>
+
+      <p className="task-capture-boundary">
+        Provider outbound messages and detailed tool traces are not captured. Agent output below is the stored runtime
+        final output.
+      </p>
+
+      <section className="task-thread" aria-label="Task conversation">
+        {turns.length > 0 ? (
+          turns.map((turn) => <TaskTurnView key={turn.deliveryId} task={task} turn={turn} />)
+        ) : (
+          <TaskNotice heading="No Turns recorded" detail="This Session has no stored IM deliveries." />
+        )}
+      </section>
+      {state.value.nextCursor ? (
+        <button className="task-load-more" type="button" disabled={loadingMore} onClick={() => void loadMoreTurns()}>
+          {loadingMore ? "Loading more Turns…" : "Load more Turns"}
+        </button>
+      ) : null}
+      {loadMoreError ? (
+        <p className="task-runtime-error" role="alert">
+          {loadMoreError.message}
+        </p>
+      ) : null}
+
+      {internalSessions.length > 0 || collaborationMessages.length > 0 ? (
+        <details className="task-related-sessions">
+          <summary>
+            Internal collaboration · {internalSessions.length} Sessions · {collaborationMessages.length} messages
+          </summary>
+          <section>
+            {internalSessions.map((session) => (
+              <p key={session.id}>
+                <strong>{session.endedAt ? "Ended" : "Active"}</strong> · <code>{session.id}</code>
+                {session.runtimeModel ? ` · ${session.runtimeModel}` : ""}
+              </p>
+            ))}
+            {collaborationMessages.map((message) => (
+              <article className="task-collaboration-message" key={message.id}>
+                <p>{message.content}</p>
+                <small>
+                  {message.outcome} · {formatTimestamp(message.createdAt)} · {message.sourceSessionId} →{" "}
+                  {message.targetSessionId}
+                </small>
+              </article>
+            ))}
+          </section>
+        </details>
+      ) : null}
     </article>
   );
 }
 
-function TaskConversationExchange({ task, exchange }: { task: TaskPreview; exchange: TaskExchange }) {
-  const processId = `${task.id}-${exchange.id}-process`;
-
+function TaskTurnView({ task, turn }: { task: TaskSummary; turn: TaskTurn }) {
+  const report = turn.report;
+  const usage = report?.usage;
+  const tokenTotal = usage
+    ? (usage.inputTokens ?? 0) + (usage.cachedInputTokens ?? 0) + (usage.outputTokens ?? 0)
+    : null;
   return (
-    <section className="task-exchange" aria-label={`Message sent at ${exchange.requestTime}`}>
+    <section className="task-exchange" aria-label={`Message sent at ${formatTimestamp(turn.message.occurredAt)}`}>
       <article className="task-message task-message--request">
         <header className="task-message-author">
           <span className="task-person-mark" aria-hidden="true">
-            {getInitials(task.initiatedBy)}
+            {getInitials(turn.message.authorDisplayName ?? turn.message.authorKind)}
           </span>
           <span>
-            <strong>{task.initiatedBy}</strong>
+            <strong>{turn.message.authorDisplayName ?? turn.message.authorKind}</strong>
             <small>
-              {task.source.context} · {exchange.requestTime}
+              {turn.attention} · {formatTimestamp(turn.message.occurredAt)}
             </small>
           </span>
         </header>
         <div className="task-request-bubble">
-          <p>{exchange.request}</p>
+          <p>{turn.message.fallbackText || "No text content"}</p>
         </div>
       </article>
 
       <article className="task-message task-message--agent">
         <header className="task-message-author task-message-author--agent">
           <span className="task-agent-mark" aria-hidden="true">
-            {task.agent.charAt(0)}
+            {task.agent.displayName.charAt(0)}
           </span>
           <span>
-            <strong>{task.agent}</strong>
-            <small>
-              {exchange.finalAnswerObservedAt ??
-                (exchange.status === "processing" ? "In progress" : "Time unavailable")}
-            </small>
+            <strong>{task.agent.displayName}</strong>
+            <small>{report ? `${report.outcome} · ${formatTimestamp(report.reportedAt)}` : turn.delivery.state}</small>
           </span>
         </header>
-
-        {exchange.status === "processing" ? <TaskProgressSummary exchange={exchange} /> : null}
-        {exchange.finalAnswer ? <TaskAgentAnswer exchange={exchange} finalAnswer={exchange.finalAnswer} /> : null}
-        {exchange.status === "needs_attention" && !exchange.finalAnswer ? (
-          <p className="task-attention-summary">
-            This request needs attention before it can continue. Open the Feishu thread for the latest context.
+        {report?.finalText ? (
+          <section className="task-agent-response" aria-label="Stored runtime final output">
+            <p className="task-answer-paragraph">{report.finalText}</p>
+          </section>
+        ) : (
+          <p className={turn.delivery.state === "accepted" ? "task-progress-summary" : "task-attention-summary"}>
+            {turn.delivery.state === "accepted"
+              ? "The Turn is running or its report has not arrived."
+              : `Delivery ${turn.delivery.state}.`}
           </p>
-        ) : null}
-        <TaskAgentProcess exchange={exchange} id={processId} />
+        )}
+        <details className="task-agent-process">
+          <summary>
+            <span>Runtime details</span>
+            <Icon name="chevron-right" />
+          </summary>
+          <section className="task-agent-events">
+            <DebugValue label="Delivery" value={turn.deliveryId} />
+            <DebugValue label="Message" value={turn.message.externalMessageId} />
+            {report ? <DebugValue label="Turn" value={report.turnId} /> : null}
+            <p className="task-process-metadata">
+              {[
+                `${turn.delivery.attemptCount} ${turn.delivery.attemptCount === 1 ? "attempt" : "attempts"}`,
+                report ? `Outcome ${report.outcome}` : null,
+                report ? `Effects ${report.executionEffects}` : null,
+                tokenTotal === null ? null : `${tokenTotal.toLocaleString()} tokens`,
+                report ? `${report.traceSummary.lastSequence} trace events` : null,
+                report?.traceSummary.droppedEvents ? `${report.traceSummary.droppedEvents} dropped` : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </p>
+            {report?.errorReason || turn.delivery.lastErrorCode || turn.delivery.reason ? (
+              <p className="task-runtime-error">
+                {report?.errorReason ?? turn.delivery.lastErrorCode ?? turn.delivery.reason}
+              </p>
+            ) : null}
+          </section>
+        </details>
       </article>
     </section>
   );
-}
-
-function TaskProgressSummary({ exchange }: { exchange: TaskExchange }) {
-  const latestReasoning = [...exchange.events].reverse().find((event) => event.kind === "reasoning_summary");
-  return (
-    <p className="task-progress-summary">
-      {latestReasoning?.kind === "reasoning_summary" ? latestReasoning.text : "Working on the request."}
-    </p>
-  );
-}
-
-function TaskAgentAnswer({
-  exchange,
-  finalAnswer,
-}: {
-  exchange: TaskExchange;
-  finalAnswer: NonNullable<TaskExchange["finalAnswer"]>;
-}) {
-  return (
-    <section className="task-agent-response" aria-label="Agent final answer">
-      {finalAnswer.blocks.map((block) => {
-        if (block.kind === "paragraph") {
-          return (
-            <p className="task-answer-paragraph" key={block.text}>
-              {block.text}
-            </p>
-          );
-        }
-        return (
-          <ul key={block.items.join("\n")}>
-            {block.items.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        );
-      })}
-      {exchange.finalAnswerObservedAt ? (
-        <p className="task-result-observation">
-          Recorded locally at {exchange.finalAnswerObservedAt} · Open Feishu for the authoritative thread
-        </p>
-      ) : null}
-    </section>
-  );
-}
-
-function TaskAgentProcess({ exchange, id }: { exchange: TaskExchange; id: string }) {
-  const toolCalls = exchange.events.filter((event): event is TaskToolCall => event.kind === "tool_call");
-  const surfacedReasoningId =
-    exchange.status === "processing"
-      ? [...exchange.events].reverse().find((event) => event.kind === "reasoning_summary")?.id
-      : undefined;
-  const processItems = groupTaskProcessItems(exchange.events).filter((item) => item.id !== surfacedReasoningId);
-  const firstToolGroup = processItems.find((item): item is TaskToolCallGroup => item.kind === "tool_call_group");
-  const usage = exchange.usage.total
-    ? [`${exchange.usage.total} tokens`]
-    : [
-        exchange.usage.input ? `${exchange.usage.input} input` : null,
-        exchange.usage.output ? `${exchange.usage.output} output` : null,
-      ].filter(Boolean);
-  const processSummary =
-    exchange.status === "processing" ? "Activity details · In progress" : `Activity details · ${exchange.duration}`;
-  const processMetadata = [
-    `${toolCalls.length} ${toolCalls.length === 1 ? "tool call" : "tool calls"}`,
-    `${exchange.retries} ${exchange.retries === 1 ? "retry" : "retries"}`,
-    ...usage,
-  ];
-
-  return (
-    <details className="task-agent-process">
-      <summary id={id}>
-        <span>{processSummary}</span>
-        <Icon name="chevron-right" />
-      </summary>
-      <section className="task-agent-events" aria-labelledby={id}>
-        {processItems.map((item) => {
-          if (item.kind === "reasoning_summary") {
-            return (
-              <p className="task-reasoning-summary" key={item.id}>
-                {item.text}
-              </p>
-            );
-          }
-          return (
-            <TaskToolCallGroupView
-              group={item}
-              initiallyOpen={item.id === firstToolGroup?.id || hasActiveToolCall(item.calls)}
-              key={item.id}
-            />
-          );
-        })}
-      </section>
-      <p className="task-process-metadata">{processMetadata.join(" · ")}</p>
-    </details>
-  );
-}
-
-function TaskToolCallGroupView({ group, initiallyOpen }: { group: TaskToolCallGroup; initiallyOpen: boolean }) {
-  const attentionCall = group.calls.find((call) => call.status !== "completed");
-
-  return (
-    <details className="task-tool-group" open={initiallyOpen}>
-      <summary>
-        <span>{group.label}</span>
-        <span className="task-tool-group-summary-end">
-          {attentionCall ? (
-            <span className={`task-tool-group-state task-tool-group-state--${attentionCall.status}`}>
-              {toolStatusPresentation[attentionCall.status].label}
-            </span>
-          ) : null}
-          <Icon name="chevron-right" />
-        </span>
-      </summary>
-      <section className="task-tool-list" aria-label={group.label}>
-        {group.calls.map((call) => (
-          <TaskToolCallRow call={call} key={call.id} />
-        ))}
-      </section>
-    </details>
-  );
-}
-
-function TaskToolCallRow({ call }: { call: TaskToolCall }) {
-  return (
-    <details className="task-tool-call">
-      <summary>
-        <span>{call.action}</span>
-        <Icon name="chevron-right" />
-      </summary>
-      <section className="task-tool-call-detail" aria-label={`${call.action} details`}>
-        <p>
-          <span>Source</span>
-          {call.detail}
-        </p>
-        <p>
-          <span>Result</span>
-          {call.result}
-        </p>
-      </section>
-    </details>
-  );
-}
-
-function groupTaskProcessItems(events: readonly TaskAgentEvent[]): readonly TaskProcessItem[] {
-  const items: TaskProcessItem[] = [];
-
-  for (const event of events) {
-    if (event.kind === "reasoning_summary") {
-      items.push(event);
-      continue;
-    }
-
-    const previous = items.at(-1);
-    if (previous?.kind === "tool_call_group" && previous.id === event.groupId) {
-      items[items.length - 1] = { ...previous, calls: [...previous.calls, event] };
-      continue;
-    }
-
-    items.push({ calls: [event], id: event.groupId, kind: "tool_call_group", label: event.groupLabel });
-  }
-
-  return items;
-}
-
-function hasActiveToolCall(calls: readonly TaskToolCall[]): boolean {
-  return calls.some((call) => call.status !== "completed");
 }
 
 function TaskSelect({
@@ -407,25 +395,27 @@ function TaskSelect({
   );
 }
 
-function TaskRow({ task }: { task: TaskPreview }) {
+function TaskRow({ task }: { task: TaskSummary }) {
   const status = statusPresentation[task.status];
   return (
     <tr className="task-table-grid task-table-row">
       <td className="task-work-cell" data-label="Task">
         <Link to={`/tasks/${task.id}`}>{task.title}</Link>
         <span className="task-list-metadata">
-          <span>{task.agent}</span>
+          <span>{task.agent.displayName}</span>
           <span aria-hidden="true">·</span>
-          <FeishuIcon compact />
-          <span>{task.source.context}</span>
+          <ProviderIcon provider={task.source.provider} compact />
+          <span>{task.source.provider}</span>
           <span aria-hidden="true">·</span>
-          <span>{task.source.detail}</span>
+          <span>{task.sessionKind}</span>
+          <span aria-hidden="true">·</span>
+          <span>{shortId(task.source.threadKey ?? task.source.channelId)}</span>
         </span>
       </td>
       <td className="task-status-cell" data-label="Status">
         <StatusIndicator
-          aria-label={`${status.label}, updated ${task.relativeUpdatedAt}`}
-          detail={task.relativeUpdatedAt}
+          aria-label={`${status.label}, updated ${formatRelativeTime(task.lastActivityAt)}`}
+          detail={formatRelativeTime(task.lastActivityAt)}
           label={status.label}
           tone={status.tone}
         />
@@ -434,19 +424,33 @@ function TaskRow({ task }: { task: TaskPreview }) {
   );
 }
 
-function SourceIdentity({ task }: { task: TaskPreview }) {
+function SourceIdentity({ task }: { task: TaskSummary }) {
   return (
     <span className="task-source-identity">
-      <FeishuIcon />
+      <ProviderIcon provider={task.source.provider} />
       <span>
-        <strong>{task.source.context}</strong>
-        <small>Feishu · {task.source.detail}</small>
+        <strong>{task.agent.displayName}</strong>
+        <small>
+          {task.source.provider} · {task.sessionKind} · {shortId(task.source.threadKey ?? task.source.channelId)}
+        </small>
       </span>
     </span>
   );
 }
 
-function FeishuIcon({ compact = false }: { compact?: boolean }) {
+function ProviderIcon({
+  provider,
+  compact = false,
+}: {
+  provider: TaskSummary["source"]["provider"];
+  compact?: boolean;
+}) {
+  if (provider !== "feishu")
+    return (
+      <span className="task-provider-mark" aria-hidden="true">
+        S
+      </span>
+    );
   return (
     <img
       alt=""
@@ -457,10 +461,55 @@ function FeishuIcon({ compact = false }: { compact?: boolean }) {
   );
 }
 
+function DebugValue({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="task-debug-value">
+      <strong>{label}</strong>
+      <code>{value}</code>
+      <button type="button" onClick={() => void navigator.clipboard?.writeText(value)} aria-label={`Copy ${label}`}>
+        Copy
+      </button>
+    </span>
+  );
+}
+
+function TaskNotice({ heading, detail }: { heading: string; detail: string }) {
+  return (
+    <section className="task-empty-state" aria-live="polite">
+      <h2>{heading}</h2>
+      <p>{detail}</p>
+    </section>
+  );
+}
+
+function formatTimestamp(value: string): string {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+}
+
+function formatRelativeTime(value: string): string {
+  const deltaSeconds = Math.round((new Date(value).getTime() - Date.now()) / 1_000);
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const absolute = Math.abs(deltaSeconds);
+  if (absolute < 60) return formatter.format(deltaSeconds, "second");
+  const deltaMinutes = Math.round(deltaSeconds / 60);
+  if (Math.abs(deltaMinutes) < 60) return formatter.format(deltaMinutes, "minute");
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (Math.abs(deltaHours) < 24) return formatter.format(deltaHours, "hour");
+  return formatter.format(Math.round(deltaHours / 24), "day");
+}
+
+function shortId(value: string): string {
+  return value.length <= 18 ? value : `${value.slice(0, 8)}…${value.slice(-6)}`;
+}
+
 function getInitials(name: string): string {
   return name
     .split(/\s+/u)
     .slice(0, 2)
     .map((part) => part.charAt(0))
     .join("");
+}
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error("The request failed");
 }

--- a/packages/server/drizzle/0018_salty_tombstone.sql
+++ b/packages/server/drizzle/0018_salty_tombstone.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "im_message_deliveries_session_id_idx" ON "im_message_deliveries" USING btree ("session_id");

--- a/packages/server/drizzle/meta/0018_snapshot.json
+++ b/packages/server/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,3386 @@
+{
+  "id": "a246d5f9-64bc-40be-aac1-22e2f67ad93b",
+  "prevId": "d3a69f86-252a-4f2e-bf84-0afc079c9164",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_runtime_configs": {
+      "name": "agent_runtime_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('runtime_config_revision_sequence')"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_duration_ms": {
+          "name": "max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_runtime_configs_agent_id_agents_id_fk": {
+          "name": "agent_runtime_configs_agent_id_agents_id_fk",
+          "tableFrom": "agent_runtime_configs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runtime_configs_revision_safe_positive": {
+          "name": "agent_runtime_configs_revision_safe_positive",
+          "value": "\"agent_runtime_configs\".\"revision\" > 0 and \"agent_runtime_configs\".\"revision\" <= 9007199254740991"
+        },
+        "agent_runtime_configs_max_duration_valid": {
+          "name": "agent_runtime_configs_max_duration_valid",
+          "value": "\"agent_runtime_configs\".\"max_duration_ms\" is null or (\"agent_runtime_configs\".\"max_duration_ms\" > 0 and \"agent_runtime_configs\".\"max_duration_ms\" <= 86400000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_intent_id": {
+          "name": "creation_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_intent_fingerprint": {
+          "name": "creation_intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "agent_runtime_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_mode": {
+          "name": "receive_mode",
+          "type": "agent_receive_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_message'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_workspace_name_active_unique": {
+          "name": "agents_workspace_name_active_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_creation_intent_unique": {
+          "name": "agents_creation_intent_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"creation_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_id_idx": {
+          "name": "agents_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_created_by_user_id_idx": {
+          "name": "agents_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_computer_id_idx": {
+          "name": "agents_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_workspace_id_workspaces_id_fk": {
+          "name": "agents_workspace_id_workspaces_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_created_by_user_id_users_id_fk": {
+          "name": "agents_created_by_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_workspace_enrollment_fk": {
+          "name": "agents_workspace_enrollment_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_creation_intent_pair": {
+          "name": "agents_creation_intent_pair",
+          "value": "(\"agents\".\"creation_intent_id\" is null) = (\"agents\".\"creation_intent_fingerprint\" is null)"
+        },
+        "agents_revision_positive": {
+          "name": "agents_revision_positive",
+          "value": "\"agents\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_cli_login_codes": {
+      "name": "account_cli_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_cli_login_codes_user_created_idx": {
+          "name": "account_cli_login_codes_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_cli_login_codes_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_cli_login_codes_issued_by_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_cli_login_codes_token_hash_unique": {
+          "name": "account_cli_login_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_cli_login_codes_expiry": {
+          "name": "account_cli_login_codes_expiry",
+          "value": "\"account_cli_login_codes\".\"expires_at\" > \"account_cli_login_codes\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_admin_grants": {
+      "name": "workspace_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_admin_grants_active_workspace_user_unique": {
+          "name": "workspace_admin_grants_active_workspace_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_active_user_workspace_idx": {
+          "name": "workspace_admin_grants_active_user_workspace_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_workspace_granted_idx": {
+          "name": "workspace_admin_grants_workspace_granted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_admin_grants_workspace_id_workspaces_id_fk": {
+          "name": "workspace_admin_grants_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_admin_grants_revocation_pair": {
+          "name": "workspace_admin_grants_revocation_pair",
+          "value": "(\"workspace_admin_grants\".\"revoked_by_user_id\" is null) = (\"workspace_admin_grants\".\"revoked_at\" is null)"
+        },
+        "workspace_admin_grants_revoked_after_granted": {
+          "name": "workspace_admin_grants_revoked_after_granted",
+          "value": "\"workspace_admin_grants\".\"revoked_at\" is null or \"workspace_admin_grants\".\"revoked_at\" >= \"workspace_admin_grants\".\"granted_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_name_unique": {
+          "name": "workspaces_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_identities_provider_subject_unique": {
+          "name": "auth_identities_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_provider_unique": {
+          "name": "auth_identities_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_id_idx": {
+          "name": "auth_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_connect_codes": {
+      "name": "computer_connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_workspace_computer_id": {
+          "name": "consumed_workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_connect_codes_workspace_created_idx": {
+          "name": "computer_connect_codes_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_connect_codes_workspace_id_workspaces_id_fk": {
+          "name": "computer_connect_codes_workspace_id_workspaces_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_revoked_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_workspace_enrollment_fk": {
+          "name": "computer_connect_codes_workspace_enrollment_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "consumed_workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_connect_codes_token_hash_unique": {
+          "name": "computer_connect_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_connect_codes_expiry": {
+          "name": "computer_connect_codes_expiry",
+          "value": "\"computer_connect_codes\".\"expires_at\" > \"computer_connect_codes\".\"created_at\""
+        },
+        "computer_connect_codes_consumption_pair": {
+          "name": "computer_connect_codes_consumption_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_workspace_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_revocation_pair": {
+          "name": "computer_connect_codes_revocation_pair",
+          "value": "(\"computer_connect_codes\".\"revoked_by_user_id\" is null) = (\"computer_connect_codes\".\"revoked_at\" is null)"
+        },
+        "computer_connect_codes_terminal_state": {
+          "name": "computer_connect_codes_terminal_state",
+          "value": "not (\"computer_connect_codes\".\"consumed_at\" is not null and \"computer_connect_codes\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computers": {
+      "name": "computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_computer_credentials": {
+      "name": "workspace_computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_computer_credentials_active_enrollment_unique": {
+          "name": "workspace_computer_credentials_active_enrollment_unique",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computer_credentials_enrollment_issued_idx": {
+          "name": "workspace_computer_credentials_enrollment_issued_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computer_credentials_secret_hash_unique": {
+          "name": "workspace_computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computer_credentials_revocation_pair": {
+          "name": "workspace_computer_credentials_revocation_pair",
+          "value": "(\"workspace_computer_credentials\".\"revoked_by_user_id\" is null) = (\"workspace_computer_credentials\".\"revoked_at\" is null)"
+        },
+        "workspace_computer_credentials_revoked_after_issued": {
+          "name": "workspace_computer_credentials_revoked_after_issued",
+          "value": "\"workspace_computer_credentials\".\"revoked_at\" is null or \"workspace_computer_credentials\".\"revoked_at\" >= \"workspace_computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_computers": {
+      "name": "workspace_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_by_user_id": {
+          "name": "enrolled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_computers_active_workspace_computer_unique": {
+          "name": "workspace_computers_active_workspace_computer_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_active_workspace_idx": {
+          "name": "workspace_computers_active_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_computer_id_idx": {
+          "name": "workspace_computers_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computers_workspace_id_workspaces_id_fk": {
+          "name": "workspace_computers_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_computer_id_computers_id_fk": {
+          "name": "workspace_computers_computer_id_computers_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_enrolled_by_user_id_users_id_fk": {
+          "name": "workspace_computers_enrolled_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enrolled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computers_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computers_workspace_id_id_unique": {
+          "name": "workspace_computers_workspace_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computers_revocation_pair": {
+          "name": "workspace_computers_revocation_pair",
+          "value": "(\"workspace_computers\".\"revoked_by_user_id\" is null) = (\"workspace_computers\".\"revoked_at\" is null)"
+        },
+        "workspace_computers_revoked_after_enrolled": {
+          "name": "workspace_computers_revoked_after_enrolled",
+          "value": "\"workspace_computers\".\"revoked_at\" is null or \"workspace_computers\".\"revoked_at\" >= \"workspace_computers\".\"enrolled_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_bindings": {
+      "name": "im_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "im_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "im_binding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_brand": {
+          "name": "external_team_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "setup_attempt_id": {
+          "name": "setup_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_intent": {
+          "name": "setup_intent",
+          "type": "feishu_setup_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_state": {
+          "name": "setup_state",
+          "type": "feishu_setup_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_instance_id": {
+          "name": "setup_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_heartbeat_at": {
+          "name": "setup_owner_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_setup_context": {
+          "name": "encrypted_setup_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_expires_at": {
+          "name": "setup_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_im_binding_id": {
+          "name": "replacement_im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_owner_instance_id": {
+          "name": "connection_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_fencing_epoch": {
+          "name": "connection_fencing_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_lease_expires_at": {
+          "name": "connection_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_bindings_agent_current_unique": {
+          "name": "im_bindings_agent_current_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_feishu_app_current_unique": {
+          "name": "im_bindings_feishu_app_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_app_team_current_unique": {
+          "name": "im_bindings_slack_app_team_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_agent_id_agents_id_fk": {
+          "name": "im_bindings_agent_id_agents_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_replacement_im_binding_id_im_bindings_id_fk": {
+          "name": "im_bindings_replacement_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "replacement_im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_bindings_credential_generation_nonnegative": {
+          "name": "im_bindings_credential_generation_nonnegative",
+          "value": "\"im_bindings\".\"credential_generation\" >= 0"
+        },
+        "im_bindings_connection_epoch_nonnegative": {
+          "name": "im_bindings_connection_epoch_nonnegative",
+          "value": "\"im_bindings\".\"connection_fencing_epoch\" >= 0"
+        },
+        "im_bindings_active_binding_shape": {
+          "name": "im_bindings_active_binding_shape",
+          "value": "\"im_bindings\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"im_bindings\".\"external_app_id\" is not null and\n        (\"im_bindings\".\"provider\" = 'feishu' or \"im_bindings\".\"external_team_id\" is not null) and\n        \"im_bindings\".\"external_bot_id\" is not null and \"im_bindings\".\"credential_schema_version\" is not null and\n        \"im_bindings\".\"credential_generation\" >= 1 and \"im_bindings\".\"encrypted_credential\" is not null and\n        \"im_bindings\".\"activated_at\" is not null and \"im_bindings\".\"disabled_at\" is null\n      )"
+        },
+        "im_bindings_disabled_secret_shape": {
+          "name": "im_bindings_disabled_secret_shape",
+          "value": "\"im_bindings\".\"status\" <> 'disabled' or (\n        \"im_bindings\".\"encrypted_credential\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"connection_owner_instance_id\" is null and\n        \"im_bindings\".\"connection_lease_expires_at\" is null and \"im_bindings\".\"disabled_at\" is not null\n      )"
+        },
+        "im_bindings_setup_owner_shape": {
+          "name": "im_bindings_setup_owner_shape",
+          "value": "(\"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"setup_owner_heartbeat_at\" is null and\n        \"im_bindings\".\"encrypted_setup_context\" is null and \"im_bindings\".\"setup_expires_at\" is null)\n        or (\"im_bindings\".\"setup_attempt_id\" is not null and \"im_bindings\".\"setup_intent\" is not null and\n        \"im_bindings\".\"setup_state\" is not null and \"im_bindings\".\"setup_owner_instance_id\" is not null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is not null and \"im_bindings\".\"encrypted_setup_context\" is not null and\n        \"im_bindings\".\"setup_expires_at\" is not null)"
+        },
+        "im_bindings_connection_owner_shape": {
+          "name": "im_bindings_connection_owner_shape",
+          "value": "(\"im_bindings\".\"connection_owner_instance_id\" is null and \"im_bindings\".\"connection_lease_expires_at\" is null)\n        or (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"connection_owner_instance_id\" is not null and\n        \"im_bindings\".\"connection_lease_expires_at\" is not null)"
+        },
+        "im_bindings_slack_setup_fields_null": {
+          "name": "im_bindings_slack_setup_fields_null",
+          "value": "\"im_bindings\".\"provider\" <> 'slack' or (\n        \"im_bindings\".\"setup_attempt_id\" is null and \"im_bindings\".\"setup_intent\" is null and\n        \"im_bindings\".\"setup_state\" is null and \"im_bindings\".\"setup_owner_instance_id\" is null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_expires_at\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_message_deliveries": {
+      "name": "im_message_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attention": {
+          "name": "attention",
+          "type": "im_delivery_attention",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "im_delivery_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_request_id": {
+          "name": "dispatch_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_input_hash": {
+          "name": "dispatch_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_payload": {
+          "name": "dispatch_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_owner_instance_id": {
+          "name": "report_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_hash": {
+          "name": "result_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_report": {
+          "name": "turn_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "im_message_deliveries_message_session_unique": {
+          "name": "im_message_deliveries_message_session_unique",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_session_id_idx": {
+          "name": "im_message_deliveries_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_pending_idx": {
+          "name": "im_message_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_dispatch_request_unique": {
+          "name": "im_message_deliveries_dispatch_request_unique",
+          "columns": [
+            {
+              "expression": "dispatch_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"dispatch_request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_turn_id_unique": {
+          "name": "im_message_deliveries_turn_id_unique",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"turn_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_deliveries_message_id_im_messages_id_fk": {
+          "name": "im_message_deliveries_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_session_id_sessions_id_fk": {
+          "name": "im_message_deliveries_session_id_sessions_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_message_deliveries_dispatch_shape": {
+          "name": "im_message_deliveries_dispatch_shape",
+          "value": "(\"im_message_deliveries\".\"dispatch_request_id\" is null and \"im_message_deliveries\".\"dispatch_input_hash\" is null and \"im_message_deliveries\".\"dispatch_payload\" is null)\n        or (\"im_message_deliveries\".\"dispatch_request_id\" is not null and \"im_message_deliveries\".\"dispatch_input_hash\" is not null\n          and (\"im_message_deliveries\".\"dispatch_payload\" is not null or \"im_message_deliveries\".\"state\" = 'accepted'))"
+        },
+        "im_message_deliveries_custody_shape": {
+          "name": "im_message_deliveries_custody_shape",
+          "value": "(\"im_message_deliveries\".\"state\" = 'accepted' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"turn_id\" is not null and \"im_message_deliveries\".\"report_owner_instance_id\" is not null and \"im_message_deliveries\".\"accepted_at\" is not null)\n        or (\"im_message_deliveries\".\"state\" <> 'accepted' and \"im_message_deliveries\".\"turn_id\" is null and \"im_message_deliveries\".\"report_owner_instance_id\" is null and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null and \"im_message_deliveries\".\"result_hash\" is null)"
+        },
+        "im_message_deliveries_report_shape": {
+          "name": "im_message_deliveries_report_shape",
+          "value": "(\"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null)\n        or (\"im_message_deliveries\".\"reported_at\" is not null and \"im_message_deliveries\".\"turn_report\" is not null and \"im_message_deliveries\".\"result_hash\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_messages": {
+      "name": "im_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_revision_key": {
+          "name": "provider_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "im_message_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "im_message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_external_id": {
+          "name": "reply_to_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "im_author_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_external_id": {
+          "name": "author_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_context": {
+          "name": "provider_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_messages_provider_event_unique": {
+          "name": "im_messages_provider_event_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_messages\".\"provider_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_semantic_revision_unique": {
+          "name": "im_messages_semantic_revision_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_revision_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_scope_occurred_idx": {
+          "name": "im_messages_scope_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_external_occurred_idx": {
+          "name": "im_messages_external_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_messages_im_binding_id_im_bindings_id_fk": {
+          "name": "im_messages_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invitations": {
+      "name": "admin_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_invitations_workspace_created_idx": {
+          "name": "admin_invitations_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_invitations_workspace_id_workspaces_id_fk": {
+          "name": "admin_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_created_by_user_id_users_id_fk": {
+          "name": "admin_invitations_created_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_accepted_by_user_id_users_id_fk": {
+          "name": "admin_invitations_accepted_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_revoked_by_user_id_users_id_fk": {
+          "name": "admin_invitations_revoked_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invitations_token_hash_unique": {
+          "name": "admin_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invitations_expiry": {
+          "name": "admin_invitations_expiry",
+          "value": "\"admin_invitations\".\"expires_at\" > \"admin_invitations\".\"created_at\""
+        },
+        "admin_invitations_acceptance_pair": {
+          "name": "admin_invitations_acceptance_pair",
+          "value": "(\"admin_invitations\".\"accepted_by_user_id\" is null) = (\"admin_invitations\".\"accepted_at\" is null)"
+        },
+        "admin_invitations_revocation_pair": {
+          "name": "admin_invitations_revocation_pair",
+          "value": "(\"admin_invitations\".\"revoked_by_user_id\" is null) = (\"admin_invitations\".\"revoked_at\" is null)"
+        },
+        "admin_invitations_terminal_state": {
+          "name": "admin_invitations_terminal_state",
+          "value": "not (\"admin_invitations\".\"accepted_at\" is not null and \"admin_invitations\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_messages": {
+      "name": "session_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_outcome": {
+          "name": "last_outcome",
+          "type": "session_message_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_messages_target_created_idx": {
+          "name": "session_messages_target_created_idx",
+          "columns": [
+            {
+              "expression": "target_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_messages_source_created_idx": {
+          "name": "session_messages_source_created_idx",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_messages_source_session_id_sessions_id_fk": {
+          "name": "session_messages_source_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "source_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_messages_target_session_id_sessions_id_fk": {
+          "name": "session_messages_target_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_messages_content_hash_shape": {
+          "name": "session_messages_content_hash_shape",
+          "value": "\"session_messages\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_messages_content_bounds": {
+          "name": "session_messages_content_bounds",
+          "value": "octet_length(\"session_messages\".\"content\") between 1 and 16384"
+        },
+        "session_messages_error_code_shape": {
+          "name": "session_messages_error_code_shape",
+          "value": "\"session_messages\".\"last_error_code\" is null or (\"session_messages\".\"last_error_code\" ~ '^[a-z][a-z0-9_]{0,127}$')"
+        },
+        "session_messages_attempt_count_nonnegative": {
+          "name": "session_messages_attempt_count_nonnegative",
+          "value": "\"session_messages\".\"attempt_count\" >= 0"
+        },
+        "session_messages_attempt_shape": {
+          "name": "session_messages_attempt_shape",
+          "value": "(\"session_messages\".\"attempt_count\" = 0 and \"session_messages\".\"last_attempt_at\" is null)\n        or (\"session_messages\".\"attempt_count\" > 0 and \"session_messages\".\"last_attempt_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_placements": {
+      "name": "session_placements",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_placements_workspace_computer_id_idx": {
+          "name": "session_placements_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_placements_session_id_sessions_id_fk": {
+          "name": "session_placements_session_id_sessions_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_placements_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_placements_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_placements_generation_positive": {
+          "name": "session_placements_generation_positive",
+          "value": "\"session_placements\".\"generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_kind": {
+          "name": "conversation_kind",
+          "type": "im_conversation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "session_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_model": {
+          "name": "runtime_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_reasoning_effort": {
+          "name": "runtime_reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_max_duration_ms": {
+          "name": "runtime_max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_active_channel_unique": {
+          "name": "sessions_active_channel_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'channel' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_active_thread_unique": {
+          "name": "sessions_active_thread_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'thread' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_im_binding_scope_idx": {
+          "name": "sessions_im_binding_scope_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_im_binding_id_im_bindings_id_fk": {
+          "name": "sessions_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sessions_created_by_session_id_sessions_id_fk": {
+          "name": "sessions_created_by_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "created_by_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sessions_shape_check": {
+          "name": "sessions_shape_check",
+          "value": "(\"sessions\".\"kind\" = 'channel' and \"sessions\".\"thread_key\" is null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'thread' and \"sessions\".\"thread_key\" is not null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'internal' and \"sessions\".\"created_by_session_id\" is not null)"
+        },
+        "sessions_runtime_max_duration_valid": {
+          "name": "sessions_runtime_max_duration_valid",
+          "value": "\"sessions\".\"runtime_max_duration_ms\" is null or (\"sessions\".\"runtime_max_duration_ms\" > 0 and \"sessions\".\"runtime_max_duration_ms\" <= 86400000)"
+        },
+        "sessions_runtime_model_bounds": {
+          "name": "sessions_runtime_model_bounds",
+          "value": "\"sessions\".\"runtime_model\" is null or octet_length(\"sessions\".\"runtime_model\") between 1 and 128"
+        },
+        "sessions_runtime_reasoning_effort_bounds": {
+          "name": "sessions_runtime_reasoning_effort_bounds",
+          "value": "\"sessions\".\"runtime_reasoning_effort\" is null or octet_length(\"sessions\".\"runtime_reasoning_effort\") between 1 and 64"
+        },
+        "sessions_revision_positive": {
+          "name": "sessions_revision_positive",
+          "value": "\"sessions\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_oauth_nonces": {
+      "name": "slack_oauth_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_binding_id": {
+          "name": "expected_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_credential_generation": {
+          "name": "expected_credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_binding_hash": {
+          "name": "session_binding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_oauth_nonces_user_agent_idx": {
+          "name": "slack_oauth_nonces_user_agent_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_oauth_nonces_expires_idx": {
+          "name": "slack_oauth_nonces_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_oauth_nonces_user_id_users_id_fk": {
+          "name": "slack_oauth_nonces_user_id_users_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_oauth_nonces_agent_id_agents_id_fk": {
+          "name": "slack_oauth_nonces_agent_id_agents_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_oauth_nonces_nonce_hash_unique": {
+          "name": "slack_oauth_nonces_nonce_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_oauth_nonces_intent": {
+          "name": "slack_oauth_nonces_intent",
+          "value": "\"slack_oauth_nonces\".\"intent\" in ('create', 'reauthorize', 'replace')"
+        },
+        "slack_oauth_nonces_expiry": {
+          "name": "slack_oauth_nonces_expiry",
+          "value": "\"slack_oauth_nonces\".\"expires_at\" > \"slack_oauth_nonces\".\"created_at\""
+        },
+        "slack_oauth_nonces_expected_binding_pair": {
+          "name": "slack_oauth_nonces_expected_binding_pair",
+          "value": "(\"slack_oauth_nonces\".\"expected_binding_id\" is null) = (\"slack_oauth_nonces\".\"expected_credential_generation\" is null)"
+        },
+        "slack_oauth_nonces_generation_positive": {
+          "name": "slack_oauth_nonces_generation_positive",
+          "value": "\"slack_oauth_nonces\".\"expected_credential_generation\" is null or \"slack_oauth_nonces\".\"expected_credential_generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_receive_mode": {
+      "name": "agent_receive_mode",
+      "schema": "public",
+      "values": [
+        "all_message",
+        "mention_only"
+      ]
+    },
+    "public.agent_runtime_provider": {
+      "name": "agent_runtime_provider",
+      "schema": "public",
+      "values": [
+        "codex",
+        "claude-code"
+      ]
+    },
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "suspended",
+        "deleted"
+      ]
+    },
+    "public.computer_platform": {
+      "name": "computer_platform",
+      "schema": "public",
+      "values": [
+        "darwin",
+        "linux",
+        "win32"
+      ]
+    },
+    "public.feishu_setup_intent": {
+      "name": "feishu_setup_intent",
+      "schema": "public",
+      "values": [
+        "create",
+        "reauthorize",
+        "replace"
+      ]
+    },
+    "public.feishu_setup_state": {
+      "name": "feishu_setup_state",
+      "schema": "public",
+      "values": [
+        "awaiting_user",
+        "validating",
+        "succeeded",
+        "failed",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.im_binding_status": {
+      "name": "im_binding_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "active",
+        "reauthorization_required",
+        "error",
+        "disabled"
+      ]
+    },
+    "public.im_conversation_kind": {
+      "name": "im_conversation_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "dm",
+        "group_dm"
+      ]
+    },
+    "public.im_provider": {
+      "name": "im_provider",
+      "schema": "public",
+      "values": [
+        "feishu",
+        "slack"
+      ]
+    },
+    "public.im_author_kind": {
+      "name": "im_author_kind",
+      "schema": "public",
+      "values": [
+        "human",
+        "bot",
+        "system"
+      ]
+    },
+    "public.im_delivery_attention": {
+      "name": "im_delivery_attention",
+      "schema": "public",
+      "values": [
+        "direct",
+        "ambient"
+      ]
+    },
+    "public.im_delivery_state": {
+      "name": "im_delivery_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "terminal_rejected",
+        "expired"
+      ]
+    },
+    "public.im_message_direction": {
+      "name": "im_message_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.im_message_operation": {
+      "name": "im_message_operation",
+      "schema": "public",
+      "values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "public.session_message_outcome": {
+      "name": "session_message_outcome",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "accepted",
+        "unreachable",
+        "rejected"
+      ]
+    },
+    "public.session_kind": {
+      "name": "session_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "thread",
+        "internal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {
+    "public.runtime_config_revision_sequence": {
+      "name": "runtime_config_revision_sequence",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1787803634944,
       "tag": "0017_sour_tiger_shark",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1787810578295,
+      "tag": "0018_salty_tombstone",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/account-api.test.ts
+++ b/packages/server/src/__tests__/account-api.test.ts
@@ -12,6 +12,7 @@ import { createApp } from "../app.js";
 import type { AgentService } from "../services/agents/index.js";
 import { AuthServiceError, type UserAuthService } from "../services/auth/index.js";
 import type { ComputerService, MachineAuthService } from "../services/computers/index.js";
+import type { TaskService } from "../services/tasks/index.js";
 import type { WorkspaceAdminService, WorkspaceSetupService } from "../services/workspaces/index.js";
 
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
@@ -73,6 +74,17 @@ const createAgentPayload = {
   runtimeProvider: "codex" as const,
   computerId,
 };
+const taskSummary = {
+  id: "11111111-1111-4111-8111-111111111111",
+  agent: { id: agentId, name: agent.name, displayName: agent.displayName, runtimeProvider: agent.runtimeProvider },
+  source: { provider: "feishu" as const, conversationKind: "dm" as const, channelId: "oc_debug", threadKey: null },
+  sessionKind: "channel" as const,
+  title: "Inspect the latest Turn",
+  status: "completed" as const,
+  createdAt: "2026-08-19T00:00:00.000Z",
+  endedAt: null,
+  lastActivityAt: "2026-08-19T00:01:00.000Z",
+};
 
 const apps: ReturnType<typeof createApp>[] = [];
 
@@ -125,6 +137,16 @@ function services() {
         issuedAt: new Date("2026-08-19T00:00:00.000Z"),
       }),
     },
+    taskService: {
+      list: vi.fn().mockResolvedValue({ tasks: [taskSummary], nextCursor: null }),
+      get: vi.fn().mockResolvedValue({
+        task: taskSummary,
+        turns: [],
+        internalSessions: [],
+        collaborationMessages: [],
+        nextCursor: null,
+      }),
+    },
     workspaceService: {
       listComputers: vi.fn().mockResolvedValue({ computers: [computerSummary] }),
     },
@@ -141,6 +163,7 @@ function appWith(overrides: Partial<ReturnType<typeof services>> = {}) {
     accountScope: service.accountScope as unknown as AccountScopeResolver,
     agentService: service.agentService as unknown as AgentService,
     machineAuthService: service.machineAuthService as unknown as MachineAuthService,
+    taskService: service.taskService as unknown as TaskService,
     // The legacy connect-code route is gated behind the runtime Computer service; the Account-native
     // route is not, so the equivalence comparison needs both registered.
     computerService: {} as unknown as ComputerService,
@@ -153,6 +176,33 @@ function appWith(overrides: Partial<ReturnType<typeof services>> = {}) {
 }
 
 describe("Account-native management collections", () => {
+  it("lists and reads read-only Tasks in the authenticated Account scope", async () => {
+    const { app, service } = appWith();
+
+    const list = await app.inject({
+      method: "GET",
+      url: `${HTTP_PATHS.accountTasks}?limit=25&kind=channel&agentId=${agentId}`,
+      headers: authorization,
+    });
+    expect(list.statusCode).toBe(200);
+    expect(list.headers["cache-control"]).toBe("no-store");
+    expect(list.json()).toEqual({ tasks: [taskSummary], nextCursor: null });
+    expect(service.taskService.list).toHaveBeenCalledWith(workspaceId, {
+      agentId,
+      kind: "channel",
+      limit: 25,
+    });
+
+    const detail = await app.inject({
+      method: "GET",
+      url: `${HTTP_PATHS.accountTasks}/${taskSummary.id}`,
+      headers: authorization,
+    });
+    expect(detail.statusCode).toBe(200);
+    expect(detail.headers["cache-control"]).toBe("no-store");
+    expect(service.taskService.get).toHaveBeenCalledWith(workspaceId, taskSummary.id, { limit: 50 });
+  });
+
   it("creates and lists Agents without a client-selected scope", async () => {
     const { app, service } = appWith();
 

--- a/packages/server/src/__tests__/integration/auth-migrations.test.ts
+++ b/packages/server/src/__tests__/integration/auth-migrations.test.ts
@@ -87,7 +87,7 @@ describe("database migrations", () => {
       entries: Array<{ idx: number; tag: string }>;
     };
 
-    expect(journal.entries.slice(-8).map(({ idx, tag }) => ({ idx, tag }))).toEqual([
+    expect(journal.entries.slice(-9).map(({ idx, tag }) => ({ idx, tag }))).toEqual([
       { idx: 10, tag: "0010_optimal_jazinda" },
       { idx: 11, tag: "0011_staging_team_setup_repair" },
       { idx: 12, tag: "0012_supreme_maddog" },
@@ -96,6 +96,7 @@ describe("database migrations", () => {
       { idx: 15, tag: "0015_spotty_machine_man" },
       { idx: 16, tag: "0016_certain_revanche" },
       { idx: 17, tag: "0017_sour_tiger_shark" },
+      { idx: 18, tag: "0018_salty_tombstone" },
     ]);
   });
 
@@ -628,7 +629,7 @@ describe("database migrations", () => {
             ) as creator_owner_constraint_removed
         `;
         expect(lifecycle).toEqual({
-          count: 18,
+          count: 19,
           creation_intents_null: true,
           deleted_at_exists: false,
           setup_completed_at_exists: true,
@@ -712,7 +713,7 @@ describe("database migrations", () => {
         const [rerun] = await sql<{ count: number }[]>`
           select count(*)::int as count from drizzle.__drizzle_migrations
         `;
-        expect(rerun?.count).toBe(18);
+        expect(rerun?.count).toBe(19);
       } finally {
         await sql.end();
       }

--- a/packages/server/src/__tests__/integration/tasks.test.ts
+++ b/packages/server/src/__tests__/integration/tasks.test.ts
@@ -1,0 +1,185 @@
+import { computeTurnResultHash, type TurnReportRequest } from "@opentag/shared";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
+import { createDatabaseClient } from "../../db/client.js";
+import {
+  agents,
+  computers,
+  imBindings,
+  imMessageDeliveries,
+  imMessages,
+  sessions,
+  workspaceComputers,
+} from "../../db/schema/index.js";
+import { TaskQueryError, TaskService } from "../../services/tasks/index.js";
+import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
+
+let testDatabase: MigratedTestDatabase;
+let databaseUrl: string;
+
+beforeAll(async () => {
+  testDatabase = await startMigratedTestDatabase();
+  databaseUrl = testDatabase.databaseUrl;
+}, 120_000);
+
+afterAll(async () => testDatabase.stop());
+beforeEach(async () => testDatabase.reset());
+
+async function fixture() {
+  const client = createDatabaseClient(databaseUrl);
+  const bootstrap = await bootstrapInitialAdmin(client.database, {
+    displayName: "Admin",
+    email: "admin@example.com",
+    workspaceDisplayName: "Example",
+    workspaceName: "example",
+  });
+  const [computer] = await client.database.insert(computers).values({ id: crypto.randomUUID() }).returning();
+  if (!computer) throw new Error("Computer fixture was not created");
+  const [workspaceComputer] = await client.database
+    .insert(workspaceComputers)
+    .values({
+      workspaceId: bootstrap.workspaceId,
+      computerId: computer.id,
+      displayName: "workstation",
+      platform: "linux",
+      arch: "x64",
+      clientVersion: "0.0.1",
+      enrolledByUserId: bootstrap.userId,
+    })
+    .returning();
+  if (!workspaceComputer) throw new Error("Workspace Computer fixture was not created");
+  const [agent] = await client.database
+    .insert(agents)
+    .values({
+      workspaceId: bootstrap.workspaceId,
+      createdByUserId: bootstrap.userId,
+      workspaceComputerId: workspaceComputer.id,
+      name: "atlas",
+      displayName: "Atlas",
+      runtimeProvider: "codex",
+    })
+    .returning();
+  if (!agent) throw new Error("Agent fixture was not created");
+  const [binding] = await client.database
+    .insert(imBindings)
+    .values({ agentId: agent.id, provider: "feishu" })
+    .returning();
+  if (!binding) throw new Error("IM Binding fixture was not created");
+  const [session] = await client.database
+    .insert(sessions)
+    .values({
+      imBindingId: binding.id,
+      channelId: "oc_debug",
+      conversationKind: "dm",
+      kind: "channel",
+      createdAt: new Date("2026-08-27T01:00:00.000Z"),
+    })
+    .returning();
+  if (!session) throw new Error("Session fixture was not created");
+  const [message] = await client.database
+    .insert(imMessages)
+    .values({
+      imBindingId: binding.id,
+      providerEventId: "event-debug",
+      channelId: "oc_debug",
+      externalMessageId: "om_debug",
+      providerRevisionKey: "1",
+      operation: "created",
+      direction: "inbound",
+      authorKind: "human",
+      authorExternalId: "ou_debug",
+      authorDisplayName: "Mia",
+      content: { version: 1, fallbackText: "Please debug this Turn.", blocks: [], truncated: false },
+      providerContext: { provider: "feishu", chatType: "p2p" },
+      occurredAt: new Date("2026-08-27T01:01:00.000Z"),
+    })
+    .returning();
+  if (!message) throw new Error("IM Message fixture was not created");
+
+  const deliveryId = crypto.randomUUID();
+  const turnId = "turn-debug";
+  const reportInput = {
+    deliveryId,
+    turnId,
+    sessionId: session.id,
+    agentId: agent.id,
+    placementGeneration: 1,
+    outcome: "completed" as const,
+    executionEffects: "completed" as const,
+    finalText: "Stored runtime output",
+    usage: { inputTokens: 100, outputTokens: 50 },
+    traceSummary: { lastSequence: 4, droppedEvents: 0 },
+  };
+  const report: TurnReportRequest = {
+    type: "turn:report",
+    requestId: crypto.randomUUID(),
+    ...reportInput,
+    resultHash: computeTurnResultHash(reportInput),
+  };
+  await client.database.insert(imMessageDeliveries).values({
+    id: deliveryId,
+    messageId: message.id,
+    sessionId: session.id,
+    attention: "direct",
+    state: "accepted",
+    placementGeneration: 1,
+    inputHash: "a".repeat(64),
+    turnId,
+    reportOwnerInstanceId: crypto.randomUUID(),
+    acceptedAt: new Date("2026-08-27T01:02:00.000Z"),
+    expiresAt: new Date("2026-08-28T01:00:00.000Z"),
+    resultHash: report.resultHash,
+    turnReport: report,
+    reportedAt: new Date("2026-08-27T01:03:00.000Z"),
+  });
+  return { ...client, agent, bootstrap, service: new TaskService(client.database), session };
+}
+
+describe("Task debug queries", () => {
+  it("projects a top-level Session and its stored Turn report", async () => {
+    const value = await fixture();
+    try {
+      const listed = await value.service.list(value.bootstrap.workspaceId, { limit: 50 });
+      expect(listed).toMatchObject({
+        nextCursor: null,
+        tasks: [
+          {
+            id: value.session.id,
+            title: "Please debug this Turn.",
+            status: "completed",
+            agent: { id: value.agent.id, displayName: "Atlas" },
+            source: { provider: "feishu", channelId: "oc_debug" },
+          },
+        ],
+      });
+
+      const detail = await value.service.get(value.bootstrap.workspaceId, value.session.id, { limit: 50 });
+      expect(detail.turns).toHaveLength(1);
+      expect(detail.turns[0]).toMatchObject({
+        attention: "direct",
+        message: { fallbackText: "Please debug this Turn.", authorDisplayName: "Mia" },
+        report: { turnId: "turn-debug", finalText: "Stored runtime output", outcome: "completed" },
+      });
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("isolates Workspace data and rejects malformed cursors", async () => {
+    const value = await fixture();
+    try {
+      await expect(value.service.list(crypto.randomUUID(), { limit: 50 })).resolves.toEqual({
+        tasks: [],
+        nextCursor: null,
+      });
+      await expect(value.service.get(crypto.randomUUID(), value.session.id, { limit: 50 })).rejects.toMatchObject({
+        statusCode: 404,
+      });
+      await expect(
+        value.service.list(value.bootstrap.workspaceId, { cursor: "invalid", limit: 50 }),
+      ).rejects.toBeInstanceOf(TaskQueryError);
+    } finally {
+      await value.sql.end();
+    }
+  });
+});

--- a/packages/server/src/api/account.ts
+++ b/packages/server/src/api/account.ts
@@ -7,17 +7,38 @@ import {
   CreateAgentRequestSchema,
   HTTP_PATHS,
   ListAgentsResponseSchema,
+  ListTasksResponseSchema,
   ListWorkspaceComputersResponseSchema,
   PROVIDER_READINESS_V1_HEADER,
+  TASK_BY_ID_TEMPLATE,
+  TaskDetailSchema,
   WorkspaceSetupCompletionSchema,
 } from "@opentag/shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
+import { z } from "zod";
 import { createUserAuthPreHandler } from "../plugins/user-auth.js";
 import type { AgentService } from "../services/agents/index.js";
 import type { UserAuthService } from "../services/auth/index.js";
 import { buildComputerConnectCommand, type MachineAuthService } from "../services/computers/index.js";
+import type { TaskService } from "../services/tasks/index.js";
 import type { WorkspaceAdminService, WorkspaceSetupService } from "../services/workspaces/index.js";
 import { parseRequest } from "./request-validation.js";
+
+const TaskListQuerySchema = z
+  .object({
+    agentId: z.string().uuid().optional(),
+    cursor: z.string().min(1).max(1024).optional(),
+    kind: z.enum(["channel", "thread"]).optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+  })
+  .strict();
+const TaskDetailQuerySchema = z
+  .object({
+    cursor: z.string().min(1).max(1024).optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+  })
+  .strict();
+const TaskParamsSchema = z.object({ sessionId: z.string().uuid() }).strict();
 
 /**
  * Resolves the authenticated Account to the compatibility Workspace that still backs management storage.
@@ -34,6 +55,7 @@ export interface AccountRoutesOptions {
   computerConnectCode?: { environment: ChannelName; publicUrl: string };
   machineAuthService?: MachineAuthService;
   publicOrigin?: string;
+  taskService?: TaskService;
   workspaceService?: WorkspaceAdminService;
   workspaceSetupService?: WorkspaceSetupService;
 }
@@ -82,6 +104,25 @@ export function registerAccountRoutes(
       return reply
         .code(200)
         .send(ListAgentsResponseSchema.parse(await agentService.listForWorkspace(scope.accountId, scope.workspaceId)));
+    });
+  }
+
+  if (options.taskService) {
+    const taskService = options.taskService;
+
+    app.get(HTTP_PATHS.accountTasks, { preHandler }, async (request, reply) => {
+      const query = parseRequest(TaskListQuerySchema, request.query);
+      const scope = await scopeOf(request);
+      const response = ListTasksResponseSchema.parse(await taskService.list(scope.workspaceId, query));
+      return reply.header("Cache-Control", "no-store").code(200).send(response);
+    });
+
+    app.get(TASK_BY_ID_TEMPLATE, { preHandler }, async (request, reply) => {
+      const { sessionId } = parseRequest(TaskParamsSchema, request.params);
+      const query = parseRequest(TaskDetailQuerySchema, request.query);
+      const scope = await scopeOf(request);
+      const response = TaskDetailSchema.parse(await taskService.get(scope.workspaceId, sessionId, query));
+      return reply.header("Cache-Control", "no-store").code(200).send(response);
     });
   }
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -27,6 +27,7 @@ import { type FeishuSetupService, feishuPublicFailure } from "./services/im-bind
 import { type ImBindingService, ImBindingServiceError } from "./services/im-bindings/index.js";
 import { type SlackConfigurationService, SlackConfigurationServiceError } from "./services/im-bindings/slack/index.js";
 import { OnboardingResetError, type OnboardingResetService } from "./services/onboarding-lab/index.js";
+import { TaskQueryError, type TaskService } from "./services/tasks/index.js";
 import {
   type WorkspaceAdminService,
   type WorkspaceSetupService,
@@ -63,6 +64,7 @@ export interface CreateAppOptions {
   slackEvents?: SlackEventsRouteOptions;
   /** Registered only by a staging deployment that configures the shared Onboarding Lab Account. */
   stagingOnboardingLab?: { reset: OnboardingResetService };
+  taskService?: TaskService;
   workspaceService?: WorkspaceAdminService;
   workspaceSetupService?: WorkspaceSetupService;
 }
@@ -202,6 +204,7 @@ export function createApp(options: CreateAppOptions = {}) {
         ...(options.machineAuthService ? { machineAuthService: options.machineAuthService } : {}),
         ...(options.workspaceService ? { workspaceService: options.workspaceService } : {}),
         ...(options.workspaceSetupService ? { workspaceSetupService: options.workspaceSetupService } : {}),
+        ...(options.taskService ? { taskService: options.taskService } : {}),
         publicOrigin,
       });
     }
@@ -273,6 +276,7 @@ export function createApp(options: CreateAppOptions = {}) {
       error instanceof AgentServiceError ||
       error instanceof ImBindingServiceError ||
       error instanceof OnboardingResetError ||
+      error instanceof TaskQueryError ||
       error instanceof SlackConfigurationServiceError ||
       error instanceof WorkspaceSetupServiceError
     ) {

--- a/packages/server/src/db/schema/im-messages.ts
+++ b/packages/server/src/db/schema/im-messages.ts
@@ -88,6 +88,7 @@ export const imMessageDeliveries = pgTable(
   },
   (table) => [
     uniqueIndex("im_message_deliveries_message_session_unique").on(table.messageId, table.sessionId),
+    index("im_message_deliveries_session_id_idx").on(table.sessionId),
     index("im_message_deliveries_pending_idx").on(table.state, table.nextAttemptAt),
     uniqueIndex("im_message_deliveries_dispatch_request_unique")
       .on(table.dispatchRequestId)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -46,6 +46,7 @@ import {
 import { OnboardingResetService } from "./services/onboarding-lab/index.js";
 import { EffectiveRuntimeSnapshotAssembler } from "./services/runtime-config/index.js";
 import { SessionCollaborationService, SessionService } from "./services/sessions/index.js";
+import { TaskService } from "./services/tasks/index.js";
 import { WorkspaceAdminAccess } from "./services/workspace-admin-access/index.js";
 import { WorkspaceAdminService, WorkspaceSetupService } from "./services/workspaces/index.js";
 import { defaultWebAppRoot } from "./web-app.js";
@@ -176,6 +177,7 @@ export async function startServer(): Promise<void> {
     const workspaceSetupService = new WorkspaceSetupService(database, imBindingService, { workspaceAdmins });
     const imMessageInbox = new ImMessageInbox(database);
     const sessionService = new SessionService(database);
+    const taskService = new TaskService(database);
     const runtimeSnapshotAssembler = new EffectiveRuntimeSnapshotAssembler(database);
     let sessionCollaborationService: SessionCollaborationService;
     const domainOwner = new RuntimeDomainOwner(registry, new PostgresRuntimeCustodyStore(database), {
@@ -300,6 +302,7 @@ export async function startServer(): Promise<void> {
       imBindingService,
       feishuSetupService,
       slackConfigurationService,
+      taskService,
       ...(slackOAuthService
         ? {
             slackOAuth: {

--- a/packages/server/src/services/tasks/index.ts
+++ b/packages/server/src/services/tasks/index.ts
@@ -1,0 +1,2 @@
+export type { GetTaskOptions, ListTaskOptions } from "./task-service.js";
+export { TaskQueryError, TaskService } from "./task-service.js";

--- a/packages/server/src/services/tasks/task-service.ts
+++ b/packages/server/src/services/tasks/task-service.ts
@@ -1,0 +1,367 @@
+import type {
+  ListTasksResponse,
+  TaskDetail,
+  TaskStatus,
+  TaskSummary,
+  TaskTurn,
+  TurnReportRequest,
+} from "@opentag/shared";
+import { asc, inArray, or, sql } from "drizzle-orm";
+import { z } from "zod";
+import type { DatabaseClient } from "../../db/client.js";
+import { sessionMessages } from "../../db/schema/index.js";
+import { workspaceNotFound } from "../workspace-admin-access/workspace-admin-access.js";
+
+const CursorSchema = z.object({ at: z.string().datetime(), id: z.string().uuid() }).strict();
+
+interface TaskSummaryRow extends Record<string, unknown> {
+  id: string;
+  agentId: string;
+  agentName: string;
+  agentDisplayName: string;
+  runtimeProvider: "codex" | "claude-code";
+  provider: "feishu" | "slack";
+  conversationKind: "channel" | "dm" | "group_dm";
+  sessionKind: "channel" | "thread";
+  channelId: string;
+  threadKey: string | null;
+  createdAt: Date | string;
+  endedAt: Date | string | null;
+  lastActivityAt: Date | string;
+  fallbackText: string | null;
+  deliveryState: "pending" | "accepted" | "terminal_rejected" | "expired" | null;
+  reportedAt: Date | string | null;
+  turnReport: TurnReportRequest | null;
+}
+
+interface TaskTurnRow extends Record<string, unknown> {
+  deliveryId: string;
+  attention: "direct" | "ambient";
+  deliveryState: "pending" | "accepted" | "terminal_rejected" | "expired";
+  attemptCount: number;
+  acceptedAt: Date | string | null;
+  expiresAt: Date | string;
+  reason: string | null;
+  lastErrorCode: string | null;
+  turnId: string | null;
+  turnReport: TurnReportRequest | null;
+  reportedAt: Date | string | null;
+  messageId: string;
+  externalMessageId: string;
+  operation: "created" | "edited" | "deleted";
+  authorKind: "human" | "bot" | "system";
+  authorDisplayName: string | null;
+  content: { fallbackText?: unknown; truncated?: unknown };
+  occurredAt: Date | string;
+}
+
+interface InternalSessionRow extends Record<string, unknown> {
+  id: string;
+  createdBySessionId: string;
+  runtimeModel: string | null;
+  runtimeReasoningEffort: string | null;
+  endedAt: Date | string | null;
+  createdAt: Date | string;
+}
+
+export interface ListTaskOptions {
+  agentId?: string;
+  cursor?: string;
+  kind?: "channel" | "thread";
+  limit: number;
+}
+
+export interface GetTaskOptions {
+  cursor?: string;
+  limit: number;
+}
+
+function parseCursor(cursor: string | undefined): { at: Date; id: string } | undefined {
+  if (!cursor) return undefined;
+  try {
+    const decoded = CursorSchema.parse(JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")));
+    return { at: new Date(decoded.at), id: decoded.id };
+  } catch {
+    throw new TaskQueryError("VALIDATION_ERROR", "The pagination cursor is invalid", 400);
+  }
+}
+
+function toIso(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function encodeCursor(at: Date | string, id: string): string {
+  return Buffer.from(JSON.stringify({ at: toIso(at), id }), "utf8").toString("base64url");
+}
+
+function taskStatus(row: TaskSummaryRow): TaskStatus {
+  if (row.endedAt) return "ended";
+  if (!row.deliveryState) return "idle";
+  if (row.deliveryState === "pending") return "queued";
+  if (row.deliveryState === "expired") return "expired";
+  if (row.deliveryState === "terminal_rejected") return "failed";
+  if (!row.reportedAt || !row.turnReport) return "running";
+  return row.turnReport.outcome === "completed" ? "completed" : "failed";
+}
+
+function toSummary(row: TaskSummaryRow): TaskSummary {
+  const fallbackTitle = row.sessionKind === "thread" ? "Thread task" : "Channel task";
+  return {
+    id: row.id,
+    agent: {
+      id: row.agentId,
+      name: row.agentName,
+      displayName: row.agentDisplayName,
+      runtimeProvider: row.runtimeProvider,
+    },
+    source: {
+      provider: row.provider,
+      conversationKind: row.conversationKind,
+      channelId: row.channelId,
+      threadKey: row.threadKey,
+    },
+    sessionKind: row.sessionKind,
+    title: row.fallbackText?.trim() || fallbackTitle,
+    status: taskStatus(row),
+    createdAt: toIso(row.createdAt),
+    endedAt: row.endedAt ? toIso(row.endedAt) : null,
+    lastActivityAt: toIso(row.lastActivityAt),
+  };
+}
+
+function toTurn(row: TaskTurnRow): TaskTurn {
+  const report = row.turnReport;
+  return {
+    deliveryId: row.deliveryId,
+    attention: row.attention,
+    delivery: {
+      state: row.deliveryState,
+      attemptCount: row.attemptCount,
+      acceptedAt: row.acceptedAt ? toIso(row.acceptedAt) : null,
+      expiresAt: toIso(row.expiresAt),
+      reason: row.reason,
+      lastErrorCode: row.lastErrorCode,
+    },
+    message: {
+      id: row.messageId,
+      externalMessageId: row.externalMessageId,
+      operation: row.operation,
+      authorKind: row.authorKind,
+      authorDisplayName: row.authorDisplayName,
+      fallbackText: typeof row.content.fallbackText === "string" ? row.content.fallbackText : "",
+      truncated: row.content.truncated === true,
+      occurredAt: toIso(row.occurredAt),
+    },
+    report:
+      report && row.turnId && row.reportedAt
+        ? {
+            turnId: row.turnId,
+            outcome: report.outcome,
+            executionEffects: report.executionEffects,
+            finalText: report.finalText ?? null,
+            errorReason: report.errorReason ?? null,
+            usage: report.usage
+              ? {
+                  inputTokens: report.usage.inputTokens ?? null,
+                  cachedInputTokens: report.usage.cachedInputTokens ?? null,
+                  outputTokens: report.usage.outputTokens ?? null,
+                }
+              : null,
+            traceSummary: report.traceSummary,
+            reportedAt: toIso(row.reportedAt),
+          }
+        : null,
+  };
+}
+
+export class TaskQueryError extends Error {
+  readonly code: string;
+  readonly category = "validation" as const;
+
+  constructor(
+    code: string,
+    message: string,
+    readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "TaskQueryError";
+    this.code = code;
+  }
+}
+
+export class TaskService {
+  constructor(readonly database: DatabaseClient) {}
+
+  async list(workspaceId: string, options: ListTaskOptions): Promise<ListTasksResponse> {
+    const cursor = parseCursor(options.cursor);
+    const rows = await this.#summaryRows(workspaceId, {
+      ...options,
+      cursor,
+      limit: options.limit + 1,
+    });
+    const page = rows.slice(0, options.limit);
+    const last = page.at(-1);
+    return {
+      tasks: page.map(toSummary),
+      nextCursor: rows.length > options.limit && last ? encodeCursor(last.lastActivityAt, last.id) : null,
+    };
+  }
+
+  async get(workspaceId: string, sessionId: string, options: GetTaskOptions): Promise<TaskDetail> {
+    const [row] = await this.#summaryRows(workspaceId, { sessionId, limit: 1 });
+    if (!row) throw workspaceNotFound();
+    const cursor = parseCursor(options.cursor);
+    const turns = await this.database.execute<TaskTurnRow>(sql`
+      select
+        d.id as "deliveryId",
+        d.attention,
+        d.state as "deliveryState",
+        d.attempt_count::int as "attemptCount",
+        d.accepted_at as "acceptedAt",
+        d.expires_at as "expiresAt",
+        d.reason,
+        d.last_error_code as "lastErrorCode",
+        d.turn_id as "turnId",
+        d.turn_report as "turnReport",
+        d.reported_at as "reportedAt",
+        m.id as "messageId",
+        m.external_message_id as "externalMessageId",
+        m.operation,
+        m.author_kind as "authorKind",
+        m.author_display_name as "authorDisplayName",
+        m.content,
+        m.occurred_at as "occurredAt"
+      from im_message_deliveries d
+      inner join im_messages m on m.id = d.message_id
+      where d.session_id = ${sessionId}::uuid
+        ${cursor ? sql`and (m.occurred_at, d.id) < (${cursor.at}, ${cursor.id}::uuid)` : sql``}
+      order by m.occurred_at desc, d.id desc
+      limit ${options.limit + 1}
+    `);
+    const page = [...turns].slice(0, options.limit);
+    const last = page.at(-1);
+
+    const internalSessions = await this.database.execute<InternalSessionRow>(sql`
+      with recursive related as (
+        select id, created_by_session_id, runtime_model, runtime_reasoning_effort, ended_at, created_at
+        from sessions
+        where created_by_session_id = ${sessionId}::uuid
+        union all
+        select child.id, child.created_by_session_id, child.runtime_model, child.runtime_reasoning_effort,
+               child.ended_at, child.created_at
+        from sessions child
+        inner join related parent on child.created_by_session_id = parent.id
+      )
+      select
+        id,
+        created_by_session_id as "createdBySessionId",
+        runtime_model as "runtimeModel",
+        runtime_reasoning_effort as "runtimeReasoningEffort",
+        ended_at as "endedAt",
+        created_at as "createdAt"
+      from related
+      order by created_at asc, id asc
+    `);
+    const relatedSessionIds = [sessionId, ...[...internalSessions].map(({ id }) => id)];
+    const collaborationRows =
+      relatedSessionIds.length === 0
+        ? []
+        : await this.database
+            .select()
+            .from(sessionMessages)
+            .where(
+              or(
+                inArray(sessionMessages.sourceSessionId, relatedSessionIds),
+                inArray(sessionMessages.targetSessionId, relatedSessionIds),
+              ),
+            )
+            .orderBy(asc(sessionMessages.createdAt), asc(sessionMessages.id));
+
+    return {
+      task: toSummary(row),
+      turns: page.map(toTurn),
+      internalSessions: [...internalSessions].map((session) => ({
+        id: session.id,
+        createdBySessionId: session.createdBySessionId,
+        createdAt: toIso(session.createdAt),
+        endedAt: session.endedAt ? toIso(session.endedAt) : null,
+        runtimeModel: session.runtimeModel,
+        runtimeReasoningEffort: session.runtimeReasoningEffort,
+      })),
+      collaborationMessages: collaborationRows.map((message) => ({
+        id: message.id,
+        sourceSessionId: message.sourceSessionId,
+        targetSessionId: message.targetSessionId,
+        content: message.content,
+        outcome: message.lastOutcome,
+        attemptCount: message.attemptCount,
+        lastErrorCode: message.lastErrorCode,
+        createdAt: message.createdAt.toISOString(),
+        updatedAt: message.updatedAt.toISOString(),
+      })),
+      nextCursor: turns.length > options.limit && last ? encodeCursor(last.occurredAt, last.deliveryId) : null,
+    };
+  }
+
+  async #summaryRows(
+    workspaceId: string,
+    options: {
+      agentId?: string;
+      cursor?: { at: Date; id: string };
+      kind?: "channel" | "thread";
+      limit: number;
+      sessionId?: string;
+    },
+  ): Promise<TaskSummaryRow[]> {
+    const rows = await this.database.execute<TaskSummaryRow>(sql`
+      with latest_delivery as (
+        select distinct on (d.session_id)
+          d.session_id,
+          d.state as delivery_state,
+          d.reported_at,
+          d.turn_report,
+          m.content ->> 'fallbackText' as fallback_text,
+          greatest(m.occurred_at, coalesce(d.accepted_at, m.occurred_at), coalesce(d.reported_at, m.occurred_at)) as activity_at
+        from im_message_deliveries d
+        inner join im_messages m on m.id = d.message_id
+        order by d.session_id, activity_at desc, d.id desc
+      )
+      select
+        s.id,
+        a.id as "agentId",
+        a.name as "agentName",
+        a.display_name as "agentDisplayName",
+        a.runtime_provider as "runtimeProvider",
+        b.provider,
+        s.conversation_kind as "conversationKind",
+        s.kind as "sessionKind",
+        s.channel_id as "channelId",
+        s.thread_key as "threadKey",
+        s.created_at as "createdAt",
+        s.ended_at as "endedAt",
+        greatest(s.created_at, coalesce(ld.activity_at, s.created_at)) as "lastActivityAt",
+        ld.fallback_text as "fallbackText",
+        ld.delivery_state as "deliveryState",
+        ld.reported_at as "reportedAt",
+        ld.turn_report as "turnReport"
+      from sessions s
+      inner join im_bindings b on b.id = s.im_binding_id
+      inner join agents a on a.id = b.agent_id
+      left join latest_delivery ld on ld.session_id = s.id
+      where a.workspace_id = ${workspaceId}::uuid
+        and a.status <> 'deleted'
+        and s.kind in ('channel', 'thread')
+        ${options.sessionId ? sql`and s.id = ${options.sessionId}::uuid` : sql``}
+        ${options.agentId ? sql`and a.id = ${options.agentId}::uuid` : sql``}
+        ${options.kind ? sql`and s.kind = ${options.kind}` : sql``}
+        ${
+          options.cursor
+            ? sql`and (greatest(s.created_at, coalesce(ld.activity_at, s.created_at)), s.id) < (${options.cursor.at}, ${options.cursor.id}::uuid)`
+            : sql``
+        }
+      order by "lastActivityAt" desc, s.id desc
+      limit ${options.limit}
+    `);
+    return [...rows];
+  }
+}

--- a/packages/shared/src/__tests__/task.test.ts
+++ b/packages/shared/src/__tests__/task.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { ListTasksResponseSchema, TaskDetailSchema, taskByIdPath } from "../index.js";
+
+const summary = {
+  id: "11111111-1111-4111-8111-111111111111",
+  agent: {
+    id: "22222222-2222-4222-8222-222222222222",
+    name: "atlas",
+    displayName: "Atlas",
+    runtimeProvider: "codex",
+  },
+  source: { provider: "feishu", conversationKind: "dm", channelId: "oc_debug", threadKey: null },
+  sessionKind: "channel",
+  title: "Debug the latest Turn",
+  status: "completed",
+  createdAt: "2026-08-27T01:00:00.000Z",
+  endedAt: null,
+  lastActivityAt: "2026-08-27T02:00:00.000Z",
+};
+
+describe("Task browser contracts", () => {
+  it("parses paginated summaries and encodes Session identifiers in detail paths", () => {
+    expect(ListTasksResponseSchema.parse({ tasks: [summary], nextCursor: "cursor" })).toEqual({
+      tasks: [summary],
+      nextCursor: "cursor",
+    });
+    expect(taskByIdPath("session/with spaces")).toBe("/api/v1/sessions/session%2Fwith%20spaces");
+  });
+
+  it("keeps debug details strict and distinguishes runtime output from Provider output", () => {
+    const detail = TaskDetailSchema.parse({
+      task: summary,
+      turns: [
+        {
+          deliveryId: "33333333-3333-4333-8333-333333333333",
+          attention: "direct",
+          delivery: {
+            state: "accepted",
+            attemptCount: 1,
+            acceptedAt: "2026-08-27T01:01:00.000Z",
+            expiresAt: "2026-08-28T01:00:00.000Z",
+            reason: null,
+            lastErrorCode: null,
+          },
+          message: {
+            id: "44444444-4444-4444-8444-444444444444",
+            externalMessageId: "om_debug",
+            operation: "created",
+            authorKind: "human",
+            authorDisplayName: "Mia",
+            fallbackText: "Please debug this.",
+            truncated: false,
+            occurredAt: "2026-08-27T01:00:00.000Z",
+          },
+          report: {
+            turnId: "turn-debug",
+            outcome: "completed",
+            executionEffects: "completed",
+            finalText: "Stored runtime final output",
+            errorReason: null,
+            usage: null,
+            traceSummary: { lastSequence: 2, droppedEvents: 0 },
+            reportedAt: "2026-08-27T02:00:00.000Z",
+          },
+        },
+      ],
+      internalSessions: [],
+      collaborationMessages: [],
+      nextCursor: null,
+    });
+    expect(detail.turns[0]?.report?.finalText).toBe("Stored runtime final output");
+    expect(() => TaskDetailSchema.parse({ ...detail, providerOutboundMessages: [] })).toThrow();
+  });
+});

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -9,4 +9,5 @@ export * from "./onboarding-lab.js";
 export { RUNTIME_DEFAULT_MAX_DURATION_MS, RUNTIME_MAX_DURATION_MS } from "./runtime-config.js";
 export * from "./runtime-configuration-options.js";
 export * from "./runtime-protocol.js";
+export * from "./task.js";
 export * from "./workspace.js";

--- a/packages/shared/src/http-paths.ts
+++ b/packages/shared/src/http-paths.ts
@@ -33,12 +33,15 @@ export const ACCOUNT_AGENTS_PATH = `${API_V1_PREFIX}/agents`;
 export const ACCOUNT_COMPUTERS_PATH = `${API_V1_PREFIX}/computers`;
 export const ACCOUNT_COMPUTER_CONNECT_CODES_PATH = `${API_V1_PREFIX}/computer-connect-codes`;
 export const ACCOUNT_SETUP_COMPLETE_PATH = `${API_V1_PREFIX}/me/setup/complete`;
+export const ACCOUNT_TASKS_PATH = `${API_V1_PREFIX}/sessions`;
+export const TASK_BY_ID_TEMPLATE = `${ACCOUNT_TASKS_PATH}/:sessionId`;
 
 export const HTTP_PATHS = {
   accountAgents: ACCOUNT_AGENTS_PATH,
   accountComputerConnectCodes: ACCOUNT_COMPUTER_CONNECT_CODES_PATH,
   accountComputers: ACCOUNT_COMPUTERS_PATH,
   accountSetupComplete: ACCOUNT_SETUP_COMPLETE_PATH,
+  accountTasks: ACCOUNT_TASKS_PATH,
   agentById: AGENT_BY_ID_TEMPLATE,
   slackEvents: SLACK_EVENTS_PATH,
   slackOAuthCallback: SLACK_OAUTH_CALLBACK_PATH,
@@ -57,6 +60,10 @@ export const HTTP_PATHS = {
   meConnectCodes: `${API_V1_PREFIX}/me/connect-codes`,
   workspaceAgents: WORKSPACE_AGENTS_TEMPLATE,
 } as const;
+
+export function taskByIdPath(sessionId: string): string {
+  return `${ACCOUNT_TASKS_PATH}/${encodeURIComponent(sessionId)}`;
+}
 
 export function workspaceSetupCompletePath(workspaceId: string): string {
   return `${API_V1_PREFIX}/workspaces/${encodeURIComponent(workspaceId)}/setup/complete`;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -130,6 +130,7 @@ export {
   ACCOUNT_COMPUTER_CONNECT_CODES_PATH,
   ACCOUNT_COMPUTERS_PATH,
   ACCOUNT_SETUP_COMPLETE_PATH,
+  ACCOUNT_TASKS_PATH,
   AGENT_BY_ID_TEMPLATE,
   AGENT_CONFIG_TEMPLATE,
   AGENT_FEISHU_SETUP_ATTEMPTS_TEMPLATE,
@@ -168,6 +169,8 @@ export {
   runtimeWebSocketUrl,
   SLACK_EVENTS_PATH,
   SLACK_OAUTH_CALLBACK_PATH,
+  TASK_BY_ID_TEMPLATE,
+  taskByIdPath,
   WORKSPACE_AGENTS_TEMPLATE,
   WORKSPACE_COMPUTER_CONNECT_CODES_TEMPLATE,
   WORKSPACE_COMPUTERS_TEMPLATE,
@@ -349,6 +352,7 @@ export {
   ServerWelcomeV2FrameSchema,
 } from "./runtime-protocol.js";
 export * from "./session.js";
+export * from "./task.js";
 export {
   type CompleteWorkspaceSetupRequest,
   CompleteWorkspaceSetupRequestSchema,

--- a/packages/shared/src/task.ts
+++ b/packages/shared/src/task.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+import { AgentRuntimeProviderSchema } from "./agent.js";
+import { ImProviderSchema } from "./im-binding.js";
+import {
+  ImAttentionSchema,
+  ImAuthorKindSchema,
+  ImConversationKindSchema,
+  ImMessageOperationSchema,
+} from "./im-message.js";
+
+export const TaskStatusSchema = z.enum(["queued", "running", "completed", "failed", "expired", "ended", "idle"]);
+export const TaskSessionKindSchema = z.enum(["channel", "thread"]);
+
+export const TaskSummarySchema = z
+  .object({
+    id: z.string().uuid(),
+    agent: z
+      .object({
+        id: z.string().uuid(),
+        name: z.string().min(1),
+        displayName: z.string().min(1),
+        runtimeProvider: AgentRuntimeProviderSchema,
+      })
+      .strict(),
+    source: z
+      .object({
+        provider: ImProviderSchema,
+        conversationKind: ImConversationKindSchema,
+        channelId: z.string().min(1),
+        threadKey: z.string().min(1).nullable(),
+      })
+      .strict(),
+    sessionKind: TaskSessionKindSchema,
+    title: z.string().min(1),
+    status: TaskStatusSchema,
+    createdAt: z.string().datetime(),
+    endedAt: z.string().datetime().nullable(),
+    lastActivityAt: z.string().datetime(),
+  })
+  .strict();
+
+export const ListTasksResponseSchema = z
+  .object({ tasks: z.array(TaskSummarySchema), nextCursor: z.string().min(1).nullable() })
+  .strict();
+
+export const TaskTurnSchema = z
+  .object({
+    deliveryId: z.string().uuid(),
+    attention: ImAttentionSchema,
+    delivery: z
+      .object({
+        state: z.enum(["pending", "accepted", "terminal_rejected", "expired"]),
+        attemptCount: z.number().int().nonnegative(),
+        acceptedAt: z.string().datetime().nullable(),
+        expiresAt: z.string().datetime(),
+        reason: z.string().nullable(),
+        lastErrorCode: z.string().nullable(),
+      })
+      .strict(),
+    message: z
+      .object({
+        id: z.string().uuid(),
+        externalMessageId: z.string().min(1),
+        operation: ImMessageOperationSchema,
+        authorKind: ImAuthorKindSchema,
+        authorDisplayName: z.string().nullable(),
+        fallbackText: z.string(),
+        truncated: z.boolean(),
+        occurredAt: z.string().datetime(),
+      })
+      .strict(),
+    report: z
+      .object({
+        turnId: z.string().min(1),
+        outcome: z.enum(["completed", "failed", "cancelled", "unknown"]),
+        executionEffects: z.enum(["not_started", "may_have_occurred", "completed"]),
+        finalText: z.string().nullable(),
+        errorReason: z.string().nullable(),
+        usage: z
+          .object({
+            inputTokens: z.number().int().nonnegative().nullable(),
+            cachedInputTokens: z.number().int().nonnegative().nullable(),
+            outputTokens: z.number().int().nonnegative().nullable(),
+          })
+          .strict()
+          .nullable(),
+        traceSummary: z
+          .object({
+            lastSequence: z.number().int().nonnegative(),
+            droppedEvents: z.number().int().nonnegative(),
+          })
+          .strict(),
+        reportedAt: z.string().datetime(),
+      })
+      .strict()
+      .nullable(),
+  })
+  .strict();
+
+export const TaskInternalSessionSchema = z
+  .object({
+    id: z.string().uuid(),
+    createdBySessionId: z.string().uuid(),
+    createdAt: z.string().datetime(),
+    endedAt: z.string().datetime().nullable(),
+    runtimeModel: z.string().nullable(),
+    runtimeReasoningEffort: z.string().nullable(),
+  })
+  .strict();
+
+export const TaskCollaborationMessageSchema = z
+  .object({
+    id: z.string().uuid(),
+    sourceSessionId: z.string().uuid(),
+    targetSessionId: z.string().uuid(),
+    content: z.string().min(1),
+    outcome: z.enum(["unknown", "accepted", "unreachable", "rejected"]),
+    attemptCount: z.number().int().nonnegative(),
+    lastErrorCode: z.string().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const TaskDetailSchema = z
+  .object({
+    task: TaskSummarySchema,
+    turns: z.array(TaskTurnSchema),
+    internalSessions: z.array(TaskInternalSessionSchema),
+    collaborationMessages: z.array(TaskCollaborationMessageSchema),
+    nextCursor: z.string().min(1).nullable(),
+  })
+  .strict();
+
+export type TaskStatus = z.infer<typeof TaskStatusSchema>;
+export type TaskSummary = z.infer<typeof TaskSummarySchema>;
+export type ListTasksResponse = z.infer<typeof ListTasksResponseSchema>;
+export type TaskTurn = z.infer<typeof TaskTurnSchema>;
+export type TaskInternalSession = z.infer<typeof TaskInternalSessionSchema>;
+export type TaskCollaborationMessage = z.infer<typeof TaskCollaborationMessageSchema>;
+export type TaskDetail = z.infer<typeof TaskDetailSchema>;


### PR DESCRIPTION
## Summary

- replace the mock-backed Tasks page with a read-only debug view over stored top-level Channel and Thread Sessions
- expose Account-scoped Session list/detail APIs with cursor pagination, inbound messages, delivery state, Turn reports, internal Sessions, and collaboration messages
- add an `im_message_deliveries.session_id` index and migration for detail queries
- document the capture boundary in the UI: Provider outbound messages and detailed tool traces are not persisted

## Task mapping

Each top-level Channel or Thread Session is shown as one Task. A Task can contain multiple Turns; internal Sessions remain nested collaboration details rather than separate Task rows.

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/server test:integration` (161 tests)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (100%)