### PR TITLE
refactor(web): make onboarding say what it is and what to do

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -2466,6 +2466,19 @@ describe("OpenTag Web App Shell", () => {
     expect(window.location.pathname).toBe("/onboarding");
   });
 
+  it("renders onboarding without the application navigation", async () => {
+    installApi({ setupCompletedAt: null });
+    render(<App />);
+    await screen.findByRole("heading", { name: "Set up OpenTag" });
+
+    // The Account has not entered the application yet. Every destination the primary navigation
+    // offers is behind the setup gate, which sends them all straight back here, and the shell
+    // brand would stand beside the one onboarding renders itself.
+    expect(screen.queryByRole("navigation", { name: "Primary navigation" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Agents" })).toBeNull();
+    expect(screen.getAllByRole("link", { name: "OpenTag" })).toHaveLength(1);
+  });
+
   it("keeps completed Workspaces out of onboarding even when it is requested directly", async () => {
     installApi();
     window.history.replaceState({}, "", "/onboarding");

--- a/apps/web/src/agent-creation/agent-creation-flow.tsx
+++ b/apps/web/src/agent-creation/agent-creation-flow.tsx
@@ -32,7 +32,17 @@ export interface AgentCreationFacts {
   readonly runtimeEvidenceAvailable: boolean;
 }
 
+/**
+ * When the derived Agent name is put in front of the Account. `always` keeps it visible, which is
+ * what a Workspace that already holds Agents needs: the name carries a uniqueness constraint, so
+ * seeing the derivation is how a collision gets avoided before it is submitted. `when-required`
+ * shows it only once a display name derives to nothing and the Account has to choose one — the
+ * onboarding case, where this is the Account's first Agent and no collision is possible.
+ */
+export type AgentNameDisclosure = "always" | "when-required";
+
 export interface AgentCreationFlowProps {
+  readonly agentNameDisclosure?: AgentNameDisclosure;
   readonly facts: AgentCreationFacts;
   readonly initialDisplayName?: string;
   readonly onCancel?: () => void;
@@ -81,6 +91,7 @@ export function deriveAgentName(displayName: string): string {
 }
 
 export function AgentCreationFlow({
+  agentNameDisclosure = "always",
   facts,
   initialDisplayName = "",
   onCancel,
@@ -122,6 +133,14 @@ export function AgentCreationFlow({
   const restoreComputerSetupFocusRef = useRef(false);
   const computerRefreshStartedRef = useRef(false);
 
+  /**
+   * A display name carrying no Latin letters or digits — a Chinese one, most often — derives to an
+   * empty Agent name, which submit refuses. That is the one case where the Account has to act on
+   * the name, so it is the one case `when-required` reveals it: hiding it here would let the first
+   * mention of the field be the error that rejects the form.
+   */
+  const nameUnderivable = name.trim() === "";
+  const agentNameVisible = agentNameDisclosure === "always" || nameUnderivable;
   const readyRoutes = useMemo(() => resolveReadyRoutes(facts), [facts]);
   const defaultReadyRoute = readyRoutes[0];
   const displayedComputer =
@@ -285,8 +304,11 @@ export function AgentCreationFlow({
             }}
           />
         </Field>
-        {!editingName ? (
+        {!editingName && agentNameVisible ? (
           <div className="agent-name-summary">
+            {nameUnderivable ? (
+              <p className="agent-name-required">This display name cannot produce an @ name. Set one to continue.</p>
+            ) : null}
             <Button
               aria-label="Edit Agent name"
               aria-controls="agent-name-editor"
@@ -459,12 +481,15 @@ function RuntimeRouteSection({
     .filter((provider) => provider.computerId === displayedComputer?.id)
     .sort((left, right) => providerRank(left.provider) - providerRank(right.provider));
   const computerOptions = [...facts.computers].sort((left, right) => left.displayName.localeCompare(right.displayName));
+  // The heading names the section and everything under it answers it: the route rows label
+  // themselves Computer and Runtime, and where there is no Computer yet the setup panel names the
+  // task. A sentence here would only say those labels again, which is one more line between the
+  // Account and the single action this step asks for.
   return (
     <section aria-labelledby="agent-runtime-heading" className="agent-create-runtime">
       <header className="agent-create-runtime-header">
         <div>
           <h3 id="agent-runtime-heading">Where it runs</h3>
-          <p>Choose the Computer and Runtime for this Agent.</p>
         </div>
       </header>
 

--- a/apps/web/src/computer-setup.test.tsx
+++ b/apps/web/src/computer-setup.test.tsx
@@ -481,4 +481,28 @@ describe("ComputerSetup", () => {
     expect(onConnected).not.toHaveBeenCalled();
     expect(vi.getTimerCount()).toBe(2);
   });
+
+  it("answers the primary action in preview without issuing a code or polling", async () => {
+    const issue = vi.spyOn(browserApi, "issueComputerConnectCode");
+    const computers = vi.spyOn(browserApi, "computers");
+    render(<ComputerSetup preview />);
+
+    await clickGenerate();
+
+    // Review has to see the step this action opens, so the command, its copy affordance and a
+    // running validity are all rendered — from a fixed command, with no Server reached.
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(screen.getByText(/^Expires in /)).toBeTruthy();
+    expect(issue).not.toHaveBeenCalled();
+    expect(computers).not.toHaveBeenCalled();
+
+    // No poll cycle started, so nothing can expire the command out from under a reviewer.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30 * 60_000);
+    });
+    expect(vi.getTimerCount()).toBe(0);
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(computers).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/computer-setup.tsx
+++ b/apps/web/src/computer-setup.tsx
@@ -7,10 +7,22 @@ const COMPUTER_POLL_INTERVAL_MS = 1_500;
 const COPY_FEEDBACK_MS = 2_000;
 const CONNECT_CODE_EXPIRED_MESSAGE = "This Computer connection command expired. Generate a new one to continue.";
 const COPY_FALLBACK_HINT = "Copying is unavailable here. The command is selected; press Ctrl or Cmd + C.";
+/**
+ * The command and validity Preview shows in place of an issued one. Review needs the shape of this
+ * step — a long install-and-connect line, its copy affordance and a running validity — and none of
+ * it is a fact about a Computer, so it is stated here rather than read from the Server.
+ */
+const PREVIEW_BOOTSTRAP_COMMAND =
+  "npm i -g @opentag/cli && opentag computer connect --server https://opentag.example.com -- preview-connect-code";
+const PREVIEW_CONNECT_CODE_REMAINING_MS = 900_000;
 
 export interface ComputerSetupProps {
   onConnected?: (computer: WorkspaceComputerSummary) => void;
-  /** Renders the panel for review only: it issues no connect code and starts no Computer polling. */
+  /**
+   * Renders the panel for review only: it issues no connect code, starts no Computer polling and
+   * never resolves a connection. The panel still answers the primary action, from a fixed command,
+   * so review sees the same hierarchy production shows after the code is issued.
+   */
   preview?: boolean;
   /** Scopes the panel to one enrollment so a recovery flow names the Computer it came from. */
   target?: { computerId: string; displayName: string };
@@ -98,7 +110,19 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
 
   async function connectComputer() {
     // Preview must never issue a connect code: that is durable Server state, not a rendered state.
-    if (preview) return;
+    // It renders the state that follows one instead. `pollCycle` stays at 0, which is what keeps the
+    // poll and expiry effect below inert, so no Computer is ever read and the validity never counts
+    // down to a failure Preview cannot recover from.
+    if (preview) {
+      setError(undefined);
+      setBootstrapCommand(PREVIEW_BOOTSTRAP_COMMAND);
+      setComputerConnected(false);
+      setRemainingMs(PREVIEW_CONNECT_CODE_REMAINING_MS);
+      setCopied(false);
+      setCopyHint(undefined);
+      setWaitingForComputer(true);
+      return;
+    }
     const attempt = connectAttempt.current + 1;
     connectAttempt.current = attempt;
     setError(undefined);
@@ -192,8 +216,14 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
   return (
     <section className="panel">
       <h2>{targetName ? `Reconnect ${targetName}` : "Connect a Local Computer"}</h2>
-      <p>Generate a short-lived command, then run it in a terminal on {targetName ?? "the Computer"}.</p>
-      <Button className="connect-command-primary" disabled={preview} onClick={() => void connectComputer()}>
+      {/*
+        Connecting a new Computer needs no machine named: whichever terminal runs the command is the
+        Computer that gets enrolled, so saying "on this computer" would only be wrong for anyone who
+        runs it over SSH. Reconnecting is the opposite — one enrollment is being restored, and it has
+        to happen on that machine.
+      */}
+      <p>Generate a command, then run it in the terminal{targetName ? ` on ${targetName}` : ""}.</p>
+      <Button className="connect-command-primary" onClick={() => void connectComputer()}>
         Generate connection command
       </Button>
       {bootstrapCommand ? (

--- a/apps/web/src/internal/onboarding-lab-page.tsx
+++ b/apps/web/src/internal/onboarding-lab-page.tsx
@@ -106,6 +106,23 @@ export function OnboardingLabPage({
       />
 
       <div className="onboarding-lab-switcher" ref={switcherRef}>
+        {/*
+          The toggle precedes the panel it controls, so a forward Tab from it reaches the controls it
+          just revealed instead of leaving the switcher and traversing the whole onboarding page. The
+          panel still reads above the toggle: that is visual order, and the stylesheet owns it.
+        */}
+        <button
+          aria-controls="onboarding-lab-switcher-panel"
+          aria-expanded={open}
+          className="onboarding-lab-switcher-toggle"
+          ref={toggleRef}
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="onboarding-lab-switcher-toggle-eyebrow">Onboarding Lab</span>
+          <span className="onboarding-lab-switcher-toggle-scenario">{scenario.title}</span>
+        </button>
+
         {open ? (
           <div className="onboarding-lab-switcher-panel" id="onboarding-lab-switcher-panel">
             <div className="onboarding-lab-switcher-intro">
@@ -175,18 +192,6 @@ export function OnboardingLabPage({
             </div>
           </div>
         ) : null}
-
-        <button
-          aria-controls="onboarding-lab-switcher-panel"
-          aria-expanded={open}
-          className="onboarding-lab-switcher-toggle"
-          ref={toggleRef}
-          type="button"
-          onClick={() => setOpen((value) => !value)}
-        >
-          <span className="onboarding-lab-switcher-toggle-eyebrow">Onboarding Lab</span>
-          <span className="onboarding-lab-switcher-toggle-scenario">{scenario.title}</span>
-        </button>
       </div>
 
       {resetAvailable && confirming ? (

--- a/apps/web/src/internal/onboarding-lab-page.tsx
+++ b/apps/web/src/internal/onboarding-lab-page.tsx
@@ -1,5 +1,5 @@
 import type { UserProfile } from "@opentag/shared/browser";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { browserApi } from "../api.js";
 import { OnboardingView } from "../onboarding/view.js";
 import { Button, Dialog } from "../ui/design-system.js";
@@ -20,9 +20,14 @@ type ResetState = { readonly kind: "idle" | "pending" } | { readonly kind: "erro
 const noop = () => undefined;
 
 /**
- * The staging-only Onboarding Lab. Scenario Preview renders fixed states through the production
- * onboarding presentation and writes nothing, so it is shown to every signed-in Account; the reset
- * action is the only Server mutation, and it always targets the authenticated Account.
+ * The staging-only Onboarding Lab. The page *is* the onboarding page: the same presentation, at the
+ * same size, with no frame or chrome of its own, so what a reviewer judges is what production
+ * renders. Everything the Lab adds — choosing a scenario and resetting the shared staging Account —
+ * lives in one floating control that production never shows.
+ *
+ * Scenario Preview renders fixed states through the production onboarding presentation and writes
+ * nothing, so it is shown to every signed-in Account; the reset action is the only Server mutation,
+ * and it always targets the authenticated Account.
  */
 export function OnboardingLabPage({
   onResetSucceeded,
@@ -32,10 +37,38 @@ export function OnboardingLabPage({
   user,
 }: OnboardingLabPageProps) {
   const scenario = findOnboardingScenario(scenarioId);
+  const [open, setOpen] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [resetState, setResetState] = useState<ResetState>({ kind: "idle" });
+  const switcherRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
   const resetTriggerRef = useRef<HTMLButtonElement>(null);
   const resetInFlight = useRef(false);
+
+  useEffect(() => {
+    if (!open) return;
+    // The confirmation Dialog renders outside the switcher and owns its own dismissal, so the
+    // switcher stops listening while it is up rather than closing under it and destroying the
+    // element the Dialog returns focus to.
+    if (confirming) return;
+    const closeOutside = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (!switcherRef.current?.contains(target)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      setOpen(false);
+      toggleRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", closeOutside);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOutside);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [confirming, open]);
 
   async function reset() {
     if (resetInFlight.current) return;
@@ -56,98 +89,105 @@ export function OnboardingLabPage({
   }
 
   return (
-    <div className="object-page">
-      <header className="page-header">
-        <div>
-          <span className="eyebrow">Staging only</span>
-          <h1>Onboarding Lab</h1>
-          <p>
-            {resetAvailable
-              ? "Review fixed onboarding states without touching the Server, or reset the shared staging Account and run the real first-run flow end to end."
-              : "Review fixed onboarding states without touching the Server. Running the real first-run flow needs the Account this deployment configures for the Lab."}
-          </p>
-        </div>
-      </header>
+    <>
+      <OnboardingView
+        completionState={{ kind: "idle" }}
+        key={scenario.id}
+        load={scenario.load}
+        mode="preview"
+        onAgentCreated={noop}
+        onChooseAgent={noop}
+        onCompleteSetup={noop}
+        onReload={noop}
+        onRetryLoad={noop}
+        refreshPending={false}
+        user={user}
+        accountId={ONBOARDING_LAB_ACCOUNT_ID}
+      />
 
-      <section aria-labelledby="onboarding-lab-preview-title" className="onboarding-lab-section">
-        <h2 id="onboarding-lab-preview-title">Scenario Preview</h2>
-        <p>
-          Each scenario renders the production onboarding page from fixed facts. Preview makes no request and creates no
-          durable state, so use it for screen hierarchy, copy and state communication — and the real reset below for
-          interaction testing.
-        </p>
-        <nav aria-label="Onboarding scenarios" className="onboarding-lab-scenarios">
-          {ONBOARDING_SCENARIOS.map((candidate) => (
-            <button
-              aria-current={candidate.id === scenario.id || undefined}
-              className="onboarding-lab-scenario"
-              key={candidate.id}
-              type="button"
-              onClick={() => onScenarioChange(candidate.id)}
-            >
-              <strong>{candidate.title}</strong>
-              <span>{candidate.description}</span>
-            </button>
-          ))}
-        </nav>
-        <figure aria-label={`Onboarding preview: ${scenario.title}`} className="onboarding-lab-preview">
-          <OnboardingView
-            completionState={{ kind: "idle" }}
-            key={scenario.id}
-            load={scenario.load}
-            mode="preview"
-            onAgentCreated={noop}
-            onChooseAgent={noop}
-            onCompleteSetup={noop}
-            onReload={noop}
-            onRetryLoad={noop}
-            refreshPending={false}
-            user={user}
-            accountId={ONBOARDING_LAB_ACCOUNT_ID}
-          />
-        </figure>
-      </section>
-
-      {resetAvailable ? (
-        <section aria-labelledby="onboarding-lab-reset-title" className="onboarding-lab-section">
-          <h2 id="onboarding-lab-reset-title">Real reset</h2>
-          <p>
-            Reset returns this Account to a first-run state and then enters the ordinary onboarding route. Your local
-            OpenTag home and Computer identity are reused, so the next run only needs a fresh Computer connect command.
-          </p>
-          <p className="notice" role="status">
-            <strong>Shared staging test account.</strong> Every tester signs in as the same Account. Resetting it
-            disables the current Agents, Computer enrollments and messaging connections, and can interrupt another
-            tester who is already running onboarding.
-          </p>
-          <div className="actions">
-            <Button
-              disabled={resetState.kind === "pending"}
-              ref={resetTriggerRef}
-              variant="danger"
-              onClick={() => setConfirming(true)}
-            >
-              {resetState.kind === "pending" ? "Resetting…" : "Reset shared account and start onboarding"}
-            </Button>
-          </div>
-          {resetState.kind === "error" ? (
-            <div className="notice error" role="alert">
-              <p>{resetState.error.message}</p>
-              <Button size="compact" variant="secondary" onClick={() => setConfirming(true)}>
-                Retry
-              </Button>
+      <div className="onboarding-lab-switcher" ref={switcherRef}>
+        {open ? (
+          <div className="onboarding-lab-switcher-panel" id="onboarding-lab-switcher-panel">
+            <div className="onboarding-lab-switcher-intro">
+              <span className="eyebrow">Staging only</span>
+              <h2>Onboarding Lab</h2>
+              <p>
+                Each scenario renders the page above from fixed facts. Preview makes no request and creates no durable
+                state, so use it for screen hierarchy, copy and state communication — and the real reset for interaction
+                testing.
+              </p>
             </div>
-          ) : null}
-        </section>
-      ) : (
-        <section aria-labelledby="onboarding-lab-reset-title" className="onboarding-lab-section">
-          <h2 id="onboarding-lab-reset-title">Real reset</h2>
-          <p>
-            Resetting the shared staging Account to a first-run state is limited to the one Account this deployment
-            configures for the Lab. Sign in as that Account to run it; Scenario Preview above needs no such access.
-          </p>
-        </section>
-      )}
+
+            <nav aria-label="Onboarding scenarios" className="onboarding-lab-scenarios">
+              {ONBOARDING_SCENARIOS.map((candidate) => (
+                <button
+                  aria-current={candidate.id === scenario.id || undefined}
+                  className="onboarding-lab-scenario"
+                  key={candidate.id}
+                  type="button"
+                  onClick={() => onScenarioChange(candidate.id)}
+                >
+                  <strong>{candidate.title}</strong>
+                  <span>{candidate.description}</span>
+                </button>
+              ))}
+            </nav>
+
+            <div className="onboarding-lab-switcher-reset">
+              <h3>Real reset</h3>
+              {resetAvailable ? (
+                <>
+                  <p>
+                    Reset returns this Account to a first-run state and then enters the ordinary onboarding route. Your
+                    local OpenTag home and Computer identity are reused, so the next run only needs a fresh Computer
+                    connect command.
+                  </p>
+                  <p className="notice" role="status">
+                    <strong>Shared staging test account.</strong> Every tester signs in as the same Account. Resetting
+                    it disables the current Agents, Computer enrollments and messaging connections, and can interrupt
+                    another tester who is already running onboarding.
+                  </p>
+                  <Button
+                    disabled={resetState.kind === "pending"}
+                    ref={resetTriggerRef}
+                    size="compact"
+                    variant="danger"
+                    onClick={() => setConfirming(true)}
+                  >
+                    {resetState.kind === "pending" ? "Resetting…" : "Reset shared account and start onboarding"}
+                  </Button>
+                  {resetState.kind === "error" ? (
+                    <div className="notice error" role="alert">
+                      <p>{resetState.error.message}</p>
+                      <Button size="compact" variant="secondary" onClick={() => setConfirming(true)}>
+                        Retry
+                      </Button>
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <p>
+                  Resetting the shared staging Account to a first-run state is limited to the one Account this
+                  deployment configures for the Lab. Sign in as that Account to run it; the scenarios above need no such
+                  access.
+                </p>
+              )}
+            </div>
+          </div>
+        ) : null}
+
+        <button
+          aria-controls="onboarding-lab-switcher-panel"
+          aria-expanded={open}
+          className="onboarding-lab-switcher-toggle"
+          ref={toggleRef}
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="onboarding-lab-switcher-toggle-eyebrow">Onboarding Lab</span>
+          <span className="onboarding-lab-switcher-toggle-scenario">{scenario.title}</span>
+        </button>
+      </div>
 
       {resetAvailable && confirming ? (
         <Dialog
@@ -168,6 +208,6 @@ export function OnboardingLabPage({
           </div>
         </Dialog>
       ) : null}
-    </div>
+    </>
   );
 }

--- a/apps/web/src/internal/onboarding-lab.test.tsx
+++ b/apps/web/src/internal/onboarding-lab.test.tsx
@@ -33,7 +33,25 @@ function renderLab(overrides: Partial<Parameters<typeof OnboardingLabPage>[0]> =
   return { onResetSucceeded, onScenarioChange };
 }
 
+/**
+ * The onboarding surface the Lab renders as its page. The Lab adds no frame of its own, so this is
+ * the same element production renders, and the floating switcher is the only thing outside it.
+ */
+function onboardingSurface(): HTMLElement {
+  const shell = document.querySelector<HTMLElement>(".onboarding-shell");
+  if (!shell) throw new Error("The Lab did not render the onboarding surface");
+  return shell;
+}
+
+/** Opens the floating switcher, which is where every control the Lab adds lives. */
+function openSwitcher(): HTMLElement {
+  const toggle = screen.getByRole("button", { name: /Onboarding Lab/ });
+  if (toggle.getAttribute("aria-expanded") !== "true") fireEvent.click(toggle);
+  return toggle;
+}
+
 async function confirmReset() {
+  openSwitcher();
   fireEvent.click(screen.getByRole("button", { name: "Reset shared account and start onboarding" }));
   const dialog = await screen.findByRole("dialog");
   fireEvent.click(within(dialog).getByRole("button", { name: "Reset and start onboarding" }));
@@ -46,6 +64,7 @@ describe("Onboarding Lab page", () => {
 
   it("warns that the staging Account is shared before any reset", () => {
     renderLab();
+    openSwitcher();
 
     expect(screen.getByText(/Shared staging test account/)).toBeTruthy();
     expect(screen.getByText(/can interrupt another tester/)).toBeTruthy();
@@ -62,8 +81,7 @@ describe("Onboarding Lab page", () => {
           onScenarioChange={vi.fn()}
         />,
       );
-      expect(screen.getByLabelText(`Onboarding preview: ${scenario.title}`)).toBeTruthy();
-      expect(screen.getByRole("heading", { level: 1, name: "Set up OpenTag" })).toBeTruthy();
+      expect(within(onboardingSurface()).getByRole("heading", { level: 1, name: "Set up OpenTag" })).toBeTruthy();
       view.unmount();
     }
   });
@@ -83,7 +101,7 @@ describe("Onboarding Lab page", () => {
       // Clicking a control can reveal another, so keep going until the preview stops changing.
       const clicked = new Set<Element>();
       for (let pass = 0; pass < 4; pass += 1) {
-        const preview = screen.getByLabelText(`Onboarding preview: ${scenario.title}`);
+        const preview = onboardingSurface();
         const controls = [
           ...within(preview).queryAllByRole("button"),
           ...within(preview).queryAllByRole("link"),
@@ -138,6 +156,7 @@ describe("Onboarding Lab page", () => {
 
   it("keeps only the selected fixture in the URL", () => {
     const { onScenarioChange } = renderLab();
+    openSwitcher();
 
     fireEvent.click(screen.getByRole("button", { name: /Computer offline/ }));
 
@@ -147,6 +166,7 @@ describe("Onboarding Lab page", () => {
   it("requires one confirmation before it resets the shared Account", async () => {
     const reset = vi.spyOn(browserApi, "resetOnboardingLab").mockResolvedValue();
     renderLab();
+    openSwitcher();
 
     fireEvent.click(screen.getByRole("button", { name: "Reset shared account and start onboarding" }));
     const dialog = await screen.findByRole("dialog");
@@ -181,7 +201,7 @@ describe("Onboarding Lab page", () => {
     const failure = await screen.findByRole("alert");
     expect(within(failure).getByText("The Account still has active OpenTag resources")).toBeTruthy();
     expect(onResetSucceeded).not.toHaveBeenCalled();
-    expect(screen.getByRole("heading", { level: 1, name: "Onboarding Lab" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Onboarding Lab/ })).toBeTruthy();
 
     fireEvent.click(within(failure).getByRole("button", { name: "Retry" }));
     const dialog = await screen.findByRole("dialog");
@@ -263,8 +283,20 @@ describe("Onboarding Lab route", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Onboarding Lab" })).toBeTruthy();
+    // The Lab renders the onboarding page itself; only the floating switcher names the Lab.
+    expect(await screen.findByRole("button", { name: /Onboarding Lab/ })).toBeTruthy();
+    expect(within(onboardingSurface()).getByRole("heading", { level: 1, name: "Set up OpenTag" })).toBeTruthy();
     expect(window.location.pathname).toBe("/internal/onboarding-lab");
+  });
+
+  it("renders the onboarding page without the application navigation", async () => {
+    installApi();
+
+    render(<App />);
+
+    await screen.findByRole("button", { name: /Onboarding Lab/ });
+    expect(document.querySelector(".shell")).toBeNull();
+    expect(screen.queryByRole("navigation", { name: "Primary navigation" })).toBeNull();
   });
 
   it("renders Not Found where the deployment offers no Lab at all", async () => {
@@ -280,8 +312,9 @@ describe("Onboarding Lab route", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Onboarding Lab" })).toBeTruthy();
-    expect(screen.getByRole("heading", { level: 2, name: "Scenario Preview" })).toBeTruthy();
+    await screen.findByRole("button", { name: /Onboarding Lab/ });
+    openSwitcher();
+    expect(screen.getByRole("heading", { level: 2, name: "Onboarding Lab" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Reset shared account and start onboarding" })).toBeNull();
     expect(resetRequests).toBe(0);
   });
@@ -292,7 +325,8 @@ describe("Onboarding Lab route", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Onboarding Lab" })).toBeTruthy();
+    await screen.findByRole("button", { name: /Onboarding Lab/ });
+    openSwitcher();
     expect(screen.getAllByRole("button", { name: /Brand new account/ }).length).toBeGreaterThan(0);
     expect(screen.queryByRole("heading", { name: "OpenTag is not ready for this account" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Reset shared account and start onboarding" })).toBeNull();
@@ -304,7 +338,8 @@ describe("Onboarding Lab route", () => {
 
     render(<App />);
 
-    const preview = await screen.findByLabelText("Onboarding preview: Computer offline");
+    await screen.findByRole("button", { name: /Onboarding Lab/ });
+    const preview = onboardingSurface();
     expect(within(preview).getByRole("heading", { level: 2, name: "Prepare your Agent" })).toBeTruthy();
     expect(within(preview).getAllByText("Computer offline").length).toBeGreaterThan(0);
     expect(within(preview).getAllByText("Reconnect").length).toBeGreaterThan(0);
@@ -314,7 +349,7 @@ describe("Onboarding Lab route", () => {
     installApi({ setupCompletedAt: "2026-08-20T00:00:00.000Z", meDelayMs: 30 });
     window.history.replaceState({}, "", "/internal/onboarding-lab?scenario=setup-complete");
     render(<App />);
-    await screen.findByRole("heading", { level: 1, name: "Onboarding Lab" });
+    await screen.findByRole("button", { name: /Onboarding Lab/ });
     const before = meRequests;
 
     await confirmReset();
@@ -334,7 +369,7 @@ describe("Onboarding Lab route", () => {
       afterResetSetupCompletedAt: "2026-08-20T00:00:00.000Z",
     });
     render(<App />);
-    await screen.findByRole("heading", { level: 1, name: "Onboarding Lab" });
+    await screen.findByRole("button", { name: /Onboarding Lab/ });
 
     await confirmReset();
 
@@ -346,7 +381,7 @@ describe("Onboarding Lab route", () => {
   it("stays on the Lab when the authoritative refresh fails", async () => {
     installApi({ setupCompletedAt: "2026-08-20T00:00:00.000Z", meFailsAfterReset: true });
     render(<App />);
-    await screen.findByRole("heading", { level: 1, name: "Onboarding Lab" });
+    await screen.findByRole("button", { name: /Onboarding Lab/ });
 
     await confirmReset();
 

--- a/apps/web/src/internal/onboarding-lab.test.tsx
+++ b/apps/web/src/internal/onboarding-lab.test.tsx
@@ -154,6 +154,23 @@ describe("Onboarding Lab page", () => {
     expect(requests).not.toHaveBeenCalled();
   });
 
+  it("puts the controls it reveals next in the tab order", () => {
+    renderLab();
+    const toggle = openSwitcher();
+    const panel = document.getElementById("onboarding-lab-switcher-panel");
+    if (!panel) throw new Error("The switcher panel did not open");
+
+    // A forward Tab from the toggle has to land inside the panel it just opened. Rendering the panel
+    // ahead of its toggle would send it into the onboarding page instead.
+    expect(toggle.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(toggle.getAttribute("aria-controls")).toBe("onboarding-lab-switcher-panel");
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(document.getElementById("onboarding-lab-switcher-panel")).toBeNull();
+    expect(document.activeElement).toBe(toggle);
+  });
+
   it("keeps only the selected fixture in the URL", () => {
     const { onScenarioChange } = renderLab();
     openSwitcher();

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -275,7 +275,7 @@ describe("OnboardingPage", () => {
     });
     render(<OnboardingPage user={user} />);
 
-    const strip = await screen.findByLabelText(/OpenTag Agent .* Feishu/);
+    const strip = await screen.findByLabelText("OpenTag Agent not confirmed ready to reach Feishu");
     expect(within(strip).getByText("Not ready")).toBeTruthy();
     expect(within(strip).queryByText("Connecting…")).toBeNull();
     expect(strip.getAttribute("data-status")).toBe("current");
@@ -303,7 +303,9 @@ describe("OnboardingPage", () => {
       });
       render(<OnboardingPage user={user} />);
 
-      const strip = await screen.findByLabelText(/OpenTag Agent .* Feishu/);
+      // The accessible name carries the same claim as the label: an expired authorization is not
+      // evidence that Feishu is unreachable, so neither representation may say so.
+      const strip = await screen.findByLabelText("OpenTag Agent needs attention on its link to Feishu");
       expect(within(strip).getByText("Needs attention")).toBeTruthy();
       expect(within(strip).queryByText("Disconnected")).toBeNull();
       expect(strip.getAttribute("data-status")).toBe("attention");

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -255,6 +255,61 @@ describe("OnboardingPage", () => {
     expect(screen.getByText("Install Codex on Ada's Mac.")).toBeTruthy();
   });
 
+  /**
+   * `handoffReady` is one combined gate. The Server clears it for an unready Agent runtime, an
+   * unready Feishu CLI or a lapsed connection lease, and reports which only as one false, so the
+   * strip may not turn any of them into a claim about the transport or about progress.
+   */
+  const readyComputer = {
+    ...computerA,
+    providerReadiness: [
+      { provider: "codex" as const, status: "ready" as const, observedAt: "2026-08-20T00:00:00.000Z" },
+    ],
+  };
+
+  it("reports an active binding that fails the readiness gate as unconfirmed, not as progress", async () => {
+    installFacts({
+      agents: [agent],
+      computers: [readyComputer],
+      handoff: { bindingState: "active", handoffReady: false },
+    });
+    render(<OnboardingPage user={user} />);
+
+    const strip = await screen.findByLabelText(/OpenTag Agent .* Feishu/);
+    expect(within(strip).getByText("Not ready")).toBeTruthy();
+    expect(within(strip).queryByText("Connecting…")).toBeNull();
+    expect(strip.getAttribute("data-status")).toBe("current");
+  });
+
+  it("reports a provisioning binding as the one state the Server states as in progress", async () => {
+    installFacts({
+      agents: [agent],
+      computers: [readyComputer],
+      handoff: { bindingState: "provisioning", handoffReady: false },
+    });
+    render(<OnboardingPage user={user} />);
+
+    const strip = await screen.findByLabelText(/OpenTag Agent .* Feishu/);
+    expect(within(strip).getByText("Connecting…")).toBeTruthy();
+  });
+
+  it.each(["reauthorization_required", "error", "disabled"] as const)(
+    "reports %s as needing attention rather than as a severed transport",
+    async (bindingState) => {
+      installFacts({
+        agents: [agent],
+        computers: [readyComputer],
+        handoff: { bindingState, handoffReady: false },
+      });
+      render(<OnboardingPage user={user} />);
+
+      const strip = await screen.findByLabelText(/OpenTag Agent .* Feishu/);
+      expect(within(strip).getByText("Needs attention")).toBeTruthy();
+      expect(within(strip).queryByText("Disconnected")).toBeNull();
+      expect(strip.getAttribute("data-status")).toBe("attention");
+    },
+  );
+
   it("reaches Ready from production runtime and authoritative handoff facts", async () => {
     installFacts({
       agents: [agent],

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -148,7 +148,7 @@ describe("OnboardingPage", () => {
     const summary = screen.getByRole("region", { name: "Agent preparation summary" });
     expect(summary.textContent).toContain("ComputerNot connected");
     expect(summary.textContent).toContain("RuntimeWaiting");
-    expect(summary.textContent).toContain("AgentName pending");
+    expect(summary.textContent).toContain("AgentNot created");
     expect(screen.queryByRole("img")).toBeNull();
   });
 
@@ -449,7 +449,7 @@ describe("OnboardingPage", () => {
   it("preserves an existing Agent identity during runtime outage", async () => {
     installFacts({ agents: [agent], computers: [computerA], handoff: { bindingState: "active", handoffReady: true } });
     renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: false }]) });
-    expect(await screen.findByRole("heading", { name: "OpenTag needs its runtime route" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "OpenTag needs a Runtime" })).toBeTruthy();
     expect(screen.getByText(/identity and Feishu setup are unchanged/)).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Connect a Local Computer" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "OpenTag is ready" })).toBeNull();
@@ -462,14 +462,14 @@ describe("OnboardingPage", () => {
     });
     renderPage({ runtime: runtimeFacts([{ computerId: computerBId, provider: "codex", runtimeReady: true }]) });
 
-    expect(await screen.findByRole("heading", { name: "OpenTag needs its runtime route" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "OpenTag needs a Runtime" })).toBeTruthy();
     const route = screen.getByText("Ada's Mac · Offline");
     expect(route.closest("div")?.dataset.status).toBe("attention");
     expect(screen.getByRole("region", { name: "Agent preparation summary" }).textContent).not.toContain("Studio Mac");
   });
 
   it.each([
-    [undefined, "Connect OpenTag to Feishu", "Connect existing or new Feishu Bot"],
+    [undefined, "Connect OpenTag to Feishu", "Connect a Feishu bot"],
     [
       { bindingState: "provisioning", handoffReady: false } as const,
       "Finish Feishu authorization",
@@ -511,6 +511,45 @@ describe("OnboardingPage", () => {
       expect(create).toHaveBeenCalledWith(
         expect.objectContaining({ displayName: "Research Partner", name: "research-partner" }),
       ),
+    );
+  });
+
+  it("keeps the derived Agent name out of the first run", async () => {
+    installFacts({ computers: [computerA] });
+    const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
+    renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]) });
+
+    const name = await screen.findByLabelText("Display name");
+    // This is the Account's first Agent, so the derived name cannot collide and needs no attention.
+    expect(screen.queryByRole("button", { name: "Edit Agent name" })).toBeNull();
+    fireEvent.change(name, { target: { value: "Research Partner" } });
+    expect(screen.queryByRole("button", { name: "Edit Agent name" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
+
+    // Hidden, not dropped: the derivation still names the Agent.
+    await waitFor(() => expect(create).toHaveBeenCalledWith(expect.objectContaining({ name: "research-partner" })));
+  });
+
+  it("asks for an Agent name only when the display name derives to none", async () => {
+    installFacts({ computers: [computerA] });
+    const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
+    renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]) });
+
+    const name = await screen.findByLabelText("Display name");
+    // A display name carrying no Latin letters or digits derives to nothing, which submit refuses.
+    // Revealing it here is what keeps that rejection from being the first mention of the field.
+    fireEvent.change(name, { target: { value: "小助手" } });
+    expect(screen.getByText("This display name cannot produce an @ name. Set one to continue.")).toBeTruthy();
+
+    const reveal = screen.getByRole("button", { name: "Edit Agent name" });
+    expect(reveal.textContent).toBe("Set Agent name");
+    fireEvent.click(reveal);
+    fireEvent.change(screen.getByLabelText("Agent name"), { target: { value: "xiao-zhu-shou" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Agent" }));
+
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith(expect.objectContaining({ displayName: "小助手", name: "xiao-zhu-shou" })),
     );
   });
 
@@ -749,7 +788,7 @@ describe("OnboardingPage", () => {
       createdAt: "2026-08-20T00:00:00.000Z",
     });
     renderPage({ runtime: runtimeFacts([{ computerId: computerAId, provider: "codex", runtimeReady: true }]) });
-    fireEvent.click(await screen.findByRole("button", { name: "Connect existing or new Feishu Bot" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Connect a Feishu bot" }));
     await waitFor(() => expect(computers.mock.calls.length).toBeGreaterThan(1));
   });
 

--- a/apps/web/src/onboarding/view.tsx
+++ b/apps/web/src/onboarding/view.tsx
@@ -295,8 +295,8 @@ const MESSAGING_LINK_COPY: Record<
 > = {
   none: { label: "Not connected", description: "not yet connected to", status: "current" },
   connecting: { label: "Connecting…", description: "connecting to", status: "working" },
-  "not-ready": { label: "Not ready", description: "not yet ready to reach", status: "current" },
-  attention: { label: "Needs attention", description: "unable to reach", status: "attention" },
+  "not-ready": { label: "Not ready", description: "not confirmed ready to reach", status: "current" },
+  attention: { label: "Needs attention", description: "needs attention on its link to", status: "attention" },
   connected: { label: "Connected", description: "connected to", status: "complete" },
 };
 

--- a/apps/web/src/onboarding/view.tsx
+++ b/apps/web/src/onboarding/view.tsx
@@ -144,7 +144,7 @@ interface JourneyFact {
  * started, one being provisioned, and one that has broken, and those ask different things of the
  * Account.
  */
-type MessagingLink = "none" | "connecting" | "attention" | "connected";
+type MessagingLink = "none" | "connecting" | "not-ready" | "attention" | "connected";
 
 interface OnboardingJourneyState {
   readonly activeStep: 1 | 2;
@@ -279,9 +279,15 @@ function OnboardingStageContext({ journey }: { journey: OnboardingJourneyState }
 }
 
 /**
- * Every label is a state of the link itself, on one axis, so the strip reads as one value changing
- * rather than as unrelated words taking turns. What has to happen to advance it — authorizing a
- * Feishu Bot — is named by the action below, which is where the Account acts on it.
+ * Every label is a state of the link itself, on one axis — whether work can be handed through it —
+ * so the strip reads as one value changing rather than as unrelated words taking turns. What has to
+ * happen to advance it is named by the action below, which is where the Account acts on it.
+ *
+ * Each label is held to the evidence the page actually has. `handoffReady` is a single combined
+ * gate: the Server clears it when the Agent runtime is not ready, when the Feishu CLI is not ready,
+ * or when the connection lease has lapsed, and it reports which of those only as one false. An
+ * active binding that fails that gate is therefore not progress and not a severed transport; it is
+ * a link the page cannot confirm, and it says exactly that.
  */
 const MESSAGING_LINK_COPY: Record<
   MessagingLink,
@@ -289,14 +295,19 @@ const MESSAGING_LINK_COPY: Record<
 > = {
   none: { label: "Not connected", description: "not yet connected to", status: "current" },
   connecting: { label: "Connecting…", description: "connecting to", status: "working" },
-  attention: { label: "Disconnected", description: "disconnected from", status: "attention" },
+  "not-ready": { label: "Not ready", description: "not yet ready to reach", status: "current" },
+  attention: { label: "Needs attention", description: "unable to reach", status: "attention" },
   connected: { label: "Connected", description: "connected to", status: "complete" },
 };
 
 function messagingLink(current: OnboardingCurrentState | undefined, messaging: JourneyStatus): MessagingLink {
   if (messaging === "complete") return "connected";
   if (current?.kind !== "handoff") return "none";
-  if (current.progress.kind === "provisioning" || current.progress.kind === "active-not-ready") return "connecting";
+  // `provisioning` is the one state the Server states as an act in progress. `active-not-ready`
+  // names no cause, and `attention` covers an expired authorization as much as a failure, so
+  // neither is reported as movement or as a disconnection.
+  if (current.progress.kind === "provisioning") return "connecting";
+  if (current.progress.kind === "active-not-ready") return "not-ready";
   if (current.progress.kind === "attention") return "attention";
   return "none";
 }

--- a/apps/web/src/onboarding/view.tsx
+++ b/apps/web/src/onboarding/view.tsx
@@ -7,6 +7,7 @@ import type {
 import { type ReactNode, useMemo, useState } from "react";
 import { type AgentCreationFacts, AgentCreationFlow } from "../agent-creation/agent-creation-flow.js";
 import { browserApi } from "../api.js";
+import feishuIconUrl from "../assets/feishu.svg";
 import { FeishuSetup, type FeishuSetupControl } from "../im/feishu-setup.js";
 import { Button, buttonClassName } from "../ui/design-system.js";
 import {
@@ -137,10 +138,19 @@ interface JourneyFact {
   readonly value: string;
 }
 
+/**
+ * The state of the link between the Agent and Feishu, as the connection strip reports it. This is
+ * finer than the step status: a step that is merely "current" covers a binding that has not been
+ * started, one being provisioned, and one that has broken, and those ask different things of the
+ * Account.
+ */
+type MessagingLink = "none" | "connecting" | "attention" | "connected";
+
 interface OnboardingJourneyState {
   readonly activeStep: 1 | 2;
   readonly agentName: string;
   readonly messaging: JourneyStatus;
+  readonly messagingLink: MessagingLink;
   readonly prepareFacts: readonly JourneyFact[];
   readonly prepare: JourneyStatus;
   readonly stageDescription: string;
@@ -152,9 +162,9 @@ function OnboardingJourney({ journey }: { journey: OnboardingJourneyState }) {
   return (
     <aside className="onboarding-journey">
       <div className="onboarding-journey-intro">
-        <span className="eyebrow">Agent setup</span>
+        <span className="eyebrow">Getting started</span>
         <h1>Set up OpenTag</h1>
-        <p>Prepare one Agent, then bring it into a shared conversation.</p>
+        <p>An AI teammate your team mentions in Feishu, working on a Computer you connect.</p>
       </div>
       <nav aria-label="Onboarding steps">
         <ol className="onboarding-steps">
@@ -172,9 +182,7 @@ function OnboardingJourney({ journey }: { journey: OnboardingJourneyState }) {
           />
         </ol>
       </nav>
-      <p className="onboarding-journey-note">
-        Progress is saved from live server state. You can leave and return at any time.
-      </p>
+      <p className="onboarding-journey-note">You can leave and return at any time.</p>
     </aside>
   );
 }
@@ -235,16 +243,20 @@ function OnboardingStageContext({ journey }: { journey: OnboardingJourneyState }
     );
   }
 
-  const connected = journey.messaging === "complete";
+  const link = MESSAGING_LINK_COPY[journey.messagingLink];
   return (
     <section
-      aria-label={`${journey.agentName} Agent ${connected ? "connected to" : "awaiting connection to"} Feishu`}
+      aria-label={`${journey.agentName} Agent ${link.description} Feishu`}
       className="onboarding-messaging-connection"
-      data-status={connected ? "complete" : "current"}
+      data-status={link.status}
     >
       <div className="onboarding-connection-endpoint">
+        {/*
+          This endpoint is the Agent, whose name the Account chose, so the mark is derived from that
+          name rather than stamped with the product's own initials — an Agent named 小助手 is not OT.
+        */}
         <span aria-hidden="true" className="onboarding-endpoint-mark">
-          OT
+          {[...journey.agentName.trim()][0] ?? "?"}
         </span>
         <span>
           <small>Agent</small>
@@ -252,12 +264,11 @@ function OnboardingStageContext({ journey }: { journey: OnboardingJourneyState }
         </span>
       </div>
       <div className="onboarding-messaging-bridge">
-        <span>{connected ? "Connected" : "Authorization"}</span>
+        <span>{link.label}</span>
       </div>
       <div className="onboarding-connection-endpoint onboarding-connection-endpoint-feishu">
-        <span aria-hidden="true" className="onboarding-endpoint-mark">
-          FS
-        </span>
+        {/* Feishu's own mark is what the Account recognises here; "FS" is an abbreviation nobody uses. */}
+        <img alt="" className="onboarding-endpoint-mark onboarding-endpoint-mark-image" src={feishuIconUrl} />
         <span>
           <small>Team chat</small>
           <strong>Feishu</strong>
@@ -265,6 +276,29 @@ function OnboardingStageContext({ journey }: { journey: OnboardingJourneyState }
       </div>
     </section>
   );
+}
+
+/**
+ * Every label is a state of the link itself, on one axis, so the strip reads as one value changing
+ * rather than as unrelated words taking turns. What has to happen to advance it — authorizing a
+ * Feishu Bot — is named by the action below, which is where the Account acts on it.
+ */
+const MESSAGING_LINK_COPY: Record<
+  MessagingLink,
+  { label: string; description: string; status: "current" | "working" | "attention" | "complete" }
+> = {
+  none: { label: "Not connected", description: "not yet connected to", status: "current" },
+  connecting: { label: "Connecting…", description: "connecting to", status: "working" },
+  attention: { label: "Disconnected", description: "disconnected from", status: "attention" },
+  connected: { label: "Connected", description: "connected to", status: "complete" },
+};
+
+function messagingLink(current: OnboardingCurrentState | undefined, messaging: JourneyStatus): MessagingLink {
+  if (messaging === "complete") return "connected";
+  if (current?.kind !== "handoff") return "none";
+  if (current.progress.kind === "provisioning" || current.progress.kind === "active-not-ready") return "connecting";
+  if (current.progress.kind === "attention") return "attention";
+  return "none";
 }
 
 function onboardingJourney(
@@ -276,6 +310,7 @@ function onboardingJourney(
       activeStep: 1,
       agentName: snapshot?.targetAgent?.displayName ?? "OpenTag",
       messaging: "upcoming",
+      messagingLink: "none",
       prepareFacts: [
         { label: "Computer", status: "current", value: "Checking" },
         { label: "Runtime", status: "waiting", value: "Waiting" },
@@ -324,8 +359,9 @@ function onboardingJourney(
       activeStep: 1,
       agentName: "OpenTag",
       messaging: "upcoming",
+      messagingLink: "none",
       prepare: "current",
-      prepareFacts: [computerFact, runtimeFact, { label: "Agent", status: "current", value: "Name pending" }],
+      prepareFacts: [computerFact, runtimeFact, { label: "Agent", status: "current", value: "Not created" }],
       stageDescription: "Name your Agent, then confirm its ready runtime.",
       stageStatus: readyRoute
         ? "Ready to create"
@@ -352,6 +388,8 @@ function onboardingJourney(
         (current.kind === "handoff" || current.kind === "ready" || current.kind === "agent-runtime"
           ? current.agent.runtimeProvider
           : undefined));
+  const messaging: JourneyStatus =
+    setupReady || messagingReady ? "complete" : messagingCurrent ? "current" : "upcoming";
   const computerFact = journeyComputerFact(current, snapshot);
   const runtimeFact: JourneyFact =
     current.kind === "workspace" || current.kind === "computer"
@@ -364,7 +402,7 @@ function onboardingJourney(
   const agentFact: JourneyFact = snapshot?.targetAgent
     ? { label: "Agent", status: agentNeedsAttention ? "attention" : "ready", value: snapshot.targetAgent.displayName }
     : current.kind === "agent"
-      ? { label: "Agent", status: "current", value: "Name pending" }
+      ? { label: "Agent", status: "current", value: "Not created" }
       : prepareComplete
         ? { label: "Agent", status: "ready", value: "Prepared" }
         : { label: "Agent", status: "waiting", value: "Not created" };
@@ -374,11 +412,12 @@ function onboardingJourney(
     agentName: snapshot?.targetAgent?.displayName ?? "OpenTag",
     prepare: prepareComplete ? "complete" : "current",
     prepareFacts: [computerFact, runtimeFact, agentFact],
-    messaging: setupReady || messagingReady ? "complete" : messagingCurrent ? "current" : "upcoming",
+    messaging,
+    messagingLink: messagingLink(current, messaging),
     stageDescription: prepareComplete
       ? setupReady
         ? "Your Agent is ready for the first conversation in Feishu."
-        : "Authorize the bot people will mention in conversations."
+        : ""
       : "Confirm where your Agent runs, then give it a clear identity.",
     stageStatus: onboardingStageStatus(current),
     stageTitle: prepareComplete
@@ -519,6 +558,10 @@ function OnboardingContent({
     return (
       <section className="onboarding-action">
         <AgentCreationFlow
+          // This branch is only reached with no Agent to continue, so the derived name cannot
+          // collide with one. It stays out of the first run unless the display name derives to
+          // nothing and the Account has to choose a name itself.
+          agentNameDisclosure="when-required"
           facts={onboardingAgentCreationFacts(snapshot)}
           initialDisplayName="OpenTag"
           preview={mode === "preview"}
@@ -551,11 +594,11 @@ function OnboardingContent({
     const copy = attention ? runtimeAttentionCopy(attention, agent?.computer.displayName ?? "its Computer") : undefined;
     return (
       <ActionSection
-        title={copy?.title ?? `${agent?.displayName ?? "Your Agent"} needs its runtime route`}
+        title={copy?.title ?? `${agent?.displayName ?? "Your Agent"} needs a Runtime`}
         description={
           copy
             ? `${copy.description} The Agent identity and Feishu setup are unchanged.`
-            : "The Agent identity and Feishu setup are unchanged. Restore its bound Computer and Provider, then check again."
+            : "The Agent identity and Feishu setup are unchanged. Restore its bound Computer and Runtime, then check again."
         }
       >
         <ReloadButton pending={refreshPending} onReload={onReload} />
@@ -564,7 +607,7 @@ function OnboardingContent({
   }
   if (current.kind === "handoff") {
     return (
-      <ActionSection title={handoffTitle(current)} description="Authorize the Feishu Bot people will mention.">
+      <ActionSection title={handoffTitle(current)} description="Authorize the Feishu bot people will mention.">
         {mode === "preview" ? (
           <FeishuAction control={INERT_FEISHU_SETUP} progress={current.progress} />
         ) : (
@@ -588,7 +631,7 @@ function OnboardingContent({
   return (
     <ActionSection
       title="OpenTag is ready"
-      description="Add the Bot to a Feishu group, then mention OpenTag with your first task."
+      description="Add the bot to a Feishu group, then mention OpenTag with your first task."
     >
       <div className="actions">
         <a className={buttonClassName()} href={FEISHU_BOT_APP_LINK} rel="noreferrer" target="_blank">
@@ -661,7 +704,7 @@ function FeishuAction({
     progress.kind === "attention" && progress.bindingState === "reauthorization_required" ? "reauthorize" : "create";
   const label =
     progress.kind === "none"
-      ? "Connect existing or new Feishu Bot"
+      ? "Connect a Feishu bot"
       : progress.kind === "attention" && progress.bindingState === "reauthorization_required"
         ? "Reauthorize Feishu"
         : "Resume Feishu setup";

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -462,17 +462,24 @@ export function AppRouter() {
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route element={<AuthenticatedAccountGate />}>
-        <Route element={<AppShell />}>
-          {/*
-            Outside the setup-completion gate so a stuck run can always reopen the Lab, and outside
-            the Workspace-authority gate because Scenario Preview needs the Account and nothing else.
-          */}
-          <Route path="/internal/onboarding-lab" element={<OnboardingLabRoute />} />
-        </Route>
+        {/*
+          Outside AppShell because the Lab renders the onboarding surface verbatim, and onboarding
+          has no primary navigation. Outside the setup-completion gate so a stuck run can always
+          reopen the Lab, and outside the Workspace-authority gate because Scenario Preview needs
+          the Account and nothing else.
+        */}
+        <Route path="/internal/onboarding-lab" element={<OnboardingLabRoute />} />
         <Route element={<WorkspaceAuthorityGate />}>
+          {/*
+            Onboarding runs before the Account has entered the application, so it carries no
+            AppShell: the primary navigation would offer destinations this gate sends straight
+            back here, and a second brand mark beside the one onboarding renders itself.
+          */}
+          <Route element={<WorkspaceSetupGate />}>
+            <Route path="/onboarding" element={<OnboardingRoute />} />
+          </Route>
           <Route element={<AppShell />}>
             <Route element={<WorkspaceSetupGate />}>
-              <Route path="/onboarding" element={<OnboardingRoute />} />
               <Route index element={<Navigate replace to="/agents" />} />
               <Route path="/agents" element={<AgentsPage />} />
               <Route path="/agents/computers" element={<ComputersPage />} />
@@ -702,7 +709,8 @@ function OnboardingLabRoute() {
             }}
           />
         ) : (
-          <NotFoundPage />
+          // The Lab renders outside AppShell, so its not-found answer must carry its own page frame.
+          <StandaloneNotFoundPage />
         )
       }
     </AsyncState>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4561,6 +4561,7 @@ textarea:focus {
 }
 
 .onboarding-lab-switcher-panel {
+  order: -1;
   display: grid;
   gap: 16px;
   width: min(380px, calc(100vw - 40px));

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1732,7 +1732,7 @@ code {
 .onboarding-journey-intro h1 {
   max-width: 8ch;
   margin-bottom: 16px;
-  font-size: var(--text-display);
+  font-size: var(--text-title);
   line-height: var(--lh-tight);
   text-wrap: balance;
 }
@@ -1956,10 +1956,8 @@ code {
 
 .onboarding-runtime-summary dt {
   color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: var(--text-micro);
-  letter-spacing: var(--track-label);
-  text-transform: uppercase;
+  font-size: var(--text-meta);
+  font-weight: var(--fw-medium);
 }
 
 .onboarding-runtime-summary dd {
@@ -2033,6 +2031,11 @@ code {
   justify-content: flex-end;
 }
 
+.onboarding-endpoint-mark-image {
+  object-fit: contain;
+  padding: 8px;
+}
+
 .onboarding-endpoint-mark {
   display: inline-flex;
   width: 42px;
@@ -2102,6 +2105,14 @@ code {
   background: var(--brand);
 }
 
+/* A link being built and a link that has broken are not the same waiting, so they do not look
+   the same either. */
+.onboarding-messaging-connection[data-status="attention"] .onboarding-messaging-bridge span {
+  border-color: var(--color-status-danger, #8a2a24);
+  background: #f6e9e7;
+  color: #6f211c;
+}
+
 .onboarding-workspace-body {
   padding: 38px 44px 48px;
 }
@@ -2116,6 +2127,15 @@ code {
   width: 100%;
   border-top: 0;
   padding-top: 0;
+}
+
+/* `form-card` dresses a form that owns its page. Here the stage card already is that surface, so the
+   form sits directly on it — the same shape step 02 has, rather than a second card inside the first. */
+.onboarding-action > .form-card {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
 }
 
 .onboarding-action-heading {
@@ -2155,7 +2175,10 @@ code {
   gap: 14px;
 }
 
-.onboarding-action .ds-button:not(.ds-button--compact) {
+/* Onboarding spends a step on one action, so its buttons are sized as that action. Text buttons
+   are excluded by variant: `inline` carries no box of its own, and giving it one centres its label
+   inside 190px of nothing, away from the control it belongs to. */
+.onboarding-action .ds-button:not(.ds-button--compact, .ds-button--inline) {
   min-height: 46px;
   min-width: 190px;
   border-radius: 10px;
@@ -2499,13 +2522,15 @@ textarea:focus {
 }
 
 .agent-name-summary {
+  display: grid;
+  justify-items: start;
+  gap: 6px;
   padding: 0 2px;
 }
 
 .agent-name-handle {
   min-width: 0;
   overflow: hidden;
-  color: var(--muted);
   font-family: var(--font-mono);
   font-size: var(--text-meta);
   font-weight: var(--fw-medium);
@@ -2513,8 +2538,10 @@ textarea:focus {
   white-space: nowrap;
 }
 
-.agent-name-handle:hover {
-  color: var(--foreground);
+.agent-name-required {
+  margin: 0;
+  color: var(--secondary-foreground);
+  font-size: var(--text-meta);
 }
 
 #agent-name-editor {
@@ -2536,13 +2563,9 @@ textarea:focus {
 
 .agent-create-runtime-header h3 {
   margin: 0;
-  font-size: var(--text-subsection);
-}
-
-.agent-create-runtime-header p {
-  margin: 4px 0 0;
-  color: var(--muted);
-  font-size: var(--text-meta);
+  color: var(--secondary-foreground);
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
 }
 
 .agent-create-route-summary {
@@ -2576,13 +2599,12 @@ textarea:focus {
   color: var(--muted);
   font-size: var(--text-meta);
   font-weight: var(--fw-medium);
-  letter-spacing: var(--track-label);
-  text-transform: uppercase;
 }
 
 .agent-create-route-copy strong {
   overflow: hidden;
   font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -3832,7 +3854,7 @@ textarea:focus {
     gap: 5px;
   }
 
-  .onboarding-action .ds-button,
+  .onboarding-action .ds-button:not(.ds-button--compact, .ds-button--inline),
   .onboarding-feedback > .ds-button {
     width: 100%;
   }
@@ -4494,40 +4516,91 @@ textarea:focus {
   }
 }
 
-/* Staging Onboarding Lab: an internal review surface, not a product page. */
-.onboarding-lab-section {
-  margin-bottom: 32px;
+/* Staging Onboarding Lab. The page under it *is* the onboarding page, so everything the Lab adds
+   floats above it and is styled to read as tooling rather than as part of the product. */
+.onboarding-lab-switcher {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 40;
+  display: grid;
+  justify-items: end;
+  gap: 10px;
+  max-width: min(380px, calc(100vw - 40px));
 }
 
-.onboarding-lab-section h2 {
-  margin-bottom: 8px;
+.onboarding-lab-switcher-toggle {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  max-width: 100%;
+  border: 1px solid rgb(22 33 27 / 12%);
+  border-radius: 12px;
+  background: var(--foreground);
+  box-shadow: 0 10px 30px rgb(45 62 34 / 22%);
+  color: var(--surface);
+  padding: 9px 15px;
+  text-align: right;
+  cursor: pointer;
 }
 
-.onboarding-lab-section > p {
-  max-width: 640px;
-  margin-bottom: 16px;
+.onboarding-lab-switcher-toggle-eyebrow {
+  color: rgb(253 252 247 / 62%);
+  font-size: var(--text-micro);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--track-label);
+  text-transform: uppercase;
+}
+
+.onboarding-lab-switcher-toggle-scenario {
+  overflow: hidden;
+  font-size: var(--text-ui);
+  font-weight: var(--fw-semibold);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.onboarding-lab-switcher-panel {
+  display: grid;
+  gap: 16px;
+  width: min(380px, calc(100vw - 40px));
+  max-height: min(74dvh, 720px);
+  overflow-y: auto;
+  border: 1px solid var(--strong-border);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: 0 18px 48px rgb(45 62 34 / 20%);
+  padding: 18px;
+  text-align: left;
+}
+
+.onboarding-lab-switcher-intro h2 {
+  margin: 6px 0 6px;
+  font-size: var(--text-subsection);
+}
+
+.onboarding-lab-switcher-intro p {
+  margin: 0;
   color: var(--muted);
-  font-size: var(--text-body);
+  font-size: var(--text-meta);
 }
 
 .onboarding-lab-scenarios {
   display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  margin-bottom: 16px;
+  gap: 6px;
 }
 
 .onboarding-lab-scenario {
   display: grid;
   align-content: start;
-  gap: 4px;
+  gap: 3px;
   min-width: 0;
-  height: 100%;
-  padding: 12px 14px;
+  padding: 9px 11px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface);
   color: var(--secondary-foreground);
+  font-size: var(--text-ui);
   font-weight: var(--fw-regular);
   text-align: left;
   white-space: normal;
@@ -4545,29 +4618,34 @@ textarea:focus {
   font-size: var(--text-meta);
 }
 
-/* The preview embeds the real onboarding shell, so its full-viewport sizing is scoped here. */
-.onboarding-lab-preview {
-  position: relative;
-  max-height: min(72dvh, 900px);
-  overflow: auto;
-  border: 1px solid var(--strong-border);
-  border-radius: var(--radius);
-}
-
-/* Reviewers judge the desktop layout, so the frame scrolls instead of reflowing the page. */
-.onboarding-lab-preview .onboarding-shell {
-  min-width: 1120px;
-  min-height: 100%;
-}
-
-.onboarding-lab-preview .onboarding-shell::before {
-  position: absolute;
-}
-
-.onboarding-lab-section .notice.error {
+.onboarding-lab-switcher-reset {
   display: grid;
-  gap: 12px;
   justify-items: start;
+  gap: 10px;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+.onboarding-lab-switcher-reset h3 {
+  margin: 0;
+  font-size: var(--text-ui);
+}
+
+.onboarding-lab-switcher-reset p {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--text-meta);
+}
+
+.onboarding-lab-switcher-reset .notice {
+  margin: 0;
+  font-size: var(--text-meta);
+}
+
+.onboarding-lab-switcher-reset .notice.error {
+  display: grid;
+  justify-items: start;
+  gap: 10px;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Onboarding is the first surface an Account sees, and it was structured around the data model rather than the reader. Reviewing it in the browser turned up defects behind the copy, so this changes structure first and wording second.

**Presentation**

- `/onboarding` and the staging Lab render outside `AppShell`. The primary navigation offered four destinations `WorkspaceSetupGate` sent straight back to `/onboarding` — clicking any of them was a no-op — and its brand stood beside the one onboarding renders itself. Removing the shell also lets the surface be full-bleed instead of inset by `main.content`'s padding, which had made the document taller than the viewport in every state (measured: 996px document against a 900px viewport with all content collapsed).
- The Lab renders the onboarding page verbatim, with no frame or page chrome of its own, so a reviewer judges what production draws. Choosing a scenario and resetting the shared staging Account move into one floating control that production never shows. The reset keeps its confirmation dialog and its `resetAvailable` gate.
- Preview answers the Computer connect action from a fixed command instead of disabling it. The command block, its copy affordance and the waiting state were unreachable in review, which is exactly the hierarchy the Lab exists to show. It still issues no connect code and starts no polling — covered by a test that advances 30 minutes and asserts no request and no timer.

**Copy**

- The journey intro says what an Agent is rather than that one is being prepared.
- The derived Agent name stays out of the first run. Onboarding creates the Account's first Agent, where the derived name cannot collide, so it appears only when a display name derives to nothing — a Chinese display name derives to an empty string, and previously the rejection at submit was the first mention of the field.
- The messaging strip reports the link on one axis (`Not connected` / `Connecting…` / `Disconnected` / `Connected`) and separates a binding being built from one that has broken. It previously showed `Authorization` for all five `HandoffProgress` states, including a failed binding.
- Sentences that restate the labels beneath them are gone, and the Feishu bot has one casing.

**Type and layout**

- One thing at the top of the scale: the rail maps the journey, the stage carries the work. Both were `--text-display` at `--fw-semibold`, side by side, so the page had no primary heading.
- Field labels read as labels — reading face, sentence case. Monospace stays with what is genuinely machine output.
- `.agent-create-route-copy strong` took its weight from the browser default for `<strong>` rather than the token layer, which is the one path the typography guard cannot see; the same value rendered at 600 in one place and 700 in another on the same screen.
- The form no longer carries a card of its own inside the stage card. Its border resolved to three sides — `.form-card:first-child` beat `.form-card` on the top edge — and step 02 rendered no such panel.
- The connection strip marks the Agent by its own name and Feishu by its own logo. The Agent mark was a hard-coded `OT` next to a display name the Account chooses, so an Agent named 小助手 was still marked `OT`; the Feishu mark was `FS`, an abbreviation nobody uses. `assets/feishu.svg` was already in the tree and already used by the Tasks page.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test` — all pass on this base.
- New coverage: onboarding renders without the primary navigation; the derived Agent name is hidden in the first run and revealed when a display name derives to nothing; the Lab renders the onboarding page with no application navigation; Preview answers the connect action without reaching the Server.
- Walked all nine Lab scenarios in a browser at 1440×900 and 375×812, against the real components and stylesheet.

## Breaking changes

None. No API, schema or route path changes; `/onboarding` and `/internal/onboarding-lab` resolve as before.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

## Known gaps

Two findings from this review are not in this PR, because both need a product decision:

1. `Install Codex` tells the Account to install something and gives no command or link, while the Computer step gives a copyable command. The step dead-ends.
2. The stage heading is the same sentence in four of five step-01 sub-states, so the largest text on the page describes the step rather than what the Account can do now. `stageStatus` already holds the sub-state this would consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)