### PR TITLE
fix(client): preserve lark message newlines

### DIFF
--- a/docs/direct-provider-cli.md
+++ b/docs/direct-provider-cli.md
@@ -6,6 +6,11 @@ OpenTag owns inbound IM routing, Integration credentials, temporary Client crede
 
 For every valid visible IM Turn, the Client creates a private `0600` environment file and passes only its path as `OPENTAG_PROVIDER_ENV_FILE`. The Agent sources that file and calls the official `lark-cli` or `slack api` command directly. The file is removed when the Turn finishes, retried during Session or Client shutdown if removal fails, and recovered by the next Client startup after a crash.
 
+For Feishu Turns, the managed Turn context instructs the Agent to pass rich or multiline `lark-cli` text through a
+non-interpolating POSIX heredoc or PowerShell here-string variable. It also requires a pre-send check that rejects an
+intended multiline body when shell quoting left multiple literal `\n` tokens but no real newline. The check deliberately
+does not rewrite every `\n`, because code and prose may intentionally discuss that token.
+
 Provider-native cards, Blocks, files, threads, stickers, and Reactions stay in the provider CLI. OpenTag does not translate them or receive their content, provider message IDs, or results. Consequently, OpenTag has no outbound delivery status, audit trail, idempotency guarantee, stale-reply guard, or conversation-level outbound target restriction.
 
 Both `direct` and `ambient` Turns receive the same credential lifecycle. `direct` means a human explicitly addressed the Agent or Session. `ambient` means the Agent overheard the message and should normally avoid redundant or intrusive participation, but it may still reply, react, send proactively, or take no action.

--- a/docs/zh-CN/direct-provider-cli.md
+++ b/docs/zh-CN/direct-provider-cli.md
@@ -6,6 +6,10 @@ OpenTag 负责 IM 入站路由、Integration 凭证、Client 临时凭证投影�
 
 每个有效且 Agent 可见的 IM Turn 开始前，Client 创建私有的 `0600` 环境文件，只通过 `OPENTAG_PROVIDER_ENV_FILE` 把文件路径交给 Agent。Agent source 该文件后直接调用官方 `lark-cli` 或 `slack api`。Turn 完成时删除文件；若删除失败，会在 Session 或 Client 关闭时重试；Client 崩溃留下的文件由下次启动恢复清理。
 
+对于 Feishu Turn，managed Turn context 会要求 Agent 使用不插值的 POSIX heredoc 或 PowerShell here-string 变量向
+`lark-cli` 传递富文本或多行正文。发送前还必须检查：如果预期为多行的正文没有真实换行，却包含多个字面量
+`\n`，则拒绝发送。该检查不会一律改写所有 `\n`，因为代码和正文可能确实需要讨论这个 token。
+
 卡片、Blocks、文件、thread、贴纸和 Reaction 都保留 provider 原生格式。OpenTag 不转换这些内容，也不接收出站正文、provider message ID 或发送结果。因此 OpenTag 不提供出站投递状态、审计、幂等、防过时回复或会话级出站目标限制。
 
 `direct` 与 `ambient` 使用相同的凭证生命周期。`direct` 表示人明确对当前 Agent/Session 说话；`ambient` 表示 Agent 旁听到消息，默认避免重复或打扰式介入，但仍可自主回复、Reaction、主动发送或不行动。

