### PR TITLE
fix: preserve all-message thread routing

### DIFF
--- a/docs/thread-sessions.md
+++ b/docs/thread-sessions.md
@@ -4,22 +4,23 @@
 
 OpenTag keeps one long-lived Channel Session per Agent, Integration, and IM channel. A top-level message addressed to the Agent is delivered to that Channel Session; OpenTag does not pre-create a Thread Session or require the Agent to reply in a native thread.
 
-The Agent receives the provider-native message reference and `direct` or `ambient` attention in managed context. Its prompt and conversation context determine whether it replies at the top level, starts or continues a native thread, reacts, sends another message, or takes no provider action. Server routing does not encode Feishu- or Slack-specific reply preferences.
+The Agent receives the provider-native message reference and per-target `direct` or `ambient` attention in managed context. Attention describes what the inbound message means to that Session; it is independent of receive mode, Session creation, and credential availability.
 
 ## Lazy Thread continuity
 
-A Thread Session is materialized only after a real inbound provider event carries a thread scope. OpenTag delivers that event directly to the Thread Session when, in priority order:
+A Thread Session is materialized only after a real inbound provider event carries a normalized thread key. Routing then depends on the Agent's receive mode:
 
-1. an active Session already owns the same thread;
-2. the current event directly addresses the Agent; or
-3. the provider supplies a reliable root identifier and that inbound root message was previously delivered directly to the same Agent's Channel Session.
+- In `all_message` mode, a thread-scoped event materializes or wakes the Thread Session even when it does not address the Agent. The Thread delivery remains `ambient` unless trusted direct-continuity evidence exists. The Channel Session receives a separate `ambient` observer copy of the same message.
+- In `mention_only` mode, an unaddressed event is delivered to the Thread Session only after trusted direct continuity has been established. Otherwise it is not delivered and does not materialize a Thread Session.
 
-Without that evidence, OpenTag does not infer Thread ownership. In `all_message` mode, the Channel Session still receives its independent ambient delivery. Ending a Thread Session blocks old root evidence from implicitly reviving it; a later event that directly addresses the Agent may create a new active Session.
+The Thread Session is the reply owner for a message delivered to both scopes. The Channel observer copy provides channel-wide context but must not reply, react, or perform another provider mutation for that message. Reply role does not remove the Channel Session's normal IM credentials or CLI capabilities. If an ended-session fence prevents an ambient Thread delivery, the remaining Channel delivery is an ordinary owner delivery, not an observer copy.
 
-Slack uses `thread_ts` as both the stable thread key and root message identifier. Feishu keeps `thread_id` as the thread key and uses `root_id` only when the provider supplies it; `parent_id` is never guessed to be the root.
+Trusted direct continuity comes only from the current event directly addressing the Agent, a prior direct inbound delivery to the active Thread Session, or a reliable root identifier whose inbound root was delivered directly to the same Agent's Channel Session. Merely creating or waking a Thread Session does not turn ambient messages into direct ones. Ending a Thread Session blocks ambient traffic and old root evidence from reviving it; a new current direct event may create a new active Session.
+
+Slack uses `thread_ts` as both the stable thread key and root message identifier. Feishu keeps `thread_id` as the thread key and uses `root_id` only when the provider supplies it; `parent_id` is never guessed to be the root. A reliable root discovered from an earlier inbound event in the same normalized thread may establish continuity for later events.
 
 ## Bootstrap history
 
-The first direct delivery to a newly materialized Thread Session includes bounded, verifiable inbound context: the visible root message when a reliable root identifier exists, followed by prior messages from the same thread. The current message is excluded from history, and sibling threads are not included.
+The first direct delivery to a newly materialized Thread Session includes bounded, verifiable inbound context: the visible root message when a reliable root identifier exists, followed by prior messages from the same thread. The current message is excluded from history, and sibling threads are not included. Ambient materialization does not by itself add direct bootstrap history or establish direct continuity.
 
 Channel and Thread Sessions remain distinct Runtime scopes. OpenTag does not copy the Channel Runtime transcript, observe Bot outbound messages, or depend on provider CLI send results to create continuity. The Agent can query additional native history with the official provider CLI when needed.

--- a/docs/zh-CN/thread-sessions.md
+++ b/docs/zh-CN/thread-sessions.md
@@ -1,26 +1,27 @@
 # IM Channel 与 Thread Session
 
 > Canonical source: [thread-sessions.md](../thread-sessions.md)
-> Last synced with: 2026-08-21
+> Last synced with: 2026-08-28
 
 OpenTag 为每个 Agent、Integration 和 IM channel 保留一个长期 Channel Session。顶层消息直接寻址 Agent 时，消息会进入该 Channel Session；OpenTag 不会提前创建 Thread Session，也不会要求 Agent 必须在 provider 原生 thread 中回复。
 
-Agent 会在 managed context 中收到 provider 原生消息引用和 `direct` 或 `ambient` attention。Agent 根据 prompt 和对话上下文自主决定平级回复、创建或继续原生 thread、Reaction、发送其他消息或不执行 provider 动作。Server routing 不编码飞书或 Slack 的回复偏好。
+Agent 会在 managed context 中收到 provider 原生消息引用，以及针对当前 target 的 `direct` 或 `ambient` attention。Attention 描述这条入站消息对该 Session 的含义；它与 receive mode、Session 创建方式及凭证可用性相互独立。
 
 ## 惰性 Thread 连续性
 
-只有真实 provider 入站事件带有 thread scope 时，OpenTag 才物化 Thread Session。系统按以下优先级判断是否把该事件 direct 投递给 Thread Session：
+只有真实 provider 入站事件带有规范化 thread key 时，OpenTag 才物化 Thread Session。之后按 Agent 的 receive mode 路由：
 
-1. 已有 active Session 持有同一 thread；
-2. 当前事件直接寻址 Agent；
-3. provider 提供可靠根消息标识，且该入站根消息此前曾 direct 投递给同一 Agent 的 Channel Session。
+- `all_message` 模式下，即使消息没有直接寻址 Agent，带 thread scope 的事件也会物化或唤醒 Thread Session。除非存在可信 direct 连续性证据，否则 Thread delivery 仍为 `ambient`。Channel Session 会同时收到同一消息的独立 `ambient` observer copy。
+- `mention_only` 模式下，未寻址消息只有在已经建立可信 direct 连续性后才投递给 Thread Session；否则既不投递，也不物化 Thread Session。
 
-没有这些证据时，OpenTag 不推断 Thread 所有权。`all_message` 模式下，Channel Session 仍独立收到 ambient delivery。结束 Thread Session 后，旧的 root 证据不能隐式复活它；后续事件若再次直接寻址 Agent，则可以创建新的 active Session。
+当同一消息同时进入两个 scope 时，Thread Session 是 reply owner；Channel observer copy 只用于频道级上下文，不得针对该消息回复、Reaction 或执行其他 provider mutation。Reply role 不会移除 Channel Session 原有的 IM 凭证或 CLI 能力。如果 ended-session fence 阻止了 ambient Thread delivery，剩余的 Channel delivery 是普通 owner，而不是 observer。
 
