### PR TITLE
feat(cli): report local Agent Runtime installations in doctor

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,11 +78,9 @@ The server listens on `http://127.0.0.1:8000` by default. In another terminal, r
 pnpm --filter open-tag start doctor
 ```
 
-Use a different server URL with `--server-url` or `OPENTAG_SERVER_URL`:
-
-```bash
-pnpm --filter open-tag start doctor --server-url http://127.0.0.1:9000
-```
+`doctor` checks the Server URL recorded by this Computer's enrollment; it does not accept a caller-selected Server URL.
+It also reports whether a supported local Agent Runtime CLI is installed. This install-only check does not inspect Agent
+Runtime authentication or Integration CLI availability.
 
 ## Local PostgreSQL
 
@@ -379,7 +377,7 @@ processes.
 | --- | --- | --- |
 | `OPENTAG_HOST` | `127.0.0.1` | Server listen host |
 | `OPENTAG_PORT` | `8000` | Server listen port |
-| `OPENTAG_SERVER_URL` | `http://127.0.0.1:8000` | CLI doctor target |
+| `OPENTAG_SERVER_URL` | `http://127.0.0.1:8000` | Optional Server target override for login and Computer connect |
 | `OPENTAG_PUBLIC_URL` | none | Required public Server origin used for browser callbacks and generated connect commands |
 | `OPENTAG_ENV` | `dev` | OpenTag environment/channel: `dev`, `staging`, or `prod`; hosted values require HTTPS |
 | `OPENTAG_DATABASE_URL` | none | Required PostgreSQL connection URL |
@@ -402,8 +400,9 @@ processes.
 | `OPENTAG_SESSION_TTL_SECONDS` | `2592000` | Account session lifetime, browser and CLI alike |
 | `OPENTAG_HOME` | channel-specific | Root for lifecycle-separated `config/`, `data/`, `state/`, and `logs/` (`~/.opentag-dev` in source) |
 
-If `doctor` fails, its error category distinguishes configuration, network, HTTP, and invalid-response failures. Confirm
-the server is running and that the configured URL points to its base address.
+If `doctor` fails, its error category distinguishes enrollment, network, HTTP, invalid-response, and local Agent Runtime
+installation failures. Confirm the Server recorded by the Computer enrollment is running. Agent Runtime authentication and
+Integration CLI availability remain separate follow-up diagnostics and are stated as unchecked in the report.
 
 ## Releases
 

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -77,11 +77,8 @@ Server 默认监听 `http://127.0.0.1:8000`。在另一个终端中运行：
 pnpm --filter open-tag start doctor
 ```
 
-可以通过 `--server-url` 或 `OPENTAG_SERVER_URL` 指定其他 Server URL：
-
-```bash
-pnpm --filter open-tag start doctor --server-url http://127.0.0.1:9000
-```
+`doctor` 检查本机 Computer enrollment 中记录的 Server URL，不接受调用方另行指定 Server URL。它还会报告本地
+是否安装了受支持的 Agent Runtime CLI。该检查只判断安装状态，不检查 Agent Runtime 登录状态或 Integration CLI。
 
 ## 本地 PostgreSQL
 
@@ -354,7 +351,7 @@ setup attempt 并记录结果，然后把一条已授权的 binding 写入数据
 | --- | --- | --- |
 | `OPENTAG_HOST` | `127.0.0.1` | Server 监听地址 |
 | `OPENTAG_PORT` | `8000` | Server 监听端口 |
-| `OPENTAG_SERVER_URL` | `http://127.0.0.1:8000` | CLI doctor 目标地址 |
+| `OPENTAG_SERVER_URL` | `http://127.0.0.1:8000` | login 和 Computer connect 的可选 Server 目标覆盖 |
 | `OPENTAG_PUBLIC_URL` | 无 | 浏览器 callback 和生成连接命令使用的必需 Server 公共 origin |
 | `OPENTAG_ENV` | `dev` | OpenTag 环境/channel：`dev`、`staging` 或 `prod`；托管值要求 HTTPS |
 | `OPENTAG_DATABASE_URL` | 无 | 必需的 PostgreSQL 连接地址 |
@@ -377,7 +374,9 @@ setup attempt 并记录结果，然后把一条已授权的 binding 写入数据
 | `OPENTAG_SESSION_TTL_SECONDS` | `2592000` | Account session 有效期，浏览器与 CLI 相同 |
 | `OPENTAG_HOME` | 随 channel 而定 | 按生命周期分层的 `config/`、`data/`、`state/`、`logs/` 根目录（源码默认为 `~/.opentag-dev`） |
 
-如果 `doctor` 失败，其错误类别会区分配置、网络、HTTP 和无效响应。请确认 Server 已启动，且配置的 URL 指向其基础地址。
+如果 `doctor` 失败，其错误类别会区分 enrollment、网络、HTTP、无效响应和本地 Agent Runtime 安装问题。请确认
+Computer enrollment 所记录的 Server 已启动。Agent Runtime 登录状态和 Integration CLI 可用性仍是后续独立诊断项，
+报告会明确标记为未检查。
 
 ## 发布
 

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -1,46 +1,135 @@
-import { ServerHealthConfigurationError, ServerHealthNetworkError } from "@opentag/client";
+import type { AgentRuntimeCliInstallation, StoredMachineCredentials } from "@opentag/client";
+import { ServerHealthNetworkError } from "@opentag/client";
 import { describe, expect, it, vi } from "vitest";
