### PR TITLE
refactor(web): clarify Agent messaging status

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -516,7 +516,7 @@ describe("OpenTag Web App Shell", () => {
     expect(within(agentCard as HTMLElement).getByText("Tasks")).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("Tokens")).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("428K")).toBeTruthy();
-    expect(within(agentCard as HTMLElement).getByText("Not connected")).toBeTruthy();
+    expect(within(agentCard as HTMLElement).getByText("Messaging not connected")).toBeTruthy();
     expect(
       within(agentCard as HTMLElement)
         .getByRole("link", { name: "Connect messaging" })
@@ -566,10 +566,10 @@ describe("OpenTag Web App Shell", () => {
     const agentCard = (await screen.findByRole("link", { name: "Open Reviewer" })).closest(".agent-card");
     expect(agentCard).toBeTruthy();
     const status = within(agentCard as HTMLElement)
-      .getByText("Needs attention")
+      .getByText("Computer offline")
       .closest(".ds-status");
     expect(status).toBeTruthy();
-    expect(within(status as HTMLElement).getByText("Computer offline")).toBeTruthy();
+    expect(within(status as HTMLElement).getByText("Cannot receive new work")).toBeTruthy();
     const exit = within(status as HTMLElement).getByRole("link", { name: "View Computer" });
     expect(exit.getAttribute("href")).toBe(`/agents/${agentId}/settings/computer`);
     expect(exit.classList.contains("ds-button--inline")).toBe(true);
@@ -1664,7 +1664,7 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByText("Reviewer")).toBeTruthy();
-    expect(screen.getByText("Unconfirmed")).toBeTruthy();
+    expect(screen.getByText("Computer status unavailable")).toBeTruthy();
     expect(screen.getByText("Unable to confirm readiness")).toBeTruthy();
     expect(screen.queryByText("Ada's Mac · macOS")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
@@ -1686,8 +1686,8 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", "/agents");
     render(<App />);
 
-    expect(await screen.findByText("Needs attention")).toBeTruthy();
-    expect(screen.getByText("Computer not ready")).toBeTruthy();
+    expect(await screen.findByText("Claude Code sign-in required")).toBeTruthy();
+    expect(screen.getByText("Cannot receive new work")).toBeTruthy();
     expect(screen.getByRole("link", { name: "View Computer" }).getAttribute("href")).toBe(
       `/agents/${agentId}/settings/computer`,
     );
@@ -1701,7 +1701,8 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
     // The detail status names the same state as the Agent list, so one failure has one name.
-    expect(screen.getAllByText("Needs attention").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Cannot receive messages").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Needs attention")).toBeNull();
     expect(screen.queryByText("Action required")).toBeNull();
     expect(screen.getByText("Messages cannot currently be handed off to this Agent.")).toBeTruthy();
     expect(screen.getByRole("link", { name: "View messaging" })).toBeTruthy();
@@ -1809,7 +1810,7 @@ describe("OpenTag Web App Shell", () => {
     installApi({ agentListStatus: () => agentListStatus, bound: true });
     window.history.replaceState({}, "", "/agents");
     render(<App />);
-    expect(await screen.findByText("Available")).toBeTruthy();
+    expect(await screen.findByText("Ready")).toBeTruthy();
 
     agentListStatus = 503;
     fireEvent(window, new Event("focus"));
@@ -2045,13 +2046,37 @@ describe("OpenTag Web App Shell", () => {
     expect(JSON.parse(String(request?.[1]?.body))).toEqual({ intent: "replace" });
   });
 
-  it("describes an active binding as needing attention when handoff is unavailable", async () => {
+  it("separates an active channel from an Agent that cannot receive messages", async () => {
     installApi({ bound: true, handoffReady: false });
     window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
     render(<App />);
 
-    expect((await screen.findByText(/Needs attention/)).closest(".ds-status")).toBeTruthy();
+    expect((await screen.findByText("Feishu · Connected")).closest(".ds-status")).toBeTruthy();
+    expect((await screen.findByText("Cannot receive messages")).closest(".ds-status")).toBeTruthy();
+    expect(
+      screen.getByText("Feishu is connected, but messages cannot currently be handed off to this Agent."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Needs attention/)).toBeNull();
     expect(screen.queryByText(/Online/)).toBeNull();
+  });
+
+  it("shows the selected runtime state beside a connected Slack channel", async () => {
+    installApi({
+      bound: true,
+      provider: "slack",
+      runtimeProvider: "codex",
+      computerProviderReadiness: [{ provider: "codex", status: "checking", observedAt: "2026-08-20T00:00:00.000Z" }],
+      handoffReady: false,
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}/settings/messaging`);
+    render(<App />);
+
+    expect((await screen.findByText("Slack · Connected")).closest(".ds-status")).toBeTruthy();
+    expect((await screen.findByText("Checking Codex")).closest(".ds-status")).toBeTruthy();
+    expect(screen.getByText("OpenTag is still checking Codex on Ada's Mac.")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "View Computer" }).getAttribute("href")).toBe(
+      `/agents/${agentId}/settings/computer`,
+    );
   });
 
   it("shows a safe occupied-App recovery and retries the original replacement intent", async () => {

--- a/apps/web/src/agent-detail-capabilities.test.tsx
+++ b/apps/web/src/agent-detail-capabilities.test.tsx
@@ -23,7 +23,7 @@ describe("Agent detail capability previews", () => {
     expect(screen.getByText("opentag-preview")).toBeTruthy();
     expect(screen.getByText("opentag/preview-repository · read and pull requests")).toBeTruthy();
     expect(screen.getByText("Available")).toBeTruthy();
-    expect(screen.getByText("Needs attention")).toBeTruthy();
+    expect(screen.getByText("Connection error")).toBeTruthy();
     expect(screen.queryByRole("button")).toBeNull();
     expect(screen.queryByText(/Feishu|Slack/)).toBeNull();
   });

--- a/apps/web/src/mock/agent-detail-capability-data.ts
+++ b/apps/web/src/mock/agent-detail-capability-data.ts
@@ -3,7 +3,7 @@ export type AgentIntegrationPreview = {
   readonly identity: string;
   readonly purpose: string;
   readonly scope: string;
-  readonly connection: "Connected" | "Needs attention";
+  readonly connection: "Connected" | "Connection error";
   readonly availability: "Available" | "Unavailable";
 };
 
@@ -21,7 +21,7 @@ export const agentIntegrationPreviews: readonly AgentIntegrationPreview[] = [
     identity: "OpenTag preview",
     purpose: "Read issue context while planning and reviewing work.",
     scope: "Shared catalog · read only",
-    connection: "Needs attention",
+    connection: "Connection error",
     availability: "Unavailable",
   },
 ];

--- a/apps/web/src/onboarding/page.test.tsx
+++ b/apps/web/src/onboarding/page.test.tsx
@@ -293,24 +293,26 @@ describe("OnboardingPage", () => {
     expect(within(strip).getByText("Connecting…")).toBeTruthy();
   });
 
-  it.each(["reauthorization_required", "error", "disabled"] as const)(
-    "reports %s as needing attention rather than as a severed transport",
-    async (bindingState) => {
-      installFacts({
-        agents: [agent],
-        computers: [readyComputer],
-        handoff: { bindingState, handoffReady: false },
-      });
-      render(<OnboardingPage user={user} />);
+  it.each([
+    ["reauthorization_required", "Authorization required", "requires authorization for its link to"],
+    ["error", "Connection error", "has a connection error on its link to"],
+    ["disabled", "Disabled", "has disabled its link to"],
+  ] as const)("reports the exact %s state rather than a generic warning", async (bindingState, label, description) => {
+    installFacts({
+      agents: [agent],
+      computers: [readyComputer],
+      handoff: { bindingState, handoffReady: false },
+    });
+    render(<OnboardingPage user={user} />);
 
-      // The accessible name carries the same claim as the label: an expired authorization is not
-      // evidence that Feishu is unreachable, so neither representation may say so.
-      const strip = await screen.findByLabelText("OpenTag Agent needs attention on its link to Feishu");
-      expect(within(strip).getByText("Needs attention")).toBeTruthy();
-      expect(within(strip).queryByText("Disconnected")).toBeNull();
-      expect(strip.getAttribute("data-status")).toBe("attention");
-    },
-  );
+    // The accessible name carries the exact state too; an expired authorization is not evidence
+    // that Feishu is unreachable, so neither representation may call it disconnected.
+    const strip = await screen.findByLabelText(`OpenTag Agent ${description} Feishu`);
+    expect(within(strip).getByText(label)).toBeTruthy();
+    expect(within(strip).queryByText("Disconnected")).toBeNull();
+    expect(within(strip).queryByText("Needs attention")).toBeNull();
+    expect(strip.getAttribute("data-status")).toBe("attention");
+  });
 
   it("reaches Ready from production runtime and authoritative handoff facts", async () => {
     installFacts({

--- a/apps/web/src/onboarding/view.tsx
+++ b/apps/web/src/onboarding/view.tsx
@@ -144,7 +144,14 @@ interface JourneyFact {
  * started, one being provisioned, and one that has broken, and those ask different things of the
  * Account.
  */
-type MessagingLink = "none" | "connecting" | "not-ready" | "attention" | "connected";
+type MessagingLink =
+  | "none"
+  | "connecting"
+  | "not-ready"
+  | "authorization-required"
+  | "connection-error"
+  | "disabled"
+  | "connected";
 
 interface OnboardingJourneyState {
   readonly activeStep: 1 | 2;
@@ -296,7 +303,17 @@ const MESSAGING_LINK_COPY: Record<
   none: { label: "Not connected", description: "not yet connected to", status: "current" },
   connecting: { label: "Connecting…", description: "connecting to", status: "working" },
   "not-ready": { label: "Not ready", description: "not confirmed ready to reach", status: "current" },
-  attention: { label: "Needs attention", description: "needs attention on its link to", status: "attention" },
+  "authorization-required": {
+    label: "Authorization required",
+    description: "requires authorization for its link to",
+    status: "attention",
+  },
+  "connection-error": {
+    label: "Connection error",
+    description: "has a connection error on its link to",
+    status: "attention",
+  },
+  disabled: { label: "Disabled", description: "has disabled its link to", status: "attention" },
   connected: { label: "Connected", description: "connected to", status: "complete" },
 };
 
@@ -304,11 +321,15 @@ function messagingLink(current: OnboardingCurrentState | undefined, messaging: J
   if (messaging === "complete") return "connected";
   if (current?.kind !== "handoff") return "none";
   // `provisioning` is the one state the Server states as an act in progress. `active-not-ready`
-  // names no cause, and `attention` covers an expired authorization as much as a failure, so
-  // neither is reported as movement or as a disconnection.
+  // names no cause, so it is not reported as movement or as a disconnection. Non-active states
+  // retain the exact Server-projected cause instead of collapsing authorization, error and disabled.
   if (current.progress.kind === "provisioning") return "connecting";
   if (current.progress.kind === "active-not-ready") return "not-ready";
-  if (current.progress.kind === "attention") return "attention";
+  if (current.progress.kind === "attention") {
+    if (current.progress.bindingState === "reauthorization_required") return "authorization-required";
+    if (current.progress.bindingState === "error") return "connection-error";
+    return "disabled";
+  }
   return "none";
 }
 
@@ -399,6 +420,17 @@ function onboardingJourney(
         (current.kind === "handoff" || current.kind === "ready" || current.kind === "agent-runtime"
           ? current.agent.runtimeProvider
           : undefined));
+  const runtimeIssue =
+    current.kind === "agent-runtime"
+      ? runtimeAttention(
+          snapshot?.runtime ?? { kind: "unavailable" },
+          current.agent.computerId,
+          current.agent.runtimeProvider,
+        )
+      : undefined;
+  const runtimeIssueCopy = runtimeIssue
+    ? runtimeAttentionCopy(runtimeIssue, snapshot?.targetAgent?.computer.displayName ?? "its Computer")
+    : undefined;
   const messaging: JourneyStatus =
     setupReady || messagingReady ? "complete" : messagingCurrent ? "current" : "upcoming";
   const computerFact = journeyComputerFact(current, snapshot);
@@ -408,7 +440,7 @@ function onboardingJourney(
       : current.kind === "provider"
         ? { label: "Runtime", status: "current", value: "Setup required" }
         : current.kind === "agent-runtime"
-          ? { label: "Runtime", status: "attention", value: "Needs attention" }
+          ? { label: "Runtime", status: "attention", value: runtimeIssueCopy?.title ?? "Runtime unavailable" }
           : { label: "Runtime", status: "ready", value: runtimeProvider ? providerLabel(runtimeProvider) : "Ready" };
   const agentFact: JourneyFact = snapshot?.targetAgent
     ? { label: "Agent", status: agentNeedsAttention ? "attention" : "ready", value: snapshot.targetAgent.displayName }
@@ -430,7 +462,7 @@ function onboardingJourney(
         ? "Your Agent is ready for the first conversation in Feishu."
         : ""
       : "Confirm where your Agent runs, then give it a clear identity.",
-    stageStatus: onboardingStageStatus(current),
+    stageStatus: onboardingStageStatus(current, runtimeIssueCopy?.title),
     stageTitle: prepareComplete
       ? setupReady
         ? "Your Agent is ready"
@@ -473,7 +505,7 @@ function journeyComputerRouteFact(
     : { label: "Computer", status: "attention", value: `${computer.displayName} · Offline` };
 }
 
-function onboardingStageStatus(current: OnboardingCurrentState): string {
+function onboardingStageStatus(current: OnboardingCurrentState, runtimeIssueTitle?: string): string {
   if (current.kind === "workspace") return "Checking OpenTag";
   if (current.kind === "computer") {
     if (current.availability === "none") return "Computer needed";
@@ -482,7 +514,7 @@ function onboardingStageStatus(current: OnboardingCurrentState): string {
   }
   if (current.kind === "provider") return "Runtime needs setup";
   if (current.kind === "agent") return "Runtime ready";
-  if (current.kind === "agent-runtime") return "Runtime needs attention";
+  if (current.kind === "agent-runtime") return runtimeIssueTitle ?? "Runtime unavailable";
   if (current.kind === "handoff") return "Agent prepared";
   return "Setup complete";
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1092,49 +1092,50 @@ function agentCardStatus(agent: AgentListItem): {
   priority: number;
   tone: StatusTone;
 } {
-  if (agent.status === "suspended") return { label: "Paused", priority: 4, tone: "neutral" };
+  const status = agentStatusPresentation(agent);
+  if (agent.status === "suspended") return { label: status.label, priority: 4, tone: status.tone };
   if (!agent.evidenceConfirmed) {
     return { detail: "Unable to refresh", label: "Unconfirmed", priority: 1, tone: "neutral" };
   }
   if (agent.availability.state === "unconfirmed") {
-    return { detail: "Unable to confirm readiness", label: "Unconfirmed", priority: 1, tone: "neutral" };
+    return { detail: "Unable to confirm readiness", label: status.label, priority: 1, tone: status.tone };
   }
   if (agent.availability.state === "action_required") {
-    const { action, detail } =
+    const action =
       agent.availability.reason === "computer_offline"
-        ? { action: { label: "View Computer", section: "computer" as const }, detail: "Computer offline" }
+        ? { label: "View Computer", section: "computer" as const }
         : agent.availability.reason === "runtime_unavailable"
           ? // Provider readiness is observed per Computer, so the Computer page is where it is explained.
-            { action: { label: "View Computer", section: "computer" as const }, detail: "Computer not ready" }
-          : { action: { label: "View messaging", section: "messaging" as const }, detail: "Messaging unavailable" };
+            { label: "View Computer", section: "computer" as const }
+          : { label: "View messaging", section: "messaging" as const };
     return {
       action,
-      detail,
-      label: "Needs attention",
+      detail: "Cannot receive new work",
+      label: status.label,
       priority: 0,
-      tone: "warning",
+      tone: status.tone,
     };
   }
   if (agent.availability.state === "setting_up") {
-    return { detail: "Messaging setup in progress", label: "Setting up", priority: 2, tone: "info" };
+    return { detail: "Messaging setup in progress", label: status.label, priority: 2, tone: status.tone };
   }
   if (agent.availability.state === "not_connected") {
     return {
       action: { label: "Connect messaging", section: "messaging" },
-      detail: "Messaging not connected",
-      label: "Not connected",
+      detail: "Cannot receive new work",
+      label: status.label,
       priority: 2,
-      tone: "neutral",
+      tone: status.tone,
     };
   }
   if (agent.activity.state === "working") {
     return {
-      label: "Working",
+      label: status.label,
       priority: 2,
-      tone: "success",
+      tone: status.tone,
     };
   }
-  return { label: "Available", priority: 3, tone: "success" };
+  return { label: status.label, priority: 3, tone: status.tone };
 }
 
 function formatElapsedCompact(value: string): string {
@@ -1536,10 +1537,11 @@ function AgentObjectHeader({ agent, backToSettings }: { agent: AgentDetailView; 
 
 function AgentRecoveryBanner({ agent }: { agent: AgentDetailView }) {
   const recovery = agentAvailabilityRecovery(agent);
+  const status = agentStatusPresentation(agent);
   return (
-    <section className="agent-recovery-banner" aria-label="Agent needs attention">
+    <section className="agent-recovery-banner" aria-label={`Agent status: ${status.label}`}>
       <div>
-        <strong>{availabilityStateLabel(agent.availability.state)}</strong>
+        <strong>{status.label}</strong>
         <p>{agentRecoveryMessage(agent)}</p>
       </div>
       {recovery ? (
@@ -1716,14 +1718,10 @@ function AccountPage() {
 }
 
 function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
-  const tone = availabilityTone(agent.availability.state);
-  const working = agent.availability.state === "ready" && agent.activity.state === "working";
+  const status = agentStatusPresentation(agent);
   return (
     <div className="agent-availability-line">
-      <StatusIndicator
-        label={working ? "Working" : availabilityStateLabel(agent.availability.state)}
-        tone={working ? "info" : tone}
-      />
+      <StatusIndicator label={status.label} tone={status.tone} />
     </div>
   );
 }
@@ -1879,10 +1877,7 @@ function agentSettingsSummary(agent: AgentDetailView, config: AgentAdminConfig, 
     if (agent.messaging.kind === "unconfirmed") return "Messaging status is temporarily unavailable";
     const binding = agent.messaging.value;
     if (!binding) return "No messaging channel connected";
-    const status =
-      binding.bindingState === "active" && agent.availability.dependencies.handoff.state === "ready"
-        ? "Connected"
-        : messagingConnectionLabel(binding, agent.availability.dependencies.handoff.state);
+    const status = messagingConnectionLabel(binding);
     return `${titleCase(binding.provider)} · @${agent.name} · ${status}`;
   }
   if (section === "identity") return config.displayName;
@@ -2325,6 +2320,8 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
             }}
           >
             {(slackConfiguration) => {
+              const agentStatus = agentStatusPresentation(agent);
+              const agentRecovery = agentAvailabilityRecovery(agent);
               const connectFeishu = async (intent: "create" | "reauthorize" | "replace" = "create") => {
                 setError(undefined);
                 await feishuSetup.start(intent);
@@ -2345,12 +2342,9 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                             </div>
                             <div className="binding-status">
                               <StatusIndicator
-                                detail={`${titleCase(binding.provider)} · ${messagingConnectionLabel(
-                                  binding,
-                                  agent.availability.dependencies.handoff.state,
-                                )}`}
+                                detail={`${titleCase(binding.provider)} · ${messagingConnectionLabel(binding)}`}
                                 label={binding.bot.displayName}
-                                tone={messagingConnectionTone(binding, agent.availability.dependencies.handoff.state)}
+                                tone={messagingConnectionTone(binding)}
                               />
                               <small>
                                 {binding.lastRuntimeObservationAt
@@ -2359,6 +2353,23 @@ function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChang
                                     ? `Validated ${formatDate(binding.lastValidatedAt)}`
                                     : "Not yet observed"}
                               </small>
+                            </div>
+                            <div className="messaging-agent-status">
+                              <StatusIndicator
+                                detail="Agent status"
+                                label={agentStatus.label}
+                                tone={agentStatus.tone}
+                              />
+                              <p>{messagingAgentStatusDescription(agent, binding.provider)}</p>
+                              {agentRecovery && agentRecovery.to !== `/agents/${agent.id}/settings/messaging` ? (
+                                <Link
+                                  className={buttonClassName({ size: "compact", variant: "secondary" })}
+                                  state={{ agent }}
+                                  to={agentRecovery.to}
+                                >
+                                  {agentRecovery.label}
+                                </Link>
+                              ) : null}
                             </div>
                             <dl className="messaging-contact-facts">
                               <div>
@@ -2528,10 +2539,10 @@ function imBindingStateLabel(binding: ImBindingSummary): string {
     return "Permissions update required";
   }
   return {
-    active: "Configured",
+    active: "Connected",
     provisioning: "Setting up",
     reauthorization_required: "Permissions update required",
-    error: "Needs attention",
+    error: "Connection error",
     disabled: "Disabled",
   }[binding.bindingState];
 }
@@ -2547,26 +2558,12 @@ function imBindingTone(binding: ImBindingSummary): StatusTone {
   return tones[binding.bindingState];
 }
 
-function messagingConnectionLabel(
-  binding: ImBindingSummary,
-  handoffState: AgentAvailability["dependencies"]["handoff"]["state"],
-): string {
-  if (binding.bindingState !== "active") return imBindingStateLabel(binding);
-  if (handoffState === "ready") return "Connected";
-  if (handoffState === "setting_up") return "Setting up";
-  if (handoffState === "unconfirmed") return "Unable to confirm";
-  return "Needs attention";
+function messagingConnectionLabel(binding: ImBindingSummary): string {
+  return imBindingStateLabel(binding);
 }
 
-function messagingConnectionTone(
-  binding: ImBindingSummary,
-  handoffState: AgentAvailability["dependencies"]["handoff"]["state"],
-): StatusTone {
-  if (binding.bindingState !== "active") return imBindingTone(binding);
-  if (handoffState === "ready") return "success";
-  if (handoffState === "setting_up") return "info";
-  if (handoffState === "unconfirmed") return "neutral";
-  return "warning";
+function messagingConnectionTone(binding: ImBindingSummary): StatusTone {
+  return imBindingTone(binding);
 }
 
 function AccountSettings({ refreshMe, user }: { refreshMe: () => Promise<MeResponse>; user: MeResponse["user"] }) {
@@ -2842,23 +2839,58 @@ function platformLabel(platform: AgentSummary["computer"]["platform"]): string {
   return "Linux";
 }
 
-function availabilityTone(state: AgentAvailability["state"]): StatusTone {
-  if (state === "ready") return "success";
-  if (state === "setting_up") return "info";
-  if (state === "action_required") return "warning";
-  return "neutral";
+type AgentStatusSource = Pick<AgentListItem, "activity" | "availability">;
+
+function runtimeProviderName(provider: AgentSummary["runtimeProvider"]): string {
+  return provider === "codex" ? "Codex" : "Claude Code";
 }
 
-function availabilityStateLabel(state: AgentAvailability["state"]): string {
-  const labels = {
-    ready: "Ready",
-    action_required: "Needs attention",
-    setting_up: "Setting up",
-    not_connected: "Not connected",
-    suspended: "Suspended",
-    unconfirmed: "Unable to confirm",
-  } satisfies Record<AgentAvailability["state"], string>;
-  return labels[state];
+/**
+ * Presents the exact Agent-level state the viewer can act on. Channel authorization is deliberately
+ * excluded: a connected Slack or Feishu App can coexist with an offline Computer or unavailable
+ * runtime, and collapsing those facts into one warning made the old status impossible to interpret.
+ */
+function agentStatusPresentation(agent: AgentStatusSource): { label: string; tone: StatusTone } {
+  const { availability } = agent;
+  if (availability.state === "ready") {
+    return agent.activity.state === "working"
+      ? { label: "Working", tone: "info" }
+      : { label: "Ready", tone: "success" };
+  }
+  if (availability.state === "suspended") return { label: "Paused", tone: "neutral" };
+  if (availability.state === "setting_up") return { label: "Messaging setup in progress", tone: "info" };
+  if (availability.state === "not_connected") return { label: "Messaging not connected", tone: "neutral" };
+
+  if (availability.state === "unconfirmed") {
+    if (availability.reason === "computer_unconfirmed") {
+      return { label: "Computer status unavailable", tone: "neutral" };
+    }
+    if (availability.reason === "runtime_unconfirmed") {
+      return { label: "Runtime status unavailable", tone: "neutral" };
+    }
+    if (availability.reason === "handoff_unconfirmed") {
+      return { label: "Messaging status unavailable", tone: "neutral" };
+    }
+    return { label: "Agent status unavailable", tone: "neutral" };
+  }
+
+  if (availability.reason === "computer_offline") return { label: "Computer offline", tone: "warning" };
+  if (availability.reason === "runtime_unavailable") {
+    const { provider, status } = availability.dependencies.runtime;
+    const providerName = runtimeProviderName(provider);
+    if (status === "checking") return { label: `Checking ${providerName}`, tone: "info" };
+    if (status === "install") return { label: `${providerName} not installed`, tone: "warning" };
+    if (status === "sign-in") return { label: `${providerName} sign-in required`, tone: "warning" };
+    return { label: `${providerName} unavailable`, tone: "warning" };
+  }
+  if (availability.reason === "im_not_connected") return { label: "Messaging not connected", tone: "neutral" };
+  if (availability.reason === "im_provisioning") return { label: "Messaging setup in progress", tone: "info" };
+  if (availability.reason === "im_reauthorization_required") {
+    return { label: "Messaging authorization required", tone: "warning" };
+  }
+  if (availability.reason === "im_error") return { label: "Messaging connection error", tone: "warning" };
+  if (availability.reason === "handoff_unavailable") return { label: "Cannot receive messages", tone: "warning" };
+  return { label: "Agent unavailable", tone: "warning" };
 }
 
 function sharedConversationLabel(provider: ImBindingSummary["provider"]): string {
@@ -2891,6 +2923,21 @@ function agentAvailabilitySummary(agent: AgentDetailView): string {
   }[agent.availability.state];
 }
 
+function messagingAgentStatusDescription(agent: AgentDetailView, provider: ImBindingSummary["provider"]): string {
+  if (agent.availability.state === "ready") {
+    return agent.activity.state === "working"
+      ? "This Agent is handling a request and remains connected for new messages."
+      : `Ready to receive new messages from ${titleCase(provider)}.`;
+  }
+  if (agent.availability.reason === "computer_offline" || agent.availability.reason === "runtime_unavailable") {
+    return computerRecoveryMessage(agent);
+  }
+  if (agent.availability.reason === "handoff_unavailable") {
+    return `${titleCase(provider)} is connected, but messages cannot currently be handed off to this Agent.`;
+  }
+  return agentRecoveryMessage(agent);
+}
+
 function agentAvailabilityRecovery(agent: AgentDetailView): { label: string; to: string } | undefined {
   if (!true || agent.availability.state === "ready") return undefined;
   if (agent.availability.reason === "agent_suspended") {
@@ -2921,7 +2968,7 @@ function agentRecoveryMessage(agent: AgentDetailView): string {
     im_not_connected: "Connect Feishu or Slack so teammates can assign work to this agent.",
     im_provisioning: "The messaging connection is still being set up.",
     im_reauthorization_required: "The messaging connection needs permission to continue receiving requests.",
-    im_error: "The messaging connection needs attention before it can receive requests.",
+    im_error: "The messaging connection has an error and cannot receive requests.",
     handoff_unavailable: "Messages cannot currently be handed off to this Agent.",
     computer_unconfirmed: "OpenTag could not confirm the assigned Computer's connection.",
     handoff_unconfirmed: "OpenTag could not confirm whether messaging is available.",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2977,6 +2977,22 @@ textarea:focus {
   font-size: var(--text-meta);
 }
 
+.messaging-agent-status {
+  display: grid;
+  align-items: center;
+  gap: 16px;
+  border-bottom: 1px solid var(--border);
+  padding: 18px 0;
+  grid-template-columns: minmax(190px, 0.45fr) minmax(0, 1fr) auto;
+}
+
+.messaging-agent-status p {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--text-ui);
+  line-height: var(--lh-prose);
+}
+
 .messaging-contact-facts {
   display: grid;
   grid-template-columns: minmax(130px, 0.35fr) minmax(0, 1fr);
@@ -3943,6 +3959,11 @@ textarea:focus {
   .messaging-contact-facts {
     grid-template-columns: 1fr;
     gap: 12px;
+  }
+
+  .messaging-agent-status {
+    align-items: flex-start;
+    grid-template-columns: 1fr;
   }
 
   .binding-status,


### PR DESCRIPTION
## Summary

- separate messaging-channel connection from Agent readiness instead of collapsing both into `Needs attention`
- show actionable Agent states such as `Computer offline`, `Checking Codex`, `Codex sign-in required`, and `Cannot receive messages`
- reuse the same Agent status projection across the Agent list, detail header, recovery banner, and Messaging settings
- preserve exact onboarding authorization, connection-error, disabled, and runtime states

## Product behavior

The Messaging page can now truthfully show both facts at once, for example:

- `Slack · Connected`
- `Checking Codex`

When the Server only exposes a combined failed handoff gate, the UI does not guess an internal cause. It reports `Cannot receive messages` and explains that the channel is connected but messages cannot currently be handed off to the Agent.

## Scope

Web presentation and tests only. This PR does not change Slack OAuth, Events handling, workspace installation routing, credentials, database schemas, or lifecycle semantics.

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — 289 tests, 100% statements/branches/functions/lines
- `pnpm --filter @opentag/server test:integration` — 236 tests

Validated at exact head `47eba72b7cfdf8c1203a7f5f35aac2e4957a2b37` after merging `origin/main@1902c70398e248640cd6dd1dcf939d04445ca2b7`.