-Slack 使用 `thread_ts` 同时作为稳定 thread key 和根消息标识。飞书使用 `thread_id` 作为 thread key；只有 provider 提供 `root_id` 时才使用它，绝不把 `parent_id` 猜测成根消息。
+可信 direct 连续性只来自：当前事件直接寻址 Agent、active Thread Session 过去已有 direct 入站 delivery，或 provider 提供可靠根消息标识且该入站根消息曾 direct 投递给同一 Agent 的 Channel Session。仅仅创建或唤醒 Thread Session 不会把 ambient 消息变成 direct。结束 Thread Session 后，ambient 流量和旧 root 证据都不能复活它；新的当前 direct 事件仍可创建新的 active Session。
+
+Slack 使用 `thread_ts` 同时作为稳定 thread key 和根消息标识。飞书使用 `thread_id` 作为 thread key；只有 provider 提供 `root_id` 时才使用它，绝不把 `parent_id` 猜测成根消息。同一规范化 thread 中更早的入站事件若携带可靠 root，后续事件可以复用该事实建立连续性。
 
 ## Bootstrap history
 
-新物化 Thread Session 的首次 direct delivery 会包含有界且可验证的入站上下文：若存在可靠根消息标识，则先包含可见根消息，再包含同一 thread 的历史消息。当前消息不会在 history 中重复，sibling thread 也不会混入。
+新物化 Thread Session 的首次 direct delivery 会包含有界且可验证的入站上下文：若存在可靠根消息标识，则先包含可见根消息，再包含同一 thread 的历史消息。当前消息不会在 history 中重复，sibling thread 也不会混入。Ambient 物化本身不会附加 direct bootstrap history，也不会建立 direct 连续性。
 
 Channel 与 Thread Session 始终是两个不同的 Runtime scope。OpenTag 不复制 Channel Runtime transcript，不观察 Bot 出站消息，也不依赖 provider CLI 发送结果建立连续性。需要更多原生历史时，Agent 可以直接使用官方 provider CLI 查询。

--- a/packages/client/src/__tests__/admission-custody.test.ts
+++ b/packages/client/src/__tests__/admission-custody.test.ts
@@ -280,6 +280,66 @@ describe("TurnCustodyOwner", () => {
     });
     expect(owner.admission.snapshot().client).toBe(1);
   });
