### PR TITLE
fix(client): preserve Claude Code default credential lookup

### DIFF
--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -432,6 +432,40 @@ describe("createClientRuntime production composition", () => {
     ).toBe("configuration_unsupported");
   });
 
+  it("omits CLAUDE_CONFIG_DIR when Claude Code uses the default home", async () => {
+    const home = await temporaryDirectory("opentag-client-claude-default-home-");
+    const { capture, runtime } = await composeClaudeCodeRuntime({
+      environment: { HOME: home, PATH: process.env.PATH },
+      home,
+    });
+    runtime.stop();
+    expect(capture).toBe("unset");
+    await expect(realpath(resolve(home, ".claude"))).resolves.toBe(resolve(home, ".claude"));
+  });
+
+  it("preserves an explicit CLAUDE_CONFIG_DIR in the Claude Code environment", async () => {
+    const home = await temporaryDirectory("opentag-client-claude-explicit-env-");
+    const claudeCodeHome = resolve(home, "explicit-env-claude");
+    const { capture, runtime } = await composeClaudeCodeRuntime({
+      environment: { HOME: home, PATH: process.env.PATH, CLAUDE_CONFIG_DIR: claudeCodeHome },
+      home,
+    });
+    runtime.stop();
+    expect(capture).toBe(`set:${await realpath(claudeCodeHome)}`);
+  });
+
+  it("preserves an explicit claudeCodeHome option in the Claude Code environment", async () => {
+    const home = await temporaryDirectory("opentag-client-claude-explicit-option-");
+    const claudeCodeHome = resolve(home, "explicit-option-claude");
+    const { capture, runtime } = await composeClaudeCodeRuntime({
+      claudeCodeHome,
+      environment: { HOME: home, PATH: process.env.PATH },
+      home,
+    });
+    runtime.stop();
+    expect(capture).toBe(`set:${await realpath(claudeCodeHome)}`);
+  });
+
   it("unit-tests composition delegates and every preflight outcome", async () => {
     const accepted = { result: { status: "accepted" } };
     const steered = { status: "steered" };
@@ -1912,6 +1946,32 @@ function delivery(runtime: EffectiveRuntimeSnapshot): DirectImMessageDeliveryReq
     },
     runtime,
   };
