### PR TITLE
fix(server): title Tasks from mention facts in unaddressed messages

### DIFF
--- a/packages/server/src/__tests__/integration/tasks.test.ts
+++ b/packages/server/src/__tests__/integration/tasks.test.ts
@@ -251,6 +251,40 @@ describe("Task debug queries", () => {
     }
   });
 
+  it("titles a Session from a follow-up message that no longer addresses the Agent", async () => {
+    const value = await fixture();
+    try {
+      const message: NormalizedMessage = {
+        messageId: "om_followup",
+        chatId: "oc_debug",
+        chatType: "group",
+        senderId: "ou_human",
+        content: "@_user_2 take another look at the regression",
+        rawContentType: "text",
+        resources: [],
+        mentions: [{ key: "@_user_2", openId: "ou_alice", name: "Alice", isBot: false }],
+        mentionAll: false,
+        mentionedBot: false,
+        createTime: 1_724_025_600_000,
+      };
+      const [event] = normalizeFeishuMessage({ appId: "cli_1", teamId: "workspace_1", message });
+      if (!event) throw new Error("Feishu follow-up event was not normalized");
+      await value.database
+        .update(imBindings)
+        .set({ externalBotId: "ou_bot" })
+        .where(eq(imBindings.id, value.binding.id));
+      await value.database
+        .update(imMessages)
+        .set({ content: event.message.content, providerContext: event.providerContext })
+        .where(eq(imMessages.id, value.message.id));
+
+      const listed = await value.service.list(value.bootstrap.workspaceId, { limit: 50 });
+      expect(listed.tasks[0]?.title).toBe("@Alice take another look at the regression");
+    } finally {
+      await value.sql.end();
+    }
+  });
+
   it("isolates Workspace data and rejects malformed cursors", async () => {
     const value = await fixture();
     try {

--- a/packages/server/src/services/tasks/task-title.test.ts
+++ b/packages/server/src/services/tasks/task-title.test.ts
@@ -1,5 +1,7 @@
+import type { NormalizedMessage } from "@larksuiteoapi/node-sdk";
 import { TASK_AUTO_TITLE_MAX_GRAPHEMES } from "@opentag/shared";
 import { describe, expect, it } from "vitest";
+import { normalizeFeishuMessage } from "../im-bindings/feishu/adapter.js";
 import { deriveTaskTitle } from "./task-title.js";
 
 describe("deriveTaskTitle", () => {
@@ -75,5 +77,33 @@ describe("deriveTaskTitle", () => {
         fallbackText: "<@U_BOT> ask <@U_ALICE> to review",
       }),
     ).toBe("ask <@U_ALICE> to review");
+  });
+
+  it("resolves mentions in a follow-up message that no longer addresses the Agent", () => {
+    const [event] = normalizeFeishuMessage({
+      appId: "cli_1",
+      teamId: "workspace_1",
+      message: {
+        messageId: "om_followup",
+        chatId: "oc_1",
+        chatType: "group",
+        senderId: "ou_human",
+        content: "@_user_2 帮忙看下这个回归",
+        rawContentType: "text",
+        resources: [],
+        mentions: [{ key: "@_user_2", openId: "ou_alice", name: "Alice", isBot: false }],
+        mentionAll: false,
+        mentionedBot: false,
+        createTime: 1_724_025_600_000,
+      } as unknown as NormalizedMessage,
+    });
+    if (!event) throw new Error("Feishu follow-up was not normalized");
+    expect(
+      deriveTaskTitle({
+        ...input,
+        fallbackText: event.message.content.fallbackText,
+        blocks: event.message.content.blocks,
+      }),
+    ).toBe("@Alice 帮忙看下这个回归");
   });
 });

--- a/packages/server/src/services/tasks/task-title.ts
+++ b/packages/server/src/services/tasks/task-title.ts
@@ -35,12 +35,15 @@ function truncateGraphemes(value: string): string {
   return title;
 }
 
+/**
+ * Resolve the stored mention facts, whoever this message addresses.
+ *
+ * A Task is titled from its latest inbound message, and a follow-up rarely mentions the
+ * Agent again, so gating this on the addressed mention would leave those Sessions titled
+ * from raw provider text — a Feishu `@_user_2` placeholder key names nobody.
+ */
 function titleTextFromStructuredBlocks(input: TaskTitleInput): string | undefined {
-  if (!input.addressedExternalId) return undefined;
-  const hasAddressedMention = input.blocks?.some(
-    (block) => block.type === "mention" && block.externalId === input.addressedExternalId,
-  );
-  if (!hasAddressedMention) return undefined;
+  if (!input.blocks?.some((block) => block.type === "mention")) return undefined;
 
   return input.blocks
     ?.map((block) => {


### PR DESCRIPTION
## Summary

Follow-up to #225. That PR records provider mention facts at ingress and resolves them when
deriving a Task title, but the structured-block projection was gated on the message mentioning
the addressed Agent:

```ts
const hasAddressedMention = input.blocks?.some(
  (block) => block.type === "mention" && block.externalId === input.addressedExternalId,
);
if (!hasAddressedMention) return undefined;
```

A Task is titled from its **latest** inbound message. Thread follow-ups do not repeat the
`@agent`, and neither do ambient messages in an `all_message` channel Session — so in the common
case the projection fell back to raw provider text and the resolved labels sitting in `blocks`
went unused. A Feishu title then showed the placeholder key `@_user_2`, which names nobody:
the same class of noise the review of #225 blocked on.

Reproduced on `c160878`:

| latest inbound message | before | after |
| --- | --- | --- |
| Feishu, mentions only a colleague: `@_user_2 帮忙看下这个回归` | `@_user_2 帮忙看下这个回归` | `@Alice 帮忙看下这个回归` |
| Feishu, also mentions the Agent: `@_user_1 请 @_user_2 看下` | `请 @Alice 看下` | `请 @Alice 看下` |

The fix resolves the stored mention facts whenever any mention block is present. Removal is
unchanged: the addressed Agent's routing mention is still the only one dropped, and plain text is
still left alone.

Not included, deliberately: `mentionsFromText` matches only `<@([A-Z0-9]+)>`, so Slack's labelled
`<@U123|handle>` form is not recognised and a message addressed that way is never treated as a
direct mention. That is a routing defect rather than a title one, and is tracked separately.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test` — all pass (shared 75, server 289,
  web 332, client 475, cli 126)
- `pnpm --filter @opentag/server test:integration` — `tasks.test.ts` 6/6 across three runs
- Confirmed both new tests fail against the gate they replace, with
  `Received: "@_user_2 帮忙看下这个回归"`

Added coverage:
- `task-title.test.ts` — a follow-up message driven through real `normalizeFeishuMessage`
- `tasks.test.ts` — the same scenario asserted on the listed Task summary

Note: the integration suite is flaky on my machine under `--maxWorkers=2` — a *different*
unrelated file fails each run with the testcontainers error `Timed out after 10000ms while
waiting for container ports to be bound to the host`. I reproduced this on unmodified `main`
(`c160878`) in a separate worktree, so it is environmental and not introduced here.

## Breaking changes

None. Titles are a read-time projection; stored messages are untouched and `fallbackText`
remains verbatim.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)