+
+  it("rejects observer custody before remembering it under v1 and retries after v2 negotiation", async () => {
+    const fixture = await custodyFixture();
+    let version = 1;
+    const start = vi.fn(async () => undefined);
+    const steer = vi.fn(async (request: RuntimeImSteerRequest) => ({
+      type: "im:steer:result" as const,
+      requestId: request.requestId,
+      deliveryId: request.deliveryId,
+      sessionId: request.sessionId,
+      placementGeneration: request.placementGeneration,
+      rootDeliveryId: request.rootDeliveryId,
+      expectedTurnId: request.expectedTurnId,
+      status: "steered" as const,
+    }));
+    const owner = new TurnCustodyOwner({
+      bindingStore: fixture.store,
+      id: () => "turn-observer",
+      imDeliveryVersion: () => version,
+      imSteerVersion: () => version,
+      reconciler: fixture.reconciler,
+      start,
+      steer,
+    });
+    const observer = {
+      ...delivery(fixture.runtime, "delivery-observer", randomUUID()),
+      replyRole: "observer" as const,
+    };
+    await expect(owner.accept(observer)).resolves.toMatchObject({
+      result: { status: "rejected", reason: "session_not_ready" },
+    });
+    expect(start).not.toHaveBeenCalled();
+    expect(owner.admission.snapshot().client).toBe(0);
+
+    version = 2;
+    await expect(owner.accept(observer)).resolves.toMatchObject({ result: { status: "accepted" } });
+    const steerRequest: RuntimeImSteerRequest = {
+      type: "im:steer",
+      requestId: randomUUID(),
+      deliveryId: "delivery-observer-steer",
+      imMessageId: "message-observer-steer",
+      sessionId: "session-1",
+      agentId: "agent-1",
+      placementGeneration: 1,
+      rootDeliveryId: "delivery-observer",
+      expectedTurnId: "turn-observer",
+      attention: "ambient",
+      replyRole: "observer",
+      content: { kind: "text", text: "observe", providerRef: providerRef("message-observer-steer") },
+    };
+    version = 1;
+    await expect(owner.acceptSteer(steerRequest)).resolves.toMatchObject({
+      status: "deferred",
+      reason: "steer_unsupported",
+    });
+    expect(steer).not.toHaveBeenCalled();
+    version = 2;
+    await expect(owner.acceptSteer(steerRequest)).resolves.toMatchObject({ status: "steered" });
+    expect(steer).toHaveBeenCalledOnce();
+  });
 });
 
 async function custodyFixture() {

--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -106,6 +106,22 @@ describe("AgentTurnRunner", () => {
     expect(context).toContain("Attention does not change provider CLI or credential availability");
   });
 
+  it("compiles observer role independently from attention without removing Session credentials", () => {
+    const request = { ...delivery(), attention: "ambient" as const, replyRole: "observer" as const };
+    const context = buildAgentInput(request).items[0]?.text;
+    expect(context).toContain("Attention: ambient");
+    expect(context).toContain("Reply role: observer");
+    expect(context).toContain("A Thread Session owns the provider reply");
+    expect(context).toContain("do not reply, react, or perform any other provider mutation");
+    expect(context).toContain("The CLI and credentials remain available");
+    expect(context).toContain("does not change this Session's authority or credential availability");
+
+    const ownerContext = buildAgentInput(delivery()).items[0]?.text;
+    expect(ownerContext).toContain("Reply role: owner");
+    expect(ownerContext).toContain("may reply, react, send another provider message, or take no provider action");
+    expect(ownerContext).not.toContain("must reply");
+  });
+
   it("exposes provider-native thread facts without adding a provider reply policy", () => {
     const slackRequest = delivery();
     slackRequest.content.providerRef = {

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -299,6 +299,10 @@ export function buildAgentInput(
     request.attention === "direct"
       ? "A human explicitly addressed this Agent/Session. Handle the message normally, then choose whether to reply, react, send proactively, or take no provider action."
       : "This Agent overheard the message. Use the conversation context to choose whether to reply, react, send proactively, or take no action; by default avoid meaningless, duplicate, intrusive, or attention-seeking intervention.";
+  const observer = request.replyRole === "observer";
+  const replyRoleMeaning = observer
+    ? "A Thread Session owns the provider reply for this same message. Use this Channel delivery only for ambient channel context; do not reply, react, or perform any other provider mutation for this message."
+    : "This Session is the reply owner for this message. It may reply, react, send another provider message, or take no provider action.";
   // Rebind the provider's native user-facing output to OpenTag's runtime console. Merely saying that
   // final text is not auto-sent is too weak when the provider treats its final channel as the reply.
   const context = [
@@ -309,8 +313,9 @@ export function buildAgentInput(
     `Agent revision: ${runtime.revision.agent.sequence}/${runtime.revision.agent.id}`,
     `Session revision: ${runtime.revision.session.sequence}/${runtime.revision.session.id}`,
     ...buildProviderOutboxInstructions({
-      actionInstruction:
-        "If you choose to reply, react, or send proactively, run the provider CLI command before ending this Turn. Choosing to take no provider action remains valid.",
+      actionInstruction: observer
+        ? "Do not run a provider CLI mutation for this observer copy. The CLI and credentials remain available because they are Session capabilities, not reply-role authorization."
+        : "If you choose to reply, react, or send proactively, run the provider CLI command before ending this Turn. Choosing to take no provider action remains valid.",
       provider,
       target: request.content.providerRef,
       targetLabel: "Current provider reference",
@@ -318,6 +323,9 @@ export function buildAgentInput(
     `Attention: ${request.attention}`,
     `Attention meaning: ${attentionMeaning}`,
     "Attention does not change provider CLI or credential availability for this Turn.",
+    `Reply role: ${observer ? "observer" : "owner"}`,
+    `Reply role meaning: ${replyRoleMeaning}`,
+    "Reply role constrains provider actions for this delivery; it does not change this Session's authority or credential availability.",
     "Session instructions:",
     sessionInstructions,
     "</opentag-im-context>",

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -460,6 +460,8 @@ export async function createClientRuntime(
   const custody = new TurnCustodyOwner({
     admission,
     bindingStore,
+    imDeliveryVersion: connection.capabilityVersion.bind(connection, RUNTIME_CAPABILITY.imDelivery),
+    imSteerVersion: connection.capabilityVersion.bind(connection, RUNTIME_CAPABILITY.imSteer),
     reconciler,
     preflight,
     /* v8 ignore next -- late binding is required because custody and runner own each other. */

--- a/packages/client/src/runtime/turn-custody-owner.ts
+++ b/packages/client/src/runtime/turn-custody-owner.ts
@@ -20,6 +20,8 @@ export interface TurnCustodyOwnerOptions {
   admission?: AdmissionController;
   bindingStore: SessionBindingStore;
   id?: () => string;
+  imDeliveryVersion?: () => number | undefined;
+  imSteerVersion?: () => number | undefined;
   maxRememberedRequests?: number;
   now?: () => number;
   preflight?(request: DirectImMessageDeliveryRequest): Promise<InputRejectReason | undefined>;
@@ -60,6 +62,8 @@ export class TurnCustodyOwner {
   readonly #bindingStore: SessionBindingStore;
   readonly #reconciler: SessionReconciler;
   readonly #id: () => string;
+  readonly #imDeliveryVersion: () => number | undefined;
+  readonly #imSteerVersion: () => number | undefined;
   readonly #maxRememberedRequests: number;
   readonly #now: () => number;
   readonly #preflight?: TurnCustodyOwnerOptions["preflight"];
@@ -76,6 +80,8 @@ export class TurnCustodyOwner {
     this.#bindingStore = options.bindingStore;
     this.#reconciler = options.reconciler;
     this.#id = options.id ?? randomUUID;
+    this.#imDeliveryVersion = options.imDeliveryVersion ?? (() => undefined);
+    this.#imSteerVersion = options.imSteerVersion ?? (() => undefined);
     this.#maxRememberedRequests = options.maxRememberedRequests ?? 512;
     this.#now = options.now ?? Date.now;
     this.#preflight = options.preflight;
@@ -87,6 +93,9 @@ export class TurnCustodyOwner {
   }
 
   acceptSteer(request: RuntimeImSteerRequest): Promise<RuntimeImSteerResult> {
+    if (request.replyRole === "observer" && this.#imSteerVersion() !== 2) {
+      return Promise.resolve(deferredSteer(request, "steer_unsupported"));
+    }
     const inputHash = computeRuntimeImSteerInputHash(request);
     const requestHash = hashTuple([request.deliveryId, inputHash]);
     const remembered = this.#steerRequests.get(request.requestId);
@@ -121,6 +130,9 @@ export class TurnCustodyOwner {
   }
 
   accept(request: DirectImMessageDeliveryRequest): Promise<DeliveryDecision> {
+    if (request.replyRole === "observer" && this.#imDeliveryVersion() !== 2) {
+      return Promise.resolve({ result: rejected(request, "session_not_ready") });
+    }
     const inputHash = computeDirectInputHash(request);
     const requestHash = hashTuple([request.deliveryId, inputHash]);
     const remembered = this.#requests.get(request.requestId);

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -347,6 +347,7 @@ async function respondingRuntime(input: {
   computerId: string;
   deliveryGate?: Promise<void>;
   instanceId: string;
+  negotiatedCapabilities?: Readonly<Record<string, number>>;
   requestTimeoutMs?: number;
   reconcileResult?: (frame: Record<string, unknown>) => Promise<Record<string, unknown>> | Record<string, unknown>;
   steerDeferredReason?: "turn_not_running" | "steer_unsupported" | "steer_state_unknown";
@@ -428,30 +429,35 @@ async function respondingRuntime(input: {
       });
     }),
   } as unknown as WebSocket;
-  await registry.register(
-    {
-      capabilities: { imCredentialGrant: 1 },
-      capabilitiesUpdatedAt: Date.now(),
-      computerId: input.computerId,
-      workspaceComputerId: input.workspaceComputerId,
-      workspaceId: input.workspaceId,
-      instanceId: input.instanceId,
-      lastHeartbeatAt: Date.now(),
-      ...(input.steerResult
-        ? {
-            connectionId: crypto.randomUUID(),
-            negotiatedCapabilities: { [RUNTIME_CAPABILITY.imSteer]: 1 },
-            protocolVersion: 2 as const,
-          }
-        : {}),
-      socket,
-    },
-    async () => undefined,
-  );
+  const register = async (negotiatedCapabilities = input.negotiatedCapabilities) =>
+    registry.register(
+      {
+        capabilities: { imCredentialGrant: 1 },
+        capabilitiesUpdatedAt: Date.now(),
+        computerId: input.computerId,
+        workspaceComputerId: input.workspaceComputerId,
+        workspaceId: input.workspaceId,
+        instanceId: input.instanceId,
+        lastHeartbeatAt: Date.now(),
+        ...(input.steerResult || negotiatedCapabilities
+          ? {
+              connectionId: crypto.randomUUID(),
+              negotiatedCapabilities: {
+                ...(input.steerResult ? { [RUNTIME_CAPABILITY.imSteer]: 1 } : {}),
+                ...negotiatedCapabilities,
+              },
+              protocolVersion: 2 as const,
+            }
+          : {}),
+        socket,
+      },
+      async () => undefined,
+    );
+  await register();
   domain = new RuntimeDomainOwner(registry, new PostgresRuntimeCustodyStore(input.database), {
     requestTimeoutMs: input.requestTimeoutMs,
   });
-  return { context, domain, frames, registry };
+  return { context, domain, frames, registry, register };
 }
 
 function turnReportFor(input: {
@@ -2015,6 +2021,105 @@ describe("IM binding persistence", () => {
     }
   });
 
+  it("materializes ambient all-message Threads without treating existence as direct continuity", async () => {
+    const value = await fixture();
+    try {
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
+      const inbox = new ImMessageInbox(value.database);
+      const first = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "ambient-thread-first",
+          externalMessageId: "2200.101",
+          rootExternalMessageId: "2200.100",
+          occurredAt: "2026-08-19T00:00:01.000Z",
+        }),
+      );
+      const firstScopes = await value.database
+        .select({ attention: imMessageDeliveries.attention, kind: sessions.kind, sessionId: sessions.id })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.messageId, first.messageId as string));
+      expect(firstScopes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ attention: "ambient", kind: "thread" }),
+          expect.objectContaining({ attention: "ambient", kind: "channel" }),
+        ]),
+      );
+      expect(firstScopes).toHaveLength(2);
+      const threadSessionId = firstScopes.find((scope) => scope.kind === "thread")?.sessionId;
+
+      const second = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "ambient-thread-second",
+          externalMessageId: "2200.102",
+          rootExternalMessageId: "2200.100",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+        }),
+      );
+      expect(
+        await value.database
+          .select({ attention: imMessageDeliveries.attention, kind: sessions.kind, sessionId: sessions.id })
+          .from(imMessageDeliveries)
+          .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+          .where(eq(imMessageDeliveries.messageId, second.messageId as string)),
+      ).toEqual(
+        expect.arrayContaining([
+          { attention: "ambient", kind: "thread", sessionId: threadSessionId },
+          expect.objectContaining({ attention: "ambient", kind: "channel" }),
+        ]),
+      );
+
+      await value.database.update(agents).set({ receiveMode: "mention_only" }).where(eq(agents.id, value.agent.id));
+      const unaddressed = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "ambient-thread-mention-only",
+          externalMessageId: "2200.103",
+          rootExternalMessageId: "2200.100",
+          occurredAt: "2026-08-19T00:00:03.000Z",
+        }),
+      );
+      expect(unaddressed.deliveryIds).toEqual([]);
+
+      const addressed = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "ambient-thread-direct",
+          externalMessageId: "2200.104",
+          rootExternalMessageId: "2200.100",
+          occurredAt: "2026-08-19T00:00:04.000Z",
+          direct: true,
+        }),
+      );
+      expect(addressed.deliveryIds).toHaveLength(1);
+      const continuation = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "ambient-thread-direct-continuation",
+          externalMessageId: "2200.105",
+          rootExternalMessageId: "2200.100",
+          occurredAt: "2026-08-19T00:00:05.000Z",
+        }),
+      );
+      expect(
+        await value.database
+          .select({ attention: imMessageDeliveries.attention, kind: sessions.kind, sessionId: sessions.id })
+          .from(imMessageDeliveries)
+          .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+          .where(eq(imMessageDeliveries.messageId, continuation.messageId as string)),
+      ).toEqual([{ attention: "direct", kind: "thread", sessionId: threadSessionId }]);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
   it("uses only a reliable Feishu rootId for implicit Thread admission", async () => {
     const value = await unboundFixture();
     try {
@@ -2079,10 +2184,114 @@ describe("IM binding persistence", () => {
       missingRoot.message.threadKey = "omt_2";
       missingRoot.mentions = [];
       expect((await inbox.ingest(imBindingId, 1, missingRoot)).deliveryIds).toEqual([]);
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
+      const allMessageMissingRoot = structuredClone(missingRoot);
+      allMessageMissingRoot.providerEventId = "feishu-thread-missing-root-all-message";
+      allMessageMissingRoot.message.externalId = "om_reply_2_all_message";
+      const ambient = await inbox.ingest(imBindingId, 1, allMessageMissingRoot);
+      expect(
+        await value.database
+          .select({ attention: imMessageDeliveries.attention, kind: sessions.kind })
+          .from(imMessageDeliveries)
+          .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+          .where(eq(imMessageDeliveries.messageId, ambient.messageId as string)),
+      ).toEqual(
+        expect.arrayContaining([
+          { attention: "ambient", kind: "thread" },
+          { attention: "ambient", kind: "channel" },
+        ]),
+      );
+      await value.database.update(agents).set({ receiveMode: "mention_only" }).where(eq(agents.id, value.agent.id));
       missingRoot.providerEventId = "feishu-thread-current-direct";
       missingRoot.message = { ...missingRoot.message, externalId: "om_reply_3" };
       missingRoot.mentions = [{ externalId: "ou_bot", displayName: "Assistant" }];
       expect((await inbox.ingest(imBindingId, 1, missingRoot)).deliveryIds).toHaveLength(1);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("upgrades only undispatched ambient Thread deliveries when a direct root arrives out of order", async () => {
+    const value = await fixture();
+    try {
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
+      const inbox = new ImMessageInbox(value.database);
+      const correlatedReply = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "correlated-reply-first",
+          externalMessageId: "2300.101",
+          rootExternalMessageId: "2300.100",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+        }),
+      );
+      const [correlatedThread] = await value.database
+        .select({ id: imMessageDeliveries.id })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(
+          and(eq(imMessageDeliveries.messageId, correlatedReply.messageId as string), eq(sessions.kind, "thread")),
+        );
+      await value.database
+        .update(imMessageDeliveries)
+        .set({
+          dispatchRequestId: crypto.randomUUID(),
+          dispatchInputHash: "a".repeat(64),
+          dispatchPayload: {} as never,
+        })
+        .where(eq(imMessageDeliveries.id, correlatedThread?.id as string));
+      await inbox.ingest(
+        value.imBindingId,
+        1,
+        revisionEvent({
+          providerEventId: "correlated-direct-root",
+          externalMessageId: "2300.100",
+          operation: "created",
+          occurredAt: "2026-08-19T00:00:01.000Z",
+          revisionKey: "1",
+        }),
+      );
+      expect(
+        await value.database
+          .select({ attention: imMessageDeliveries.attention })
+          .from(imMessageDeliveries)
+          .where(eq(imMessageDeliveries.id, correlatedThread?.id as string)),
+      ).toEqual([{ attention: "ambient" }]);
+
+      const pendingReply = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "pending-reply-first",
+          externalMessageId: "2400.101",
+          rootExternalMessageId: "2400.100",
+          occurredAt: "2026-08-19T00:00:04.000Z",
+        }),
+      );
+      await inbox.ingest(
+        value.imBindingId,
+        1,
+        revisionEvent({
+          providerEventId: "pending-direct-root",
+          externalMessageId: "2400.100",
+          operation: "created",
+          occurredAt: "2026-08-19T00:00:03.000Z",
+          revisionKey: "1",
+        }),
+      );
+      expect(
+        await value.database
+          .select({ attention: imMessageDeliveries.attention, kind: sessions.kind })
+          .from(imMessageDeliveries)
+          .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+          .where(eq(imMessageDeliveries.messageId, pendingReply.messageId as string)),
+      ).toEqual(
+        expect.arrayContaining([
+          { attention: "direct", kind: "thread" },
+          { attention: "ambient", kind: "channel" },
+        ]),
+      );
     } finally {
       await value.sql.end();
     }
@@ -2243,19 +2452,8 @@ describe("IM binding persistence", () => {
   it("converges concurrent first Thread admissions on one active Session and placement", async () => {
     const value = await fixture();
     try {
-      await value.database.update(agents).set({ receiveMode: "mention_only" }).where(eq(agents.id, value.agent.id));
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
       const inbox = new ImMessageInbox(value.database);
-      await inbox.ingest(
-        value.imBindingId,
-        1,
-        revisionEvent({
-          providerEventId: "concurrent-root",
-          externalMessageId: "6000.100",
-          operation: "created",
-          occurredAt: "2026-08-19T00:00:01.000Z",
-          revisionKey: "1",
-        }),
-      );
       const admissions = await Promise.all([
         inbox.ingest(
           value.imBindingId,
@@ -2278,7 +2476,7 @@ describe("IM binding persistence", () => {
           }),
         ),
       ]);
-      expect(admissions.every((admission) => admission.deliveryIds.length === 1)).toBe(true);
+      expect(admissions.every((admission) => admission.deliveryIds.length === 2)).toBe(true);
       const threadRows = await value.database
         .select({ id: sessions.id })
         .from(sessions)
@@ -2294,10 +2492,14 @@ describe("IM binding persistence", () => {
         await value.database
           .select({ sessionId: imMessageDeliveries.sessionId })
           .from(imMessageDeliveries)
+          .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
           .where(
-            inArray(
-              imMessageDeliveries.id,
-              admissions.flatMap((admission) => admission.deliveryIds),
+            and(
+              eq(sessions.kind, "thread"),
+              inArray(
+                imMessageDeliveries.id,
+                admissions.flatMap((admission) => admission.deliveryIds),
+              ),
             ),
           ),
       ).toEqual([{ sessionId: threadRows[0]?.id }, { sessionId: threadRows[0]?.id }]);
@@ -2863,6 +3065,88 @@ describe("IM binding persistence", () => {
         reason: "input_conflict",
         lastErrorCode: "IM_DELIVERY_TERMINAL",
       });
+      runtime.domain.close();
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("fails observer steer closed under v1 and retries it after v2 negotiation", async () => {
+    const value = await fixture();
+    try {
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
+      const instanceId = crypto.randomUUID();
+      await value.database
+        .update(workspaceComputers)
+        .set({ currentInstanceId: instanceId })
+        .where(eq(workspaceComputers.id, value.workspaceComputer.id));
+      const inbox = new ImMessageInbox(value.database);
+      await inbox.ingest(value.imBindingId, 1, inbound("observer-steer-root"));
+      const runtime = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId,
+        negotiatedCapabilities: { [RUNTIME_CAPABILITY.imDelivery]: 2, [RUNTIME_CAPABILITY.imSteer]: 1 },
+        steerResult: "steered",
+        workspaceComputerId: value.workspaceComputer.id,
+        workspaceId: value.bootstrap.workspaceId,
+      });
+      const worker = imDeliveryWorker({ database: value.database, registry: runtime.registry, domain: runtime.domain });
+      await worker.runOnce();
+      const [root] = await value.database.select().from(imMessageDeliveries);
+      if (!root?.turnId) throw new Error("Root Channel Turn custody was not accepted");
+
+      const followUp = await inbox.ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "observer-steer-follow-up",
+          externalMessageId: "7100.101",
+          rootExternalMessageId: "7100.100",
+          occurredAt: "2026-08-19T00:00:02.000Z",
+        }),
+      );
+      const scoped = await value.database
+        .select({ id: imMessageDeliveries.id, kind: sessions.kind })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.messageId, followUp.messageId as string));
+      const channelDelivery = scoped.find((row) => row.kind === "channel");
+      const threadDelivery = scoped.find((row) => row.kind === "thread");
+      if (!channelDelivery || !threadDelivery) throw new Error("Expected observer fan-out deliveries");
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date("2099-01-01T00:00:00.000Z") })
+        .where(eq(imMessageDeliveries.id, threadDelivery.id));
+
+      const beforeV1 = runtime.frames.length;
+      await worker.runOnce();
+      expect(
+        runtime.frames.slice(beforeV1).filter((frame) => (frame as { type?: unknown }).type === "im:steer"),
+      ).toEqual([]);
+      expect(
+        await value.database
+          .select({ dispatchRequestId: imMessageDeliveries.dispatchRequestId, state: imMessageDeliveries.state })
+          .from(imMessageDeliveries)
+          .where(eq(imMessageDeliveries.id, channelDelivery.id)),
+      ).toEqual([{ dispatchRequestId: null, state: "pending" }]);
+
+      await runtime.register({ [RUNTIME_CAPABILITY.imDelivery]: 2, [RUNTIME_CAPABILITY.imSteer]: 2 });
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date(0) })
+        .where(eq(imMessageDeliveries.id, channelDelivery.id));
+      await worker.runOnce();
+      expect(runtime.frames).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "im:steer",
+            deliveryId: channelDelivery.id,
+            rootDeliveryId: root.id,
+            replyRole: "observer",
+          }),
+        ]),
+      );
       runtime.domain.close();
     } finally {
       await value.sql.end();
@@ -4065,6 +4349,105 @@ describe("IM binding persistence", () => {
       await expect(
         third.domain.handle({ ...report, requestId: crypto.randomUUID() }, third.context),
       ).resolves.toMatchObject({ status: "already_recorded" });
+    } finally {
+      for (const owner of owners) owner.close();
+      await value.sql.end();
+    }
+  });
+
+  it("fails observer delivery closed under v1 and retries the same delivery after v2 negotiation", async () => {
+    const value = await fixture();
+    const owners: RuntimeDomainOwner[] = [];
+    try {
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
+      const admitted = await new ImMessageInbox(value.database).ingest(
+        value.imBindingId,
+        1,
+        slackThreadEvent({
+          providerEventId: "observer-capability-message",
+          externalMessageId: "7000.101",
+          rootExternalMessageId: "7000.100",
+          occurredAt: "2026-08-19T00:00:01.000Z",
+        }),
+      );
+      const scoped = await value.database
+        .select({ id: imMessageDeliveries.id, kind: sessions.kind })
+        .from(imMessageDeliveries)
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(eq(imMessageDeliveries.messageId, admitted.messageId as string));
+      const channelDelivery = scoped.find((row) => row.kind === "channel");
+      const threadDelivery = scoped.find((row) => row.kind === "thread");
+      if (!channelDelivery || !threadDelivery) throw new Error("Expected Channel and Thread deliveries");
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date("2099-01-01T00:00:00.000Z") })
+        .where(eq(imMessageDeliveries.id, threadDelivery.id));
+
+      const instanceId = crypto.randomUUID();
+      await value.database
+        .update(workspaceComputers)
+        .set({ currentInstanceId: instanceId })
+        .where(eq(workspaceComputers.id, value.workspaceComputer.id));
+      const runtime = await respondingRuntime({
+        database: value.database,
+        computerId: value.computer.id,
+        instanceId,
+        negotiatedCapabilities: { [RUNTIME_CAPABILITY.imDelivery]: 1 },
+        workspaceComputerId: value.workspaceComputer.id,
+        workspaceId: value.bootstrap.workspaceId,
+      });
+      owners.push(runtime.domain);
+      const worker = imDeliveryWorker({ database: value.database, registry: runtime.registry, domain: runtime.domain });
+      await worker.runOnce();
+      expect(runtime.frames).toEqual([]);
+      expect(
+        await value.database
+          .select({ dispatchRequestId: imMessageDeliveries.dispatchRequestId, state: imMessageDeliveries.state })
+          .from(imMessageDeliveries)
+          .where(eq(imMessageDeliveries.id, channelDelivery.id)),
+      ).toEqual([{ dispatchRequestId: null, state: "pending" }]);
+
+      await runtime.register({ [RUNTIME_CAPABILITY.imDelivery]: 2 });
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date(0) })
+        .where(eq(imMessageDeliveries.id, channelDelivery.id));
+      await worker.runOnce();
+      const observerFrames = runtime.frames.filter(
+        (frame): frame is DirectImMessageDeliveryRequest =>
+          typeof frame === "object" && frame !== null && (frame as { type?: unknown }).type === "im:deliver",
+      );
+      expect(observerFrames).toHaveLength(1);
+      expect(observerFrames[0]).toMatchObject({ deliveryId: channelDelivery.id, replyRole: "observer" });
+
+      const accepted = observerFrames[0];
+      if (!accepted) throw new Error("Expected accepted observer frame");
+      await expect(
+        runtime.domain.handle(
+          turnReportFor({
+            agentId: accepted.agentId,
+            deliveryId: accepted.deliveryId,
+            placementGeneration: accepted.placementGeneration,
+            sessionId: accepted.sessionId,
+            turnId: `turn-${accepted.deliveryId}`,
+          }),
+          runtime.context,
+        ),
+      ).resolves.toMatchObject({ status: "recorded" });
+      await value.database
+        .update(imMessageDeliveries)
+        .set({ nextAttemptAt: new Date(0) })
+        .where(eq(imMessageDeliveries.id, threadDelivery.id));
+      await worker.runOnce();
+      const ownerFrame = runtime.frames.find(
+        (frame): frame is DirectImMessageDeliveryRequest =>
+          typeof frame === "object" &&
+          frame !== null &&
+          (frame as { type?: unknown }).type === "im:deliver" &&
+          (frame as { deliveryId?: unknown }).deliveryId === threadDelivery.id,
+      );
+      expect(ownerFrame).toBeDefined();
+      expect(ownerFrame).not.toHaveProperty("replyRole");
     } finally {
       for (const owner of owners) owner.close();
       await value.sql.end();

--- a/packages/server/src/runtime/im-delivery-worker.ts
+++ b/packages/server/src/runtime/im-delivery-worker.ts
@@ -437,6 +437,14 @@ export class ImDeliveryWorker {
         await this.#recordFailure(claim.id, "IM_DELIVERY_STEER_UNAVAILABLE", claim.claimToken);
         return;
       }
+      const replyRole = await this.#replyRole(row.message.id, row.session.kind, row.message.threadKey);
+      if (
+        replyRole === "observer" &&
+        this.#registry.capabilityVersion(row.computer.id, instanceId, RUNTIME_CAPABILITY.imSteer) !== 2
+      ) {
+        await this.#recordFailure(claim.id, "IM_DELIVERY_OBSERVER_STEER_UNSUPPORTED", claim.claimToken);
+        return;
+      }
       const [target] = await this.#database
         .select({
           id: imMessageDeliveries.id,
@@ -477,6 +485,7 @@ export class ImDeliveryWorker {
         rootDeliveryId: target.id,
         expectedTurnId: claim.expectedTurnId,
         attention: row.delivery.attention,
+        ...(replyRole ? { replyRole } : {}),
         content,
         deadlineAt: row.delivery.expiresAt.toISOString(),
       };
@@ -595,6 +604,16 @@ export class ImDeliveryWorker {
       return;
     }
     const persistedRequest = parsedPersistedRequest?.data;
+    const replyRole = persistedRequest
+      ? persistedRequest.replyRole
+      : await this.#replyRole(row.message.id, row.session.kind, row.message.threadKey);
+    if (
+      replyRole === "observer" &&
+      this.#registry.capabilityVersion(row.computer.id, instanceId, RUNTIME_CAPABILITY.imDelivery) !== 2
+    ) {
+      await this.#recordFailure(deliveryId, "IM_DELIVERY_OBSERVER_UNSUPPORTED", claimToken);
+      return;
+    }
     const runtime =
       persistedRequest?.runtime ?? (await this.#assembleRuntime(deliveryId, row.session.id, "delivery", claimToken));
     if (!runtime) return;
@@ -680,6 +699,7 @@ export class ImDeliveryWorker {
         agentId: row.agent.id,
         placementGeneration: row.placement.generation,
         attention: row.delivery.attention,
+        ...(replyRole ? { replyRole } : {}),
         content,
         runtime,
         deadlineAt: row.delivery.expiresAt.toISOString(),
@@ -1195,6 +1215,27 @@ export class ImDeliveryWorker {
           }
         : {}),
     };
+  }
+
+  async #replyRole(
+    messageId: string,
+    sessionKind: (typeof sessions.$inferSelect)["kind"],
+    threadKey: string | null,
+  ): Promise<"observer" | undefined> {
+    if (sessionKind !== "channel" || threadKey === null) return undefined;
+    const [threadDelivery] = await this.#database
+      .select({ id: imMessageDeliveries.id })
+      .from(imMessageDeliveries)
+      .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+      .where(
+        and(
+          eq(imMessageDeliveries.messageId, messageId),
+          eq(sessions.kind, "thread"),
+          eq(sessions.threadKey, threadKey),
+        ),
+      )
+      .limit(1);
+    return threadDelivery ? "observer" : undefined;
   }
 }
 