+}
+
+async function composeClaudeCodeRuntime(options: {
+  readonly claudeCodeHome?: string;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly home: string;
+}): Promise<{ readonly capture: string; readonly runtime: ComposedClientRuntime }> {
+  const capturePath = resolve(options.home, "claude-config-dir.capture");
+  const command = resolve(options.home, "claude-env-fixture");
+  await writeFile(
+    command,
+    `#!/bin/sh\nif [ -n "\${CLAUDE_CONFIG_DIR+x}" ]; then printf 'set:%s' "$CLAUDE_CONFIG_DIR" > ${JSON.stringify(capturePath)}; else printf 'unset' > ${JSON.stringify(capturePath)}; fi\nif [ "$1" = "--version" ]; then printf "2.1.210 (Claude Code)\\n"; exit 0; fi\nif [ "$1" = "--help" ]; then printf "stream-json --session-id --resume --mcp-config --strict-mcp-config --allowedTools --append-system-prompt\\n"; exit 0; fi\nexit 0\n`,
+    "utf8",
+  );
+  await chmod(command, 0o755);
+  const runtime = await createClientRuntime(runtimeConnection(), {
+    clientVersion: "0.0.1",
+    claudeCodeCommand: command,
+    ...(options.claudeCodeHome === undefined ? {} : { claudeCodeHome: options.claudeCodeHome }),
+    codexCommand: resolve(options.home, "missing-codex"),
+    environment: options.environment,
+    home: options.home,
+    larkCliCommand: resolve(options.home, "missing-lark"),
+    slackCliCommand: resolve(options.home, "missing-slack"),
+  });
+  return { capture: await readFile(capturePath, "utf8"), runtime };
 }
 
 function readyFactory(

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -220,8 +220,9 @@ export async function createClientRuntime(
   options.signal?.throwIfAborted();
   const defaultHome = sourceEnvironment.HOME ?? homedir();
   const configuredCodexHome = resolve(options.codexHome ?? sourceEnvironment.CODEX_HOME ?? join(defaultHome, ".codex"));
+  const defaultClaudeCodeHome = resolve(join(defaultHome, ".claude"));
   const configuredClaudeCodeHome = resolve(
-    options.claudeCodeHome ?? sourceEnvironment.CLAUDE_CONFIG_DIR ?? join(defaultHome, ".claude"),
+    options.claudeCodeHome ?? sourceEnvironment.CLAUDE_CONFIG_DIR ?? defaultClaudeCodeHome,
   );
   await mkdir(configuredCodexHome, { recursive: true, mode: 0o700 });
   await mkdir(configuredClaudeCodeHome, { recursive: true, mode: 0o700 });
@@ -231,10 +232,12 @@ export async function createClientRuntime(
   const claudeCodeCommand = options.claudeCodeCommand ?? "claude";
   options.signal?.throwIfAborted();
   const codexEnvironment = codexAgentRuntimeEnvironment({ ...sourceEnvironment, CODEX_HOME: codexHome });
-  const claudeCodeEnvironment = claudeCodeAgentRuntimeEnvironment({
-    ...sourceEnvironment,
-    CLAUDE_CONFIG_DIR: claudeCodeHome,
-  });
+  const canonicalDefaultClaudeCodeHome = await realpath(defaultClaudeCodeHome).catch(() => defaultClaudeCodeHome);
+  const claudeCodeEnvironment = claudeCodeProcessEnvironment(
+    sourceEnvironment,
+    claudeCodeHome,
+    canonicalDefaultClaudeCodeHome,
+  );
   const providerHomes: Readonly<Record<"codex" | "claude-code", string>> = {
     codex: codexHome,
     "claude-code": claudeCodeHome,
@@ -582,6 +585,24 @@ export interface ResolvedCodexFactoryOptions {
   readonly command: string;
   readonly environment: NodeJS.ProcessEnv;
   readonly sourceEnvironment: NodeJS.ProcessEnv;
+}
+
+function claudeCodeProcessEnvironment(
+  sourceEnvironment: NodeJS.ProcessEnv,
+  claudeCodeHome: string,
+  defaultClaudeCodeHome: string,
+): NodeJS.ProcessEnv {
+  // Claude Code treats a set CLAUDE_CONFIG_DIR as a distinct credential record, even when the
+  // value equals its own default. Omit the variable only when the resolved home is that default.
+  if (claudeCodeHome === defaultClaudeCodeHome) {
+    const environment = { ...sourceEnvironment };
+    delete environment.CLAUDE_CONFIG_DIR;
+    return claudeCodeAgentRuntimeEnvironment(environment);
+  }
+  return claudeCodeAgentRuntimeEnvironment({
+    ...sourceEnvironment,
+    CLAUDE_CONFIG_DIR: claudeCodeHome,
+  });
 }
 
 function productionProviderRegistration(


### PR DESCRIPTION
## Summary

- omit `CLAUDE_CONFIG_DIR` when the resolved Claude Code home is the CLI default for the same child `HOME`
- keep injecting the canonical path for every non-default configured home
- preserve provider-home identity and artifact verification against the resolved path
- add process-level tests for default omission plus explicit environment and option preservation

This restores ordinary Claude Code macOS Keychain credential discovery without changing Session binding identity.

Closes #236

## Validation

Validated on synchronized head `f9d3733` against `main@a0f6e84`:

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (client 490, server 292, CLI 152)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (292 tests, 100%)
- `pnpm --filter @opentag/server test:integration` (265 passed)
- `git diff --check`
- exact-head GitHub CI (6/6 passed)
