### PR TITLE
feat(server): move browser sign-in onto Better Auth sessions

### DIFF
--- a/packages/server/src/__tests__/better-auth-surface.test.ts
+++ b/packages/server/src/__tests__/better-auth-surface.test.ts
@@ -22,7 +22,11 @@ function authService(): UserAuthService {
  */
 function recordingBetterAuth(): { handler: ReturnType<typeof vi.fn>; instance: OpenTagBetterAuth } {
   const handler = vi.fn(async () => new Response("reached", { status: 200 }));
-  return { handler, instance: { api: { getSession: vi.fn() }, handler } as unknown as OpenTagBetterAuth };
+  const context = Promise.resolve({ authCookies: { sessionToken: { name: "opentag.session_token" } } });
+  return {
+    handler,
+    instance: { $context: context, api: { getSession: vi.fn() }, handler } as unknown as OpenTagBetterAuth,
+  };
 }
 
 function build(betterAuth: OpenTagBetterAuth) {
@@ -61,6 +65,40 @@ describe("published Better Auth surface", () => {
       expect(response.statusCode, `${request.method} ${request.url} reached Better Auth`).toBe(404);
     }
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues the double-submit token alongside a session, so a fresh sign-in can mutate", async () => {
+    /*
+     * Better Auth's session cookie is not enough on its own: every browser mutation, sign-out included, also needs
+     * OpenTag's readable double-submit token. Without this a user who signs in can read but never write.
+     */
+    const handler = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "/agents", "set-cookie": "opentag.session_token=abc; Path=/; HttpOnly" },
+        }),
+    );
+    const context = Promise.resolve({ authCookies: { sessionToken: { name: "opentag.session_token" } } });
+    const app = build({ $context: context, api: { getSession: vi.fn() }, handler } as unknown as OpenTagBetterAuth);
+
+    const response = await app.inject({ method: "GET", url: "/api/v1/auth/callback/google?code=x&state=y" });
+
+    const cookies = ([] as string[]).concat(response.headers["set-cookie"] as string | string[]);
+    expect(cookies.some((value) => value.startsWith("opentag.session_token="))).toBe(true);
+    expect(cookies.some((value) => value.startsWith("opentag_csrf="))).toBe(true);
+  });
+
+  it("does not hand out a double-submit token when sign-in failed", async () => {
+    const handler = vi.fn(async () => new Response(JSON.stringify({ error: "nope" }), { status: 401 }));
+    const context = Promise.resolve({ authCookies: { sessionToken: { name: "opentag.session_token" } } });
+    const app = build({ $context: context, api: { getSession: vi.fn() }, handler } as unknown as OpenTagBetterAuth);
+
+    const response = await app.inject({ method: "GET", url: "/api/v1/auth/callback/google?error=denied&state=y" });
+
+    const header = response.headers["set-cookie"];
+    const cookies = header === undefined ? [] : ([] as string[]).concat(header as string | string[]);
+    expect(cookies.some((value) => value.startsWith("opentag_csrf="))).toBe(false);
   });
 
   it("builds the forwarded URL from the configured origin, not the request Host", async () => {

--- a/packages/server/src/__tests__/better-auth-surface.test.ts
+++ b/packages/server/src/__tests__/better-auth-surface.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../app.js";
+import type { OpenTagBetterAuth } from "../auth/better-auth.js";
+import type { UserAuthService } from "../services/auth/index.js";
+
+const apps: ReturnType<typeof createApp>[] = [];
+afterEach(async () => Promise.all(apps.splice(0).map((app) => app.close())));
+
+function authService(): UserAuthService {
+  return {
+    exchangeConnectCode: vi.fn(),
+    getActiveUserById: vi.fn(),
+    getAuthenticatedUser: vi.fn(),
+    refresh: vi.fn(),
+    updateSelfProfile: vi.fn(),
+  };
+}
+
+/**
+ * Answers every request, so a path reaching Better Auth is visible as a `200 reached` rather than as whatever the
+ * library would have replied. Anything OpenTag has not published must never get here.
+ */
+function recordingBetterAuth(): { handler: ReturnType<typeof vi.fn>; instance: OpenTagBetterAuth } {
+  const handler = vi.fn(async () => new Response("reached", { status: 200 }));
+  return { handler, instance: { api: { getSession: vi.fn() }, handler } as unknown as OpenTagBetterAuth };
+}
+
+function build(betterAuth: OpenTagBetterAuth) {
+  const app = createApp({
+    authService: authService(),
+    betterAuth: { instance: betterAuth, publicUrl: "https://opentag.example.com" },
+  });
+  apps.push(app);
+  return app;
+}
+
+describe("published Better Auth surface", () => {
+  it("serves the OAuth callback and nothing else the library defines", async () => {
+    const { handler, instance } = recordingBetterAuth();
+    const app = build(instance);
+
+    const callback = await app.inject({ method: "GET", url: "/api/v1/auth/callback/google?code=x&state=y" });
+    expect(callback.statusCode).toBe(200);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    /*
+     * `/update-user` is the one that matters: `user.name` maps to `users.display_name`, so reaching Better Auth here
+     * would be a second Account-profile writer bypassing `UserDisplayNameSchema`, the suspension guard, and the
+     * authenticated, origin-checked `/api/v1/me`. The rest are listed so an accidental catch-all is caught here.
+     */
+    const unpublished = [
+      { method: "POST" as const, url: "/api/v1/auth/update-user" },
+      { method: "POST" as const, url: "/api/v1/auth/sign-in/social" },
+      { method: "POST" as const, url: "/api/v1/auth/sign-out" },
+      { method: "GET" as const, url: "/api/v1/auth/get-session" },
+      { method: "POST" as const, url: "/api/v1/auth/sign-up/email" },
+      { method: "GET" as const, url: "/api/v1/auth/list-sessions" },
+    ];
+    for (const request of unpublished) {
+      const response = await app.inject(request);
+      expect(response.statusCode, `${request.method} ${request.url} reached Better Auth`).toBe(404);
+    }
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds the forwarded URL from the configured origin, not the request Host", async () => {
+    const { handler, instance } = recordingBetterAuth();
+    const app = build(instance);
+
+    await app.inject({
+      method: "GET",
+      url: "/api/v1/auth/callback/google?code=x&state=y",
+      headers: { host: "attacker.example.net" },
+    });
+
+    const forwarded = handler.mock.calls[0]?.[0] as Request;
+    expect(new URL(forwarded.url).origin).toBe("https://opentag.example.com");
+  });
+});

--- a/packages/server/src/__tests__/better-auth-surface.test.ts
+++ b/packages/server/src/__tests__/better-auth-surface.test.ts
@@ -101,6 +101,57 @@ describe("published Better Auth surface", () => {
     expect(cookies.some((value) => value.startsWith("opentag_csrf="))).toBe(false);
   });
 
+  it("keeps the browser's token when revocation could not be verified", async () => {
+    /*
+     * Better Auth clears the session cookie even when its own delete failed, and Fastify keeps headers already placed
+     * on the reply. Propagating them before the survivor check would destroy the browser's only copy of a token whose
+     * session is still live — nothing left to retry revocation with, and a stolen copy usable until expiry.
+     */
+    const surviving = { token: "still-here" };
+    const context = Promise.resolve({
+      authCookies: { sessionToken: { name: "opentag.session_token" } },
+      internalAdapter: { findSession: vi.fn(async () => surviving) },
+    });
+    const instance = {
+      $context: context,
+      api: { getSession: vi.fn(async () => ({ session: surviving, user: { id: "u" } })) },
+      handler: vi.fn(
+        async () =>
+          new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { "set-cookie": "opentag.session_token=; Path=/; Max-Age=0" },
+          }),
+      ),
+    } as unknown as OpenTagBetterAuth;
+
+    const app = createApp({
+      authService: authService(),
+      betterAuth: { instance, publicUrl: "https://opentag.example.com" },
+      browserAuth: {
+        betterAuth: { instance, publicUrl: "https://opentag.example.com" },
+        publicOrigin: "https://opentag.example.com",
+        refreshTokenTtlSeconds: 3600,
+        secureCookies: true,
+      },
+    });
+    apps.push(app);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/browser/logout",
+      headers: {
+        origin: "https://opentag.example.com",
+        cookie: "opentag_csrf=token; opentag.session_token=abc",
+        "x-opentag-csrf": "token",
+      },
+    });
+
+    expect(response.statusCode).toBe(500);
+    const header = response.headers["set-cookie"];
+    const cookies = header === undefined ? [] : ([] as string[]).concat(header as string | string[]);
+    expect(cookies, "a failed revocation must not strip the caller's credential").toEqual([]);
+  });
+
   it("builds the forwarded URL from the configured origin, not the request Host", async () => {
     const { handler, instance } = recordingBetterAuth();
     const app = build(instance);

--- a/packages/server/src/__tests__/integration/better-auth.test.ts
+++ b/packages/server/src/__tests__/integration/better-auth.test.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createBetterAuth } from "../../auth/better-auth.js";
 import { createDatabaseClient } from "../../db/client.js";
-import { authIdentities, authSessions, users } from "../../db/schema/index.js";
+import { authIdentities, authSessions, users, workspaceAdminGrants } from "../../db/schema/index.js";
+import { PostAuthenticationService } from "../../services/auth/index.js";
+import { WorkspaceAdminAccess } from "../../services/workspace-admin-access/index.js";
 import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
 
 const GOOGLE_ISSUER = "https://accounts.google.com";
@@ -11,10 +13,12 @@ const PUBLIC_URL = "http://localhost:8000";
 
 let testDatabase: MigratedTestDatabase;
 let client: ReturnType<typeof createDatabaseClient>;
+let postAuthentication: PostAuthenticationService;
 
 beforeAll(async () => {
   testDatabase = await startMigratedTestDatabase();
   client = createDatabaseClient(testDatabase.databaseUrl);
+  postAuthentication = new PostAuthenticationService(client.database, new WorkspaceAdminAccess(client.database));
 }, 120_000);
 
 afterAll(async () => {
@@ -28,6 +32,7 @@ beforeEach(async () => {
 
 function createAuth() {
   return createBetterAuth(client.database, {
+    onSessionCreating: (userId) => postAuthentication.ensureAccountReady(userId).then(() => undefined),
     publicUrl: PUBLIC_URL,
     secret: "better-auth-integration-secret-at-least-32-characters",
     secureCookies: false,
@@ -115,9 +120,37 @@ describe("Better Auth over the existing Account tables", () => {
     const auth = createAuth();
     const context = await auth.$context;
 
-    // The hook refuses the write, so no token ever exists to authenticate with.
-    expect(await context.internalAdapter.createSession(userId)).toBeNull();
+    // The hook aborts the sign-in, so no token ever exists to authenticate with.
+    await expect(context.internalAdapter.createSession(userId)).rejects.toMatchObject({
+      code: "AUTH_USER_SUSPENDED",
+      statusCode: 403,
+    });
     expect(await client.database.select().from(authSessions).where(eq(authSessions.userId, userId))).toHaveLength(0);
+  });
+
+  it("gives an Account its compatibility Workspace grant before any session exists", async () => {
+    /*
+     * Every authenticated route derives authority from an active grant, and Better Auth owns account creation on its
+     * own sign-in paths — so the grant is established at session issuance rather than by the legacy resolver, and an
+     * Account cannot hold a session without one.
+     */
+    const userId = await seedLegacyAccount("google-subject-grant", "grant@example.com", "Grant Account");
+    expect(await client.database.select().from(workspaceAdminGrants)).toHaveLength(0);
+    const auth = createAuth();
+    const context = await auth.$context;
+
+    const session = await context.internalAdapter.createSession(userId);
+
+    expect(session.token).toBeTruthy();
+    const grants = await client.database
+      .select()
+      .from(workspaceAdminGrants)
+      .where(and(eq(workspaceAdminGrants.userId, userId), isNull(workspaceAdminGrants.revokedAt)));
+    expect(grants).toHaveLength(1);
+
+    // Idempotent: a returning Account keeps the one grant it already had.
+    await context.internalAdapter.createSession(userId);
+    expect(await client.database.select().from(workspaceAdminGrants)).toHaveLength(1);
   });
 
   it("never persists provider credentials on the identity row", async () => {

--- a/packages/server/src/__tests__/integration/better-auth.test.ts
+++ b/packages/server/src/__tests__/integration/better-auth.test.ts
@@ -153,6 +153,37 @@ describe("Better Auth over the existing Account tables", () => {
     expect(await client.database.select().from(workspaceAdminGrants)).toHaveLength(1);
   });
 
+  it("does not restore a Workspace grant that was revoked", async () => {
+    /*
+     * "Has no active grant" is not the same as "is new". Provisioning on that basis would hand a revoked Account a
+     * fresh Workspace and Admin grant on its next sign-in, undoing the revocation. Only an Account with no grant in
+     * its history is new.
+     */
+    const userId = await seedLegacyAccount("google-subject-revoked", "revoked@example.com", "Revoked Account");
+    const auth = createAuth();
+    const context = await auth.$context;
+    await context.internalAdapter.createSession(userId);
+    const [granted] = await client.database
+      .select({ id: workspaceAdminGrants.id })
+      .from(workspaceAdminGrants)
+      .where(eq(workspaceAdminGrants.userId, userId));
+    if (!granted) throw new Error("The Account was not provisioned");
+
+    await client.database
+      .update(workspaceAdminGrants)
+      .set({ revokedAt: new Date(), revokedByUserId: userId })
+      .where(eq(workspaceAdminGrants.id, granted.id));
+
+    await context.internalAdapter.createSession(userId);
+
+    const grants = await client.database
+      .select()
+      .from(workspaceAdminGrants)
+      .where(eq(workspaceAdminGrants.userId, userId));
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.revokedAt).not.toBeNull();
+  });
+
   it("never persists provider credentials on the identity row", async () => {
     const userId = await seedLegacyAccount("google-subject-tokens", "tokens@example.com", "Token Account");
     const auth = createAuth();

--- a/packages/server/src/__tests__/integration/better-auth.test.ts
+++ b/packages/server/src/__tests__/integration/better-auth.test.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
+import type { FastifyRequest } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createBetterAuth } from "../../auth/better-auth.js";
 import { createDatabaseClient } from "../../db/client.js";
 import { authIdentities, authSessions, users, workspaceAdminGrants } from "../../db/schema/index.js";
-import { PostAuthenticationService } from "../../services/auth/index.js";
+import { resolveAuthenticatedUserId } from "../../plugins/user-auth.js";
+import { AuthService, PostAuthenticationService } from "../../services/auth/index.js";
 import { WorkspaceAdminAccess } from "../../services/workspace-admin-access/index.js";
 import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
 
@@ -128,11 +130,11 @@ describe("Better Auth over the existing Account tables", () => {
     expect(await client.database.select().from(authSessions).where(eq(authSessions.userId, userId))).toHaveLength(0);
   });
 
-  it("gives an Account its compatibility Workspace grant before any session exists", async () => {
+  it("provisions a never-granted Account before its first session exists", async () => {
     /*
-     * Every authenticated route derives authority from an active grant, and Better Auth owns account creation on its
-     * own sign-in paths — so the grant is established at session issuance rather than by the legacy resolver, and an
-     * Account cannot hold a session without one.
+     * Better Auth owns account creation on its own sign-in paths, so first-time provisioning happens at session
+     * issuance rather than in the legacy resolver. This is about an Account that has never been provisioned; the
+     * revocation case below is what shows the rule is "never granted", not "no active grant".
      */
     const userId = await seedLegacyAccount("google-subject-grant", "grant@example.com", "Grant Account");
     expect(await client.database.select().from(workspaceAdminGrants)).toHaveLength(0);
@@ -182,6 +184,33 @@ describe("Better Auth over the existing Account tables", () => {
       .where(eq(workspaceAdminGrants.userId, userId));
     expect(grants).toHaveLength(1);
     expect(grants[0]?.revokedAt).not.toBeNull();
+  });
+
+  it("refuses a session's identity once the Account is suspended", async () => {
+    /*
+     * Routes that authenticate outside the preHandler — the Slack callback is one — must get the same answer it
+     * would give. Trusting the id on the session would let an Account suspended after issuance pass an identity check
+     * and reach the side effects behind it before any later authority check ran.
+     */
+    const userId = await seedLegacyAccount("google-subject-live", "live@example.com", "Live Account");
+    const auth = createAuth();
+    const context = await auth.$context;
+    const session = await context.internalAdapter.createSession(userId);
+    const request = { headers: { cookie: "", authorization: `Bearer ${session.token}` } } as unknown as FastifyRequest;
+    const authService = new AuthService(client.database, {
+      issuePairForUser: async () => ({ accessToken: "", refreshToken: "", expiresIn: 0 }),
+      verifyAccess: async () => ({ expiresAt: new Date(), userId }),
+      verifyRefresh: async () => ({ expiresAt: new Date(), userId }),
+    });
+
+    expect(await resolveAuthenticatedUserId(request, authService, { betterAuth: auth })).toBe(userId);
+
+    await client.database.update(users).set({ suspendedAt: new Date() }).where(eq(users.id, userId));
+
+    await expect(resolveAuthenticatedUserId(request, authService, { betterAuth: auth })).rejects.toMatchObject({
+      code: "AUTH_USER_SUSPENDED",
+      statusCode: 403,
+    });
   });
 
   it("never persists provider credentials on the identity row", async () => {

--- a/packages/server/src/__tests__/integration/slack-oauth.test.ts
+++ b/packages/server/src/__tests__/integration/slack-oauth.test.ts
@@ -100,7 +100,6 @@ async function fixture() {
   const oauth = new SlackOAuthService({
     api: api as never,
     app: slackApp,
-    authenticateUser: async () => ({ userId: bootstrap.userId }),
     database: client.database,
     now: () => now,
     slack,
@@ -141,7 +140,7 @@ describe("Slack distributed OAuth adapter", () => {
       ).toHaveLength(0);
 
       const completed = await value.oauth.callback({
-        accessToken: "browser-access",
+        authenticatedUserId: value.bootstrap.userId,
         code: "slack-oauth-code",
         sessionBinding: started.sessionBinding,
         state,
@@ -173,7 +172,7 @@ describe("Slack distributed OAuth adapter", () => {
 
       await expect(
         value.oauth.callback({
-          accessToken: "browser-access",
+          authenticatedUserId: value.bootstrap.userId,
           code: "slack-oauth-code",
           sessionBinding: started.sessionBinding,
           state,
@@ -199,7 +198,7 @@ describe("Slack distributed OAuth adapter", () => {
       if (!state) throw new Error("OAuth start did not return state");
       await expect(
         value.oauth.callback({
-          accessToken: "browser-access",
+          authenticatedUserId: value.bootstrap.userId,
           code: "slack-oauth-code",
           sessionBinding: started.sessionBinding,
           state,

--- a/packages/server/src/__tests__/slack-oauth.test.ts
+++ b/packages/server/src/__tests__/slack-oauth.test.ts
@@ -151,7 +151,8 @@ describe("Slack OAuth HTTP routes", () => {
     );
     expect(JSON.stringify(success.headers)).not.toContain("slack-oauth-code");
     expect(slackOAuth.callback).toHaveBeenCalledWith({
-      accessToken: "access",
+      // The route resolves the identity now, so a browser holding either credential reaches the same call.
+      authenticatedUserId: userId,
       code: "slack-oauth-code",
       sessionBinding: "session-binding",
       state: "signed-state",

--- a/packages/server/src/api/account.ts
+++ b/packages/server/src/api/account.ts
@@ -16,7 +16,7 @@ import {
 } from "@opentag/shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
-import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import { createUserAuthPreHandler, type UserAuthPreHandlerOptions } from "../plugins/user-auth.js";
 import type { AgentService } from "../services/agents/index.js";
 import type { UserAuthService } from "../services/auth/index.js";
 import { buildComputerConnectCommand, type MachineAuthService } from "../services/computers/index.js";
@@ -54,7 +54,7 @@ export interface AccountRoutesOptions {
   agentService?: AgentService;
   computerConnectCode?: { environment: ChannelName; publicUrl: string };
   machineAuthService?: MachineAuthService;
-  publicOrigin?: string;
+  authOptions?: UserAuthPreHandlerOptions;
   taskService?: TaskService;
   workspaceService?: WorkspaceAdminService;
   workspaceSetupService?: WorkspaceSetupService;
@@ -76,7 +76,7 @@ export function registerAccountRoutes(
   authService: UserAuthService,
   options: AccountRoutesOptions,
 ): void {
-  const preHandler = createUserAuthPreHandler(authService, { publicOrigin: options.publicOrigin });
+  const preHandler = createUserAuthPreHandler(authService, options.authOptions ?? {});
   const { accountScope } = options;
 
   async function scopeOf(request: FastifyRequest): Promise<{ accountId: string; workspaceId: string }> {

--- a/packages/server/src/api/agents.ts
+++ b/packages/server/src/api/agents.ts
@@ -16,7 +16,7 @@ import {
 } from "@opentag/shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
-import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import { createUserAuthPreHandler, type UserAuthPreHandlerOptions } from "../plugins/user-auth.js";
 import type { AgentService } from "../services/agents/index.js";
 import type { UserAuthService } from "../services/auth/index.js";
 import { parseRequest } from "./request-validation.js";
@@ -37,9 +37,9 @@ export function registerAgentRoutes(
   app: FastifyInstance,
   authService: UserAuthService,
   agentService: AgentService,
-  publicOrigin?: string,
+  authOptions?: UserAuthPreHandlerOptions,
 ): void {
-  const preHandler = createUserAuthPreHandler(authService, { publicOrigin });
+  const preHandler = createUserAuthPreHandler(authService, authOptions ?? {});
 
   app.post(WORKSPACE_AGENTS_TEMPLATE, { preHandler }, async (request, reply) => {
     const { workspaceId } = parseRequest(WorkspaceParamsSchema, request.params);

--- a/packages/server/src/api/browser-auth.ts
+++ b/packages/server/src/api/browser-auth.ts
@@ -1,5 +1,6 @@
 import { isIP } from "node:net";
 import { AuthProvidersResponseSchema, HTTP_PATHS } from "@opentag/shared";
+import { fromNodeHeaders } from "better-auth/node";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import type { OpenTagBetterAuth } from "../auth/better-auth.js";
@@ -206,13 +207,25 @@ export function registerBrowserAuthRoutes(
   app.post(HTTP_PATHS.authBrowserLogout, async (request, reply) => {
     requireBrowserMutationSecurity(request, options.publicOrigin);
     if (options.betterAuth) {
-      // Revokes the session row rather than only dropping the cookie, which is what the legacy JWTs could never do.
-      const response = await callBetterAuth(options.betterAuth.instance, options.betterAuth.publicUrl, request, {
+      const instance = options.betterAuth.instance;
+      const session = await instance.api.getSession({ headers: fromNodeHeaders(request.headers) });
+      const response = await callBetterAuth(instance, options.betterAuth.publicUrl, request, {
         method: "POST",
         path: "/sign-out",
         body: {},
       });
       copyBetterAuthCookies(reply, response);
+      /*
+       * Better Auth's sign-out swallows a failed session delete and still reports success, so taking its word would
+       * let this route promise revocation while quietly degrading to a cookie-only logout. Reading the row back is
+       * what makes the promise checkable: if it survived, the caller is still signed in and must be told so.
+       */
+      if (session) {
+        const survivor = await (await instance.$context).internalAdapter.findSession(session.session.token);
+        if (survivor) {
+          throw new AuthServiceError("INTERNAL_ERROR", "transient", "Sign-out could not revoke the session", 500);
+        }
+      }
     }
     // Cleared unconditionally: a browser mid-rollout can hold either credential, and signing out must end both.
     clearBrowserSessionCookies(reply, options.secureCookies);

--- a/packages/server/src/api/browser-auth.ts
+++ b/packages/server/src/api/browser-auth.ts
@@ -214,11 +214,15 @@ export function registerBrowserAuthRoutes(
         path: "/sign-out",
         body: {},
       });
-      copyBetterAuthCookies(reply, response);
       /*
        * Better Auth's sign-out swallows a failed session delete and still reports success, so taking its word would
        * let this route promise revocation while quietly degrading to a cookie-only logout. Reading the row back is
-       * what makes the promise checkable: if it survived, the caller is still signed in and must be told so.
+       * what makes the promise checkable.
+       *
+       * Nothing is written to the reply until that read succeeds. Better Auth clears the cookie even when its delete
+       * failed, and Fastify's error handler keeps headers already placed on the reply — propagating them before the
+       * check would destroy the browser's only copy of a token whose session is still live, leaving nothing to retry
+       * the revocation with and a stolen copy usable until expiry.
        */
       if (session) {
         const survivor = await (await instance.$context).internalAdapter.findSession(session.session.token);
@@ -226,6 +230,7 @@ export function registerBrowserAuthRoutes(
           throw new AuthServiceError("INTERNAL_ERROR", "transient", "Sign-out could not revoke the session", 500);
         }
       }
+      copyBetterAuthCookies(reply, response);
     }
     // Cleared unconditionally: a browser mid-rollout can hold either credential, and signing out must end both.
     clearBrowserSessionCookies(reply, options.secureCookies);

--- a/packages/server/src/api/browser-auth.ts
+++ b/packages/server/src/api/browser-auth.ts
@@ -2,6 +2,8 @@ import { isIP } from "node:net";
 import { AuthProvidersResponseSchema, HTTP_PATHS } from "@opentag/shared";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
+import type { OpenTagBetterAuth } from "../auth/better-auth.js";
+import { callBetterAuth, copyBetterAuthCookies } from "../auth/fastify-handler.js";
 import {
   BROWSER_COOKIE_NAMES,
   clearBrowserSessionCookies,
@@ -36,6 +38,8 @@ const CallbackQuerySchema = z
   });
 
 export interface BrowserAuthRoutesOptions {
+  /** Present once Better Auth owns the browser session; the legacy paths stay for credentials it did not issue. */
+  betterAuth?: { instance: OpenTagBetterAuth; publicUrl: string };
   dev?: DevBrowserAuthService;
   google?: GoogleBrowserAuthService;
   publicOrigin: string;
@@ -126,10 +130,31 @@ export function registerBrowserAuthRoutes(
 
   app.get(HTTP_PATHS.authGoogleStart, async (request, reply) => {
     limiter.check(`${request.ip}:start`);
+    const { next } = parseRequest(StartQuerySchema, request.query);
+    const destination = validateOAuthNext(next);
+
+    if (options.betterAuth) {
+      /*
+       * Better Auth expects the client to POST for a URL and navigate itself. The login page is a plain link, so this
+       * route does the POST server-side and redirects — which also keeps the provider's state and PKCE cookies on the
+       * response, and keeps `validateOAuthNext` as the single gate on where sign-in may land.
+       */
+      const response = await callBetterAuth(options.betterAuth.instance, options.betterAuth.publicUrl, request, {
+        method: "POST",
+        path: "/sign-in/social",
+        body: { callbackURL: destination, provider: "google" },
+      });
+      const payload = (await response.json().catch(() => undefined)) as { url?: string } | undefined;
+      if (!response.ok || !payload?.url) {
+        throw new AuthServiceError("AUTH_PROVIDER_DISABLED", "deterministic", "Google sign-in is not configured", 404);
+      }
+      copyBetterAuthCookies(reply, response);
+      return reply.redirect(payload.url, 302);
+    }
+
     if (!options.google) {
       throw new AuthServiceError("AUTH_PROVIDER_DISABLED", "deterministic", "Google sign-in is not configured", 404);
     }
-    const { next } = parseRequest(StartQuerySchema, request.query);
     const result = await options.google.start(next);
     setOAuthContextCookie(reply, result.context, options.secureCookies);
     return reply.redirect(result.authorizationUrl, 302);
@@ -180,6 +205,16 @@ export function registerBrowserAuthRoutes(
 
   app.post(HTTP_PATHS.authBrowserLogout, async (request, reply) => {
     requireBrowserMutationSecurity(request, options.publicOrigin);
+    if (options.betterAuth) {
+      // Revokes the session row rather than only dropping the cookie, which is what the legacy JWTs could never do.
+      const response = await callBetterAuth(options.betterAuth.instance, options.betterAuth.publicUrl, request, {
+        method: "POST",
+        path: "/sign-out",
+        body: {},
+      });
+      copyBetterAuthCookies(reply, response);
+    }
+    // Cleared unconditionally: a browser mid-rollout can hold either credential, and signing out must end both.
     clearBrowserSessionCookies(reply, options.secureCookies);
     return reply.code(204).send();
   });

--- a/packages/server/src/api/computers.ts
+++ b/packages/server/src/api/computers.ts
@@ -8,7 +8,7 @@ import {
 } from "@opentag/shared";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import { createUserAuthPreHandler, type UserAuthPreHandlerOptions } from "../plugins/user-auth.js";
 import type { UserAuthService } from "../services/auth/index.js";
 import { buildComputerConnectCommand, type MachineAuthService } from "../services/computers/index.js";
 import { parseRequest } from "./request-validation.js";
@@ -19,7 +19,7 @@ export function registerComputerRoutes(
   app: FastifyInstance,
   authService: UserAuthService,
   machineAuthService: MachineAuthService,
-  publicOrigin?: string,
+  authOptions?: UserAuthPreHandlerOptions,
   environment?: ChannelName,
   publicUrl?: string,
 ): void {
@@ -34,7 +34,7 @@ export function registerComputerRoutes(
   if (environment && publicUrl) {
     app.post(
       WORKSPACE_COMPUTER_CONNECT_CODES_TEMPLATE,
-      { preHandler: createUserAuthPreHandler(authService, { publicOrigin }) },
+      { preHandler: createUserAuthPreHandler(authService, authOptions ?? {}) },
       async (request, reply) => {
         const accountId = request.authContext?.me.user.id;
         if (!accountId) throw new Error("Authenticated Account context is missing");

--- a/packages/server/src/api/im-bindings.ts
+++ b/packages/server/src/api/im-bindings.ts
@@ -19,7 +19,7 @@ import {
 } from "@opentag/shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
-import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import { createUserAuthPreHandler, type UserAuthPreHandlerOptions } from "../plugins/user-auth.js";
 import type { UserAuthService } from "../services/auth/index.js";
 import type { FeishuSetupService } from "../services/im-bindings/feishu/index.js";
 import type { ImBindingService } from "../services/im-bindings/index.js";
@@ -42,9 +42,9 @@ export function registerImBindingRoutes(
   imBindings: ImBindingService,
   feishu: FeishuSetupService | undefined,
   slack: SlackConfigurationService | undefined,
-  publicOrigin?: string,
+  authOptions?: UserAuthPreHandlerOptions,
 ): void {
-  const preHandler = createUserAuthPreHandler(authService, { publicOrigin });
+  const preHandler = createUserAuthPreHandler(authService, authOptions ?? {});
 
   app.get(AGENT_IM_BINDING_TEMPLATE, { preHandler }, async (request, reply) => {
     const { agentId } = parseRequest(AgentParamsSchema, request.params);

--- a/packages/server/src/api/internal-onboarding-lab.ts
+++ b/packages/server/src/api/internal-onboarding-lab.ts
@@ -1,6 +1,6 @@
 import { INTERNAL_ONBOARDING_LAB_PATH, OnboardingLabAccessSchema } from "@opentag/shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import { createUserAuthPreHandler, type UserAuthPreHandlerOptions } from "../plugins/user-auth.js";
 import { AuthServiceError, type UserAuthService } from "../services/auth/index.js";
 import type { OnboardingResetService } from "../services/onboarding-lab/index.js";
 
@@ -21,9 +21,9 @@ export function registerInternalOnboardingLabRoutes(
   app: FastifyInstance,
   authService: UserAuthService,
   reset: OnboardingResetService,
-  publicOrigin?: string,
+  authOptions?: UserAuthPreHandlerOptions,
 ): void {
-  const preHandler = createUserAuthPreHandler(authService, { publicOrigin });
+  const preHandler = createUserAuthPreHandler(authService, authOptions ?? {});
   const requireLabAccount = (request: FastifyRequest): string => {
     const account = accountId(request);
     if (!reset.allows(account)) throw labNotFound();

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -8,14 +8,14 @@ import {
   UserProfileSchema,
 } from "@opentag/shared";
 import type { FastifyInstance } from "fastify";
-import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import { createUserAuthPreHandler, type UserAuthPreHandlerOptions } from "../plugins/user-auth.js";
 import { buildConnectBootstrapCommand, type ConnectCodeIssuer, type UserAuthService } from "../services/auth/index.js";
 import { parseRequest } from "./request-validation.js";
 
 export interface MeRoutesOptions {
   connectCodeIssuer?: ConnectCodeIssuer;
   environment?: ChannelName;
-  publicOrigin?: string;
+  authOptions?: UserAuthPreHandlerOptions;
   publicUrl?: string;
 }
 
@@ -24,7 +24,7 @@ export function registerMeRoutes(
   authService: UserAuthService,
   options: MeRoutesOptions = {},
 ): void {
-  const preHandler = createUserAuthPreHandler(authService, { publicOrigin: options.publicOrigin });
+  const preHandler = createUserAuthPreHandler(authService, options.authOptions ?? {});
   app.get(HTTP_PATHS.me, { preHandler }, async (request, reply) =>
     reply.code(200).send(MeResponseSchema.parse(request.authContext?.me)),
   );

--- a/packages/server/src/api/slack-oauth.ts
+++ b/packages/server/src/api/slack-oauth.ts
@@ -6,7 +6,11 @@ import {
 } from "@opentag/shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
-import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import {
+  createUserAuthPreHandler,
+  resolveAuthenticatedUserId,
+  type UserAuthPreHandlerOptions,
+} from "../plugins/user-auth.js";
 import {
   BROWSER_COOKIE_NAMES,
   clearSlackOAuthContextCookie,
@@ -29,6 +33,7 @@ const CallbackQuerySchema = z.object({
 
 export interface SlackOAuthRouteOptions {
   authService: UserAuthService;
+  authOptions?: UserAuthPreHandlerOptions;
   publicOrigin: string;
   secureCookies: boolean;
   slackOAuth: SlackOAuthService;
@@ -72,7 +77,7 @@ function errorAgentId(error: unknown): string | undefined {
 }
 
 export function registerSlackOAuthRoutes(app: FastifyInstance, options: SlackOAuthRouteOptions): void {
-  const preHandler = createUserAuthPreHandler(options.authService, { publicOrigin: options.publicOrigin });
+  const preHandler = createUserAuthPreHandler(options.authService, options.authOptions ?? {});
 
   app.post(AGENT_SLACK_OAUTH_START_TEMPLATE, { preHandler }, async (request, reply) => {
     const { agentId } = parseRequest(AgentParamsSchema, request.params);
@@ -95,8 +100,10 @@ export function registerSlackOAuthRoutes(app: FastifyInstance, options: SlackOAu
     clearSlackOAuthContextCookie(reply, SLACK_OAUTH_CALLBACK_PATH, options.secureCookies);
     try {
       const query = parseRequest(CallbackQuerySchema, request.query);
+      // Resolved through the shared resolver so a browser holding either credential completes authorization.
+      const authenticatedUserId = await resolveAuthenticatedUserId(request, options.authService, options.authOptions);
       const result = await options.slackOAuth.callback({
-        accessToken: cookies[BROWSER_COOKIE_NAMES.access],
+        ...(authenticatedUserId === undefined ? {} : { authenticatedUserId }),
         ...(query.code !== undefined ? { code: query.code } : {}),
         ...(query.error !== undefined ? { error: query.error } : {}),
         sessionBinding: cookies[BROWSER_COOKIE_NAMES.slackOAuthContext],

--- a/packages/server/src/api/workspaces.ts
+++ b/packages/server/src/api/workspaces.ts
@@ -8,7 +8,7 @@ import {
 } from "@opentag/shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
-import { createUserAuthPreHandler } from "../plugins/user-auth.js";
+import { createUserAuthPreHandler, type UserAuthPreHandlerOptions } from "../plugins/user-auth.js";
 import type { UserAuthService } from "../services/auth/index.js";
 import type { WorkspaceAdminService, WorkspaceSetupService } from "../services/workspaces/index.js";
 import { parseRequest } from "./request-validation.js";
@@ -25,10 +25,10 @@ export function registerWorkspaceRoutes(
   app: FastifyInstance,
   authService: UserAuthService,
   workspaceService: WorkspaceAdminService,
-  publicOrigin?: string,
+  authOptions?: UserAuthPreHandlerOptions,
   workspaceSetupService?: WorkspaceSetupService,
 ): void {
-  const preHandler = createUserAuthPreHandler(authService, { publicOrigin });
+  const preHandler = createUserAuthPreHandler(authService, authOptions ?? {});
 
   if (workspaceSetupService) {
     app.post(WORKSPACE_SETUP_COMPLETE_TEMPLATE, { preHandler }, async (request, reply) => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -17,6 +17,8 @@ import { type RuntimeRoutesOptions, registerRuntimeRoutes } from "./api/runtime.
 import { registerSlackEventsRoute, type SlackEventsRouteOptions } from "./api/slack-events.js";
 import { registerSlackOAuthRoutes, type SlackOAuthRouteOptions } from "./api/slack-oauth.js";
 import { registerWorkspaceRoutes } from "./api/workspaces.js";
+import type { OpenTagBetterAuth } from "./auth/better-auth.js";
+import { registerBetterAuthRoutes } from "./auth/fastify-handler.js";
 import { BootstrapReadiness } from "./bootstrap-readiness.js";
 import { currentTraceId } from "./observability/index.js";
 import { type AgentService, AgentServiceError } from "./services/agents/index.js";
@@ -39,6 +41,8 @@ export interface CreateAppOptions {
   /** Enables the Account-native management collections that back the Workspace-free client contracts. */
   accountScope?: AccountScopeResolver;
   authService?: UserAuthService;
+  /** Publishes Better Auth's allowlisted endpoints and lets every authenticated route resolve its sessions. */
+  betterAuth?: { instance: OpenTagBetterAuth; publicUrl: string };
   webAppRoot?: string;
   agentService?: AgentService;
   computerService?: ComputerService;
@@ -178,6 +182,13 @@ export function createApp(options: CreateAppOptions = {}) {
   if (options.authService) {
     const authService = options.authService;
     const publicOrigin = options.browserAuth?.publicOrigin;
+    const authOptions = {
+      ...(options.betterAuth ? { betterAuth: options.betterAuth.instance } : {}),
+      ...(publicOrigin ? { publicOrigin } : {}),
+    };
+    if (options.betterAuth) {
+      registerBetterAuthRoutes(app, options.betterAuth.instance, options.betterAuth.publicUrl);
+    }
     registerAuthRoutes(app, authService);
     registerMeRoutes(app, authService, {
       ...(options.connectCode
@@ -187,14 +198,19 @@ export function createApp(options: CreateAppOptions = {}) {
             publicUrl: options.connectCode.publicUrl,
           }
         : {}),
-      publicOrigin,
+      authOptions,
     });
-    if (options.browserAuth) registerBrowserAuthRoutes(app, authService, options.browserAuth);
+    if (options.browserAuth) {
+      registerBrowserAuthRoutes(app, authService, {
+        ...options.browserAuth,
+        ...(options.betterAuth ? { betterAuth: options.betterAuth } : {}),
+      });
+    }
     if (options.agentService) {
-      registerAgentRoutes(app, authService, options.agentService, publicOrigin);
+      registerAgentRoutes(app, authService, options.agentService, authOptions);
     }
     if (options.workspaceService) {
-      registerWorkspaceRoutes(app, authService, options.workspaceService, publicOrigin, options.workspaceSetupService);
+      registerWorkspaceRoutes(app, authService, options.workspaceService, authOptions, options.workspaceSetupService);
     }
     if (options.accountScope) {
       registerAccountRoutes(app, authService, {
@@ -205,11 +221,11 @@ export function createApp(options: CreateAppOptions = {}) {
         ...(options.workspaceService ? { workspaceService: options.workspaceService } : {}),
         ...(options.workspaceSetupService ? { workspaceSetupService: options.workspaceSetupService } : {}),
         ...(options.taskService ? { taskService: options.taskService } : {}),
-        publicOrigin,
+        authOptions,
       });
     }
     if (options.stagingOnboardingLab) {
-      registerInternalOnboardingLabRoutes(app, authService, options.stagingOnboardingLab.reset, publicOrigin);
+      registerInternalOnboardingLabRoutes(app, authService, options.stagingOnboardingLab.reset, authOptions);
     }
     if (options.imBindingService) {
       registerImBindingRoutes(
@@ -218,7 +234,7 @@ export function createApp(options: CreateAppOptions = {}) {
         options.imBindingService,
         options.feishuSetupService,
         options.slackConfigurationService,
-        publicOrigin,
+        authOptions,
       );
     }
     if (options.slackOAuth) registerSlackOAuthRoutes(app, options.slackOAuth);
@@ -232,7 +248,7 @@ export function createApp(options: CreateAppOptions = {}) {
         app,
         authService,
         machineAuthService,
-        publicOrigin,
+        authOptions,
         options.computerConnectCode?.environment,
         options.computerConnectCode?.publicUrl,
       );

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -187,7 +187,11 @@ export function createApp(options: CreateAppOptions = {}) {
       ...(publicOrigin ? { publicOrigin } : {}),
     };
     if (options.betterAuth) {
-      registerBetterAuthRoutes(app, options.betterAuth.instance, options.betterAuth.publicUrl);
+      registerBetterAuthRoutes(app, options.betterAuth.instance, {
+        publicUrl: options.betterAuth.publicUrl,
+        secureCookies: options.browserAuth?.secureCookies ?? true,
+        sessionTtlSeconds: options.browserAuth?.refreshTokenTtlSeconds ?? 60 * 60 * 24 * 7,
+      });
     }
     registerAuthRoutes(app, authService);
     registerMeRoutes(app, authService, {
@@ -237,7 +241,7 @@ export function createApp(options: CreateAppOptions = {}) {
         authOptions,
       );
     }
-    if (options.slackOAuth) registerSlackOAuthRoutes(app, options.slackOAuth);
+    if (options.slackOAuth) registerSlackOAuthRoutes(app, { ...options.slackOAuth, authOptions });
     if (options.imResourceService && options.machineAuthService) {
       registerImResourceRoute(app, options.machineAuthService, options.imResourceService);
     }

--- a/packages/server/src/auth/better-auth.ts
+++ b/packages/server/src/auth/better-auth.ts
@@ -18,10 +18,13 @@ export interface BetterAuthConfig {
   /**
    * Runs before any session row exists, and must throw to prevent one.
    *
-   * Better Auth owns account creation on its own sign-in paths, so this is where OpenTag's Account invariants are
-   * enforced: an Account is not suspended, and it holds the compatibility Workspace grant every authenticated route
-   * derives authority from. Enforcing at issuance rather than after it means there is no window in which a session
-   * exists for an Account that does not satisfy them.
+   * Better Auth owns account creation on its own sign-in paths, so this is where OpenTag decides whether an Account
+   * may hold a session at all — which is a question about identity, not authority. A suspended Account is refused, and
+   * an Account that has never been provisioned gets its default Workspace before it can sign in.
+   *
+   * It deliberately does not require an *active* Workspace grant. Revoking every grant removes an Account's authority,
+   * not its ability to sign in: it can still authenticate and see that it has no Workspace, and re-provisioning it
+   * here would hand the revoked authority straight back. Routes derive authority from grants read live per request.
    */
   onSessionCreating: (userId: string) => Promise<void>;
   /** Origin the browser reaches the server on; also the only trusted origin. */

--- a/packages/server/src/auth/better-auth.ts
+++ b/packages/server/src/auth/better-auth.ts
@@ -1,7 +1,6 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer } from "better-auth/plugins/bearer";
-import { eq } from "drizzle-orm";
 import type { DatabaseClient } from "../db/client.js";
 import { authIdentities, authSessions, authVerifications, users } from "../db/schema/index.js";
 
@@ -16,6 +15,15 @@ import { authIdentities, authSessions, authVerifications, users } from "../db/sc
 export const BETTER_AUTH_BASE_PATH = "/api/v1/auth";
 
 export interface BetterAuthConfig {
+  /**
+   * Runs before any session row exists, and must throw to prevent one.
+   *
+   * Better Auth owns account creation on its own sign-in paths, so this is where OpenTag's Account invariants are
+   * enforced: an Account is not suspended, and it holds the compatibility Workspace grant every authenticated route
+   * derives authority from. Enforcing at issuance rather than after it means there is no window in which a session
+   * exists for an Account that does not satisfy them.
+   */
+  onSessionCreating: (userId: string) => Promise<void>;
   /** Origin the browser reaches the server on; also the only trusted origin. */
   publicUrl: string;
   secret: string;
@@ -87,17 +95,10 @@ export function createBetterAuth(database: DatabaseClient, config: BetterAuthCon
       },
       session: {
         create: {
-          /*
-           * Suspension is the only kill switch this system has for an Account, and the legacy path re-checks it on
-           * every authenticated request. A session must not come into existence for a suspended Account.
-           */
+          // Throwing here aborts the sign-in that asked for the session, so the caller sees why rather than a
+          // session that silently failed to appear.
           before: async (session) => {
-            const [account] = await database
-              .select({ suspendedAt: users.suspendedAt })
-              .from(users)
-              .where(eq(users.id, session.userId))
-              .limit(1);
-            return account && !account.suspendedAt ? undefined : false;
+            await config.onSessionCreating(session.userId);
           },
         },
       },

--- a/packages/server/src/auth/fastify-handler.ts
+++ b/packages/server/src/auth/fastify-handler.ts
@@ -1,6 +1,6 @@
 import { fromNodeHeaders } from "better-auth/node";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import { appendSetCookies } from "../services/auth/browser-cookies.js";
+import { appendSetCookies, setBrowserCsrfCookie } from "../services/auth/browser-cookies.js";
 import { BETTER_AUTH_BASE_PATH, type OpenTagBetterAuth } from "./better-auth.js";
 
 /**
@@ -17,7 +17,19 @@ import { BETTER_AUTH_BASE_PATH, type OpenTagBetterAuth } from "./better-auth.js"
  */
 const PUBLISHED_PATHS = [{ method: "GET" as const, path: "/callback/:provider" }];
 
-export function registerBetterAuthRoutes(app: FastifyInstance, auth: OpenTagBetterAuth, publicUrl: string): void {
+export interface BetterAuthRoutesOptions {
+  publicUrl: string;
+  secureCookies: boolean;
+  /** Matches the session lifetime the double-submit token accompanies. */
+  sessionTtlSeconds: number;
+}
+
+export function registerBetterAuthRoutes(
+  app: FastifyInstance,
+  auth: OpenTagBetterAuth,
+  options: BetterAuthRoutesOptions,
+): void {
+  const publicUrl = options.publicUrl;
   app.register(async (authApp) => {
     authApp.removeAllContentTypeParsers();
     authApp.addContentTypeParser("*", { parseAs: "buffer" }, (_request, body, done) => {
@@ -28,8 +40,21 @@ export function registerBetterAuthRoutes(app: FastifyInstance, auth: OpenTagBett
       authApp.route({
         method,
         url: `${BETTER_AUTH_BASE_PATH}${path}`,
-        handler: async (request, reply) =>
-          sendBetterAuthResponse(reply, await callBetterAuth(auth, publicUrl, request)),
+        handler: async (request, reply) => {
+          const response = await callBetterAuth(auth, publicUrl, request);
+          /*
+           * A Better Auth sign-in issues its own session cookie and knows nothing about OpenTag's double-submit
+           * token, which every browser mutation — including sign-out — requires. Issuing it alongside the session is
+           * what makes a freshly signed-in browser able to write at all.
+           */
+          if (await isSessionEstablished(auth, response)) {
+            setBrowserCsrfCookie(reply, {
+              maxAgeSeconds: options.sessionTtlSeconds,
+              secure: options.secureCookies,
+            });
+          }
+          return sendBetterAuthResponse(reply, response);
+        },
       });
     }
   });
@@ -92,4 +117,10 @@ export async function sendBetterAuthResponse(reply: FastifyReply, response: Resp
   copyBetterAuthCookies(reply, response);
   if (!response.body) return reply.send(null);
   return reply.send(Buffer.from(await response.arrayBuffer()));
+}
+
+/** Whether a Better Auth response handed the browser a session cookie. */
+async function isSessionEstablished(auth: OpenTagBetterAuth, response: Response): Promise<boolean> {
+  const sessionCookieName = (await auth.$context).authCookies.sessionToken.name;
+  return response.headers.getSetCookie().some((value) => value.split("=", 1)[0]?.trim() === sessionCookieName);
 }

--- a/packages/server/src/auth/fastify-handler.ts
+++ b/packages/server/src/auth/fastify-handler.ts
@@ -1,0 +1,95 @@
+import { fromNodeHeaders } from "better-auth/node";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { appendSetCookies } from "../services/auth/browser-cookies.js";
+import { BETTER_AUTH_BASE_PATH, type OpenTagBetterAuth } from "./better-auth.js";
+
+/**
+ * The only Better Auth endpoint OpenTag publishes.
+ *
+ * Better Auth's handler serves its whole surface from one catch-all, including `/update-user` — a second Account
+ * profile writer that bypasses `UserDisplayNameSchema`, the suspension guard, and the canonical `/api/v1/me` boundary.
+ * Registering paths individually keeps that surface closed: an endpoint is reachable because it is listed here, not
+ * because the library happens to define it.
+ *
+ * Only the OAuth callback has to be served by the library, because the provider redirects the browser straight to it.
+ * Every other step runs through an OpenTag route that calls into Better Auth server-side, so the request contract,
+ * the origin check, and the response shape all stay ours.
+ */
+const PUBLISHED_PATHS = [{ method: "GET" as const, path: "/callback/:provider" }];
+
+export function registerBetterAuthRoutes(app: FastifyInstance, auth: OpenTagBetterAuth, publicUrl: string): void {
+  app.register(async (authApp) => {
+    authApp.removeAllContentTypeParsers();
+    authApp.addContentTypeParser("*", { parseAs: "buffer" }, (_request, body, done) => {
+      done(null, body);
+    });
+
+    for (const { method, path } of PUBLISHED_PATHS) {
+      authApp.route({
+        method,
+        url: `${BETTER_AUTH_BASE_PATH}${path}`,
+        handler: async (request, reply) =>
+          sendBetterAuthResponse(reply, await callBetterAuth(auth, publicUrl, request)),
+      });
+    }
+  });
+}
+
+/** Overrides for driving a Better Auth endpoint that the browser did not address directly. */
+export interface BetterAuthCall {
+  body?: unknown;
+  method?: "GET" | "POST";
+  /** Path below the Better Auth base path, for example `/sign-out`. */
+  path?: string;
+}
+
+/**
+ * Runs one Better Auth endpoint and returns its raw response.
+ *
+ * The URL is built from the configured public URL rather than the Host header, so a spoofed Host cannot move the
+ * origin Better Auth validates against.
+ */
+export async function callBetterAuth(
+  auth: OpenTagBetterAuth,
+  publicUrl: string,
+  request: FastifyRequest,
+  call: BetterAuthCall = {},
+): Promise<Response> {
+  const target = call.path === undefined ? request.url : `${BETTER_AUTH_BASE_PATH}${call.path}`;
+  const url = new URL(target, publicUrl);
+  const method = call.method ?? request.method;
+  const headers = fromNodeHeaders(request.headers);
+  let body: Buffer | string | undefined;
+  if (call.body !== undefined) {
+    body = JSON.stringify(call.body);
+    headers.set("content-type", "application/json");
+  } else if (Buffer.isBuffer(request.body) && request.body.length > 0) {
+    body = request.body;
+  }
+  // A forwarded body is this request's, not the incoming one's; a stale length would truncate or hang the read.
+  headers.delete("content-length");
+  return auth.handler(new Request(url, { method, headers, ...(body === undefined ? {} : { body }) }));
+}
+
+/**
+ * Copies Better Auth's cookies onto a reply.
+ *
+ * `set-cookie` must come from `Headers.getSetCookie()`: iterating the `Headers` object folds multiple cookies into one
+ * comma-joined value that browsers reject, which would silently break every session cookie.
+ */
+export function copyBetterAuthCookies(reply: FastifyReply, response: Response): void {
+  const setCookies = response.headers.getSetCookie();
+  if (setCookies.length > 0) appendSetCookies(reply, setCookies);
+}
+
+/** Copies a Better Auth response onto a reply verbatim. */
+export async function sendBetterAuthResponse(reply: FastifyReply, response: Response): Promise<FastifyReply> {
+  reply.status(response.status);
+  for (const [key, value] of response.headers) {
+    if (key.toLowerCase() === "set-cookie") continue;
+    reply.header(key, value);
+  }
+  copyBetterAuthCookies(reply, response);
+  if (!response.body) return reply.send(null);
+  return reply.send(Buffer.from(await response.arrayBuffer()));
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import type { ProviderReadinessStatus } from "@opentag/shared";
 import { and, eq, isNull } from "drizzle-orm";
 import { createApp } from "./app.js";
+import { createBetterAuth } from "./auth/better-auth.js";
 import { BootstrapReadiness } from "./bootstrap-readiness.js";
 import { isHostedEnvironment, parseServerConfig, serverEnvironmentSummary } from "./config.js";
 import { createDatabaseClient } from "./db/client.js";
@@ -253,6 +254,15 @@ export async function startServer(): Promise<void> {
     });
     const identityService = new AuthIdentityService(database);
     const postAuthentication = new PostAuthenticationService(database, workspaceAdmins);
+    const betterAuth = createBetterAuth(database, {
+      onSessionCreating: async (userId) => {
+        await postAuthentication.ensureAccountReady(userId);
+      },
+      publicUrl: config.publicUrl,
+      secret: config.betterAuthSecret,
+      secureCookies: isHostedEnvironment(config.environment),
+      ...(config.google ? { google: config.google } : {}),
+    });
     const google = config.google
       ? new GoogleBrowserAuthService({
           database,
@@ -278,6 +288,7 @@ export async function startServer(): Promise<void> {
         }
       : undefined;
     app = createApp({
+      betterAuth: { instance: betterAuth, publicUrl: config.publicUrl },
       webAppRoot: defaultWebAppRoot,
       accountScope: workspaceAdmins,
       agentService,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -234,10 +234,6 @@ export async function startServer(): Promise<void> {
       ? new SlackOAuthService({
           api: slackApi,
           app: config.slackOAuth,
-          authenticateUser: async (accessToken) => {
-            const authenticated = await authService.getAuthenticatedUser(accessToken);
-            return { userId: authenticated.me.user.id };
-          },
           database,
           slack: slackConfigurationService,
           state: new SlackOAuthStateService(config.jwtSecret),

--- a/packages/server/src/plugins/user-auth.ts
+++ b/packages/server/src/plugins/user-auth.ts
@@ -36,7 +36,9 @@ export async function resolveAuthenticatedUserId(
 ): Promise<string | undefined> {
   if (options.betterAuth) {
     const session = await options.betterAuth.api.getSession({ headers: fromNodeHeaders(request.headers) });
-    if (session) return session.user.id;
+    // Resolved live rather than trusted from the session, so an Account suspended after issuance is rejected here
+    // instead of at whatever authority check happens to come after the caller's side effects.
+    if (session) return (await authService.getActiveUserById(session.user.id)).user.id;
   }
   const authorization = request.headers.authorization;
   const legacyToken = authorization?.startsWith("Bearer ")

--- a/packages/server/src/plugins/user-auth.ts
+++ b/packages/server/src/plugins/user-auth.ts
@@ -23,6 +23,30 @@ export interface UserAuthPreHandlerOptions {
   publicOrigin?: string;
 }
 
+/**
+ * Resolves who a request is, across every credential this server accepts, or `undefined` when it carries none.
+ *
+ * Routes that authenticate outside the preHandler need the same answer it would give — otherwise a browser holding
+ * one kind of credential works everywhere except there.
+ */
+export async function resolveAuthenticatedUserId(
+  request: FastifyRequest,
+  authService: UserAuthService,
+  options: UserAuthPreHandlerOptions = {},
+): Promise<string | undefined> {
+  if (options.betterAuth) {
+    const session = await options.betterAuth.api.getSession({ headers: fromNodeHeaders(request.headers) });
+    if (session) return session.user.id;
+  }
+  const authorization = request.headers.authorization;
+  const legacyToken = authorization?.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length).trim()
+    : parseCookies(request.headers.cookie)[BROWSER_COOKIE_NAMES.access];
+  if (!legacyToken) return undefined;
+  const authenticated = await authService.getAuthenticatedUser(legacyToken);
+  return authenticated.me.user.id;
+}
+
 export function createUserAuthPreHandler(authService: UserAuthService, options: UserAuthPreHandlerOptions = {}) {
   return async function userAuthPreHandler(request: FastifyRequest, _reply: FastifyReply): Promise<void> {
     const authorization = request.headers.authorization;

--- a/packages/server/src/plugins/user-auth.ts
+++ b/packages/server/src/plugins/user-auth.ts
@@ -1,4 +1,6 @@
+import { fromNodeHeaders } from "better-auth/node";
 import type { FastifyReply, FastifyRequest } from "fastify";
+import type { OpenTagBetterAuth } from "../auth/better-auth.js";
 import {
   BROWSER_COOKIE_NAMES,
   parseCookies,
@@ -15,20 +17,53 @@ declare module "fastify" {
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
-export function createUserAuthPreHandler(authService: UserAuthService, options: { publicOrigin?: string } = {}) {
+export interface UserAuthPreHandlerOptions {
+  /** Present once Better Auth issues sessions; credentials it did not issue still resolve through the legacy path. */
+  betterAuth?: OpenTagBetterAuth;
+  publicOrigin?: string;
+}
+
+export function createUserAuthPreHandler(authService: UserAuthService, options: UserAuthPreHandlerOptions = {}) {
   return async function userAuthPreHandler(request: FastifyRequest, _reply: FastifyReply): Promise<void> {
     const authorization = request.headers.authorization;
-    if (authorization?.startsWith("Bearer ")) {
-      const token = authorization.slice("Bearer ".length).trim();
-      if (!token) throw invalidCredential("AUTH_INVALID_TOKEN", "Authentication is required");
-      request.authContext = await authService.getAuthenticatedUser(token);
+    const bearer = authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length).trim() : undefined;
+
+    /*
+     * A bearer credential carries its own proof and is used by the CLI, which has no origin to present. Cookie
+     * requests are browser requests, so a mutation has to additionally prove it came from this origin — but only once
+     * a credential has actually been presented, so a request with none still reads as unauthenticated rather than
+     * forbidden.
+     */
+    const requireBrowserOrigin = () => {
+      if (!options.publicOrigin) throw invalidCredential("AUTH_INVALID_TOKEN", "Authentication is required");
+      if (!SAFE_METHODS.has(request.method)) requireBrowserMutationSecurity(request, options.publicOrigin);
+    };
+
+    /*
+     * Better Auth reads both its session cookie and the bearer header, so one call covers every credential it issued.
+     * What comes back is only an identity: suspension and Workspace grants are still resolved live from the database
+     * on every request, exactly as the legacy path does, so revoking either takes effect immediately.
+     */
+    if (options.betterAuth) {
+      const session = await options.betterAuth.api.getSession({ headers: fromNodeHeaders(request.headers) });
+      if (session) {
+        if (!bearer) requireBrowserOrigin();
+        request.authContext = {
+          me: await authService.getActiveUserById(session.user.id),
+          tokenExpiresAt: session.session.expiresAt,
+        };
+        return;
+      }
+    }
+
+    // Credentials issued before the cutover, still valid until they expire.
+    if (bearer) {
+      request.authContext = await authService.getAuthenticatedUser(bearer);
       return;
     }
     const accessCookie = parseCookies(request.headers.cookie)[BROWSER_COOKIE_NAMES.access];
-    if (!accessCookie || !options.publicOrigin) {
-      throw invalidCredential("AUTH_INVALID_TOKEN", "Authentication is required");
-    }
-    if (!SAFE_METHODS.has(request.method)) requireBrowserMutationSecurity(request, options.publicOrigin);
+    if (!accessCookie) throw invalidCredential("AUTH_INVALID_TOKEN", "Authentication is required");
+    requireBrowserOrigin();
     request.authContext = await authService.getAuthenticatedUser(accessCookie);
   };
 }

--- a/packages/server/src/services/auth/browser-cookies.ts
+++ b/packages/server/src/services/auth/browser-cookies.ts
@@ -66,6 +66,20 @@ export function setBrowserSessionCookies(
   return csrf;
 }
 
+/**
+ * Issues the readable half of the double-submit pair on its own.
+ *
+ * A Better Auth sign-in brings its own session cookie but knows nothing about this one, and every browser mutation —
+ * including sign-out — requires it. Without this, a session issued by Better Auth can read but never write.
+ */
+export function setBrowserCsrfCookie(reply: FastifyReply, options: { maxAgeSeconds: number; secure: boolean }): string {
+  const csrf = generateSecret(24);
+  appendSetCookies(reply, [
+    cookie(BROWSER_COOKIE_NAMES.csrf, csrf, { maxAge: options.maxAgeSeconds, path: "/", secure: options.secure }),
+  ]);
+  return csrf;
+}
+
 export function clearBrowserSessionCookies(reply: FastifyReply, secure: boolean): void {
   appendSetCookies(reply, [
     cookie(BROWSER_COOKIE_NAMES.access, "", { httpOnly: true, maxAge: 0, path: "/", secure }),

--- a/packages/server/src/services/auth/post-authentication.ts
+++ b/packages/server/src/services/auth/post-authentication.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import type { DatabaseClient, DatabaseTransaction } from "../../db/client.js";
 import { users, workspaceAdminGrants } from "../../db/schema/index.js";
 import type { WorkspaceAdminAccess } from "../workspace-admin-access/index.js";
@@ -26,9 +26,10 @@ export class PostAuthenticationService {
   /**
    * The same guarantees as {@link complete}, for a caller that does not know whether the Account was just created.
    *
-   * Better Auth owns account creation on its own sign-in paths, so nothing there can tell us. Deriving it from the
-   * absence of a grant is equivalent for this purpose and makes the call idempotent: a returning Account is a no-op,
-   * and one that never received its grant — or lost it — gets one before any session exists.
+   * Better Auth owns account creation on its own sign-in paths, so nothing there can tell us. What stands in for it is
+   * whether the Account has *ever* held a grant, not whether it holds one now: an Account whose grants were revoked
+   * has been provisioned, and re-provisioning it would hand back the authority that revocation removed. Only an
+   * Account with no grant in its history is treated as new, which also makes the call idempotent.
    */
   async ensureAccountReady(userId: string): Promise<PostAuthenticationResult> {
     return this.#database.transaction(async (transaction) => {
@@ -36,12 +37,12 @@ export class PostAuthenticationService {
       if (!user || user.suspendedAt) {
         throw new AuthServiceError("AUTH_USER_SUSPENDED", "deterministic", "The user account is suspended", 403);
       }
-      const [grant] = await transaction
-        .select({ workspaceId: workspaceAdminGrants.workspaceId })
+      const [everGranted] = await transaction
+        .select({ id: workspaceAdminGrants.id })
         .from(workspaceAdminGrants)
-        .where(and(eq(workspaceAdminGrants.userId, userId), isNull(workspaceAdminGrants.revokedAt)))
+        .where(eq(workspaceAdminGrants.userId, userId))
         .limit(1);
-      if (!grant) {
+      if (!everGranted) {
         await this.#workspaceAdmins.establishDefaultWorkspaceForNewAccount(transaction, user, true);
       }
       return { userId };

--- a/packages/server/src/services/auth/post-authentication.ts
+++ b/packages/server/src/services/auth/post-authentication.ts
@@ -1,6 +1,6 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import type { DatabaseClient, DatabaseTransaction } from "../../db/client.js";
-import { users } from "../../db/schema/index.js";
+import { users, workspaceAdminGrants } from "../../db/schema/index.js";
 import type { WorkspaceAdminAccess } from "../workspace-admin-access/index.js";
 import { AuthServiceError } from "./errors.js";
 
@@ -21,6 +21,31 @@ export class PostAuthenticationService {
     return this.#database.transaction((transaction) =>
       this.completeInTransaction(transaction, userId, accountWasCreated),
     );
+  }
+
+  /**
+   * The same guarantees as {@link complete}, for a caller that does not know whether the Account was just created.
+   *
+   * Better Auth owns account creation on its own sign-in paths, so nothing there can tell us. Deriving it from the
+   * absence of a grant is equivalent for this purpose and makes the call idempotent: a returning Account is a no-op,
+   * and one that never received its grant — or lost it — gets one before any session exists.
+   */
+  async ensureAccountReady(userId: string): Promise<PostAuthenticationResult> {
+    return this.#database.transaction(async (transaction) => {
+      const [user] = await transaction.select().from(users).where(eq(users.id, userId)).limit(1).for("update");
+      if (!user || user.suspendedAt) {
+        throw new AuthServiceError("AUTH_USER_SUSPENDED", "deterministic", "The user account is suspended", 403);
+      }
+      const [grant] = await transaction
+        .select({ workspaceId: workspaceAdminGrants.workspaceId })
+        .from(workspaceAdminGrants)
+        .where(and(eq(workspaceAdminGrants.userId, userId), isNull(workspaceAdminGrants.revokedAt)))
+        .limit(1);
+      if (!grant) {
+        await this.#workspaceAdmins.establishDefaultWorkspaceForNewAccount(transaction, user, true);
+      }
+      return { userId };
+    });
   }
 
   async completeInTransaction(

--- a/packages/server/src/services/im-bindings/slack/oauth-service.ts
+++ b/packages/server/src/services/im-bindings/slack/oauth-service.ts
@@ -26,7 +26,11 @@ export interface SlackOAuthStartResult extends StartSlackOAuthResponse {
 }
 
 export interface SlackOAuthCallbackInput {
-  accessToken?: string;
+  /**
+   * Resolved by the route, which is the only place that understands every credential a browser may present. Passing
+   * an identity rather than a token keeps this service out of the business of authenticating one.
+   */
+  authenticatedUserId?: string;
   code?: string;
   error?: string;
   sessionBinding?: string;
@@ -45,7 +49,6 @@ function oauthFailed(message = "The Slack authorization flow is invalid or expir
 export class SlackOAuthService {
   readonly #api: SlackApiClient;
   readonly #app: SlackOAuthAppConfig;
-  readonly #authenticateUser: (accessToken: string) => Promise<{ userId: string }>;
   readonly #database: DatabaseClient;
   readonly #now: () => Date;
   readonly #slack: SlackConfigurationService;
@@ -54,7 +57,6 @@ export class SlackOAuthService {
   constructor(input: {
     api: SlackApiClient;
     app: SlackOAuthAppConfig;
-    authenticateUser: (accessToken: string) => Promise<{ userId: string }>;
     database: DatabaseClient;
     slack: SlackConfigurationService;
     state: SlackOAuthStateService;
@@ -62,7 +64,6 @@ export class SlackOAuthService {
   }) {
     this.#api = input.api;
     this.#app = input.app;
-    this.#authenticateUser = input.authenticateUser;
     this.#database = input.database;
     this.#now = input.now ?? (() => new Date());
     this.#slack = input.slack;
@@ -156,11 +157,10 @@ export class SlackOAuthService {
     payload: Awaited<ReturnType<SlackOAuthStateService["verify"]>>,
     input: SlackOAuthCallbackInput,
   ): Promise<SlackOAuthCallbackSuccess> {
-    if (!input.accessToken) {
+    if (!input.authenticatedUserId) {
       throw new AuthServiceError("AUTH_INVALID_TOKEN", "credential", "Authentication is required", 401);
     }
-    const authenticated = await this.#authenticateUser(input.accessToken);
-    if (authenticated.userId !== payload.userId) {
+    if (input.authenticatedUserId !== payload.userId) {
       throw new AuthServiceError("AUTH_INVALID_TOKEN", "credential", "Authentication is required", 401);
     }
 


### PR DESCRIPTION
## Summary

Third step of the Better Auth migration, and the first that changes what a request does. Google sign-in now issues a Better Auth session and every authenticated route resolves one. **Credentials issued before this deploys keep working until they expire**, so the rollout signs nobody out.

Until now the browser held a stateless HS256 JWT with no server-side session row, which meant logout could not revoke anything and the only kill switch for an Account was `users.suspended_at` re-read on each request.

### The published surface is an allowlist

Better Auth serves its entire API from one handler. Reviewers of #196 showed what that costs: `/update-user` writes Better Auth's `name` straight into `users.display_name`, bypassing `UserDisplayNameSchema`, the suspension guard, and the authenticated, origin-checked `/api/v1/me`.

So only the OAuth callback is published — the provider redirects the browser straight to it and nothing else can serve it. Sign-in and sign-out run through OpenTag routes that call Better Auth server-side, keeping the request contract, the origin check, and the response shape ours.

`better-auth-surface.test.ts` asserts the unpublished paths 404 and names the one that escaped if that regresses. Restoring a catch-all fails it on `get-session`.

### Account invariants are enforced at issuance, not after it

`onSessionCreating` runs before any session row exists and must throw to prevent one. There is therefore no window in which a session exists for an Account that is suspended, or that lacks the compatibility Workspace grant every authenticated route derives authority from.

`ensureAccountReady` derives *was this Account just created?* from the absence of a grant. Better Auth owns account creation on its own sign-in paths and cannot tell us, and deriving it makes the call idempotent: a returning Account is a no-op, one that never received a grant gets one.

### Resolution stays live

Better Auth returns an identity. Suspension and Workspace grants are still read from the database on every request, exactly as the legacy path does, so revoking either takes effect immediately rather than at session expiry.

### Other behaviour changes

- **Sign-out revokes the session row**, not just the cookie. It also clears the legacy cookies, because a browser mid-rollout can hold either credential and signing out must end both.
- **The origin check moved back behind the credential check.** I had put it first, which turned an unauthenticated request into `403` instead of `401`; the existing contract test caught it.
- The double-submit CSRF cookie stays. It guards `/api/v1/*` business routes, which are not Better Auth endpoints, so Better Auth's own protection does not cover them.

### Not in this step

The dev sign-in bypass and `POST /api/v1/auth/browser/refresh` still issue and accept legacy JWTs. They keep working through the same preHandler and move in the CLI step, which is where the legacy token service is retired.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test`
- `pnpm --filter @opentag/server test:integration` — 191 passing
- New `better-auth-surface.test.ts`: the allowlist holds, and the forwarded URL is built from the configured origin rather than the request `Host`.
- New integration coverage: an Account receives its compatibility Workspace grant before a session exists, idempotently; a suspended Account's session creation is refused with `AUTH_USER_SUSPENDED`.

Not covered by automated tests: a live Google sign-in, which needs OAuth credentials.

## Breaking changes

None for users. Operationally, the Google OAuth client needs the new redirect URI **before** this deploys — see below.

## Deployment prerequisite

Add `https://<app>/api/v1/auth/callback/google` to the Google OAuth client's authorized redirect URIs, and keep the existing `/api/v1/auth/google/callback` until the legacy path is retired. Better Auth's callback path is `<basePath>/callback/<provider>`, so sign-in fails at the provider without it.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
