### PR TITLE
Preserve IM outbox for visible Session callbacks

### DIFF
--- a/docs/direct-provider-cli.md
+++ b/docs/direct-provider-cli.md
@@ -4,7 +4,17 @@
 
 OpenTag owns inbound IM routing, Integration credentials, temporary Client credential projection, and provider-native inbound references. It does not expose a message send, reply, Reaction, or upload API.
 
-For every valid visible IM Turn, the Client creates a private `0600` environment file and passes only its path as `OPENTAG_PROVIDER_ENV_FILE`. The Agent sources that file and calls the official `lark-cli` or `slack api` command directly. The file is removed when the Turn finishes, retried during Session or Client shutdown if removal fails, and recovered by the next Client startup after a crash.
+For every valid visible Session Turn that may write to IM, including an IM delivery or an internal-collaboration callback,
+the Client creates a private `0600` environment file and passes only its path as `OPENTAG_PROVIDER_ENV_FILE`. The Agent
+sources that file and calls the official `lark-cli` or `slack api` command directly. The file is removed when the Turn
+finishes, retried during Session or Client shutdown if removal fails, and recovered by the next Client startup after a
+crash. Internal Sessions never receive the file.
+
+An IM-delivery Turn receives the provider-native message reference from that event. A visible collaboration callback
+instead receives a non-secret default outbox context from credential grant v2. The Server derives that context from the
+target Session's existing channel or thread scope in the same authorization operation that grants credentials; the
+Client and Agent cannot nominate an OpenTag outbox target. A callback to a thread Session keeps its provider-native thread
+scope. This context is a default delivery target, not a restriction on the broader Bot-token authority described below.
 
 For Feishu Turns, the managed Turn context instructs the Agent to pass rich or multiline `lark-cli` text through a
 non-interpolating POSIX heredoc or PowerShell here-string variable. It also requires a pre-send check that rejects an

--- a/docs/internal-session-collaboration.md
+++ b/docs/internal-session-collaboration.md
@@ -36,13 +36,27 @@ override the model, reasoning effort, or maximum Run duration. Internal Sessions
 temporary `OPENTAG_PROVIDER_ENV_FILE`; they report through `opentag session send`. Both visible and internal Sessions
 receive role-aware managed instructions and may create further internal Sessions.
 
+OpenTag internal Sessions are distinct from Provider-native subagents. When a person explicitly requests an OpenTag
+internal Session, the visible Session uses `opentag session create` rather than substituting a Provider-native subagent.
+OpenTag does not otherwise impose one automatic routing policy between direct work, Provider-native subagents, and
+internal Sessions.
+
+When a SessionMessage returns to a visible channel or thread Session, that callback Run retains the visible Session's IM
+authority. Credential grant v2 atomically supplies a temporary provider credential environment and a non-secret default
+outbox context derived by the Server from the Session's existing conversation scope. The visible Session synthesizes and
+publishes any user-facing result through the official provider CLI during that callback Run; OpenTag does not forward the
+child's text automatically. Channel callbacks target the existing chat or channel, while thread callbacks retain the
+existing thread scope. Internal targets never receive provider credentials or outbox context.
+
 Session collaboration is real-time and best-effort, not a persistent job queue. The Server stores authorized logical
 messages and their latest observed outcome for idempotency and conflict detection, while target delivery remains an
 in-memory bounded FIFO with no automatic replay. Agent-facing Session operations intentionally provide no `end`;
 administrative lifecycle invalidation may still set the existing `sessions.ended_at` field. Retention is out of scope.
 
-This CLI surface requires `runtime.sessionCollaboration` capability version 2. Older Clients do not negotiate the
-capability and do not receive a Session proof.
+This CLI surface requires `runtime.sessionCollaboration` capability version 2. Visible callback delivery also requires
+`runtime.imCredentialGrant` version 2. A new Server reports `outbox_unavailable` before delivery when the target Client is
+older; a new Client connected to an older Server rejects the delivery before acknowledging it so the same logical message
+remains retryable. Both upgrade directions fail closed before the callback Run instead of silently removing its IM outbox.
 
 OpenTag currently supports this path only with a single Server replica. Proof-authenticated Session CLI HTTP and
 source/target SessionMessage Runtime delivery both use that replica's local WebSocket owner. Ordinary multi-replica

--- a/docs/zh-CN/direct-provider-cli.md
+++ b/docs/zh-CN/direct-provider-cli.md
@@ -4,7 +4,15 @@
 
 OpenTag 负责 IM 入站路由、Integration 凭证、Client 临时凭证投影和 provider 原生入站引用，不提供消息发送、回复、Reaction 或上传 API。
 
-每个有效且 Agent 可见的 IM Turn 开始前，Client 创建私有的 `0600` 环境文件，只通过 `OPENTAG_PROVIDER_ENV_FILE` 把文件路径交给 Agent。Agent source 该文件后直接调用官方 `lark-cli` 或 `slack api`。Turn 完成时删除文件；若删除失败，会在 Session 或 Client 关闭时重试；Client 崩溃留下的文件由下次启动恢复清理。
+每个可以写入 IM 的有效可见 Session Turn（包括 IM delivery 与 Internal Session 协作回调）开始前，Client 创建私有的
+`0600` 环境文件，只通过 `OPENTAG_PROVIDER_ENV_FILE` 把文件路径交给 Agent。Agent source 该文件后直接调用官方
+`lark-cli` 或 `slack api`。Turn 完成时删除文件；若删除失败，会在 Session 或 Client 关闭时重试；Client 崩溃留下的
+文件由下次启动恢复清理。Internal Session 永远不会收到该文件。
+
+IM delivery Turn 使用该事件携带的 provider 原生消息引用；可见 Session 的协作 callback 则使用 credential grant v2
+提供的非敏感默认 outbox context。Server 在授予凭证的同一次授权操作中，从目标 Session 既有 channel/thread scope
+派生该 context；Client 和 Agent 不能自报 OpenTag outbox target。回调目标为 thread Session 时会保持 provider 原生
+thread scope。这个 context 是默认交付目标，不会缩小下文所述 Bot token 的整体权限范围。
 
 对于 Feishu Turn，managed Turn context 会要求 Agent 使用不插值的 POSIX heredoc 或 PowerShell here-string 变量向
 `lark-cli` 传递富文本或多行正文。发送前还必须检查：如果预期为多行的正文没有真实换行，却包含多个字面量

--- a/docs/zh-CN/internal-session-collaboration.md
+++ b/docs/zh-CN/internal-session-collaboration.md
@@ -1,7 +1,7 @@
 # Internal Session 协作
 
 > Canonical source: [internal-session-collaboration.md](../internal-session-collaboration.md)
-> Last synced with: 2026-08-27
+> Last synced with: 2026-08-28
 
 OpenTag Agent 在每个 managed Session 内通过 CLI 委派工作：
 
@@ -33,12 +33,24 @@ reasoning effort 和最长 Run duration。Internal Session 不接收 IM delivery
 `OPENTAG_PROVIDER_ENV_FILE`，而是通过 `opentag session send` 回报。两类 Session 都收到角色化 managed instructions，
 也都可以继续创建下一层 internal Session。
 
+OpenTag Internal Session 与 Provider 原生 subagent 是两种不同机制。人明确要求使用 OpenTag Internal Session 时，
+可见 Session 必须调用 `opentag session create`，不能以 Provider 原生 subagent 代替。除此之外，OpenTag 本次不强制规定
+直接处理、Provider 原生 subagent 与 Internal Session 之间的自动选路策略。
+
+SessionMessage 回传到可见的 channel/thread Session 时，该 callback Run 继续拥有可见 Session 的 IM 权限。credential
+grant v2 会原子提供临时 provider 凭证环境，以及由 Server 从 Session 既有 conversation scope 派生的非敏感默认
+outbox context。可见 Session 在同一 callback Run 中整理用户可见结果，再通过官方 provider CLI 发布；OpenTag 不会自动
+原样转发子 Session 文本。channel callback 使用既有 chat/channel，thread callback 保持既有 thread scope。Internal
+Session 目标始终拿不到 provider 凭证或 outbox context。
+
 Session 协作是实时 best-effort 通道，不是持久 job queue。Server 保存已授权逻辑消息及最近结果用于幂等和冲突检测，
 目标投递仍使用有界内存 FIFO，不自动 replay。Agent-facing Session 命令刻意不提供 `end`；管理生命周期失效流程仍可设置
 既有 `sessions.ended_at`。Retention 不在本功能范围。
 
-CLI surface 仅协商 `runtime.sessionCollaboration` capability v2；旧 Client 不会协商该 capability，也不会收到 Session
-proof。
+CLI surface 仅协商 `runtime.sessionCollaboration` capability v2。可见 callback 投递还要求
+`runtime.imCredentialGrant` v2：新 Server 面对旧 Client 时会在投递前返回 `outbox_unavailable`；新 Client 连接旧 Server
+时会在 ACK 前拒绝投递，让同一逻辑消息仍可重试。两种升级方向都会在 callback Run 启动前 fail closed，不会静默移除
+IM outbox。
 
 OpenTag 当前仅在单 Server replica 下支持这条路径。proof-authenticated Session CLI HTTP 与 source/target
 SessionMessage Runtime 投递都依赖该 replica 本地的 WebSocket owner。当前不支持普通多 replica 负载均衡、sticky