--- a/packages/server/src/runtime/runtime-custody-store.ts
+++ b/packages/server/src/runtime/runtime-custody-store.ts
@@ -608,7 +608,8 @@ function deliveryRequestMatches(scope: DeliveryScope, request: DirectImMessageDe
     scope.delivery.id === request.deliveryId &&
     scope.delivery.sessionId === request.sessionId &&
     scope.message.id === request.imMessageId &&
-    scope.agentId === request.agentId
+    scope.agentId === request.agentId &&
+    scope.delivery.attention === request.attention
   );
 }
 
@@ -617,7 +618,8 @@ function steerRequestMatches(scope: DeliveryScope, request: RuntimeImSteerReques
     scope.delivery.id === request.deliveryId &&
     scope.delivery.sessionId === request.sessionId &&
     scope.message.id === request.imMessageId &&
-    scope.agentId === request.agentId
+    scope.agentId === request.agentId &&
+    scope.delivery.attention === request.attention
   );
 }
 

--- a/packages/server/src/services/im/im-message-inbox.ts
+++ b/packages/server/src/services/im/im-message-inbox.ts
@@ -351,17 +351,29 @@ export class ImMessageInbox {
                       event.conversation.externalId,
                       threadKey,
                     );
-                const rootExternalId = threadRootExternalId(event.providerContext);
-                const rootWasDirect =
-                  !existingThread && !direct && !endedThreadExists && rootExternalId
-                    ? await this.#rootWasDirectToChannelSession(
-                        transaction,
-                        imBindingId,
-                        event.conversation.externalId,
-                        rootExternalId,
-                      )
-                    : false;
-                if (existingThread || direct || rootWasDirect) {
+                const rootExternalId = await this.#reliableThreadRootExternalId(
+                  transaction,
+                  imBindingId,
+                  event.conversation.externalId,
+                  threadKey,
+                  event.providerContext,
+                );
+                const rootWasDirect = rootExternalId
+                  ? await this.#rootWasDirectToChannelSession(
+                      transaction,
+                      imBindingId,
+                      event.conversation.externalId,
+                      rootExternalId,
+                    )
+                  : false;
+                const threadWasDirect = existingThread
+                  ? await this.#threadSessionWasDirect(transaction, existingThread.id)
+                  : false;
+                const directContinuity = direct || threadWasDirect || rootWasDirect;
+                const shouldDeliverThread = existingThread
+                  ? directContinuity || scope.agent.receiveMode === "all_message"
+                  : direct || (!endedThreadExists && (rootWasDirect || scope.agent.receiveMode === "all_message"));
+                if (shouldDeliverThread) {
                   const thread =
                     existingThread ??
                     (await this.#ensureChatSession(transaction, {
@@ -373,7 +385,11 @@ export class ImMessageInbox {
                       workspaceComputerId: scope.agent.workspaceComputerId,
                       now,
                     }));