-import { resolveServerUrl, runDoctor } from "../core/diagnostics/doctor.js";
+import { createProgram } from "../cli/program.js";
+import { runDoctor } from "../core/diagnostics/doctor.js";
 
-describe("resolveServerUrl", () => {
-  it("prefers the command option over the environment", () => {
-    expect(resolveServerUrl("http://cli.example", { OPENTAG_SERVER_URL: "http://env.example" })).toBe(
-      "http://cli.example",
-    );
-  });
+const COMPUTER_ID = "00000000-0000-4000-8000-000000000001";
+const ENROLLMENT_ID = "00000000-0000-4000-8000-000000000002";
 
-  it("uses the environment before the default", () => {
-    expect(resolveServerUrl(undefined, { OPENTAG_SERVER_URL: "http://env.example" })).toBe("http://env.example");
-    expect(resolveServerUrl(undefined, {})).toBe("http://127.0.0.1:8000");
+function credentials(...serverUrls: string[]): StoredMachineCredentials {
+  return {
+    version: 1,
+    enrollments: serverUrls.map((serverUrl, index) => ({
+      computerId: COMPUTER_ID,
+      machineToken: `otmc_fixture-${index}`,
+      serverUrl,
+      workspaceComputerId: index === 0 ? ENROLLMENT_ID : `00000000-0000-4000-8000-00000000000${index + 2}`,
+    })),
+  };
+}
+
+function runtimes(codex: boolean, claudeCode: boolean): AgentRuntimeCliInstallation[] {
+  return [
+    {
+      provider: "codex",
+      displayName: "Codex CLI",
+      installed: codex,
+      ...(codex ? { path: "/opt/codex", source: "path" as const } : {}),
+    },
+    {
+      provider: "claude-code",
+      displayName: "Claude Code CLI",
+      installed: claudeCode,
+      ...(claudeCode ? { path: "/opt/claude", source: "well-known" as const } : {}),
+    },
+  ];
+}
+
+describe("doctor command contract", () => {
+  it("does not expose a Server URL selector", () => {
+    const doctor = createProgram().commands.find((command) => command.name() === "doctor");
+    expect(doctor?.options.map((option) => option.long)).not.toContain("--server-url");
   });
 });
 
 describe("runDoctor", () => {
-  it("reports a healthy server", async () => {
+  it("checks the enrolled Server and reports install-only Agent Runtime facts", async () => {
     const healthChecker = vi.fn().mockResolvedValue({ status: "ok", service: "opentag-server" } as const);
 
-    await expect(runDoctor({ serverUrl: "http://server.example", healthChecker })).resolves.toEqual({
-      exitCode: 0,
-      message: "OpenTag server is healthy (opentag-server) at http://server.example",
+    const result = await runDoctor({
+      env: { OPENTAG_SERVER_URL: "https://ignored.example" },
+      healthChecker,
+      home: "/configured-home",
+      readCredentials: async (home) => {
+        expect(home).toBe("/configured-home");
+        return credentials("https://operator:secret@enrolled.example/private");
+      },
+      probeRuntimeInstallations: async () => runtimes(true, false),
     });
-    expect(healthChecker).toHaveBeenCalledWith("http://server.example");
+
+    expect(result.exitCode).toBe(0);
+    expect(healthChecker).toHaveBeenCalledWith("https://operator:secret@enrolled.example/private");
+    expect(healthChecker).not.toHaveBeenCalledWith("https://ignored.example");
+    expect(result.message).toContain("healthy (opentag-server) at https://enrolled.example");
+    expect(result.message).not.toContain("secret");
+    expect(result.message).toContain("✓ Agent Runtime CLI: Codex CLI installed");
+    expect(result.message).toContain("- Claude Code CLI: not installed");
+    expect(result.message).toContain("Agent Runtime authentication was not checked.");
+    expect(result.message).toContain("Integration CLI availability was not checked.");
   });
 
-  it("reports a categorized failure and a non-zero exit code", async () => {
-    const healthChecker = vi.fn().mockRejectedValue(new ServerHealthNetworkError("offline"));
-
-    await expect(runDoctor({ serverUrl: "http://server.example", healthChecker })).resolves.toEqual({
-      exitCode: 1,
-      message: "Network error: could not reach the OpenTag server at http://server.example",
+  it("fails closed when this computer has no configured enrollment", async () => {
+    const healthChecker = vi.fn();
+    const result = await runDoctor({
+      healthChecker,
+      readCredentials: async () => undefined,
+      probeRuntimeInstallations: async () => runtimes(true, false),
     });
+
+    expect(result.exitCode).toBe(1);
+    expect(healthChecker).not.toHaveBeenCalled();
+    expect(result.message).toContain("✗ OpenTag server: not configured");
   });
 
-  it("reports an invalid server URL as a configuration error", async () => {
-    const healthChecker = vi.fn().mockRejectedValue(new ServerHealthConfigurationError("invalid URL"));
-
-    await expect(runDoctor({ serverUrl: "not-a-url", healthChecker })).resolves.toEqual({
-      exitCode: 1,
-      message: "Configuration error: invalid OpenTag server URL not-a-url",
+  it("checks every distinct enrolled Server exactly once", async () => {
+    const healthChecker = vi.fn().mockResolvedValue({ status: "ok", service: "opentag-server" } as const);
+    const result = await runDoctor({
+      healthChecker,
+      readCredentials: async () => credentials("https://two.example", "https://one.example", "https://two.example"),
+      probeRuntimeInstallations: async () => runtimes(false, true),
     });
+
+    expect(result.exitCode).toBe(0);
+    expect(healthChecker.mock.calls.map(([url]) => url)).toEqual(["https://one.example", "https://two.example"]);
+  });
+
+  it("categorizes a configured Server network failure", async () => {
+    const result = await runDoctor({
+      healthChecker: async () => {
+        throw new ServerHealthNetworkError("offline");
+      },
+      readCredentials: async () => credentials("https://offline.example"),
+      probeRuntimeInstallations: async () => runtimes(true, true),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("✗ OpenTag server: unreachable at https://offline.example");
+  });
+
+  it("requires at least one supported Agent Runtime CLI without requiring both", async () => {
+    const result = await runDoctor({
+      healthChecker: async () => ({ status: "ok", service: "opentag-server" }),
+      readCredentials: async () => credentials("https://server.example"),
+      probeRuntimeInstallations: async () => runtimes(false, false),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("✗ Agent Runtime CLI: no supported Agent Runtime CLI is installed");
+  });
+
+  it("reports credential and installation detector failures without hiding the other section", async () => {
+    const result = await runDoctor({
+      readCredentials: async () => {
+        throw new Error("invalid credential file");
+      },
+      probeRuntimeInstallations: async () => {
+        throw new Error("probe failed");
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("cannot read this computer's enrollment (invalid credential file)");
+    expect(result.message).toContain("installation detection failed (probe failed)");
   });
 });

--- a/apps/cli/src/__tests__/public-surface.test.ts
+++ b/apps/cli/src/__tests__/public-surface.test.ts
@@ -14,7 +14,6 @@ const EXPECTED_ROOT_EXPORTS = [
   "formatSessionCommandResult",
   "formatSessionList",
   "listComputers",
-  "resolveServerUrl",
   "runAgentCreate",
   "runAgentDelete",
   "runAgentList",

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,17 +1,12 @@
 import type { Command } from "commander";
 import { runDoctor } from "../core/diagnostics/doctor.js";
 
-interface DoctorCommandOptions {
-  serverUrl?: string;
-}
-
 export function registerDoctorCommand(program: Command): void {
   program
     .command("doctor")
-    .description("Check connectivity to the OpenTag server")
-    .option("--server-url <url>", "OpenTag server base URL")
-    .action(async (options: DoctorCommandOptions) => {
-      const result = await runDoctor({ serverUrl: options.serverUrl });
+    .description("Check the configured OpenTag servers and local Agent Runtime CLIs")
+    .action(async () => {
+      const result = await runDoctor();
       const write = result.exitCode === 0 ? console.log : console.error;
       write(result.message);
       process.exitCode = result.exitCode;

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -1,68 +1,167 @@
 import {
+  type AgentRuntimeCliInstallation,
   checkServerHealth,
+  probeAgentRuntimeCliInstallations,
+  readMachineCredentials,
+  resolveOpenTagHome,
   ServerHealthConfigurationError,
   ServerHealthHttpError,
   ServerHealthNetworkError,
   ServerHealthResponseError,
+  type StoredMachineCredentials,
 } from "@opentag/client";
 import type { ServerHealth } from "@opentag/shared";
 import { channelConfig } from "../channel/config.js";
 
 export type HealthChecker = (serverUrl: string) => Promise<ServerHealth>;
+type DoctorCheckState = "pass" | "fail" | "info";
+
+interface DoctorCheck {
+  state: DoctorCheckState;
+  label: string;
+  detail: string;
+}
 
 export interface DoctorOptions {
-  serverUrl?: string;
   env?: NodeJS.ProcessEnv;
   healthChecker?: HealthChecker;
+  home?: string;
+  readCredentials?: (home: string) => Promise<StoredMachineCredentials | undefined>;
+  probeRuntimeInstallations?: () => Promise<AgentRuntimeCliInstallation[]>;
 }
 
 export interface DoctorResult {
+  checks: DoctorCheck[];
   exitCode: 0 | 1;
   message: string;
 }
 
-export function resolveServerUrl(serverUrl: string | undefined, env: NodeJS.ProcessEnv = process.env): string {
-  const resolved = serverUrl ?? env.OPENTAG_SERVER_URL ?? channelConfig.defaultServerUrl;
-  if (!resolved) throw new ServerHealthConfigurationError(`The ${channelConfig.channel} channel requires a server URL`);
-  return resolved;
-}
-
+/**
+ * Diagnose the local OpenTag installation. The Server target is local machine
+ * state, never a caller-selected URL: every distinct enrolled Server is checked.
+ */
 export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResult> {
-  let serverUrl: string;
-  try {
-    serverUrl = resolveServerUrl(options.serverUrl, options.env);
-  } catch (error) {
-    return { exitCode: 1, message: formatDoctorError(error, "<not configured>") };
-  }
-  const healthChecker = options.healthChecker ?? checkServerHealth;
-
-  try {
-    const health = await healthChecker(serverUrl);
-    return {
-      exitCode: 0,
-      message: `OpenTag server is healthy (${health.service}) at ${serverUrl}`,
-    };
-  } catch (error) {
-    return {
-      exitCode: 1,
-      message: formatDoctorError(error, serverUrl),
-    };
-  }
+  const environment = options.env ?? process.env;
+  const home = options.home ?? resolveOpenTagHome(environment);
+  const checks = await Promise.all([
+    checkConfiguredServers(
+      home,
+      options.readCredentials ?? readMachineCredentials,
+      options.healthChecker ?? checkServerHealth,
+    ),
+    checkAgentRuntimeInstallations(
+      options.probeRuntimeInstallations ?? (() => probeAgentRuntimeCliInstallations({ environment })),
+    ),
+  ]).then((groups) => groups.flat());
+  const exitCode = checks.some((check) => check.state === "fail") ? 1 : 0;
+  return { checks, exitCode, message: formatDoctorReport(checks) };
 }
 
-function formatDoctorError(error: unknown, serverUrl: string): string {
-  if (error instanceof ServerHealthConfigurationError) {
-    return `Configuration error: invalid OpenTag server URL ${serverUrl}`;
+async function checkConfiguredServers(
+  home: string,
+  readCredentials: (home: string) => Promise<StoredMachineCredentials | undefined>,
+  healthChecker: HealthChecker,
+): Promise<DoctorCheck[]> {
+  let credentials: StoredMachineCredentials | undefined;
+  try {
+    credentials = await readCredentials(home);
+  } catch (error) {
+    return [
+      {
+        state: "fail",
+        label: "OpenTag server",
+        detail: `cannot read this computer's enrollment (${error instanceof Error ? error.message : String(error)})`,
+      },
+    ];
   }
-  if (error instanceof ServerHealthNetworkError) {
-    return `Network error: could not reach the OpenTag server at ${serverUrl}`;
+  const serverUrls = [...new Set(credentials?.enrollments.map((enrollment) => enrollment.serverUrl) ?? [])].sort();
+  if (serverUrls.length === 0) {
+    return [
+      {
+        state: "fail",
+        label: "OpenTag server",
+        detail: `not configured — run \`${channelConfig.binName} computer connect <code>\` first`,
+      },
+    ];
   }
-  if (error instanceof ServerHealthHttpError) {
-    return `HTTP error: the OpenTag server at ${serverUrl} returned status ${error.status}`;
+  return Promise.all(
+    serverUrls.map(async (serverUrl): Promise<DoctorCheck> => {
+      const displayUrl = displayServerUrl(serverUrl);
+      try {
+        const health = await healthChecker(serverUrl);
+        return { state: "pass", label: "OpenTag server", detail: `healthy (${health.service}) at ${displayUrl}` };
+      } catch (error) {
+        return { state: "fail", label: "OpenTag server", detail: formatServerHealthError(error, displayUrl) };
+      }
+    }),
+  );
+}
+
+async function checkAgentRuntimeInstallations(
+  probeRuntimeInstallations: () => Promise<AgentRuntimeCliInstallation[]>,
+): Promise<DoctorCheck[]> {
+  let installations: AgentRuntimeCliInstallation[];
+  try {
+    installations = await probeRuntimeInstallations();
+  } catch (error) {
+    return [
+      {
+        state: "fail",
+        label: "Agent Runtime CLI",
+        detail: `installation detection failed (${error instanceof Error ? error.message : String(error)})`,
+      },
+    ];
   }
-  if (error instanceof ServerHealthResponseError) {
-    return `Response error: the OpenTag server at ${serverUrl} returned an invalid health response`;
+  const installed = installations.filter((installation) => installation.installed);
+  const summary: DoctorCheck =
+    installed.length > 0
+      ? {
+          state: "pass",
+          label: "Agent Runtime CLI",
+          detail: `${installed.map((installation) => installation.displayName).join(", ")} installed`,
+        }
+      : { state: "fail", label: "Agent Runtime CLI", detail: "no supported Agent Runtime CLI is installed" };
+  return [
+    summary,
+    ...installations.map(
+      (installation): DoctorCheck => ({
+        state: "info",
+        label: installation.displayName,
+        detail: installation.installed
+          ? `installed${installation.path ? ` at ${installation.path}` : ""}`
+          : "not installed",
+      }),
+    ),
+  ];
+}
+
+function formatDoctorReport(checks: readonly DoctorCheck[]): string {
+  const lines = ["Checks"];
+  for (const check of checks) {
+    const marker = check.state === "pass" ? "✓" : check.state === "fail" ? "✗" : "-";
+    lines.push(`  ${marker} ${check.label}: ${check.detail}`);
   }
+  const failures = checks.filter((check) => check.state === "fail").length;
+  lines.push("");
+  lines.push(failures === 0 ? "All required checks passed." : `${failures} required check(s) failed.`);
+  lines.push("Agent Runtime authentication was not checked.");
+  lines.push("Integration CLI availability was not checked.");
+  return lines.join("\n");
+}
+
+function formatServerHealthError(error: unknown, serverUrl: string): string {
+  if (error instanceof ServerHealthConfigurationError) return `invalid configured URL ${serverUrl}`;
+  if (error instanceof ServerHealthNetworkError) return `unreachable at ${serverUrl}`;
+  if (error instanceof ServerHealthHttpError) return `HTTP ${error.status} at ${serverUrl}`;
+  if (error instanceof ServerHealthResponseError) return `invalid health response from ${serverUrl}`;
   const detail = error instanceof Error ? error.message : String(error);
-  return `Unexpected error while checking ${serverUrl}: ${detail}`;
+  return `unexpected failure at ${serverUrl} (${detail})`;
+}
+
+function displayServerUrl(serverUrl: string): string {
+  try {
+    return new URL(serverUrl).origin;
+  } catch {
+    return "<invalid configured URL>";
+  }
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,7 +12,11 @@ export { type LoginOptions, type LoginResult, runLogin } from "./core/auth/login
 export { channelConfig } from "./core/channel/config.js";
 export { formatComputerList } from "./core/computer/formatting.js";
 export { listComputers } from "./core/computer/queries.js";
-export { type DoctorOptions, type DoctorResult, resolveServerUrl, runDoctor } from "./core/diagnostics/doctor.js";
+export {
+  type DoctorOptions,
+  type DoctorResult,
+  runDoctor,
+} from "./core/diagnostics/doctor.js";
 export {
   formatSessionCommandResult,
   formatSessionList,

--- a/packages/client/src/__tests__/agent-runtime-installation.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-installation.test.ts
@@ -1,0 +1,162 @@
+import { constants } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  codexDesktopAppBinDirs,
+  probeAgentRuntimeCliInstallations,
+  resolveAgentRuntimeExecutable,
+  wellKnownAgentRuntimeBinDirs,
+} from "../runtime/agent-runtime-installation.js";
+import { resolveOutsideProtectedRoots } from "../runtime/protected-paths.js";
+
+describe("Agent Runtime CLI install-only discovery", () => {
+  it("prefers PATH before well-known and desktop-app candidates", async () => {
+    const attempts: string[] = [];
+    const resolved = await resolveAgentRuntimeExecutable(
+      "codex",
+      "codex",
+      { PATH: "/path/bin", HOME: "/home/u" },
+      {
+        access: async (path, mode) => {
+          expect(mode).toBe(constants.X_OK);
+          attempts.push(path);
+          if (path !== "/path/bin/codex") throw new Error("missing");
+        },
+        realpath: async (path) => `/real${path}`,
+        platform: "darwin",
+        pathDelimiter: ":",
+        wellKnownDirs: () => ["/well-known"],
+        desktopAppDirs: () => ["/Applications/ChatGPT.app/Contents/Resources"],
+        candidateAllowed: () => true,
+      },
+    );
+
+    expect(attempts).toEqual(["/path/bin/codex"]);
+    expect(resolved).toEqual({ provider: "codex", path: "/real/path/bin/codex", source: "path" });
+  });
+
+  it("finds Codex in the macOS desktop app after cheaper candidates miss", async () => {
+    const desktop = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const resolved = await resolveAgentRuntimeExecutable(
+      "codex",
+      "codex",
+      { PATH: "", HOME: "/home/u" },
+      {
+        access: async (path) => {
+          if (path !== desktop) throw new Error("missing");
+        },
+        realpath: async (path) => path,
+        platform: "darwin",
+        wellKnownDirs: () => ["/well-known"],
+        desktopAppDirs: () => ["/Applications/ChatGPT.app/Contents/Resources"],
+        candidateAllowed: () => true,
+      },
+    );
+
+    expect(resolved).toEqual({ provider: "codex", path: desktop, source: "desktop-app" });
+  });
+
+  it("does not use Codex desktop-app locations for Claude Code", async () => {
+    const access = vi.fn(async (path: string) => {
+      if (path.includes("ChatGPT.app")) return;
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveAgentRuntimeExecutable(
+        "claude-code",
+        "claude",
+        { PATH: "", HOME: "/home/u" },
+        {
+          access,
+          realpath: async (path) => path,
+          platform: "darwin",
+          wellKnownDirs: () => [],
+          desktopAppDirs: () => ["/Applications/ChatGPT.app/Contents/Resources"],
+          candidateAllowed: () => true,
+        },
+      ),
+    ).rejects.toThrow("not installed");
+    expect(access).not.toHaveBeenCalled();
+  });
+
+  it("skips automatic candidates rejected by the protected-path guard", async () => {
+    const access = vi.fn(async () => undefined);
+    const resolved = await resolveAgentRuntimeExecutable(
+      "codex",
+      "codex",
+      { PATH: "/blocked:/safe", HOME: "/home/u" },
+      {
+        access,
+        realpath: async (path) => path,
+        platform: "darwin",
+        pathDelimiter: ":",
+        wellKnownDirs: () => [],
+        desktopAppDirs: () => [],
+        candidateAllowed: (path) => !path.startsWith("/blocked"),
+      },
+    );
+
+    expect(access).toHaveBeenCalledOnce();
+    expect(resolved.path).toBe("/safe/codex");
+  });
+
+  it("treats an explicit absolute path as operator-directed", async () => {
+    const candidateAllowed = vi.fn(() => false);
+    const resolved = await resolveAgentRuntimeExecutable(
+      "claude-code",
+      "/custom/claude",
+      {},
+      {
+        access: async () => undefined,
+        realpath: async (path) => path,
+        candidateAllowed,
+      },
+    );
+
+    expect(resolved.source).toBe("explicit");
+    expect(candidateAllowed).not.toHaveBeenCalled();
+  });
+
+  it("reports both supported providers without launching either CLI", async () => {
+    const access = vi.fn(async (path: string) => {
+      if (path === "/bin/codex") return;
+      throw new Error("missing");
+    });
+    const result = await probeAgentRuntimeCliInstallations({
+      access,
+      realpath: async (path) => path,
+      environment: { PATH: "/bin", HOME: "/home/u" },
+      platform: "linux",
+      wellKnownDirs: () => [],
+      desktopAppDirs: () => [],
+      candidateAllowed: () => true,
+    });
+
+    expect(result).toEqual([
+      { provider: "codex", displayName: "Codex CLI", installed: true, path: "/bin/codex", source: "path" },
+      { provider: "claude-code", displayName: "Claude Code CLI", installed: false },
+    ]);
+  });
+});
+
+describe("First Tree-compatible install locations", () => {
+  it("includes native and common global install locations", () => {
+    expect(wellKnownAgentRuntimeBinDirs("/home/u", "darwin")).toEqual(
+      expect.arrayContaining(["/home/u/.local/bin", "/home/u/.claude/local", "/opt/homebrew/bin"]),
+    );
+    expect(codexDesktopAppBinDirs("/home/u", "darwin")[0]).toBe("/Applications/ChatGPT.app/Contents/Resources");
+    expect(codexDesktopAppBinDirs("/home/u", "linux")).toEqual([]);
+  });
+
+  it("rejects a symlink expansion into a protected root before following it", () => {
+    const touched: string[] = [];
+    const resolved = resolveOutsideProtectedRoots("/Users/u/.local/bin/codex", ["/Users/u/Documents"], (path) => {
+      touched.push(path);
+      if (path === "/Users/u/.local") return "/Users/u/Documents/tools";
+      throw new Error("not a link");
+    });
+
+    expect(resolved).toBeNull();
+    expect(touched).not.toContain("/Users/u/Documents");
+  });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -147,6 +147,17 @@ export {
   type AdmissionSnapshot,
 } from "./runtime/admission-controller.js";
 export {
+  type AgentRuntimeCliInstallation,
+  type AgentRuntimeExecutableSource,
+  codexDesktopAppBinDirs,
+  type ProbeAgentRuntimeCliInstallationsOptions,
+  probeAgentRuntimeCliInstallations,
+  type ResolveAgentRuntimeExecutableOptions,
+  type ResolvedAgentRuntimeExecutable,
+  resolveAgentRuntimeExecutable,
+  wellKnownAgentRuntimeBinDirs,
+} from "./runtime/agent-runtime-installation.js";
+export {
   type AgentRuntimeProviderRegistration,
   AgentRuntimeProviderRegistry,
   AgentRuntimeProviderUnavailableError,

--- a/packages/client/src/runtime/agent-runtime-installation.ts
+++ b/packages/client/src/runtime/agent-runtime-installation.ts
@@ -1,0 +1,155 @@
+import { constants } from "node:fs";
+import { access, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import { delimiter, isAbsolute, join } from "node:path";
+import type { AgentRuntimeProvider } from "@opentag/shared";
+import { automaticCandidateAllowed } from "./protected-paths.js";
+
+export type AgentRuntimeExecutableSource = "explicit" | "path" | "well-known" | "desktop-app";
+
+export interface ResolvedAgentRuntimeExecutable {
+  provider: AgentRuntimeProvider;
+  path: string;
+  source: AgentRuntimeExecutableSource;
+}
+
+export interface AgentRuntimeCliInstallation {
+  provider: AgentRuntimeProvider;
+  displayName: string;
+  installed: boolean;
+  path?: string;
+  source?: AgentRuntimeExecutableSource;
+}
+
+type Candidate = { path: string; source: Exclude<AgentRuntimeExecutableSource, "explicit"> };
+
+export interface ResolveAgentRuntimeExecutableOptions {
+  access?: (path: string, mode: number) => Promise<void>;
+  realpath?: (path: string) => Promise<string>;
+  platform?: NodeJS.Platform;
+  home?: string;
+  pathDelimiter?: string;
+  wellKnownDirs?: (home: string, platform: NodeJS.Platform) => readonly string[];
+  desktopAppDirs?: (home: string, platform: NodeJS.Platform) => readonly string[];
+  candidateAllowed?: (path: string, options: { platform: NodeJS.Platform; home: string }) => boolean;
+}
+
+export interface ProbeAgentRuntimeCliInstallationsOptions extends ResolveAgentRuntimeExecutableOptions {
+  environment?: NodeJS.ProcessEnv;
+  commands?: Partial<Record<AgentRuntimeProvider, string>>;
+}
+
+const PROVIDERS = [
+  { provider: "codex", displayName: "Codex CLI", command: "codex" },
+  { provider: "claude-code", displayName: "Claude Code CLI", command: "claude" },
+] as const;
+
+/** Cheap, spawn-free directories mirrored from First Tree's install-only capability discovery. */
+export function wellKnownAgentRuntimeBinDirs(home: string, platform: NodeJS.Platform = process.platform): string[] {
+  return [
+    join(home, ".local", "bin"),
+    join(home, ".claude", "local"),
+    join(home, ".volta", "bin"),
+    join(home, ".asdf", "shims"),
+    join(home, ".local", "share", "mise", "shims"),
+    join(home, ".npm-global", "bin"),
+    join(home, ".local", "share", "pnpm"),
+    ...(platform === "darwin" ? [join(home, "Library", "pnpm")] : []),
+    join(home, ".bun", "bin"),
+    ...(platform === "darwin" ? ["/opt/homebrew/bin"] : []),
+    "/usr/local/bin",
+  ];
+}
+
+export function codexDesktopAppBinDirs(home: string, platform: NodeJS.Platform = process.platform): string[] {
+  if (platform !== "darwin") return [];
+  return [
+    join("/Applications", "ChatGPT.app", "Contents", "Resources"),
+    join(home, "Applications", "ChatGPT.app", "Contents", "Resources"),
+    join("/Applications", "Codex.app", "Contents", "Resources"),
+    join(home, "Applications", "Codex.app", "Contents", "Resources"),
+  ];
+}
+
+export async function resolveAgentRuntimeExecutable(
+  provider: AgentRuntimeProvider,
+  command: string,
+  environment: NodeJS.ProcessEnv,
+  options: ResolveAgentRuntimeExecutableOptions = {},
+): Promise<ResolvedAgentRuntimeExecutable> {
+  const checkAccess = options.access ?? access;
+  const canonicalize = options.realpath ?? realpath;
+  if (isAbsolute(command)) {
+    await checkAccess(command, constants.X_OK);
+    return { provider, path: await canonicalize(command), source: "explicit" };
+  }
+
+  const platform = options.platform ?? process.platform;
+  const home = options.home ?? environment.HOME ?? homedir();
+  const pathDelimiter = options.pathDelimiter ?? delimiter;
+  const wellKnownDirs = options.wellKnownDirs ?? wellKnownAgentRuntimeBinDirs;
+  const desktopAppDirs = options.desktopAppDirs ?? codexDesktopAppBinDirs;
+  const candidateAllowed = options.candidateAllowed ?? automaticCandidateAllowed;
+  const extensions = platform === "win32" ? (environment.PATHEXT ?? ".EXE;.CMD;.BAT").split(";") : [""];
+  const seen = new Set<string>();
+
+  for (const candidate of executableCandidates({
+    command,
+    desktopAppDirs: provider === "codex" ? desktopAppDirs(home, platform) : [],
+    extensions,
+    pathDirs: (environment.PATH ?? "").split(pathDelimiter).filter(Boolean),
+    wellKnownDirs: wellKnownDirs(home, platform),
+  })) {
+    if (seen.has(candidate.path)) continue;
+    seen.add(candidate.path);
+    if (!candidateAllowed(candidate.path, { platform, home })) continue;
+    try {
+      await checkAccess(candidate.path, constants.X_OK);
+      return { provider, path: await canonicalize(candidate.path), source: candidate.source };
+    } catch {
+      // Continue to the next automatic candidate.
+    }
+  }
+  throw new Error(`The ${provider} Agent Runtime CLI is not installed`);
+}
+
+export async function probeAgentRuntimeCliInstallations(
+  options: ProbeAgentRuntimeCliInstallationsOptions = {},
+): Promise<AgentRuntimeCliInstallation[]> {
+  const environment = options.environment ?? process.env;
+  return Promise.all(
+    PROVIDERS.map(async ({ provider, displayName, command }) => {
+      try {
+        const resolved = await resolveAgentRuntimeExecutable(
+          provider,
+          options.commands?.[provider] ?? command,
+          environment,
+          options,
+        );
+        return { provider, displayName, installed: true, path: resolved.path, source: resolved.source };
+      } catch {
+        return { provider, displayName, installed: false };
+      }
+    }),
+  );
+}
+
+function* executableCandidates(options: {
+  command: string;
+  extensions: readonly string[];
+  pathDirs: readonly string[];
+  wellKnownDirs: readonly string[];
+  desktopAppDirs: readonly string[];
+}): Generator<Candidate> {
+  for (const [source, directories] of [
+    ["path", options.pathDirs],
+    ["well-known", options.wellKnownDirs],
+    ["desktop-app", options.desktopAppDirs],
+  ] as const) {
+    for (const directory of directories) {
+      for (const extension of options.extensions) {
+        yield { path: join(directory, `${options.command}${extension}`), source };
+      }
+    }
+  }
+}

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -37,6 +37,7 @@ import {
 import { codexRuntimePolicy, validateCodexRuntimePolicy } from "../providers/codex/runtime-policy.js";
 import { RuntimeStorageError } from "../storage/durable-file.js";
 import { AdmissionController } from "./admission-controller.js";
+import { resolveAgentRuntimeExecutable } from "./agent-runtime-installation.js";
 import {
   type AgentRuntimeProviderRegistration,
   AgentRuntimeProviderRegistry,
@@ -622,7 +623,7 @@ export function resolvedCodexFactory(options: ResolvedCodexFactoryOptions): Agen
       let command: string;
       try {
         request.signal?.throwIfAborted();
-        command = await resolveExecutable(options.command, options.sourceEnvironment);
+        command = (await resolveAgentRuntimeExecutable("codex", options.command, options.sourceEnvironment)).path;
       } catch (error) {
         if (request.signal?.aborted) throw error;
         return { ready: false, issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }] };
@@ -664,7 +665,7 @@ export function resolvedClaudeCodeFactory(options: ResolvedClaudeCodeFactoryOpti
       let command: string;
       try {
         request.signal?.throwIfAborted();
-        command = await resolveExecutable(options.command, options.sourceEnvironment);
+        command = (await resolveAgentRuntimeExecutable("claude-code", options.command, options.sourceEnvironment)).path;
       } catch (error) {
         if (request.signal?.aborted) throw error;
         return {

--- a/packages/client/src/runtime/protected-paths.ts
+++ b/packages/client/src/runtime/protected-paths.ts
@@ -1,0 +1,80 @@
+import { readlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve, sep } from "node:path";
+
+const MACOS_PROTECTED_HOME_SUBPATHS = [
+  "Desktop",
+  "Documents",
+  "Downloads",
+  "Library/Mobile Documents",
+  "Library/CloudStorage",
+] as const;
+
+export type ReadLink = (path: string) => string;
+
+const MAX_SYMLINK_HOPS = 32;
+
+export function protectedRoots(
+  platform: NodeJS.Platform = process.platform,
+  home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir(),
+): string[] {
+  if (platform !== "darwin") return [];
+  return MACOS_PROTECTED_HOME_SUBPATHS.map((subpath) => join(home, subpath));
+}
+
+function fold(value: string): string {
+  return value.toLocaleLowerCase("en-US");
+}
+
+function insideAny(path: string, roots: readonly string[]): boolean {
+  const candidate = fold(path);
+  return roots.some((root) => {
+    const protectedRoot = fold(root);
+    return candidate === protectedRoot || candidate.startsWith(`${protectedRoot}${sep}`);
+  });
+}
+
+/**
+ * Resolve symlink hops without entering a macOS TCC-protected directory.
+ * Automatic background discovery must not trigger a Files & Folders prompt.
+ */
+export function resolveOutsideProtectedRoots(
+  path: string,
+  roots: readonly string[],
+  readLink: ReadLink = readlinkSync,
+): string | null {
+  let pending = resolve(path).split(sep).filter(Boolean);
+  let resolved: string = sep;
+  let hops = 0;
+  while (pending.length > 0) {
+    const [head = "", ...rest] = pending;
+    const candidate = join(resolved, head);
+    if (insideAny(candidate, roots)) return null;
+    let target: string | null = null;
+    try {
+      target = readLink(candidate);
+    } catch {
+      // A non-link, missing, or unreadable component is handled by the later access check.
+    }
+    if (target === null) {
+      resolved = candidate;
+      pending = rest;
+      continue;
+    }
+    hops += 1;
+    if (hops > MAX_SYMLINK_HOPS) return null;
+    const expanded = isAbsolute(target) ? target : join(resolved, target);
+    pending = [...resolve(expanded).split(sep).filter(Boolean), ...rest];
+    resolved = sep;
+  }
+  return resolved;
+}
+
+export function automaticCandidateAllowed(
+  candidate: string,
+  options: { platform?: NodeJS.Platform; home?: string; readLink?: ReadLink } = {},
+): boolean {
+  const roots = protectedRoots(options.platform, options.home);
+  if (roots.length === 0) return true;
+  return resolveOutsideProtectedRoots(candidate, roots, options.readLink) !== null;
+}

--- a/scripts/cli-pack-smoke.mjs
+++ b/scripts/cli-pack-smoke.mjs
@@ -172,9 +172,16 @@ export async function runCliPackSmoke({ channel, expectedName, expectedVersion, 
     if (!computerConnectHelp.stdout.includes("--no-start")) {
       throw new Error("CLI Computer connect help is missing --no-start");
     }
-    const doctor = run(binaryPath, ["doctor", "--server-url", "http://127.0.0.1:1"], { expectedStatus: 1 });
-    if (!doctor.stderr.includes("Network error:")) {
-      throw new Error("CLI doctor smoke did not report the expected network failure");
+    const doctorHelp = run(binaryPath, ["doctor", "--help"]);
+    if (doctorHelp.stdout.includes("--server-url")) {
+      throw new Error("CLI doctor still exposes a caller-selected Server URL");
+    }
+    const doctor = run(binaryPath, ["doctor"], {
+      expectedStatus: 1,
+      env: { OPENTAG_HOME: join(temporaryRoot, "empty-opentag-home") },
+    });
+    if (!doctor.stderr.includes("OpenTag server: not configured")) {
+      throw new Error("CLI doctor smoke did not report the expected missing enrollment");
     }
 
     const installedManifest = JSON.parse(


### PR DESCRIPTION
## Summary

- redefine `opentag doctor` around this Computer local enrollment state: remove `--server-url` and do not read `OPENTAG_SERVER_URL`
- check every distinct Server recorded in machine credentials and fail closed when the Computer has no enrollment
- report install-only Codex and Claude Code CLI discovery without launching either provider
- share the cheap discovery path with the actual Agent Runtime factories: service PATH, First Tree compatible well-known directories, and macOS ChatGPT or Codex app resources
- prevent automatic macOS discovery from entering TCC-protected roots, including through symlinks

## Contract boundary

A doctor pass requires a healthy enrolled Server and at least one supported Agent Runtime CLI. A missing alternate Runtime is informational.

This PR deliberately does not check Agent Runtime authentication or Integration CLI availability, and the report states both omissions explicitly. It does not change daemon to Server readiness reporting, `handoffReady`, or any Server schema.

This replaces the broader contract proposed in closed PR #235; no commit from that branch is merged.

## Follow-ups

- #247 defines the deferred Agent Runtime authentication diagnostic contract
- #248 defines the deferred Integration CLI diagnostic and interaction contract
- #237 remains open for login-shell discovery and per-candidate runtime verification
- #239 remains an independent service-definition lookup issue
- #244 remains an independent service-manager executable authority issue
- Claude Code default credential lookup is handled separately in the PR that closes #236

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (100%)
- `pnpm --filter @opentag/server test:integration` (222 passed)
- source CLI tarball smoke via `scripts/cli-pack-smoke.mjs`
- `git diff --check`