### PR TITLE
feat(cli): implement doctor baseline diagnostics

### DIFF
--- a/apps/cli/src/__tests__/daemon-service-shared.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-shared.test.ts
@@ -21,6 +21,7 @@ import {
   quoteSystemdEnvironment,
   quoteSystemdToken,
   resolveCliInvocation,
+  resolveServiceManagerExecutable,
   runRequired,
   writeFileAtomically,
 } from "../core/daemon/service/shared.js";
@@ -100,6 +101,46 @@ describe("daemon service primitives", () => {
     expect(servicePath).not.toContain("relative");
     expect(servicePath.filter((entry) => entry === "/opt/opentag/bin")).toHaveLength(1);
     expect(servicePath.filter((entry) => entry === "/usr/bin")).toHaveLength(1);
+  });
+
+  it("resolves a bare service-manager name only through reviewed absolute locations", async () => {
+    const inspected: string[] = [];
+
+    await expect(
+      resolveServiceManagerExecutable("launchctl", "darwin", {
+        access: async (path) => {
+          inspected.push(`access:${path}`);
+        },
+        stat: async (path) => {
+          inspected.push(`stat:${path}`);
+          return { isFile: () => true };
+        },
+      }),
+    ).resolves.toBe("/bin/launchctl");
+
+    expect(inspected).toEqual(["stat:/bin/launchctl", "access:/bin/launchctl"]);
+    expect(inspected).not.toContain("stat:launchctl");
+  });
+
+  it("supports the governed NixOS systemd manager location", async () => {
+    const inspected: string[] = [];
+
+    await expect(
+      resolveServiceManagerExecutable("systemctl", "linux", {
+        access: async (path) => {
+          inspected.push(`access:${path}`);
+        },
+        stat: async (path) => {
+          inspected.push(`stat:${path}`);
+          return { isFile: () => path === "/run/current-system/systemd/bin/systemctl" };
+        },
+      }),
+    ).resolves.toBe("/run/current-system/systemd/bin/systemctl");
+
+    expect(inspected).toEqual([
+      "stat:/run/current-system/systemd/bin/systemctl",
+      "access:/run/current-system/systemd/bin/systemctl",
+    ]);
   });
 
   it("atomically replaces files and leaves no temporary files", async () => {

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -1,46 +1,517 @@
-import { ServerHealthConfigurationError, ServerHealthNetworkError } from "@opentag/client";
-import { describe, expect, it, vi } from "vitest";
-import { resolveServerUrl, runDoctor } from "../core/diagnostics/doctor.js";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { ServerHealthTimeoutError } from "@opentag/client";
+import { Command, type CommanderError } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerDoctorCommand } from "../commands/doctor.js";
+import { channelConfig } from "../core/channel/config.js";
+import {
+  type DoctorCheck,
+  type DoctorOptions,
+  renderDoctorReport,
+  resolveDoctorTarget,
+  runDoctor,
+} from "../core/diagnostics/doctor.js";
 
-describe("resolveServerUrl", () => {
-  it("prefers the command option over the environment", () => {
-    expect(resolveServerUrl("http://cli.example", { OPENTAG_SERVER_URL: "http://env.example" })).toBe(
-      "http://cli.example",
-    );
+const computerId = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
+const otherComputerId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
+const serverUrl = "https://server.example";
+const secretToken = "otmc_NEVER_PRINT_THIS_SECRET";
+const homes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map((home) => rm(home, { force: true, recursive: true })));
+  vi.restoreAllMocks();
+});
+
+describe("doctor command target", () => {
+  it("does not accept a caller-selected Server URL", async () => {
+    const program = new Command().name("opentag").exitOverride();
+    program.configureOutput({ writeErr: () => undefined, writeOut: () => undefined });
+    registerDoctorCommand(program);
+
+    await expect(
+      program.parseAsync(["node", "opentag", "doctor", "--server-url", "https://other.example"]),
+    ).rejects.toMatchObject({
+      code: "commander.unknownOption",
+    } satisfies Partial<CommanderError>);
   });
 
-  it("uses the environment before the default", () => {
-    expect(resolveServerUrl(undefined, { OPENTAG_SERVER_URL: "http://env.example" })).toBe("http://env.example");
-    expect(resolveServerUrl(undefined, {})).toBe("http://127.0.0.1:8000");
+  it("uses the canonical OPENTAG_HOME and ignores OPENTAG_SERVER_URL", async () => {
+    const home = await createHome();
+    const healthChecker = vi.fn().mockResolvedValue({ service: "opentag-server", status: "ok" } as const);
+    const result = await runHealthyDoctor(home, {
+      env: { OPENTAG_HOME: join(home, ".", "nested", ".."), OPENTAG_SERVER_URL: "https://ignored.example" },
+      healthChecker,
+    });
+
+    expect(result.target).toMatchObject({ home: resolve(home), homeSource: "environment" });
+    expect(result.message).toContain(`OpenTag Home: ${resolve(home)} (environment)`);
+    expect(result.message).not.toContain("ignored.example");
+    expect(healthChecker).toHaveBeenCalledTimes(1);
+    expect(healthChecker).toHaveBeenCalledWith(serverUrl);
+  });
+
+  it("reports an explicitly selected default path as environment-sourced", () => {
+    expect(
+      resolveDoctorTarget({
+        arch: "arm64",
+        channel: "stable",
+        cliVersion: "0.1.0",
+        environment: { OPENTAG_HOME: channelConfig.defaultHome },
+        nodeVersion: "v24.0.0",
+        platform: "darwin",
+      }),
+    ).toMatchObject({ home: resolve(channelConfig.defaultHome), homeSource: "environment" });
+  });
+
+  it("reports the channel default when OPENTAG_HOME is absent", () => {
+    expect(
+      resolveDoctorTarget({
+        arch: "arm64",
+        channel: "stable",
+        cliVersion: "0.1.0",
+        environment: {},
+        nodeVersion: "v24.0.0",
+        platform: "darwin",
+      }),
+    ).toMatchObject({ home: resolve(channelConfig.defaultHome), homeSource: "channel-default" });
   });
 });
 
-describe("runDoctor", () => {
-  it("reports a healthy server", async () => {
-    const healthChecker = vi.fn().mockResolvedValue({ status: "ok", service: "opentag-server" } as const);
-
-    await expect(runDoctor({ serverUrl: "http://server.example", healthChecker })).resolves.toEqual({
-      exitCode: 0,
-      message: "OpenTag server is healthy (opentag-server) at http://server.example",
+describe("doctor local configuration", () => {
+  it("accepts multiple enrollments for the same Computer and canonical Server", async () => {
+    const home = await createHome({
+      enrollments: [
+        enrollment("19eb4f37-2cc0-49d4-85e2-b9987f9c71a4"),
+        enrollment("e8ffbc17-a769-42c2-9214-76f28b7d2a42"),
+      ],
     });
-    expect(healthChecker).toHaveBeenCalledWith("http://server.example");
+
+    const result = await runHealthyDoctor(home);
+
+    expect(check(result.checks, "local.identity")).toMatchObject({ blocking: true, status: "pass" });
+    expect(check(result.checks, "local.enrollments")).toMatchObject({ blocking: true, status: "pass" });
+    expect(check(result.checks, "local.binding")).toMatchObject({
+      blocking: true,
+      detail: expect.stringMatching(/2 enrollment/),
+      status: "pass",
+    });
   });
 
-  it("reports a categorized failure and a non-zero exit code", async () => {
-    const healthChecker = vi.fn().mockRejectedValue(new ServerHealthNetworkError("offline"));
+  it("rejects duplicate enrollment identifiers instead of accepting a partial projection", async () => {
+    const duplicateId = "19eb4f37-2cc0-49d4-85e2-b9987f9c71a4";
+    const home = await createHome({ enrollments: [enrollment(duplicateId), enrollment(duplicateId)] });
+    const healthChecker = vi.fn();
 
-    await expect(runDoctor({ serverUrl: "http://server.example", healthChecker })).resolves.toEqual({
-      exitCode: 1,
-      message: "Network error: could not reach the OpenTag server at http://server.example",
-    });
+    const result = await runHealthyDoctor(home, { healthChecker });
+
+    expect(check(result.checks, "local.enrollments")).toMatchObject({ blocking: true, status: "fail" });
+    expect(check(result.checks, "server.health")).toMatchObject({ status: "skipped" });
+    expect(healthChecker).not.toHaveBeenCalled();
   });
 
-  it("reports an invalid server URL as a configuration error", async () => {
-    const healthChecker = vi.fn().mockRejectedValue(new ServerHealthConfigurationError("invalid URL"));
+  it("fails a missing identity, skips Server health, and continues independent checks", async () => {
+    const home = await createHome({ identity: undefined });
+    const inspectDaemonService = vi.fn().mockResolvedValue(activeService(home));
+    const healthChecker = vi.fn();
+    const runtimeDetector = vi.fn().mockResolvedValue(installedCodex());
 
-    await expect(runDoctor({ serverUrl: "not-a-url", healthChecker })).resolves.toEqual({
-      exitCode: 1,
-      message: "Configuration error: invalid OpenTag server URL not-a-url",
+    const result = await runDoctor({
+      env: { OPENTAG_HOME: home },
+      healthChecker,
+      inspectDaemonService,
+      runtimeDetector,
     });
+
+    expect(check(result.checks, "local.identity")).toMatchObject({ blocking: true, status: "fail" });
+    expect(check(result.checks, "server.health")).toMatchObject({
+      blocking: true,
+      detail: expect.stringMatching(/no authoritative enrolled Server/i),
+      status: "skipped",
+    });
+    expect(check(result.checks, "daemon.service")).toMatchObject({ status: "pass" });
+    expect(check(result.checks, "runtime.any-installed")).toMatchObject({ status: "pass" });
+    expect(inspectDaemonService).toHaveBeenCalledTimes(1);
+    expect(runtimeDetector).toHaveBeenCalledTimes(1);
+    expect(healthChecker).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("does not silently discard a malformed enrollment or disclose its token", async () => {
+    const home = await createHome({
+      rawCredentials: {
+        version: 1,
+        enrollments: [
+          enrollment("19eb4f37-2cc0-49d4-85e2-b9987f9c71a4"),
+          {
+            computerId,
+            machineToken: secretToken,
+            serverUrl,
+            workspaceComputerId: "not-a-uuid",
+          },
+        ],
+      },
+    });
+    const healthChecker = vi.fn();
+
+    const result = await runHealthyDoctor(home, { healthChecker });
+
+    expect(check(result.checks, "local.enrollments")).toMatchObject({ blocking: true, status: "fail" });
+    expect(check(result.checks, "server.health")).toMatchObject({ status: "skipped" });
+    expect(healthChecker).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(1);
+    expect(result.message).not.toContain(secretToken);
+    expect(JSON.stringify(result)).not.toContain(secretToken);
+  });
+
+  it("fails closed for an unsafe symlinked config directory", async () => {
+    const home = await createHome();
+    const external = await mkdtemp(join(tmpdir(), "opentag-doctor-external-"));
+    homes.push(external);
+    await rm(join(home, "config"), { force: true, recursive: true });
+    await mkdir(join(external, "config"), { mode: 0o700 });
+    await symlink(join(external, "config"), join(home, "config"), "dir");
+    const healthChecker = vi.fn();
+
+    const result = await runHealthyDoctor(home, { healthChecker });
+
+    expect(check(result.checks, "local.identity")).toMatchObject({ blocking: true, status: "fail" });
+    expect(check(result.checks, "local.enrollments")).toMatchObject({ blocking: true, status: "fail" });
+    expect(check(result.checks, "server.health")).toMatchObject({ status: "skipped" });
+    expect(healthChecker).not.toHaveBeenCalled();
+  });
+
+  it("rejects enrollments for different Servers without contacting either Server", async () => {
+    const home = await createHome({
+      enrollments: [
+        enrollment("19eb4f37-2cc0-49d4-85e2-b9987f9c71a4"),
+        enrollment("e8ffbc17-a769-42c2-9214-76f28b7d2a42", { serverUrl: "https://other.example" }),
+      ],
+    });
+    const healthChecker = vi.fn();
+
+    const result = await runHealthyDoctor(home, { healthChecker });
+
+    expect(check(result.checks, "local.binding")).toMatchObject({ blocking: true, status: "fail" });
+    expect(check(result.checks, "server.health")).toMatchObject({ status: "skipped" });
+    expect(healthChecker).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("rejects an enrollment whose Computer differs from the local identity", async () => {
+    const home = await createHome({
+      enrollments: [enrollment("19eb4f37-2cc0-49d4-85e2-b9987f9c71a4", { computerId: otherComputerId })],
+    });
+
+    const result = await runHealthyDoctor(home);
+
+    expect(check(result.checks, "local.binding")).toMatchObject({ blocking: true, status: "fail" });
+    expect(check(result.checks, "server.health")).toMatchObject({ status: "skipped" });
+    expect(result.exitCode).toBe(1);
   });
 });
+
+describe("doctor daemon service", () => {
+  it("passes only an active, current service for this OpenTag Home", async () => {
+    const home = await createHome();
+    const result = await runHealthyDoctor(home);
+
+    expect(check(result.checks, "daemon.service")).toMatchObject({ blocking: true, status: "pass" });
+  });
+
+  it.each([
+    ["inactive", { state: "inactive" as const }],
+    ["drifted", { drifted: true }],
+    ["unknown", { state: "unknown" as const }],
+    ["different Home", { configuredHome: "/different/opentag-home" }],
+    ["unverifiable Home", { configuredHome: undefined }],
+    ["not installed", { state: "not-installed" as const }],
+    ["malformed owner", { runtimeOwner: { consistency: "malformed" as const } }],
+    ["unverified owner", { runtimeOwner: { consistency: "unverified" as const } }],
+  ])("fails closed for a %s service observation", async (_label, override) => {
+    const home = await createHome();
+    const result = await runHealthyDoctor(home, {
+      inspectDaemonService: vi.fn().mockResolvedValue({ ...activeService(home), ...override }),
+    });
+
+    expect(check(result.checks, "daemon.service")).toMatchObject({
+      blocking: true,
+      status: "state" in override && override.state === "unknown" ? "unknown" : "fail",
+    });
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("treats a service inspection error as blocking unknown", async () => {
+    const home = await createHome();
+    const result = await runHealthyDoctor(home, {
+      inspectDaemonService: vi.fn().mockRejectedValue(new Error("manager unavailable")),
+    });
+
+    expect(check(result.checks, "daemon.service")).toMatchObject({ blocking: true, status: "unknown" });
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("doctor Server health", () => {
+  it("reports the enrolled Server public health endpoint without claiming higher-layer readiness", async () => {
+    const home = await createHome();
+    const healthChecker = vi.fn().mockResolvedValue({ service: "opentag-server", status: "ok" } as const);
+    const result = await runHealthyDoctor(home, { healthChecker });
+
+    expect(check(result.checks, "server.health")).toMatchObject({
+      blocking: true,
+      detail: expect.stringContaining(serverUrl),
+      status: "pass",
+    });
+    expect(result.message).toContain("Server health endpoint");
+    expect(result.message).not.toMatch(/WebSocket.*(?:pass|ready|reachable)/iu);
+    expect(result.message).not.toMatch(/handoff.*ready/iu);
+  });
+
+  it("classifies a bounded Server timeout as a blocking failure", async () => {
+    const home = await createHome();
+    const healthChecker = vi.fn().mockRejectedValue(new ServerHealthTimeoutError("timed out after 5000 ms"));
+    const result = await runHealthyDoctor(home, { healthChecker });
+
+    expect(healthChecker).toHaveBeenCalledWith(serverUrl);
+    expect(check(result.checks, "server.health")).toMatchObject({
+      blocking: true,
+      detail: expect.stringMatching(/timed out|timeout/i),
+      status: "fail",
+    });
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("doctor Agent Runtime CLI observations", () => {
+  it.each([
+    ["Codex", installedCodex()],
+    [
+      "Claude Code",
+      [
+        { displayName: "Codex CLI", provider: "codex", status: "not-installed" as const },
+        {
+          displayName: "Claude Code CLI",
+          path: "/usr/local/bin/claude",
+          provider: "claude-code",
+          source: "well-known",
+          status: "installed" as const,
+        },
+      ],
+    ],
+  ])("passes the aggregate when only %s is installed", async (_label, detection) => {
+    const home = await createHome();
+    const result = await runHealthyDoctor(home, {
+      runtimeDetector: vi.fn().mockResolvedValue(detection),
+    });
+
+    expect(check(result.checks, "runtime.any-installed")).toMatchObject({ blocking: true, status: "pass" });
+    const providerChecks = [
+      check(result.checks, "runtime.codex.installation"),
+      check(result.checks, "runtime.claude-code.installation"),
+    ];
+    expect(providerChecks).toContainEqual(expect.objectContaining({ blocking: false, status: "pass" }));
+    expect(providerChecks).toContainEqual(expect.objectContaining({ blocking: false, status: "info" }));
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("fails the aggregate when neither supported Runtime is installed", async () => {
+    const home = await createHome();
+    const result = await runHealthyDoctor(home, {
+      runtimeDetector: vi.fn().mockResolvedValue([
+        { displayName: "Codex CLI", provider: "codex", status: "not-installed" },
+        { displayName: "Claude Code CLI", provider: "claude-code", status: "not-installed" },
+      ]),
+    });
+
+    expect(check(result.checks, "runtime.any-installed")).toMatchObject({ blocking: true, status: "fail" });
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("keeps a discovered Provider when the other detector is unknown", async () => {
+    const home = await createHome();
+    const result = await runHealthyDoctor(home, {
+      runtimeDetector: vi.fn().mockResolvedValue([
+        {
+          displayName: "Codex CLI",
+          path: "/usr/local/bin/codex",
+          provider: "codex",
+          source: "caller-path",
+          status: "installed",
+        },
+        {
+          detail: "filesystem inspection failed",
+          displayName: "Claude Code CLI",
+          provider: "claude-code",
+          status: "unknown",
+        },
+      ]),
+    });
+
+    expect(check(result.checks, "runtime.any-installed")).toMatchObject({ blocking: true, status: "pass" });
+    expect(check(result.checks, "runtime.codex.installation")).toMatchObject({
+      detail: expect.stringContaining("caller-path"),
+      observedFrom: "current CLI process environment",
+      path: "/usr/local/bin/codex",
+      status: "pass",
+    });
+    expect(check(result.checks, "runtime.claude-code.installation")).toMatchObject({ status: "unknown" });
+    expect(result.message).toContain("/usr/local/bin/codex (caller-path)");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("doctor report and exit contract", () => {
+  it("renders fixed sections, sources, baseline wording, and the complete not-evaluated list", async () => {
+    const home = await createHome();
+    const result = await runHealthyDoctor(home);
+    const rendered = renderDoctorReport(result);
+    const headings = [
+      "Target",
+      "Local configuration",
+      "Daemon service",
+      "Server",
+      "Agent Runtime CLIs",
+      "Summary",
+      "Not evaluated",
+    ];
+
+    const headingOffsets = headings.map((heading) => rendered.indexOf(`\n${heading}\n`));
+    expect(headingOffsets.every((offset) => offset >= 0)).toBe(true);
+    expect(headingOffsets).toEqual([...headingOffsets].sort((left, right) => left - right));
+    expect(rendered).toContain("/usr/local/bin/codex (caller-path)");
+    expect(rendered).toContain("Baseline checks passed for this OpenTag Home.");
+    expect(rendered).not.toContain("All required checks passed");
+    expect(rendered).not.toMatch(/OpenTag is ready|handoff is ready/iu);
+    expect(result.notEvaluated).toEqual([
+      "Agent Runtime authentication",
+      "Agent Runtime version or protocol compatibility",
+      "Agent Runtime visibility from the installed daemon environment",
+      "machine-token authentication or WebSocket registration",
+      "Integration CLI availability or authentication",
+      "end-to-end Turn or handoff delivery",
+    ]);
+    expect(result.checks.map((item) => item.code)).toEqual([
+      "target.home",
+      "local.identity",
+      "local.enrollments",
+      "local.binding",
+      "daemon.service",
+      "server.health",
+      "runtime.any-installed",
+      "runtime.codex.installation",
+      "runtime.claude-code.installation",
+    ]);
+    for (const item of result.notEvaluated) expect(rendered).toContain(item);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("returns exit 1 for any blocking fail or unknown and reports the exact count", async () => {
+    const home = await createHome();
+    const result = await runHealthyDoctor(home, {
+      inspectDaemonService: vi.fn().mockRejectedValue(new Error("unavailable")),
+      runtimeDetector: vi.fn().mockResolvedValue([
+        { displayName: "Codex CLI", provider: "codex", status: "not-installed" },
+        { displayName: "Claude Code CLI", provider: "claude-code", status: "not-installed" },
+      ]),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain("2 blocking baseline check(s) failed for this OpenTag Home.");
+    expect(result.message).not.toContain("Baseline checks passed for this OpenTag Home.");
+  });
+});
+
+function check(checks: DoctorCheck[], code: string): DoctorCheck {
+  const result = checks.find((candidate) => candidate.code === code);
+  expect(result, `missing doctor check ${code}`).toBeDefined();
+  return result as DoctorCheck;
+}
+
+async function runHealthyDoctor(home: string, overrides: Partial<DoctorOptions> = {}) {
+  return runDoctor({
+    arch: "arm64",
+    channel: "stable",
+    cliVersion: "0.1.0",
+    env: { OPENTAG_HOME: home },
+    healthChecker: vi.fn().mockResolvedValue({ service: "opentag-server", status: "ok" } as const),
+    inspectDaemonService: vi.fn().mockResolvedValue(activeService(home)),
+    nodeVersion: "v24.0.0",
+    platform: "darwin",
+    runtimeDetector: vi.fn().mockResolvedValue(installedCodex()),
+    ...overrides,
+  });
+}
+
+function activeService(home: string) {
+  return {
+    configuredHome: resolve(home),
+    currentHome: resolve(home),
+    definitionPath: "/Users/test/Library/LaunchAgents/ai.first-tree.opentag.plist",
+    drifted: false,
+    logHint: "/Users/test/Library/Logs/OpenTag/daemon.log",
+    pid: 1234,
+    platform: "launchd" as const,
+    runtimeOwner: { consistency: "consistent" as const, pid: 1234 },
+    serviceId: "opentag",
+    state: "active" as const,
+  };
+}
+
+function installedCodex() {
+  return [
+    {
+      displayName: "Codex CLI",
+      path: "/usr/local/bin/codex",
+      provider: "codex" as const,
+      source: "caller-path" as const,
+      status: "installed" as const,
+    },
+    { displayName: "Claude Code CLI", provider: "claude-code" as const, status: "not-installed" as const },
+  ];
+}
+
+interface EnrollmentOverrides {
+  computerId?: string;
+  serverUrl?: string;
+}
+
+function enrollment(workspaceComputerId: string, overrides: EnrollmentOverrides = {}) {
+  return {
+    computerId: overrides.computerId ?? computerId,
+    machineToken: secretToken,
+    serverUrl: overrides.serverUrl ?? serverUrl,
+    workspaceComputerId,
+  };
+}
+
+interface CreateHomeOptions {
+  enrollments?: ReturnType<typeof enrollment>[];
+  identity?: { computerId: string; serverUrl: string; version: 2 } | undefined;
+  rawCredentials?: unknown;
+}
+
+async function createHome(options: CreateHomeOptions = {}): Promise<string> {
+  const home = await realpath(await mkdtemp(join(tmpdir(), "opentag-doctor-")));
+  homes.push(home);
+  const config = join(home, "config");
+  await mkdir(config, { mode: 0o700 });
+
+  const identity = Object.hasOwn(options, "identity")
+    ? options.identity
+    : { computerId, serverUrl, version: 2 as const };
+  if (identity !== undefined) {
+    await writeFile(join(config, "computer.json"), `${JSON.stringify(identity)}\n`, { mode: 0o600 });
+  }
+
+  const credentials =
+    options.rawCredentials ??
+    ({
+      enrollments: options.enrollments ?? [enrollment("19eb4f37-2cc0-49d4-85e2-b9987f9c71a4")],
+      version: 1,
+    } as const);
+  await writeFile(join(config, "computer-credentials.json"), `${JSON.stringify(credentials)}\n`, { mode: 0o600 });
+  return home;
+}

--- a/apps/cli/src/__tests__/public-surface.test.ts
+++ b/apps/cli/src/__tests__/public-surface.test.ts
@@ -14,7 +14,6 @@ const EXPECTED_ROOT_EXPORTS = [
   "formatSessionCommandResult",
   "formatSessionList",
   "listComputers",
-  "resolveServerUrl",
   "runAgentCreate",
   "runAgentDelete",
   "runAgentList",

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,19 +1,13 @@
 import type { Command } from "commander";
 import { runDoctor } from "../core/diagnostics/doctor.js";
 
-interface DoctorCommandOptions {
-  serverUrl?: string;
-}
-
 export function registerDoctorCommand(program: Command): void {
   program
     .command("doctor")
-    .description("Check connectivity to the OpenTag server")
-    .option("--server-url <url>", "OpenTag server base URL")
-    .action(async (options: DoctorCommandOptions) => {
-      const result = await runDoctor({ serverUrl: options.serverUrl });
-      const write = result.exitCode === 0 ? console.log : console.error;
-      write(result.message);
+    .description("Run read-only baseline diagnostics for the selected OpenTag Home")
+    .action(async () => {
+      const result = await runDoctor();
+      console.log(result.message);
       process.exitCode = result.exitCode;
     });
 }

--- a/apps/cli/src/core/channel/environment.ts
+++ b/apps/cli/src/core/channel/environment.ts
@@ -1,5 +1,7 @@
 import { channelConfig } from "./config.js";
+import { markChannelDefaultHomeApplied } from "./home-source.js";
 
 if (!process.env.OPENTAG_HOME) {
   process.env.OPENTAG_HOME = channelConfig.defaultHome;
+  markChannelDefaultHomeApplied();
 }

--- a/apps/cli/src/core/channel/home-source.ts
+++ b/apps/cli/src/core/channel/home-source.ts
@@ -1,0 +1,9 @@
+let channelDefaultHomeApplied = false;
+
+export function markChannelDefaultHomeApplied(): void {
+  channelDefaultHomeApplied = true;
+}
+
+export function wasChannelDefaultHomeApplied(): boolean {
+  return channelDefaultHomeApplied;
+}

--- a/apps/cli/src/core/daemon/service/shared.ts
+++ b/apps/cli/src/core/daemon/service/shared.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { access, chmod, lstat, mkdir, open, readFile, realpath, rename, rm } from "node:fs/promises";
+import { access, chmod, lstat, mkdir, open, readFile, realpath, rename, rm, stat } from "node:fs/promises";
 import { basename, delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { ensurePrivateDirectory } from "@opentag/client";
 import { resolveDaemonPaths } from "../paths.js";
@@ -40,10 +40,11 @@ export interface ServiceIdentity {
 }
 
 export const defaultServiceRunner: ServiceRunner = {
-  run(program, args, options) {
+  async run(program, args, options) {
+    const resolvedProgram = await resolveServiceManagerExecutable(program);
     return new Promise<CommandResult>((complete) => {
       execFile(
-        program,
+        resolvedProgram,
         [...args],
         {
           encoding: "utf8",
@@ -64,6 +65,59 @@ export const defaultServiceRunner: ServiceRunner = {
     });
   },
 };
+
+const SERVICE_MANAGER_LOCATIONS = {
+  darwin: {
+    launchctl: ["/bin/launchctl"],
+  },
+  linux: {
+    loginctl: ["/run/current-system/systemd/bin/loginctl", "/usr/bin/loginctl", "/bin/loginctl"],
+    systemctl: ["/run/current-system/systemd/bin/systemctl", "/usr/bin/systemctl", "/bin/systemctl"],
+  },
+} as const;
+
+export async function resolveServiceManagerExecutable(
+  program: string,
+  platform: NodeJS.Platform = process.platform,
+  dependencies: {
+    access?: (path: string, mode: number) => Promise<void>;
+    stat?: (path: string) => Promise<{ isFile(): boolean }>;
+  } = {},
+): Promise<string> {
+  const platformLocations =
+    platform === "darwin"
+      ? SERVICE_MANAGER_LOCATIONS.darwin
+      : platform === "linux"
+        ? SERVICE_MANAGER_LOCATIONS.linux
+        : undefined;
+  const managerName = isAbsolute(program) ? basename(program) : program;
+  if (!platformLocations || !(managerName in platformLocations)) {
+    throw new DaemonServiceError(
+      "MANAGER_UNAVAILABLE",
+      `The ${program} service manager is not governed on ${platform}`,
+    );
+  }
+  const candidates = platformLocations[managerName as keyof typeof platformLocations] as readonly string[];
+  const allowedCandidates = isAbsolute(program) ? candidates.filter((candidate) => candidate === program) : candidates;
+  if (allowedCandidates.length === 0) {
+    throw new DaemonServiceError("MANAGER_UNAVAILABLE", `The service manager path is not supported: ${program}`);
+  }
+  const checkAccess = dependencies.access ?? access;
+  const checkStat = dependencies.stat ?? stat;
+  for (const candidate of allowedCandidates) {
+    try {
+      if (!(await checkStat(candidate)).isFile()) continue;
+      await checkAccess(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Continue through the reviewed absolute location list only.
+    }
+  }
+  throw new DaemonServiceError(
+    "MANAGER_UNAVAILABLE",
+    `The ${program} service manager is unavailable at supported system locations`,
+  );
+}
 
 export function deriveServiceIdentity(serviceId: string): ServiceIdentity {
   return {

--- a/apps/cli/src/core/diagnostics/doctor.ts
+++ b/apps/cli/src/core/diagnostics/doctor.ts
@@ -1,68 +1,474 @@
+import { resolve } from "node:path";
 import {
+  type AgentRuntimeCliInstallation,
   checkServerHealth,
+  inspectLocalComputerConfiguration,
+  type LocalComputerConfigurationInspection,
+  probeAgentRuntimeCliInstallations,
   ServerHealthConfigurationError,
   ServerHealthHttpError,
   ServerHealthNetworkError,
   ServerHealthResponseError,
+  ServerHealthTimeoutError,
 } from "@opentag/client";
 import type { ServerHealth } from "@opentag/shared";
+import { CHANNEL, CLI_VERSION } from "../../build-info.js";
 import { channelConfig } from "../channel/config.js";
+import { wasChannelDefaultHomeApplied } from "../channel/home-source.js";
+import { createDaemonServiceManager } from "../daemon/service/index.js";
+import { canonicalizeServiceHome } from "../daemon/service/shared.js";
+import type { DaemonServiceInfo } from "../daemon/service/types.js";
 
-export type HealthChecker = (serverUrl: string) => Promise<ServerHealth>;
+export type DoctorCheckStatus = "pass" | "fail" | "unknown" | "info" | "skipped";
+export type DoctorCheckScope = "target" | "local-configuration" | "daemon-service" | "server" | "agent-runtime";
 
-export interface DoctorOptions {
-  serverUrl?: string;
-  env?: NodeJS.ProcessEnv;
-  healthChecker?: HealthChecker;
+export interface DoctorCheck {
+  code: string;
+  scope: DoctorCheckScope;
+  status: DoctorCheckStatus;
+  blocking: boolean;
+  label: string;
+  detail: string;
+  observedFrom?: string;
+  path?: string;
+  remediation?: string;
 }
 
-export interface DoctorResult {
+export interface DoctorTarget {
+  home: string;
+  homeSource: "environment" | "channel-default";
+  cliVersion: string;
+  channel: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  nodeVersion: string;
+}
+
+export interface DoctorReport {
+  target: DoctorTarget;
+  checks: DoctorCheck[];
+  notEvaluated: readonly string[];
   exitCode: 0 | 1;
+}
+
+export interface DoctorResult extends DoctorReport {
   message: string;
 }
 
-export function resolveServerUrl(serverUrl: string | undefined, env: NodeJS.ProcessEnv = process.env): string {
-  const resolved = serverUrl ?? env.OPENTAG_SERVER_URL ?? channelConfig.defaultServerUrl;
-  if (!resolved) throw new ServerHealthConfigurationError(`The ${channelConfig.channel} channel requires a server URL`);
-  return resolved;
+export type HealthChecker = (serverUrl: string) => Promise<ServerHealth>;
+export type LocalConfigurationInspector = (home: string) => Promise<LocalComputerConfigurationInspection>;
+export type DaemonServiceInspector = (home: string) => Promise<DaemonServiceInfo>;
+export type RuntimeDetector = (options: {
+  environment: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+}) => Promise<AgentRuntimeCliInstallation[]>;
+
+export interface DoctorOptions {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  nodeVersion?: string;
+  cliVersion?: string;
+  channel?: string;
+  healthChecker?: HealthChecker;
+  inspectLocalConfiguration?: LocalConfigurationInspector;
+  inspectDaemonService?: DaemonServiceInspector;
+  runtimeDetector?: RuntimeDetector;
 }
+
+export const DOCTOR_NOT_EVALUATED = [
+  "Agent Runtime authentication",
+  "Agent Runtime version or protocol compatibility",
+  "Agent Runtime visibility from the installed daemon environment",
+  "machine-token authentication or WebSocket registration",
+  "Integration CLI availability or authentication",
+  "end-to-end Turn or handoff delivery",
+] as const;
 
 export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorResult> {
-  let serverUrl: string;
-  try {
-    serverUrl = resolveServerUrl(options.serverUrl, options.env);
-  } catch (error) {
-    return { exitCode: 1, message: formatDoctorError(error, "<not configured>") };
-  }
+  const environment = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const selectedTarget = resolveDoctorTarget({
+    environment,
+    platform,
+    arch: options.arch ?? process.arch,
+    nodeVersion: options.nodeVersion ?? process.version,
+    cliVersion: options.cliVersion ?? CLI_VERSION,
+    channel: options.channel ?? CHANNEL,
+    channelDefaultHomeApplied: environment === process.env && wasChannelDefaultHomeApplied(),
+  });
+  const target = {
+    ...selectedTarget,
+    home: await canonicalizeServiceHome(selectedTarget.home).catch(() => selectedTarget.home),
+  };
+  const localInspector = options.inspectLocalConfiguration ?? inspectLocalComputerConfiguration;
+  const daemonInspector =
+    options.inspectDaemonService ??
+    (async (home: string) => (await createDaemonServiceManager({ env: environment, home, platform })).status());
+  const runtimeDetector =
+    options.runtimeDetector ??
+    ((request) =>
+      probeAgentRuntimeCliInstallations({
+        environment: request.environment,
+        platform: request.platform,
+      }));
   const healthChecker = options.healthChecker ?? checkServerHealth;
 
-  try {
-    const health = await healthChecker(serverUrl);
-    return {
-      exitCode: 0,
-      message: `OpenTag server is healthy (${health.service}) at ${serverUrl}`,
-    };
-  } catch (error) {
-    return {
-      exitCode: 1,
-      message: formatDoctorError(error, serverUrl),
-    };
-  }
+  const localPromise = settle(localInspector(target.home));
+  const daemonPromise = settle(daemonInspector(target.home));
+  const runtimePromise = settle(runtimeDetector({ environment, platform }));
+  const healthPromise = localPromise.then(async (localResult) => {
+    if (localResult.status === "rejected") return { status: "skipped" as const };
+    const serverUrl = localResult.value.binding.serverUrl;
+    if (!serverUrl || localResult.value.binding.status !== "valid") return { status: "skipped" as const };
+    return settle(healthChecker(serverUrl));
+  });
+
+  const [localResult, daemonResult, healthResult, runtimeResult] = await Promise.all([
+    localPromise,
+    daemonPromise,
+    healthPromise,
+    runtimePromise,
+  ]);
+  const checks: DoctorCheck[] = [
+    targetCheck(target),
+    ...localChecks(localResult),
+    daemonCheck(daemonResult, target.home),
+    serverCheck(healthResult, localResult),
+    ...runtimeChecks(runtimeResult),
+  ];
+  const exitCode: 0 | 1 = checks.some(
+    (check) => check.blocking && (check.status === "fail" || check.status === "unknown"),
+  )
+    ? 1
+    : 0;
+  const report: DoctorReport = { target, checks, notEvaluated: DOCTOR_NOT_EVALUATED, exitCode };
+  return { ...report, message: renderDoctorReport(report) };
 }
 
-function formatDoctorError(error: unknown, serverUrl: string): string {
-  if (error instanceof ServerHealthConfigurationError) {
-    return `Configuration error: invalid OpenTag server URL ${serverUrl}`;
+export function resolveDoctorTarget(options: {
+  environment: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+  arch: string;
+  nodeVersion: string;
+  cliVersion: string;
+  channel: string;
+  channelDefaultHomeApplied?: boolean;
+}): DoctorTarget {
+  const selected = options.environment.OPENTAG_HOME?.trim();
+  const homeSource = selected && !options.channelDefaultHomeApplied ? "environment" : "channel-default";
+  return {
+    home: resolve(selected || channelConfig.defaultHome),
+    homeSource,
+    cliVersion: options.cliVersion,
+    channel: options.channel,
+    platform: options.platform,
+    arch: options.arch,
+    nodeVersion: options.nodeVersion,
+  };
+}
+
+export function renderDoctorReport(report: DoctorReport): string {
+  const blockingFailures = report.checks.filter(
+    (check) => check.blocking && (check.status === "fail" || check.status === "unknown"),
+  ).length;
+  const summary =
+    blockingFailures === 0
+      ? "Baseline checks passed for this OpenTag Home."
+      : `${blockingFailures} blocking baseline check(s) failed for this OpenTag Home.`;
+  const lines = [
+    "OpenTag Doctor",
+    "",
+    "Target",
+    `  - OpenTag Home: ${report.target.home} (${report.target.homeSource === "environment" ? "environment" : "channel default"})`,
+    `  - CLI: ${report.target.cliVersion}, ${report.target.channel}, ${report.target.platform} ${report.target.arch}, Node.js ${report.target.nodeVersion}`,
+  ];
+  for (const [heading, scope] of [
+    ["Local configuration", "local-configuration"],
+    ["Daemon service", "daemon-service"],
+    ["Server", "server"],
+    ["Agent Runtime CLIs", "agent-runtime"],
+  ] as const) {
+    lines.push("", heading);
+    for (const check of report.checks.filter((candidate) => candidate.scope === scope)) {
+      lines.push(`  ${statusMarker(check.status)} ${check.label}: ${check.detail}`);
+      if (check.remediation) lines.push(`    Next: ${check.remediation}`);
+    }
   }
-  if (error instanceof ServerHealthNetworkError) {
-    return `Network error: could not reach the OpenTag server at ${serverUrl}`;
+  lines.push("", "Summary", `  ${summary}`, "", "Not evaluated");
+  for (const item of report.notEvaluated) lines.push(`  - ${item}`);
+  return lines.join("\n");
+}
+
+function targetCheck(target: DoctorTarget): DoctorCheck {
+  return {
+    code: "target.home",
+    scope: "target",
+    status: "info",
+    blocking: false,
+    label: "OpenTag Home",
+    detail: target.home,
+    path: target.home,
+    observedFrom: target.homeSource,
+  };
+}
+
+function localChecks(result: PromiseSettledResult<LocalComputerConfigurationInspection>): DoctorCheck[] {
+  if (result.status === "rejected") {
+    const detail = safeErrorDetail(result.reason, "Local Computer configuration could not be inspected");
+    return [
+      localCheck("local.identity", "Computer identity", "unknown", detail),
+      localCheck("local.enrollments", "Computer enrollments", "unknown", detail),
+      localCheck("local.binding", "Local Computer binding", "unknown", "Local binding could not be verified"),
+    ];
   }
-  if (error instanceof ServerHealthHttpError) {
-    return `HTTP error: the OpenTag server at ${serverUrl} returned status ${error.status}`;
+  const { identity, enrollments, binding } = result.value;
+  return [
+    localCheck(
+      "local.identity",
+      "Computer identity",
+      localStatus(identity.status),
+      identity.status === "valid" ? "valid for one Computer and one Server" : (identity.detail ?? "invalid"),
+    ),
+    localCheck(
+      "local.enrollments",
+      "Computer enrollments",
+      localStatus(enrollments.status),
+      enrollments.status === "valid"
+        ? `${enrollments.value?.enrollments.length ?? 0} valid enrollment(s)`
+        : (enrollments.detail ?? "invalid"),
+    ),
+    localCheck(
+      "local.binding",
+      "Local Computer configuration",
+      localStatus(binding.status),
+      binding.status === "valid"
+        ? `${binding.enrollmentCount} enrollment(s), one Computer, one Server`
+        : (binding.detail ?? "invalid"),
+    ),
+  ];
+}
+
+function localCheck(code: string, label: string, status: "pass" | "fail" | "unknown", detail: string): DoctorCheck {
+  return {
+    code,
+    scope: "local-configuration",
+    status,
+    blocking: true,
+    label,
+    detail,
+    ...(status === "fail"
+      ? {
+          remediation: `Review this OpenTag Home and run '${channelConfig.binName} computer connect' with a valid connect code`,
+        }
+      : {}),
+  };
+}
+
+function localStatus(status: LocalComputerConfigurationInspection["identity"]["status"]): "pass" | "fail" {
+  return status === "valid" ? "pass" : "fail";
+}
+
+function daemonCheck(result: PromiseSettledResult<DaemonServiceInfo>, home: string): DoctorCheck {
+  if (result.status === "rejected") {
+    return {
+      code: "daemon.service",
+      scope: "daemon-service",
+      status: "unknown",
+      blocking: true,
+      label: "Daemon service",
+      detail: safeErrorDetail(result.reason, "Daemon service status could not be determined"),
+    };
   }
-  if (error instanceof ServerHealthResponseError) {
-    return `Response error: the OpenTag server at ${serverUrl} returned an invalid health response`;
+  const info = result.value;
+  const sameHome = info.configuredHome !== undefined && resolve(info.configuredHome) === home;
+  const passed =
+    info.platform !== "unsupported" &&
+    info.state === "active" &&
+    sameHome &&
+    info.drifted === false &&
+    info.runtimeOwner?.consistency === "consistent";
+  const detail = passed
+    ? `active for this OpenTag Home; logs: ${info.logHint}`
+    : `${daemonFailureDetail(info, sameHome)}; logs: ${info.logHint}`;
+  return {
+    code: "daemon.service",
+    scope: "daemon-service",
+    status: passed ? "pass" : info.state === "unknown" ? "unknown" : "fail",
+    blocking: true,
+    label: "Daemon service",
+    detail,
+    ...(passed
+      ? {}
+      : { remediation: `Inspect with '${channelConfig.binName} daemon status' before changing the service` }),
+  };
+}
+
+function daemonFailureDetail(info: DaemonServiceInfo, sameHome: boolean): string {
+  if (info.platform === "unsupported") return "unsupported on this platform";
+  if (info.state !== "active") return info.detail ? `${info.state} (${truncate(info.detail)})` : info.state;
+  if (!sameHome) return "active for a different or unverifiable OpenTag Home";
+  if (info.drifted !== false) return "service definition is drifted or unverifiable";
+  if (info.runtimeOwner?.consistency !== "consistent") {
+    return `runtime owner is ${info.runtimeOwner?.consistency ?? "unverified"}`;
   }
-  const detail = error instanceof Error ? error.message : String(error);
-  return `Unexpected error while checking ${serverUrl}: ${detail}`;
+  return "status could not be verified";
+}
+
+function serverCheck(
+  result: { status: "skipped" } | PromiseSettledResult<ServerHealth>,
+  localResult: PromiseSettledResult<LocalComputerConfigurationInspection>,
+): DoctorCheck {
+  const serverUrl = localResult.status === "fulfilled" ? localResult.value.binding.serverUrl : undefined;
+  if (result.status === "skipped" || !serverUrl) {
+    return {
+      code: "server.health",
+      scope: "server",
+      status: "skipped",
+      blocking: true,
+      label: "Server health endpoint",
+      detail: "not checked because there is no authoritative enrolled Server",
+    };
+  }
+  if (result.status === "fulfilled") {
+    return {
+      code: "server.health",
+      scope: "server",
+      status: "pass",
+      blocking: true,
+      label: "Server health endpoint",
+      detail: `reachable at ${serverUrl}`,
+    };
+  }
+  return {
+    code: "server.health",
+    scope: "server",
+    status: "fail",
+    blocking: true,
+    label: "Server health endpoint",
+    detail: formatHealthFailure(result.reason, serverUrl),
+    remediation: "Check network access and the enrolled Server health endpoint",
+  };
+}
+
+function runtimeChecks(result: PromiseSettledResult<AgentRuntimeCliInstallation[]>): DoctorCheck[] {
+  if (result.status === "rejected") {
+    return [
+      {
+        code: "runtime.any-installed",
+        scope: "agent-runtime",
+        status: "unknown",
+        blocking: true,
+        label: "Agent Runtime CLI",
+        detail: safeErrorDetail(result.reason, "Runtime installation could not be determined"),
+        observedFrom: "current CLI process environment",
+      },
+      runtimeProviderUnknown("codex", "Codex CLI"),
+      runtimeProviderUnknown("claude-code", "Claude Code CLI"),
+    ];
+  }
+  const byProvider = new Map(result.value.map((entry) => [entry.provider, entry]));
+  const codex = byProvider.get("codex") ?? unknownRuntime("codex", "Codex CLI");
+  const claude = byProvider.get("claude-code") ?? unknownRuntime("claude-code", "Claude Code CLI");
+  const installed = [codex, claude].filter((entry) => entry.status === "installed");
+  const hasUnknown = [codex, claude].some((entry) => entry.status === "unknown");
+  return [
+    {
+      code: "runtime.any-installed",
+      scope: "agent-runtime",
+      status: installed.length > 0 ? "pass" : hasUnknown ? "unknown" : "fail",
+      blocking: true,
+      label: "Agent Runtime CLI",
+      detail:
+        installed.length > 0
+          ? "at least one supported Runtime is installed"
+          : hasUnknown
+            ? "no supported Runtime was found and at least one result is unknown"
+            : "no supported Runtime is installed",
+      observedFrom: "current CLI process environment",
+      ...(installed.length > 0 ? {} : { remediation: "Install Codex CLI or Claude Code CLI" }),
+    },
+    runtimeProviderCheck(codex),
+    runtimeProviderCheck(claude),
+  ];
+}
+
+function runtimeProviderCheck(entry: AgentRuntimeCliInstallation): DoctorCheck {
+  if (entry.status === "installed") {
+    return {
+      code: `runtime.${entry.provider}.installation`,
+      scope: "agent-runtime",
+      status: "pass",
+      blocking: false,
+      label: entry.displayName,
+      detail: `installed at ${entry.path} (${entry.source})`,
+      path: entry.path,
+      observedFrom: "current CLI process environment",
+    };
+  }
+  if (entry.status === "unknown") return runtimeProviderUnknown(entry.provider, entry.displayName, entry.detail);
+  return {
+    code: `runtime.${entry.provider}.installation`,
+    scope: "agent-runtime",
+    status: "info",
+    blocking: false,
+    label: entry.displayName,
+    detail: "not installed",
+    observedFrom: "current CLI process environment",
+  };
+}
+
+function runtimeProviderUnknown(provider: "codex" | "claude-code", label: string, detail?: string): DoctorCheck {
+  return {
+    code: `runtime.${provider}.installation`,
+    scope: "agent-runtime",
+    status: "unknown",
+    blocking: false,
+    label,
+    detail: truncate(detail ?? "installation could not be determined"),
+    observedFrom: "current CLI process environment",
+  };
+}
+
+function unknownRuntime(provider: "codex" | "claude-code", displayName: string): AgentRuntimeCliInstallation {
+  return { provider, displayName, status: "unknown", detail: "Detector did not return a result" };
+}
+
+function formatHealthFailure(error: unknown, serverUrl: string): string {
+  if (error instanceof ServerHealthConfigurationError) return `invalid enrolled Server URL ${serverUrl}`;
+  if (error instanceof ServerHealthTimeoutError) return `timed out while reaching ${serverUrl}`;
+  if (error instanceof ServerHealthNetworkError) return `could not reach ${serverUrl}`;
+  if (error instanceof ServerHealthHttpError) return `${serverUrl} returned HTTP ${error.status}`;
+  if (error instanceof ServerHealthResponseError) return `${serverUrl} returned an invalid health response`;
+  return `health status could not be determined for ${serverUrl}`;
+}
+
+function statusMarker(status: DoctorCheckStatus): string {
+  if (status === "pass") return "✓";
+  if (status === "fail") return "✗";
+  if (status === "unknown") return "?";
+  return "-";
+}
+
+function settle<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
+  return promise.then(
+    (value) => ({ status: "fulfilled", value }),
+    (reason: unknown) => ({ status: "rejected", reason }),
+  );
+}
+
+function safeErrorDetail(error: unknown, fallback: string): string {
+  if (!(error instanceof Error) || error.message.length === 0) return fallback;
+  return truncate(error.message);
+}
+
+function truncate(value: string): string {
+  const redacted = value.replace(/otmc_[^\s]+/giu, "[redacted]");
+  return [...redacted]
+    .map((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code < 32 || code === 127 ? " " : character;
+    })
+    .join("")
+    .slice(0, 300);
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,7 +12,11 @@ export { type LoginOptions, type LoginResult, runLogin } from "./core/auth/login
 export { channelConfig } from "./core/channel/config.js";
 export { formatComputerList } from "./core/computer/formatting.js";
 export { listComputers } from "./core/computer/queries.js";
-export { type DoctorOptions, type DoctorResult, resolveServerUrl, runDoctor } from "./core/diagnostics/doctor.js";
+export {
+  type DoctorOptions,
+  type DoctorResult,
+  runDoctor,
+} from "./core/diagnostics/doctor.js";
 export {
   formatSessionCommandResult,
   formatSessionList,

--- a/docs/design/doctor-product-spec.md
+++ b/docs/design/doctor-product-spec.md
@@ -1,0 +1,517 @@
+# Doctor 产品需求与 P0 技术规格
+
+状态：提案
+
+最后更新：2026-08-29
+
+## 1. 文档目的
+
+本文档定义：
+
+1. 通用 CLI `doctor` 命令应承担的基础职责；
+2. OpenTag 应当参考或避免照搬 First Tree `doctor` 的哪些设计；
+3. `opentag doctor` 的最小 P0 产品与技术契约。
+
+P0 的核心决策是：
+
+> `opentag doctor` 诊断当前 CLI 调用所选 OpenTag Home 的基础状态。它不证明
+> Daemon、Provider、Integration 或端到端 handoff 已经就绪。
+
+这一区分是规范性要求。P0 成功只表示本文定义的所有 blocking 检查均已通过。
+输出不得将其表述为“OpenTag 已就绪”“handoff 已就绪”或“所有必要检查均已通过”。
+
+## 2. 通用 CLI Doctor 契约
+
+### 2.1 产品职责
+
+CLI doctor 是只读的诊断编排器。它应当按顺序回答五个问题：
+
+1. **正在诊断哪个目标？**
+2. **实际检查了哪些前置层？**
+3. **哪些检查通过、失败、无法判断或被明确排除？**
+4. **每个失败最窄、最可能的原因是什么？**
+5. **操作员下一步可以安全地做什么？**
+
+Doctor 不是通用状态页，也不是修复命令。相关命令应保持以下边界：
+
+| 命令类型 | 职责 | 是否允许修改状态 |
+| --- | --- | --- |
+| `status` | 快速展示单个子系统的当前状态 | 否 |
+| `doctor` | 对多个前置层执行有界、只读的关联诊断 | 否 |
+| `probe` 或 `test` | 执行显式选择、可能更深或带副作用的检查 | 仅在自身契约明确允许时 |
+| `repair`、`install`、`login`、`connect` | 修改本地或远端状态 | 是，但必须由操作员明确发起 |
+
+### 2.2 基础能力
+
+无论产品的具体检查项如何，生产级 doctor 都应具备以下能力：
+
+| 能力 | 要求 |
+| --- | --- |
+| 明确诊断目标 | 解析并打印被检查的精确 profile、home、cluster、project 或其他作用域。不得静默混合多个权威来源。 |
+| 分层检查 | 区分本地配置、本地依赖、服务/进程状态、网络可达性、认证和端到端行为。不得用低层检查推断高层结论。 |
+| 类型化结果 | 至少支持 `pass`、`fail`、`unknown`、`info` 和 `skipped`。不得把 `unknown` 或 `skipped` 显示成通过。 |
+| Blocking 策略 | 根据明确的产品承诺标记 blocking 与 non-blocking，不能把所有结果行等同处理。 |
+| 依赖处理 | 前置条件无效时跳过依赖检查，同时继续执行相互独立的检查，并说明跳过原因。 |
+| 可执行诊断 | 给出有界的原因、可安全执行的修复建议或文档入口，但不直接执行修复。 |
+| 有界执行 | 为网络请求和子进程设置超时。任何一个依赖都不能无限阻塞命令。 |
+| 安全性 | 保持只读、无交互提示、无模型/API 消耗，且绝不输出秘密或不受信任的原始响应正文。 |
+| 自动化能力 | 返回可靠的退出码，并将展示层与结构化结果模型分离。 |
+| 诚实总结 | 明确说明通过的是哪一级能力，并列出重要但未检查的部分。 |
+
+### 2.3 结果语义
+
+最小内部结果模型如下：
+
+```ts
+type DoctorCheckStatus = "pass" | "fail" | "unknown" | "info" | "skipped";
+
+type DoctorCheckScope =
+  | "target"
+  | "local-configuration"
+  | "daemon-service"
+  | "server"
+  | "agent-runtime";
+
+interface DoctorCheck {
+  code: string;
+  scope: DoctorCheckScope;
+  status: DoctorCheckStatus;
+  blocking: boolean;
+  label: string;
+  detail: string;
+  observedFrom?: string;
+  path?: string;
+  remediation?: string;
+}
+
+interface DoctorReport {
+  target: {
+    home: string;
+    homeSource: "environment" | "channel-default";
+  };
+  checks: DoctorCheck[];
+  exitCode: 0 | 1;
+}
+```
+
+只有所有 blocking 检查均为 `pass` 时，进程才返回 `0`。任意 blocking 检查为
+`fail` 或 `unknown` 时返回 `1`。`info` 和 `skipped` 本身不影响退出码。无效命令
+语法仍由 CLI 框架作为 usage error 处理，不属于 doctor 的诊断结果。
+
+即使发现问题并返回 `1`，人类可读的完整报告仍输出到 stdout；意外的命令级错误
+可以额外输出到 stderr。P0 不要求公开 `--json` 参数，但展示层必须消费结构化结果，
+以便未来增加稳定 JSON 接口时不需要重写检查逻辑。
+
+## 3. First Tree 参考分析
+
+### 3.1 证据基线
+
+本分析基于 First Tree `main`：
+[`2851a9e021bbb3cc9579d165f04825f767ebb8fc`](https://github.com/first-tree-ai/first-tree/tree/2851a9e021bbb3cc9579d165f04825f767ebb8fc)，
+以及 OpenTag `main`：
+[`0e8410e68f53fe1e369e12c17617e1e6a370ee05`](https://github.com/first-tree-ai/opentag/tree/0e8410e68f53fe1e369e12c17617e1e6a370ee05)。
+
+First Tree 顶层 `doctor` 与 `daemon doctor` 当前共用同一个检查编排器，已实现的检查包括：
+
+- Node.js 版本；
+- Client 配置；
+- 带五秒超时的 Server `/healthz` 可达性；
+- 本地 Agent 配置，以及条件允许时与 Server 的登记状态核对；
+- 一条名为 WebSocket 的检查；
+- 后台服务状态；
+- 权威 Daemon owner 状态；
+- Local Context 完整性；
+- install-only 的 Runtime Provider 能力检测，包括 `lark-cli`。
+
+相关源码：
+
+- [`apps/cli/src/commands/_shared/doctor-checks.ts`](https://github.com/first-tree-ai/first-tree/blob/2851a9e021bbb3cc9579d165f04825f767ebb8fc/apps/cli/src/commands/_shared/doctor-checks.ts)
+- [`apps/cli/src/core/doctor.ts`](https://github.com/first-tree-ai/first-tree/blob/2851a9e021bbb3cc9579d165f04825f767ebb8fc/apps/cli/src/core/doctor.ts)
+- [`packages/client/src/providers/capabilities/detect.ts`](https://github.com/first-tree-ai/first-tree/blob/2851a9e021bbb3cc9579d165f04825f767ebb8fc/packages/client/src/providers/capabilities/detect.ts)
+- [`packages/client/src/runtime/install-locations.ts`](https://github.com/first-tree-ai/first-tree/blob/2851a9e021bbb3cc9579d165f04825f767ebb8fc/packages/client/src/runtime/install-locations.ts)
+- [`packages/client/src/runtime/protected-paths.ts`](https://github.com/first-tree-ai/first-tree/blob/2851a9e021bbb3cc9579d165f04825f767ebb8fc/packages/client/src/runtime/protected-paths.ts)
+
+### 3.2 OpenTag 应当参考的设计
+
+1. **复用生产检测逻辑。** Runtime 安装检查应使用 Runtime 自己的 Provider
+   capability probe，不能重新实现另一套“已安装”定义。
+2. **将安装与认证分开。** First Tree 当前的 capability 契约只回答是否存在可启动的
+   artifact。它不启动 Provider、不执行 `--version`、不读取凭据，也不发起模型请求。
+3. **报告 artifact 来源。** Capability 数据区分 bundled 和外部路径来源，并能携带
+   实际解析到的路径。
+4. **不要只搜索调用方 PATH。** 受控的安装位置清单覆盖常见 native installer、
+   package manager 和 version manager 路径；macOS App bundle 单独处理。
+5. **保护自动文件系统发现。** 自动探测不得进入 macOS TCC 保护的 Desktop、
+   Documents、Downloads、iCloud Drive 或云盘目录，包括通过符号链接间接进入。
+6. **限制远端检查时间。** Server 可达性检查有固定 deadline。
+7. **只诊断，不修复。** Doctor 只输出修复建议；安装、登录、清理和服务修改必须由
+   显式命令完成。
+
+### 3.3 OpenTag 不应照搬的设计
+
+First Tree 是有价值的实现参考，但不是 OpenTag 的产品契约。以下行为不应原样复制：
+
+1. **只有布尔结果不够。** First Tree 的 `CheckResult` 只有 `ok: boolean`，无法区分
+   blocking 失败、可选 Provider 缺失、无法判断的探测以及因依赖而跳过的检查。
+2. **汇总结论过宽。** `All checks passed` 没有说明它代表本地安装、Daemon 可用、
+   已认证还是端到端交付。
+3. **WebSocket 检查并没有建立 WebSocket。** 它重复执行 HTTP health 请求并格式化
+   一个 `ws:` URL。Doctor 不得把 HTTP 可达性标记为 WebSocket 已验证。
+4. **检查失败不会驱动命令退出码。** Renderer 会打印问题数量，但命令没有根据这些
+   结果设置非零退出码。
+5. **观察权威不明确。** Runtime discovery 运行在 doctor 进程中，却与 Daemon service
+   状态一起展示。调用方 `PATH` 的观察不能被表述成已安装 Daemon 可解析该 artifact
+   的证明。
+6. **所有 Provider 缺失被当成同一种问题。** 产品必须明确一个 Runtime 是否足够，
+   并把缺少的可选 Provider 单独展示。
+
+## 4. OpenTag P0 产品规格
+
+### 4.1 用户与使用场景
+
+P0 面向已经安装 OpenTag CLI、需要判断当前 OpenTag Home 为什么无法完成基础本地职责
+的操作员。
+
+命令为：
+
+```console
+opentag doctor
+```
+
+P0 不接受 doctor 专属的目标参数。它没有 `--server-url` 或 `--server`，并忽略
+`OPENTAG_SERVER_URL`。Server 是 enrollment 的属性，不是诊断命令的调用方输入。
+
+`OPENTAG_HOME` 仍然有效，因为它是选择一套完整本地 OpenTag 安装的既有全局入口。
+没有设置时，使用当前 channel 的默认 Home。报告始终打印解析后的绝对 Home 路径及其来源。
+
+### 4.2 P0 产品承诺
+
+P0 只回答以下问题：
+
+1. 当前 OpenTag Home 的本地 Computer identity 与 enrollment 是否结构有效、内部一致？
+2. 同一 Home 的 Daemon service 是否 active，并且在既有 service-status 边界内保持一致？
+3. 该 Home 记录的唯一 Server 是否通过公开 health endpoint 正常响应？
+4. 当前 CLI 诊断上下文能否找到至少一个受支持的本地 Agent Runtime CLI artifact，
+   每个 artifact 从哪里找到？
+
+第四项明确属于 **CLI 上下文中的安装观察**。它不能证明已安装 Daemon 拥有相同环境，
+也不能证明 Daemon 能执行该 artifact。输出必须明确说明这一点。
+
+P0 决策如下：
+
+| 决策 | P0 契约 | 理由 |
+| --- | --- | --- |
+| 诊断目标 | 当前 OpenTag Home | Home 是 OpenTag 完整本地安装的边界。 |
+| Server 来源 | 仅使用 Home 内经过验证的 enrollment | 调用方指定 URL 会诊断一个 Computer 可能永远不会使用的 Server。 |
+| Daemon service | 检查状态及 Home 一致性 | 停止或绑定错误的服务属于基础本地故障，即使 P0 不承诺端到端就绪。 |
+| Runtime 安装 | Codex 与 Claude Code，只做 install-only 检查 | Artifact 缺失可以在不调用 Provider、不读取凭据的前提下安全诊断。 |
+| Runtime 充分条件 | 至少安装一个受支持 Runtime | P0 没有权威的 Agent-to-Provider 分配视图；缺少其他 Provider 仍需展示，但不 blocking。 |
+| Runtime 观察权威 | 当前 CLI 上下文，并明确披露 | 准确判断已安装 Daemon 的 Provider 解析能力需要单独评审权威契约。 |
+| Runtime 认证 | 不检查 | 凭据存在、Provider 登录状态与可用的已认证执行是不同产品承诺。 |
+| Integration CLI | 不检查 | 尚未定义需要哪些 CLI、交互方式以及条件 blocking 策略。 |
+| 自动修复 | 禁止 | 诊断必须保持安全、可重复和只读。 |
+
+### 4.3 P0 Blocking 检查
+
+#### A. 目标 Home
+
+报告必须展示：
+
+- OpenTag Home 的规范化绝对路径；
+- 路径来自 `OPENTAG_HOME` 还是 channel 默认值；
+- CLI 版本、channel、platform、architecture 和 Node.js 版本，作为信息性诊断上下文。
+
+解析路径不得创建 Home 或任何缺失目录。
+
+#### B. 本地 Computer 配置
+
+本地配置属于 blocking 检查。Doctor 必须只读检查文件，不得调用可能创建或重写
+identity 状态的 helper。
+
+只有全部满足以下条件时，检查才通过：
+
+- Home/config 路径符合现有 private-storage 安全读取规则；
+- `computer.json` 存在且有效；
+- `computer-credentials.json` 存在，使用受支持的 envelope version，并至少包含一个
+  可用 enrollment；
+- Doctor 结果中不存在被静默丢弃的格式错误 enrollment；
+- enrollment identifier 符合 credential format 的唯一性规则；
+- 每个 enrollment 的 `computerId` 都与 `computer.json` 相同；
+- 每个 enrollment 都包含完全相同的规范 Server origin；
+- identity 的 `serverUrl` 与该规范 Server origin 完全一致；
+- 允许多个 Workspace Computer enrollment 指向同一个 Server。
+
+一个 Home 中出现多个不同 Server origin 属于 blocking 配置错误。Doctor 不得联系其中
+任何一个，因为 Daemon 会拒绝该 Home，而 Doctor 选择其中之一等同于捏造权威。
+
+Doctor 绝不能打印 `machineToken`、credential 文件内容，或可能包含文件数据的未脱敏
+解析错误。
+
+#### C. Daemon service 基线
+
+Daemon service status 属于 P0 blocking 检查，并且必须复用现有只读 Daemon service
+manager/status 实现。
+
+只有全部满足以下条件时，检查才通过：
+
+- 当前 platform 受支持；
+- service 已安装且为 active；
+- service 的 configured Home 可验证为当前 OpenTag Home；
+- service definition 不存在 drift；
+- 既有 runtime-owner consistency 结果与 active service 一致。
+
+Inactive、not-installed、unsupported、drifted、Home 不匹配、malformed、unverified 或其他
+unknown 状态都必须 fail closed。报告应包含既有 log hint；在可以安全给出时，提供最窄
+修复命令。
+
+Service-status 边界必须从经过评审的绝对位置执行受治理的系统程序，包括 NixOS systemd
+路径等受支持的非 FHS 位置。通过调用进程 `PATH` 解析裸的 `launchctl`、`systemctl` 或
+`loginctl` 不具备权威性，不能产生 P0 pass。Issue
+[#244](https://github.com/first-tree-ai/opentag/issues/244) 可以在独立的 service-module
+变更中实现，但它的正确性条件是 `daemon.service` 检查能够通过的前置条件。
+
+Issue [#239](https://github.com/first-tree-ai/opentag/issues/239) 涉及 service definition
+lookup 如何解析 account home 与 XDG 路径，继续作为独立 service-module follow-up，
+不阻塞 P0。存在歧义时结果保持失败，不得猜测或转成 pass。
+
+#### D. 已登记 Server 的健康状态
+
+Server URL 只能来自经过验证的本地 enrollment。Server health 检查必须：
+
+- 对该 origin 执行 `GET /healthz`；
+- 设置五秒 deadline；
+- 使用 `ServerHealthSchema` 验证响应；
+- 区分配置错误、timeout/network failure、非 2xx HTTP 和响应结构无效，同时不暴露原始
+  response body。
+
+该检查只证明公开 health endpoint 可达并返回预期 schema。它不证明 machine token
+有效、不证明 WebSocket registration 可用，也不证明 Server 可以交付 Turn。
+
+如果本地配置无效，Server 检查应为 `skipped`，原因为“没有权威的 enrolled Server”；
+Daemon service 与 Runtime artifact 等独立检查仍需继续运行。
+
+#### E. Agent Runtime CLI artifact
+
+P0 分别报告 Codex CLI 与 Claude Code CLI。只要至少一个受支持 Runtime artifact 被确定为
+已安装，blocking 汇总检查就通过。缺少另一个 Provider 只属于信息性结果，不 blocking。
+
+P0 中“已安装”的定义是：
+
+> 共享的生产 resolver 在不启动 Provider 的前提下，为该 Provider 选中了一个普通、
+> 可执行的文件。
+
+Resolver 必须由生产 Client Runtime 与 doctor 共用，避免两套解析逻辑漂移。它必须：
+
+- 只有在 OpenTag 真正提供显式路径配置时才接受该配置；P0 不得发明 doctor 专属的
+  Provider override；
+- 搜索诊断进程的 `PATH`；
+- 搜索经过评审的 well-known 安装目录；
+- 仅为 Codex 搜索经过验证的 macOS ChatGPT/Codex App bundle 位置；
+- 不得把具有执行位的目录、broken link、不可执行文件或不安全的自动候选项当成已安装；
+- 在 `stat`、`access`、`realpath`、目录枚举或其他会跟随路径的读取之前，应用相同的
+  macOS protected-root 策略；
+- 返回选中的规范路径及来源：`caller-path`、`well-known`、`desktop-app`，或未来真实
+  存在的配置来源；
+- 每个 Provider 独立失败，单个 detector 错误不能隐藏另一个 Provider 的结果。
+
+P0 不得启动 `codex` 或 `claude`，不得请求 `--version`/`--help`，不得检查认证、初始化
+app server、发起模型请求、安装 binary 或修改 Provider 配置。
+
+`CLAUDE_CONFIG_DIR` 具有 credential 语义，不是安装信号。Artifact discovery 不得合成或
+注入它：未设置时保持未设置；显式值只作为已标记的观察上下文保留。Client Runtime 在
+[#236](https://github.com/first-tree-ai/opentag/issues/236) 中的缺陷属于独立 Runtime
+正确性修复，不能成为 doctor 声称已检查 Claude Code 认证的理由。
+
+### 4.4 必需输出
+
+人类可读报告采用固定 section 顺序，避免并发检查改变输出顺序：
+
+1. Target
+2. Local configuration
+3. Daemon service
+4. Server
+5. Agent Runtime CLIs
+6. Summary
+7. Not evaluated
+
+示例结构如下。实际 CLI 文案保持英语：
+
+```text
+OpenTag Doctor
+
+Target
+  - OpenTag Home: /Users/alice/.opentag (channel default)
+  - CLI: 0.x.y, stable, darwin arm64, Node.js v24.x
+
+Checks
+  ✓ Local Computer configuration: 2 enrollments, one Computer, one Server
+  ✓ Daemon service: active for this OpenTag Home
+  ✓ Server health endpoint: reachable at https://example.opentag.dev
+  ✓ Agent Runtime CLI: at least one supported Runtime is installed
+  ✓ Codex CLI: installed at /Applications/ChatGPT.app/.../codex (desktop-app)
+  - Claude Code CLI: not installed
+
+Baseline checks passed for this OpenTag Home.
+
+Not evaluated
+  - Agent Runtime authentication
+  - Agent Runtime version or protocol compatibility
+  - Agent Runtime visibility from the installed daemon environment
+  - machine-token authentication or WebSocket registration
+  - Integration CLI availability or authentication
+  - end-to-end Turn or handoff delivery
+```
+
+Summary 只能是以下两种之一：
+
+- `Baseline checks passed for this OpenTag Home.`
+- `N blocking baseline check(s) failed for this OpenTag Home.`
+
+报告必须始终包含上述 `Not evaluated` section。只有在对应能力拥有经过评审的契约，并且
+确实执行了该检查之后，未来版本才能移除某一项。
+
+### 4.5 修复建议策略
+
+Doctor 只打印指导，不执行任何修改。修复建议必须遵守以下规则：
+
+- 只有全部必需的非秘密参数已知时，才打印可直接执行的完整命令；
+- 否则说明应采取的操作，并指向相关命令或文档；
+- 不得嵌入 connect code、token、credential 文件内容或直接复制的原始 Provider 错误；
+- 不得代替操作员执行删除、重写、重新连接、重新安装、重启或登录；
+- 未检查 Runtime 认证时，不得建议用户登录 Runtime。
+
+## 5. P0 技术架构
+
+### 5.1 所有权与依赖方向
+
+Commander 注册层保持轻量。`apps/cli` 负责编排与展示；可复用的本地存储检查、Server
+health 和 Runtime artifact inspection 通过 `@opentag/client` 的公共接口提供。
+
+```text
+apps/cli command
+  -> apps/cli doctor orchestrator
+       -> client local Computer inspector
+       -> existing CLI daemon service manager.status()
+       -> client Server health checker
+       -> client shared Runtime artifact resolver
+  -> apps/cli renderer
+```
+
+Doctor 可以并发协调检查，但依赖关系必须显式：
+
+- 先解析 target，再运行任何检查；
+- local configuration 与 Runtime artifact 检查可以相互独立地启动；
+- Daemon service status 不依赖 Server health；
+- 只有解析出唯一权威 Server 后才启动 Server health；
+- renderer 等待所有独立检查结束，并按固定 section 顺序输出。
+
+### 5.2 必需实现边界
+
+1. **Doctor 不得复用 `resolveComputerIdentity`。** 它可能创建或重写 identity 状态；
+   Doctor 需要严格只读的 inspector。
+2. **不得把宽容的 credential projection 当作完整 doctor 结论。** Runtime reader 可以
+   有意丢弃不可用 enrollment，但 doctor 必须报告这种损坏，不能只把剩余 projection
+   报告为健康。
+3. **不得在 CLI 中重复实现 Runtime resolution。** 应提取或扩展生产 resolver，随后由
+   Runtime composition 与 doctor 共用。
+4. **不得把 `/healthz` 转换成 readiness 结论。** Result code 和 label 必须只描述公开
+   Server health。
+5. **不得把 exception 折叠成“未安装”。** 必须区分明确缺失与 detector 无法判断。
+6. **不得让并发完成顺序决定报告顺序。** 先汇总结构化结果，再统一渲染。
+
+### 5.3 稳定检查代码
+
+P0 check code 属于内部契约，也是未来 JSON 接口的基础：
+
+| Code | Blocking | 含义 |
+| --- | --- | --- |
+| `target.home` | 否 | 选中的规范 OpenTag Home 及来源 |
+| `local.identity` | 是 | `computer.json` 存在、安全且有效 |
+| `local.enrollments` | 是 | credential envelope 及每个存储的 enrollment 均有效 |
+| `local.binding` | 是 | Computer identity、enrollment 和唯一 Server origin 一致 |
+| `daemon.service` | 是 | 已安装 service active、配置未漂移并属于当前 Home |
+| `server.health` | 是 | enrolled Server 的公开 `/healthz` 在 deadline 内通过 |
+| `runtime.any-installed` | 是 | 至少找到一个受支持 Runtime artifact |
+| `runtime.codex.installation` | 否 | Codex artifact 观察结果 |
+| `runtime.claude-code.installation` | 否 | Claude Code artifact 观察结果 |
+
+### 5.4 性能与安全预算
+
+- 不启动 Provider 子进程，不发起模型/API 请求。
+- Server health deadline：5 秒。
+- Service manager 子进程使用既有显式 deadline。
+- 文件系统检查仅限当前 Home 和经过评审的安装根目录；不得递归扫描整个用户 Home。
+- macOS 自动发现不得触发 TCC 授权提示。
+- 在安全前提下并发执行独立检查；健康主机的预期总耗时低于 6 秒。
+- 所有展示错误必须有长度上限并经过脱敏。
+
+## 6. 验收标准
+
+P0 至少需要使用确定性测试覆盖以下场景：
+
+| 场景 | 必需结果 |
+| --- | --- |
+| 调用时提供 `--server-url` | CLI usage error；doctor 不接受该参数 |
+| 环境中设置 `OPENTAG_SERVER_URL` | Doctor 的目标解析忽略该变量 |
+| 环境中设置 `OPENTAG_HOME` | 打印规范 Home 以及 environment 来源 |
+| 缺少 identity 或 enrollment | 本地配置失败；Server skipped；独立检查继续运行 |
+| 本地文件 malformed 或 unsafe | 本地配置失败，且不暴露文件内容 |
+| 多个 enrollment 使用相同 Computer 和 Server | 本地 binding 通过 |
+| Enrollment 包含不同 Server | 本地 binding 失败；不联系任何 Server |
+| Enrollment Computer ID 与 identity 不同 | 本地 binding 失败 |
+| Service 对当前 Home 为 active | Daemon service 通过 |
+| Service inactive、drifted、unknown 或属于其他 Home | Daemon service fail closed |
+| 调用方 `PATH` shadow `launchctl`、`systemctl` 或 `loginctl` | 不执行 shadow；只有受支持的绝对 manager 才能提供状态 |
+| `/healthz` timeout | Server health 在 deadline 内失败 |
+| `/healthz` 返回非 2xx、无效 JSON 或无效 schema | 返回分类后的 Server failure |
+| 名为 `codex` 的目录具有执行位 | 不得被识别为已安装 executable |
+| 自动候选项穿过 macOS protected root 或符号链接 | 在跟随读取之前拒绝该候选项 |
+| 只安装 Codex 或只安装 Claude Code | Runtime 汇总通过；缺少的另一个 Provider 为 info |
+| 两个 Runtime 都未安装 | Runtime 汇总失败 |
+| 一个 Provider detector 报错，另一个找到 artifact | 仍报告已找到的 Provider；detector error 为 `unknown` |
+| Runtime 只从调用方 `PATH` 找到 | 来源标记为 `caller-path`；Daemon 可见性继续列为未检查 |
+| 任意报告包含 credential | 测试失败 |
+| 所有 blocking P0 检查通过 | Exit `0`，并且只使用 baseline success 文案 |
+| 任意 blocking 检查失败或 unknown | Exit `1`，不得使用 readiness 文案 |
+
+## 7. 明确不属于 P0 的范围
+
+以下能力推迟到各自产品契约完成评审后再实现：
+
+- Agent Runtime authentication 或 credential presence
+  ([#247](https://github.com/first-tree-ai/opentag/issues/247))；
+- Agent Runtime version 与 protocol compatibility；
+- 已安装 Daemon effective environment 内的权威 Provider resolution；
+- Integration CLI 的选择、安装、认证或交互
+  ([#248](https://github.com/first-tree-ai/opentag/issues/248))；
+- machine-token validation、WebSocket registration 或端到端 Turn/handoff delivery；
+- 自动安装、登录、重启、重新连接或修复；
+- 对外公开的 JSON 输出及其兼容性保证；
+- 超出现有已发布 platform contract 的 Windows Daemon service 支持。
+
+这些未检查项不等于通过，并且必须持续显示在每次 P0 报告中。
+
+## 8. 对当前工作的影响
+
+OpenTag `main` 当前只实现调用方选择的 Server `/healthz` 检查，并接受 `--server-url` /
+`OPENTAG_SERVER_URL`。该行为不符合本规格。
+
+PR [#246](https://github.com/first-tree-ai/opentag/pull/246) 在
+`1f241dc42097471e2e194a4efbf8fba8098ba00e` 上已将 Server 选择改为本地 enrollment，
+并增加 install-only Runtime 观察，但不能按现状直接合并，原因包括：
+
+- 将多个不同 enrolled Server 视为有效，但 Daemon 会拒绝这种配置；
+- 未验证本地 Computer identity 与 enrollment binding；
+- 缺少 Daemon service 基线检查；
+- Server 请求没有 deadline；
+- 可能把具有执行位的目录当成 Runtime artifact；
+- 人类可读输出中没有展示 Runtime source；
+- 没有披露 Runtime detection 使用调用进程上下文；
+- 使用 `All required checks passed.` 作为汇总。
+
+后续实现应以本文作为 P0 source of truth，在合理情况下把共享 Runtime discovery 与 doctor
+presentation 拆分，并继续将 authentication 和 Integration 留在各自 follow-up issue 中。
+Runtime discovery issue
+[#237](https://github.com/first-tree-ai/opentag/issues/237) 提供主要 artifact-resolution
+实现范围。Service manager issue #244 继续保持独立代码变更，但必须在 P0 service 结果
+能够被信任为 pass 之前落地。

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck",
     "test": "node --test --test-concurrency=1 scripts/__tests__/*.test.mjs && turbo run test --concurrency=2",
+    "test:e2e:doctor-docker": "node scripts/e2e/doctor-docker.mjs",
     "test:coverage": "pnpm build && vitest run --config vitest.coverage.config.ts --maxWorkers=1",
     "check:node-compat": "pnpm build && pnpm test && node scripts/node-compat-smoke.mjs",
     "notices:write": "node scripts/third-party-notices.mjs --write"

--- a/packages/client/src/__tests__/agent-runtime-installation.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-installation.test.ts
@@ -1,0 +1,198 @@
+import { chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AgentRuntimeExecutableNotFoundError,
+  probeAgentRuntimeCliInstallations,
+  resolveAgentRuntimeExecutable,
+} from "../runtime/agent-runtime-installation.js";
+import { automaticCandidateAllowed } from "../runtime/protected-paths.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("Agent Runtime CLI installation discovery", () => {
+  it("reports a canonical ordinary executable found on caller PATH", async () => {
+    const root = await temporaryRoot();
+    const bin = join(root, "bin");
+    const executable = join(bin, "codex");
+    await mkdir(bin);
+    await writeFile(executable, "#!/bin/sh\n", { mode: 0o700 });
+
+    await expect(
+      resolveAgentRuntimeExecutable("codex", "codex", { PATH: bin }, emptyAutomaticLocations(root)),
+    ).resolves.toEqual({
+      path: await realpath(executable),
+      provider: "codex",
+      source: "caller-path",
+    });
+  });
+
+  it("does not treat an executable directory as an installed Runtime CLI", async () => {
+    const root = await temporaryRoot();
+    const directoryNamedCodex = join(root, "bin", "codex");
+    await mkdir(directoryNamedCodex, { mode: 0o700, recursive: true });
+    await chmod(directoryNamedCodex, 0o700);
+
+    await expect(
+      resolveAgentRuntimeExecutable("codex", "codex", { PATH: join(root, "bin") }, emptyAutomaticLocations(root)),
+    ).rejects.toBeInstanceOf(AgentRuntimeExecutableNotFoundError);
+  });
+
+  it("does not treat a non-executable file or broken link as an installed Runtime CLI", async () => {
+    const root = await temporaryRoot();
+    const nonExecutableBin = join(root, "non-executable-bin");
+    const brokenLinkBin = join(root, "broken-link-bin");
+    await Promise.all([mkdir(nonExecutableBin), mkdir(brokenLinkBin)]);
+    await writeFile(join(nonExecutableBin, "codex"), "#!/bin/sh\n", { mode: 0o600 });
+    await symlink(join(root, "missing-codex"), join(brokenLinkBin, "codex"));
+
+    for (const bin of [nonExecutableBin, brokenLinkBin]) {
+      await expect(
+        resolveAgentRuntimeExecutable("codex", "codex", { PATH: bin }, emptyAutomaticLocations(root)),
+      ).rejects.toBeInstanceOf(AgentRuntimeExecutableNotFoundError);
+    }
+  });
+
+  it("labels a reviewed installation directory as well-known", async () => {
+    const root = await temporaryRoot();
+    const bin = join(root, "reviewed-bin");
+    const executable = join(bin, "claude");
+    await mkdir(bin);
+    await writeFile(executable, "#!/bin/sh\n", { mode: 0o700 });
+
+    await expect(
+      resolveAgentRuntimeExecutable(
+        "claude-code",
+        "claude",
+        { PATH: "" },
+        {
+          candidateAllowed: () => true,
+          desktopAppDirs: () => [],
+          home: root,
+          platform: "linux",
+          wellKnownDirs: () => [bin],
+        },
+      ),
+    ).resolves.toMatchObject({ path: await realpath(executable), source: "well-known" });
+  });
+
+  it("rejects a protected automatic candidate before any path-following filesystem read", async () => {
+    const stat = vi.fn();
+    const access = vi.fn();
+    const resolvePath = vi.fn();
+    const protectedBin = "/Users/alice/Documents/runtime-bin";
+
+    await expect(
+      resolveAgentRuntimeExecutable(
+        "codex",
+        "codex",
+        { PATH: protectedBin },
+        {
+          access,
+          candidateAllowed: () => false,
+          desktopAppDirs: () => [],
+          home: "/Users/alice",
+          platform: "darwin",
+          realpath: resolvePath,
+          stat,
+          wellKnownDirs: () => [],
+        },
+      ),
+    ).rejects.toBeInstanceOf(AgentRuntimeExecutableNotFoundError);
+
+    expect(stat).not.toHaveBeenCalled();
+    expect(access).not.toHaveBeenCalled();
+    expect(resolvePath).not.toHaveBeenCalled();
+  });
+
+  it("rejects a candidate whose symlink chain enters a macOS protected root", () => {
+    const visited: string[] = [];
+    const readLink = (path: string): string => {
+      visited.push(path);
+      if (path === "/safe/runtime-bin") return "/Users/alice/Documents/runtime-bin";
+      throw Object.assign(new Error("not a symlink"), { code: "EINVAL" });
+    };
+
+    expect(
+      automaticCandidateAllowed("/safe/runtime-bin/codex", {
+        home: "/Users/alice",
+        platform: "darwin",
+        readLink,
+      }),
+    ).toBe(false);
+    expect(visited).toContain("/safe/runtime-bin");
+    expect(visited.some((path) => path.startsWith("/Users/alice/Documents"))).toBe(false);
+  });
+
+  it("keeps one installed Provider when the other detector cannot determine its state", async () => {
+    const options = {
+      access: vi.fn().mockResolvedValue(undefined),
+      candidateAllowed: () => true,
+      commands: { "claude-code": "claude", codex: "codex" },
+      desktopAppDirs: () => [],
+      environment: { PATH: `/runtime${delimiter}/unused` },
+      home: "/home/alice",
+      platform: "linux" as const,
+      realpath: vi.fn(async (path: string) => path),
+      stat: vi.fn(async (path: string) => {
+        if (path === "/runtime/codex") throw Object.assign(new Error("I/O failure"), { code: "EIO" });
+        if (path === "/runtime/claude") return { isFile: () => true };
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }),
+      wellKnownDirs: () => [],
+    };
+
+    await expect(probeAgentRuntimeCliInstallations(options)).resolves.toEqual([
+      {
+        detail: "A Runtime candidate could not be inspected safely",
+        displayName: "Codex CLI",
+        provider: "codex",
+        status: "unknown",
+      },
+      {
+        displayName: "Claude Code CLI",
+        path: "/runtime/claude",
+        provider: "claude-code",
+        source: "caller-path",
+        status: "installed",
+      },
+    ]);
+  });
+
+  it("does not collapse an inaccessible candidate into not-installed", async () => {
+    const result = await probeAgentRuntimeCliInstallations({
+      candidateAllowed: () => true,
+      desktopAppDirs: () => [],
+      environment: { PATH: "/runtime" },
+      home: "/home/alice",
+      platform: "linux",
+      stat: async () => {
+        throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+      },
+      wellKnownDirs: () => [],
+    });
+
+    expect(result.every((entry) => entry.status === "unknown")).toBe(true);
+  });
+});
+
+function emptyAutomaticLocations(home: string) {
+  return {
+    candidateAllowed: () => true,
+    desktopAppDirs: () => [],
+    home,
+    platform: "linux" as const,
+    wellKnownDirs: () => [],
+  };
+}
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "opentag-runtime-installation-"));
+  temporaryRoots.push(root);
+  return root;
+}

--- a/packages/client/src/__tests__/health.test.ts
+++ b/packages/client/src/__tests__/health.test.ts
@@ -26,7 +26,9 @@ describe("checkServerHealth", () => {
       status: "ok",
       service: "opentag-server",
     });
-    expect(fetchImpl).toHaveBeenCalledWith(new URL("http://127.0.0.1:8000/healthz"));
+    expect(fetchImpl).toHaveBeenCalledWith(new URL("http://127.0.0.1:8000/healthz"), {
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it("classifies network failures", async () => {
@@ -35,6 +37,34 @@ describe("checkServerHealth", () => {
     await expect(checkServerHealth("http://127.0.0.1:8000", fetchImpl)).rejects.toBeInstanceOf(
       ServerHealthNetworkError,
     );
+  });
+
+  it("classifies the fixed deadline separately from other network failures", async () => {
+    const fetchImpl = vi.fn<typeof fetch>((_input, init) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      });
+    });
+
+    await expect(checkServerHealth("http://127.0.0.1:8000", fetchImpl, 1)).rejects.toMatchObject({
+      name: "ServerHealthTimeoutError",
+    });
+  });
+
+  it("keeps the deadline active while the health response body is read", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      return {
+        ok: true,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(new Error("body aborted")), { once: true });
+          }),
+      } as Response;
+    });
+
+    await expect(checkServerHealth("http://127.0.0.1:8000", fetchImpl, 1)).rejects.toMatchObject({
+      name: "ServerHealthTimeoutError",
+    });
   });
 
   it("classifies non-success HTTP responses", async () => {

--- a/packages/client/src/auth/machine-credentials.ts
+++ b/packages/client/src/auth/machine-credentials.ts
@@ -29,6 +29,17 @@ export function readMachineCredentials(home = resolveOpenTagHome()): Promise<Sto
   return readPrivateJson(home, machineCredentialsPath(home), validateMachineCredentials);
 }
 
+/**
+ * Strict, read-only projection for diagnostics. Unlike the runtime reader, this rejects the whole
+ * file when any stored enrollment is unusable, so corruption cannot be reported as a healthy
+ * partial configuration.
+ */
+export function readMachineCredentialsStrict(
+  home = resolveOpenTagHome(),
+): Promise<StoredMachineCredentials | undefined> {
+  return readPrivateJson(home, machineCredentialsPath(home), checkMachineCredentialsStrict);
+}
+
 /** Rejects rather than throwing synchronously, so a caller handling the returned promise sees the refusal. */
 export async function writeMachineCredentialsAtomically(
   credentials: StoredMachineCredentials,
@@ -79,15 +90,22 @@ function validateMachineCredentials(value: unknown): StoredMachineCredentials {
  * bytes just written. Unusable input is rejected, and the validated projection is what reaches disk.
  */
 function checkMachineCredentialsToWrite(value: StoredMachineCredentials): StoredMachineCredentials {
+  return checkMachineCredentialsStrict(value, "Refusing to write");
+}
+
+function checkMachineCredentialsStrict(
+  value: unknown,
+  failurePrefix = "The stored OpenTag Computer credentials contain",
+): StoredMachineCredentials {
   const enrollmentIds = new Set<string>();
   const enrollments: MachineEnrollmentCredential[] = [];
   for (const [index, entry] of readCredentialsEnvelope(value).entries()) {
     const credential = readEnrollmentEntry(entry);
     if (!credential) {
-      throw new Error(`Refusing to write an unusable OpenTag Computer credential (entry ${index})`);
+      throw new Error(`${failurePrefix} an unusable OpenTag Computer credential (entry ${index})`);
     }
     if (enrollmentIds.has(credential.workspaceComputerId)) {
-      throw new Error(`Refusing to write a duplicate OpenTag Computer enrollment (entry ${index})`);
+      throw new Error(`${failurePrefix} a duplicate OpenTag Computer enrollment (entry ${index})`);
     }
     enrollmentIds.add(credential.workspaceComputerId);
     enrollments.push(credential);

--- a/packages/client/src/health.ts
+++ b/packages/client/src/health.ts
@@ -8,6 +8,10 @@ export class ServerHealthNetworkError extends Error {
   override readonly name = "ServerHealthNetworkError";
 }
 
+export class ServerHealthTimeoutError extends Error {
+  override readonly name = "ServerHealthTimeoutError";
+}
+
 export class ServerHealthHttpError extends Error {
   override readonly name = "ServerHealthHttpError";
 
@@ -20,7 +24,13 @@ export class ServerHealthResponseError extends Error {
   override readonly name = "ServerHealthResponseError";
 }
 
-export async function checkServerHealth(serverUrl: string, fetchImpl: typeof fetch = fetch): Promise<ServerHealth> {
+export const SERVER_HEALTH_TIMEOUT_MS = 5_000;
+
+export async function checkServerHealth(
+  serverUrl: string,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = SERVER_HEALTH_TIMEOUT_MS,
+): Promise<ServerHealth> {
   let healthUrl: URL;
   try {
     healthUrl = new URL("/healthz", serverUrl);
@@ -28,20 +38,33 @@ export async function checkServerHealth(serverUrl: string, fetchImpl: typeof fet
     throw new ServerHealthConfigurationError(`Invalid OpenTag server URL: ${serverUrl}`, { cause: error });
   }
 
-  let response: Response;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    response = await fetchImpl(healthUrl);
+    const response = await fetchImpl(healthUrl, { signal: controller.signal });
+    if (!response.ok) {
+      throw new ServerHealthHttpError(response.status);
+    }
+    try {
+      return ServerHealthSchema.parse(await response.json());
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new ServerHealthTimeoutError(`OpenTag server health check timed out after ${timeoutMs}ms`, {
+          cause: error,
+        });
+      }
+      throw new ServerHealthResponseError("OpenTag server returned an invalid health response", { cause: error });
+    }
   } catch (error) {
+    if (error instanceof ServerHealthHttpError || error instanceof ServerHealthResponseError) throw error;
+    if (error instanceof ServerHealthTimeoutError) throw error;
+    if (controller.signal.aborted) {
+      throw new ServerHealthTimeoutError(`OpenTag server health check timed out after ${timeoutMs}ms`, {
+        cause: error,
+      });
+    }
     throw new ServerHealthNetworkError("Could not reach the OpenTag server", { cause: error });
-  }
-
-  if (!response.ok) {
-    throw new ServerHealthHttpError(response.status);
-  }
-
-  try {
-    return ServerHealthSchema.parse(await response.json());
-  } catch (error) {
-    throw new ServerHealthResponseError("OpenTag server returned an invalid health response", { cause: error });
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -66,6 +66,7 @@ export {
   type MachineEnrollmentCredential,
   machineCredentialsPath,
   readMachineCredentials,
+  readMachineCredentialsStrict,
   type StoredMachineCredentials,
   storeMachineEnrollmentCredential,
   writeMachineCredentialsAtomically,
@@ -73,10 +74,12 @@ export {
 export { type AccessTokenLease, AccessTokenProvider, type TokenProviderOptions } from "./auth/token-provider.js";
 export {
   checkServerHealth,
+  SERVER_HEALTH_TIMEOUT_MS,
   ServerHealthConfigurationError,
   ServerHealthHttpError,
   ServerHealthNetworkError,
   ServerHealthResponseError,
+  ServerHealthTimeoutError,
 } from "./health.js";
 export {
   type ClientLogBindings,
@@ -147,6 +150,19 @@ export {
   type AdmissionSnapshot,
 } from "./runtime/admission-controller.js";
 export {
+  type AgentRuntimeCliInstallation,
+  AgentRuntimeExecutableDiscoveryError,
+  AgentRuntimeExecutableNotFoundError,
+  type AgentRuntimeExecutableSource,
+  codexDesktopAppBinDirs,
+  type ProbeAgentRuntimeCliInstallationsOptions,
+  probeAgentRuntimeCliInstallations,
+  type ResolveAgentRuntimeExecutableOptions,
+  type ResolvedAgentRuntimeExecutable,
+  resolveAgentRuntimeExecutable,
+  wellKnownAgentRuntimeBinDirs,
+} from "./runtime/agent-runtime-installation.js";
+export {
   type AgentRuntimeProviderRegistration,
   AgentRuntimeProviderRegistry,
   AgentRuntimeProviderUnavailableError,
@@ -186,6 +202,11 @@ export {
   serializeEnvironment,
 } from "./runtime/im-credential-environment-manager.js";
 export { ImResourceFetcher } from "./runtime/im-resource-fetcher.js";
+export {
+  inspectLocalComputerConfiguration,
+  type LocalComputerConfigurationInspection,
+  type LocalConfigurationStatus,
+} from "./runtime/local-computer-configuration.js";
 export { renderManagedSystemPrompt } from "./runtime/managed-instructions.js";
 export {
   type RuntimeBusinessFrame,

--- a/packages/client/src/runtime/agent-runtime-installation.ts
+++ b/packages/client/src/runtime/agent-runtime-installation.ts
@@ -1,0 +1,240 @@
+import { constants, type Stats } from "node:fs";
+import { access, realpath, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { delimiter, isAbsolute, join } from "node:path";
+import type { AgentRuntimeProvider } from "@opentag/shared";
+import { automaticCandidateAllowed } from "./protected-paths.js";
+
+export type AgentRuntimeExecutableSource = "explicit" | "caller-path" | "well-known" | "desktop-app";
+
+export interface ResolvedAgentRuntimeExecutable {
+  provider: AgentRuntimeProvider;
+  path: string;
+  source: AgentRuntimeExecutableSource;
+}
+
+export type AgentRuntimeCliInstallation =
+  | {
+      provider: "codex" | "claude-code";
+      displayName: string;
+      status: "installed";
+      path: string;
+      source: AgentRuntimeExecutableSource;
+    }
+  | {
+      provider: "codex" | "claude-code";
+      displayName: string;
+      status: "not-installed";
+    }
+  | {
+      provider: "codex" | "claude-code";
+      displayName: string;
+      status: "unknown";
+      detail: string;
+    };
+
+type Candidate = { path: string; source: Exclude<AgentRuntimeExecutableSource, "explicit"> };
+
+export interface ResolveAgentRuntimeExecutableOptions {
+  access?: (path: string, mode: number) => Promise<void>;
+  realpath?: (path: string) => Promise<string>;
+  stat?: (path: string) => Promise<Pick<Stats, "isFile">>;
+  platform?: NodeJS.Platform;
+  home?: string;
+  pathDelimiter?: string;
+  wellKnownDirs?: (home: string, platform: NodeJS.Platform) => readonly string[];
+  desktopAppDirs?: (home: string, platform: NodeJS.Platform) => readonly string[];
+  candidateAllowed?: (path: string, options: { platform: NodeJS.Platform; home: string }) => boolean;
+}
+
+export interface ProbeAgentRuntimeCliInstallationsOptions extends ResolveAgentRuntimeExecutableOptions {
+  environment?: NodeJS.ProcessEnv;
+  commands?: Partial<Record<"codex" | "claude-code", string>>;
+}
+
+const PROVIDERS = [
+  { provider: "codex", displayName: "Codex CLI", command: "codex" },
+  { provider: "claude-code", displayName: "Claude Code CLI", command: "claude" },
+] as const;
+
+export class AgentRuntimeExecutableNotFoundError extends Error {
+  override readonly name = "AgentRuntimeExecutableNotFoundError";
+}
+
+export class AgentRuntimeExecutableDiscoveryError extends Error {
+  override readonly name = "AgentRuntimeExecutableDiscoveryError";
+}
+
+/** Cheap, spawn-free directories mirrored from First Tree's install-only discovery. */
+export function wellKnownAgentRuntimeBinDirs(home: string, platform: NodeJS.Platform = process.platform): string[] {
+  return [
+    join(home, ".local", "bin"),
+    join(home, ".claude", "local"),
+    join(home, ".volta", "bin"),
+    join(home, ".asdf", "shims"),
+    join(home, ".local", "share", "mise", "shims"),
+    join(home, ".npm-global", "bin"),
+    join(home, ".local", "share", "pnpm"),
+    ...(platform === "darwin" ? [join(home, "Library", "pnpm")] : []),
+    join(home, ".bun", "bin"),
+    ...(platform === "darwin" ? ["/opt/homebrew/bin"] : []),
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+  ];
+}
+
+export function codexDesktopAppBinDirs(home: string, platform: NodeJS.Platform = process.platform): string[] {
+  if (platform !== "darwin") return [];
+  return [
+    join("/Applications", "ChatGPT.app", "Contents", "Resources"),
+    join(home, "Applications", "ChatGPT.app", "Contents", "Resources"),
+    join("/Applications", "Codex.app", "Contents", "Resources"),
+    join(home, "Applications", "Codex.app", "Contents", "Resources"),
+  ];
+}
+
+export async function resolveAgentRuntimeExecutable(
+  provider: AgentRuntimeProvider,
+  command: string,
+  environment: NodeJS.ProcessEnv,
+  options: ResolveAgentRuntimeExecutableOptions = {},
+): Promise<ResolvedAgentRuntimeExecutable> {
+  const dependencies = {
+    access: options.access ?? access,
+    realpath: options.realpath ?? realpath,
+    stat: options.stat ?? stat,
+  };
+  if (isAbsolute(command)) {
+    const outcome = await inspectExecutableCandidate(command, dependencies);
+    if (outcome.status !== "installed") {
+      if (outcome.status === "unknown") throw new AgentRuntimeExecutableDiscoveryError(outcome.detail);
+      throw new AgentRuntimeExecutableNotFoundError(`The ${provider} Agent Runtime CLI is not installed`);
+    }
+    return { provider, path: outcome.path, source: "explicit" };
+  }
+
+  const platform = options.platform ?? process.platform;
+  const home = options.home ?? environment.HOME ?? homedir();
+  const pathDelimiter = options.pathDelimiter ?? delimiter;
+  const wellKnownDirs = options.wellKnownDirs ?? wellKnownAgentRuntimeBinDirs;
+  const desktopAppDirs = options.desktopAppDirs ?? codexDesktopAppBinDirs;
+  const candidateAllowed = options.candidateAllowed ?? automaticCandidateAllowed;
+  const extensions = platform === "win32" ? (environment.PATHEXT ?? ".EXE;.CMD;.BAT").split(";") : [""];
+  const seen = new Set<string>();
+  let firstUnknown: string | undefined;
+
+  for (const candidate of executableCandidates({
+    command,
+    desktopAppDirs: provider === "codex" ? desktopAppDirs(home, platform) : [],
+    extensions,
+    pathDirs: (environment.PATH ?? "").split(pathDelimiter).filter(Boolean),
+    wellKnownDirs: wellKnownDirs(home, platform),
+  })) {
+    if (seen.has(candidate.path)) continue;
+    seen.add(candidate.path);
+    try {
+      if (!candidateAllowed(candidate.path, { platform, home })) continue;
+    } catch {
+      firstUnknown ??= "An automatic Runtime candidate could not be inspected safely";
+      continue;
+    }
+    const outcome = await inspectExecutableCandidate(candidate.path, dependencies);
+    if (outcome.status === "installed") {
+      return { provider, path: outcome.path, source: candidate.source };
+    }
+    if (outcome.status === "unknown") firstUnknown ??= outcome.detail;
+  }
+  if (firstUnknown) throw new AgentRuntimeExecutableDiscoveryError(firstUnknown);
+  throw new AgentRuntimeExecutableNotFoundError(`The ${provider} Agent Runtime CLI is not installed`);
+}
+
+export async function probeAgentRuntimeCliInstallations(
+  options: ProbeAgentRuntimeCliInstallationsOptions = {},
+): Promise<AgentRuntimeCliInstallation[]> {
+  const environment = options.environment ?? process.env;
+  return Promise.all(
+    PROVIDERS.map(async ({ provider, displayName, command }): Promise<AgentRuntimeCliInstallation> => {
+      try {
+        const resolved = await resolveAgentRuntimeExecutable(
+          provider,
+          options.commands?.[provider] ?? command,
+          environment,
+          options,
+        );
+        return { provider, displayName, status: "installed", path: resolved.path, source: resolved.source };
+      } catch (error) {
+        if (error instanceof AgentRuntimeExecutableNotFoundError) {
+          return { provider, displayName, status: "not-installed" };
+        }
+        return {
+          provider,
+          displayName,
+          status: "unknown",
+          detail: safeErrorDetail(error, "Runtime installation could not be determined"),
+        };
+      }
+    }),
+  );
+}
+
+async function inspectExecutableCandidate(
+  candidate: string,
+  dependencies: Pick<Required<ResolveAgentRuntimeExecutableOptions>, "access" | "realpath" | "stat">,
+): Promise<{ status: "installed"; path: string } | { status: "absent" } | { status: "unknown"; detail: string }> {
+  try {
+    const status = await dependencies.stat(candidate);
+    if (!status.isFile()) return { status: "absent" };
+  } catch (error) {
+    return missingOrUnknown(error);
+  }
+  try {
+    await dependencies.access(candidate, constants.X_OK);
+  } catch (error) {
+    if (isMissing(error) || (error as NodeJS.ErrnoException | undefined)?.code === "EACCES") {
+      return { status: "absent" };
+    }
+    return { status: "unknown", detail: "A Runtime candidate's executable permission could not be inspected" };
+  }
+  try {
+    return { status: "installed", path: await dependencies.realpath(candidate) };
+  } catch (error) {
+    return missingOrUnknown(error);
+  }
+}
+
+function missingOrUnknown(error: unknown): { status: "absent" } | { status: "unknown"; detail: string } {
+  if (isMissing(error)) return { status: "absent" };
+  return { status: "unknown", detail: "A Runtime candidate could not be inspected safely" };
+}
+
+function isMissing(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function safeErrorDetail(error: unknown, fallback: string): string {
+  if (!(error instanceof Error) || error.message.length === 0) return fallback;
+  return error.message.slice(0, 300);
+}
+
+function* executableCandidates(options: {
+  command: string;
+  extensions: readonly string[];
+  pathDirs: readonly string[];
+  wellKnownDirs: readonly string[];
+  desktopAppDirs: readonly string[];
+}): Generator<Candidate> {
+  for (const [source, directories] of [
+    ["caller-path", options.pathDirs],
+    ["well-known", options.wellKnownDirs],
+    ["desktop-app", options.desktopAppDirs],
+  ] as const) {
+    for (const directory of directories) {
+      if (!isAbsolute(directory)) continue;
+      for (const extension of options.extensions) {
+        yield { path: join(directory, `${options.command}${extension}`), source };
+      }
+    }
+  }
+}

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -37,6 +37,7 @@ import {
 import { codexRuntimePolicy, validateCodexRuntimePolicy } from "../providers/codex/runtime-policy.js";
 import { RuntimeStorageError } from "../storage/durable-file.js";
 import { AdmissionController } from "./admission-controller.js";
+import { resolveAgentRuntimeExecutable } from "./agent-runtime-installation.js";
 import {
   type AgentRuntimeProviderRegistration,
   AgentRuntimeProviderRegistry,
@@ -622,7 +623,7 @@ export function resolvedCodexFactory(options: ResolvedCodexFactoryOptions): Agen
       let command: string;
       try {
         request.signal?.throwIfAborted();
-        command = await resolveExecutable(options.command, options.sourceEnvironment);
+        command = (await resolveAgentRuntimeExecutable("codex", options.command, options.sourceEnvironment)).path;
       } catch (error) {
         if (request.signal?.aborted) throw error;
         return { ready: false, issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }] };
@@ -664,7 +665,7 @@ export function resolvedClaudeCodeFactory(options: ResolvedClaudeCodeFactoryOpti
       let command: string;
       try {
         request.signal?.throwIfAborted();
-        command = await resolveExecutable(options.command, options.sourceEnvironment);
+        command = (await resolveAgentRuntimeExecutable("claude-code", options.command, options.sourceEnvironment)).path;
       } catch (error) {
         if (request.signal?.aborted) throw error;
         return {

--- a/packages/client/src/runtime/local-computer-configuration.ts
+++ b/packages/client/src/runtime/local-computer-configuration.ts
@@ -1,0 +1,143 @@
+import { normalizeServerUrl } from "../api.js";
+import { readMachineCredentialsStrict, type StoredMachineCredentials } from "../auth/machine-credentials.js";
+import { type ComputerIdentity, readComputerIdentity } from "./computer-identity.js";
+
+export type LocalConfigurationStatus = "valid" | "missing" | "invalid";
+
+export interface LocalComputerConfigurationInspection {
+  identity: {
+    status: LocalConfigurationStatus;
+    value?: ComputerIdentity;
+    detail?: string;
+  };
+  enrollments: {
+    status: LocalConfigurationStatus;
+    value?: StoredMachineCredentials;
+    detail?: string;
+  };
+  binding: {
+    status: LocalConfigurationStatus;
+    enrollmentCount: number;
+    serverUrl?: string;
+    detail?: string;
+  };
+}
+
+/** Strict, read-only inspection of the Computer identity and every stored enrollment. */
+export async function inspectLocalComputerConfiguration(home: string): Promise<LocalComputerConfigurationInspection> {
+  const [identityResult, credentialsResult] = await Promise.allSettled([
+    readComputerIdentity(home),
+    readMachineCredentialsStrict(home),
+  ]);
+
+  const identity = inspectIdentity(identityResult);
+  const enrollments = inspectEnrollments(credentialsResult);
+  if (identity.status !== "valid" || enrollments.status !== "valid") {
+    return {
+      identity,
+      enrollments,
+      binding: {
+        status: "invalid",
+        enrollmentCount: enrollments.value?.enrollments.length ?? 0,
+        detail: "A valid identity and enrollment set are required before their binding can be verified",
+      },
+    };
+  }
+
+  const identityValue = identity.value;
+  const credentialsValue = enrollments.value;
+  if (!identityValue || !credentialsValue) {
+    return {
+      identity,
+      enrollments,
+      binding: { status: "invalid", enrollmentCount: 0, detail: "Validated local configuration is incomplete" },
+    };
+  }
+
+  const stored = credentialsValue.enrollments;
+  const servers = new Set(stored.map((entry) => entry.serverUrl));
+  const computers = new Set(stored.map((entry) => entry.computerId));
+  if (servers.size !== 1) {
+    return {
+      identity,
+      enrollments,
+      binding: {
+        status: "invalid",
+        enrollmentCount: stored.length,
+        detail: "Stored enrollments refer to more than one Server origin",
+      },
+    };
+  }
+  if (computers.size !== 1 || !computers.has(identityValue.computerId)) {
+    return {
+      identity,
+      enrollments,
+      binding: {
+        status: "invalid",
+        enrollmentCount: stored.length,
+        detail: "Stored enrollments do not belong to the local Computer identity",
+      },
+    };
+  }
+  const [serverUrl] = servers;
+  if (!serverUrl || identityValue.serverUrl !== serverUrl) {
+    return {
+      identity,
+      enrollments,
+      binding: {
+        status: "invalid",
+        enrollmentCount: stored.length,
+        detail: "The Computer identity and stored enrollments refer to different Server origins",
+      },
+    };
+  }
+
+  return {
+    identity,
+    enrollments,
+    binding: { status: "valid", enrollmentCount: stored.length, serverUrl },
+  };
+}
+
+function inspectIdentity(
+  result: PromiseSettledResult<ComputerIdentity | undefined>,
+): LocalComputerConfigurationInspection["identity"] {
+  if (result.status === "rejected") {
+    return { status: "invalid", detail: safeErrorDetail(result.reason, "Computer identity could not be read") };
+  }
+  if (!result.value) return { status: "missing", detail: "Computer identity is not configured" };
+  try {
+    if (normalizeServerUrl(result.value.serverUrl) !== result.value.serverUrl) {
+      return { status: "invalid", detail: "Computer identity contains a non-canonical Server origin" };
+    }
+  } catch {
+    return { status: "invalid", detail: "Computer identity contains an invalid Server origin" };
+  }
+  return { status: "valid", value: result.value };
+}
+
+function inspectEnrollments(
+  result: PromiseSettledResult<StoredMachineCredentials | undefined>,
+): LocalComputerConfigurationInspection["enrollments"] {
+  if (result.status === "rejected") {
+    return { status: "invalid", detail: safeErrorDetail(result.reason, "Computer enrollments could not be read") };
+  }
+  if (!result.value || result.value.enrollments.length === 0) {
+    return { status: "missing", detail: "No Computer enrollments are configured" };
+  }
+  for (const entry of result.value.enrollments) {
+    try {
+      if (normalizeServerUrl(entry.serverUrl) !== entry.serverUrl) {
+        return { status: "invalid", detail: "A stored enrollment contains a non-canonical Server origin" };
+      }
+    } catch {
+      return { status: "invalid", detail: "A stored enrollment contains an invalid Server origin" };
+    }
+  }
+  return { status: "valid", value: result.value };
+}
+
+function safeErrorDetail(error: unknown, fallback: string): string {
+  if (!(error instanceof Error) || error.message.length === 0) return fallback;
+  return error.message.slice(0, 300);
+}

--- a/packages/client/src/runtime/protected-paths.ts
+++ b/packages/client/src/runtime/protected-paths.ts
@@ -1,0 +1,77 @@
+import { readlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve, sep } from "node:path";
+
+const MACOS_PROTECTED_HOME_SUBPATHS = [
+  "Desktop",
+  "Documents",
+  "Downloads",
+  "Library/Mobile Documents",
+  "Library/CloudStorage",
+] as const;
+
+export type ReadLink = (path: string) => string;
+
+const MAX_SYMLINK_HOPS = 32;
+
+export function protectedRoots(
+  platform: NodeJS.Platform = process.platform,
+  home = process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir(),
+): string[] {
+  if (platform !== "darwin") return [];
+  return MACOS_PROTECTED_HOME_SUBPATHS.map((subpath) => join(home, subpath));
+}
+
+function fold(value: string): string {
+  return value.toLocaleLowerCase("en-US");
+}
+
+function insideAny(path: string, roots: readonly string[]): boolean {
+  const candidate = fold(path);
+  return roots.some((root) => {
+    const protectedRoot = fold(root);
+    return candidate === protectedRoot || candidate.startsWith(`${protectedRoot}${sep}`);
+  });
+}
+
+/** Resolve symlink hops without entering a macOS TCC-protected directory. */
+export function resolveOutsideProtectedRoots(
+  path: string,
+  roots: readonly string[],
+  readLink: ReadLink = readlinkSync,
+): string | null {
+  let pending = resolve(path).split(sep).filter(Boolean);
+  let resolved: string = sep;
+  let hops = 0;
+  while (pending.length > 0) {
+    const [head = "", ...rest] = pending;
+    const candidate = join(resolved, head);
+    if (insideAny(candidate, roots)) return null;
+    let target: string | null = null;
+    try {
+      target = readLink(candidate);
+    } catch {
+      // A non-link, missing, or unreadable component is handled by the later bounded file checks.
+    }
+    if (target === null) {
+      resolved = candidate;
+      pending = rest;
+      continue;
+    }
+    hops += 1;
+    if (hops > MAX_SYMLINK_HOPS) return null;
+    const expanded = isAbsolute(target) ? target : join(resolved, target);
+    pending = [...resolve(expanded).split(sep).filter(Boolean), ...rest];
+    resolved = sep;
+  }
+  return resolved;
+}
+
+export function automaticCandidateAllowed(
+  candidate: string,
+  options: { platform?: NodeJS.Platform; home?: string; readLink?: ReadLink } = {},
+): boolean {
+  const roots = protectedRoots(options.platform, options.home);
+  if (roots.length === 0) return true;
+  return resolveOutsideProtectedRoots(candidate, roots, options.readLink) !== null;
+}

--- a/scripts/cli-pack-smoke.mjs
+++ b/scripts/cli-pack-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -172,9 +172,46 @@ export async function runCliPackSmoke({ channel, expectedName, expectedVersion, 
     if (!computerConnectHelp.stdout.includes("--no-start")) {
       throw new Error("CLI Computer connect help is missing --no-start");
     }
-    const doctor = run(binaryPath, ["doctor", "--server-url", "http://127.0.0.1:1"], { expectedStatus: 1 });
-    if (!doctor.stderr.includes("Network error:")) {
-      throw new Error("CLI doctor smoke did not report the expected network failure");
+    const doctorHome = join(temporaryRoot, "doctor-home");
+    await mkdir(doctorHome, { mode: 0o700 });
+    const doctor = run(binaryPath, ["doctor"], {
+      env: {
+        OPENTAG_HOME: doctorHome,
+        OPENTAG_SERVER_URL: "http://127.0.0.1:1",
+      },
+      expectedStatus: 1,
+    });
+    for (const expectedOutput of [
+      "OpenTag Doctor",
+      "OpenTag Home:",
+      "(environment)",
+      "Local configuration",
+      "not checked because there is no authoritative enrolled Server",
+      "Not evaluated",
+    ]) {
+      if (!doctor.stdout.includes(expectedOutput)) {
+        throw new Error(`CLI doctor smoke is missing expected output: ${expectedOutput}`);
+      }
+    }
+    if (doctor.stdout.includes("127.0.0.1:1")) {
+      throw new Error("CLI doctor smoke used OPENTAG_SERVER_URL instead of the enrolled Server");
+    }
+    if (doctor.stderr !== "") {
+      throw new Error(`CLI doctor diagnostics must be written to stdout, got stderr:\n${doctor.stderr}`);
+    }
+    if ((await readdir(doctorHome)).length !== 0) {
+      throw new Error("CLI doctor smoke mutated its OpenTag Home");
+    }
+
+    const removedDoctorOption = run(binaryPath, ["doctor", "--server-url", "http://127.0.0.1:1"], {
+      env: { OPENTAG_HOME: doctorHome },
+      expectedStatus: 1,
+    });
+    if (
+      !removedDoctorOption.stderr.includes("unknown option") ||
+      !removedDoctorOption.stderr.includes("--server-url")
+    ) {
+      throw new Error("CLI doctor smoke accepted the removed --server-url option");
     }
 
     const installedManifest = JSON.parse(

--- a/scripts/e2e/doctor-docker.mjs
+++ b/scripts/e2e/doctor-docker.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+const suffix = `${process.pid}-${randomBytes(3).toString("hex")}`;
+const prefix = `opentag-doctor-e2e-${suffix}`;
+const network = `${prefix}-network`;
+const systemdImage = `${prefix}-systemd`;
+const minimalImage = `${prefix}-minimal`;
+const serverImage = `${prefix}-server`;
+const runner = `${prefix}-runner`;
+const containers = [];
+const keep = process.argv.includes("--keep");
+
+function run(arguments_, options = {}) {
+  const result = spawnSync("docker", arguments_, {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+    stdio: options.inherit ? "inherit" : "pipe",
+  });
+  if (result.error) throw result.error;
+  if (!options.allowFailure && result.status !== (options.expectedStatus ?? 0)) {
+    throw new Error(
+      `docker ${arguments_.join(" ")} exited with ${result.status}\nstdout:\n${result.stdout ?? ""}\nstderr:\n${result.stderr ?? ""}`,
+    );
+  }
+  return result;
+}
+
+function start(name, arguments_) {
+  run(["run", "--detach", "--name", name, ...arguments_]);
+  containers.push(name);
+}
+
+function waitForContainerHealth(name, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const state = run([
+      "inspect",
+      "--format",
+      "{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}",
+      name,
+    ]).stdout.trim();
+    if (state === "healthy" || state === "running") return;
+    if (state === "unhealthy" || state === "exited" || state === "dead") {
+      throw new Error(`${name} entered ${state}`);
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+  }
+  throw new Error(`timed out waiting for ${name}`);
+}
+
+function waitForUserManager(timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = run(
+      [
+        "exec",
+        "--user",
+        "node",
+        "--env",
+        "XDG_RUNTIME_DIR=/run/user/1000",
+        "--env",
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus",
+        runner,
+        "/usr/bin/systemctl",
+        "--user",
+        "show-environment",
+      ],
+      { allowFailure: true },
+    );
+    if (last.status === 0) return;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+  }
+  throw new Error(`systemd user manager did not become ready: ${last?.stderr ?? "no result"}`);
+}
+
+function waitForSystemManager(timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = run(["exec", runner, "/usr/bin/systemctl", "is-system-running"], { allowFailure: true });
+    if (["running", "degraded"].includes(last.stdout.trim())) return;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+  }
+  throw new Error(
+    `systemd system manager did not become ready: ${last?.stdout.trim() || last?.stderr.trim() || "no result"}`,
+  );
+}
+
+function dumpLogs() {
+  for (const name of containers) {
+    const result = run(["logs", "--tail", "200", name], { allowFailure: true });
+    process.stderr.write(`\n--- ${name} logs ---\n${result.stdout}${result.stderr}`);
+  }
+}
+
+function cleanup() {
+  if (keep) {
+    process.stdout.write(`Preserved Docker resources with prefix ${prefix}\n`);
+    return;
+  }
+  for (const name of [...containers].reverse()) run(["rm", "--force", name], { allowFailure: true });
+  run(["network", "rm", network], { allowFailure: true });
+  for (const image of [systemdImage, minimalImage, serverImage]) {
+    run(["image", "rm", "--force", image], { allowFailure: true });
+  }
+}
+
+async function main() {
+  run(["version"]);
+  process.stdout.write("Building Docker doctor QA images...\n");
+  run(
+    [
+      "build",
+      "--target",
+      "systemd-runner",
+      "--tag",
+      systemdImage,
+      "--file",
+      "scripts/e2e/doctor-docker/Dockerfile",
+      ".",
+    ],
+    { inherit: true },
+  );
+  run([
+    "build",
+    "--target",
+    "minimal-runner",
+    "--tag",
+    minimalImage,
+    "--file",
+    "scripts/e2e/doctor-docker/Dockerfile",
+    ".",
+  ]);
+  run(["build", "--tag", serverImage, "."]);
+  run(["network", "create", network]);
+
+  const postgres = `${prefix}-postgres`;
+  start(postgres, [
+    "--network",
+    network,
+    "--network-alias",
+    "postgres",
+    "--env",
+    "POSTGRES_DB=opentag",
+    "--env",
+    "POSTGRES_USER=opentag",
+    "--env",
+    "POSTGRES_PASSWORD=opentag",
+    "--health-cmd",
+    "pg_isready -U opentag -d opentag",
+    "--health-interval",
+    "1s",
+    "--health-timeout",
+    "5s",
+    "--health-retries",
+    "30",
+    "postgres:17",
+  ]);
+  waitForContainerHealth(postgres);
+
+  start(runner, [
+    "--privileged",
+    "--cgroupns=host",
+    "--volume",
+    "/sys/fs/cgroup:/sys/fs/cgroup:rw",
+    "--tmpfs",
+    "/run",
+    "--tmpfs",
+    "/run/lock",
+    "--network",
+    network,
+    systemdImage,
+  ]);
+  waitForContainerHealth(runner);
+  waitForSystemManager();
+  run(["exec", runner, "/usr/bin/mkdir", "-p", "/var/lib/systemd/linger"]);
+  run(["exec", runner, "/usr/bin/touch", "/var/lib/systemd/linger/node"]);
+  run(["exec", runner, "/usr/bin/systemctl", "start", "user@1000.service"]);
+  waitForUserManager();
+
+  const realServer = `${prefix}-real-server`;
+  start(realServer, [
+    "--network",
+    `container:${runner}`,
+    "--env",
+    "OPENTAG_HOST=0.0.0.0",
+    "--env",
+    "OPENTAG_PORT=8000",
+    "--env",
+    "OPENTAG_SERVER_URL=http://127.0.0.1:8000",
+    "--env",
+    "OPENTAG_PUBLIC_URL=http://127.0.0.1:8000",
+    "--env",
+    "OPENTAG_ENV=dev",
+    "--env",
+    "OPENTAG_DATABASE_URL=postgresql://opentag:opentag@postgres:5432/opentag",
+    "--env",
+    "OPENTAG_JWT_SECRET=doctor-e2e-jwt-secret-with-32-characters",
+    "--env",
+    "BETTER_AUTH_SECRET=doctor-e2e-auth-secret-that-is-different",
+    "--env",
+    "OPENTAG_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    "--env",
+    "OPENTAG_AUTO_MIGRATE=true",
+    serverImage,
+  ]);
+
+  for (const [label, mode, port] of [
+    ["health-ok", "healthy", "18080"],
+    ["sentinel-a", "healthy", "18081"],
+    ["sentinel-b", "healthy", "18082"],
+    ["http-503", "http-503", "18083"],
+    ["invalid-schema", "invalid-schema", "18084"],
+    ["health-hang", "hang", "18085"],
+    ["baseline", "baseline", "18086"],
+  ]) {
+    const name = `${prefix}-doctor-${label}`;
+    start(name, [
+      "--network",
+      `container:${runner}`,
+      systemdImage,
+      "node",
+      "/opt/doctor-e2e/fault-server.mjs",
+      mode,
+      port,
+    ]);
+  }
+
+  process.stdout.write("Running Docker doctor fault scenarios...\n");
+  run(["run", "--rm", "--network", `container:${runner}`, minimalImage, "minimal"], { inherit: true });
+  run(
+    [
+      "exec",
+      "--user",
+      "node",
+      "--env",
+      "HOME=/home/node",
+      "--env",
+      "XDG_RUNTIME_DIR=/run/user/1000",
+      "--env",
+      "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus",
+      runner,
+      nodePath(),
+      "/opt/doctor-e2e/scenario-runner.mjs",
+      "core",
+    ],
+    { inherit: true },
+  );
+}
+
+function nodePath() {
+  return "/usr/local/bin/node";
+}
+
+let failed = false;
+try {
+  await main();
+} catch (error) {
+  failed = true;
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  try {
+    dumpLogs();
+  } catch (logError) {
+    process.stderr.write(`Could not collect Docker logs: ${logError}\n`);
+  }
+} finally {
+  try {
+    cleanup();
+  } catch (cleanupError) {
+    failed = true;
+    process.stderr.write(`Docker cleanup failed: ${cleanupError}\n`);
+  }
+}
+
+if (failed) process.exitCode = 1;

--- a/scripts/e2e/doctor-docker/Dockerfile
+++ b/scripts/e2e/doctor-docker/Dockerfile
@@ -1,0 +1,52 @@
+FROM node:24-bookworm AS build
+
+WORKDIR /src
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/cli/package.json apps/cli/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY packages/client/package.json packages/client/package.json
+COPY packages/server/package.json packages/server/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN pnpm install --frozen-lockfile --config.engine-strict=true
+
+COPY tsconfig.json ./
+COPY apps/cli apps/cli
+COPY packages/client packages/client
+COPY packages/shared packages/shared
+RUN pnpm --filter @opentag/shared build \
+  && pnpm --filter @opentag/client build \
+  && pnpm --filter open-tag build
+
+FROM node:24-bookworm AS systemd-runner
+
+ENV container=docker
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends dbus dbus-user-session systemd systemd-sysv \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/apps/cli/dist /opt/opentag/apps/cli/dist
+COPY scripts/e2e/doctor-docker/fault-server.mjs /opt/doctor-e2e/fault-server.mjs
+COPY scripts/e2e/doctor-docker/scenario-runner.mjs /opt/doctor-e2e/scenario-runner.mjs
+
+RUN chmod 0755 /opt/opentag/apps/cli/dist/cli/index.mjs \
+  && ln -s /opt/opentag/apps/cli/dist/cli/index.mjs /usr/local/bin/opentag-dev \
+  && mkdir -p /home/node/doctor-e2e \
+  && chown -R node:node /home/node/doctor-e2e
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]
+
+FROM node:24-alpine AS minimal-runner
+
+COPY --from=build /src/apps/cli/dist /opt/opentag/apps/cli/dist
+COPY scripts/e2e/doctor-docker/scenario-runner.mjs /opt/doctor-e2e/scenario-runner.mjs
+
+RUN chmod 0755 /opt/opentag/apps/cli/dist/cli/index.mjs \
+  && ln -s /opt/opentag/apps/cli/dist/cli/index.mjs /usr/local/bin/opentag-dev
+
+ENTRYPOINT ["node", "/opt/doctor-e2e/scenario-runner.mjs"]

--- a/scripts/e2e/doctor-docker/README.md
+++ b/scripts/e2e/doctor-docker/README.md
@@ -1,0 +1,38 @@
+# Docker doctor fault suite
+
+This local-only black-box suite runs the built `opentag doctor` CLI across real
+container process, filesystem, TCP, HTTP, PostgreSQL, OpenTag Server, and Linux
+systemd boundaries.
+
+Run it from the repository root:
+
+```sh
+pnpm test:e2e:doctor-docker
+```
+
+The suite builds two CLI runners and the production OpenTag Server image. It
+then creates an isolated Docker network containing:
+
+- an Alpine runner with no supported service manager;
+- a privileged Debian runner booted with systemd as PID 1 and a real user
+  manager for the unprivileged `node` account;
+- a real PostgreSQL-backed OpenTag Server;
+- independent fault-server containers for healthy, HTTP 503, invalid schema,
+  hanging response, zero-request sentinel, and daemon connection scenarios.
+
+The scenarios execute the built CLI entrypoint and assert the command's process
+exit status, stdout/stderr contract, filesystem immutability, network request
+counts, response redaction, wall-clock deadline, Runtime artifact rules, and
+systemd service state. The systemd scenarios perform a real `daemon install`,
+reach a fully passing P0 baseline, and then inject wrong-Home, drifted,
+malformed, and stopped-service failures.
+
+The systemd runner requires Docker's `--privileged` mode and a writable cgroup
+mount. All created containers, networks, and tagged images are removed after
+the run. Pass `--keep` directly to `scripts/e2e/doctor-docker.mjs` to preserve
+them for debugging.
+
+This suite proves the Linux behavior inside Docker Desktop's Linux VM. It does
+not replace release QA on a separately installed physical or virtual Linux
+host, and it does not cover deferred Runtime authentication, Integration CLI,
+machine-token/WebSocket registration, or end-to-end Turn delivery.

--- a/scripts/e2e/doctor-docker/fault-server.mjs
+++ b/scripts/e2e/doctor-docker/fault-server.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { createServer } from "node:http";
+
+const mode = process.argv[2];
+const port = Number.parseInt(process.argv[3] ?? "8080", 10);
+const secretBody = "doctor-e2e-response-secret";
+
+if (!mode || !Number.isInteger(port)) {
+  throw new Error("usage: fault-server.mjs <healthy|baseline|http-503|invalid-schema|hang> [port]");
+}
+
+let requestCount = 0;
+const sockets = new Set();
+const server = createServer((request, response) => {
+  if (request.url === "/__count") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ count: requestCount }));
+    return;
+  }
+
+  requestCount += 1;
+  if (request.url !== "/healthz") {
+    response.writeHead(404);
+    response.end("not found");
+    return;
+  }
+  if (mode === "hang") return;
+  if (mode === "http-503") {
+    response.writeHead(503, { "content-type": "text/plain" });
+    response.end(secretBody);
+    return;
+  }
+  if (mode === "invalid-schema") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ status: "ok", service: secretBody }));
+    return;
+  }
+  if (mode === "healthy" || mode === "baseline") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ status: "ok", service: "opentag-server" }));
+    return;
+  }
+  response.writeHead(500);
+  response.end("unknown fault mode");
+});
+
+server.on("connection", (socket) => {
+  sockets.add(socket);
+  socket.on("close", () => sockets.delete(socket));
+});
+
+server.on("upgrade", (_request, socket) => {
+  requestCount += 1;
+  if (mode !== "baseline") socket.destroy();
+  // Baseline mode intentionally leaves the real TCP connection open without completing
+  // the WebSocket handshake. The daemon remains alive, but doctor still checks only /healthz.
+});
+
+const stop = () => {
+  for (const socket of sockets) socket.destroy();
+  server.close(() => process.exit(0));
+};
+process.once("SIGINT", stop);
+process.once("SIGTERM", stop);
+
+server.listen(port, "0.0.0.0", () => {
+  process.stdout.write(`doctor fault server ${mode} listening on ${port}\n`);
+});

--- a/scripts/e2e/doctor-docker/scenario-runner.mjs
+++ b/scripts/e2e/doctor-docker/scenario-runner.mjs
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { access, chmod, lstat, mkdir, readdir, readFile, readlink, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+
+const suite = process.argv[2] ?? "core";
+const cli = "/opt/opentag/apps/cli/dist/cli/index.mjs";
+const node = process.execPath;
+const root = suite === "minimal" ? "/tmp/doctor-e2e" : "/home/node/doctor-e2e";
+const runtimeBin = join(root, "runtime-bin");
+const defaultPath = `${runtimeBin}:/usr/local/bin:/usr/bin:/bin`;
+const computerId = "11111111-1111-4111-8111-111111111111";
+const otherComputerId = "22222222-2222-4222-8222-222222222222";
+const responseSecret = "doctor-e2e-response-secret";
+const credentialSecret = "otmc_doctor-e2e-machine-token-secret";
+const results = [];
+
+function fail(message, result) {
+  const diagnostics = result ? `\nexit: ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}` : "";
+  throw new Error(`${message}${diagnostics}`);
+}
+
+function expect(condition, message, result) {
+  if (!condition) fail(message, result);
+}
+
+function expectIncludes(value, fragment, label, result) {
+  expect(value.includes(fragment), `${label} is missing ${JSON.stringify(fragment)}`, result);
+}
+
+function expectExcludes(value, fragment, label, result) {
+  expect(!value.includes(fragment), `${label} exposed ${JSON.stringify(fragment)}`, result);
+}
+
+async function record(name, operation) {
+  const startedAt = performance.now();
+  await operation();
+  const elapsedMs = Math.round(performance.now() - startedAt);
+  results.push({ elapsedMs, name, status: "PASS" });
+  process.stdout.write(`PASS ${name} (${elapsedMs}ms)\n`);
+}
+
+function doctorEnvironment(home, options = {}) {
+  return {
+    ...process.env,
+    HOME: process.env.HOME ?? "/home/node",
+    OPENTAG_HOME: home,
+    OPENTAG_SERVER_URL: "http://caller-controlled.invalid:65535",
+    PATH: options.path ?? defaultPath,
+  };
+}
+
+function runCli(home, arguments_, options = {}) {
+  const result = spawnSync(node, [cli, ...arguments_], {
+    encoding: "utf8",
+    env: doctorEnvironment(home, options),
+    timeout: options.timeoutMs ?? 25_000,
+  });
+  if (result.error) fail(`CLI process failed: ${result.error.message}`);
+  return result;
+}
+
+function runDoctor(home, options = {}) {
+  const result = runCli(home, ["doctor"], options);
+  expect(result.signal === null, "doctor was terminated by a signal", result);
+  expect(result.stderr === "", "doctor diagnostics were not stdout-only", result);
+  expectIncludes(result.stdout, "OpenTag Doctor", "doctor report", result);
+  expectIncludes(result.stdout, "Not evaluated", "doctor report", result);
+  expectExcludes(result.stdout, credentialSecret, "doctor report", result);
+  expectExcludes(result.stdout, "caller-controlled.invalid", "doctor report", result);
+  return result;
+}
+
+async function resetRoot() {
+  await rm(root, { force: true, recursive: true });
+  await mkdir(root, { mode: 0o700, recursive: true });
+}
+
+async function createHome(name) {
+  const home = join(root, name);
+  await mkdir(home, { mode: 0o700, recursive: true });
+  return home;
+}
+
+async function writePrivateJson(path, value) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+function enrollment({
+  computer = computerId,
+  serverUrl,
+  workspaceComputerId = "33333333-3333-4333-8333-333333333333",
+}) {
+  return {
+    workspaceComputerId,
+    computerId: computer,
+    machineToken: credentialSecret,
+    serverUrl,
+  };
+}
+
+async function writeValidHome(name, serverUrl, enrollments = [enrollment({ serverUrl })]) {
+  const home = await createHome(name);
+  const config = join(home, "config");
+  await mkdir(config, { mode: 0o700 });
+  await writePrivateJson(join(config, "computer.json"), { version: 2, computerId, serverUrl });
+  await writePrivateJson(join(config, "computer-credentials.json"), { version: 1, enrollments });
+  return home;
+}
+
+async function snapshot(path) {
+  const entries = [];
+  async function visit(current, relative) {
+    const metadata = await lstat(current);
+    if (metadata.isSymbolicLink()) {
+      entries.push({ kind: "symlink", mode: metadata.mode & 0o777, path: relative, target: await readlink(current) });
+      return;
+    }
+    if (metadata.isDirectory()) {
+      entries.push({ kind: "directory", mode: metadata.mode & 0o777, path: relative });
+      for (const child of (await readdir(current)).sort()) await visit(join(current, child), join(relative, child));
+      return;
+    }
+    const content = await readFile(current);
+    entries.push({
+      hash: createHash("sha256").update(content).digest("hex"),
+      kind: "file",
+      mode: metadata.mode & 0o777,
+      path: relative,
+      size: content.length,
+    });
+  }
+  await visit(path, ".");
+  return JSON.stringify(entries);
+}
+
+async function requestCount(port) {
+  const response = await fetch(`http://127.0.0.1:${port}/__count`);
+  expect(response.ok, `could not read request count from port ${port}`);
+  return (await response.json()).count;
+}
+
+async function waitForHttp(url, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`timed out waiting for ${url}: ${lastError instanceof Error ? lastError.message : lastError}`);
+}
+
+async function installRuntimeFixture(name) {
+  await mkdir(runtimeBin, { mode: 0o700, recursive: true });
+  const path = join(runtimeBin, name);
+  await writeFile(path, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  await chmod(path, 0o755);
+  return path;
+}
+
+async function runMinimalSuite() {
+  const home = await createHome("manager-missing");
+  await record("linux manager missing fails closed", async () => {
+    const result = runDoctor(home, { path: "/usr/local/bin:/usr/bin:/bin" });
+    expect(result.status === 1, "manager-missing doctor must exit 1", result);
+    expectIncludes(
+      result.stdout,
+      "systemctl service manager is unavailable at supported system locations",
+      "daemon result",
+      result,
+    );
+  });
+}
+
+async function runCoreSuite() {
+  await installRuntimeFixture("codex");
+  await waitForHttp("http://127.0.0.1:18080/healthz");
+  await waitForHttp("http://127.0.0.1:8000/healthz", 60_000);
+
+  await record("empty Home remains byte-for-byte untouched", async () => {
+    const home = await createHome("empty-home");
+    const before = await snapshot(home);
+    const result = runDoctor(home);
+    expect(result.status === 1, "empty Home doctor must exit 1", result);
+    expectIncludes(result.stdout, "Computer identity is not configured", "local result", result);
+    expectIncludes(
+      result.stdout,
+      "not checked because there is no authoritative enrolled Server",
+      "server result",
+      result,
+    );
+    expect((await snapshot(home)) === before, "doctor mutated the empty Home", result);
+  });
+
+  await record("malformed identity fails closed without content disclosure", async () => {
+    const home = await createHome("malformed-identity");
+    const config = join(home, "config");
+    await mkdir(config, { mode: 0o700 });
+    await writePrivateJson(join(config, "computer.json"), {
+      version: 2,
+      computerId,
+      serverUrl: "http://127.0.0.1:18080",
+      secret: responseSecret,
+    });
+    await writePrivateJson(join(config, "computer-credentials.json"), {
+      version: 1,
+      enrollments: [enrollment({ serverUrl: "http://127.0.0.1:18080" })],
+    });
+    const result = runDoctor(home);
+    expectIncludes(result.stdout, "identity file is invalid", "identity result", result);
+    expectExcludes(result.stdout, responseSecret, "identity result", result);
+  });
+
+  await record("one malformed enrollment invalidates the full credential set", async () => {
+    const serverUrl = "http://127.0.0.1:18080";
+    const before = await requestCount(18080);
+    const home = await writeValidHome("malformed-enrollment", serverUrl, [
+      enrollment({ serverUrl }),
+      { workspaceComputerId: "not-a-uuid", machineToken: responseSecret, computerId, serverUrl },
+    ]);
+    const result = runDoctor(home);
+    expectIncludes(result.stdout, "unusable OpenTag Computer credential", "enrollment result", result);
+    expectExcludes(result.stdout, responseSecret, "enrollment result", result);
+    expect((await requestCount(18080)) === before, "doctor contacted Server for malformed credentials");
+  });
+
+  await record("multiple enrolled Server origins receive zero requests", async () => {
+    const first = "http://127.0.0.1:18081";
+    const second = "http://127.0.0.1:18082";
+    const beforeA = await requestCount(18081);
+    const beforeB = await requestCount(18082);
+    const home = await writeValidHome("multiple-servers", first, [
+      enrollment({ serverUrl: first }),
+      enrollment({
+        serverUrl: second,
+        workspaceComputerId: "44444444-4444-4444-8444-444444444444",
+      }),
+    ]);
+    const result = runDoctor(home);
+    expectIncludes(result.stdout, "more than one Server origin", "binding result", result);
+    expect((await requestCount(18081)) === beforeA, "doctor contacted the first ambiguous Server");
+    expect((await requestCount(18082)) === beforeB, "doctor contacted the second ambiguous Server");
+  });
+
+  await record("Computer mismatch skips the enrolled Server", async () => {
+    const serverUrl = "http://127.0.0.1:18081";
+    const before = await requestCount(18081);
+    const home = await writeValidHome("computer-mismatch", serverUrl, [
+      enrollment({ computer: otherComputerId, serverUrl }),
+    ]);
+    const result = runDoctor(home);
+    expectIncludes(result.stdout, "do not belong to the local Computer identity", "binding result", result);
+    expect((await requestCount(18081)) === before, "doctor contacted Server after Computer mismatch");
+  });
+
+  await record("symlinked private config is rejected without target disclosure", async () => {
+    const home = await createHome("unsafe-symlink");
+    const outside = join(root, "outside-config");
+    await mkdir(outside, { mode: 0o700 });
+    await writePrivateJson(join(outside, "computer.json"), { secret: responseSecret });
+    await symlink(outside, join(home, "config"));
+    const result = runDoctor(home);
+    expect(result.status === 1, "unsafe symlink doctor must exit 1", result);
+    expectExcludes(result.stdout, responseSecret, "symlink result", result);
+    expectIncludes(
+      result.stdout,
+      "not checked because there is no authoritative enrolled Server",
+      "server result",
+      result,
+    );
+  });
+
+  await record("HTTP 503 is classified without response-body disclosure", async () => {
+    const home = await writeValidHome("http-503", "http://127.0.0.1:18083");
+    const result = runDoctor(home);
+    expectIncludes(result.stdout, "returned HTTP 503", "server result", result);
+    expectExcludes(result.stdout, responseSecret, "server result", result);
+  });
+
+  await record("invalid health schema is classified without body disclosure", async () => {
+    const home = await writeValidHome("invalid-schema", "http://127.0.0.1:18084");
+    const result = runDoctor(home);
+    expectIncludes(result.stdout, "returned an invalid health response", "server result", result);
+    expectExcludes(result.stdout, responseSecret, "server result", result);
+  });
+
+  await record("hanging health response reaches the real five-second deadline", async () => {
+    const home = await writeValidHome("health-timeout", "http://127.0.0.1:18085");
+    const startedAt = performance.now();
+    const result = runDoctor(home, { timeoutMs: 10_000 });
+    const elapsedMs = performance.now() - startedAt;
+    expectIncludes(result.stdout, "timed out while reaching", "server result", result);
+    expect(elapsedMs >= 4_750 && elapsedMs <= 7_000, `deadline elapsed in ${Math.round(elapsedMs)}ms`, result);
+  });
+
+  await record("connection refusal is classified as a network failure", async () => {
+    const home = await writeValidHome("network-refused", "http://127.0.0.1:9");
+    const result = runDoctor(home);
+    expectIncludes(result.stdout, "could not reach http://127.0.0.1:9", "server result", result);
+  });
+
+  await record("real OpenTag Server container passes the public health check", async () => {
+    const home = await writeValidHome("real-server", "http://127.0.0.1:8000");
+    const result = runDoctor(home);
+    expectIncludes(
+      result.stdout,
+      "Server health endpoint: reachable at http://127.0.0.1:8000",
+      "server result",
+      result,
+    );
+  });
+
+  await record("Runtime detection uses a real executable artifact", async () => {
+    const home = await createHome("runtime-executable");
+    const result = runDoctor(home);
+    expectIncludes(
+      result.stdout,
+      "Agent Runtime CLI: at least one supported Runtime is installed",
+      "runtime result",
+      result,
+    );
+    expectIncludes(
+      result.stdout,
+      `Codex CLI: installed at ${join(runtimeBin, "codex")} (caller-path)`,
+      "runtime result",
+      result,
+    );
+  });
+
+  await record("executable directory is not a Runtime artifact", async () => {
+    const path = join(root, "directory-runtime-bin");
+    await mkdir(join(path, "codex"), { mode: 0o755, recursive: true });
+    const home = await createHome("runtime-directory");
+    const result = runDoctor(home, { path: `${path}:/usr/local/bin:/usr/bin:/bin` });
+    expectIncludes(result.stdout, "Agent Runtime CLI: no supported Runtime is installed", "runtime result", result);
+    expectIncludes(result.stdout, "Codex CLI: not installed", "runtime result", result);
+  });
+
+  await record("broken Runtime symlink is not an installed artifact", async () => {
+    const path = join(root, "broken-runtime-bin");
+    await mkdir(path, { mode: 0o700 });
+    await symlink(join(path, "missing-target"), join(path, "codex"));
+    const home = await createHome("runtime-broken-link");
+    const result = runDoctor(home, { path: `${path}:/usr/local/bin:/usr/bin:/bin` });
+    expectIncludes(result.stdout, "Agent Runtime CLI: no supported Runtime is installed", "runtime result", result);
+  });
+
+  await record("caller PATH cannot shadow the governed systemctl", async () => {
+    const path = join(root, "shadow-bin");
+    const marker = join(root, "shadow-systemctl-invoked");
+    await mkdir(path, { mode: 0o700 });
+    await writeFile(join(path, "systemctl"), `#!/bin/sh\ntouch ${marker}\nexit 0\n`, { mode: 0o755 });
+    const home = await createHome("systemctl-shadow");
+    runDoctor(home, { path: `${path}:/usr/local/bin:/usr/bin:/bin` });
+    await expectMissing(marker, "PATH-shadowed systemctl was executed");
+  });
+
+  const baselineHome = await writeValidHome("systemd-baseline", "http://127.0.0.1:18086");
+  await record("real systemd user service produces a fully passing P0 baseline", async () => {
+    const install = runCli(baselineHome, ["daemon", "install"]);
+    expect(install.status === 0, "daemon install failed in the systemd container", install);
+    const result = await waitForDoctor(baselineHome, (candidate) => candidate.status === 0, 30_000);
+    expectIncludes(result.stdout, "Daemon service: active for this OpenTag Home", "daemon result", result);
+    expectIncludes(result.stdout, "Baseline checks passed for this OpenTag Home.", "summary", result);
+  });
+
+  await record("active service bound to another Home fails closed", async () => {
+    const otherHome = await writeValidHome("systemd-other-home", "http://127.0.0.1:18086");
+    const result = runDoctor(otherHome);
+    expectIncludes(result.stdout, "active for a different or unverifiable OpenTag Home", "daemon result", result);
+  });
+
+  const unitPath = join(process.env.HOME ?? "/home/node", ".config/systemd/user/opentag-dev.service");
+  const originalUnit = await readFile(unitPath, "utf8");
+  await record("drifted live systemd definition fails closed", async () => {
+    await writeFile(unitPath, `${originalUnit}\n# doctor-e2e-drift\n`, { mode: 0o644 });
+    const result = runDoctor(baselineHome);
+    expectIncludes(result.stdout, "service definition is drifted or unverifiable", "daemon result", result);
+    await writeFile(unitPath, originalUnit, { mode: 0o644 });
+  });
+
+  await record("malformed live systemd definition is unknown", async () => {
+    await writeFile(unitPath, originalUnit.replace(/^Environment="OPENTAG_HOME=.*"$/mu, ""), { mode: 0o644 });
+    const result = runDoctor(baselineHome);
+    expectIncludes(
+      result.stdout,
+      "installed systemd unit does not contain a valid OPENTAG_HOME",
+      "daemon result",
+      result,
+    );
+    await writeFile(unitPath, originalUnit, { mode: 0o644 });
+  });
+
+  await record("stopped real systemd service is reported inactive", async () => {
+    const stop = runCli(baselineHome, ["daemon", "stop"]);
+    expect(stop.status === 0, "daemon stop failed in the systemd container", stop);
+    const result = runDoctor(baselineHome);
+    expectIncludes(result.stdout, "Daemon service: inactive", "daemon result", result);
+  });
+}
+
+async function expectMissing(path, message) {
+  try {
+    await access(path);
+    throw new Error(message);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+async function waitForDoctor(home, predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = runDoctor(home);
+    if (predicate(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  fail(`doctor did not reach the expected state within ${timeoutMs}ms`, last);
+}
+
+async function main() {
+  await resetRoot();
+  if (suite === "minimal") await runMinimalSuite();
+  else if (suite === "core") await runCoreSuite();
+  else throw new Error(`unknown suite: ${suite}`);
+  process.stdout.write(`RESULT ${results.length}/${results.length} Docker doctor scenarios passed\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`FAIL ${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- define the P0 product and technical contract for `opentag doctor`
- diagnose the selected OpenTag Home with typed, fail-closed checks for local Computer configuration, daemon service, enrolled Server health, and Agent Runtime CLI installation artifacts
- remove the doctor-specific Server override: `--server-url` is now a usage error and `OPENTAG_SERVER_URL` is ignored
- keep Agent Runtime authentication, version/protocol compatibility, daemon-environment visibility, Integration CLI readiness, machine-token/WebSocket registration, and end-to-end Turn/handoff delivery explicitly out of P0

This supersedes #246 and replaces the broader contract from closed #235. The source of truth is `docs/design/doctor-product-spec.md`.

## P0 behavior

### Local configuration

- read `computer.json` and `computer-credentials.json` without creating or rewriting either file
- reject the entire credential set when any stored enrollment is malformed or duplicated; do not reuse the runtime reader's tolerant partial projection
- require every enrollment to match the local Computer ID and one canonical Server origin
- permit multiple Workspace Computer enrollments only when they refer to the same Computer and Server
- skip Server health rather than choosing an arbitrary origin when local authority is invalid

### Daemon service

- reuse the existing daemon service manager `status()` boundary
- pass only for an active, current, same-Home service with a consistent runtime owner
- resolve `launchctl`, `systemctl`, and `loginctl` only from reviewed absolute system locations, including the NixOS systemd path; caller `PATH` cannot shadow the service manager

### Server health

- derive the Server only from the verified local enrollment
- apply a five-second deadline across the request and response-body validation
- preserve separate configuration, timeout/network, HTTP, and invalid-response classifications without printing raw response bodies

### Agent Runtime CLIs

- share one install-only resolver between Client Runtime composition and doctor
- inspect Codex and Claude Code independently without spawning either provider
- require an ordinary executable file and reject directories, broken links, non-executable files, and unsafe automatic candidates
- search caller `PATH`, reviewed well-known directories, and macOS ChatGPT/Codex app resources while applying the protected-root policy before path-following reads
- report the canonical artifact path and its source; at least one supported Runtime is sufficient for the blocking aggregate

## Safety and output

- doctor remains read-only and prints the complete human report to stdout even when it exits 1
- fixed report order: Target, Local configuration, Daemon service, Server, Agent Runtime CLIs, Summary, Not evaluated
- summaries describe only the baseline checks and never claim OpenTag, handoff, authentication, or delivery readiness
- machine tokens and raw Server response bodies are never included in the report

## Validation on exact head

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
  - CLI: 152 tests
  - Client: 487 tests
  - Web: 344 tests
- `pnpm --filter @opentag/client test:agent-runtime:coverage`
  - 289 tests; 100% statements, branches, functions, and lines
- `pnpm --filter @opentag/server test:integration`
  - 230 tests
- `pnpm test:e2e:doctor-docker`
  - 21/21 Docker black-box scenarios passed: one minimal Linux scenario and 20 core scenarios
- `git diff --check`

The Docker suite builds and invokes the packaged CLI as an external process. It uses isolated containers for PostgreSQL, the production OpenTag Server image, a privileged Debian systemd PID 1 runner with a real user manager, and purpose-built HTTP/TCP fault endpoints. It creates real private files, symlinks, executable artifacts, service definitions, sockets, and deadlines instead of mocking the doctor modules.

Covered scenarios include:

1. Linux service manager unavailable fails closed
2. empty Home remains byte-for-byte untouched
3. malformed identity fails without content disclosure
4. one malformed enrollment invalidates the full credential set
5. multiple Server origins receive zero requests
6. Computer mismatch skips Server health
7. symlinked private config is rejected without target disclosure
8. HTTP 503, invalid health schema, five-second hang, and connection refusal are classified separately
9. a real PostgreSQL-backed OpenTag Server passes its public health check
10. executable, directory, and broken-symlink Runtime artifacts are distinguished
11. caller `PATH` cannot shadow the governed `systemctl`
12. a service installed through `opentag-dev daemon install` under a real systemd user manager produces a passing P0 baseline
13. wrong-Home, drifted, malformed, and stopped systemd services fail closed with the expected classifications

The Runtime-positive scenario uses a real executable filesystem artifact, not an installed Codex or Claude Code product. The fault endpoints are dedicated test servers; only the healthy production-image scenario uses the real OpenTag Server.

## Follow-ups and platform limits

- #239 remains an independent service-definition lookup follow-up and does not block this PR
- #236 remains the separate Claude Code runtime configuration correction
- #247 remains the deferred Agent Runtime authentication contract
- #248 remains the deferred Integration CLI contract
- Debian systemd user-service behavior is now exercised inside Docker Desktop's Linux VM; separately installed Linux distributions and NixOS still require release QA under #240

Closes #237.
Closes #244.