-                  deliveries.push({ sessionId: thread.id, attention: "direct", generation: thread.generation });
+                  deliveries.push({
+                    sessionId: thread.id,
+                    attention: directContinuity ? "direct" : "ambient",
+                    generation: thread.generation,
+                  });
                 }
                 if (scope.agent.receiveMode === "all_message") {
                   const channel = await this.#ensureChatSession(transaction, {
@@ -468,17 +484,37 @@ export class ImMessageInbox {
                   workspaceComputerId: scope.agent.workspaceComputerId,
                   now,
                 });
-                await transaction
-                  .insert(imMessageDeliveries)
-                  .values({
-                    messageId: pending.id,
-                    sessionId: thread.id,
+                const [upgraded] = await transaction
+                  .update(imMessageDeliveries)
+                  .set({
                     attention: "direct",
-                    placementGeneration: thread.generation,
-                    nextAttemptAt: now,
                     expiresAt: new Date(now.getTime() + DIRECT_TTL_MS),
                   })
-                  .onConflictDoNothing();
+                  .where(
+                    and(
+                      eq(imMessageDeliveries.messageId, pending.id),
+                      eq(imMessageDeliveries.sessionId, thread.id),
+                      eq(imMessageDeliveries.state, "pending"),
+                      eq(imMessageDeliveries.attention, "ambient"),
+                      isNull(imMessageDeliveries.dispatchRequestId),
+                      isNull(imMessageDeliveries.dispatchInputHash),
+                      isNull(imMessageDeliveries.dispatchPayload),
+                      isNull(imMessageDeliveries.inputHash),
+                    ),
+                  )
+                  .returning({ id: imMessageDeliveries.id });
+                if (!upgraded)
+                  await transaction
+                    .insert(imMessageDeliveries)
+                    .values({
+                      messageId: pending.id,
+                      sessionId: thread.id,
+                      attention: "direct",
+                      placementGeneration: thread.generation,
+                      nextAttemptAt: now,
+                      expiresAt: new Date(now.getTime() + DIRECT_TTL_MS),
+                    })
+                    .onConflictDoNothing();
                 await this.#expireOverflow(transaction, thread.id, "direct");
               }
             }