--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -602,7 +602,7 @@ function steerRequest(): RuntimeImSteerRequest {
 
 function credentialEnvironment() {
   return {
-    prepare: vi.fn(async () => "/tmp/provider-env.sh"),
+    prepare: vi.fn(async () => ({ path: "/tmp/provider-env.sh", provider: "slack" as const })),
     cleanup: vi.fn(async () => undefined),
   };
 }

--- a/packages/client/src/__tests__/client-turn.integration.test.ts
+++ b/packages/client/src/__tests__/client-turn.integration.test.ts
@@ -331,7 +331,7 @@ async function runtimeFixture(
     } as never,
     runtimeManager,
     credentialEnvironment: {
-      prepare: async () => "/tmp/provider-env.sh",
+      prepare: async () => ({ path: "/tmp/provider-env.sh", provider: "slack" }),
       cleanup: async () => undefined,
     },
     logger: recordingLogger(logs, { computerId, instanceId: "instance-1" }),

--- a/packages/client/src/__tests__/im-credential-environment-manager.test.ts
+++ b/packages/client/src/__tests__/im-credential-environment-manager.test.ts
@@ -32,7 +32,7 @@ describe("ImCredentialEnvironmentManager", () => {
       const manager = new ImCredentialEnvironmentManager({ connection, home, platform: "linux" });
       const request = delivery(attention);
 
-      const path = await manager.prepare(request);
+      const { path } = await manager.prepare(request);
       expect(await readFile(path, "utf8")).toBe(
         `export SLACK_BOT_TOKEN='xoxb-${attention}'\nunset SLACK_USER_TOKEN\nunset SLACK_APP_TOKEN\n`,
       );
@@ -79,7 +79,7 @@ describe("ImCredentialEnvironmentManager", () => {
       platform: "linux",
     });
 
-    const path = await manager.prepare(delivery("ambient"));
+    const { path } = await manager.prepare(delivery("ambient"));
     expect(await readFile(path, "utf8")).toContain("export LARKSUITE_CLI_APP_SECRET='secret-1'");
     await manager.prepare(delivery("ambient"));
     const rotated = await readFile(path, "utf8");
@@ -105,7 +105,7 @@ describe("ImCredentialEnvironmentManager", () => {
       grant: { provider: "slack", botAccessToken: "xoxb-ambient-cli" },
     }));
     const manager = new ImCredentialEnvironmentManager({ connection, home, platform: "linux" });
-    const environmentPath = await manager.prepare(delivery("ambient"));
+    const { path: environmentPath } = await manager.prepare(delivery("ambient"));
 
     const result = await execFileAsync(
       "/bin/sh",
@@ -143,21 +143,7 @@ describe("ImCredentialEnvironmentManager", () => {
       home,
       platform: "linux",
     });
-    const environmentPath = await manager.prepare({
-      ...delivery("direct"),
-      content: {
-        kind: "text",
-        text: "hello",
-        providerRef: {
-          provider: "feishu",
-          teamBrand: "feishu",
-          appId: "cli-direct",
-          botOpenId: "bot-1",
-          chatId: "chat-1",
-          messageId: "message-1",
-        },
-      },
-    });
+    const { path: environmentPath } = await manager.prepare(delivery("direct"));
 
     const result = await execFileAsync(
       "/bin/sh",
@@ -226,7 +212,7 @@ describe("ImCredentialEnvironmentManager", () => {
         await rm(path, options);
       },
     });
-    const path = await manager.prepare(delivery("direct"));
+    const { path } = await manager.prepare(delivery("direct"));
 
     await expect(manager.cleanup("session-1")).rejects.toMatchObject({ code: "cleanup_failed" });
     await expect(stat(path)).resolves.toBeDefined();

--- a/packages/client/src/__tests__/session-message-inbox.test.ts
+++ b/packages/client/src/__tests__/session-message-inbox.test.ts
@@ -23,8 +23,13 @@ describe("SessionMessageInbox", () => {
     };
     const inbox = new SessionMessageInbox({
       admission,
+      credentialEnvironment: credentialEnvironment(),
+      imCredentialGrantVersion: () => 2,
       reconciler: inboxReconciler(),
-      runtimeManager: { ensureRuntime: vi.fn(async () => runtime as never) },
+      runtimeManager: {
+        ensureRuntime: vi.fn(async () => runtime as never),
+        sessionKind: vi.fn(() => "internal" as const),
+      },
     });
     const first = delivery({ targetSessionId, agentId, text: "first" });
     const second = delivery({ targetSessionId, agentId, text: "second" });
@@ -40,8 +45,10 @@ describe("SessionMessageInbox", () => {
   it("deduplicates the same logical payload and rejects a conflicting retry", async () => {
     const inbox = new SessionMessageInbox({
       admission: new AdmissionController(),
+      credentialEnvironment: credentialEnvironment(),
+      imCredentialGrantVersion: () => 2,
       reconciler: inboxReconciler("session_not_ready"),
-      runtimeManager: { ensureRuntime: vi.fn() },
+      runtimeManager: { ensureRuntime: vi.fn(), sessionKind: vi.fn(() => "internal" as const) },
     });
     const original = delivery({ text: "same" });
     await expect(inbox.accept(original)).resolves.toMatchObject({ status: "rejected", reason: "session_not_ready" });
@@ -62,8 +69,13 @@ describe("SessionMessageInbox", () => {
     };
     const inbox = new SessionMessageInbox({
       admission: new AdmissionController(),
+      credentialEnvironment: credentialEnvironment(),
+      imCredentialGrantVersion: () => 2,
       reconciler: inboxReconciler(),
-      runtimeManager: { ensureRuntime: vi.fn(async () => runtime as never) },
+      runtimeManager: {
+        ensureRuntime: vi.fn(async () => runtime as never),
+        sessionKind: vi.fn(() => "internal" as const),
+      },
     });
     const original = delivery({ text: "same logical message" });
     expect((await inbox.accept(original)).status).toBe("accepted");
@@ -115,8 +127,13 @@ describe("SessionMessageInbox", () => {
     };
     const inbox = new SessionMessageInbox({
       admission: new AdmissionController(),
+      credentialEnvironment: credentialEnvironment(),
+      imCredentialGrantVersion: () => 2,
       reconciler,
-      runtimeManager: { ensureRuntime: vi.fn(async () => runtime as never) },
+      runtimeManager: {
+        ensureRuntime: vi.fn(async () => runtime as never),
+        sessionKind: vi.fn(() => "internal" as const),
+      },
     });
     expect((await inbox.accept(request)).status).toBe("accepted");
     await vi.waitFor(() => expect(promptStarted).toHaveBeenCalledOnce());
@@ -163,9 +180,14 @@ describe("SessionMessageInbox", () => {
       waitForIdle: vi.fn(async () => undefined),
       prompt: vi.fn(async ({ runId }: { runId: string }) => ({ runId, status: "completed", output: [] })),
     };
-    const runtimeManager = { ensureRuntime: vi.fn(async () => runtime as never) };
+    const runtimeManager = {
+      ensureRuntime: vi.fn(async () => runtime as never),
+      sessionKind: vi.fn(() => "internal" as const),
+    };
     const inbox = new SessionMessageInbox({
       admission: new AdmissionController(),
+      credentialEnvironment: credentialEnvironment(),
+      imCredentialGrantVersion: () => 2,
       reconciler,
       runtimeManager,
     });
@@ -209,6 +231,141 @@ describe("SessionMessageInbox", () => {
     expect(input.items[1]?.text).toBe("Report the result");
   });
 
+  it("prepares visible Session outbox resources before Provider start and cleans them after the Run", async () => {
+    const order: string[] = [];
+    const credentials = {
+      prepare: vi.fn(async () => {
+        order.push("prepare");
+        return {
+          path: "/tmp/provider-env.sh",
+          provider: "slack" as const,
+          outboxContext: {
+            provider: "slack" as const,
+            sessionKind: "thread" as const,
+            channelId: "C-visible",
+            threadTs: "1710000000.000001",
+          },
+        };
+      }),
+      cleanup: vi.fn(async () => {
+        order.push("cleanup");
+      }),
+    };
+    const runtime = {
+      waitForIdle: vi.fn(async () => undefined),
+      prompt: vi.fn(async (request: { runId: string; input: { items: readonly { text: string }[] } }) => {
+        order.push("prompt");
+        expect(request.input.items[0]?.text).toContain("OPENTAG_PROVIDER_ENV_FILE");
+        expect(request.input.items[0]?.text).toContain('"threadTs":"1710000000.000001"');
+        expect(request.input.items[0]?.text).toContain("Do not wait for another IM message");
+        return { runId: request.runId, status: "completed", output: [] };
+      }),
+    };
+    const runtimeManager = {
+      ensureRuntime: vi.fn(async () => {
+        order.push("runtime");
+        return runtime as never;
+      }),
+      sessionKind: vi.fn(() => "visible" as const),
+    };
+    const inbox = new SessionMessageInbox({
+      admission: new AdmissionController(),
+      credentialEnvironment: credentials,
+      imCredentialGrantVersion: () => 2,
+      reconciler: inboxReconciler(),
+      runtimeManager,
+    });
+
+    expect((await inbox.accept(delivery())).status).toBe("accepted");
+    await inbox.settled();
+    expect(order).toEqual(["prepare", "runtime", "prompt", "cleanup"]);
+    expect(credentials.prepare).toHaveBeenCalledWith(
+      expect.objectContaining({ placementGeneration: 1 }),
+      expect.any(AbortSignal),
+    );
+    inbox.stop();
+  });
+
+  it("rejects a visible callback before ACK under grant v1 and accepts the same message after v2 is restored", async () => {
+    let grantVersion = 1;
+    const credentials = {
+      prepare: vi.fn(async () => ({
+        path: "/tmp/provider-env.sh",
+        provider: "slack" as const,
+        outboxContext: {
+          provider: "slack" as const,
+          sessionKind: "channel" as const,
+          channelId: "C-visible",
+        },
+      })),
+      cleanup: vi.fn(async () => undefined),
+    };
+    const runtime = {
+      waitForIdle: vi.fn(async () => undefined),
+      prompt: vi.fn(async (request: { runId: string }) => ({
+        runId: request.runId,
+        status: "completed" as const,
+        output: [],
+      })),
+    };
+    const runtimeManager = {
+      ensureRuntime: vi.fn(async () => runtime as never),
+      sessionKind: vi.fn(() => "visible" as const),
+    };
+    const inbox = new SessionMessageInbox({
+      admission: new AdmissionController(),
+      credentialEnvironment: credentials,
+      imCredentialGrantVersion: () => grantVersion,
+      reconciler: inboxReconciler(),
+      runtimeManager,
+    });
+    const request = delivery();
+
+    await expect(inbox.accept(request)).resolves.toMatchObject({
+      status: "rejected",
+      reason: "session_not_ready",
+    });
+    expect(credentials.prepare).not.toHaveBeenCalled();
+    expect(runtimeManager.ensureRuntime).not.toHaveBeenCalled();
+
+    grantVersion = 2;
+    await expect(inbox.accept({ ...request, requestId: randomUUID() })).resolves.toMatchObject({ status: "accepted" });
+    await inbox.settled();
+    expect(credentials.prepare).toHaveBeenCalledOnce();
+    expect(runtime.prompt).toHaveBeenCalledOnce();
+    inbox.stop();
+  });
+
+  it("fails closed before Provider start when a v2 credential grant omits visible Session outbox context", async () => {
+    const credentials = {
+      prepare: vi.fn(async () => ({ path: "/tmp/provider-env.sh", provider: "slack" as const })),
+      cleanup: vi.fn(async () => undefined),
+    };
+    const runtimeManager = {
+      ensureRuntime: vi.fn(),
+      sessionKind: vi.fn(() => "visible" as const),
+    };
+    const logger = { warn: vi.fn() };
+    const inbox = new SessionMessageInbox({
+      admission: new AdmissionController(),
+      credentialEnvironment: credentials,
+      imCredentialGrantVersion: () => 2,
+      logger,
+      reconciler: inboxReconciler(),
+      runtimeManager,
+    });
+
+    expect((await inbox.accept(delivery())).status).toBe("accepted");
+    await inbox.settled();
+    expect(runtimeManager.ensureRuntime).not.toHaveBeenCalled();
+    expect(credentials.cleanup).toHaveBeenCalledOnce();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "SESSION_MESSAGE_OUTBOX_PREPARATION_FAILED" }),
+      expect.any(String),
+    );
+    inbox.stop();
+  });
+
   it("enforces bounded capacity and rejects new work after shutdown", async () => {
     const admission = new AdmissionController();
     const targetSessionId = randomUUID();
@@ -216,9 +373,11 @@ describe("SessionMessageInbox", () => {
     const held = admission.reserve(targetSessionId, agentId);
     if (!held.accepted) throw new Error("Expected the test reservation");
     held.reservation.markActive();
-    const runtimeManager = { ensureRuntime: vi.fn() };
+    const runtimeManager = { ensureRuntime: vi.fn(), sessionKind: vi.fn(() => "internal" as const) };
     const inbox = new SessionMessageInbox({
       admission,
+      credentialEnvironment: credentialEnvironment(),
+      imCredentialGrantVersion: () => 2,
       maxQueuedPerSession: 1,
       maxQueuedTotal: 1,
       reconciler: inboxReconciler(),
@@ -287,5 +446,14 @@ function inboxReconciler(reason?: InputRejectReason) {
     clearActivity: () => true,
     setActivity: () => undefined,
     withAgentLock: async <T>(_agentId: string, task: () => Promise<T>) => task(),
+  };
+}
+
+function credentialEnvironment() {
+  return {
+    cleanup: vi.fn(async () => undefined),
+    prepare: vi.fn(async () => {
+      throw new Error("Internal Sessions must not prepare provider credentials");
+    }),
   };
 }

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -74,6 +74,7 @@ describe("SessionRuntimeManager", () => {
 
     expect(manager.requiresSessionPreparation(request)).toBe(false);
     await expect(reconciler.reconcile(request)).resolves.toMatchObject({ status: "ready" });
+    expect(manager.sessionKind(request.sessionId)).toBe("internal");
     await manager.ensureRuntime(request.sessionId);
 
     expect(proofManager.materialize).toHaveBeenCalledWith(request.sessionId, request.sessionCliProof);
@@ -83,6 +84,10 @@ describe("SessionRuntimeManager", () => {
     });
     expect(factory.created[0]?.hostedTools).toBeUndefined();
     expect(factory.created[0]?.systemPrompt).toContain("opentag-dev session send");
+    expect(factory.created[0]?.systemPrompt).toContain(
+      "OpenTag internal Sessions and Provider-native subagents are separate mechanisms",
+    );
+    expect(factory.created[0]?.systemPrompt).toContain("do not substitute a Provider-native subagent");
     expect(factory.created[0]?.systemPrompt).toContain(request.creatorSessionId);
     expect(manager.requiresSessionPreparation(request)).toBe(false);
     const rotated = {
@@ -135,7 +140,9 @@ describe("SessionRuntimeManager", () => {
     const reconciler = new SessionReconciler({ computerId, preparation: manager, localPolicy: manager });
     const first = reconcile(computerId, snapshot(1));
 
+    expect(() => manager.sessionKind(first.sessionId)).toThrow("has not been prepared");
     await expect(reconciler.reconcile(first)).resolves.toMatchObject({ status: "ready" });
+    expect(manager.sessionKind(first.sessionId)).toBe("visible");
     await manager.ensureRuntime("session-1");
     await manager.ensureRuntime("session-1", new AbortController().signal);
     expect(manager.runtime("session-1")).toBe(factory.runtimes[0]);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -181,6 +181,8 @@ export {
   ImCredentialEnvironmentError,
   ImCredentialEnvironmentManager,
   type ImCredentialEnvironmentManagerOptions,
+  type ImCredentialGrantSubject,
+  type PreparedImCredentialEnvironment,
   serializeEnvironment,
 } from "./runtime/im-credential-environment-manager.js";
 export { ImResourceFetcher } from "./runtime/im-resource-fetcher.js";
@@ -226,6 +228,7 @@ export {
   buildSessionMessageInput,
   SessionMessageInbox,
   type SessionMessageInboxOptions,
+  type SessionMessageTurnContext,
 } from "./runtime/session-message-inbox.js";
 export {
   type AgentRuntimeState,

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -18,6 +18,7 @@ import {
   type ImCredentialEnvironmentManager,
 } from "./im-credential-environment-manager.js";
 import type { ImResourceFetcher } from "./im-resource-fetcher.js";
+import { buildProviderOutboxInstructions } from "./provider-outbox-instructions.js";
 import type { RuntimeConnection } from "./runtime-connection.js";
 import type { SessionBindingStore } from "./session-binding-store.js";
 import { ClientRuntimeProviderStartError, type SessionRuntimeManager } from "./session-runtime-manager.js";
@@ -294,34 +295,6 @@ export function buildAgentInput(
   if (!runtime) throw new Error("A steer input requires the root runtime snapshot");
   const sessionInstructions = runtime.instructions.session?.trim() || "No additional Session instructions.";
   const provider = request.content.providerRef.provider;
-  const providerCommand = provider === "feishu" ? "lark-cli" : "slack api";
-  const providerBodyInstructions =
-    provider === "feishu"
-      ? [
-          "For lark-cli text and Markdown bodies, intended line breaks must reach the CLI as real newline characters; never write literal `\\n` sequences for layout.",
-          "Before sending, inspect the body: if it has no real newline and contains two or more literal `\\n` sequences, treat it as malformed and rebuild it instead of sending. Do not blindly replace `\\n`, because code or prose may intentionally discuss that token.",
-          "Keep rich or multiline bodies out of ordinary inline shell quoting. Populate a task-specific variable with shell-native, non-interpolating multiline syntax, then pass the variable as one quoted `--text` or `--markdown` argument.",
-          "POSIX shell pattern:",
-          "```bash",
-          "IFS= read -r -d '' OPENTAG_LARK_BODY <<'EOF' || true",
-          "first line",
-          "",
-          'second line with `code`, $variables, "quotes", and apostrophes',
-          "EOF",
-          'lark-cli ... --markdown "$OPENTAG_LARK_BODY"',
-          "```",
-          "PowerShell pattern:",
-          "```powershell",
-          "$OpenTagLarkBody = @'",
-          "first line",
-          "",
-          'second line with `code`, $variables, "quotes", and apostrophes',
-          "'@",
-          "lark-cli ... --markdown $OpenTagLarkBody",
-          "```",
-          "Replace `...` with the version-specific lark-cli subcommand and provider-native target options before running it.",
-        ]
-      : [];
   const attentionMeaning =
     request.attention === "direct"
       ? "A human explicitly addressed this Agent/Session. Handle the message normally, then choose whether to reply, react, send proactively, or take no provider action."
@@ -335,20 +308,16 @@ export function buildAgentInput(
     `Session: ${request.sessionId}`,
     `Agent revision: ${runtime.revision.agent.sequence}/${runtime.revision.agent.id}`,
     `Session revision: ${runtime.revision.session.sequence}/${runtime.revision.session.id}`,
-    'Who reads your output: inside OpenTag, the "user" your underlying agent addresses — the reader of everything you produce apart from running a provider CLI command, including the text that closes this Turn — is the OpenTag runtime. This is your runtime console; ordinary output is not delivered to the IM participant.',
-    `The IM participant is a separate audience. The official ${providerCommand} CLI is your outbox and the only path from this Turn to that audience.`,
-    "The console addresses OpenTag; running the provider CLI performs the provider action. Describing a reply, reaction, or proactive message in your output only records it in OpenTag; it does not deliver it.",
-    "If you choose to reply, react, or send proactively, run the provider CLI command before ending this Turn. Choosing to take no provider action remains valid.",
-    `To write to this ${provider} conversation, load the credentials from $OPENTAG_PROVIDER_ENV_FILE in your shell, then use the official ${providerCommand} CLI directly.`,
-    ...providerBodyInstructions,
-    "OpenTag has no message send, reply, or reaction interface, and you do not report provider send results to OpenTag.",
-    "Use the provider-native identifiers below. Do not substitute an OpenTag Session or message ID.",
-    "If a provider result is unknown, query the provider before deciding whether to retry.",
+    ...buildProviderOutboxInstructions({
+      actionInstruction:
+        "If you choose to reply, react, or send proactively, run the provider CLI command before ending this Turn. Choosing to take no provider action remains valid.",
+      provider,
+      target: request.content.providerRef,
+      targetLabel: "Current provider reference",
+    }),
     `Attention: ${request.attention}`,
     `Attention meaning: ${attentionMeaning}`,
     "Attention does not change provider CLI or credential availability for this Turn.",
-    `Current provider reference: ${JSON.stringify(request.content.providerRef)}`,
-    `For version-specific commands and native formats, run ${provider === "feishu" ? "lark-cli im --help" : "slack api --help"}.`,
     "Session instructions:",
     sessionInstructions,
     "</opentag-im-context>",

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import {
   type AgentRuntimeProvider,
   computeRuntimeSnapshotHashes,
+  RUNTIME_CAPABILITY,
   RUNTIME_CLIENT_CAPABILITY_TTL_MS,
   type RuntimeImCliReadinessObservation,
   type RuntimeProviderReadinessObservation,
@@ -435,6 +436,8 @@ export async function createClientRuntime(
   const sessionMessageInbox = new SessionMessageInbox({
     admission,
     cliCommand: options.cliCommand ?? "opentag",
+    credentialEnvironment,
+    imCredentialGrantVersion: connection.capabilityVersion.bind(connection, RUNTIME_CAPABILITY.imCredentialGrant),
     reconciler,
     runtimeManager,
   });

--- a/packages/client/src/runtime/im-credential-environment-manager.ts
+++ b/packages/client/src/runtime/im-credential-environment-manager.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
-import type { DirectImMessageDeliveryRequest, RuntimeImCredentialGrantResult } from "@opentag/shared";
+import type { RuntimeImCredentialGrantResult, RuntimeImOutboxContext } from "@opentag/shared";
 import { type ClientLogger, createLogger } from "../observability/logger.js";
 import { ensurePrivateDirectory, writeDurableFile } from "../storage/durable-file.js";
 import { resolveOpenTagHomeLayout } from "../storage/home-layout.js";
@@ -36,6 +36,18 @@ export interface ImCredentialEnvironmentManagerOptions {
   readonly platform?: NodeJS.Platform;
   readonly removePath?: (path: string, options: { force: true; recursive?: true }) => Promise<void>;
   readonly writeEnvironmentFile?: (path: string, content: string, mode: number) => Promise<void>;
+}
+
+export interface ImCredentialGrantSubject {
+  readonly agentId: string;
+  readonly placementGeneration: number;
+  readonly sessionId: string;
+}
+
+export interface PreparedImCredentialEnvironment {
+  readonly outboxContext?: RuntimeImOutboxContext;
+  readonly path: string;
+  readonly provider: "feishu" | "slack";
 }
 
 export class ImCredentialEnvironmentManager {
@@ -76,7 +88,7 @@ export class ImCredentialEnvironmentManager {
     return join(this.#root, `${sessionId}${this.#platform === "win32" ? ".ps1" : ".sh"}`);
   }
 
-  async prepare(request: DirectImMessageDeliveryRequest, signal?: AbortSignal): Promise<string> {
+  async prepare(request: ImCredentialGrantSubject, signal?: AbortSignal): Promise<PreparedImCredentialEnvironment> {
     if (this.#closed) throw new ImCredentialEnvironmentError("client_shutdown");
     try {
       const startupFailure = await this.#startupCleanup;
@@ -95,7 +107,11 @@ export class ImCredentialEnvironmentManager {
               SLACK_APP_TOKEN: undefined,
             };
       await this.#writeEnvironmentFile(path, serializeEnvironment(environment, this.#platform), 0o600);
-      return path;
+      return {
+        path,
+        provider: result.grant.provider,
+        ...(result.outboxContext ? { outboxContext: result.outboxContext } : {}),
+      };
     } catch (error) {
       await this.cleanup(request.sessionId).catch(() => undefined);
       throw credentialEnvironmentError(error, signal, "credential_materialization_failed");
@@ -175,10 +191,7 @@ export class ImCredentialEnvironmentManager {
     };
   }
 
-  #requestGrant(
-    request: DirectImMessageDeliveryRequest,
-    signal?: AbortSignal,
-  ): Promise<RuntimeImCredentialGrantResult> {
+  #requestGrant(request: ImCredentialGrantSubject, signal?: AbortSignal): Promise<RuntimeImCredentialGrantResult> {
     if (signal?.aborted) return Promise.reject(new ImCredentialEnvironmentError("aborted"));
     const requestId = randomUUID();
     return new Promise((resolve, reject) => {

--- a/packages/client/src/runtime/managed-instructions.ts
+++ b/packages/client/src/runtime/managed-instructions.ts
@@ -20,11 +20,13 @@ export function renderManagedSystemPrompt(snapshot: EffectiveRuntimeSnapshot, co
         ...(context.sessionKind === "internal"
           ? [
               "You are an internal Session. Focus on the delegated task, report progress, questions, and the final result to the creating or coordinating Session, and do not publish directly to IM.",
-              "You may create further internal Sessions when the work benefits from delegation or parallelism.",
+              "You may create further internal Sessions when platform-level Session collaboration is useful.",
             ]
           : [
-              "You are a visible Session. Handle simple work directly; delegate complex, parallel, or context-isolated work to internal Sessions, then synthesize their results before deciding what to publish to IM.",
+              "You are a visible Session. You may handle work directly, use Provider-native subagents when available, or create OpenTag internal Sessions when platform-level Session collaboration is useful.",
             ]),
+        "OpenTag internal Sessions and Provider-native subagents are separate mechanisms and are not interchangeable.",
+        `When a user explicitly requests an OpenTag internal Session and Session collaboration is available, use ${context.cliCommand} session create; do not substitute a Provider-native subagent.`,
         "",
         ...(context.sessionCliAvailable
           ? [

--- a/packages/client/src/runtime/provider-outbox-instructions.ts
+++ b/packages/client/src/runtime/provider-outbox-instructions.ts
@@ -1,0 +1,53 @@
+export type ProviderOutboxProvider = "feishu" | "slack";
+
+export interface ProviderOutboxInstructionOptions {
+  readonly actionInstruction: string;
+  readonly provider: ProviderOutboxProvider;
+  readonly target: Readonly<Record<string, unknown>>;
+  readonly targetLabel: string;
+}
+
+export function buildProviderOutboxInstructions(options: ProviderOutboxInstructionOptions): readonly string[] {
+  const providerCommand = options.provider === "feishu" ? "lark-cli" : "slack api";
+  return [
+    'Who reads your output: inside OpenTag, the "user" your underlying agent addresses — the reader of everything you produce apart from running a provider CLI command, including the text that closes this Turn — is the OpenTag runtime. This is your runtime console; ordinary output is not delivered to the IM participant.',
+    `The IM participant is a separate audience. The official ${providerCommand} CLI is your outbox and the only path from this Turn to that audience.`,
+    "The console addresses OpenTag; running the provider CLI performs the provider action. Describing a reply, reaction, or proactive message in your output only records it in OpenTag; it does not deliver it.",
+    options.actionInstruction,
+    `To write to this ${options.provider} conversation, load the credentials from $OPENTAG_PROVIDER_ENV_FILE in your shell, then use the official ${providerCommand} CLI directly.`,
+    ...providerBodyInstructions(options.provider),
+    "OpenTag has no message send, reply, or reaction interface, and you do not report provider send results to OpenTag.",
+    "Use the provider-native identifiers below. Do not substitute an OpenTag Session or message ID.",
+    "If a provider result is unknown, query the provider before deciding whether to retry.",
+    `${options.targetLabel}: ${JSON.stringify(options.target)}`,
+    `For version-specific commands and native formats, run ${options.provider === "feishu" ? "lark-cli im --help" : "slack api --help"}.`,
+  ];
+}
+
+function providerBodyInstructions(provider: ProviderOutboxProvider): readonly string[] {
+  if (provider !== "feishu") return [];
+  return [
+    "For lark-cli text and Markdown bodies, intended line breaks must reach the CLI as real newline characters; never write literal `\\n` sequences for layout.",
+    "Before sending, inspect the body: if it has no real newline and contains two or more literal `\\n` sequences, treat it as malformed and rebuild it instead of sending. Do not blindly replace `\\n`, because code or prose may intentionally discuss that token.",
+    "Keep rich or multiline bodies out of ordinary inline shell quoting. Populate a task-specific variable with shell-native, non-interpolating multiline syntax, then pass the variable as one quoted `--text` or `--markdown` argument.",
+    "POSIX shell pattern:",
+    "```bash",
+    "IFS= read -r -d '' OPENTAG_LARK_BODY <<'EOF' || true",
+    "first line",
+    "",
+    'second line with `code`, $variables, "quotes", and apostrophes',
+    "EOF",
+    'lark-cli ... --markdown "$OPENTAG_LARK_BODY"',
+    "```",
+    "PowerShell pattern:",
+    "```powershell",
+    "$OpenTagLarkBody = @'",
+    "first line",
+    "",
+    'second line with `code`, $variables, "quotes", and apostrophes',
+    "'@",
+    "lark-cli ... --markdown $OpenTagLarkBody",
+    "```",
+    "Replace `...` with the version-specific lark-cli subcommand and provider-native target options before running it.",
+  ];
+}

--- a/packages/client/src/runtime/runtime-connection.ts
+++ b/packages/client/src/runtime/runtime-connection.ts
@@ -220,6 +220,10 @@ export class RuntimeConnection {
     return this.#state === "registered" && this.#negotiatedCapabilities[capability] !== undefined;
   }
 
+  capabilityVersion(capability: string): number | undefined {
+    return this.#state === "registered" ? this.#negotiatedCapabilities[capability] : undefined;
+  }
+
   setVerifiedCapabilities(
     capabilities: RuntimeClientCapabilities,
     validForMs = RUNTIME_CLIENT_CAPABILITY_TTL_MS,

--- a/packages/client/src/runtime/session-message-inbox.ts
+++ b/packages/client/src/runtime/session-message-inbox.ts
@@ -2,12 +2,16 @@ import {
   hashTuple,
   type InputRejectReason,
   RUNTIME_DEFAULT_MAX_DURATION_MS,
+  type RuntimeImOutboxContext,
   type SessionMessageDeliveryRequest,
   SessionMessageDeliveryRequestSchema,
   type SessionMessageDeliveryResult,
 } from "@opentag/shared";
 import type { AgentInput } from "../agent-runtime/types.js";
+import { type ClientLogger, createLogger } from "../observability/logger.js";
 import type { AdmissionController } from "./admission-controller.js";
+import type { ImCredentialEnvironmentManager } from "./im-credential-environment-manager.js";
+import { buildProviderOutboxInstructions } from "./provider-outbox-instructions.js";
 import type { SessionReconciler } from "./session-reconciler.js";
 import type { SessionRuntimeManager } from "./session-runtime-manager.js";
 
@@ -25,6 +29,9 @@ interface RememberedMessage {
 export interface SessionMessageInboxOptions {
   admission: AdmissionController;
   cliCommand?: string;
+  credentialEnvironment: Pick<ImCredentialEnvironmentManager, "cleanup" | "prepare">;
+  imCredentialGrantVersion(): number | undefined;
+  logger?: Pick<ClientLogger, "warn">;
   maxQueuedPerSession?: number;
   maxQueuedTotal?: number;
   maxRememberedMessages?: number;
@@ -32,12 +39,15 @@ export interface SessionMessageInboxOptions {
     SessionReconciler,
     "checkSessionMessageDelivery" | "clearActivity" | "setActivity" | "withAgentLock"
   >;
-  runtimeManager: Pick<SessionRuntimeManager, "ensureRuntime">;
+  runtimeManager: Pick<SessionRuntimeManager, "ensureRuntime" | "sessionKind">;
 }
 
 export class SessionMessageInbox {
   readonly #admission: AdmissionController;
   readonly #cliCommand: string;
+  readonly #credentialEnvironment: SessionMessageInboxOptions["credentialEnvironment"];
+  readonly #imCredentialGrantVersion: SessionMessageInboxOptions["imCredentialGrantVersion"];
+  readonly #logger: Pick<ClientLogger, "warn">;
   readonly #maxQueuedPerSession: number;
   readonly #maxQueuedTotal: number;
   readonly #maxRememberedMessages: number;
@@ -52,6 +62,9 @@ export class SessionMessageInbox {
   constructor(options: SessionMessageInboxOptions) {
     this.#admission = options.admission;
     this.#cliCommand = options.cliCommand ?? "opentag";
+    this.#credentialEnvironment = options.credentialEnvironment;
+    this.#imCredentialGrantVersion = options.imCredentialGrantVersion;
+    this.#logger = options.logger ?? createLogger("session-message-inbox");
     this.#maxQueuedPerSession = positive(options.maxQueuedPerSession ?? 64, "maxQueuedPerSession");
     this.#maxQueuedTotal = positive(options.maxQueuedTotal ?? 256, "maxQueuedTotal");
     this.#maxRememberedMessages = positive(options.maxRememberedMessages ?? 512, "maxRememberedMessages");
@@ -79,6 +92,13 @@ export class SessionMessageInbox {
           retryableAuthorityReason(reason) ? { hash, status: "retryable" } : { hash, status: "rejected", reason },
         );
         return deliveryResult(request, "rejected", reason);
+      }
+      if (
+        this.#runtimeManager.sessionKind(request.targetSessionId) === "visible" &&
+        this.#imCredentialGrantVersion() !== 2
+      ) {
+        this.#remember(key, { hash, status: "retryable" });
+        return deliveryResult(request, "rejected", "session_not_ready");
       }
       const queue = this.#queues.get(request.targetSessionId) ?? [];
       if (queue.length >= this.#maxQueuedPerSession || this.#queuedTotal >= this.#maxQueuedTotal) {
@@ -138,7 +158,38 @@ export class SessionMessageInbox {
           turnId: runId,
         });
       });
+      let credentialPrepared = false;
       try {
+        const sessionKind = this.#runtimeManager.sessionKind(sessionId);
+        let outboxContext: RuntimeImOutboxContext | undefined;
+        if (sessionKind === "visible") {
+          try {
+            const prepared = await this.#credentialEnvironment.prepare(
+              {
+                sessionId,
+                agentId: next.request.agentId,
+                placementGeneration: next.request.placementGeneration,
+              },
+              this.#abort.signal,
+            );
+            credentialPrepared = true;
+            if (!prepared.outboxContext) {
+              throw new Error("The credential grant did not include visible Session outbox context");
+            }
+            outboxContext = prepared.outboxContext;
+          } catch (error) {
+            this.#logger.warn(
+              {
+                code: "SESSION_MESSAGE_OUTBOX_PREPARATION_FAILED",
+                errorCode: error instanceof Error && "code" in error ? error.code : undefined,
+                messageId: next.request.messageId,
+                sessionId,
+              },
+              "Visible Session collaboration outbox preparation failed",
+            );
+            throw error;
+          }
+        }
         const runtime = await this.#runtimeManager.ensureRuntime(sessionId, this.#abort.signal);
         await runtime.waitForIdle();
         const timeout = new AbortController();
@@ -150,13 +201,22 @@ export class SessionMessageInbox {
         try {
           await runtime.prompt({
             runId,
-            input: buildSessionMessageInput(next.request, this.#cliCommand),
+            input: buildSessionMessageInput(
+              next.request,
+              this.#cliCommand,
+              sessionKind === "visible"
+                ? { sessionKind, outboxContext: requireOutboxContext(outboxContext) }
+                : { sessionKind },
+            ),
             signal: AbortSignal.any([this.#abort.signal, timeout.signal]),
           });
         } finally {
           clearTimeout(timer);
         }
       } finally {
+        if (credentialPrepared) {
+          await this.#credentialEnvironment.cleanup(sessionId).catch(() => undefined);
+        }
         await this.#reconciler.withAgentLock(next.request.agentId, async () => {
           this.#reconciler.clearActivity(sessionId, runId);
           reservation.reservation.release();
@@ -184,12 +244,43 @@ function retryableAuthorityReason(reason: InputRejectReason): boolean {
   );
 }
 
-export function buildSessionMessageInput(request: SessionMessageDeliveryRequest, cliCommand = "opentag"): AgentInput {
-  return {
-    items: [
-      {
-        type: "text",
-        text: [
+export type SessionMessageTurnContext =
+  | { readonly sessionKind: "internal" }
+  | { readonly outboxContext: RuntimeImOutboxContext; readonly sessionKind: "visible" };
+
+export function buildSessionMessageInput(
+  request: SessionMessageDeliveryRequest,
+  cliCommand = "opentag",
+  turnContext: SessionMessageTurnContext = { sessionKind: "internal" },
+): AgentInput {
+  const managedContext =
+    turnContext.sessionKind === "visible"
+      ? [
+          '<opentag-session-message-context source="managed">',
+          "OpenTag internal collaboration message continuing the visible Session's existing work.",
+          `Message ID: ${request.messageId}`,
+          `Source Session: ${request.sourceSessionId}`,
+          `Target Session: ${request.targetSessionId}`,
+          "This message is not an IM provider event, but the target visible Session retains its IM outbox authority.",
+          ...buildProviderOutboxInstructions({
+            actionInstruction:
+              "When this collaboration message contains a user-visible result, question, or blocker, synthesize it and deliver it through the provider CLI in this Turn before ending. Do not wait for another IM message. Do not automatically forward the source text verbatim.",
+            provider: turnContext.outboxContext.provider,
+            target: turnContext.outboxContext,
+            targetLabel: "Default provider outbox context",
+          }),
+          ...(turnContext.outboxContext.sessionKind === "thread"
+            ? turnContext.outboxContext.provider === "slack"
+              ? ["Keep this collaboration continuation in the supplied Slack threadTs scope."]
+              : [
+                  "Keep this collaboration continuation in the supplied Feishu threadId scope. Use lark-cli to inspect the thread when a native message reply target is required.",
+                ]
+            : []),
+          `Use ${cliCommand} session send <target-session-id> to continue Session collaboration when needed.`,
+          "Ordinary final text remains Runtime console output and is not published automatically.",
+          "</opentag-session-message-context>",
+        ]
+      : [
           '<opentag-session-message-context source="managed">',
           "OpenTag internal collaboration message.",
           `Message ID: ${request.messageId}`,
@@ -200,11 +291,21 @@ export function buildSessionMessageInput(request: SessionMessageDeliveryRequest,
           `Use ${cliCommand} session send <target-session-id> to report progress or results, ask a question, or continue collaboration.`,
           "No IM provider reference or credential is attached to this message.",
           "</opentag-session-message-context>",
-        ].join("\n"),
+        ];
+  return {
+    items: [
+      {
+        type: "text",
+        text: managedContext.join("\n"),
       },
       { type: "text", text: request.content.text },
     ],
   };
+}
+
+function requireOutboxContext(context: RuntimeImOutboxContext | undefined): RuntimeImOutboxContext {
+  if (!context) throw new Error("Visible Session collaboration requires outbox context");
+  return context;
 }
 
 function deliveryResult(

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -196,6 +196,12 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
     return waitForStart(start, signal);
   }
 
+  sessionKind(sessionId: string): "visible" | "internal" {
+    const managed = this.#sessions.get(sessionId);
+    if (!managed) throw new Error("The Session Agent Runtime has not been prepared");
+    return managed.sessionKind;
+  }
+
   async #startRuntime(managed: ManagedSessionRuntime): Promise<AgentRuntime> {
     const provider = this.#providers.registration(managed.providerId);
     /* v8 ignore next -- registrations are immutable for the lifetime of a managed Session. */

--- a/packages/server/src/__tests__/connection-registry.test.ts
+++ b/packages/server/src/__tests__/connection-registry.test.ts
@@ -189,7 +189,10 @@ describe("ConnectionRegistry", () => {
         computerId,
         instanceId: verifiedInstanceId,
         lastHeartbeatAt: 2,
-        negotiatedCapabilities: { [RUNTIME_CAPABILITY.sessionCollaboration]: 1 },
+        negotiatedCapabilities: {
+          [RUNTIME_CAPABILITY.imCredentialGrant]: 2,
+          [RUNTIME_CAPABILITY.sessionCollaboration]: 1,
+        },
         providerReadiness: [{ provider: "codex", status: "ready" }],
         providerReadinessObservedAt: 2,
         providerReadinessProviders: ["codex"],
@@ -204,6 +207,7 @@ describe("ConnectionRegistry", () => {
     expect(registry.supportsCapability(computerId, verifiedInstanceId, RUNTIME_CAPABILITY.sessionCollaboration)).toBe(
       true,
     );
+    expect(registry.capabilityVersion(computerId, verifiedInstanceId, RUNTIME_CAPABILITY.imCredentialGrant, 2)).toBe(2);
     expect(registry.supportsCapability(computerId, firstInstanceId, RUNTIME_CAPABILITY.sessionCollaboration)).toBe(
       false,
     );

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -667,6 +667,19 @@ describe("IM binding persistence", () => {
         grant: { provider: "slack", botAccessToken: "xoxb-secret" },
       });
       expect(ambient).toMatchObject({ status: "succeeded", grant: { provider: "slack" } });
+      await expect(
+        value.imBindingService.issueRuntimeCredentialGrant(request, {
+          ...computerAuthFor(value),
+          imCredentialGrantVersion: 2,
+        }),
+      ).resolves.toMatchObject({
+        status: "succeeded",
+        outboxContext: {
+          provider: "slack",
+          sessionKind: "channel",
+          channelId: session.channelId,
+        },
+      });
       expect(JSON.stringify(direct)).not.toContain("signing-secret");
       expect(JSON.stringify(direct)).not.toContain("attention");
 
@@ -683,9 +696,18 @@ describe("IM binding persistence", () => {
       await expect(
         value.imBindingService.issueRuntimeCredentialGrant(
           { ...request, requestId: crypto.randomUUID(), sessionId: thread.session.id },
-          computerAuthFor(value),
+          { ...computerAuthFor(value), imCredentialGrantVersion: 2 },
         ),
-      ).resolves.toMatchObject({ status: "succeeded", grant: { provider: "slack" } });
+      ).resolves.toMatchObject({
+        status: "succeeded",
+        grant: { provider: "slack" },
+        outboxContext: {
+          provider: "slack",
+          sessionKind: "thread",
+          channelId: session.channelId,
+          threadTs: "credential-thread",
+        },
+      });
       const sourceConnectionInstanceId = crypto.randomUUID();
       await value.database
         .update(workspaceComputers)

--- a/packages/server/src/__tests__/integration/session-collaboration.test.ts
+++ b/packages/server/src/__tests__/integration/session-collaboration.test.ts
@@ -950,6 +950,7 @@ async function createCollaborationFixture(
       assembler: { assembleForSession: options.assemble ?? (async () => runtimeSnapshot(fixture.agentId)) },
       domain,
       registry: {
+        capabilityVersion: () => 2,
         currentInstanceId: () => instanceId,
         supportsCapability: () => true,
       },

--- a/packages/server/src/__tests__/runtime-domain-owner.test.ts
+++ b/packages/server/src/__tests__/runtime-domain-owner.test.ts
@@ -4,6 +4,7 @@ import {
   computeTurnResultHash,
   type DirectImMessageDeliveryRequest,
   type EffectiveRuntimeSnapshot,
+  RUNTIME_CAPABILITY,
   type RuntimeImSteerRequest,
   type SessionMessageDeliveryRequest,
   type SessionMessageDeliveryResult,
@@ -28,6 +29,29 @@ import {
 import type { RuntimeBusinessContext } from "../runtime/runtime-session.js";
 
 describe("RuntimeDomainOwner", () => {
+  it("passes the negotiated credential grant version to the authority callback", async () => {
+    const onImCredentialGrant = vi.fn(async (request) => ({
+      type: "im:credential:result" as const,
+      requestId: request.requestId,
+      status: "rejected" as const,
+      code: "binding_inactive" as const,
+    }));
+    const fixture = await ownerFixture(1_000, { onImCredentialGrant });
+    const request = {
+      type: "im:credential" as const,
+      requestId: randomUUID(),
+      sessionId: "session-1",
+      agentId: "agent-1",
+      placementGeneration: 1,
+    };
+
+    await expect(fixture.owner.handle(request, fixture.context)).resolves.toMatchObject({
+      type: "im:credential:result",
+      requestId: request.requestId,
+    });
+    expect(onImCredentialGrant).toHaveBeenCalledWith(request, expect.objectContaining({ imCredentialGrantVersion: 2 }));
+  });
+
   it("B-19 joins identical requests and rejects a reused request ID with different payload", async () => {
     const fixture = await ownerFixture();
     const request = reconcileRequest(fixture.computerId);
@@ -524,7 +548,7 @@ async function waitForDeliveryFrame(frames: unknown[], requestId: string): Promi
 
 async function ownerFixture(
   requestTimeoutMs = 1_000,
-  options: Pick<RuntimeDomainOwnerOptions, "prepareReconcile"> = {},
+  options: Pick<RuntimeDomainOwnerOptions, "onImCredentialGrant" | "prepareReconcile"> = {},
 ) {
   const registry = new ConnectionRegistry();
   const computerId = randomUUID();
@@ -538,6 +562,7 @@ async function ownerFixture(
       workspaceId,
       instanceId,
       lastHeartbeatAt: 1,
+      negotiatedCapabilities: { [RUNTIME_CAPABILITY.imCredentialGrant]: 2 },
       socket: socketFixture(frames),
     },
     async () => undefined,

--- a/packages/server/src/__tests__/session-collaboration-service.test.ts
+++ b/packages/server/src/__tests__/session-collaboration-service.test.ts
@@ -75,6 +75,20 @@ describe("SessionCollaborationService", () => {
     expect(fixture.domain.requestSessionMessageDelivery).not.toHaveBeenCalled();
   });
 
+  it("fails closed before reconcile when a visible target lacks credential grant v2", async () => {
+    const fixture = serviceFixture({ targetSessionKind: "channel" });
+    fixture.registry.capabilityVersion.mockReturnValue(1);
+
+    await expect(fixture.service.send(sendRequest(fixture), fixture.source)).resolves.toMatchObject({
+      status: "unreachable",
+      code: "outbox_unavailable",
+    });
+    expect(fixture.domain.requestReconcile).not.toHaveBeenCalled();
+    expect(fixture.sessions.recordMessageOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "unreachable", errorCode: "outbox_unavailable" }),
+    );
+  });
+
   it("records an uncertain delivery timeout as unknown and keeps it unknown if outcome fencing fails", async () => {
     const fixture = serviceFixture();
     fixture.domain.requestSessionMessageDelivery.mockRejectedValue(
@@ -105,7 +119,13 @@ describe("SessionCollaborationService", () => {
   });
 });
 
-function serviceFixture(options: { attemptCount?: number | null; lastOutcome?: "accepted" | "unknown" } = {}) {
+function serviceFixture(
+  options: {
+    attemptCount?: number | null;
+    lastOutcome?: "accepted" | "unknown";
+    targetSessionKind?: "channel" | "thread" | "internal";
+  } = {},
+) {
   const sourceSessionId = randomUUID();
   const targetSessionId = randomUUID();
   const messageId = randomUUID();
@@ -132,7 +152,7 @@ function serviceFixture(options: { attemptCount?: number | null; lastOutcome?: "
       targetComputerId,
       targetWorkspaceComputerId,
       targetPlacementGeneration: 1,
-      targetSessionKind: "internal" as const,
+      targetSessionKind: options.targetSessionKind ?? ("internal" as const),
       targetCreatorSessionId: sourceSessionId,
     },
     message: {
@@ -185,10 +205,16 @@ function serviceFixture(options: { attemptCount?: number | null; lastOutcome?: "
     }),
   };
   const onDiagnostic = vi.fn();
+  const registry = {
+    capabilityVersion: vi.fn().mockReturnValue(2),
+    currentInstanceId: vi.fn().mockReturnValue(instanceId),
+    supportsCapability: vi.fn().mockReturnValue(true),
+  };
   return {
     domain,
     messageId,
     onDiagnostic,
+    registry,
     sessions,
     source,
     targetSessionId,
@@ -196,10 +222,7 @@ function serviceFixture(options: { attemptCount?: number | null; lastOutcome?: "
       assembler: { assembleForSession: vi.fn().mockResolvedValue(snapshot(agentId)) },
       domain: domain as never,
       onDiagnostic,
-      registry: {
-        currentInstanceId: vi.fn().mockReturnValue(instanceId),
-        supportsCapability: vi.fn().mockReturnValue(true),
-      },
+      registry,
       sessions: sessions as never,
     }),
   };

--- a/packages/server/src/runtime/connection-registry.ts
+++ b/packages/server/src/runtime/connection-registry.ts
@@ -1,6 +1,7 @@
 import {
   type AgentRuntimeProvider,
   type ImCliProvider,
+  RUNTIME_CAPABILITY,
   RUNTIME_CLIENT_CAPABILITY_TTL_MS,
   RUNTIME_MAX_FRAME_BYTES,
   RUNTIME_PROTOCOL_V1,
@@ -89,6 +90,26 @@ export class ConnectionRegistry {
       current.active !== false &&
       current.negotiatedCapabilities?.[capability] !== undefined
     );
+  }
+
+  capabilityVersion(
+    workspaceComputerId: string,
+    instanceId: string,
+    capability: string,
+    now = Date.now(),
+  ): number | undefined {
+    const current = this.#entries.get(workspaceComputerId);
+    if (!current || current.instanceId !== instanceId || current.active === false) return undefined;
+    const negotiated = current.negotiatedCapabilities?.[capability];
+    if (negotiated !== undefined) return negotiated;
+    if (
+      capability === RUNTIME_CAPABILITY.imCredentialGrant &&
+      now - (current.capabilitiesUpdatedAt ?? Number.NEGATIVE_INFINITY) <= RUNTIME_CLIENT_CAPABILITY_TTL_MS &&
+      current.capabilities?.imCredentialGrant === 1
+    ) {
+      return 1;
+    }
+    return undefined;
   }
 
   supports(

--- a/packages/server/src/runtime/runtime-domain-owner.ts
+++ b/packages/server/src/runtime/runtime-domain-owner.ts
@@ -9,6 +9,7 @@ import {
   type DirectImMessageDeliveryRequest,
   hashTuple,
   type ImMessageDeliveryResult,
+  RUNTIME_CAPABILITY,
   type RuntimeImCredentialGrantRequest,
   type RuntimeImCredentialGrantResult,
   type RuntimeImSteerRequest,
@@ -62,7 +63,7 @@ export interface RuntimeDomainOwnerOptions {
   onTrace?(batch: AgentTraceBatch, context: RuntimeBusinessContext): Promise<void> | void;
   onImCredentialGrant?(
     request: RuntimeImCredentialGrantRequest,
-    context: RuntimeBusinessContext,
+    context: RuntimeBusinessContext & { imCredentialGrantVersion: 1 | 2 },
   ): Promise<RuntimeImCredentialGrantResult>;
   prepareReconcile?(
     workspaceComputerId: string,
@@ -585,7 +586,13 @@ export class RuntimeDomainOwner {
     }
     if (frame.type === "im:credential") {
       if (!this.#options.onImCredentialGrant) return businessFailureResult(frame);
-      return this.#options.onImCredentialGrant(frame, context);
+      const version = this.#registry.capabilityVersion(
+        context.workspaceComputerId,
+        context.instanceId,
+        RUNTIME_CAPABILITY.imCredentialGrant,
+      );
+      if (version !== 1 && version !== 2) return businessFailureResult(frame);
+      return this.#options.onImCredentialGrant(frame, { ...context, imCredentialGrantVersion: version });
     }
     return withSpan(
       "runtime.report",

--- a/packages/server/src/services/im-bindings/im-binding-service.ts
+++ b/packages/server/src/services/im-bindings/im-binding-service.ts
@@ -276,13 +276,20 @@ export class ImBindingService {
 
   async issueRuntimeCredentialGrant(
     request: RuntimeImCredentialGrantRequest,
-    computerAuth: { computerId: string; workspaceComputerId: string; workspaceId: string },
+    computerAuth: {
+      computerId: string;
+      workspaceComputerId: string;
+      workspaceId: string;
+      imCredentialGrantVersion?: 1 | 2;
+    },
   ): Promise<RuntimeImCredentialGrantResult> {
     const [row] = await this.#database
       .select({
         sessionId: sessions.id,
         sessionKind: sessions.kind,
         sessionEndedAt: sessions.endedAt,
+        channelId: sessions.channelId,
+        threadKey: sessions.threadKey,
         binding: imBindings,
         boundAgentId: imBindings.agentId,
         agentWorkspaceComputerId: agents.workspaceComputerId,
@@ -351,6 +358,16 @@ export class ImBindingService {
           appSecret: credential.appSecret,
           teamBrand: binding.externalTeamBrand === "lark" ? "lark" : "feishu",
         },
+        ...(computerAuth.imCredentialGrantVersion === 2
+          ? {
+              outboxContext: {
+                provider: "feishu" as const,
+                sessionKind: row.sessionKind,
+                chatId: row.channelId,
+                ...(row.threadKey ? { threadId: row.threadKey } : {}),
+              },
+            }
+          : {}),
       };
     }
     if (!binding.observedConnectedAt) return rejected("binding_inactive");
@@ -362,6 +379,16 @@ export class ImBindingService {
       status: "succeeded",
       credentialGeneration: binding.credentialGeneration,
       grant: { provider: "slack", botAccessToken: credential.botAccessToken },
+      ...(computerAuth.imCredentialGrantVersion === 2
+        ? {
+            outboxContext: {
+              provider: "slack" as const,
+              sessionKind: row.sessionKind,
+              channelId: row.channelId,
+              ...(row.threadKey ? { threadTs: row.threadKey } : {}),
+            },
+          }
+        : {}),
     };
   }
 

--- a/packages/server/src/services/sessions/session-collaboration-service.ts
+++ b/packages/server/src/services/sessions/session-collaboration-service.ts
@@ -18,7 +18,7 @@ import type { SessionMessageAttempt, SessionMessageOutcome, SessionService } fro
 export interface SessionCollaborationServiceOptions {
   assembler: Pick<EffectiveRuntimeSnapshotAssembler, "assembleForSession">;
   domain: Pick<RuntimeDomainOwner, "requestReconcile" | "requestSessionMessageDelivery">;
-  registry: Pick<ConnectionRegistry, "currentInstanceId" | "supportsCapability">;
+  registry: Pick<ConnectionRegistry, "capabilityVersion" | "currentInstanceId" | "supportsCapability">;
   sessions: Pick<
     SessionService,
     | "authorizeAndRecordMessage"
@@ -113,6 +113,19 @@ export class SessionCollaborationService {
     ) {
       return this.#record(
         response(attempt.message.id, "unreachable", sessionId, "runtime_unavailable"),
+        attempt.attemptCount,
+      );
+    }
+    if (
+      attempt.route.targetSessionKind !== "internal" &&
+      this.#registry.capabilityVersion(
+        attempt.route.targetWorkspaceComputerId,
+        targetInstanceId,
+        RUNTIME_CAPABILITY.imCredentialGrant,
+      ) !== 2
+    ) {
+      return this.#record(
+        response(attempt.message.id, "unreachable", sessionId, "outbox_unavailable"),
         attempt.attemptCount,
       );
     }

--- a/packages/shared/src/__tests__/runtime-domain.test.ts
+++ b/packages/shared/src/__tests__/runtime-domain.test.ts
@@ -13,6 +13,7 @@ import {
   EffectiveRuntimeSnapshotSchema,
   ImMessageDeliveryResultSchema,
   RUNTIME_DIRECT_TEXT_MAX_BYTES,
+  RuntimeImCredentialGrantResultSchema,
   RuntimeImSteerRequestSchema,
   RuntimeImSteerResultSchema,
   runtimeUsageTotalTokens,
@@ -354,6 +355,41 @@ describe("runtime domain contract", () => {
       SessionMessageDeliveryRequestSchema.parse({
         ...delivery,
         content: { kind: "text", text: `${"你".repeat(Math.floor(RUNTIME_DIRECT_TEXT_MAX_BYTES / 3))}你` },
+      }),
+    ).toThrow();
+  });
+
+  it("validates optional v2 outbox context without weakening v1 credential grants", () => {
+    const requestId = randomUUID();
+    const base = {
+      type: "im:credential:result" as const,
+      requestId,
+      status: "succeeded" as const,
+      credentialGeneration: 1,
+      grant: { provider: "slack" as const, botAccessToken: "xoxb-secret" },
+    };
+    expect(RuntimeImCredentialGrantResultSchema.parse(base)).toEqual(base);
+    expect(
+      RuntimeImCredentialGrantResultSchema.parse({
+        ...base,
+        outboxContext: {
+          provider: "slack",
+          sessionKind: "thread",
+          channelId: "C1",
+          threadTs: "1710000000.000001",
+        },
+      }),
+    ).toMatchObject({ outboxContext: { sessionKind: "thread", channelId: "C1" } });
+    expect(() =>
+      RuntimeImCredentialGrantResultSchema.parse({
+        ...base,
+        outboxContext: { provider: "slack", sessionKind: "thread", channelId: "C1" },
+      }),
+    ).toThrow();
+    expect(() =>
+      RuntimeImCredentialGrantResultSchema.parse({
+        ...base,
+        outboxContext: { provider: "feishu", sessionKind: "channel", chatId: "oc_1" },
       }),
     ).toThrow();
   });

--- a/packages/shared/src/__tests__/runtime-protocol.test.ts
+++ b/packages/shared/src/__tests__/runtime-protocol.test.ts
@@ -19,6 +19,17 @@ import {
 } from "../runtime-protocol.js";
 
 describe("runtime protocol", () => {
+  it("negotiates credential grants across v1 and v2", () => {
+    expect(RUNTIME_SERVER_CAPABILITY_OFFERS[RUNTIME_CAPABILITY.imCredentialGrant]).toEqual({ min: 1, max: 2 });
+    expect(RUNTIME_CLIENT_CAPABILITY_OFFERS[RUNTIME_CAPABILITY.imCredentialGrant]).toEqual({ min: 1, max: 2 });
+    expect(
+      negotiateRuntimeCapabilities(
+        { [RUNTIME_CAPABILITY.imCredentialGrant]: { min: 1, max: 1 } },
+        RUNTIME_SERVER_CAPABILITY_OFFERS,
+      ),
+    ).toEqual({ [RUNTIME_CAPABILITY.imCredentialGrant]: 1 });
+  });
+
   it("keeps the v1 handshake strict after the credential-grant capability replacement", () => {
     expect(
       ServerRuntimeFrameSchema.parse({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -233,6 +233,8 @@ export {
   RuntimeImDeliveryContentSchema,
   type RuntimeImHistoryItem,
   RuntimeImHistoryItemSchema,
+  type RuntimeImOutboxContext,
+  RuntimeImOutboxContextSchema,
   type RuntimeImResourceReference,
   RuntimeImResourceReferenceSchema,
   type RuntimeImSteerRequest,

--- a/packages/shared/src/runtime-domain.ts
+++ b/packages/shared/src/runtime-domain.ts
@@ -402,25 +402,70 @@ const RuntimeImCredentialGrantSchema = z.discriminatedUnion("provider", [
     .strict(),
 ]);
 
-export const RuntimeImCredentialGrantResultSchema = z.discriminatedUnion("status", [
-  z
-    .object({
-      type: z.literal("im:credential:result"),
-      requestId: RuntimeRequestIdSchema,
-      status: z.literal("succeeded"),
-      credentialGeneration: z.number().int().safe().positive(),
-      grant: RuntimeImCredentialGrantSchema,
-    })
-    .strict(),
-  z
-    .object({
-      type: z.literal("im:credential:result"),
-      requestId: RuntimeRequestIdSchema,
-      status: z.literal("rejected"),
-      code: z.enum(["binding_inactive", "credential_stale", "placement_stale", "agent_mismatch"]),
-    })
-    .strict(),
-]);
+export const RuntimeImOutboxContextSchema = z
+  .discriminatedUnion("provider", [
+    z
+      .object({
+        provider: z.literal("feishu"),
+        sessionKind: z.enum(["channel", "thread"]),
+        chatId: RuntimeProviderExternalIdSchema,
+        threadId: RuntimeProviderExternalIdSchema.optional(),
+      })
+      .strict(),
+    z
+      .object({
+        provider: z.literal("slack"),
+        sessionKind: z.enum(["channel", "thread"]),
+        channelId: RuntimeProviderExternalIdSchema,
+        threadTs: RuntimeProviderExternalIdSchema.optional(),
+      })
+      .strict(),
+  ])
+  .superRefine((context, refinement) => {
+    const threadReference = context.provider === "feishu" ? context.threadId : context.threadTs;
+    if ((context.sessionKind === "thread") !== Boolean(threadReference)) {
+      refinement.addIssue({
+        code: "custom",
+        path: [context.provider === "feishu" ? "threadId" : "threadTs"],
+        message: `${context.provider === "feishu" ? "Feishu" : "Slack"} thread outbox context must match the Session kind`,
+      });
+    }
+  });
+
+export const RuntimeImCredentialGrantResultSchema = z
+  .discriminatedUnion("status", [
+    z
+      .object({
+        type: z.literal("im:credential:result"),
+        requestId: RuntimeRequestIdSchema,
+        status: z.literal("succeeded"),
+        credentialGeneration: z.number().int().safe().positive(),
+        grant: RuntimeImCredentialGrantSchema,
+        outboxContext: RuntimeImOutboxContextSchema.optional(),
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal("im:credential:result"),
+        requestId: RuntimeRequestIdSchema,
+        status: z.literal("rejected"),
+        code: z.enum(["binding_inactive", "credential_stale", "placement_stale", "agent_mismatch"]),
+      })
+      .strict(),
+  ])
+  .superRefine((result, context) => {
+    if (
+      result.status === "succeeded" &&
+      result.outboxContext &&
+      result.outboxContext.provider !== result.grant.provider
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["outboxContext", "provider"],
+        message: "The outbox context provider must match the credential grant provider",
+      });
+    }
+  });
 
 const ImMessageDeliveryResultBaseSchema = z.object({
   type: z.literal("im:deliver:result"),
@@ -660,6 +705,7 @@ export type RuntimeImHistoryItem = z.infer<typeof RuntimeImHistoryItemSchema>;
 export type RuntimeProviderMessageRef = z.infer<typeof RuntimeProviderMessageRefSchema>;
 export type RuntimeImCredentialGrantRequest = z.infer<typeof RuntimeImCredentialGrantRequestSchema>;
 export type RuntimeImCredentialGrantResult = z.infer<typeof RuntimeImCredentialGrantResultSchema>;
+export type RuntimeImOutboxContext = z.infer<typeof RuntimeImOutboxContextSchema>;
 export type ImMessageDeliveryResult = z.infer<typeof ImMessageDeliveryResultSchema>;
 export type InternalSessionRuntimeOverrides = z.infer<typeof InternalSessionRuntimeOverridesSchema>;
 export type SessionMessageDeliveryRequest = z.infer<typeof SessionMessageDeliveryRequestSchema>;

--- a/packages/shared/src/runtime-protocol.ts
+++ b/packages/shared/src/runtime-protocol.ts
@@ -36,7 +36,7 @@ export const RUNTIME_SERVER_CAPABILITY_OFFERS = {
   [RUNTIME_CAPABILITY.agentTrace]: { min: 1, max: 1 },
   [RUNTIME_CAPABILITY.imDelivery]: { min: 1, max: 1 },
   [RUNTIME_CAPABILITY.imSteer]: { min: 1, max: 1 },
-  [RUNTIME_CAPABILITY.imCredentialGrant]: { min: 1, max: 1 },
+  [RUNTIME_CAPABILITY.imCredentialGrant]: { min: 1, max: 2 },
   [RUNTIME_CAPABILITY.sessionCollaboration]: { min: 2, max: 2 },
   [RUNTIME_CAPABILITY.sessionReconcile]: { min: 1, max: 1 },
   [RUNTIME_CAPABILITY.turnReport]: { min: 1, max: 1 },


### PR DESCRIPTION
## Summary

- negotiate `runtime.imCredentialGrant` v2 and atomically derive non-secret Feishu/Slack outbox context from visible Session scope
- prepare and clean up Turn-scoped IM credentials for visible Session collaboration callbacks while keeping Internal Sessions credential-free
- make callback input complete user-visible delivery through the official provider CLI in the same Turn, with minimal Internal Session/provider-subagent clarification
- synchronize canonical English and Chinese documentation; no database migration or new outbound API

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage -- --maxWorkers=2`
- `pnpm --filter @opentag/server test:integration`
- `git diff --check`

## Breaking changes

None. Credential grant v1 remains supported for ordinary IM Turns; visible collaboration callbacks fail closed with `outbox_unavailable` unless v2 is negotiated.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
