### PR TITLE
feat(cli): check the Agent Runtime and messaging CLI in doctor

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -407,8 +407,10 @@ coding agent can run it.
 
 Readiness is published by the installed daemon service, so `doctor` answers for that service rather than for the shell
 it was typed into. It reads the installed service definition and probes with the environment that service actually
-runs with: the account-level variables its service manager provides, plus exactly what the definition declares, plus
-`daemon.env` layered on top the way the daemon layers it. A shell-only `ANTHROPIC_API_KEY`, `CODEX_HOME`, or
+runs with: the account identity from the operating system, the service manager's own variables read from an authority
+that represents the manager rather than from the caller, exactly what the definition declares, and `daemon.env` layered
+on top the way the daemon layers it. A manager variable that cannot be established from that authority is omitted
+rather than borrowed from the shell. A shell-only `ANTHROPIC_API_KEY`, `CODEX_HOME`, or
 `CLAUDE_CONFIG_DIR` therefore never reaches a probe, because it never reaches the daemon either. Every report names the
 definition it answered for.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -401,9 +401,20 @@ processes.
 | `OPENTAG_HOME` | channel-specific | Root for lifecycle-separated `config/`, `data/`, `state/`, and `logs/` (`~/.opentag-dev` in source) |
 
 `doctor` reports one line per check: the OpenTag server, each Agent Runtime CLI, and each messaging CLI. The Agent
-Runtime and messaging CLI checks run the same probes the daemon runs, in the same environment the daemon uses, so they
-never claim a readiness the daemon would not publish. Each failed check prints the exact fix command, phrased so the
-user's own coding agent can run it.
+Runtime and messaging CLI checks run the same probes the daemon runs and use the same readiness vocabulary, so `install`
+and `sign-in` mean what the Server sees. Each failed check prints the exact fix command, phrased so the user's own
+coding agent can run it.
+
+Readiness is published by the installed daemon service, so `doctor` answers for that service rather than for the shell
+it was typed into. It reads the installed service definition, probes with the `PATH` that definition declares, and names
+the definition it used at the end of every report. When a CLI resolves on the invoking shell's `PATH` but not on the
+service's — the usual outcome of installing a runtime after connecting the computer — `doctor` says exactly that and
+tells the operator to re-install the service from the current shell, instead of telling them to install what they
+already have.
+
+`doctor` fails closed rather than guessing: no installed service, a service that is not running, an unreadable
+definition, or an unsupported platform each become a blocking check, and none of them can produce a
+computer-is-ready verdict.
 
 Without `--runtime` or `--im`, one ready Agent Runtime and one ready messaging CLI are enough. Pass `--runtime codex`
 or `--im feishu` (both repeatable) to require a specific one, and `--json` for machine-readable output.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -406,11 +406,15 @@ and `sign-in` mean what the Server sees. Each failed check prints the exact fix 
 coding agent can run it.
 
 Readiness is published by the installed daemon service, so `doctor` answers for that service rather than for the shell
-it was typed into. It reads the installed service definition, probes with the `PATH` that definition declares, and names
-the definition it used at the end of every report. When a CLI resolves on the invoking shell's `PATH` but not on the
-service's — the usual outcome of installing a runtime after connecting the computer — `doctor` says exactly that and
-tells the operator to re-install the service from the current shell, instead of telling them to install what they
-already have.
+it was typed into. It reads the installed service definition and probes with the environment that service actually
+runs with: the account-level variables its service manager provides, plus exactly what the definition declares, plus
+`daemon.env` layered on top the way the daemon layers it. A shell-only `ANTHROPIC_API_KEY`, `CODEX_HOME`, or
+`CLAUDE_CONFIG_DIR` therefore never reaches a probe, because it never reaches the daemon either. Every report names the
+definition it answered for.
+
+The invoking shell's `PATH` is kept for comparison only. When a CLI resolves there but not on the service's `PATH` —
+the usual outcome of installing a runtime after connecting the computer — `doctor` says exactly that and tells the
+operator to re-install the service from the current shell, instead of telling them to install what they already have.
 
 `doctor` fails closed rather than guessing: no installed service, a service that is not running, an unreadable
 definition, or an unsupported platform each become a blocking check, and none of them can produce a

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -418,7 +418,9 @@ operator to re-install the service from the current shell, instead of telling th
 
 `doctor` fails closed rather than guessing: no installed service, a service that is not running, an unreadable
 definition, or an unsupported platform each become a blocking check, and none of them can produce a
-computer-is-ready verdict.
+computer-is-ready verdict. Those paths still apply the same account reconstruction, so an individual check line means
+the same thing everywhere; only the executable search path falls back to the invoking shell, because without a
+definition there is no other one to read.
 
 Without `--runtime` or `--im`, one ready Agent Runtime and one ready messaging CLI are enough. Pass `--runtime codex`
 or `--im feishu` (both repeatable) to require a specific one, and `--json` for machine-readable output.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,8 +400,16 @@ processes.
 | `OPENTAG_REFRESH_TOKEN_TTL_SECONDS` | `2592000` | Refresh-JWT lifetime; only credentials issued before the Better Auth cutover |
 | `OPENTAG_HOME` | channel-specific | Root for lifecycle-separated `config/`, `data/`, `state/`, and `logs/` (`~/.opentag-dev` in source) |
 
-If `doctor` fails, its error category distinguishes configuration, network, HTTP, and invalid-response failures. Confirm
-the server is running and that the configured URL points to its base address.
+`doctor` reports one line per check: the OpenTag server, each Agent Runtime CLI, and each messaging CLI. The Agent
+Runtime and messaging CLI checks run the same probes the daemon runs, in the same environment the daemon uses, so they
+never claim a readiness the daemon would not publish. Each failed check prints the exact fix command, phrased so the
+user's own coding agent can run it.
+
+Without `--runtime` or `--im`, one ready Agent Runtime and one ready messaging CLI are enough. Pass `--runtime codex`
+or `--im feishu` (both repeatable) to require a specific one, and `--json` for machine-readable output.
+
+If the server check fails, its error category distinguishes configuration, network, HTTP, and invalid-response failures.
+Confirm the server is running and that the configured URL points to its base address.
 
 ## Releases
 

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -381,9 +381,13 @@ setup attempt 并记录结果，然后把一条已授权的 binding 写入数据
 失败检查都会打印可直接执行的修复命令，其措辞便于用户自己的 coding agent 直接执行。
 
 readiness 是由已安装的 daemon service 上报的，所以 `doctor` 回答的是那个 service 的处境，而不是敲命令的这个 shell 的。
-它会读取已安装的 service 定义，用定义里声明的 `PATH` 做探测，并在每次报告末尾点名用的是哪个定义文件。当某个 CLI 在
-调用方 shell 的 `PATH` 上能解析、在 service 的 `PATH` 上不能时——这正是「连上 computer 之后才装 runtime」的典型结果
-——`doctor` 会直接这么说，并让用户从当前 shell 重装 service，而不是让他去装一个他已经装过的东西。
+它读取已安装的 service 定义，并用那个 service 真正运行时的环境做探测：service manager 提供的账户级变量 + 定义里显式
+声明的变量 + 按 daemon 的方式叠加的 `daemon.env`。因此只存在于 shell 里的 `ANTHROPIC_API_KEY`、`CODEX_HOME`、
+`CLAUDE_CONFIG_DIR` 不会进入任何探测——因为它们同样不会进入 daemon。每次报告都会点名它为哪个定义文件作答。
+
+调用方 shell 的 `PATH` 只用于对比。当某个 CLI 在 shell 的 `PATH` 上能解析、在 service 的 `PATH` 上不能时——这正是
+「连上 computer 之后才装 runtime」的典型结果——`doctor` 会直接这么说，并让用户从当前 shell 重装 service，而不是让
+他去装一个他已经装过的东西。
 
 `doctor` 宁可 fail closed 也不猜：没有安装 service、service 没在运行、定义读不出来、平台不支持，这四种情况都会变成
 blocking 检查，任何一种都不会给出「这台机器已就绪」的结论。

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -390,7 +390,8 @@ readiness 是由已安装的 daemon service 上报的，所以 `doctor` 回答�
 他去装一个他已经装过的东西。
 
 `doctor` 宁可 fail closed 也不猜：没有安装 service、service 没在运行、定义读不出来、平台不支持，这四种情况都会变成
-blocking 检查，任何一种都不会给出「这台机器已就绪」的结论。
+blocking 检查，任何一种都不会给出「这台机器已就绪」的结论。这些路径同样会做账户重建，因此单条检查结果在任何路径下
+含义一致；只有可执行搜索路径会回落到调用方 shell——没有 definition 时本来也没有别的可读。
 
 不带 `--runtime` 或 `--im` 时，只要有一个可用的 Agent Runtime 和一个可用的消息 CLI 即可通过。可用 `--runtime codex`
 或 `--im feishu`（均可重复）指定必须可用的实现，用 `--json` 输出机器可读结果。

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -377,8 +377,16 @@ setup attempt 并记录结果，然后把一条已授权的 binding 写入数据
 | `OPENTAG_HOME` | 随 channel 而定 | 按生命周期分层的 `config/`、`data/`、`state/`、`logs/` 根目录（源码默认为 `~/.opentag-dev`） |
 
 `doctor` 会逐项输出检查结果：OpenTag Server、各 Agent Runtime CLI、各消息 CLI。Agent Runtime 与消息 CLI 检查
-复用 daemon 的探测逻辑，并使用 daemon 所用的同一份环境，因此不会给出 daemon 不会上报的 readiness。每个失败检查
-都会打印可直接执行的修复命令，其措辞便于用户自己的 coding agent 直接执行。
+复用 daemon 的探测逻辑，并使用同一套 readiness 词汇，因此 `install` 和 `sign-in` 与 Server 看到的含义一致。每个
+失败检查都会打印可直接执行的修复命令，其措辞便于用户自己的 coding agent 直接执行。
+
+readiness 是由已安装的 daemon service 上报的，所以 `doctor` 回答的是那个 service 的处境，而不是敲命令的这个 shell 的。
+它会读取已安装的 service 定义，用定义里声明的 `PATH` 做探测，并在每次报告末尾点名用的是哪个定义文件。当某个 CLI 在
+调用方 shell 的 `PATH` 上能解析、在 service 的 `PATH` 上不能时——这正是「连上 computer 之后才装 runtime」的典型结果
+——`doctor` 会直接这么说，并让用户从当前 shell 重装 service，而不是让他去装一个他已经装过的东西。
+
+`doctor` 宁可 fail closed 也不猜：没有安装 service、service 没在运行、定义读不出来、平台不支持，这四种情况都会变成
+blocking 检查，任何一种都不会给出「这台机器已就绪」的结论。
 
 不带 `--runtime` 或 `--im` 时，只要有一个可用的 Agent Runtime 和一个可用的消息 CLI 即可通过。可用 `--runtime codex`
 或 `--im feishu`（均可重复）指定必须可用的实现，用 `--json` 输出机器可读结果。

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -381,8 +381,9 @@ setup attempt 并记录结果，然后把一条已授权的 binding 写入数据
 失败检查都会打印可直接执行的修复命令，其措辞便于用户自己的 coding agent 直接执行。
 
 readiness 是由已安装的 daemon service 上报的，所以 `doctor` 回答的是那个 service 的处境，而不是敲命令的这个 shell 的。
-它读取已安装的 service 定义，并用那个 service 真正运行时的环境做探测：service manager 提供的账户级变量 + 定义里显式
-声明的变量 + 按 daemon 的方式叠加的 `daemon.env`。因此只存在于 shell 里的 `ANTHROPIC_API_KEY`、`CODEX_HOME`、
+它读取已安装的 service 定义，并用那个 service 真正运行时的环境做探测：来自操作系统的账户身份 + 由「代表 service
+manager 的权威来源」而非调用方提供的 manager 变量 + 定义里显式声明的变量 + 按 daemon 的方式叠加的 `daemon.env`。
+无法从该权威来源确定的 manager 变量会被省略，而不是从 shell 借用。因此只存在于 shell 里的 `ANTHROPIC_API_KEY`、`CODEX_HOME`、
 `CLAUDE_CONFIG_DIR` 不会进入任何探测——因为它们同样不会进入 daemon。每次报告都会点名它为哪个定义文件作答。
 
 调用方 shell 的 `PATH` 只用于对比。当某个 CLI 在 shell 的 `PATH` 上能解析、在 service 的 `PATH` 上不能时——这正是

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -376,7 +376,14 @@ setup attempt 并记录结果，然后把一条已授权的 binding 写入数据
 | `OPENTAG_REFRESH_TOKEN_TTL_SECONDS` | `2592000` | refresh JWT 有效期；仅适用于 Better Auth 切换前签发的凭据 |
 | `OPENTAG_HOME` | 随 channel 而定 | 按生命周期分层的 `config/`、`data/`、`state/`、`logs/` 根目录（源码默认为 `~/.opentag-dev`） |
 
-如果 `doctor` 失败，其错误类别会区分配置、网络、HTTP 和无效响应。请确认 Server 已启动，且配置的 URL 指向其基础地址。
+`doctor` 会逐项输出检查结果：OpenTag Server、各 Agent Runtime CLI、各消息 CLI。Agent Runtime 与消息 CLI 检查
+复用 daemon 的探测逻辑，并使用 daemon 所用的同一份环境，因此不会给出 daemon 不会上报的 readiness。每个失败检查
+都会打印可直接执行的修复命令，其措辞便于用户自己的 coding agent 直接执行。
+
+不带 `--runtime` 或 `--im` 时，只要有一个可用的 Agent Runtime 和一个可用的消息 CLI 即可通过。可用 `--runtime codex`
+或 `--im feishu`（均可重复）指定必须可用的实现，用 `--json` 输出机器可读结果。
+
+如果 Server 检查失败，其错误类别会区分配置、网络、HTTP 和无效响应。请确认 Server 已启动，且配置的 URL 指向其基础地址。
 
 ## 发布
 

--- a/apps/cli/src/__tests__/daemon-service-shared.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-shared.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, isAbsolute, join } from "node:path";
 import { getChannelConfig } from "@opentag/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadDaemonEnvironment } from "../core/daemon/environment.js";
@@ -23,6 +23,7 @@ import {
   quoteSystemdToken,
   resolveCliInvocation,
   runRequired,
+  SERVICE_MANAGER_PATHS,
   SERVICE_MANAGER_PROGRAMS,
   writeFileAtomically,
 } from "../core/daemon/service/shared.js";
@@ -387,22 +388,41 @@ describe("defaultServiceRunner", () => {
     });
   });
 