@@ -629,5 +665,49 @@ export class ImMessageInbox {
       )
       .limit(1);
     return row !== undefined;
+  }
+
+  async #threadSessionWasDirect(transaction: DatabaseTransaction, sessionId: string): Promise<boolean> {
+    const [row] = await transaction
+      .select({ id: imMessageDeliveries.id })
+      .from(imMessageDeliveries)
+      .innerJoin(imMessages, eq(imMessages.id, imMessageDeliveries.messageId))
+      .where(
+        and(
+          eq(imMessageDeliveries.sessionId, sessionId),
+          eq(imMessageDeliveries.attention, "direct"),
+          eq(imMessages.direction, "inbound"),
+        ),
+      )
+      .limit(1);
+    return row !== undefined;
+  }
+
+  async #reliableThreadRootExternalId(
+    transaction: DatabaseTransaction,
+    imBindingId: string,
+    channelId: string,
+    threadKey: string,
+    currentContext: NormalizedInboundImEvent["providerContext"],
+  ): Promise<string | undefined> {
+    const current = threadRootExternalId(currentContext);
+    if (current) return current;
+    const contexts = await transaction
+      .select({ providerContext: imMessages.providerContext })
+      .from(imMessages)
+      .where(
+        and(
+          eq(imMessages.imBindingId, imBindingId),
+          eq(imMessages.channelId, channelId),
+          eq(imMessages.threadKey, threadKey),
+          eq(imMessages.direction, "inbound"),
+        ),
+      )
+      .orderBy(desc(imMessages.occurredAt), desc(imMessages.providerRevisionKey), desc(imMessages.id));
+    for (const row of contexts) {
+      const rootExternalId = threadRootExternalId(row.providerContext);
+      if (rootExternalId) return rootExternalId;
+    }
+    return undefined;
   }
 }

