### PR TITLE
fix(server): recover roots for pending thread events

### DIFF
--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -2310,7 +2310,12 @@ describe("IM binding persistence", () => {
         grantedScopes: [...FEISHU_REQUIRED_TENANT_SCOPES],
       });
       await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
-      const inbox = new ImMessageInbox(value.database);
+      let rootHistoryLookups = 0;
+      const inbox = new ImMessageInbox(value.database, {
+        beforeReliableThreadRootLookup: () => {
+          rootHistoryLookups += 1;
+        },
+      });
 
       const firstReply = revisionEvent({
         providerEventId: "feishu-out-of-order-first-reply",
@@ -2349,6 +2354,31 @@ describe("IM binding persistence", () => {
       laterReply.mentions = [];
       const later = await inbox.ingest(imBindingId, 1, laterReply);
 
+      const unrelatedFirstReply = structuredClone(firstReply);
+      unrelatedFirstReply.providerEventId = "feishu-out-of-order-unrelated-first-reply";
+      unrelatedFirstReply.message.externalId = "om_unrelated_reply_1";
+      unrelatedFirstReply.message.threadKey = "omt_unrelated";
+      unrelatedFirstReply.message.occurredAt = new Date("2026-08-19T00:00:04.000Z");
+      unrelatedFirstReply.providerContext = {
+        provider: "feishu",
+        chatType: "group",
+        threadId: "omt_unrelated",
+        rootId: "om_unrelated_root",
+      };
+      await inbox.ingest(imBindingId, 1, unrelatedFirstReply);
+
+      const unrelatedLaterReply = structuredClone(unrelatedFirstReply);
+      unrelatedLaterReply.providerEventId = "feishu-out-of-order-unrelated-later-reply";
+      unrelatedLaterReply.message.externalId = "om_unrelated_reply_2";
+      unrelatedLaterReply.message.occurredAt = new Date("2026-08-19T00:00:05.000Z");
+      unrelatedLaterReply.providerContext = {
+        provider: "feishu",
+        chatType: "group",
+        threadId: "omt_unrelated",
+      };
+      await inbox.ingest(imBindingId, 1, unrelatedLaterReply);
+      const lookupsBeforeDirectRoot = rootHistoryLookups;
+
       const root = revisionEvent({
         providerEventId: "feishu-out-of-order-direct-root",
         externalMessageId: "om_out_of_order_root",
@@ -2361,6 +2391,7 @@ describe("IM binding persistence", () => {
       root.providerContext = { provider: "feishu", chatType: "group" };
       root.mentions = [{ externalId: "ou_out_of_order_bot", displayName: "Assistant" }];
       await inbox.ingest(imBindingId, 1, root);
+      expect(rootHistoryLookups).toBe(lookupsBeforeDirectRoot);
 
       const upgradedDeliveries = await value.database
         .select({ attention: imMessageDeliveries.attention, externalMessageId: imMessages.externalMessageId })

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -2297,6 +2297,94 @@ describe("IM binding persistence", () => {
     }
   });
 
+  it("upgrades every pending Feishu Thread delivery when later events omit the out-of-order rootId", async () => {
+    const value = await unboundFixture();
+    try {
+      const imBindingId = await value.imBindingService.activateFeishu({
+        agentId: value.agent.id,
+        appId: "cli_out_of_order",
+        teamId: "workspace_out_of_order",
+        botOpenId: "ou_out_of_order_bot",
+        teamBrand: "feishu",
+        appSecret: "secret",
+        grantedScopes: [...FEISHU_REQUIRED_TENANT_SCOPES],
+      });
+      await value.database.update(agents).set({ receiveMode: "all_message" }).where(eq(agents.id, value.agent.id));
+      const inbox = new ImMessageInbox(value.database);
+
+      const firstReply = revisionEvent({
+        providerEventId: "feishu-out-of-order-first-reply",
+        externalMessageId: "om_out_of_order_reply_1",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:02.000Z",
+        revisionKey: "1",
+      });
+      firstReply.externalAppId = "cli_out_of_order";
+      firstReply.externalTeamId = "workspace_out_of_order";
+      firstReply.providerContext = {
+        provider: "feishu",
+        chatType: "group",
+        threadId: "omt_out_of_order",
+        rootId: "om_out_of_order_root",
+      };
+      firstReply.message.threadKey = "omt_out_of_order";
+      firstReply.mentions = [];
+      const first = await inbox.ingest(imBindingId, 1, firstReply);
+
+      const laterReply = revisionEvent({
+        providerEventId: "feishu-out-of-order-later-reply",
+        externalMessageId: "om_out_of_order_reply_2",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:03.000Z",
+        revisionKey: "1",
+      });
+      laterReply.externalAppId = "cli_out_of_order";
+      laterReply.externalTeamId = "workspace_out_of_order";
+      laterReply.providerContext = {
+        provider: "feishu",
+        chatType: "group",
+        threadId: "omt_out_of_order",
+      };
+      laterReply.message.threadKey = "omt_out_of_order";
+      laterReply.mentions = [];
+      const later = await inbox.ingest(imBindingId, 1, laterReply);
+
+      const root = revisionEvent({
+        providerEventId: "feishu-out-of-order-direct-root",
+        externalMessageId: "om_out_of_order_root",
+        operation: "created",
+        occurredAt: "2026-08-19T00:00:01.000Z",
+        revisionKey: "1",
+      });
+      root.externalAppId = "cli_out_of_order";
+      root.externalTeamId = "workspace_out_of_order";
+      root.providerContext = { provider: "feishu", chatType: "group" };
+      root.mentions = [{ externalId: "ou_out_of_order_bot", displayName: "Assistant" }];
+      await inbox.ingest(imBindingId, 1, root);
+
+      const upgradedDeliveries = await value.database
+        .select({ attention: imMessageDeliveries.attention, externalMessageId: imMessages.externalMessageId })
+        .from(imMessageDeliveries)
+        .innerJoin(imMessages, eq(imMessages.id, imMessageDeliveries.messageId))
+        .innerJoin(sessions, eq(sessions.id, imMessageDeliveries.sessionId))
+        .where(
+          and(
+            inArray(imMessageDeliveries.messageId, [first.messageId as string, later.messageId as string]),
+            eq(sessions.kind, "thread"),
+          ),
+        );
+      expect(upgradedDeliveries).toHaveLength(2);
+      expect(upgradedDeliveries).toEqual(
+        expect.arrayContaining([
+          { attention: "direct", externalMessageId: "om_out_of_order_reply_1" },
+          { attention: "direct", externalMessageId: "om_out_of_order_reply_2" },
+        ]),
+      );
+    } finally {
+      await value.sql.end();
+    }
+  });
+
   it("inherits an unknown Feishu revision when only a Thread Session exists", async () => {
     const value = await unboundFixture();
     try {

--- a/packages/server/src/services/im/im-message-inbox.ts
+++ b/packages/server/src/services/im/im-message-inbox.ts
@@ -460,12 +460,28 @@ export class ImMessageInbox {
                 )
                 .orderBy(desc(imMessages.occurredAt), desc(imMessages.providerRevisionKey), desc(imMessages.id));
               const seenExternalMessageIds = new Set<string>();
+              const reliableRootsByThreadKey = new Map<string, string | undefined>();
               for (const pending of pendingThreadMessages) {
                 if (seenExternalMessageIds.has(pending.externalMessageId)) continue;
                 seenExternalMessageIds.add(pending.externalMessageId);
+                let reliableRootExternalId: string | undefined;
+                if (pending.threadKey) {
+                  if (reliableRootsByThreadKey.has(pending.threadKey)) {
+                    reliableRootExternalId = reliableRootsByThreadKey.get(pending.threadKey);
+                  } else {
+                    reliableRootExternalId = await this.#reliableThreadRootExternalId(
+                      transaction,
+                      imBindingId,
+                      event.conversation.externalId,
+                      pending.threadKey,
+                      pending.providerContext,
+                    );
+                    reliableRootsByThreadKey.set(pending.threadKey, reliableRootExternalId);
+                  }
+                }
                 if (
                   !pending.threadKey ||
-                  threadRootExternalId(pending.providerContext) !== event.message.externalId ||
+                  reliableRootExternalId !== event.message.externalId ||
                   (await this.#hasEndedThreadSession(
                     transaction,
                     imBindingId,

--- a/packages/server/src/services/im/im-message-inbox.ts
+++ b/packages/server/src/services/im/im-message-inbox.ts
@@ -45,6 +45,7 @@ export function classifyImInboundPersistenceError(error: unknown): ImInboundPers
 export class ImMessageInbox {
   readonly #afterAdmissionFence: (() => Promise<void>) | undefined;
   readonly #afterMessageAuthority: (() => Promise<void>) | undefined;
+  readonly #beforeReliableThreadRootLookup: (() => void) | undefined;
   readonly #beforeSupersedeDeliveries: (() => Promise<void>) | undefined;
   readonly #database: DatabaseClient;
   readonly #now: () => Date;
@@ -56,6 +57,7 @@ export class ImMessageInbox {
       now?: () => Date;
       afterAdmissionFence?: () => Promise<void>;
       afterMessageAuthority?: () => Promise<void>;
+      beforeReliableThreadRootLookup?: () => void;
       beforeSupersedeDeliveries?: () => Promise<void>;
     } = {},
   ) {
@@ -63,6 +65,7 @@ export class ImMessageInbox {
     this.#now = options.now ?? (() => new Date());
     this.#afterAdmissionFence = options.afterAdmissionFence;
     this.#afterMessageAuthority = options.afterMessageAuthority;
+    this.#beforeReliableThreadRootLookup = options.beforeReliableThreadRootLookup;
     this.#beforeSupersedeDeliveries = options.beforeSupersedeDeliveries;
     this.#sessions = new SessionService(database, { now: this.#now });
   }
@@ -459,29 +462,21 @@ export class ImMessageInbox {
                   ),
                 )
                 .orderBy(desc(imMessages.occurredAt), desc(imMessages.providerRevisionKey), desc(imMessages.id));
+              const reliableRootsByThreadKey = new Map<string, string>();
+              for (const pending of pendingThreadMessages) {
+                if (!pending.threadKey || reliableRootsByThreadKey.has(pending.threadKey)) continue;
+                const reliableRootExternalId = threadRootExternalId(pending.providerContext);
+                if (reliableRootExternalId) {
+                  reliableRootsByThreadKey.set(pending.threadKey, reliableRootExternalId);
+                }
+              }
               const seenExternalMessageIds = new Set<string>();
-              const reliableRootsByThreadKey = new Map<string, string | undefined>();
               for (const pending of pendingThreadMessages) {
                 if (seenExternalMessageIds.has(pending.externalMessageId)) continue;
                 seenExternalMessageIds.add(pending.externalMessageId);
-                let reliableRootExternalId: string | undefined;
-                if (pending.threadKey) {
-                  if (reliableRootsByThreadKey.has(pending.threadKey)) {
-                    reliableRootExternalId = reliableRootsByThreadKey.get(pending.threadKey);
-                  } else {
-                    reliableRootExternalId = await this.#reliableThreadRootExternalId(
-                      transaction,
-                      imBindingId,
-                      event.conversation.externalId,
-                      pending.threadKey,
-                      pending.providerContext,
-                    );
-                    reliableRootsByThreadKey.set(pending.threadKey, reliableRootExternalId);
-                  }
-                }
                 if (
                   !pending.threadKey ||
-                  reliableRootExternalId !== event.message.externalId ||
+                  reliableRootsByThreadKey.get(pending.threadKey) !== event.message.externalId ||
                   (await this.#hasEndedThreadSession(
                     transaction,
                     imBindingId,
@@ -708,6 +703,7 @@ export class ImMessageInbox {
   ): Promise<string | undefined> {
     const current = threadRootExternalId(currentContext);
     if (current) return current;
+    this.#beforeReliableThreadRootLookup?.();
     const contexts = await transaction
       .select({ providerContext: imMessages.providerContext })
       .from(imMessages)


### PR DESCRIPTION
## Summary

- Recover a reliable Feishu root once per normalized `threadKey` while processing an out-of-order direct root.
- Apply that root to every eligible pending ambient Thread delivery, including later events that omit the repeated `rootId`.
- Preserve the existing ended-session fence and the pending/unclaimed atomic upgrade boundary.
- Add a regression covering one same-thread event with `rootId`, a later event without it, and the direct root arriving last.

This follows up on the blocker discovered after #230 was merged.

## Validation

- `pnpm check`
- `pnpm --filter @opentag/server typecheck`
- Targeted Feishu out-of-order root regression
- Full `im-binding.test.ts` (90/90)
- `pnpm --filter @opentag/server test:integration` (236/236)
- `git diff --check`

## Review

First Tree chat review passed with no blocking findings.