-  it("governs every program the service backends hand it", async () => {
+  it("registers every program name the backends can hand the runner", async () => {
     // The omission this guards against already happened once: moving resolution into the runner put
     // every program behind this list, and `loginctl` was not on it, so Linux installs silently
-    // stopped enabling lingering.
+    // stopped enabling lingering. Naming a program through `serviceManagerProgram` makes that a
+    // compile error; this catches the two shapes a type cannot — a bare literal handed to the
+    // runner, and a bare default for an injectable manager option.
     const sources = await Promise.all(
       ["launchd.ts", "systemd.ts"].map((file) =>
         readFile(new URL(`../core/daemon/service/${file}`, import.meta.url), "utf8"),
       ),
     );
-    const invoked = new Set(
-      sources.flatMap((source) => [...source.matchAll(/runner\.run\(\s*"([a-z][a-z-]*)"/gu)].map((match) => match[1])),
+    const named = new Set(
+      sources.flatMap((source) =>
+        [
+          ...source.matchAll(/runner\.run\(\s*"([a-z][a-z-]*)"/gu),
+          ...source.matchAll(/\?\?\s*"([a-z][a-z-]*)"/gu),
+          ...source.matchAll(/serviceManagerProgram\("([a-z][a-z-]*)"\)/gu),
+        ].map((match) => match[1]),
+      ),
     );
 
-    expect(invoked.size).toBeGreaterThan(0);
-    for (const program of invoked) {
+    // All three managers in use must be visible here, not just the one introduced as a literal.
+    expect([...named].sort()).toEqual(["launchctl", "loginctl", "systemctl"]);
+    for (const program of named) {
       expect(SERVICE_MANAGER_PROGRAMS).toContain(program);
+    }
+  });
+
+  it("looks for a service manager where a distribution's root actually keeps it", () => {
+    // The absolute-path rule replaced a PATH search, so this list is the supported-platform
+    // contract: a layout missing from it cannot resolve at all rather than degrading.
+    expect(SERVICE_MANAGER_PATHS.systemctl).toContain("/run/current-system/systemd/bin/systemctl");
+    expect(SERVICE_MANAGER_PATHS.loginctl).toContain("/run/current-system/systemd/bin/loginctl");
+    for (const candidates of Object.values(SERVICE_MANAGER_PATHS)) {
+      for (const candidate of candidates) expect(isAbsolute(candidate)).toBe(true);
     }
   });
 });

--- a/apps/cli/src/__tests__/daemon-service-shared.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-shared.test.ts
@@ -23,6 +23,7 @@ import {
   quoteSystemdToken,
   resolveCliInvocation,
   runRequired,
+  SERVICE_MANAGER_PROGRAMS,
   writeFileAtomically,
 } from "../core/daemon/service/shared.js";
 
@@ -371,15 +372,38 @@ describe("defaultServiceRunner", () => {
     }
   });
 
-  it("refuses a program it cannot place at a known system location", async () => {
-    await expect(
-      defaultServiceRunner.run("definitely-not-a-service-manager", [], { timeoutMs: 1_000 }),
-    ).resolves.toEqual({
+  it("says a program it does not govern is a defect, not a missing binary", async () => {
+    // /bin/echo exists and is executable; it is refused because nobody registered it. That has to
+    // read differently from "this host does not have it", or the next omission looks environmental.
+    await expect(defaultServiceRunner.run("echo", ["hello"], { timeoutMs: 1_000 })).resolves.toEqual({
       code: null,
-      stderr: "definitely-not-a-service-manager was not found at a known system location",
+      stderr: "echo is not a program this runner may execute",
       stdout: "",
       timedOut: false,
     });
+    await expect(defaultServiceRunner.run("/bin/echo", ["hello"], { timeoutMs: 1_000 })).resolves.toMatchObject({
+      code: 0,
+      stdout: "hello",
+    });
+  });
+
+  it("governs every program the service backends hand it", async () => {
+    // The omission this guards against already happened once: moving resolution into the runner put
+    // every program behind this list, and `loginctl` was not on it, so Linux installs silently
+    // stopped enabling lingering.
+    const sources = await Promise.all(
+      ["launchd.ts", "systemd.ts"].map((file) =>
+        readFile(new URL(`../core/daemon/service/${file}`, import.meta.url), "utf8"),
+      ),
+    );
+    const invoked = new Set(
+      sources.flatMap((source) => [...source.matchAll(/runner\.run\(\s*"([a-z][a-z-]*)"/gu)].map((match) => match[1])),
+    );
+
+    expect(invoked.size).toBeGreaterThan(0);
+    for (const program of invoked) {
+      expect(SERVICE_MANAGER_PROGRAMS).toContain(program);
+    }
   });
 });
 

--- a/apps/cli/src/__tests__/daemon-service-shared.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-shared.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { getChannelConfig } from "@opentag/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadDaemonEnvironment } from "../core/daemon/environment.js";
@@ -15,6 +15,7 @@ import {
   acquireServiceTargetLease,
   buildServicePath,
   canonicalizeServiceHome,
+  defaultServiceRunner,
   deriveServiceIdentity,
   escapeXml,
   quotePosix,
@@ -348,6 +349,37 @@ describe("daemon service primitives", () => {
         12,
       ),
     ).rejects.toThrow("timed out after 12ms");
+  });
+});
+
+describe("defaultServiceRunner", () => {
+  it("cannot be redirected to a service manager on the caller's PATH", async () => {
+    const directory = await temporaryDirectory("opentag-fake-launchctl-");
+    await writeFile(join(directory, "launchctl"), "#!/bin/sh\necho FAKE-LAUNCHCTL\n", { mode: 0o755 });
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${directory}${delimiter}${originalPath ?? ""}`;
+    try {
+      // A hostile launchctl first on PATH decides what OpenTag believes about its own daemon.
+      const result = await defaultServiceRunner.run("launchctl", ["print", "gui/0/opentag-absent"], {
+        timeoutMs: 5_000,
+      });
+
+      expect(result.stdout).not.toContain("FAKE-LAUNCHCTL");
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+    }
+  });
+
+  it("refuses a program it cannot place at a known system location", async () => {
+    await expect(
+      defaultServiceRunner.run("definitely-not-a-service-manager", [], { timeoutMs: 1_000 }),
+    ).resolves.toEqual({
+      code: null,
+      stderr: "definitely-not-a-service-manager was not found at a known system location",
+      stdout: "",
+      timedOut: false,
+    });
   });
 });
 

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -19,7 +19,13 @@ import { renderLaunchdPlist } from "../core/daemon/service/launchd.js";
 import { renderSystemdUnit } from "../core/daemon/service/systemd.js";
 import type { DaemonServiceState } from "../core/daemon/service/types.js";
 import { checkAgentRuntimes, checkImClis } from "../core/diagnostics/checks.js";
-import { type DoctorOptions, renderDoctorJson, resolveServerUrl, runDoctor } from "../core/diagnostics/doctor.js";
+import {
+  type DoctorOptions,
+  renderDoctorJson,
+  resolveServerUrl,
+  runDoctor,
+  serviceProcessEnvironment,
+} from "../core/diagnostics/doctor.js";
 import { readDaemonServiceEnvironment } from "../core/diagnostics/service-environment.js";
 
 const directories: string[] = [];
@@ -199,6 +205,48 @@ describe("runDoctor", () => {
   });
 });
 
+describe("serviceProcessEnvironment", () => {
+  it("drops shell-only credentials and provider overrides the service never receives", () => {
+    const environment = serviceProcessEnvironment(
+      {
+        ANTHROPIC_API_KEY: "shell-only",
+        CLAUDE_CODE_OAUTH_TOKEN: "shell-only",
+        CLAUDE_CONFIG_DIR: "/shell/claude",
+        CODEX_HOME: "/shell/codex",
+        HOME: "/Users/tester",
+        PATH: "/shell/bin",
+        SHELL: "/bin/zsh",
+        TMPDIR: "/tmp/user",
+        USER: "tester",
+      },
+      {
+        environment: { OPENTAG_HOME: "/Users/tester/.opentag", OPENTAG_SERVICE_MODE: "1", PATH: "/service/bin" },
+        platform: "launchd",
+      },
+    );
+
+    // A launchd job receives the account's own variables plus exactly what its definition declares.
+    expect(environment).toEqual({
+      HOME: "/Users/tester",
+      OPENTAG_HOME: "/Users/tester/.opentag",
+      OPENTAG_SERVICE_MODE: "1",
+      PATH: "/service/bin",
+      SHELL: "/bin/zsh",
+      TMPDIR: "/tmp/user",
+      USER: "tester",
+    });
+  });
+
+  it("gives a systemd unit its own manager variables", () => {
+    const environment = serviceProcessEnvironment(
+      { HOME: "/home/tester", TMPDIR: "/tmp/user", XDG_RUNTIME_DIR: "/run/user/1000" },
+      { environment: { PATH: "/service/bin" }, platform: "systemd" },
+    );
+
+    expect(environment).toEqual({ HOME: "/home/tester", PATH: "/service/bin", XDG_RUNTIME_DIR: "/run/user/1000" });
+  });
+});
+
 describe("readDaemonServiceEnvironment", () => {
   it("reads the PATH out of a systemd unit", async () => {
     const home = await temporaryDirectory("opentag-service-systemd-");
@@ -216,10 +264,19 @@ describe("readDaemonServiceEnvironment", () => {
 
     await expect(
       readDaemonServiceEnvironment({
+        home,
         manager: statusManager({ definitionPath, platform: "systemd", state: "active" }),
         platform: "linux",
       }),
-    ).resolves.toEqual({ definitionPath, kind: "installed", path: "/opt/tools/bin:/usr/bin", state: "active" });
+    ).resolves.toEqual({
+      definitionPath,
+      environment: { OPENTAG_HOME: home, OPENTAG_SERVICE_MODE: "1", PATH: "/opt/tools/bin:/usr/bin" },
+      kind: "installed",
+      path: "/opt/tools/bin:/usr/bin",
+      platform: "systemd",
+      serviceHome: home,
+      state: "active",
+    });
   });
 
   it("fails closed when an installed definition declares no PATH", async () => {
@@ -229,6 +286,7 @@ describe("readDaemonServiceEnvironment", () => {
 
     await expect(
       readDaemonServiceEnvironment({
+        home,
         manager: statusManager({ definitionPath, platform: "launchd", state: "active" }),
         platform: "darwin",
       }),
@@ -277,6 +335,46 @@ describe("daemon service environment", () => {
       "active; checks below use the PATH it runs with",
     );
     expect(result.message).toMatch(/CLI checks used the PATH declared by .*opentag\.plist/u);
+  });
+
+  it("refuses a service that belongs to another OpenTag home", async () => {
+    const other = await temporaryDirectory("opentag-doctor-other-home-");
+    const options = await doctorOptions({ service: { home: other } });
+
+    const result = await runDoctor(options);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.checks.find((check) => check.id === "daemon-service")).toMatchObject({
+      detail: `active for another OpenTag home (${other}), not ${options.home as string}`,
+      status: "error",
+    });
+    expect(result.message).not.toContain("can run an OpenTag agent on");
+  });
+
+  it("keeps shell-only credentials and provider overrides out of what it probes with", async () => {
+    const captured: NodeJS.ProcessEnv[] = [];
+    const options = await doctorOptions({
+      // A launchd job never sees these; only the operator's shell has them.
+      env: { ANTHROPIC_API_KEY: "shell-only", CLAUDE_CONFIG_DIR: "/shell/claude", PATH: "/shell/bin" },
+      service: { path: "/service/bin" },
+    });
+
+    const result = await runDoctor({
+      ...options,
+      runtimeProbe: async (provider, _signal, environment) => {
+        captured.push(environment);
+        return provider === "codex" ? READY : NOT_INSTALLED;
+      },
+    });
+
+    expect(captured).toHaveLength(2);
+    for (const environment of captured) {
+      expect(environment.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(environment.CLAUDE_CONFIG_DIR).toBeUndefined();
+      expect(environment.PATH).toBe("/service/bin");
+    }
+    // The shell PATH stays available for the divergence diagnosis, never for probing.
+    expect(result.checks.find((check) => check.id === "runtime:codex")?.status).toBe("ok");
   });
 
   it("explains a CLI the operator can run but the daemon cannot", async () => {
@@ -347,7 +445,7 @@ async function doctorOptions(overrides: {
   imStatuses?: Partial<Record<ImCliProvider, "install" | "ready" | "unavailable">>;
   runtimeResults?: Partial<Record<AgentRuntimeProvider, AgentRuntimeProbeResult>>;
   runtimes?: readonly AgentRuntimeProvider[];
-  service?: { path?: string; state?: DaemonServiceState } | "not-installed";
+  service?: { home?: string; path?: string; state?: DaemonServiceState } | "not-installed";
 }): Promise<DoctorOptions> {
   const home = await temporaryDirectory("opentag-doctor-");
   return {
@@ -383,15 +481,16 @@ function statusManager(info: {
 /** Stands in for launchd: a real plist on disk, so the PATH parser is exercised for real. */
 async function fakeServiceManager(
   home: string,
-  service: { path?: string; state?: DaemonServiceState } | "not-installed" = {},
+  service: { home?: string; path?: string; state?: DaemonServiceState } | "not-installed" = {},
 ): Promise<DaemonServiceManager> {
   const definitionPath = resolve(home, "opentag.plist");
   const state: DaemonServiceState = service === "not-installed" ? "not-installed" : (service.state ?? "active");
+  const serviceHome = service === "not-installed" ? home : (service.home ?? home);
   if (service !== "not-installed") {
     await writeFile(
       definitionPath,
       renderLaunchdPlist({
-        home,
+        home: serviceHome,
         label: "opentag-test",
         path: service.path ?? "/usr/bin:/bin",
         stderrPath: resolve(home, "err.log"),
@@ -402,6 +501,7 @@ async function fakeServiceManager(
     );
   }
   const info = {
+    configuredHome: serviceHome,
     currentHome: home,
     definitionPath,
     logHint: resolve(home, "logs"),

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -1,6 +1,31 @@
-import { ServerHealthConfigurationError, ServerHealthNetworkError } from "@opentag/client";
-import { describe, expect, it, vi } from "vitest";
-import { resolveServerUrl, runDoctor } from "../core/diagnostics/doctor.js";
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import {
+  type AgentRuntimeProbeResult,
+  ServerHealthConfigurationError,
+  ServerHealthNetworkError,
+} from "@opentag/client";
+import type { AgentRuntimeProvider, ImCliProvider } from "@opentag/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveDaemonPaths } from "../core/daemon/paths.js";
+import { type DoctorOptions, renderDoctorJson, resolveServerUrl, runDoctor } from "../core/diagnostics/doctor.js";
+
+const directories: string[] = [];
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+const READY: AgentRuntimeProbeResult = { issues: [], ready: true, version: "1.2.3" };
+const NOT_INSTALLED: AgentRuntimeProbeResult = {
+  issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }],
+  ready: false,
+};
+const NOT_SIGNED_IN: AgentRuntimeProbeResult = {
+  issues: [{ code: "credential_missing", message: "Claude Code credentials were not found" }],
+  ready: false,
+  version: "1.2.3",
+};
 
 describe("resolveServerUrl", () => {
   it("prefers the command option over the environment", () => {
@@ -16,31 +41,158 @@ describe("resolveServerUrl", () => {
 });
 
 describe("runDoctor", () => {
-  it("reports a healthy server", async () => {
-    const healthChecker = vi.fn().mockResolvedValue({ status: "ok", service: "opentag-server" } as const);
+  it("reports a computer that can run an Agent", async () => {
+    const result = await runDoctor(await doctorOptions({}));
 
-    await expect(runDoctor({ serverUrl: "http://server.example", healthChecker })).resolves.toEqual({
-      exitCode: 0,
-      message: "OpenTag server is healthy (opentag-server) at http://server.example",
-    });
-    expect(healthChecker).toHaveBeenCalledWith("http://server.example");
+    expect(result.exitCode).toBe(0);
+    expect(result.checks.map((check) => [check.id, check.status])).toEqual([
+      ["server", "ok"],
+      ["runtime:codex", "ok"],
+      ["runtime:claude-code", "ok"],
+      ["im:feishu", "ok"],
+      ["im:slack", "ok"],
+    ]);
+    expect(result.message).toContain("Codex CLI: ready (1.2.3)");
+    expect(result.message).toContain("This computer is ready to run an OpenTag agent.");
   });
 
-  it("reports a categorized failure and a non-zero exit code", async () => {
-    const healthChecker = vi.fn().mockRejectedValue(new ServerHealthNetworkError("offline"));
+  it("accepts one ready Agent Runtime and one ready messaging CLI when the caller selects none", async () => {
+    const result = await runDoctor(
+      await doctorOptions({
+        imStatuses: { feishu: "ready", slack: "install" },
+        runtimeResults: { codex: READY, "claude-code": NOT_INSTALLED },
+      }),
+    );
 
-    await expect(runDoctor({ serverUrl: "http://server.example", healthChecker })).resolves.toEqual({
-      exitCode: 1,
-      message: "Network error: could not reach the OpenTag server at http://server.example",
+    expect(result.exitCode).toBe(0);
+    expect(result.message).toContain("Claude Code CLI: not installed");
+    expect(result.message).not.toContain("Fix 1/");
+  });
+
+  it("blocks when the caller selects a runtime that is not signed in", async () => {
+    const result = await runDoctor(
+      await doctorOptions({
+        runtimeResults: { codex: READY, "claude-code": NOT_SIGNED_IN },
+        runtimes: ["claude-code"],
+      }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.checks.map((check) => check.id)).toEqual(["server", "runtime:claude-code", "im:feishu", "im:slack"]);
+    expect(result.message).toContain("Claude Code CLI: installed (1.2.3) but not signed in");
+    expect(result.message).toContain("Fix 1/1 — Sign in to Claude Code on this computer");
+    expect(result.message).toContain("  claude auth login");
+  });
+
+  it("blocks and prints one fix per failure when no Agent Runtime and no messaging CLI is ready", async () => {
+    const result = await runDoctor(
+      await doctorOptions({
+        imStatuses: { feishu: "install", slack: "unavailable" },
+        runtimeResults: { codex: NOT_INSTALLED, "claude-code": NOT_SIGNED_IN },
+      }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("4 checks must be fixed");
+    expect(result.message).toContain("Fix 1/4 — Install the Codex CLI");
+    expect(result.message).toContain("  npm install -g @openai/codex");
+    expect(result.message).toContain("Fix 2/4 — Sign in to Claude Code on this computer");
+    expect(result.message).toContain("Fix 3/4 — Install the Feishu (Lark) CLI");
+    expect(result.message).toContain("Fix 4/4 — Reinstall or upgrade the Slack CLI");
+  });
+
+  it("reports an unreachable server as a blocking check", async () => {
+    const result = await runDoctor({
+      ...(await doctorOptions({})),
+      healthChecker: vi.fn().mockRejectedValue(new ServerHealthNetworkError("offline")),
     });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("network error: could not reach the OpenTag server at http://server.example");
+    expect(result.message).toContain("Fix 1/1 — Check this computer's network access");
   });
 
   it("reports an invalid server URL as a configuration error", async () => {
-    const healthChecker = vi.fn().mockRejectedValue(new ServerHealthConfigurationError("invalid URL"));
+    const result = await runDoctor({
+      ...(await doctorOptions({})),
+      healthChecker: vi.fn().mockRejectedValue(new ServerHealthConfigurationError("invalid URL")),
+      serverUrl: "not-a-url",
+    });
 
-    await expect(runDoctor({ serverUrl: "not-a-url", healthChecker })).resolves.toEqual({
-      exitCode: 1,
-      message: "Configuration error: invalid OpenTag server URL not-a-url",
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("configuration error: invalid OpenTag server URL not-a-url");
+  });
+
+  it("reports a probe failure without claiming readiness", async () => {
+    const options = await doctorOptions({});
+    const result = await runDoctor({
+      ...options,
+      runtimeProbe: vi.fn().mockRejectedValue(new Error("Codex Home identity changed")),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.checks.filter((check) => check.status === "error").map((check) => check.detail)).toEqual([
+      "Codex Home identity changed",
+      "Codex Home identity changed",
+    ]);
+  });
+
+  it("surfaces an unreadable daemon environment because the daemon reads the same file", async () => {
+    const options = await doctorOptions({});
+    const paths = resolveDaemonPaths(options.home as string);
+    await mkdir(paths.config, { mode: 0o700, recursive: true });
+    await writeFile(paths.daemonEnvironment, "KEY=value\n", { mode: 0o600 });
+    await chmod(paths.daemonEnvironment, 0o644);
+
+    const result = await runDoctor(options);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.checks.find((check) => check.id === "daemon-environment")?.detail).toContain("permissions");
+  });
+
+  it("renders machine-readable checks for an Agent that reads the output", async () => {
+    const result = await runDoctor(
+      await doctorOptions({ runtimeResults: { codex: NOT_INSTALLED, "claude-code": NOT_INSTALLED } }),
+    );
+
+    expect(JSON.parse(renderDoctorJson(result))).toMatchObject({
+      checks: expect.arrayContaining([
+        {
+          detail: "not installed, or not on the PATH this computer runs OpenTag with",
+          fix: {
+            commands: ["npm install -g @openai/codex"],
+            docsUrl: "https://developers.openai.com/codex/cli",
+            summary: "Install the Codex CLI so that `codex` runs from this computer's PATH",
+          },
+          id: "runtime:codex",
+          status: "install",
+          title: "Codex CLI",
+        },
+      ]),
+      ok: false,
     });
   });
 });
+
+async function doctorOptions(overrides: {
+  imStatuses?: Partial<Record<ImCliProvider, "install" | "ready" | "unavailable">>;
+  runtimeResults?: Partial<Record<AgentRuntimeProvider, AgentRuntimeProbeResult>>;
+  runtimes?: readonly AgentRuntimeProvider[];
+}): Promise<DoctorOptions> {
+  return {
+    env: {},
+    healthChecker: vi.fn().mockResolvedValue({ service: "opentag-server", status: "ok" }),
+    home: await temporaryDirectory("opentag-doctor-"),
+    imProbe: async (provider) => overrides.imStatuses?.[provider] ?? "ready",
+    runtimeProbe: async (provider) => overrides.runtimeResults?.[provider] ?? READY,
+    serverUrl: "http://server.example",
+    ...(overrides.runtimes ? { runtimes: overrides.runtimes } : {}),
+  };
+}
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  // Temp roots are symlinked on macOS, so canonicalize to match the paths the code under test resolves.
+  const directory = await realpath(await mkdtemp(resolve(tmpdir(), prefix)));
+  directories.push(directory);
+  return directory;
+}

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -206,6 +206,8 @@ describe("runDoctor", () => {
 });
 
 describe("serviceProcessEnvironment", () => {
+  const account = { homedir: "/Users/tester", shell: "/bin/zsh", username: "tester" };
+
   it("drops shell-only credentials and provider overrides the service never receives", () => {
     const environment = serviceProcessEnvironment(
       {
@@ -213,21 +215,20 @@ describe("serviceProcessEnvironment", () => {
         CLAUDE_CODE_OAUTH_TOKEN: "shell-only",
         CLAUDE_CONFIG_DIR: "/shell/claude",
         CODEX_HOME: "/shell/codex",
-        HOME: "/Users/tester",
         PATH: "/shell/bin",
-        SHELL: "/bin/zsh",
         TMPDIR: "/tmp/user",
-        USER: "tester",
       },
       {
         environment: { OPENTAG_HOME: "/Users/tester/.opentag", OPENTAG_SERVICE_MODE: "1", PATH: "/service/bin" },
         platform: "launchd",
       },
+      account,
     );
 
     // A launchd job receives the account's own variables plus exactly what its definition declares.
     expect(environment).toEqual({
       HOME: "/Users/tester",
+      LOGNAME: "tester",
       OPENTAG_HOME: "/Users/tester/.opentag",
       OPENTAG_SERVICE_MODE: "1",
       PATH: "/service/bin",
@@ -237,13 +238,31 @@ describe("serviceProcessEnvironment", () => {
     });
   });
 
-  it("gives a systemd unit its own manager variables", () => {
+  it("takes the account identity from the operating system, not the invoking shell", () => {
     const environment = serviceProcessEnvironment(
-      { HOME: "/home/tester", TMPDIR: "/tmp/user", XDG_RUNTIME_DIR: "/run/user/1000" },
-      { environment: { PATH: "/service/bin" }, platform: "systemd" },
+      // A shell can export any HOME; the service manager still starts the job from the account.
+      { HOME: "/tmp/pretend-home", USER: "someone-else" },
+      { environment: { PATH: "/service/bin" }, platform: "launchd" },
+      account,
     );
 
-    expect(environment).toEqual({ HOME: "/home/tester", PATH: "/service/bin", XDG_RUNTIME_DIR: "/run/user/1000" });
+    expect(environment).toMatchObject({ HOME: "/Users/tester", USER: "tester" });
+  });
+
+  it("gives a systemd unit its own manager variables", () => {
+    const environment = serviceProcessEnvironment(
+      { TMPDIR: "/tmp/user", XDG_RUNTIME_DIR: "/run/user/1000" },
+      { environment: { PATH: "/service/bin" }, platform: "systemd" },
+      { homedir: "/home/tester", shell: null, username: "tester" },
+    );
+
+    expect(environment).toEqual({
+      HOME: "/home/tester",
+      LOGNAME: "tester",
+      PATH: "/service/bin",
+      USER: "tester",
+      XDG_RUNTIME_DIR: "/run/user/1000",
+    });
   });
 });
 

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import {
@@ -6,10 +6,21 @@ import {
   ServerHealthConfigurationError,
   ServerHealthNetworkError,
 } from "@opentag/client";
-import type { AgentRuntimeProvider, ImCliProvider } from "@opentag/shared";
+import {
+  AGENT_RUNTIME_PROVIDERS,
+  type AgentRuntimeProvider,
+  IM_CLI_PROVIDERS,
+  type ImCliProvider,
+} from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveDaemonPaths } from "../core/daemon/paths.js";
+import type { DaemonServiceManager } from "../core/daemon/service/index.js";
+import { renderLaunchdPlist } from "../core/daemon/service/launchd.js";
+import { renderSystemdUnit } from "../core/daemon/service/systemd.js";
+import type { DaemonServiceState } from "../core/daemon/service/types.js";
+import { checkAgentRuntimes, checkImClis } from "../core/diagnostics/checks.js";
 import { type DoctorOptions, renderDoctorJson, resolveServerUrl, runDoctor } from "../core/diagnostics/doctor.js";
+import { readDaemonServiceEnvironment } from "../core/diagnostics/service-environment.js";
 
 const directories: string[] = [];
 afterEach(async () => {
@@ -47,13 +58,16 @@ describe("runDoctor", () => {
     expect(result.exitCode).toBe(0);
     expect(result.checks.map((check) => [check.id, check.status])).toEqual([
       ["server", "ok"],
+      ["daemon-service", "ok"],
       ["runtime:codex", "ok"],
       ["runtime:claude-code", "ok"],
       ["im:feishu", "ok"],
       ["im:slack", "ok"],
     ]);
     expect(result.message).toContain("Codex CLI: ready (1.2.3)");
-    expect(result.message).toContain("This computer is ready to run an OpenTag agent.");
+    expect(result.message).toContain("run an OpenTag agent on Codex or Claude Code");
+    expect(result.message).toContain("delivering through Feishu or Slack");
+    expect(result.message).toContain("It does not know which of those");
   });
 
   it("accepts one ready Agent Runtime and one ready messaging CLI when the caller selects none", async () => {
@@ -66,6 +80,8 @@ describe("runDoctor", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.message).toContain("Claude Code CLI: not installed");
+    expect(result.message).toContain("run an OpenTag agent on Codex,");
+    expect(result.message).toContain("delivering through Feishu.");
     expect(result.message).not.toContain("Fix 1/");
   });
 
@@ -78,10 +94,17 @@ describe("runDoctor", () => {
     );
 
     expect(result.exitCode).toBe(1);
-    expect(result.checks.map((check) => check.id)).toEqual(["server", "runtime:claude-code", "im:feishu", "im:slack"]);
+    expect(result.checks.map((check) => check.id)).toEqual([
+      "server",
+      "daemon-service",
+      "runtime:claude-code",
+      "im:feishu",
+      "im:slack",
+    ]);
     expect(result.message).toContain("Claude Code CLI: installed (1.2.3) but not signed in");
     expect(result.message).toContain("Fix 1/1 — Sign in to Claude Code on this computer");
     expect(result.message).toContain("  claude auth login");
+    expect(result.message).toContain("first-tree-ai/opentag#236");
   });
 
   it("blocks and prints one fix per failure when no Agent Runtime and no messaging CLI is ready", async () => {
@@ -98,7 +121,7 @@ describe("runDoctor", () => {
     expect(result.message).toContain("  npm install -g @openai/codex");
     expect(result.message).toContain("Fix 2/4 — Sign in to Claude Code on this computer");
     expect(result.message).toContain("Fix 3/4 — Install the Feishu (Lark) CLI");
-    expect(result.message).toContain("Fix 4/4 — Reinstall or upgrade the Slack CLI");
+    expect(result.message).toContain("Fix 4/4 — Repair the Slack CLI");
   });
 
   it("reports an unreachable server as a blocking check", async () => {
@@ -158,7 +181,7 @@ describe("runDoctor", () => {
     expect(JSON.parse(renderDoctorJson(result))).toMatchObject({
       checks: expect.arrayContaining([
         {
-          detail: "not installed, or not on the PATH this computer runs OpenTag with",
+          detail: "not installed, or not on this shell's PATH",
           fix: {
             commands: ["npm install -g @openai/codex"],
             docsUrl: "https://developers.openai.com/codex/cli",
@@ -174,20 +197,224 @@ describe("runDoctor", () => {
   });
 });
 
+describe("readDaemonServiceEnvironment", () => {
+  it("reads the PATH out of a systemd unit", async () => {
+    const home = await temporaryDirectory("opentag-service-systemd-");
+    const definitionPath = resolve(home, "opentag.service");
+    await writeFile(
+      definitionPath,
+      renderSystemdUnit({
+        home,
+        invocation: { args: [], program: "/usr/local/bin/opentag" },
+        path: "/opt/tools/bin:/usr/bin",
+        serviceId: "opentag-test",
+      }),
+      "utf8",
+    );
+
+    await expect(
+      readDaemonServiceEnvironment({
+        manager: statusManager({ definitionPath, platform: "systemd", state: "active" }),
+        platform: "linux",
+      }),
+    ).resolves.toEqual({ definitionPath, kind: "installed", path: "/opt/tools/bin:/usr/bin", state: "active" });
+  });
+
+  it("fails closed when an installed definition declares no PATH", async () => {
+    const home = await temporaryDirectory("opentag-service-broken-");
+    const definitionPath = resolve(home, "opentag.plist");
+    await writeFile(definitionPath, "<plist><dict></dict></plist>\n", "utf8");
+
+    await expect(
+      readDaemonServiceEnvironment({
+        manager: statusManager({ definitionPath, platform: "launchd", state: "active" }),
+        platform: "darwin",
+      }),
+    ).resolves.toEqual({
+      definitionPath,
+      kind: "unreadable",
+      reason: "the installed service definition declares no PATH",
+    });
+  });
+
+  it("reports an unsupported platform instead of guessing", async () => {
+    await expect(readDaemonServiceEnvironment({ platform: "win32" })).resolves.toEqual({
+      kind: "unsupported",
+      platform: "win32",
+    });
+  });
+});
+
+describe("daemon service environment", () => {
+  it("refuses to call a computer ready when no daemon service is installed", async () => {
+    const result = await runDoctor(await doctorOptions({ service: "not-installed" }));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.checks.find((check) => check.id === "daemon-service")).toMatchObject({
+      detail: "not installed, so nothing runs Agents or publishes readiness from this computer",
+      status: "install",
+    });
+    expect(result.message).toContain("Install the OpenTag daemon service");
+    expect(result.message).not.toContain("can run an OpenTag agent on");
+    expect(result.message).toContain("CLI checks used this shell's PATH");
+  });
+
+  it("blocks on an installed service that is not running", async () => {
+    const result = await runDoctor(await doctorOptions({ service: { state: "inactive" } }));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("installed but inactive, so nothing runs Agents");
+    expect(result.message).toContain("daemon restart");
+  });
+
+  it("names the definition its CLI checks came from", async () => {
+    const result = await runDoctor(await doctorOptions({}));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.checks.find((check) => check.id === "daemon-service")?.detail).toBe(
+      "active; checks below use the PATH it runs with",
+    );
+    expect(result.message).toMatch(/CLI checks used the PATH declared by .*opentag\.plist/u);
+  });
+
+  it("explains a CLI the operator can run but the daemon cannot", async () => {
+    const shell = await temporaryDirectory("opentag-doctor-shell-path-");
+    await writeFile(resolve(shell, "codex"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    const result = await runDoctor(
+      await doctorOptions({
+        env: { PATH: shell },
+        runtimeResults: { codex: NOT_INSTALLED, "claude-code": NOT_INSTALLED },
+        service: { path: "/usr/bin:/bin" },
+      }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.checks.find((check) => check.id === "runtime:codex")).toMatchObject({
+      detail: "on this shell's PATH, but not on the PATH the daemon service runs with",
+    });
+    expect(result.message).toContain("Give the daemon the same PATH this shell has");
+    expect(result.message).toContain("daemon install");
+    // The runtime the shell cannot resolve either keeps the ordinary install fix.
+    expect(result.message).toContain("Install the Claude Code CLI");
+  });
+});
+
+describe("default probe wiring", () => {
+  it("resolves the real provider factories and messaging commands without touching the computer", async () => {
+    const home = await temporaryDirectory("opentag-doctor-wiring-");
+    // An empty PATH is the honest "nothing is installed" case: it exercises the real factories and
+    // the real messaging CLI commands without spawning anything.
+    const environment = { HOME: home, PATH: "" };
+
+    const [runtimeChecks, imChecks] = await Promise.all([
+      checkAgentRuntimes({ clientVersion: "0.0.0-test", environment, providers: AGENT_RUNTIME_PROVIDERS }),
+      checkImClis({ environment, providers: IM_CLI_PROVIDERS }),
+    ]);
+
+    expect([...runtimeChecks, ...imChecks].map((check) => [check.id, check.status])).toEqual([
+      ["runtime:codex", "install"],
+      ["runtime:claude-code", "install"],
+      ["im:feishu", "install"],
+      ["im:slack", "install"],
+    ]);
+    // Observing a Computer must not create the provider homes the report is about.
+    await expect(stat(resolve(home, ".codex"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(resolve(home, ".claude"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports an installed messaging CLI that answers the probe", async () => {
+    const home = await temporaryDirectory("opentag-doctor-lark-");
+    const lark = resolve(home, "lark-cli");
+    await writeFile(
+      lark,
+      '#!/bin/sh\nif [ "$1" = "--version" ] || { [ "$1" = "im" ] && [ "$2" = "--help" ]; }; then exit 0; fi\nexit 1\n',
+      { mode: 0o755 },
+    );
+
+    const checks = await checkImClis({ environment: { PATH: home }, providers: ["feishu"] });
+
+    expect(checks).toEqual([{ detail: "ready", id: "im:feishu", status: "ok", title: "Feishu CLI (lark-cli)" }]);
+  });
+});
+
 async function doctorOptions(overrides: {
+  env?: NodeJS.ProcessEnv;
   imStatuses?: Partial<Record<ImCliProvider, "install" | "ready" | "unavailable">>;
   runtimeResults?: Partial<Record<AgentRuntimeProvider, AgentRuntimeProbeResult>>;
   runtimes?: readonly AgentRuntimeProvider[];
+  service?: { path?: string; state?: DaemonServiceState } | "not-installed";
 }): Promise<DoctorOptions> {
+  const home = await temporaryDirectory("opentag-doctor-");
   return {
-    env: {},
+    env: overrides.env ?? {},
     healthChecker: vi.fn().mockResolvedValue({ service: "opentag-server", status: "ok" }),
-    home: await temporaryDirectory("opentag-doctor-"),
+    home,
     imProbe: async (provider) => overrides.imStatuses?.[provider] ?? "ready",
+    platform: "darwin",
     runtimeProbe: async (provider) => overrides.runtimeResults?.[provider] ?? READY,
     serverUrl: "http://server.example",
+    serviceManager: await fakeServiceManager(home, overrides.service),
     ...(overrides.runtimes ? { runtimes: overrides.runtimes } : {}),
   };
+}
+
+function statusManager(info: {
+  definitionPath: string;
+  platform: "launchd" | "systemd";
+  state: DaemonServiceState;
+}): DaemonServiceManager {
+  return {
+    status: async () => ({
+      currentHome: "/unused",
+      definitionPath: info.definitionPath,
+      logHint: "/unused",
+      platform: info.platform,
+      serviceId: "opentag-test",
+      state: info.state,
+    }),
+  } as unknown as DaemonServiceManager;
+}
+
+/** Stands in for launchd: a real plist on disk, so the PATH parser is exercised for real. */
+async function fakeServiceManager(
+  home: string,
+  service: { path?: string; state?: DaemonServiceState } | "not-installed" = {},
+): Promise<DaemonServiceManager> {
+  const definitionPath = resolve(home, "opentag.plist");
+  const state: DaemonServiceState = service === "not-installed" ? "not-installed" : (service.state ?? "active");
+  if (service !== "not-installed") {
+    await writeFile(
+      definitionPath,
+      renderLaunchdPlist({
+        home,
+        label: "opentag-test",
+        path: service.path ?? "/usr/bin:/bin",
+        stderrPath: resolve(home, "err.log"),
+        stdoutPath: resolve(home, "out.log"),
+        wrapperPath: resolve(home, "wrapper"),
+      }),
+      "utf8",
+    );
+  }
+  const info = {
+    currentHome: home,
+    definitionPath,
+    logHint: resolve(home, "logs"),
+    platform: "launchd",
+    serviceId: "opentag-test",
+    state,
+  } as const;
+  const unsupported = () => Promise.reject(new Error("not used by doctor"));
+  return {
+    installAndStart: unsupported,
+    preflight: unsupported,
+    restart: unsupported,
+    start: unsupported,
+    status: async () => info,
+    stop: unsupported,
+    uninstall: unsupported,
+  } as unknown as DaemonServiceManager;
 }
 
 async function temporaryDirectory(prefix: string): Promise<string> {

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -26,7 +26,7 @@ import {
   runDoctor,
   serviceProcessEnvironment,
 } from "../core/diagnostics/doctor.js";
-import { readDaemonServiceEnvironment } from "../core/diagnostics/service-environment.js";
+import { readDaemonServiceEnvironment, serviceManagerVariables } from "../core/diagnostics/service-environment.js";
 
 const directories: string[] = [];
 afterEach(async () => {
@@ -208,24 +208,17 @@ describe("runDoctor", () => {
 describe("serviceProcessEnvironment", () => {
   const account = { homedir: "/Users/tester", shell: "/bin/zsh", username: "tester" };
 
-  it("drops shell-only credentials and provider overrides the service never receives", () => {
+  it("builds the environment from the account, the manager, and the definition alone", () => {
     const environment = serviceProcessEnvironment(
-      {
-        ANTHROPIC_API_KEY: "shell-only",
-        CLAUDE_CODE_OAUTH_TOKEN: "shell-only",
-        CLAUDE_CONFIG_DIR: "/shell/claude",
-        CODEX_HOME: "/shell/codex",
-        PATH: "/shell/bin",
-        TMPDIR: "/tmp/user",
-      },
       {
         environment: { OPENTAG_HOME: "/Users/tester/.opentag", OPENTAG_SERVICE_MODE: "1", PATH: "/service/bin" },
         platform: "launchd",
       },
       account,
+      { TMPDIR: "/var/folders/ab/cd/T/" },
     );
 
-    // A launchd job receives the account's own variables plus exactly what its definition declares.
+    // No parameter carries the invoking shell, so nothing of it can reach a probe.
     expect(environment).toEqual({
       HOME: "/Users/tester",
       LOGNAME: "tester",
@@ -233,27 +226,26 @@ describe("serviceProcessEnvironment", () => {
       OPENTAG_SERVICE_MODE: "1",
       PATH: "/service/bin",
       SHELL: "/bin/zsh",
-      TMPDIR: "/tmp/user",
+      TMPDIR: "/var/folders/ab/cd/T/",
       USER: "tester",
     });
   });
 
-  it("takes the account identity from the operating system, not the invoking shell", () => {
+  it("lets the definition override a manager variable, because the job would receive that", () => {
     const environment = serviceProcessEnvironment(
-      // A shell can export any HOME; the service manager still starts the job from the account.
-      { HOME: "/tmp/pretend-home", USER: "someone-else" },
-      { environment: { PATH: "/service/bin" }, platform: "launchd" },
+      { environment: { PATH: "/service/bin", TMPDIR: "/declared/tmp" }, platform: "launchd" },
       account,
+      { TMPDIR: "/var/folders/ab/cd/T/" },
     );
 
-    expect(environment).toMatchObject({ HOME: "/Users/tester", USER: "tester" });
+    expect(environment.TMPDIR).toBe("/declared/tmp");
   });
 
-  it("gives a systemd unit its own manager variables", () => {
+  it("omits a manager variable the manager authority could not supply", () => {
     const environment = serviceProcessEnvironment(
-      { TMPDIR: "/tmp/user", XDG_RUNTIME_DIR: "/run/user/1000" },
       { environment: { PATH: "/service/bin" }, platform: "systemd" },
       { homedir: "/home/tester", shell: null, username: "tester" },
+      {},
     );
 
     expect(environment).toEqual({
@@ -261,8 +253,41 @@ describe("serviceProcessEnvironment", () => {
       LOGNAME: "tester",
       PATH: "/service/bin",
       USER: "tester",
-      XDG_RUNTIME_DIR: "/run/user/1000",
     });
+  });
+});
+
+describe("serviceManagerVariables", () => {
+  it("asks the operating system for the launchd temporary directory", async () => {
+    await expect(
+      serviceManagerVariables("launchd", {
+        readDarwinUserTemporaryDirectory: async () => "/var/folders/ab/cd/T/",
+      }),
+    ).resolves.toEqual({ TMPDIR: "/var/folders/ab/cd/T/" });
+  });
+
+  it("omits the variable when that authority cannot answer", async () => {
+    await expect(
+      serviceManagerVariables("launchd", { readDarwinUserTemporaryDirectory: async () => undefined }),
+    ).resolves.toEqual({});
+    await expect(
+      serviceManagerVariables("systemd", { directoryExists: async () => false, uid: 1000 }),
+    ).resolves.toEqual({});
+    await expect(serviceManagerVariables(undefined)).resolves.toEqual({});
+  });
+
+  it("derives the systemd runtime directory from the account uid", async () => {
+    const asked: string[] = [];
+    await expect(
+      serviceManagerVariables("systemd", {
+        directoryExists: async (path) => {
+          asked.push(path);
+          return true;
+        },
+        uid: 1000,
+      }),
+    ).resolves.toEqual({ XDG_RUNTIME_DIR: "/run/user/1000" });
+    expect(asked).toEqual(["/run/user/1000"]);
   });
 });
 
@@ -423,6 +448,48 @@ describe("daemon service environment", () => {
     expect(result.checks.find((check) => check.id === "runtime:codex")?.status).toBe("ok");
   });
 
+  it("never hands the probes a manager variable the invoking shell set", async () => {
+    const captured: NodeJS.ProcessEnv[] = [];
+    const options = await doctorOptions({
+      // Overriding TMPDIR for one command changes nothing about the installed service, so it must
+      // not change what the probes see: it can still move where a provider reads temporary state.
+      env: { PATH: "/shell/bin", TMPDIR: "/shell/tmp", XDG_RUNTIME_DIR: "/shell/run" },
+      service: { path: "/service/bin" },
+    });
+
+    await runDoctor({
+      ...options,
+      runtimeProbe: async (_provider, _signal, environment) => {
+        captured.push(environment);
+        return NOT_INSTALLED;
+      },
+    });
+
+    expect(captured).toHaveLength(2);
+    for (const environment of captured) {
+      expect(environment.TMPDIR).not.toBe("/shell/tmp");
+      expect(environment.XDG_RUNTIME_DIR).toBeUndefined();
+    }
+  });
+
+  it("hands the probes a manager variable the definition declares", async () => {
+    const captured: NodeJS.ProcessEnv[] = [];
+    const options = await doctorOptions({
+      env: { TMPDIR: "/shell/tmp" },
+      service: { declared: { TMPDIR: "/declared/tmp" }, path: "/service/bin" },
+    });
+
+    await runDoctor({
+      ...options,
+      runtimeProbe: async (_provider, _signal, environment) => {
+        captured.push(environment);
+        return NOT_INSTALLED;
+      },
+    });
+
+    expect(captured[0]?.TMPDIR).toBe("/declared/tmp");
+  });
+
   it("explains a CLI the operator can run but the daemon cannot", async () => {
     const shell = await temporaryDirectory("opentag-doctor-shell-path-");
     await writeFile(resolve(shell, "codex"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
@@ -491,7 +558,9 @@ async function doctorOptions(overrides: {
   imStatuses?: Partial<Record<ImCliProvider, "install" | "ready" | "unavailable">>;
   runtimeResults?: Partial<Record<AgentRuntimeProvider, AgentRuntimeProbeResult>>;
   runtimes?: readonly AgentRuntimeProvider[];
-  service?: { home?: string; path?: string; state?: DaemonServiceState } | "not-installed";
+  service?:
+    | { declared?: Record<string, string>; home?: string; path?: string; state?: DaemonServiceState }
+    | "not-installed";
 }): Promise<DoctorOptions> {
   const home = await temporaryDirectory("opentag-doctor-");
   return {
@@ -505,6 +574,14 @@ async function doctorOptions(overrides: {
     serviceManager: await fakeServiceManager(home, overrides.service),
     ...(overrides.runtimes ? { runtimes: overrides.runtimes } : {}),
   };
+}
+
+/** Adds extra declared variables to a rendered plist, the way an operator-edited definition would. */
+function declaredPlist(plist: string, declared: Record<string, string>): string {
+  const entries = Object.entries(declared)
+    .map(([key, value]) => `    <key>${key}</key>\n    <string>${value}</string>`)
+    .join("\n");
+  return entries ? plist.replace("    <key>PATH</key>", `${entries}\n    <key>PATH</key>`) : plist;
 }
 
 function statusManager(info: {
@@ -527,7 +604,9 @@ function statusManager(info: {
 /** Stands in for launchd: a real plist on disk, so the PATH parser is exercised for real. */
 async function fakeServiceManager(
   home: string,
-  service: { home?: string; path?: string; state?: DaemonServiceState } | "not-installed" = {},
+  service:
+    | { declared?: Record<string, string>; home?: string; path?: string; state?: DaemonServiceState }
+    | "not-installed" = {},
 ): Promise<DaemonServiceManager> {
   const definitionPath = resolve(home, "opentag.plist");
   const state: DaemonServiceState = service === "not-installed" ? "not-installed" : (service.state ?? "active");
@@ -535,14 +614,17 @@ async function fakeServiceManager(
   if (service !== "not-installed") {
     await writeFile(
       definitionPath,
-      renderLaunchdPlist({
-        home: serviceHome,
-        label: "opentag-test",
-        path: service.path ?? "/usr/bin:/bin",
-        stderrPath: resolve(home, "err.log"),
-        stdoutPath: resolve(home, "out.log"),
-        wrapperPath: resolve(home, "wrapper"),
-      }),
+      declaredPlist(
+        renderLaunchdPlist({
+          home: serviceHome,
+          label: "opentag-test",
+          path: service.path ?? "/usr/bin:/bin",
+          stderrPath: resolve(home, "err.log"),
+          stdoutPath: resolve(home, "out.log"),
+          wrapperPath: resolve(home, "wrapper"),
+        }),
+        service.declared ?? {},
+      ),
       "utf8",
     );
   }

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -122,6 +122,8 @@ describe("runDoctor", () => {
     expect(result.message).toContain("Fix 2/4 — Sign in to Claude Code on this computer");
     expect(result.message).toContain("Fix 3/4 — Install the Feishu (Lark) CLI");
     expect(result.message).toContain("Fix 4/4 — Repair the Slack CLI");
+    // A CLI that is installed but unresponsive must not be told to reinstall.
+    expect(result.message).not.toContain("npm install -g @larksuite/cli\n  Note: OpenTag needs it");
   });
 
   it("reports an unreachable server as a blocking check", async () => {
@@ -295,6 +297,8 @@ describe("daemon service environment", () => {
     });
     expect(result.message).toContain("Give the daemon the same PATH this shell has");
     expect(result.message).toContain("daemon install");
+    // One cause, one instruction: a second diverging CLI must not repeat the same fix.
+    expect(result.message.match(/Give the daemon the same PATH/gu)).toHaveLength(1);
     // The runtime the shell cannot resolve either keeps the ordinary install fix.
     expect(result.message).toContain("Install the Claude Code CLI");
   });

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -335,7 +335,34 @@ describe("daemon service environment", () => {
     });
     expect(result.message).toContain("Install the OpenTag daemon service");
     expect(result.message).not.toContain("can run an OpenTag agent on");
-    expect(result.message).toContain("CLI checks used this shell's PATH");
+    expect(result.message).toContain("used this account and this shell's PATH");
+  });
+
+  it("keeps shell authority out of the check lines even when no service can be read", async () => {
+    const captured: NodeJS.ProcessEnv[] = [];
+    const options = await doctorOptions({
+      env: { ANTHROPIC_API_KEY: "shell-only", CODEX_HOME: "/shell/codex", HOME: "/tmp/pretend", PATH: "/shell/bin" },
+      service: "not-installed",
+    });
+
+    const result = await runDoctor({
+      ...options,
+      runtimeProbe: async (_provider, _signal, environment) => {
+        captured.push(environment);
+        return NOT_INSTALLED;
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    for (const environment of captured) {
+      // Without a definition there is no service PATH to borrow, but the rest must not become a
+      // shell-authority claim wearing a service-authority shape.
+      expect(environment.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(environment.CODEX_HOME).toBeUndefined();
+      expect(environment.HOME).not.toBe("/tmp/pretend");
+      expect(environment.PATH).toBe("/shell/bin");
+    }
+    expect(result.message).toContain("used this account and this shell's PATH");
   });
 
   it("blocks on an installed service that is not running", async () => {

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -266,6 +266,22 @@ describe("serviceManagerVariables", () => {
     ).resolves.toEqual({ TMPDIR: "/var/folders/ab/cd/T/" });
   });
 
+  it("cannot be redirected by an executable on the invoking process's PATH", async () => {
+    const injected = await temporaryDirectory("opentag-fake-getconf-");
+    await writeFile(resolve(injected, "getconf"), "#!/bin/sh\necho /shell/injected/tmp\n", { mode: 0o755 });
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${injected}:${originalPath ?? ""}`;
+    try {
+      // The real implementation, with a hostile getconf first on this process's PATH.
+      const variables = await serviceManagerVariables("launchd");
+
+      expect(variables.TMPDIR).not.toBe("/shell/injected/tmp");
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+    }
+  });
+
   it("omits the variable when that authority cannot answer", async () => {
     await expect(
       serviceManagerVariables("launchd", { readDarwinUserTemporaryDirectory: async () => undefined }),

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,19 +1,61 @@
-import type { Command } from "commander";
-import { runDoctor } from "../core/diagnostics/doctor.js";
+import {
+  AGENT_RUNTIME_PROVIDERS,
+  type AgentRuntimeProvider,
+  IM_CLI_PROVIDERS,
+  type ImCliProvider,
+} from "@opentag/shared";
+import { type Command, InvalidArgumentError } from "commander";
+import { renderDoctorJson, runDoctor } from "../core/diagnostics/doctor.js";
 
 interface DoctorCommandOptions {
+  home?: string;
+  im?: ImCliProvider[];
+  json?: boolean;
+  runtime?: AgentRuntimeProvider[];
   serverUrl?: string;
 }
 
 export function registerDoctorCommand(program: Command): void {
   program
     .command("doctor")
-    .description("Check connectivity to the OpenTag server")
+    .description("Check this computer: OpenTag server, Agent Runtime CLI, and messaging CLI")
     .option("--server-url <url>", "OpenTag server base URL")
+    .option("--home <path>", "OpenTag home directory")
+    .option(
+      "--runtime <provider>",
+      `require a ready Agent Runtime (${AGENT_RUNTIME_PROVIDERS.join(", ")}); repeatable`,
+      collectChoice(AGENT_RUNTIME_PROVIDERS, "runtime"),
+    )
+    .option(
+      "--im <provider>",
+      `require a ready messaging CLI (${IM_CLI_PROVIDERS.join(", ")}); repeatable`,
+      collectChoice(IM_CLI_PROVIDERS, "IM"),
+    )
+    .option("--json", "print the checks as JSON")
     .action(async (options: DoctorCommandOptions) => {
-      const result = await runDoctor({ serverUrl: options.serverUrl });
-      const write = result.exitCode === 0 ? console.log : console.error;
-      write(result.message);
+      const result = await runDoctor({
+        ...(options.home ? { home: options.home } : {}),
+        ...(options.im?.length ? { imProviders: options.im } : {}),
+        ...(options.runtime?.length ? { runtimes: options.runtime } : {}),
+        ...(options.serverUrl ? { serverUrl: options.serverUrl } : {}),
+      });
+      // JSON output stays on stdout even when checks fail: the exit code carries the verdict, and a
+      // caller parsing the report should not have to merge two streams.
+      if (options.json) console.log(renderDoctorJson(result));
+      else (result.exitCode === 0 ? console.log : console.error)(result.message);
       process.exitCode = result.exitCode;
     });
+}
+
+function collectChoice<Choice extends string>(
+  choices: readonly Choice[],
+  label: string,
+): (value: string, previous: Choice[] | undefined) => Choice[] {
+  return (value, previous) => {
+    const choice = choices.find((candidate) => candidate === value);
+    if (!choice) {
+      throw new InvalidArgumentError(`Unknown ${label} provider: ${value}. Choose one of ${choices.join(", ")}.`);
+    }
+    return [...(previous ?? []), choice];
+  };
 }

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -56,6 +56,8 @@ function collectChoice<Choice extends string>(
     if (!choice) {
       throw new InvalidArgumentError(`Unknown ${label} provider: ${value}. Choose one of ${choices.join(", ")}.`);
     }
-    return [...(previous ?? []), choice];
+    const selected = previous ?? [];
+    // Repeating a value must not probe the same provider twice or duplicate an id in --json.
+    return selected.includes(choice) ? selected : [...selected, choice];
   };
 }

--- a/apps/cli/src/core/daemon/service/launchd.ts
+++ b/apps/cli/src/core/daemon/service/launchd.ts
@@ -12,6 +12,7 @@ import {
   quotePosix,
   readRegularFile,
   runRequired,
+  serviceManagerProgram,
   sleep,
   writeFileAtomically,
 } from "./shared.js";
@@ -91,7 +92,7 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
   const userHome = options.userHome ?? homedir();
   const domain = `gui/${uid}`;
   const target = `${domain}/${identity.launchdLabel}`;
-  const launchctl = options.launchctl ?? "launchctl";
+  const launchctl = options.launchctl ?? serviceManagerProgram("launchctl");
   const plistPath = join(userHome, "Library", "LaunchAgents", identity.launchdPlistName);
   const paths = resolveDaemonPaths(options.home);
   const wrapperPath = paths.serviceWrapper(identity.launchdWrapperName);

--- a/apps/cli/src/core/daemon/service/launchd.ts
+++ b/apps/cli/src/core/daemon/service/launchd.ts
@@ -117,7 +117,9 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
   const readStatus = async (failOnTimeout = false): Promise<DaemonServiceInfo> => {
     const plist = await readRegularFile(plistPath);
     if (plist === undefined) {
-      const orphaned = await options.runner.run(launchctl, ["print", target], { timeoutMs: LAUNCHD_TIMEOUT_MS });
+      const orphaned = await options.runner.run(launchctl, ["print", target], {
+        timeoutMs: LAUNCHD_TIMEOUT_MS,
+      });
       if (orphaned.timedOut) {
         if (failOnTimeout) {
           throw new DaemonServiceError("OPERATION_FAILED", "launchd activation status check timed out");
@@ -148,7 +150,9 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
         drifted: true,
       });
     }
-    const result = await options.runner.run(launchctl, ["print", target], { timeoutMs: LAUNCHD_TIMEOUT_MS });
+    const result = await options.runner.run(launchctl, ["print", target], {
+      timeoutMs: LAUNCHD_TIMEOUT_MS,
+    });
     const drifted = plist !== expectedPlist || wrapper !== expectedWrapper;
     if (result.timedOut) {
       if (failOnTimeout) {
@@ -183,7 +187,9 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
   const status = (): Promise<DaemonServiceInfo> => readStatus();
 
   const preflight = async (): Promise<void> => {
-    const result = await options.runner.run(launchctl, ["print", domain], { timeoutMs: LAUNCHD_TIMEOUT_MS });
+    const result = await options.runner.run(launchctl, ["print", domain], {
+      timeoutMs: LAUNCHD_TIMEOUT_MS,
+    });
     if (result.code !== 0 || result.timedOut) {
       throw new DaemonServiceError(
         "MANAGER_UNAVAILABLE",
@@ -193,7 +199,9 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
   };
 
   const bootout = async (): Promise<void> => {
-    const result = await options.runner.run(launchctl, ["bootout", target], { timeoutMs: LAUNCHD_TIMEOUT_MS });
+    const result = await options.runner.run(launchctl, ["bootout", target], {
+      timeoutMs: LAUNCHD_TIMEOUT_MS,
+    });
     if (result.code !== 0 && !isManagerNotLoaded(result)) {
       throw new DaemonServiceError("OPERATION_FAILED", `launchd bootout failed: ${result.stderr || "unknown error"}`);
     }
@@ -201,7 +209,9 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
 
   const waitForEviction = async (): Promise<void> => {
     for (let attempt = 0; attempt < evictionAttempts; attempt += 1) {
-      const result = await options.runner.run(launchctl, ["print", target], { timeoutMs: LAUNCHD_TIMEOUT_MS });
+      const result = await options.runner.run(launchctl, ["print", target], {
+        timeoutMs: LAUNCHD_TIMEOUT_MS,
+      });
       if (isManagerNotLoaded(result)) return;
       if (result.timedOut) throw new DaemonServiceError("OPERATION_FAILED", "launchd eviction check timed out");
       await wait(evictionDelayMs);
@@ -215,7 +225,9 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
     });
     if (result.code !== 0 || result.timedOut) {
       await wait(evictionDelayMs);
-      result = await options.runner.run(launchctl, ["bootstrap", domain, plistPath], { timeoutMs: LAUNCHD_TIMEOUT_MS });
+      result = await options.runner.run(launchctl, ["bootstrap", domain, plistPath], {
+        timeoutMs: LAUNCHD_TIMEOUT_MS,
+      });
     }
     if (result.code !== 0 || result.timedOut) {
       throw new DaemonServiceError(
@@ -260,7 +272,9 @@ export function createLaunchdBackend(options: LaunchdBackendOptions): DaemonServ
       }
       const current = await status();
       if (current.state === "active") return current;
-      const loaded = await options.runner.run(launchctl, ["print", target], { timeoutMs: LAUNCHD_TIMEOUT_MS });
+      const loaded = await options.runner.run(launchctl, ["print", target], {
+        timeoutMs: LAUNCHD_TIMEOUT_MS,
+      });
       if (loaded.timedOut) {
         throw new DaemonServiceError("OPERATION_FAILED", "launchd start state check timed out");
       }

--- a/apps/cli/src/core/daemon/service/shared.ts
+++ b/apps/cli/src/core/daemon/service/shared.ts
@@ -95,14 +95,36 @@ export const defaultServiceRunner: ServiceRunner = {
  * variables that address the user manager, so stripping them would break the call rather than
  * secure it; the executable is what had to stop being the caller's choice.
  */
-const SERVICE_MANAGER_PATHS: Readonly<Record<string, readonly string[]>> = {
+/**
+ * Where each service manager lives, by absolute path.
+ *
+ * A candidate qualifies only if the system owns it: an FHS system directory, or a distribution's
+ * root-managed equivalent. That is the whole rule — the list exists because the caller's `PATH` must
+ * not choose the binary, so anything a caller can write to would defeat it.
+ *
+ * The list is therefore also the supported-platform contract. A Linux layout that keeps systemd
+ * somewhere else needs an entry here; omitting one does not degrade the daemon service, it stops it
+ * from resolving at all.
+ */
+export const SERVICE_MANAGER_PATHS = {
   launchctl: ["/bin/launchctl", "/usr/bin/launchctl"],
-  loginctl: ["/usr/bin/loginctl", "/bin/loginctl"],
-  systemctl: ["/usr/bin/systemctl", "/bin/systemctl"],
-};
+  // NixOS keeps the root-managed systemd outside the FHS locations, and both tools ship together.
+  loginctl: ["/usr/bin/loginctl", "/bin/loginctl", "/run/current-system/systemd/bin/loginctl"],
+  systemctl: ["/usr/bin/systemctl", "/bin/systemctl", "/run/current-system/systemd/bin/systemctl"],
+} as const satisfies Record<string, readonly string[]>;
 
-/** Every program name this runner is allowed to execute, for the drift guard that enforces it. */
+export type ServiceManagerProgram = keyof typeof SERVICE_MANAGER_PATHS;
+
+/** Every program name this runner is allowed to execute. */
 export const SERVICE_MANAGER_PROGRAMS: readonly string[] = Object.keys(SERVICE_MANAGER_PATHS).sort();
+
+/**
+ * Name a program for the runner. Passing a name through here is what makes registration a compile
+ * error rather than a runtime degradation: a manager added without an entry above cannot be named.
+ */
+export function serviceManagerProgram(program: ServiceManagerProgram): string {
+  return program;
+}
 
 type ServiceManagerResolution =
   /** A program this runner governs, present on this host. */
@@ -114,7 +136,7 @@ type ServiceManagerResolution =
 
 async function resolveServiceManagerCommand(program: string): Promise<ServiceManagerResolution> {
   if (isAbsolute(program)) return { kind: "resolved", path: program };
-  const candidates = SERVICE_MANAGER_PATHS[program];
+  const candidates = (SERVICE_MANAGER_PATHS as Record<string, readonly string[] | undefined>)[program];
   if (!candidates) return { kind: "ungoverned" };
   for (const candidate of candidates) {
     try {

--- a/apps/cli/src/core/daemon/service/shared.ts
+++ b/apps/cli/src/core/daemon/service/shared.ts
@@ -44,18 +44,24 @@ export const defaultServiceRunner: ServiceRunner = {
     // Resolution happens here rather than in the backends because this is where a name becomes a
     // running process. A service manager reached through the caller's PATH would let an executable
     // placed earlier there decide what OpenTag believes about its own daemon.
-    const resolved = await resolveServiceManagerCommand(program);
-    if (!resolved) {
+    const resolution = await resolveServiceManagerCommand(program);
+    if (resolution.kind !== "resolved") {
+      // The two cases read differently on purpose. "Not installed here" is a fact about the host that
+      // callers are entitled to degrade around; "not governed" means this runner was handed a program
+      // nobody registered, which is a defect that should not be mistaken for a missing binary.
       return {
         code: null,
-        stderr: `${program} was not found at a known system location`,
+        stderr:
+          resolution.kind === "ungoverned"
+            ? `${program} is not a program this runner may execute`
+            : `${program} was not found at a known system location`,
         stdout: "",
         timedOut: false,
       };
     }
     return new Promise<CommandResult>((complete) => {
       execFile(
-        resolved,
+        resolution.path,
         [...args],
         {
           encoding: "utf8",
@@ -89,24 +95,36 @@ export const defaultServiceRunner: ServiceRunner = {
  * variables that address the user manager, so stripping them would break the call rather than
  * secure it; the executable is what had to stop being the caller's choice.
  */
-const SERVICE_MANAGER_PATHS: Readonly<Record<"launchctl" | "systemctl", readonly string[]>> = {
+const SERVICE_MANAGER_PATHS: Readonly<Record<string, readonly string[]>> = {
   launchctl: ["/bin/launchctl", "/usr/bin/launchctl"],
+  loginctl: ["/usr/bin/loginctl", "/bin/loginctl"],
   systemctl: ["/usr/bin/systemctl", "/bin/systemctl"],
 };
 
-async function resolveServiceManagerCommand(program: string): Promise<string | undefined> {
-  if (isAbsolute(program)) return program;
-  const candidates = SERVICE_MANAGER_PATHS[program as "launchctl" | "systemctl"];
-  if (!candidates) return undefined;
+/** Every program name this runner is allowed to execute, for the drift guard that enforces it. */
+export const SERVICE_MANAGER_PROGRAMS: readonly string[] = Object.keys(SERVICE_MANAGER_PATHS).sort();
+
+type ServiceManagerResolution =
+  /** A program this runner governs, present on this host. */
+  | { readonly kind: "resolved"; readonly path: string }
+  /** A program this runner governs that this host does not have; callers degrade on their own terms. */
+  | { readonly kind: "unavailable" }
+  /** A program this runner does not govern. That is a defect here, not a fact about the host. */
+  | { readonly kind: "ungoverned" };
+
+async function resolveServiceManagerCommand(program: string): Promise<ServiceManagerResolution> {
+  if (isAbsolute(program)) return { kind: "resolved", path: program };
+  const candidates = SERVICE_MANAGER_PATHS[program];
+  if (!candidates) return { kind: "ungoverned" };
   for (const candidate of candidates) {
     try {
       await access(candidate, constants.X_OK);
-      return candidate;
+      return { kind: "resolved", path: candidate };
     } catch {
       // Try the next well-known location.
     }
   }
-  return undefined;
+  return { kind: "unavailable" };
 }
 
 export function deriveServiceIdentity(serviceId: string): ServiceIdentity {

--- a/apps/cli/src/core/daemon/service/shared.ts
+++ b/apps/cli/src/core/daemon/service/shared.ts
@@ -40,10 +40,22 @@ export interface ServiceIdentity {
 }
 
 export const defaultServiceRunner: ServiceRunner = {
-  run(program, args, options) {
+  async run(program, args, options) {
+    // Resolution happens here rather than in the backends because this is where a name becomes a
+    // running process. A service manager reached through the caller's PATH would let an executable
+    // placed earlier there decide what OpenTag believes about its own daemon.
+    const resolved = await resolveServiceManagerCommand(program);
+    if (!resolved) {
+      return {
+        code: null,
+        stderr: `${program} was not found at a known system location`,
+        stdout: "",
+        timedOut: false,
+      };
+    }
     return new Promise<CommandResult>((complete) => {
       execFile(
-        program,
+        resolved,
         [...args],
         {
           encoding: "utf8",
@@ -64,6 +76,38 @@ export const defaultServiceRunner: ServiceRunner = {
     });
   },
 };
+
+/**
+ * Absolute locations for the service managers OpenTag drives.
+ *
+ * A service manager is an authority about the installed service, so it must not be reachable through
+ * the caller's `PATH`: an executable placed earlier there would decide what OpenTag believes about
+ * its own daemon. Resolution is by absolute path only, and an unresolvable manager fails closed
+ * rather than falling back to a name lookup.
+ *
+ * The inherited environment is deliberately left alone. `systemctl --user` needs the session
+ * variables that address the user manager, so stripping them would break the call rather than
+ * secure it; the executable is what had to stop being the caller's choice.
+ */
+const SERVICE_MANAGER_PATHS: Readonly<Record<"launchctl" | "systemctl", readonly string[]>> = {
+  launchctl: ["/bin/launchctl", "/usr/bin/launchctl"],
+  systemctl: ["/usr/bin/systemctl", "/bin/systemctl"],
+};
+
+async function resolveServiceManagerCommand(program: string): Promise<string | undefined> {
+  if (isAbsolute(program)) return program;
+  const candidates = SERVICE_MANAGER_PATHS[program as "launchctl" | "systemctl"];
+  if (!candidates) return undefined;
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next well-known location.
+    }
+  }
+  return undefined;
+}
 
 export function deriveServiceIdentity(serviceId: string): ServiceIdentity {
   return {

--- a/apps/cli/src/core/daemon/service/systemd.ts
+++ b/apps/cli/src/core/daemon/service/systemd.ts
@@ -10,6 +10,7 @@ import {
   quoteSystemdToken,
   readRegularFile,
   runRequired,
+  serviceManagerProgram,
   writeFileAtomically,
 } from "./shared.js";
 import type { ResolvedCliInvocation, ServiceRunner } from "./types.js";
@@ -75,7 +76,7 @@ export function createSystemdBackend(options: SystemdBackendOptions): DaemonServ
     "user",
     identity.systemdUnitName,
   );
-  const systemctl = options.systemctl ?? "systemctl";
+  const systemctl = options.systemctl ?? serviceManagerProgram("systemctl");
   const servicePath = buildServicePath(options.invocation, "linux", options.sourcePath);
   const expected = renderSystemdUnit({
     home: options.home,
@@ -208,7 +209,7 @@ export function createSystemdBackend(options: SystemdBackendOptions): DaemonServ
       } else if (previous.state !== "active") {
         await runRequired(options.runner, systemctl, ["--user", "start", identity.systemdUnitName], "systemd start");
       }
-      const linger = await options.runner.run("loginctl", ["enable-linger", username], {
+      const linger = await options.runner.run(serviceManagerProgram("loginctl"), ["enable-linger", username], {
         timeoutMs: SYSTEMD_TIMEOUT_MS,
       });
       const current = await status();

--- a/apps/cli/src/core/diagnostics/checks.ts
+++ b/apps/cli/src/core/diagnostics/checks.ts
@@ -13,14 +13,14 @@ import {
   agentRuntimeUpgradeFix,
   type DoctorFix,
   imCliInstallFix,
+  imCliRepairFix,
   imCliTitle,
-  imCliUpgradeFix,
 } from "./fixes.js";
 
 /**
  * The Client Runtime abandons a provider probe after this long and reports the provider as
- * unavailable. Doctor uses the same deadline so that it never claims a readiness the daemon would
- * never publish.
+ * unavailable. Doctor uses the same deadline so that it never calls a provider ready on evidence the
+ * daemon would have thrown away.
  */
 export const DOCTOR_PROBE_DEADLINE_MS = 10_000;
 
@@ -51,7 +51,6 @@ export interface AgentRuntimeCheckOptions {
 }
 
 export interface ImCliCheckOptions {
-  readonly commands?: Partial<Record<ImCliProvider, string>>;
   readonly environment: NodeJS.ProcessEnv;
   readonly probe?: ImCliProbe;
   readonly probeDeadlineMs?: number;
@@ -59,7 +58,15 @@ export interface ImCliCheckOptions {
   readonly signal?: AbortSignal;
 }
 
-const DEFAULT_IM_CLI_COMMANDS: Readonly<Record<ImCliProvider, string>> = { feishu: "lark-cli", slack: "slack" };
+const IM_CLI_COMMANDS: Readonly<Record<ImCliProvider, string>> = { feishu: "lark-cli", slack: "slack" };
+
+/** The bare command each check resolves through PATH, keyed by check id. */
+export const DOCTOR_PROBE_COMMANDS: Readonly<Record<string, string | undefined>> = {
+  "im:feishu": IM_CLI_COMMANDS.feishu,
+  "im:slack": IM_CLI_COMMANDS.slack,
+  "runtime:claude-code": "claude",
+  "runtime:codex": "codex",
+};
 
 export async function checkAgentRuntimes(options: AgentRuntimeCheckOptions): Promise<DoctorCheck[]> {
   const deadlineMs = options.probeDeadlineMs ?? DOCTOR_PROBE_DEADLINE_MS;
@@ -75,7 +82,7 @@ export async function checkAgentRuntimes(options: AgentRuntimeCheckOptions): Pro
     } catch (error) {
       options.signal?.throwIfAborted();
       checks.push({
-        detail: deadline.aborted ? `readiness probe timed out after ${deadlineMs}ms` : failureDetail(error),
+        detail: deadline.aborted ? timedOutDetail(deadlineMs) : failureDetail(error),
         fix: agentRuntimeUpgradeFix(provider),
         id,
         status: deadline.aborted ? "unavailable" : "error",
@@ -100,12 +107,7 @@ export async function checkImClis(options: ImCliCheckOptions): Promise<DoctorChe
   const probe =
     options.probe ??
     ((provider: ImCliProvider, signal: AbortSignal) =>
-      probeImCliReadiness(
-        provider,
-        options.commands?.[provider] ?? DEFAULT_IM_CLI_COMMANDS[provider],
-        options.environment,
-        signal,
-      ));
+      probeImCliReadiness(provider, IM_CLI_COMMANDS[provider], options.environment, signal));
   const checks: DoctorCheck[] = [];
   for (const provider of options.providers) {
     const id = `im:${provider}`;
@@ -117,19 +119,22 @@ export async function checkImClis(options: ImCliCheckOptions): Promise<DoctorChe
     } catch (error) {
       options.signal?.throwIfAborted();
       checks.push({
-        detail: deadline.aborted ? `readiness probe timed out after ${deadlineMs}ms` : failureDetail(error),
-        fix: imCliUpgradeFix(provider),
+        detail: deadline.aborted ? timedOutDetail(deadlineMs) : failureDetail(error),
+        fix: imCliRepairFix(provider),
         id,
         status: deadline.aborted ? "unavailable" : "error",
         title,
       });
       continue;
     }
+    // The messaging CLI probe reports a spent deadline as "unavailable" instead of throwing, so the
+    // timed-out wording has to be recovered here to stay accurate.
+    const timedOut = status !== "ready" && deadline.aborted;
     checks.push({
-      detail: imCliDetail(status),
+      detail: timedOut ? timedOutDetail(deadlineMs) : imCliDetail(status),
       ...(status === "ready"
         ? {}
-        : { fix: status === "install" ? imCliInstallFix(provider) : imCliUpgradeFix(provider) }),
+        : { fix: status === "install" ? imCliInstallFix(provider) : imCliRepairFix(provider) }),
       id,
       status: status === "ready" ? "ok" : status,
       title,
@@ -143,6 +148,8 @@ function createAgentRuntimeProbe(options: AgentRuntimeCheckOptions): AgentRuntim
   return async (provider, signal) => {
     composition ??= resolveAgentRuntimeProviders({
       clientVersion: options.clientVersion,
+      // Doctor observes a Computer; it must not create the provider homes it is reporting on.
+      ensureProviderHomes: false,
       environment: options.environment,
       ...(options.signal ? { signal: options.signal } : {}),
     }).then((resolved) => new Map(resolved.factories.map((factory) => [factory.manifest.providerId, factory])));
@@ -163,12 +170,19 @@ function agentRuntimeStatus(
 }
 
 function agentRuntimeDetail(status: Exclude<DoctorCheckStatus, "error">, result: AgentRuntimeProbeResult): string {
-  const version = result.version ? ` (${result.version})` : "";
+  const version = formatVersion(result.version);
   if (status === "ok") return `ready${version}`;
-  if (status === "install") return "not installed, or not on the PATH this computer runs OpenTag with";
+  if (status === "install") return "not installed, or not on this shell's PATH";
   if (status === "sign-in") return `installed${version} but not signed in`;
   const issues = result.issues.map((issue) => issue.message).join("; ");
   return issues || "installed but not usable";
+}
+
+/** `claude --version` prints `2.1.248 (Claude Code)`, which would otherwise nest parentheses. */
+function formatVersion(version: string | undefined): string {
+  if (!version) return "";
+  const trimmed = version.replace(/\s*\([^()]*\)\s*$/u, "").trim();
+  return ` (${trimmed || version})`;
 }
 
 function agentRuntimeFix(
@@ -182,8 +196,12 @@ function agentRuntimeFix(
 
 function imCliDetail(status: "install" | "ready" | "unavailable"): string {
   if (status === "ready") return "ready";
-  if (status === "install") return "not installed, or not on the PATH this computer runs OpenTag with";
-  return "installed but not usable";
+  if (status === "install") return "not installed, or not on this shell's PATH";
+  return "installed but does not answer OpenTag's probe";
+}
+
+function timedOutDetail(deadlineMs: number): string {
+  return `readiness probe timed out after ${deadlineMs}ms`;
 }
 
 function failureDetail(error: unknown): string {

--- a/apps/cli/src/core/diagnostics/checks.ts
+++ b/apps/cli/src/core/diagnostics/checks.ts
@@ -1,0 +1,195 @@
+import {
+  type AgentRuntimeFactory,
+  type AgentRuntimeProbeResult,
+  probeImCliReadiness,
+  providerReadiness,
+  resolveAgentRuntimeProviders,
+} from "@opentag/client";
+import type { AgentRuntimeProvider, ImCliProvider } from "@opentag/shared";
+import {
+  agentRuntimeInstallFix,
+  agentRuntimeSignInFix,
+  agentRuntimeTitle,
+  agentRuntimeUpgradeFix,
+  type DoctorFix,
+  imCliInstallFix,
+  imCliTitle,
+  imCliUpgradeFix,
+} from "./fixes.js";
+
+/**
+ * The Client Runtime abandons a provider probe after this long and reports the provider as
+ * unavailable. Doctor uses the same deadline so that it never claims a readiness the daemon would
+ * never publish.
+ */
+export const DOCTOR_PROBE_DEADLINE_MS = 10_000;
+
+export type DoctorCheckStatus = "error" | "install" | "ok" | "sign-in" | "unavailable";
+
+export interface DoctorCheck {
+  readonly detail: string;
+  readonly fix?: DoctorFix;
+  readonly id: string;
+  readonly status: DoctorCheckStatus;
+  readonly title: string;
+}
+
+export type AgentRuntimeProbe = (
+  provider: AgentRuntimeProvider,
+  signal: AbortSignal,
+) => Promise<AgentRuntimeProbeResult>;
+
+export type ImCliProbe = (provider: ImCliProvider, signal: AbortSignal) => Promise<"install" | "ready" | "unavailable">;
+
+export interface AgentRuntimeCheckOptions {
+  readonly clientVersion: string;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly probe?: AgentRuntimeProbe;
+  readonly probeDeadlineMs?: number;
+  readonly providers: readonly AgentRuntimeProvider[];
+  readonly signal?: AbortSignal;
+}
+
+export interface ImCliCheckOptions {
+  readonly commands?: Partial<Record<ImCliProvider, string>>;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly probe?: ImCliProbe;
+  readonly probeDeadlineMs?: number;
+  readonly providers: readonly ImCliProvider[];
+  readonly signal?: AbortSignal;
+}
+
+const DEFAULT_IM_CLI_COMMANDS: Readonly<Record<ImCliProvider, string>> = { feishu: "lark-cli", slack: "slack" };
+
+export async function checkAgentRuntimes(options: AgentRuntimeCheckOptions): Promise<DoctorCheck[]> {
+  const deadlineMs = options.probeDeadlineMs ?? DOCTOR_PROBE_DEADLINE_MS;
+  const probe = options.probe ?? createAgentRuntimeProbe(options);
+  const checks: DoctorCheck[] = [];
+  for (const provider of options.providers) {
+    const id = `runtime:${provider}`;
+    const title = agentRuntimeTitle(provider);
+    const deadline = AbortSignal.timeout(deadlineMs);
+    let result: AgentRuntimeProbeResult;
+    try {
+      result = await probe(provider, mergeSignals(options.signal, deadline));
+    } catch (error) {
+      options.signal?.throwIfAborted();
+      checks.push({
+        detail: deadline.aborted ? `readiness probe timed out after ${deadlineMs}ms` : failureDetail(error),
+        fix: agentRuntimeUpgradeFix(provider),
+        id,
+        status: deadline.aborted ? "unavailable" : "error",
+        title,
+      });
+      continue;
+    }
+    const status = agentRuntimeStatus(provider, result);
+    checks.push({
+      detail: agentRuntimeDetail(status, result),
+      ...(status === "ok" ? {} : { fix: agentRuntimeFix(provider, status) }),
+      id,
+      status,
+      title,
+    });
+  }
+  return checks;
+}
+
+export async function checkImClis(options: ImCliCheckOptions): Promise<DoctorCheck[]> {
+  const deadlineMs = options.probeDeadlineMs ?? DOCTOR_PROBE_DEADLINE_MS;
+  const probe =
+    options.probe ??
+    ((provider: ImCliProvider, signal: AbortSignal) =>
+      probeImCliReadiness(
+        provider,
+        options.commands?.[provider] ?? DEFAULT_IM_CLI_COMMANDS[provider],
+        options.environment,
+        signal,
+      ));
+  const checks: DoctorCheck[] = [];
+  for (const provider of options.providers) {
+    const id = `im:${provider}`;
+    const title = imCliTitle(provider);
+    const deadline = AbortSignal.timeout(deadlineMs);
+    let status: "install" | "ready" | "unavailable";
+    try {
+      status = await probe(provider, mergeSignals(options.signal, deadline));
+    } catch (error) {
+      options.signal?.throwIfAborted();
+      checks.push({
+        detail: deadline.aborted ? `readiness probe timed out after ${deadlineMs}ms` : failureDetail(error),
+        fix: imCliUpgradeFix(provider),
+        id,
+        status: deadline.aborted ? "unavailable" : "error",
+        title,
+      });
+      continue;
+    }
+    checks.push({
+      detail: imCliDetail(status),
+      ...(status === "ready"
+        ? {}
+        : { fix: status === "install" ? imCliInstallFix(provider) : imCliUpgradeFix(provider) }),
+      id,
+      status: status === "ready" ? "ok" : status,
+      title,
+    });
+  }
+  return checks;
+}
+
+function createAgentRuntimeProbe(options: AgentRuntimeCheckOptions): AgentRuntimeProbe {
+  let composition: Promise<ReadonlyMap<string, AgentRuntimeFactory>> | undefined;
+  return async (provider, signal) => {
+    composition ??= resolveAgentRuntimeProviders({
+      clientVersion: options.clientVersion,
+      environment: options.environment,
+      ...(options.signal ? { signal: options.signal } : {}),
+    }).then((resolved) => new Map(resolved.factories.map((factory) => [factory.manifest.providerId, factory])));
+    const factory = (await composition).get(provider);
+    if (!factory) throw new Error(`The Client Runtime does not register the Agent Runtime provider: ${provider}`);
+    return factory.probe({ signal });
+  };
+}
+
+function agentRuntimeStatus(
+  provider: AgentRuntimeProvider,
+  result: AgentRuntimeProbeResult,
+): Exclude<DoctorCheckStatus, "error"> {
+  const { status } = providerReadiness(provider, result.ready, result);
+  if (status === "ready") return "ok";
+  // "checking" only describes a probe still in flight, which a settled probe result cannot be.
+  return status === "checking" ? "unavailable" : status;
+}
+
+function agentRuntimeDetail(status: Exclude<DoctorCheckStatus, "error">, result: AgentRuntimeProbeResult): string {
+  const version = result.version ? ` (${result.version})` : "";
+  if (status === "ok") return `ready${version}`;
+  if (status === "install") return "not installed, or not on the PATH this computer runs OpenTag with";
+  if (status === "sign-in") return `installed${version} but not signed in`;
+  const issues = result.issues.map((issue) => issue.message).join("; ");
+  return issues || "installed but not usable";
+}
+
+function agentRuntimeFix(
+  provider: AgentRuntimeProvider,
+  status: Exclude<DoctorCheckStatus, "error" | "ok">,
+): DoctorFix {
+  if (status === "install") return agentRuntimeInstallFix(provider);
+  if (status === "sign-in") return agentRuntimeSignInFix(provider);
+  return agentRuntimeUpgradeFix(provider);
+}
+
+function imCliDetail(status: "install" | "ready" | "unavailable"): string {
+  if (status === "ready") return "ready";
+  if (status === "install") return "not installed, or not on the PATH this computer runs OpenTag with";
+  return "installed but not usable";
+}
+
+function failureDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function mergeSignals(signal: AbortSignal | undefined, deadline: AbortSignal): AbortSignal {
+  return signal ? AbortSignal.any([signal, deadline]) : deadline;
+}

--- a/apps/cli/src/core/diagnostics/checks.ts
+++ b/apps/cli/src/core/diagnostics/checks.ts
@@ -1,6 +1,8 @@
 import {
   type AgentRuntimeFactory,
   type AgentRuntimeProbeResult,
+  DEFAULT_AGENT_RUNTIME_COMMANDS,
+  DEFAULT_IM_CLI_COMMANDS,
   probeImCliReadiness,
   providerReadiness,
   resolveAgentRuntimeProviders,
@@ -58,14 +60,12 @@ export interface ImCliCheckOptions {
   readonly signal?: AbortSignal;
 }
 
-const IM_CLI_COMMANDS: Readonly<Record<ImCliProvider, string>> = { feishu: "lark-cli", slack: "slack" };
-
 /** The bare command each check resolves through PATH, keyed by check id. */
 export const DOCTOR_PROBE_COMMANDS: Readonly<Record<string, string | undefined>> = {
-  "im:feishu": IM_CLI_COMMANDS.feishu,
-  "im:slack": IM_CLI_COMMANDS.slack,
-  "runtime:claude-code": "claude",
-  "runtime:codex": "codex",
+  "im:feishu": DEFAULT_IM_CLI_COMMANDS.feishu,
+  "im:slack": DEFAULT_IM_CLI_COMMANDS.slack,
+  "runtime:claude-code": DEFAULT_AGENT_RUNTIME_COMMANDS["claude-code"],
+  "runtime:codex": DEFAULT_AGENT_RUNTIME_COMMANDS.codex,
 };
 
 export async function checkAgentRuntimes(options: AgentRuntimeCheckOptions): Promise<DoctorCheck[]> {
@@ -107,7 +107,7 @@ export async function checkImClis(options: ImCliCheckOptions): Promise<DoctorChe
   const probe =
     options.probe ??
     ((provider: ImCliProvider, signal: AbortSignal) =>
-      probeImCliReadiness(provider, IM_CLI_COMMANDS[provider], options.environment, signal));
+      probeImCliReadiness(provider, DEFAULT_IM_CLI_COMMANDS[provider], options.environment, signal));
   const checks: DoctorCheck[] = [];
   for (const provider of options.providers) {
     const id = `im:${provider}`;

--- a/apps/cli/src/core/diagnostics/checks.ts
+++ b/apps/cli/src/core/diagnostics/checks.ts
@@ -39,9 +39,14 @@ export interface DoctorCheck {
 export type AgentRuntimeProbe = (
   provider: AgentRuntimeProvider,
   signal: AbortSignal,
+  environment: NodeJS.ProcessEnv,
 ) => Promise<AgentRuntimeProbeResult>;
 
-export type ImCliProbe = (provider: ImCliProvider, signal: AbortSignal) => Promise<"install" | "ready" | "unavailable">;
+export type ImCliProbe = (
+  provider: ImCliProvider,
+  signal: AbortSignal,
+  environment: NodeJS.ProcessEnv,
+) => Promise<"install" | "ready" | "unavailable">;
 
 export interface AgentRuntimeCheckOptions {
   readonly clientVersion: string;
@@ -78,7 +83,7 @@ export async function checkAgentRuntimes(options: AgentRuntimeCheckOptions): Pro
     const deadline = AbortSignal.timeout(deadlineMs);
     let result: AgentRuntimeProbeResult;
     try {
-      result = await probe(provider, mergeSignals(options.signal, deadline));
+      result = await probe(provider, mergeSignals(options.signal, deadline), options.environment);
     } catch (error) {
       options.signal?.throwIfAborted();
       checks.push({
@@ -106,8 +111,8 @@ export async function checkImClis(options: ImCliCheckOptions): Promise<DoctorChe
   const deadlineMs = options.probeDeadlineMs ?? DOCTOR_PROBE_DEADLINE_MS;
   const probe =
     options.probe ??
-    ((provider: ImCliProvider, signal: AbortSignal) =>
-      probeImCliReadiness(provider, DEFAULT_IM_CLI_COMMANDS[provider], options.environment, signal));
+    ((provider: ImCliProvider, signal: AbortSignal, environment: NodeJS.ProcessEnv) =>
+      probeImCliReadiness(provider, DEFAULT_IM_CLI_COMMANDS[provider], environment, signal));
   const checks: DoctorCheck[] = [];
   for (const provider of options.providers) {
     const id = `im:${provider}`;
@@ -115,7 +120,7 @@ export async function checkImClis(options: ImCliCheckOptions): Promise<DoctorChe
     const deadline = AbortSignal.timeout(deadlineMs);
     let status: "install" | "ready" | "unavailable";
     try {
-      status = await probe(provider, mergeSignals(options.signal, deadline));
+      status = await probe(provider, mergeSignals(options.signal, deadline), options.environment);
     } catch (error) {
       options.signal?.throwIfAborted();
       checks.push({
@@ -145,12 +150,12 @@ export async function checkImClis(options: ImCliCheckOptions): Promise<DoctorChe
 
 function createAgentRuntimeProbe(options: AgentRuntimeCheckOptions): AgentRuntimeProbe {
   let composition: Promise<ReadonlyMap<string, AgentRuntimeFactory>> | undefined;
-  return async (provider, signal) => {
+  return async (provider, signal, environment) => {
     composition ??= resolveAgentRuntimeProviders({
       clientVersion: options.clientVersion,
       // Doctor observes a Computer; it must not create the provider homes it is reporting on.
       ensureProviderHomes: false,
-      environment: options.environment,
+      environment,
       ...(options.signal ? { signal: options.signal } : {}),
     }).then((resolved) => new Map(resolved.factories.map((factory) => [factory.manifest.providerId, factory])));
     const factory = (await composition).get(provider);

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -1,5 +1,6 @@
 import {
   checkServerHealth,
+  resolveExecutable,
   resolveOpenTagHome,
   ServerHealthConfigurationError,
   ServerHealthHttpError,
@@ -16,13 +17,16 @@ import {
 import { CLI_VERSION } from "../../build-info.js";
 import { channelConfig } from "../channel/config.js";
 import { loadDaemonEnvironment } from "../daemon/environment.js";
+import type { DaemonServiceManager } from "../daemon/service/index.js";
 import {
   type AgentRuntimeProbe,
   checkAgentRuntimes,
   checkImClis,
+  DOCTOR_PROBE_COMMANDS,
   type DoctorCheck,
   type ImCliProbe,
 } from "./checks.js";
+import { type DaemonServiceEnvironment, readDaemonServiceEnvironment } from "./service-environment.js";
 
 export type HealthChecker = (serverUrl: string) => Promise<ServerHealth>;
 
@@ -35,7 +39,9 @@ export interface DoctorOptions {
   /** Messaging CLIs that must be ready. Defaults to "any one of them is enough". */
   imProviders?: readonly ImCliProvider[];
   probeDeadlineMs?: number;
+  platform?: NodeJS.Platform;
   runtimeProbe?: AgentRuntimeProbe;
+  serviceManager?: DaemonServiceManager;
   /** Agent Runtimes that must be ready. Defaults to "any one of them is enough". */
   runtimes?: readonly AgentRuntimeProvider[];
   serverUrl?: string;
@@ -71,35 +77,60 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResu
     });
   }
 
+  // Readiness is published by the installed daemon service, which resolves provider CLIs through the
+  // PATH captured when it was installed. Probing with anything else answers a different question.
+  const service = await readDaemonServiceEnvironment({
+    env: baseEnvironment,
+    home,
+    ...(options.serviceManager ? { manager: options.serviceManager } : {}),
+    ...(options.platform ? { platform: options.platform } : {}),
+  });
+  const serviceCheck = daemonServiceCheck(service);
+  const shellPath = environment.PATH ?? "";
+  const probeEnvironment = service.kind === "installed" ? { ...environment, PATH: service.path } : { ...environment };
+
   const runtimeProviders = options.runtimes ?? AGENT_RUNTIME_PROVIDERS;
   const imProviders = options.imProviders ?? IM_CLI_PROVIDERS;
   const [serverCheck, runtimeChecks, imChecks] = await Promise.all([
     checkServer(options),
     checkAgentRuntimes({
       clientVersion: options.clientVersion ?? CLI_VERSION,
-      environment,
+      environment: probeEnvironment,
       providers: runtimeProviders,
       ...(options.probeDeadlineMs ? { probeDeadlineMs: options.probeDeadlineMs } : {}),
       ...(options.runtimeProbe ? { probe: options.runtimeProbe } : {}),
       ...(options.signal ? { signal: options.signal } : {}),
     }),
     checkImClis({
-      environment,
+      environment: probeEnvironment,
       providers: imProviders,
       ...(options.probeDeadlineMs ? { probeDeadlineMs: options.probeDeadlineMs } : {}),
       ...(options.imProbe ? { probe: options.imProbe } : {}),
       ...(options.signal ? { signal: options.signal } : {}),
     }),
   ]);
+  const probedRuntimeChecks =
+    service.kind === "installed" ? await explainPathDivergence(runtimeChecks, shellPath, service.path) : runtimeChecks;
+  const probedImChecks =
+    service.kind === "installed" ? await explainPathDivergence(imChecks, shellPath, service.path) : imChecks;
 
-  const checks = [serverCheck, ...environmentChecks, ...runtimeChecks, ...imChecks];
+  const checks = [serverCheck, serviceCheck, ...environmentChecks, ...probedRuntimeChecks, ...probedImChecks];
   const blocking = [
     ...(serverCheck.status === "ok" ? [] : [serverCheck]),
+    ...(serviceCheck.status === "ok" ? [] : [serviceCheck]),
     ...environmentChecks,
-    ...blockingGroup(runtimeChecks, Boolean(options.runtimes)),
-    ...blockingGroup(imChecks, Boolean(options.imProviders)),
+    ...blockingGroup(probedRuntimeChecks, Boolean(options.runtimes)),
+    ...blockingGroup(probedImChecks, Boolean(options.imProviders)),
   ];
-  return { checks, exitCode: blocking.length > 0 ? 1 : 0, message: renderDoctorText(checks, blocking) };
+  const ready = {
+    imProviders: imProviders.filter((provider) => isReady(probedImChecks, `im:${provider}`)),
+    runtimes: runtimeProviders.filter((provider) => isReady(probedRuntimeChecks, `runtime:${provider}`)),
+  };
+  return {
+    checks,
+    exitCode: blocking.length > 0 ? 1 : 0,
+    message: renderDoctorText(checks, blocking, ready, service),
+  };
 }
 
 export function renderDoctorJson(result: DoctorResult): string {
@@ -127,6 +158,99 @@ function blockingGroup(checks: readonly DoctorCheck[], selected: boolean): Docto
   const failed = checks.filter((check) => check.status !== "ok");
   if (selected) return failed;
   return failed.length === checks.length ? failed : [];
+}
+
+/**
+ * The daemon is what runs Agents and publishes readiness, so a Computer without a usable service is
+ * not ready however healthy its CLIs look. Anything short of an installed, readable, active service
+ * fails closed: doctor then has no authority to declare the Computer ready.
+ */
+function daemonServiceCheck(service: DaemonServiceEnvironment): DoctorCheck {
+  const title = "Daemon service";
+  const id = "daemon-service";
+  if (service.kind === "installed" && service.state === "active") {
+    return { detail: "active; checks below use the PATH it runs with", id, status: "ok", title };
+  }
+  if (service.kind === "installed") {
+    return {
+      detail: `installed but ${service.state}, so nothing runs Agents or publishes readiness`,
+      fix: { commands: [`${channelConfig.binName} daemon restart`], summary: "Start the OpenTag daemon service" },
+      id,
+      status: "unavailable",
+      title,
+    };
+  }
+  if (service.kind === "not-installed") {
+    return {
+      detail: "not installed, so nothing runs Agents or publishes readiness from this computer",
+      fix: {
+        commands: [`${channelConfig.binName} daemon install`],
+        note: `If this computer is not connected yet, run \`${channelConfig.binName} computer connect <code>\` instead; it installs the service for you`,
+        summary: "Install the OpenTag daemon service",
+      },
+      id,
+      status: "install",
+      title,
+    };
+  }
+  if (service.kind === "unsupported") {
+    return {
+      detail: `the OpenTag daemon does not support ${service.platform}`,
+      fix: { commands: [], summary: "Run OpenTag on macOS or Linux" },
+      id,
+      status: "error",
+      title,
+    };
+  }
+  return {
+    detail: `installed but unreadable: ${service.reason}`,
+    fix: {
+      commands: [`${channelConfig.binName} daemon install`],
+      summary: "Rewrite the OpenTag daemon service definition",
+    },
+    id,
+    status: "error",
+    title,
+  };
+}
+
+/**
+ * A CLI the operator can run is not necessarily a CLI the daemon can run. When the two PATHs
+ * disagree, saying so — and how to close the gap — beats telling them to install what they have.
+ */
+async function explainPathDivergence(
+  checks: readonly DoctorCheck[],
+  shellPath: string,
+  daemonPath: string,
+): Promise<DoctorCheck[]> {
+  if (shellPath === daemonPath) return [...checks];
+  const explained: DoctorCheck[] = [];
+  for (const check of checks) {
+    const command = DOCTOR_PROBE_COMMANDS[check.id];
+    if (check.status !== "install" || !command || !(await resolvesOnPath(command, shellPath))) {
+      explained.push(check);
+      continue;
+    }
+    explained.push({
+      ...check,
+      detail: `on this shell's PATH, but not on the PATH the daemon service runs with`,
+      fix: {
+        commands: [`${channelConfig.binName} daemon install`],
+        note: `\`${command}\` resolves for you but not for the daemon, which uses the PATH captured when its service was installed. Re-installing the service from this shell captures the current one.`,
+        summary: `Give the daemon the same PATH this shell has, so that it can run \`${command}\``,
+      },
+    });
+  }
+  return explained;
+}
+
+async function resolvesOnPath(command: string, path: string): Promise<boolean> {
+  try {
+    await resolveExecutable(command, { PATH: path });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function checkServer(options: DoctorOptions): Promise<DoctorCheck> {
@@ -166,10 +290,21 @@ function serverFixSummary(error: unknown, serverUrl: string): string {
   return `Wait for the OpenTag server at ${serverUrl} to become healthy, or point OpenTag at another one`;
 }
 
-function renderDoctorText(checks: readonly DoctorCheck[], blocking: readonly DoctorCheck[]): string {
+function renderDoctorText(
+  checks: readonly DoctorCheck[],
+  blocking: readonly DoctorCheck[],
+  ready: { imProviders: readonly ImCliProvider[]; runtimes: readonly AgentRuntimeProvider[] },
+  service: DaemonServiceEnvironment,
+): string {
   const lines = ["Checks", ...checks.map((check) => `  ${check.title}: ${check.detail}`), ""];
   if (blocking.length === 0) {
-    lines.push("This computer is ready to run an OpenTag agent.");
+    lines.push(
+      `This computer can run an OpenTag agent on ${orList(ready.runtimes.map(agentRuntimeName))},`,
+      `delivering through ${orList(ready.imProviders.map(imCliName))}. It does not know which of those`,
+      "your Agent is bound to; pass --runtime and --im to check a specific pair.",
+      "",
+      pathSource(service),
+    );
     return lines.join("\n");
   }
   lines.push(
@@ -180,14 +315,42 @@ function renderDoctorText(checks: readonly DoctorCheck[], blocking: readonly Doc
   for (const [index, fix] of fixes.entries()) {
     lines.push(`Fix ${index + 1}/${fixes.length} — ${fix.summary}`);
     for (const command of fix.commands) lines.push(`  ${command}`);
+    if (fix.note) lines.push(`  Note: ${fix.note}`);
     if (fix.docsUrl) lines.push(`  Docs: ${fix.docsUrl}`);
   }
   lines.push(
     "",
     `Re-run \`${channelConfig.binName} doctor\` once the fixes are done. The OpenTag daemon republishes readiness`,
     "about twice a minute, so a setup page waiting on this computer turns green on its own.",
+    "",
+    pathSource(service),
   );
   return lines.join("\n");
+}
+
+/** Naming the PATH a report was produced with is what makes the report checkable. */
+function pathSource(service: DaemonServiceEnvironment): string {
+  if (service.kind === "installed") {
+    return `CLI checks used the PATH declared by ${service.definitionPath}, which is what the daemon service runs with.`;
+  }
+  return "CLI checks used this shell's PATH, because no installed daemon service could be read; the daemon may resolve a different one.";
+}
+
+function isReady(checks: readonly DoctorCheck[], id: string): boolean {
+  return checks.some((check) => check.id === id && check.status === "ok");
+}
+
+function agentRuntimeName(provider: AgentRuntimeProvider): string {
+  return provider === "codex" ? "Codex" : "Claude Code";
+}
+
+function imCliName(provider: ImCliProvider): string {
+  return provider === "feishu" ? "Feishu" : "Slack";
+}
+
+function orList(names: readonly string[]): string {
+  if (names.length <= 1) return names[0] ?? "nothing";
+  return `${names.slice(0, -1).join(", ")} or ${names[names.length - 1]}`;
 }
 
 function formatServerError(error: unknown, serverUrl: string): string {

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -1,3 +1,4 @@
+import { userInfo } from "node:os";
 import {
   checkServerHealth,
   resolveExecutable,
@@ -170,22 +171,39 @@ function blockingGroup(checks: readonly DoctorCheck[], selected: boolean): Docto
  * strict makes the diagnostic err toward "not ready", which is the safe direction: the daemon
  * gets its extra configuration from `daemon.env`, and that is layered on separately.
  */
-const SERVICE_ACCOUNT_VARIABLES = ["HOME", "LOGNAME", "SHELL", "USER"] as const;
 const SERVICE_MANAGER_VARIABLES: Readonly<Record<"launchd" | "systemd", readonly string[]>> = {
   launchd: ["TMPDIR"],
   systemd: ["XDG_RUNTIME_DIR"],
 };
 
+export interface ServiceAccount {
+  readonly homedir: string;
+  readonly shell: string | null;
+  readonly username: string;
+}
+
 /**
  * Reconstruct the environment the installed service's process actually has: the account-level
  * variables its manager provides, overlaid with exactly what its definition declares.
+ *
+ * The account identity comes from the operating system rather than the invoking environment. A
+ * service manager starts the job from the user account itself, so a shell that exported a different
+ * `HOME` would otherwise send the probes looking for provider homes the daemon never uses. The
+ * per-user temporary directory still comes from the environment: the same account resolves it to
+ * the same value, and it carries no credential.
  */
 export function serviceProcessEnvironment(
   base: NodeJS.ProcessEnv,
   service: { readonly environment: Readonly<Record<string, string>>; readonly platform: "launchd" | "systemd" },
+  account: ServiceAccount = userInfo(),
 ): NodeJS.ProcessEnv {
-  const environment: NodeJS.ProcessEnv = {};
-  for (const key of [...SERVICE_ACCOUNT_VARIABLES, ...SERVICE_MANAGER_VARIABLES[service.platform]]) {
+  const environment: NodeJS.ProcessEnv = {
+    HOME: account.homedir,
+    LOGNAME: account.username,
+    USER: account.username,
+    ...(account.shell ? { SHELL: account.shell } : {}),
+  };
+  for (const key of SERVICE_MANAGER_VARIABLES[service.platform]) {
     const value = base[key];
     if (value !== undefined) environment[key] = value;
   }

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -64,10 +64,22 @@ export function resolveServerUrl(serverUrl: string | undefined, env: NodeJS.Proc
 export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResult> {
   const baseEnvironment = options.env ?? process.env;
   const home = options.home ?? resolveOpenTagHome(baseEnvironment);
+  // Readiness is published by the installed daemon service, so the service's own environment — not
+  // the operator's shell — is the only one whose answer matches what the Server receives.
+  const service = await readDaemonServiceEnvironment({
+    env: baseEnvironment,
+    home,
+    ...(options.serviceManager ? { manager: options.serviceManager } : {}),
+    ...(options.platform ? { platform: options.platform } : {}),
+  });
+  const serviceCheck = daemonServiceCheck(service);
   const environmentChecks: DoctorCheck[] = [];
-  let environment = baseEnvironment;
+  const serviceEnvironment =
+    service.kind === "installed" ? serviceProcessEnvironment(baseEnvironment, service) : { ...baseEnvironment };
+  let probeEnvironment = serviceEnvironment;
   try {
-    environment = (await loadDaemonEnvironment(home, baseEnvironment)).env;
+    // The daemon layers daemon.env over its service environment, filling only unset keys.
+    probeEnvironment = (await loadDaemonEnvironment(home, serviceEnvironment)).env;
   } catch (error) {
     environmentChecks.push({
       detail: `${describeError(error)}; the daemon reads the same file and fails the same way`,
@@ -77,18 +89,8 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResu
       title: "Daemon environment",
     });
   }
-
-  // Readiness is published by the installed daemon service, which resolves provider CLIs through the
-  // PATH captured when it was installed. Probing with anything else answers a different question.
-  const service = await readDaemonServiceEnvironment({
-    env: baseEnvironment,
-    home,
-    ...(options.serviceManager ? { manager: options.serviceManager } : {}),
-    ...(options.platform ? { platform: options.platform } : {}),
-  });
-  const serviceCheck = daemonServiceCheck(service);
-  const shellPath = environment.PATH ?? "";
-  const probeEnvironment = service.kind === "installed" ? { ...environment, PATH: service.path } : { ...environment };
+  // The invoking shell's PATH is comparison-only: it explains a divergence, it never probes.
+  const shellPath = baseEnvironment.PATH ?? "";
 
   const runtimeProviders = options.runtimes ?? AGENT_RUNTIME_PROVIDERS;
   const imProviders = options.imProviders ?? IM_CLI_PROVIDERS;
@@ -162,6 +164,35 @@ function blockingGroup(checks: readonly DoctorCheck[], selected: boolean): Docto
 }
 
 /**
+ * Variables a user service receives from the service manager itself rather than from any shell.
+ * launchd and systemd both establish the account's own identity and locations for the process; a
+ * shell export such as `ANTHROPIC_API_KEY` or `CODEX_HOME` never reaches it. Keeping this list
+ * strict makes the diagnostic err toward "not ready", which is the safe direction: the daemon
+ * gets its extra configuration from `daemon.env`, and that is layered on separately.
+ */
+const SERVICE_ACCOUNT_VARIABLES = ["HOME", "LOGNAME", "SHELL", "USER"] as const;
+const SERVICE_MANAGER_VARIABLES: Readonly<Record<"launchd" | "systemd", readonly string[]>> = {
+  launchd: ["TMPDIR"],
+  systemd: ["XDG_RUNTIME_DIR"],
+};
+
+/**
+ * Reconstruct the environment the installed service's process actually has: the account-level
+ * variables its manager provides, overlaid with exactly what its definition declares.
+ */
+export function serviceProcessEnvironment(
+  base: NodeJS.ProcessEnv,
+  service: { readonly environment: Readonly<Record<string, string>>; readonly platform: "launchd" | "systemd" },
+): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const key of [...SERVICE_ACCOUNT_VARIABLES, ...SERVICE_MANAGER_VARIABLES[service.platform]]) {
+    const value = base[key];
+    if (value !== undefined) environment[key] = value;
+  }
+  return { ...environment, ...service.environment };
+}
+
+/**
  * The daemon is what runs Agents and publishes readiness, so a Computer without a usable service is
  * not ready however healthy its CLIs look. Anything short of an installed, readable, active service
  * fails closed: doctor then has no authority to declare the Computer ready.
@@ -178,6 +209,18 @@ function daemonServiceCheck(service: DaemonServiceEnvironment): DoctorCheck {
       fix: { commands: [`${channelConfig.binName} daemon restart`], summary: "Start the OpenTag daemon service" },
       id,
       status: "unavailable",
+      title,
+    };
+  }
+  if (service.kind === "home-mismatch") {
+    return {
+      detail: `active for another OpenTag home (${service.serviceHome}), not ${service.requestedHome}`,
+      fix: {
+        commands: [],
+        summary: `Run doctor against the home the installed service belongs to: OPENTAG_HOME=${service.serviceHome}`,
+      },
+      id,
+      status: "error",
       title,
     };
   }

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -28,11 +28,16 @@ import {
   type ImCliProbe,
 } from "./checks.js";
 import type { DoctorFix } from "./fixes.js";
-import { type DaemonServiceEnvironment, readDaemonServiceEnvironment } from "./service-environment.js";
+import {
+  type DaemonServiceEnvironment,
+  readDaemonServiceEnvironment,
+  serviceManagerVariables,
+} from "./service-environment.js";
 
 export type HealthChecker = (serverUrl: string) => Promise<ServerHealth>;
 
 export interface DoctorOptions {
+  account?: ServiceAccount;
   clientVersion?: string;
   env?: NodeJS.ProcessEnv;
   healthChecker?: HealthChecker;
@@ -75,10 +80,15 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResu
   });
   const serviceCheck = daemonServiceCheck(service);
   const environmentChecks: DoctorCheck[] = [];
+  const account = options.account ?? userInfo();
+  const platform = options.platform ?? process.platform;
+  const managerVariables = await serviceManagerVariables(
+    service.kind === "installed" ? service.platform : serviceManagerFor(platform),
+  );
   const serviceEnvironment =
     service.kind === "installed"
-      ? serviceProcessEnvironment(baseEnvironment, service)
-      : unmanagedProbeEnvironment(baseEnvironment, options.platform ?? process.platform);
+      ? serviceProcessEnvironment(service, account, managerVariables)
+      : unmanagedProbeEnvironment(baseEnvironment, account, managerVariables);
   let probeEnvironment = serviceEnvironment;
   try {
     // The daemon layers daemon.env over its service environment, filling only unset keys.
@@ -173,11 +183,6 @@ function blockingGroup(checks: readonly DoctorCheck[], selected: boolean): Docto
  * strict makes the diagnostic err toward "not ready", which is the safe direction: the daemon
  * gets its extra configuration from `daemon.env`, and that is layered on separately.
  */
-const SERVICE_MANAGER_VARIABLES: Readonly<Record<"launchd" | "systemd", readonly string[]>> = {
-  launchd: ["TMPDIR"],
-  systemd: ["XDG_RUNTIME_DIR"],
-};
-
 export interface ServiceAccount {
   readonly homedir: string;
   readonly shell: string | null;
@@ -195,11 +200,11 @@ export interface ServiceAccount {
  * the same value, and it carries no credential.
  */
 export function serviceProcessEnvironment(
-  base: NodeJS.ProcessEnv,
   service: { readonly environment: Readonly<Record<string, string>>; readonly platform: "launchd" | "systemd" },
-  account: ServiceAccount = userInfo(),
+  account: ServiceAccount,
+  managerVariables: Readonly<Record<string, string>>,
 ): NodeJS.ProcessEnv {
-  return { ...accountEnvironment(base, service.platform, account), ...service.environment };
+  return { ...accountEnvironment(account), ...managerVariables, ...service.environment };
 }
 
 /**
@@ -211,31 +216,26 @@ export function serviceProcessEnvironment(
  */
 export function unmanagedProbeEnvironment(
   base: NodeJS.ProcessEnv,
-  platform: NodeJS.Platform,
-  account: ServiceAccount = userInfo(),
+  account: ServiceAccount,
+  managerVariables: Readonly<Record<string, string>>,
 ): NodeJS.ProcessEnv {
-  const manager = platform === "linux" ? "systemd" : platform === "darwin" ? "launchd" : undefined;
-  const environment = accountEnvironment(base, manager, account);
+  const environment: NodeJS.ProcessEnv = { ...accountEnvironment(account), ...managerVariables };
   if (base.PATH !== undefined) environment.PATH = base.PATH;
   return environment;
 }
 
-function accountEnvironment(
-  base: NodeJS.ProcessEnv,
-  manager: "launchd" | "systemd" | undefined,
-  account: ServiceAccount,
-): NodeJS.ProcessEnv {
-  const environment: NodeJS.ProcessEnv = {
+function accountEnvironment(account: ServiceAccount): NodeJS.ProcessEnv {
+  return {
     HOME: account.homedir,
     LOGNAME: account.username,
     USER: account.username,
     ...(account.shell ? { SHELL: account.shell } : {}),
   };
-  for (const key of manager ? SERVICE_MANAGER_VARIABLES[manager] : []) {
-    const value = base[key];
-    if (value !== undefined) environment[key] = value;
-  }
-  return environment;
+}
+
+function serviceManagerFor(platform: NodeJS.Platform): "launchd" | "systemd" | undefined {
+  if (platform === "linux") return "systemd";
+  return platform === "darwin" ? "launchd" : undefined;
 }
 
 /**

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -76,7 +76,9 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResu
   const serviceCheck = daemonServiceCheck(service);
   const environmentChecks: DoctorCheck[] = [];
   const serviceEnvironment =
-    service.kind === "installed" ? serviceProcessEnvironment(baseEnvironment, service) : { ...baseEnvironment };
+    service.kind === "installed"
+      ? serviceProcessEnvironment(baseEnvironment, service)
+      : unmanagedProbeEnvironment(baseEnvironment, options.platform ?? process.platform);
   let probeEnvironment = serviceEnvironment;
   try {
     // The daemon layers daemon.env over its service environment, filling only unset keys.
@@ -197,17 +199,43 @@ export function serviceProcessEnvironment(
   service: { readonly environment: Readonly<Record<string, string>>; readonly platform: "launchd" | "systemd" },
   account: ServiceAccount = userInfo(),
 ): NodeJS.ProcessEnv {
+  return { ...accountEnvironment(base, service.platform, account), ...service.environment };
+}
+
+/**
+ * What to probe with when no service definition can be read. The account reconstruction still
+ * applies, so a check line means the same thing on every path; only the executable search path falls
+ * back to the invoking shell, because nothing else has one to offer. A service installed later
+ * captures its own, and inherits none of this shell's credentials either — so dropping them here
+ * predicts that service rather than flattering the current terminal.
+ */
+export function unmanagedProbeEnvironment(
+  base: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  account: ServiceAccount = userInfo(),
+): NodeJS.ProcessEnv {
+  const manager = platform === "linux" ? "systemd" : platform === "darwin" ? "launchd" : undefined;
+  const environment = accountEnvironment(base, manager, account);
+  if (base.PATH !== undefined) environment.PATH = base.PATH;
+  return environment;
+}
+
+function accountEnvironment(
+  base: NodeJS.ProcessEnv,
+  manager: "launchd" | "systemd" | undefined,
+  account: ServiceAccount,
+): NodeJS.ProcessEnv {
   const environment: NodeJS.ProcessEnv = {
     HOME: account.homedir,
     LOGNAME: account.username,
     USER: account.username,
     ...(account.shell ? { SHELL: account.shell } : {}),
   };
-  for (const key of SERVICE_MANAGER_VARIABLES[service.platform]) {
+  for (const key of manager ? SERVICE_MANAGER_VARIABLES[manager] : []) {
     const value = base[key];
     if (value !== undefined) environment[key] = value;
   }
-  return { ...environment, ...service.environment };
+  return environment;
 }
 
 /**
@@ -410,7 +438,7 @@ function pathSource(service: DaemonServiceEnvironment): string {
   if (service.kind === "installed") {
     return `CLI checks used the PATH declared by ${service.definitionPath}, which is what the daemon service runs with.`;
   }
-  return "CLI checks used this shell's PATH, because no installed daemon service could be read; the daemon may resolve a different one.";
+  return "CLI checks used this account and this shell's PATH, because no installed daemon service could be read. A service installed later resolves its own PATH and inherits nothing else from this shell.";
 }
 
 function isReady(checks: readonly DoctorCheck[], id: string): boolean {

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -183,6 +183,17 @@ function blockingGroup(checks: readonly DoctorCheck[], selected: boolean): Docto
  * strict makes the diagnostic err toward "not ready", which is the safe direction: the daemon
  * gets its extra configuration from `daemon.env`, and that is layered on separately.
  */
+/**
+ * The account identity a service manager establishes for the jobs it starts.
+ *
+ * This is a deliberate subset, not the whole of what a job receives. A real launchd job also gets
+ * `SSH_AUTH_SOCK` and launchd bookkeeping such as `XPC_SERVICE_NAME`, `XPC_FLAGS` and
+ * `OSLogRateLimit` — measured, not assumed. Omitting them is safe because omission can only make a
+ * probe fail where the daemon would succeed, never the reverse. `SSH_AUTH_SOCK` is the one worth
+ * revisiting if a provider ever authenticates through the SSH agent during a probe: it would then
+ * be a value that changes the answer, which is the test that matters rather than whether it is
+ * secret.
+ */
 export interface ServiceAccount {
   readonly homedir: string;
   readonly shell: string | null;

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -1,22 +1,49 @@
 import {
   checkServerHealth,
+  resolveOpenTagHome,
   ServerHealthConfigurationError,
   ServerHealthHttpError,
   ServerHealthNetworkError,
   ServerHealthResponseError,
 } from "@opentag/client";
-import type { ServerHealth } from "@opentag/shared";
+import {
+  AGENT_RUNTIME_PROVIDERS,
+  type AgentRuntimeProvider,
+  IM_CLI_PROVIDERS,
+  type ImCliProvider,
+  type ServerHealth,
+} from "@opentag/shared";
+import { CLI_VERSION } from "../../build-info.js";
 import { channelConfig } from "../channel/config.js";
+import { loadDaemonEnvironment } from "../daemon/environment.js";
+import {
+  type AgentRuntimeProbe,
+  checkAgentRuntimes,
+  checkImClis,
+  type DoctorCheck,
+  type ImCliProbe,
+} from "./checks.js";
 
 export type HealthChecker = (serverUrl: string) => Promise<ServerHealth>;
 
 export interface DoctorOptions {
-  serverUrl?: string;
+  clientVersion?: string;
   env?: NodeJS.ProcessEnv;
   healthChecker?: HealthChecker;
+  home?: string;
+  imProbe?: ImCliProbe;
+  /** Messaging CLIs that must be ready. Defaults to "any one of them is enough". */
+  imProviders?: readonly ImCliProvider[];
+  probeDeadlineMs?: number;
+  runtimeProbe?: AgentRuntimeProbe;
+  /** Agent Runtimes that must be ready. Defaults to "any one of them is enough". */
+  runtimes?: readonly AgentRuntimeProvider[];
+  serverUrl?: string;
+  signal?: AbortSignal;
 }
 
 export interface DoctorResult {
+  checks: DoctorCheck[];
   exitCode: 0 | 1;
   message: string;
 }
@@ -28,41 +55,157 @@ export function resolveServerUrl(serverUrl: string | undefined, env: NodeJS.Proc
 }
 
 export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResult> {
+  const baseEnvironment = options.env ?? process.env;
+  const home = options.home ?? resolveOpenTagHome(baseEnvironment);
+  const environmentChecks: DoctorCheck[] = [];
+  let environment = baseEnvironment;
+  try {
+    environment = (await loadDaemonEnvironment(home, baseEnvironment)).env;
+  } catch (error) {
+    environmentChecks.push({
+      detail: `${describeError(error)}; the daemon reads the same file and fails the same way`,
+      fix: { commands: [], summary: `Repair or remove the daemon environment file under ${home}` },
+      id: "daemon-environment",
+      status: "error",
+      title: "Daemon environment",
+    });
+  }
+
+  const runtimeProviders = options.runtimes ?? AGENT_RUNTIME_PROVIDERS;
+  const imProviders = options.imProviders ?? IM_CLI_PROVIDERS;
+  const [serverCheck, runtimeChecks, imChecks] = await Promise.all([
+    checkServer(options),
+    checkAgentRuntimes({
+      clientVersion: options.clientVersion ?? CLI_VERSION,
+      environment,
+      providers: runtimeProviders,
+      ...(options.probeDeadlineMs ? { probeDeadlineMs: options.probeDeadlineMs } : {}),
+      ...(options.runtimeProbe ? { probe: options.runtimeProbe } : {}),
+      ...(options.signal ? { signal: options.signal } : {}),
+    }),
+    checkImClis({
+      environment,
+      providers: imProviders,
+      ...(options.probeDeadlineMs ? { probeDeadlineMs: options.probeDeadlineMs } : {}),
+      ...(options.imProbe ? { probe: options.imProbe } : {}),
+      ...(options.signal ? { signal: options.signal } : {}),
+    }),
+  ]);
+
+  const checks = [serverCheck, ...environmentChecks, ...runtimeChecks, ...imChecks];
+  const blocking = [
+    ...(serverCheck.status === "ok" ? [] : [serverCheck]),
+    ...environmentChecks,
+    ...blockingGroup(runtimeChecks, Boolean(options.runtimes)),
+    ...blockingGroup(imChecks, Boolean(options.imProviders)),
+  ];
+  return { checks, exitCode: blocking.length > 0 ? 1 : 0, message: renderDoctorText(checks, blocking) };
+}
+
+export function renderDoctorJson(result: DoctorResult): string {
+  return JSON.stringify(
+    {
+      checks: result.checks.map((check) => ({
+        detail: check.detail,
+        id: check.id,
+        status: check.status,
+        title: check.title,
+        ...(check.fix ? { fix: check.fix } : {}),
+      })),
+      ok: result.exitCode === 0,
+    },
+    undefined,
+    2,
+  );
+}
+
+/**
+ * A group passes when the caller-selected members are ready. Without a selection, one ready member
+ * is enough: a computer that runs Codex does not need Claude Code installed as well.
+ */
+function blockingGroup(checks: readonly DoctorCheck[], selected: boolean): DoctorCheck[] {
+  const failed = checks.filter((check) => check.status !== "ok");
+  if (selected) return failed;
+  return failed.length === checks.length ? failed : [];
+}
+
+async function checkServer(options: DoctorOptions): Promise<DoctorCheck> {
+  const title = "OpenTag server";
   let serverUrl: string;
   try {
     serverUrl = resolveServerUrl(options.serverUrl, options.env);
   } catch (error) {
-    return { exitCode: 1, message: formatDoctorError(error, "<not configured>") };
+    return {
+      detail: formatServerError(error, "<not configured>"),
+      fix: { commands: [], summary: `Set OPENTAG_SERVER_URL or pass --server-url to ${channelConfig.binName} doctor` },
+      id: "server",
+      status: "error",
+      title,
+    };
   }
   const healthChecker = options.healthChecker ?? checkServerHealth;
-
   try {
     const health = await healthChecker(serverUrl);
-    return {
-      exitCode: 0,
-      message: `OpenTag server is healthy (${health.service}) at ${serverUrl}`,
-    };
+    return { detail: `healthy (${health.service}) at ${serverUrl}`, id: "server", status: "ok", title };
   } catch (error) {
     return {
-      exitCode: 1,
-      message: formatDoctorError(error, serverUrl),
+      detail: formatServerError(error, serverUrl),
+      fix: { commands: [], summary: serverFixSummary(error, serverUrl) },
+      id: "server",
+      status: "error",
+      title,
     };
   }
 }
 
-function formatDoctorError(error: unknown, serverUrl: string): string {
+function serverFixSummary(error: unknown, serverUrl: string): string {
+  if (error instanceof ServerHealthNetworkError) return `Check this computer's network access to ${serverUrl}`;
+  if (error instanceof ServerHealthConfigurationError || error instanceof ServerHealthResponseError) {
+    return `Point OpenTag at an OpenTag server base URL with --server-url or OPENTAG_SERVER_URL, instead of ${serverUrl}`;
+  }
+  return `Wait for the OpenTag server at ${serverUrl} to become healthy, or point OpenTag at another one`;
+}
+
+function renderDoctorText(checks: readonly DoctorCheck[], blocking: readonly DoctorCheck[]): string {
+  const lines = ["Checks", ...checks.map((check) => `  ${check.title}: ${check.detail}`), ""];
+  if (blocking.length === 0) {
+    lines.push("This computer is ready to run an OpenTag agent.");
+    return lines.join("\n");
+  }
+  lines.push(
+    `${blocking.length} ${blocking.length === 1 ? "check" : "checks"} must be fixed before this computer can run an OpenTag agent.`,
+    "",
+  );
+  const fixes = blocking.flatMap((check) => (check.fix ? [check.fix] : []));
+  for (const [index, fix] of fixes.entries()) {
+    lines.push(`Fix ${index + 1}/${fixes.length} — ${fix.summary}`);
+    for (const command of fix.commands) lines.push(`  ${command}`);
+    if (fix.docsUrl) lines.push(`  Docs: ${fix.docsUrl}`);
+  }
+  lines.push(
+    "",
+    `Re-run \`${channelConfig.binName} doctor\` once the fixes are done. The OpenTag daemon republishes readiness`,
+    "about twice a minute, so a setup page waiting on this computer turns green on its own.",
+  );
+  return lines.join("\n");
+}
+
+function formatServerError(error: unknown, serverUrl: string): string {
   if (error instanceof ServerHealthConfigurationError) {
-    return `Configuration error: invalid OpenTag server URL ${serverUrl}`;
+    return `configuration error: invalid OpenTag server URL ${serverUrl}`;
   }
   if (error instanceof ServerHealthNetworkError) {
-    return `Network error: could not reach the OpenTag server at ${serverUrl}`;
+    return `network error: could not reach the OpenTag server at ${serverUrl}`;
   }
   if (error instanceof ServerHealthHttpError) {
     return `HTTP error: the OpenTag server at ${serverUrl} returned status ${error.status}`;
   }
   if (error instanceof ServerHealthResponseError) {
-    return `Response error: the OpenTag server at ${serverUrl} returned an invalid health response`;
+    return `response error: the OpenTag server at ${serverUrl} returned an invalid health response`;
   }
-  const detail = error instanceof Error ? error.message : String(error);
-  return `Unexpected error while checking ${serverUrl}: ${detail}`;
+  return `unexpected error while checking ${serverUrl}: ${describeError(error)}`;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -26,6 +26,7 @@ import {
   type DoctorCheck,
   type ImCliProbe,
 } from "./checks.js";
+import type { DoctorFix } from "./fixes.js";
 import { type DaemonServiceEnvironment, readDaemonServiceEnvironment } from "./service-environment.js";
 
 export type HealthChecker = (serverUrl: string) => Promise<ServerHealth>;
@@ -233,16 +234,20 @@ async function explainPathDivergence(
     }
     explained.push({
       ...check,
-      detail: `on this shell's PATH, but not on the PATH the daemon service runs with`,
-      fix: {
-        commands: [`${channelConfig.binName} daemon install`],
-        note: `\`${command}\` resolves for you but not for the daemon, which uses the PATH captured when its service was installed. Re-installing the service from this shell captures the current one.`,
-        summary: `Give the daemon the same PATH this shell has, so that it can run \`${command}\``,
-      },
+      detail: "on this shell's PATH, but not on the PATH the daemon service runs with",
+      // One shared fix object: several diverging CLIs have one cause and one remedy, and the
+      // renderer collapses identical fixes so the operator is not told the same thing four times.
+      fix: STALE_DAEMON_PATH_FIX,
     });
   }
   return explained;
 }
+
+const STALE_DAEMON_PATH_FIX: DoctorFix = {
+  commands: [`${channelConfig.binName} daemon install`],
+  note: "The daemon uses the PATH captured when its service was installed. Re-installing the service from this shell captures the current one.",
+  summary: "Give the daemon the same PATH this shell has, so that it can resolve the CLIs above",
+};
 
 async function resolvesOnPath(command: string, path: string): Promise<boolean> {
   try {
@@ -311,7 +316,7 @@ function renderDoctorText(
     `${blocking.length} ${blocking.length === 1 ? "check" : "checks"} must be fixed before this computer can run an OpenTag agent.`,
     "",
   );
-  const fixes = blocking.flatMap((check) => (check.fix ? [check.fix] : []));
+  const fixes = uniqueFixes(blocking.flatMap((check) => (check.fix ? [check.fix] : [])));
   for (const [index, fix] of fixes.entries()) {
     lines.push(`Fix ${index + 1}/${fixes.length} — ${fix.summary}`);
     for (const command of fix.commands) lines.push(`  ${command}`);
@@ -326,6 +331,17 @@ function renderDoctorText(
     pathSource(service),
   );
   return lines.join("\n");
+}
+
+/** Two checks with one cause deserve one instruction, not the same instruction twice. */
+function uniqueFixes(fixes: readonly DoctorFix[]): DoctorFix[] {
+  const seen = new Set<string>();
+  return fixes.filter((fix) => {
+    const key = JSON.stringify([fix.summary, fix.commands, fix.note, fix.docsUrl]);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 /** Naming the PATH a report was produced with is what makes the report checkable. */

--- a/apps/cli/src/core/diagnostics/fixes.ts
+++ b/apps/cli/src/core/diagnostics/fixes.ts
@@ -2,11 +2,13 @@ import type { AgentRuntimeProvider, ImCliProvider } from "@opentag/shared";
 
 /**
  * A repair a person or their coding agent can run directly. Commands are printed, never executed
- * silently: installing software and signing in are the operator's decisions, not the CLI's.
+ * silently: installing software and signing in are the operator's decisions, not the CLI's. A fix
+ * with no command needs a human to follow the documentation instead.
  */
 export interface DoctorFix {
   readonly commands: readonly string[];
   readonly docsUrl?: string;
+  readonly note?: string;
   readonly summary: string;
 }
 
@@ -34,6 +36,9 @@ const AGENT_RUNTIME_FIXES: Readonly<
     signIn: {
       commands: ["claude auth login"],
       docsUrl: "https://docs.claude.com/en/docs/claude-code/setup",
+      // Known defect: OpenTag always sets CLAUDE_CONFIG_DIR, and Claude Code then cannot see an
+      // ordinary macOS Keychain login, so this sign-in can report the same failure afterwards.
+      note: "If this reports the same failure after a successful sign-in, you are hitting first-tree-ai/opentag#236",
       summary: "Sign in to Claude Code on this computer",
     },
   },
@@ -46,10 +51,18 @@ const IM_CLI_INSTALL_FIXES: Readonly<Record<ImCliProvider, DoctorFix>> = {
     summary: "Install the Feishu (Lark) CLI so that OpenTag can deliver messages",
   },
   slack: {
-    commands: ["curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash"],
+    // The Slack CLI ships as a shell installer rather than a package. Printing a piped installer for
+    // an Agent to run is a different risk class from `npm install -g`, so this one stays human-only.
+    commands: [],
     docsUrl: "https://docs.slack.dev/tools/slack-cli",
+    note: "Install it yourself from the documentation; OpenTag does not print an installer to pipe into a shell",
     summary: "Install the Slack CLI so that OpenTag can deliver messages",
   },
+};
+
+const IM_CLI_REQUIREMENTS: Readonly<Record<ImCliProvider, string>> = {
+  feishu: "`lark-cli --version` and `lark-cli im --help` must both succeed quickly",
+  slack: "`slack version` and `slack api --help` must both succeed quickly",
 };
 
 export function agentRuntimeInstallFix(provider: AgentRuntimeProvider): DoctorFix {
@@ -72,9 +85,17 @@ export function imCliInstallFix(provider: ImCliProvider): DoctorFix {
   return IM_CLI_INSTALL_FIXES[provider];
 }
 
-export function imCliUpgradeFix(provider: ImCliProvider): DoctorFix {
+/**
+ * An installed messaging CLI can also be broken, hung, or too old. Naming what OpenTag needs beats
+ * guessing at a remedy, because reinstalling does not fix a command that hangs.
+ */
+export function imCliRepairFix(provider: ImCliProvider): DoctorFix {
   const install = IM_CLI_INSTALL_FIXES[provider];
-  return { ...install, summary: `Reinstall or upgrade the ${imCliTitle(provider)}` };
+  return {
+    ...install,
+    note: `OpenTag needs it to answer its own probe: ${IM_CLI_REQUIREMENTS[provider]}`,
+    summary: `Repair the ${imCliTitle(provider)}: it is installed but does not answer OpenTag's probe`,
+  };
 }
 
 export function agentRuntimeTitle(provider: AgentRuntimeProvider): string {

--- a/apps/cli/src/core/diagnostics/fixes.ts
+++ b/apps/cli/src/core/diagnostics/fixes.ts
@@ -1,0 +1,86 @@
+import type { AgentRuntimeProvider, ImCliProvider } from "@opentag/shared";
+
+/**
+ * A repair a person or their coding agent can run directly. Commands are printed, never executed
+ * silently: installing software and signing in are the operator's decisions, not the CLI's.
+ */
+export interface DoctorFix {
+  readonly commands: readonly string[];
+  readonly docsUrl?: string;
+  readonly summary: string;
+}
+
+const AGENT_RUNTIME_FIXES: Readonly<
+  Record<AgentRuntimeProvider, { readonly install: DoctorFix; readonly signIn: DoctorFix }>
+> = {
+  codex: {
+    install: {
+      commands: ["npm install -g @openai/codex"],
+      docsUrl: "https://developers.openai.com/codex/cli",
+      summary: "Install the Codex CLI so that `codex` runs from this computer's PATH",
+    },
+    signIn: {
+      commands: ["codex login"],
+      docsUrl: "https://developers.openai.com/codex/cli",
+      summary: "Sign in to Codex on this computer",
+    },
+  },
+  "claude-code": {
+    install: {
+      commands: ["npm install -g @anthropic-ai/claude-code"],
+      docsUrl: "https://docs.claude.com/en/docs/claude-code/setup",
+      summary: "Install the Claude Code CLI so that `claude` runs from this computer's PATH",
+    },
+    signIn: {
+      commands: ["claude auth login"],
+      docsUrl: "https://docs.claude.com/en/docs/claude-code/setup",
+      summary: "Sign in to Claude Code on this computer",
+    },
+  },
+};
+
+const IM_CLI_INSTALL_FIXES: Readonly<Record<ImCliProvider, DoctorFix>> = {
+  feishu: {
+    commands: ["npm install -g @larksuite/cli"],
+    docsUrl: "https://www.npmjs.com/package/@larksuite/cli",
+    summary: "Install the Feishu (Lark) CLI so that OpenTag can deliver messages",
+  },
+  slack: {
+    commands: ["curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash"],
+    docsUrl: "https://docs.slack.dev/tools/slack-cli",
+    summary: "Install the Slack CLI so that OpenTag can deliver messages",
+  },
+};
+
+export function agentRuntimeInstallFix(provider: AgentRuntimeProvider): DoctorFix {
+  return AGENT_RUNTIME_FIXES[provider].install;
+}
+
+export function agentRuntimeSignInFix(provider: AgentRuntimeProvider): DoctorFix {
+  return AGENT_RUNTIME_FIXES[provider].signIn;
+}
+
+export function agentRuntimeUpgradeFix(provider: AgentRuntimeProvider): DoctorFix {
+  const install = AGENT_RUNTIME_FIXES[provider].install;
+  return {
+    ...install,
+    summary: `Reinstall or upgrade the ${agentRuntimeTitle(provider)} so that OpenTag can drive it`,
+  };
+}
+
+export function imCliInstallFix(provider: ImCliProvider): DoctorFix {
+  return IM_CLI_INSTALL_FIXES[provider];
+}
+
+export function imCliUpgradeFix(provider: ImCliProvider): DoctorFix {
+  const install = IM_CLI_INSTALL_FIXES[provider];
+  return { ...install, summary: `Reinstall or upgrade the ${imCliTitle(provider)}` };
+}
+
+export function agentRuntimeTitle(provider: AgentRuntimeProvider): string {
+  return provider === "codex" ? "Codex CLI" : "Claude Code CLI";
+}
+
+export function imCliTitle(provider: ImCliProvider): string {
+  return provider === "feishu" ? "Feishu CLI (lark-cli)" : "Slack CLI";
+}

--- a/apps/cli/src/core/diagnostics/fixes.ts
+++ b/apps/cli/src/core/diagnostics/fixes.ts
@@ -93,6 +93,9 @@ export function imCliRepairFix(provider: ImCliProvider): DoctorFix {
   const install = IM_CLI_INSTALL_FIXES[provider];
   return {
     ...install,
+    // No command: reinstalling does not fix a CLI that hangs, and printing one would contradict the
+    // summary. Naming what OpenTag needs lets the operator decide what to repair.
+    commands: [],
     note: `OpenTag needs it to answer its own probe: ${IM_CLI_REQUIREMENTS[provider]}`,
     summary: `Repair the ${imCliTitle(provider)}: it is installed but does not answer OpenTag's probe`,
   };

--- a/apps/cli/src/core/diagnostics/service-environment.ts
+++ b/apps/cli/src/core/diagnostics/service-environment.ts
@@ -1,4 +1,8 @@
-import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { userInfo } from "node:os";
+import { isAbsolute } from "node:path";
+import { promisify } from "node:util";
 import { resolveOpenTagHome } from "@opentag/client";
 import {
   createDaemonServiceManager,
@@ -31,6 +35,62 @@ export type DaemonServiceEnvironment =
   | { readonly kind: "not-installed" }
   | { readonly kind: "unsupported"; readonly platform: string }
   | { readonly definitionPath?: string; readonly kind: "unreadable"; readonly reason: string };
+
+const execFileAsync = promisify(execFile);
+
+export interface ServiceManagerProbes {
+  readonly directoryExists?: (path: string) => Promise<boolean>;
+  readonly readDarwinUserTemporaryDirectory?: () => Promise<string | undefined>;
+  readonly uid?: number;
+}
+
+/**
+ * The variables a service manager sets for the jobs it starts. They must come from an authority that
+ * represents the installed service, never from the invoking shell: an operator can point `TMPDIR` or
+ * `XDG_RUNTIME_DIR` somewhere else for one command without changing anything the daemon runs with,
+ * and a provider that reads sockets or temporary state from there answers differently because of it.
+ * Whether the value is secret is not the test; whether it can change the answer is.
+ *
+ * When no such authority can be reached, the variable is omitted so the probe fails closed rather
+ * than borrowing the caller's.
+ */
+export async function serviceManagerVariables(
+  manager: "launchd" | "systemd" | undefined,
+  probes: ServiceManagerProbes = {},
+): Promise<Readonly<Record<string, string>>> {
+  if (manager === "launchd") {
+    const directory = await (probes.readDarwinUserTemporaryDirectory ?? darwinUserTemporaryDirectory)();
+    return directory ? { TMPDIR: directory } : {};
+  }
+  if (manager === "systemd") {
+    const directory = `/run/user/${probes.uid ?? userInfo().uid}`;
+    return (await (probes.directoryExists ?? directoryExists)(directory)) ? { XDG_RUNTIME_DIR: directory } : {};
+  }
+  return {};
+}
+
+/** launchd assigns each account a private temporary directory; `getconf` reports that assignment. */
+async function darwinUserTemporaryDirectory(): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("getconf", ["DARWIN_USER_TEMP_DIR"], {
+      encoding: "utf8",
+      timeout: 5_000,
+      windowsHide: true,
+    });
+    const directory = stdout.trim();
+    return isAbsolute(directory) ? directory : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function directoryExists(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
 export interface ReadDaemonServiceEnvironmentOptions {
   readonly env?: NodeJS.ProcessEnv;

--- a/apps/cli/src/core/diagnostics/service-environment.ts
+++ b/apps/cli/src/core/diagnostics/service-environment.ts
@@ -5,14 +5,29 @@ import {
   type DaemonServiceInfo,
   type DaemonServiceManager,
 } from "../daemon/service/index.js";
+import { canonicalizeServiceHome } from "../daemon/service/shared.js";
 
 /**
- * The PATH an installed daemon service actually runs with. It is a snapshot taken when the service
- * was installed, not the invoking shell's PATH, so it is the only PATH whose answer matches the
- * readiness the Server receives.
+ * What an installed daemon service actually runs with. A launchd or systemd unit does not inherit
+ * the operator's shell, so only the variables its definition declares — plus the account-level ones
+ * the service manager itself provides — describe the environment that publishes readiness.
  */
 export type DaemonServiceEnvironment =
-  | { readonly definitionPath: string; readonly kind: "installed"; readonly path: string; readonly state: string }
+  | {
+      readonly definitionPath: string;
+      readonly environment: Readonly<Record<string, string>>;
+      readonly kind: "installed";
+      readonly path: string;
+      readonly platform: "launchd" | "systemd";
+      readonly serviceHome: string;
+      readonly state: string;
+    }
+  | {
+      readonly definitionPath: string;
+      readonly kind: "home-mismatch";
+      readonly requestedHome: string;
+      readonly serviceHome: string;
+    }
   | { readonly kind: "not-installed" }
   | { readonly kind: "unsupported"; readonly platform: string }
   | { readonly definitionPath?: string; readonly kind: "unreadable"; readonly reason: string };
@@ -30,26 +45,28 @@ export async function readDaemonServiceEnvironment(
 ): Promise<DaemonServiceEnvironment> {
   const platform = options.platform ?? process.platform;
   if (platform !== "darwin" && platform !== "linux") return { kind: "unsupported", platform };
+  const requestedHome = options.home ?? resolveOpenTagHome(options.env);
   let info: DaemonServiceInfo;
   try {
     const manager =
       options.manager ??
-      (await createDaemonServiceManager({
-        ...(options.env ? { env: options.env } : {}),
-        home: options.home ?? resolveOpenTagHome(options.env),
-      }));
+      (await createDaemonServiceManager({ ...(options.env ? { env: options.env } : {}), home: requestedHome }));
     info = await manager.status();
   } catch (error) {
     return { kind: "unreadable", reason: describe(error) };
   }
   if (info.state === "not-installed") return { kind: "not-installed" };
+  if (info.platform !== "launchd" && info.platform !== "systemd") {
+    return { definitionPath: info.definitionPath, kind: "unreadable", reason: "unsupported service platform" };
+  }
   let definition: string;
   try {
     definition = await (options.readDefinition ?? ((path: string) => readFile(path, "utf8")))(info.definitionPath);
   } catch (error) {
     return { definitionPath: info.definitionPath, kind: "unreadable", reason: describe(error) };
   }
-  const path = info.platform === "systemd" ? systemdPath(definition) : launchdPath(definition);
+  const environment = info.platform === "systemd" ? systemdEnvironment(definition) : launchdEnvironment(definition);
+  const path = environment.PATH;
   if (!path) {
     return {
       definitionPath: info.definitionPath,
@@ -57,17 +74,74 @@ export async function readDaemonServiceEnvironment(
       reason: "the installed service definition declares no PATH",
     };
   }
-  return { definitionPath: info.definitionPath, kind: "installed", path, state: info.state };
+  // The running service belongs to whichever home its definition names. Probing a different home's
+  // provider configuration would answer for a Computer this service does not run.
+  const declaredHome = info.configuredHome ?? environment.OPENTAG_HOME;
+  if (!declaredHome) {
+    return {
+      definitionPath: info.definitionPath,
+      kind: "unreadable",
+      reason: "the installed service definition declares no OPENTAG_HOME",
+    };
+  }
+  let serviceHome: string;
+  let canonicalRequestedHome: string;
+  try {
+    [serviceHome, canonicalRequestedHome] = await Promise.all([
+      canonicalizeServiceHome(declaredHome),
+      canonicalizeServiceHome(requestedHome),
+    ]);
+  } catch (error) {
+    return { definitionPath: info.definitionPath, kind: "unreadable", reason: describe(error) };
+  }
+  if (serviceHome !== canonicalRequestedHome) {
+    return {
+      definitionPath: info.definitionPath,
+      kind: "home-mismatch",
+      requestedHome: canonicalRequestedHome,
+      serviceHome,
+    };
+  }
+  return {
+    definitionPath: info.definitionPath,
+    environment,
+    kind: "installed",
+    path,
+    platform: info.platform,
+    serviceHome,
+    state: info.state,
+  };
 }
 
-function launchdPath(definition: string): string | undefined {
-  const match = definition.match(/<key>PATH<\/key>\s*<string>([^<]*)<\/string>/u);
-  return match?.[1] === undefined ? undefined : unescapeXml(match[1]);
+function launchdEnvironment(definition: string): Readonly<Record<string, string>> {
+  const marker = definition.indexOf("<key>EnvironmentVariables</key>");
+  if (marker < 0) return {};
+  const open = definition.indexOf("<dict>", marker);
+  if (open < 0) return {};
+  const close = definition.indexOf("</dict>", open);
+  if (close < 0) return {};
+  const body = definition.slice(open, close);
+  const environment: Record<string, string> = {};
+  for (const match of body.matchAll(/<key>([^<]*)<\/key>\s*<string>([^<]*)<\/string>/gu)) {
+    const key = match[1];
+    const value = match[2];
+    if (key === undefined || value === undefined) continue;
+    environment[unescapeXml(key)] = unescapeXml(value);
+  }
+  return environment;
 }
 
-function systemdPath(definition: string): string | undefined {
-  const match = definition.match(/^Environment="PATH=((?:[^"\\]|\\.)*)"$/mu);
-  return match?.[1] === undefined ? undefined : unescapeSystemd(match[1]);
+function systemdEnvironment(definition: string): Readonly<Record<string, string>> {
+  const environment: Record<string, string> = {};
+  for (const match of definition.matchAll(/^Environment="((?:[^"\\]|\\.)*)"$/gmu)) {
+    const declaration = match[1];
+    if (declaration === undefined) continue;
+    const assignment = unescapeSystemd(declaration);
+    const separator = assignment.indexOf("=");
+    if (separator <= 0) continue;
+    environment[assignment.slice(0, separator)] = assignment.slice(separator + 1);
+  }
+  return environment;
 }
 
 function unescapeXml(value: string): string {

--- a/apps/cli/src/core/diagnostics/service-environment.ts
+++ b/apps/cli/src/core/diagnostics/service-environment.ts
@@ -1,0 +1,93 @@
+import { readFile } from "node:fs/promises";
+import { resolveOpenTagHome } from "@opentag/client";
+import {
+  createDaemonServiceManager,
+  type DaemonServiceInfo,
+  type DaemonServiceManager,
+} from "../daemon/service/index.js";
+
+/**
+ * The PATH an installed daemon service actually runs with. It is a snapshot taken when the service
+ * was installed, not the invoking shell's PATH, so it is the only PATH whose answer matches the
+ * readiness the Server receives.
+ */
+export type DaemonServiceEnvironment =
+  | { readonly definitionPath: string; readonly kind: "installed"; readonly path: string; readonly state: string }
+  | { readonly kind: "not-installed" }
+  | { readonly kind: "unsupported"; readonly platform: string }
+  | { readonly definitionPath?: string; readonly kind: "unreadable"; readonly reason: string };
+
+export interface ReadDaemonServiceEnvironmentOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly home?: string;
+  readonly manager?: DaemonServiceManager;
+  readonly platform?: NodeJS.Platform;
+  readonly readDefinition?: (path: string) => Promise<string>;
+}
+
+export async function readDaemonServiceEnvironment(
+  options: ReadDaemonServiceEnvironmentOptions = {},
+): Promise<DaemonServiceEnvironment> {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "darwin" && platform !== "linux") return { kind: "unsupported", platform };
+  let info: DaemonServiceInfo;
+  try {
+    const manager =
+      options.manager ??
+      (await createDaemonServiceManager({
+        ...(options.env ? { env: options.env } : {}),
+        home: options.home ?? resolveOpenTagHome(options.env),
+      }));
+    info = await manager.status();
+  } catch (error) {
+    return { kind: "unreadable", reason: describe(error) };
+  }
+  if (info.state === "not-installed") return { kind: "not-installed" };
+  let definition: string;
+  try {
+    definition = await (options.readDefinition ?? ((path: string) => readFile(path, "utf8")))(info.definitionPath);
+  } catch (error) {
+    return { definitionPath: info.definitionPath, kind: "unreadable", reason: describe(error) };
+  }
+  const path = info.platform === "systemd" ? systemdPath(definition) : launchdPath(definition);
+  if (!path) {
+    return {
+      definitionPath: info.definitionPath,
+      kind: "unreadable",
+      reason: "the installed service definition declares no PATH",
+    };
+  }
+  return { definitionPath: info.definitionPath, kind: "installed", path, state: info.state };
+}
+
+function launchdPath(definition: string): string | undefined {
+  const match = definition.match(/<key>PATH<\/key>\s*<string>([^<]*)<\/string>/u);
+  return match?.[1] === undefined ? undefined : unescapeXml(match[1]);
+}
+
+function systemdPath(definition: string): string | undefined {
+  const match = definition.match(/^Environment="PATH=((?:[^"\\]|\\.)*)"$/mu);
+  return match?.[1] === undefined ? undefined : unescapeSystemd(match[1]);
+}
+
+function unescapeXml(value: string): string {
+  return value
+    .replace(/&lt;/gu, "<")
+    .replace(/&gt;/gu, ">")
+    .replace(/&quot;/gu, '"')
+    .replace(/&apos;/gu, "'")
+    .replace(/&amp;/gu, "&");
+}
+
+function unescapeSystemd(value: string): string {
+  return value.replace(/%%/gu, "%").replace(/\\([\\"nrt])/gu, (_match, escaped: string) => {
+    if (escaped === "n") return "\n";
+    if (escaped === "r") return "\r";
+    if (escaped === "t") return "\t";
+    return escaped;
+  });
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/cli/src/core/diagnostics/service-environment.ts
+++ b/apps/cli/src/core/diagnostics/service-environment.ts
@@ -52,7 +52,8 @@ export interface ServiceManagerProbes {
  * Whether the value is secret is not the test; whether it can change the answer is.
  *
  * When no such authority can be reached, the variable is omitted so the probe fails closed rather
- * than borrowing the caller's.
+ * than borrowing the caller's. The authority itself must not be reachable through the caller either:
+ * an executable it resolves through `PATH` is the caller's choice, not the system's.
  */
 export async function serviceManagerVariables(
   manager: "launchd" | "systemd" | undefined,
@@ -69,11 +70,21 @@ export async function serviceManagerVariables(
   return {};
 }
 
-/** launchd assigns each account a private temporary directory; `getconf` reports that assignment. */
+/**
+ * launchd assigns each account a private temporary directory, and this is the system utility that
+ * reports that assignment.
+ *
+ * It is invoked by absolute path with an empty environment. Resolving `getconf` through the caller's
+ * `PATH` would put the answer back in the caller's hands — an executable earlier on that path could
+ * name any directory, and the authority would be the shell's again with an extra step in between.
+ */
+const DARWIN_GETCONF = "/usr/bin/getconf";
+
 async function darwinUserTemporaryDirectory(): Promise<string | undefined> {
   try {
-    const { stdout } = await execFileAsync("getconf", ["DARWIN_USER_TEMP_DIR"], {
+    const { stdout } = await execFileAsync(DARWIN_GETCONF, ["DARWIN_USER_TEMP_DIR"], {
       encoding: "utf8",
+      env: {},
       timeout: 5_000,
       windowsHide: true,
     });

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -24,7 +24,9 @@ import {
   createClientRuntime,
   createClientRuntimeHandlers,
   createClientRuntimePreflight,
+  probeImCliReadiness,
   refreshImCliReadiness,
+  resolveAgentRuntimeProviders,
   resolveCodexHome,
   resolvedClaudeCodeFactory,
   resolvedCodexFactory,
@@ -43,6 +45,41 @@ afterEach(async () => {
 });
 
 describe("createClientRuntime production composition", () => {
+  it("resolves the production Agent Runtime factories without a Server connection", async () => {
+    const home = await temporaryDirectory("opentag-provider-composition-");
+    const environment = { HOME: home };
+
+    const resolved = await resolveAgentRuntimeProviders({ clientVersion: "0.0.0-test", environment });
+
+    expect(resolved.factories.map((factory) => factory.manifest.providerId)).toEqual(["codex", "claude-code"]);
+    expect(resolved.providerHomes).toEqual({
+      codex: resolve(home, ".codex"),
+      "claude-code": resolve(home, ".claude"),
+    });
+    expect(resolved.artifactIdentities.codex).toBe(
+      createHash("sha256").update(resolved.providerHomes.codex, "utf8").digest("hex"),
+    );
+    await expect(resolved.factories[0]?.probe({})).resolves.toEqual({
+      ready: false,
+      issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }],
+    });
+  });
+
+  it("observes messaging CLI readiness without publishing it", async () => {
+    const home = await temporaryDirectory("opentag-im-cli-probe-");
+    const lark = resolve(home, "lark-cli");
+    await writeFile(
+      lark,
+      '#!/bin/sh\nif [ "$1" = "--version" ] || { [ "$1" = "im" ] && [ "$2" = "--help" ]; }; then exit 0; fi\nexit 1\n',
+      "utf8",
+    );
+    await chmod(lark, 0o755);
+
+    await expect(probeImCliReadiness("feishu", lark, {})).resolves.toBe("ready");
+    await expect(probeImCliReadiness("slack", lark, {})).resolves.toBe("unavailable");
+    await expect(probeImCliReadiness("feishu", resolve(home, "missing"), {})).resolves.toBe("install");
+  });
+
   it("probes Feishu and Slack CLI readiness independently from Agent Runtime providers", async () => {
     const home = await temporaryDirectory("opentag-im-cli-readiness-");
     const lark = resolve(home, "lark-cli");

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { homedir, tmpdir } from "node:os";
@@ -63,6 +63,34 @@ describe("createClientRuntime production composition", () => {
       ready: false,
       issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }],
     });
+  });
+
+  it("names provider homes it must not create, and still surfaces a broken one", async () => {
+    const home = await temporaryDirectory("opentag-provider-read-only-");
+
+    const resolved = await resolveAgentRuntimeProviders({
+      clientVersion: "0.0.0-test",
+      ensureProviderHomes: false,
+      environment: { HOME: home },
+    });
+
+    expect(resolved.providerHomes).toEqual({
+      codex: resolve(home, ".codex"),
+      "claude-code": resolve(home, ".claude"),
+    });
+    await expect(stat(resolve(home, ".codex"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(resolve(home, ".claude"))).rejects.toMatchObject({ code: "ENOENT" });
+
+    // A home that cannot exist is a real fault rather than a home waiting to be created.
+    const file = resolve(home, "not-a-directory");
+    await writeFile(file, "", "utf8");
+    await expect(
+      resolveAgentRuntimeProviders({
+        clientVersion: "0.0.0-test",
+        ensureProviderHomes: false,
+        environment: { HOME: file },
+      }),
+    ).rejects.toMatchObject({ code: "ENOTDIR" });
   });
 
   it("observes messaging CLI readiness without publishing it", async () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -162,11 +162,15 @@ export {
   type DeliveryDecision,
 } from "./runtime/client-runtime.js";
 export {
+  type AgentRuntimeProviderComposition,
   ComposedClientRuntime,
   type CreateClientRuntimeOptions,
   createClientRuntime,
+  probeImCliReadiness,
   providerReadiness,
+  type ResolveAgentRuntimeProvidersOptions,
   type ResolvedClaudeCodeFactoryOptions,
+  resolveAgentRuntimeProviders,
   resolveCodexHome,
   resolvedClaudeCodeFactory,
 } from "./runtime/client-runtime-composition.js";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -166,6 +166,8 @@ export {
   ComposedClientRuntime,
   type CreateClientRuntimeOptions,
   createClientRuntime,
+  DEFAULT_AGENT_RUNTIME_COMMANDS,
+  DEFAULT_IM_CLI_COMMANDS,
   probeImCliReadiness,
   providerReadiness,
   type ResolveAgentRuntimeProvidersOptions,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -173,6 +173,7 @@ export {
   resolveAgentRuntimeProviders,
   resolveCodexHome,
   resolvedClaudeCodeFactory,
+  resolveExecutable,
 } from "./runtime/client-runtime-composition.js";
 export {
   COMPUTER_IDENTITY_FILE_NAME,

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -57,6 +57,18 @@ import { SessionRuntimeManager } from "./session-runtime-manager.js";
 import { TurnCustodyOwner } from "./turn-custody-owner.js";
 import { TurnReportOwner } from "./turn-report-owner.js";
 
+/** The bare commands the Client Runtime resolves through PATH, so no caller has to restate them. */
+export const DEFAULT_AGENT_RUNTIME_COMMANDS: Readonly<Record<"codex" | "claude-code", string>> = {
+  "claude-code": "claude",
+  codex: "codex",
+};
+
+/** The bare commands the Client Runtime resolves for messaging delivery. */
+export const DEFAULT_IM_CLI_COMMANDS: Readonly<Record<"feishu" | "slack", string>> = {
+  feishu: "lark-cli",
+  slack: "slack",
+};
+
 const DEFAULT_CAPABILITY_REFRESH_INTERVAL_MS = Math.floor(RUNTIME_CLIENT_CAPABILITY_TTL_MS / 2);
 const DEFAULT_PROVIDER_PROBE_DEADLINE_MS = 10_000;
 const execFileAsync = promisify(execFile);
@@ -262,8 +274,8 @@ export async function resolveAgentRuntimeProviders(
   }
   const codexHome = await canonicalProviderHome(configuredCodexHome);
   const claudeCodeHome = await canonicalProviderHome(configuredClaudeCodeHome);
-  const codexCommand = options.codexCommand ?? "codex";
-  const claudeCodeCommand = options.claudeCodeCommand ?? "claude";
+  const codexCommand = options.codexCommand ?? DEFAULT_AGENT_RUNTIME_COMMANDS.codex;
+  const claudeCodeCommand = options.claudeCodeCommand ?? DEFAULT_AGENT_RUNTIME_COMMANDS["claude-code"];
   options.signal?.throwIfAborted();
   const codexEnvironment = codexAgentRuntimeEnvironment({ ...sourceEnvironment, CODEX_HOME: codexHome });
   const claudeCodeEnvironment = claudeCodeAgentRuntimeEnvironment({
@@ -410,14 +422,14 @@ export async function createClientRuntime(
       refreshImCliReadiness(
         connection,
         "feishu",
-        options.larkCliCommand ?? "lark-cli",
+        options.larkCliCommand ?? DEFAULT_IM_CLI_COMMANDS.feishu,
         sourceEnvironment,
         readinessSignal,
       ),
       refreshImCliReadiness(
         connection,
         "slack",
-        options.slackCliCommand ?? "slack",
+        options.slackCliCommand ?? DEFAULT_IM_CLI_COMMANDS.slack,
         sourceEnvironment,
         readinessSignal,
       ),

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -211,11 +211,29 @@ export class ComposedClientRuntime {
   }
 }
 
-export async function createClientRuntime(
-  connection: RuntimeConnection,
-  options: CreateClientRuntimeOptions,
-): Promise<ComposedClientRuntime> {
-  const moduleLogger = (module: string) => options.logger?.child({ module }) ?? createLogger(module);
+/**
+ * The Agent Runtime provider factories the production Client Runtime uses, resolved without a Server
+ * connection so local diagnostics can probe exactly what the daemon probes.
+ */
+export interface AgentRuntimeProviderComposition {
+  readonly artifactIdentities: Readonly<Record<"codex" | "claude-code", string>>;
+  readonly factories: readonly AgentRuntimeFactory[];
+  readonly providerHomes: Readonly<Record<"codex" | "claude-code", string>>;
+}
+
+export interface ResolveAgentRuntimeProvidersOptions {
+  readonly claudeCodeCommand?: string;
+  readonly claudeCodeHome?: string;
+  readonly clientVersion: string;
+  readonly codexCommand?: string;
+  readonly codexHome?: string;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly signal?: AbortSignal;
+}
+
+export async function resolveAgentRuntimeProviders(
+  options: ResolveAgentRuntimeProvidersOptions,
+): Promise<AgentRuntimeProviderComposition> {
   const sourceEnvironment = options.environment ?? process.env;
   options.signal?.throwIfAborted();
   const defaultHome = sourceEnvironment.HOME ?? homedir();
@@ -235,35 +253,42 @@ export async function createClientRuntime(
     ...sourceEnvironment,
     CLAUDE_CONFIG_DIR: claudeCodeHome,
   });
-  const providerHomes: Readonly<Record<"codex" | "claude-code", string>> = {
-    codex: codexHome,
-    "claude-code": claudeCodeHome,
+  return {
+    artifactIdentities: {
+      codex: createHash("sha256").update(codexHome, "utf8").digest("hex"),
+      "claude-code": createHash("sha256").update(claudeCodeHome, "utf8").digest("hex"),
+    },
+    factories: [
+      resolvedCodexFactory({
+        clientVersion: options.clientVersion,
+        command: codexCommand,
+        codexHome,
+        environment: codexEnvironment,
+        sourceEnvironment,
+      }),
+      resolvedClaudeCodeFactory({
+        claudeCodeHome,
+        command: claudeCodeCommand,
+        environment: claudeCodeEnvironment,
+        sourceEnvironment,
+      }),
+    ],
+    providerHomes: { codex: codexHome, "claude-code": claudeCodeHome },
   };
-  const providerArtifactIdentities: Readonly<Record<"codex" | "claude-code", string>> = {
-    codex: createHash("sha256").update(codexHome, "utf8").digest("hex"),
-    "claude-code": createHash("sha256").update(claudeCodeHome, "utf8").digest("hex"),
-  };
-  const factories =
-    options.factories ??
-    (options.factory
-      ? [options.factory]
-      : [
-          resolvedCodexFactory({
-            clientVersion: options.clientVersion,
-            command: codexCommand,
-            codexHome,
-            environment: codexEnvironment,
-            sourceEnvironment,
-          }),
-          resolvedClaudeCodeFactory({
-            claudeCodeHome,
-            command: claudeCodeCommand,
-            environment: claudeCodeEnvironment,
-            sourceEnvironment,
-          }),
-        ]);
+}
+
+export async function createClientRuntime(
+  connection: RuntimeConnection,
+  options: CreateClientRuntimeOptions,
+): Promise<ComposedClientRuntime> {
+  const moduleLogger = (module: string) => options.logger?.child({ module }) ?? createLogger(module);
+  const sourceEnvironment = options.environment ?? process.env;
+  const composition = await resolveAgentRuntimeProviders(options);
+  const factories = options.factories ?? (options.factory ? [options.factory] : composition.factories);
   const providers = new AgentRuntimeProviderRegistry(
-    factories.map((factory) => productionProviderRegistration(factory, providerArtifactIdentities, providerHomes)),
+    factories.map((factory) =>
+      productionProviderRegistration(factory, composition.artifactIdentities, composition.providerHomes),
+    ),
   );
   const capabilityAbort = new AbortController();
   const readinessSignal = options.signal
@@ -526,6 +551,37 @@ export function providerReadiness(
   return { provider, status: "unavailable" };
 }
 
+/**
+ * Observe one messaging CLI without publishing the result, so both the Client Runtime and local
+ * diagnostics decide readiness from the same probe.
+ */
+export async function probeImCliReadiness(
+  provider: RuntimeImCliReadinessObservation["provider"],
+  configuredCommand: string,
+  environment: NodeJS.ProcessEnv,
+  signal?: AbortSignal,
+): Promise<"install" | "ready" | "unavailable"> {
+  let command: string;
+  try {
+    command = await resolveExecutable(configuredCommand, environment);
+  } catch {
+    return "install";
+  }
+  const execution = { env: environment, signal, timeout: 10_000, windowsHide: true } as const;
+  try {
+    if (provider === "feishu") {
+      await execFileAsync(command, ["--version"], execution);
+      await execFileAsync(command, ["im", "--help"], execution);
+    } else {
+      await execFileAsync(command, ["version"], execution);
+      await execFileAsync(command, ["api", "--help"], execution);
+    }
+    return "ready";
+  } catch {
+    return "unavailable";
+  }
+}
+
 export async function refreshImCliReadiness(
   connection: Pick<RuntimeConnection, "setImCliReadiness">,
   provider: RuntimeImCliReadinessObservation["provider"],
@@ -535,27 +591,7 @@ export async function refreshImCliReadiness(
 ): Promise<void> {
   if (signal?.aborted) return;
   connection.setImCliReadiness({ provider, status: "checking" });
-  const probe = (async () => {
-    let command: string;
-    try {
-      command = await resolveExecutable(configuredCommand, environment);
-    } catch {
-      return "install" as const;
-    }
-    const execution = { env: environment, signal, timeout: 10_000, windowsHide: true } as const;
-    try {
-      if (provider === "feishu") {
-        await execFileAsync(command, ["--version"], execution);
-        await execFileAsync(command, ["im", "--help"], execution);
-      } else {
-        await execFileAsync(command, ["version"], execution);
-        await execFileAsync(command, ["api", "--help"], execution);
-      }
-      return "ready" as const;
-    } catch {
-      return "unavailable" as const;
-    }
-  })();
+  const probe = probeImCliReadiness(provider, configuredCommand, environment, signal);
   let onAbort: (() => void) | undefined;
   const status = await (signal
     ? Promise.race([

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -227,8 +227,23 @@ export interface ResolveAgentRuntimeProvidersOptions {
   readonly clientVersion: string;
   readonly codexCommand?: string;
   readonly codexHome?: string;
+  /**
+   * Create the provider homes when they are missing. The Client Runtime owns them and needs them to
+   * exist; a read-only caller passes `false` so that observing a Computer never changes it.
+   */
+  readonly ensureProviderHomes?: boolean;
   readonly environment?: NodeJS.ProcessEnv;
   readonly signal?: AbortSignal;
+}
+
+/** A provider home that does not exist yet still names the path the Client Runtime would use. */
+async function canonicalProviderHome(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return path;
+  }
 }
 
 export async function resolveAgentRuntimeProviders(
@@ -241,10 +256,12 @@ export async function resolveAgentRuntimeProviders(
   const configuredClaudeCodeHome = resolve(
     options.claudeCodeHome ?? sourceEnvironment.CLAUDE_CONFIG_DIR ?? join(defaultHome, ".claude"),
   );
-  await mkdir(configuredCodexHome, { recursive: true, mode: 0o700 });
-  await mkdir(configuredClaudeCodeHome, { recursive: true, mode: 0o700 });
-  const codexHome = await realpath(configuredCodexHome);
-  const claudeCodeHome = await realpath(configuredClaudeCodeHome);
+  if (options.ensureProviderHomes !== false) {
+    await mkdir(configuredCodexHome, { recursive: true, mode: 0o700 });
+    await mkdir(configuredClaudeCodeHome, { recursive: true, mode: 0o700 });
+  }
+  const codexHome = await canonicalProviderHome(configuredCodexHome);
+  const claudeCodeHome = await canonicalProviderHome(configuredClaudeCodeHome);
   const codexCommand = options.codexCommand ?? "codex";
   const claudeCodeCommand = options.claudeCodeCommand ?? "claude";
   options.signal?.throwIfAborted();

--- a/scripts/cli-pack-smoke.mjs
+++ b/scripts/cli-pack-smoke.mjs
@@ -173,7 +173,7 @@ export async function runCliPackSmoke({ channel, expectedName, expectedVersion, 
       throw new Error("CLI Computer connect help is missing --no-start");
     }
     const doctor = run(binaryPath, ["doctor", "--server-url", "http://127.0.0.1:1"], { expectedStatus: 1 });
-    if (!doctor.stderr.includes("Network error:")) {
+    if (!doctor.stderr.includes("network error: could not reach the OpenTag server at http://127.0.0.1:1")) {
       throw new Error("CLI doctor smoke did not report the expected network failure");
     }
 


### PR DESCRIPTION
## Why

Onboarding step 4 ("check the runtime") needs a command that tells the operator, on their own
machine, what is missing and how to fix it. `opentag doctor` only pinged the Server, so a Computer
could look healthy while the Agent Runtime it must drive was missing or signed out, or while no
messaging CLI existed to deliver a reply. The server's `handoffReady` gate requires all three, and a
user with a perfect Codex setup and no `lark-cli` hits a silent dead end.

## What

`opentag doctor` now reports one line per check and, for every blocking failure, the exact fix
command — phrased so the operator's own coding agent can run it after the command output is pasted
to it.

```
Checks
  OpenTag server: healthy (opentag-server) at http://127.0.0.1:8000
  Codex CLI: ready (codex-cli 0.149.0)
  Claude Code CLI: installed (2.1.248) but not signed in
  Feishu CLI (lark-cli): ready
  Slack CLI: ready

1 check must be fixed before this computer can run an OpenTag agent.

Fix 1/1 — Sign in to Claude Code on this computer
  claude auth login
  Docs: https://docs.claude.com/en/docs/claude-code/setup
```

- `--runtime <provider>` / `--im <provider>` (both repeatable) require specific implementations.
  Without them, one ready Agent Runtime and one ready messaging CLI are enough, so a Codex machine
  is not told to install Claude Code.
- `--json` prints the report on stdout — including when checks fail, so a caller that parses it does
  not have to merge two streams.
- Fixes are printed, never executed: installing software and signing in stay the operator's
  decisions.

## Reuse, not a second implementation

The point of this command is that its answer matches the daemon's. So the probing is shared:

- `resolveAgentRuntimeProviders` (new export) is the provider composition `createClientRuntime`
  already performed inline — same homes, same sanitized environments, same factories. Doctor passes
  `ensureProviderHomes: false`, because observing a Computer must not create the provider homes it
  is reporting on.
- `probeImCliReadiness` (new export) is the probe half of `refreshImCliReadiness`, which previously
  welded probing to writing into a `RuntimeConnection`. The daemon path is unchanged; doctor no
  longer needs to fake a connection.
- Status vocabulary comes from the existing `providerReadiness` mapping, so `install` / `sign-in`
  mean exactly what the Server sees.
- The probe deadline matches the Client Runtime's, so doctor cannot call a provider ready on
  evidence the daemon would have thrown away.

## It answers for the daemon, and fails closed when it cannot

Readiness is published by the installed daemon service, which resolves provider CLIs through the
`PATH` captured when the service was installed — not the `PATH` of the shell `doctor` was typed
into, and not something `daemon.env` can supply. So `doctor` reads the installed service definition,
probes with the `PATH` that definition declares, and names the definition at the end of every
report.

When a CLI resolves for the operator but not for the service — installing a runtime after connecting
the computer, which is the dead end this command exists to remove — it says exactly that and points
at re-installing the service, rather than telling the operator to install what they already have.

No installed service, a service that is not running, an unreadable definition, and an unsupported
platform are each blocking checks. A shell-only probe can never end in a computer-is-ready verdict.

## Verification

- `pnpm check`, `pnpm typecheck`, `pnpm build` pass.
- `pnpm test`: all suites pass except three pre-existing timing failures in
  `client-runtime-composition.test.ts` (`publishes delivery-triggered Provider recovery…`, `does not
  let a cancelled sole waiter…`, `does not let cancelled-owner cleanup…`). Verified identical on
  `origin/main` with this branch stashed — not introduced here.
- `node scripts/cli-pack-smoke.mjs --channel source …` passes; its doctor assertion was updated to
  the new wording.
- Ran the real command on a macOS machine against real `codex`, `claude`, `lark-cli`, and `slack`
  installs (output above is from that run), plus `--json --runtime codex --im feishu`.
- Review round 1 (@code-reviewer QA `FAIL` on S10, @yuezengwu changes requested) is answered in
  `1e2b4f05`; see the response comment on this PR.

Independent exact-head QA still owed by @code-reviewer.

## Follow-ups (not in this PR)

1. `--fix` execution: attempt the safe repairs in a TTY after explicit confirmation, print
   instructions when stdout is a pipe, with an explicit override in both directions because some
   agent harnesses allocate a pty.
2. Immediate re-report after a fix. `doctor` is a separate process from the daemon, and only the
   daemon publishes readiness, so a terminal-side fix takes up to ~65s to turn a web page green.
   The daemon has no local control channel today; the two candidates are a signal via the process
   lease PID, or a minimal local control socket. Design decision still open.
3. A separate defect found while testing this: OpenTag always sets `CLAUDE_CONFIG_DIR`, and Claude
   Code then reports `loggedIn: false` for a normal macOS Keychain login — so `claude-code` is
   reported as `sign-in` forever and the printed fix cannot help. Filed as #236.