--- a/packages/shared/src/__tests__/runtime-domain.test.ts
+++ b/packages/shared/src/__tests__/runtime-domain.test.ts
@@ -231,6 +231,18 @@ describe("runtime domain contract", () => {
     ).toBe(computeRuntimeImMessageSemanticHash(steer));
     expect(computeRuntimeImSteerInputHash(steer)).toMatch(/^[a-f0-9]{64}$/);
 
+    const observerDelivery = { ...delivery, replyRole: "observer" as const };
+    const observerSteer = { ...steer, replyRole: "observer" as const };
+    expect(DirectImMessageDeliveryRequestSchema.parse(observerDelivery)).toEqual(observerDelivery);
+    expect(RuntimeImSteerRequestSchema.parse(observerSteer)).toEqual(observerSteer);
+    expect(computeDirectInputHash(observerDelivery)).not.toBe(computeDirectInputHash(delivery));
+    expect(computeRuntimeImMessageSemanticHash(observerDelivery)).toBe(
+      computeRuntimeImMessageSemanticHash(observerSteer),
+    );
+    expect(computeRuntimeImMessageSemanticHash(observerDelivery)).not.toBe(
+      computeRuntimeImMessageSemanticHash(delivery),
+    );
+
     const steered = {
       type: "im:steer:result" as const,
       requestId: steer.requestId,

--- a/packages/shared/src/__tests__/runtime-protocol.test.ts
+++ b/packages/shared/src/__tests__/runtime-protocol.test.ts
@@ -30,6 +30,20 @@ describe("runtime protocol", () => {
     ).toEqual({ [RUNTIME_CAPABILITY.imCredentialGrant]: 1 });
   });
 
+  it("negotiates observer-safe IM delivery and steer independently from owner-compatible v1", () => {
+    expect(RUNTIME_SERVER_CAPABILITY_OFFERS[RUNTIME_CAPABILITY.imDelivery]).toEqual({ min: 1, max: 2 });
+    expect(RUNTIME_SERVER_CAPABILITY_OFFERS[RUNTIME_CAPABILITY.imSteer]).toEqual({ min: 1, max: 2 });
+    expect(
+      negotiateRuntimeCapabilities(
+        {
+          [RUNTIME_CAPABILITY.imDelivery]: { min: 1, max: 1 },
+          [RUNTIME_CAPABILITY.imSteer]: { min: 1, max: 1 },
+        },
+        RUNTIME_SERVER_CAPABILITY_OFFERS,
+      ),
+    ).toEqual({ [RUNTIME_CAPABILITY.imDelivery]: 1, [RUNTIME_CAPABILITY.imSteer]: 1 });
+  });
+
   it("keeps the v1 handshake strict after the credential-grant capability replacement", () => {
     expect(
       ServerRuntimeFrameSchema.parse({
@@ -152,7 +166,8 @@ describe("runtime protocol", () => {
     expect(missingRuntimeCapabilities(["runtime.imDelivery"], negotiated)).toEqual([]);
     expect(missingRuntimeCapabilities(["future.requiredFeature"], negotiated)).toEqual(["future.requiredFeature"]);
     expect(negotiated[RUNTIME_CAPABILITY.sessionCollaboration]).toBe(2);
-    expect(negotiated[RUNTIME_CAPABILITY.imSteer]).toBe(1);
+    expect(negotiated[RUNTIME_CAPABILITY.imDelivery]).toBe(2);
+    expect(negotiated[RUNTIME_CAPABILITY.imSteer]).toBe(2);
     expect(RUNTIME_REQUIRED_CLIENT_CAPABILITIES).not.toContain(RUNTIME_CAPABILITY.sessionCollaboration);
     expect(RUNTIME_REQUIRED_SERVER_CAPABILITIES).not.toContain(RUNTIME_CAPABILITY.sessionCollaboration);
   });

--- a/packages/shared/src/runtime-domain.ts
+++ b/packages/shared/src/runtime-domain.ts
@@ -347,6 +347,7 @@ export const DirectImMessageDeliveryRequestSchema = z
     agentId: RuntimeOpaqueIdSchema,
     placementGeneration: RuntimeSequenceSchema,
     attention: z.enum(["direct", "ambient"]),
+    replyRole: z.literal("observer").optional(),
     content: RuntimeImDeliveryContentSchema,
     runtime: EffectiveRuntimeSnapshotSchema,
     deadlineAt: z.string().datetime({ offset: true }).optional(),
@@ -370,6 +371,7 @@ export const RuntimeImSteerRequestSchema = z
     rootDeliveryId: RuntimeOpaqueIdSchema,
     expectedTurnId: RuntimeOpaqueIdSchema,
     attention: z.enum(["direct", "ambient"]),
+    replyRole: z.literal("observer").optional(),
     content: RuntimeImDeliveryContentSchema,
     deadlineAt: z.string().datetime({ offset: true }).optional(),
   })
@@ -767,7 +769,7 @@ export function computeRuntimeSnapshotHashes(input: EffectiveRuntimeSnapshot): R
 
 export function computeDirectInputHash(input: DirectImMessageDeliveryRequest): string {
   const frame = DirectImMessageDeliveryRequestSchema.parse(input);
-  return hashTuple([
+  const payload = [
     1,
     frame.imMessageId,
     frame.sessionId,
@@ -782,7 +784,8 @@ export function computeDirectInputHash(input: DirectImMessageDeliveryRequest): s
     frame.content.resources ?? [],
     computeRuntimeSnapshotHashes(frame.runtime).effectiveSnapshotHash,
     frame.deadlineAt ?? null,
-  ]);
+  ];
+  return frame.replyRole === "observer" ? hashTuple([2, "observer", ...payload.slice(1)]) : hashTuple(payload);
 }
 
 export function computeRuntimeImMessageSemanticHash(
@@ -792,7 +795,7 @@ export function computeRuntimeImMessageSemanticHash(
     input.type === "im:deliver"
       ? DirectImMessageDeliveryRequestSchema.parse(input)
       : RuntimeImSteerRequestSchema.parse(input);
-  return hashTuple([
+  const payload = [
     1,
     frame.imMessageId,
     frame.sessionId,
@@ -803,7 +806,8 @@ export function computeRuntimeImMessageSemanticHash(
     frame.content.text,
     frame.content.providerRef,
     frame.deadlineAt ?? null,
-  ]);
+  ];
+  return frame.replyRole === "observer" ? hashTuple([2, "observer", ...payload.slice(1)]) : hashTuple(payload);
 }
 
 export function computeRuntimeImSteerInputHash(input: RuntimeImSteerRequest): string {

--- a/packages/shared/src/runtime-protocol.ts
+++ b/packages/shared/src/runtime-protocol.ts
@@ -34,8 +34,8 @@ export const RUNTIME_CAPABILITY = {
 
 export const RUNTIME_SERVER_CAPABILITY_OFFERS = {
   [RUNTIME_CAPABILITY.agentTrace]: { min: 1, max: 1 },
-  [RUNTIME_CAPABILITY.imDelivery]: { min: 1, max: 1 },
-  [RUNTIME_CAPABILITY.imSteer]: { min: 1, max: 1 },
+  [RUNTIME_CAPABILITY.imDelivery]: { min: 1, max: 2 },
+  [RUNTIME_CAPABILITY.imSteer]: { min: 1, max: 2 },
   [RUNTIME_CAPABILITY.imCredentialGrant]: { min: 1, max: 2 },
   [RUNTIME_CAPABILITY.sessionCollaboration]: { min: 2, max: 2 },
   [RUNTIME_CAPABILITY.sessionReconcile]: { min: 1, max: 1 },


### PR DESCRIPTION
## Summary

- Route `all_message` thread-scoped messages to a Thread Session owner and a Channel Session observer without changing per-target attention.
- Preserve trusted direct continuity, ended-session fencing, and atomic out-of-order root upgrades.
- Add negotiated `replyRole` delivery/steer v2 handling with fail-closed rolling compatibility while keeping legacy owner payload hashes stable.
- Document the shared Feishu/Slack thread-routing model in English and Chinese. No database migration is required.

## Validation

- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (100% statements, branches, functions, and lines)
- `pnpm --filter @opentag/server test:integration` (234 tests passed)

## Review

First Tree chat review passed with no blocking findings.