--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -84,6 +84,14 @@ describe("AgentTurnRunner", () => {
     expect(feishuInput.items[0]?.text).toContain("The official lark-cli CLI is your outbox and the only path");
     expect(feishuInput.items[0]?.text).toContain("official lark-cli CLI");
     expect(feishuInput.items[0]?.text).toContain("lark-cli im --help");
+    expect(feishuInput.items[0]?.text).toContain("never write literal `\\n` sequences for layout");
+    expect(feishuInput.items[0]?.text).toContain("two or more literal `\\n` sequences");
+    expect(feishuInput.items[0]?.text).toContain(
+      "IFS= read -r -d '' OPENTAG_LARK_BODY <<'EOF' || true\nfirst line\n\nsecond line",
+    );
+    expect(feishuInput.items[0]?.text).toContain("$OpenTagLarkBody = @'\nfirst line\n\nsecond line");
+    expect(feishuInput.items[0]?.text).toContain('lark-cli ... --markdown "$OPENTAG_LARK_BODY"');
+    expect(input.items[0]?.text).not.toContain("OPENTAG_LARK_BODY");
   });
 
   it("preserves ambient attention beside the provider reference without disabling provider credentials", () => {

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -213,6 +213,33 @@ export function buildAgentInput(request: DirectImMessageDeliveryRequest, supplem
   const sessionInstructions = request.runtime.instructions.session?.trim() || "No additional Session instructions.";
   const provider = request.content.providerRef.provider;
   const providerCommand = provider === "feishu" ? "lark-cli" : "slack api";
+  const providerBodyInstructions =
+    provider === "feishu"
+      ? [
+          "For lark-cli text and Markdown bodies, intended line breaks must reach the CLI as real newline characters; never write literal `\\n` sequences for layout.",
+          "Before sending, inspect the body: if it has no real newline and contains two or more literal `\\n` sequences, treat it as malformed and rebuild it instead of sending. Do not blindly replace `\\n`, because code or prose may intentionally discuss that token.",
+          "Keep rich or multiline bodies out of ordinary inline shell quoting. Populate a task-specific variable with shell-native, non-interpolating multiline syntax, then pass the variable as one quoted `--text` or `--markdown` argument.",
+          "POSIX shell pattern:",
+          "```bash",
+          "IFS= read -r -d '' OPENTAG_LARK_BODY <<'EOF' || true",
+          "first line",
+          "",
+          'second line with `code`, $variables, "quotes", and apostrophes',
+          "EOF",
+          'lark-cli ... --markdown "$OPENTAG_LARK_BODY"',
+          "```",
+          "PowerShell pattern:",
+          "```powershell",
+          "$OpenTagLarkBody = @'",
+          "first line",
+          "",
+          'second line with `code`, $variables, "quotes", and apostrophes',
+          "'@",
+          "lark-cli ... --markdown $OpenTagLarkBody",
+          "```",
+          "Replace `...` with the version-specific lark-cli subcommand and provider-native target options before running it.",
+        ]
+      : [];
   const attentionMeaning =
     request.attention === "direct"
       ? "A human explicitly addressed this Agent/Session. Handle the message normally, then choose whether to reply, react, send proactively, or take no provider action."
@@ -231,6 +258,7 @@ export function buildAgentInput(request: DirectImMessageDeliveryRequest, supplem
     "The console addresses OpenTag; running the provider CLI performs the provider action. Describing a reply, reaction, or proactive message in your output only records it in OpenTag; it does not deliver it.",
     "If you choose to reply, react, or send proactively, run the provider CLI command before ending this Turn. Choosing to take no provider action remains valid.",
     `To write to this ${provider} conversation, load the credentials from $OPENTAG_PROVIDER_ENV_FILE in your shell, then use the official ${providerCommand} CLI directly.`,
+    ...providerBodyInstructions,
     "OpenTag has no message send, reply, or reaction interface, and you do not report provider send results to OpenTag.",
     "Use the provider-native identifiers below. Do not substitute an OpenTag Session or message ID.",
     "If a provider result is unknown, query the provider before deciding whether to retry.",


### PR DESCRIPTION
## Summary

- add Feishu-only managed Turn instructions requiring real line breaks instead of literal `\n` layout text
- add a narrow pre-send self-check and safe POSIX/PowerShell multiline body patterns for `lark-cli`
- keep Slack prompts unchanged and document the behavior in English and Chinese

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage`
- `pnpm --filter @opentag/server test:integration`