### PR TITLE
feat(server): add account-owned Computer expansion

### DIFF
--- a/packages/server/drizzle/0026_wakeful_wildside.sql
+++ b/packages/server/drizzle/0026_wakeful_wildside.sql
@@ -1,0 +1,59 @@
+CREATE TYPE "public"."computer_connect_code_mode" AS ENUM('create', 'repair');--> statement-breakpoint
+CREATE TABLE "account_computers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_account_id" uuid NOT NULL,
+	"current_installation_id" uuid NOT NULL,
+	"display_name" text NOT NULL,
+	"platform" "computer_platform" NOT NULL,
+	"arch" text NOT NULL,
+	"client_version" text NOT NULL,
+	"current_instance_id" uuid,
+	"connected_at" timestamp with time zone,
+	"last_seen_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "computer_credentials" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"computer_id" uuid NOT NULL,
+	"secret_hash" text NOT NULL,
+	"issued_by_user_id" uuid NOT NULL,
+	"issued_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_by_user_id" uuid,
+	"revoked_at" timestamp with time zone,
+	CONSTRAINT "computer_credentials_secret_hash_unique" UNIQUE("secret_hash"),
+	CONSTRAINT "computer_credentials_revocation_pair" CHECK (("computer_credentials"."revoked_by_user_id" is null) = ("computer_credentials"."revoked_at" is null)),
+	CONSTRAINT "computer_credentials_revoked_after_issued" CHECK ("computer_credentials"."revoked_at" is null or "computer_credentials"."revoked_at" >= "computer_credentials"."issued_at")
+);
+--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "computer_id" uuid;--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD COLUMN "issued_by_account_id" uuid;--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD COLUMN "mode" "computer_connect_code_mode";--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD COLUMN "target_computer_id" uuid;--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD COLUMN "consumed_computer_id" uuid;--> statement-breakpoint
+ALTER TABLE "session_cli_proofs" ADD COLUMN "computer_id" uuid;--> statement-breakpoint
+ALTER TABLE "session_placements" ADD COLUMN "computer_id" uuid;--> statement-breakpoint
+ALTER TABLE "slack_installations" ADD COLUMN "agent_id" uuid;--> statement-breakpoint
+ALTER TABLE "account_computers" ADD CONSTRAINT "account_computers_owner_account_id_users_id_fk" FOREIGN KEY ("owner_account_id") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "account_computers" ADD CONSTRAINT "account_computers_current_installation_id_computers_id_fk" FOREIGN KEY ("current_installation_id") REFERENCES "public"."computers"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "computer_credentials" ADD CONSTRAINT "computer_credentials_computer_id_account_computers_id_fk" FOREIGN KEY ("computer_id") REFERENCES "public"."account_computers"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "computer_credentials" ADD CONSTRAINT "computer_credentials_issued_by_user_id_users_id_fk" FOREIGN KEY ("issued_by_user_id") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "computer_credentials" ADD CONSTRAINT "computer_credentials_revoked_by_user_id_users_id_fk" FOREIGN KEY ("revoked_by_user_id") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "account_computers_owner_account_id_idx" ON "account_computers" USING btree ("owner_account_id");--> statement-breakpoint
+CREATE INDEX "account_computers_current_installation_id_idx" ON "account_computers" USING btree ("current_installation_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "computer_credentials_active_computer_unique" ON "computer_credentials" USING btree ("computer_id") WHERE "computer_credentials"."revoked_at" is null;--> statement-breakpoint
+CREATE INDEX "computer_credentials_computer_issued_idx" ON "computer_credentials" USING btree ("computer_id","issued_at");--> statement-breakpoint
+ALTER TABLE "agents" ADD CONSTRAINT "agents_computer_id_account_computers_id_fk" FOREIGN KEY ("computer_id") REFERENCES "public"."account_computers"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD CONSTRAINT "computer_connect_codes_issued_by_account_id_users_id_fk" FOREIGN KEY ("issued_by_account_id") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD CONSTRAINT "computer_connect_codes_target_computer_id_account_computers_id_fk" FOREIGN KEY ("target_computer_id") REFERENCES "public"."account_computers"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD CONSTRAINT "computer_connect_codes_consumed_computer_id_account_computers_id_fk" FOREIGN KEY ("consumed_computer_id") REFERENCES "public"."account_computers"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session_cli_proofs" ADD CONSTRAINT "session_cli_proofs_computer_id_account_computers_id_fk" FOREIGN KEY ("computer_id") REFERENCES "public"."account_computers"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session_placements" ADD CONSTRAINT "session_placements_computer_id_account_computers_id_fk" FOREIGN KEY ("computer_id") REFERENCES "public"."account_computers"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "slack_installations" ADD CONSTRAINT "slack_installations_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "agents_computer_id_idx" ON "agents" USING btree ("computer_id");--> statement-breakpoint
+CREATE INDEX "computer_connect_codes_target_computer_id_idx" ON "computer_connect_codes" USING btree ("target_computer_id");--> statement-breakpoint
+CREATE INDEX "computer_connect_codes_consumed_computer_id_idx" ON "computer_connect_codes" USING btree ("consumed_computer_id");--> statement-breakpoint
+CREATE INDEX "session_cli_proofs_computer_id_idx" ON "session_cli_proofs" USING btree ("computer_id");--> statement-breakpoint
+CREATE INDEX "session_placements_computer_id_idx" ON "session_placements" USING btree ("computer_id");--> statement-breakpoint
+CREATE INDEX "slack_installations_agent_id_idx" ON "slack_installations" USING btree ("agent_id");

--- a/packages/server/drizzle/meta/0026_snapshot.json
+++ b/packages/server/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,4939 @@
+{
+  "id": "aee65499-5dbd-4025-b1be-0b47d7a1de69",
+  "prevId": "69a7bbb6-1281-4fe2-b89e-9febb8550c67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_runtime_configs": {
+      "name": "agent_runtime_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('runtime_config_revision_sequence')"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_duration_ms": {
+          "name": "max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_runtime_configs_agent_id_agents_id_fk": {
+          "name": "agent_runtime_configs_agent_id_agents_id_fk",
+          "tableFrom": "agent_runtime_configs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runtime_configs_revision_safe_positive": {
+          "name": "agent_runtime_configs_revision_safe_positive",
+          "value": "\"agent_runtime_configs\".\"revision\" > 0 and \"agent_runtime_configs\".\"revision\" <= 9007199254740991"
+        },
+        "agent_runtime_configs_max_duration_valid": {
+          "name": "agent_runtime_configs_max_duration_valid",
+          "value": "\"agent_runtime_configs\".\"max_duration_ms\" is null or (\"agent_runtime_configs\".\"max_duration_ms\" > 0 and \"agent_runtime_configs\".\"max_duration_ms\" <= 86400000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_intent_id": {
+          "name": "creation_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_intent_fingerprint": {
+          "name": "creation_intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "agent_runtime_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_mode": {
+          "name": "receive_mode",
+          "type": "agent_receive_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_message'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_workspace_name_active_unique": {
+          "name": "agents_workspace_name_active_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_creation_intent_unique": {
+          "name": "agents_creation_intent_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"creation_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_id_idx": {
+          "name": "agents_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_created_by_user_id_idx": {
+          "name": "agents_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_computer_id_idx": {
+          "name": "agents_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_computer_id_idx": {
+          "name": "agents_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_workspace_id_workspaces_id_fk": {
+          "name": "agents_workspace_id_workspaces_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_created_by_user_id_users_id_fk": {
+          "name": "agents_created_by_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_computer_id_account_computers_id_fk": {
+          "name": "agents_computer_id_account_computers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_workspace_enrollment_fk": {
+          "name": "agents_workspace_enrollment_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_creation_intent_pair": {
+          "name": "agents_creation_intent_pair",
+          "value": "(\"agents\".\"creation_intent_id\" is null) = (\"agents\".\"creation_intent_fingerprint\" is null)"
+        },
+        "agents_revision_positive": {
+          "name": "agents_revision_positive",
+          "value": "\"agents\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_cli_login_codes": {
+      "name": "account_cli_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_cli_login_codes_user_created_idx": {
+          "name": "account_cli_login_codes_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_cli_login_codes_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_cli_login_codes_issued_by_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_cli_login_codes_token_hash_unique": {
+          "name": "account_cli_login_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_cli_login_codes_expiry": {
+          "name": "account_cli_login_codes_expiry",
+          "value": "\"account_cli_login_codes\".\"expires_at\" > \"account_cli_login_codes\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_admin_grants": {
+      "name": "workspace_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_admin_grants_active_workspace_user_unique": {
+          "name": "workspace_admin_grants_active_workspace_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_active_user_workspace_idx": {
+          "name": "workspace_admin_grants_active_user_workspace_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_workspace_granted_idx": {
+          "name": "workspace_admin_grants_workspace_granted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_admin_grants_workspace_id_workspaces_id_fk": {
+          "name": "workspace_admin_grants_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_admin_grants_revocation_pair": {
+          "name": "workspace_admin_grants_revocation_pair",
+          "value": "(\"workspace_admin_grants\".\"revoked_by_user_id\" is null) = (\"workspace_admin_grants\".\"revoked_at\" is null)"
+        },
+        "workspace_admin_grants_revoked_after_granted": {
+          "name": "workspace_admin_grants_revoked_after_granted",
+          "value": "\"workspace_admin_grants\".\"revoked_at\" is null or \"workspace_admin_grants\".\"revoked_at\" >= \"workspace_admin_grants\".\"granted_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_name_unique": {
+          "name": "workspaces_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_identities_provider_subject_unique": {
+          "name": "auth_identities_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_provider_unique": {
+          "name": "auth_identities_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_issuer_subject_unique": {
+          "name": "auth_identities_issuer_subject_unique",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_id_idx": {
+          "name": "auth_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_user_id_idx": {
+          "name": "auth_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expires_at_idx": {
+          "name": "auth_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_verifications_expires_at_idx": {
+          "name": "auth_verifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_computers": {
+      "name": "account_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_installation_id": {
+          "name": "current_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_computers_owner_account_id_idx": {
+          "name": "account_computers_owner_account_id_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_computers_current_installation_id_idx": {
+          "name": "account_computers_current_installation_id_idx",
+          "columns": [
+            {
+              "expression": "current_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_computers_owner_account_id_users_id_fk": {
+          "name": "account_computers_owner_account_id_users_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_computers_current_installation_id_computers_id_fk": {
+          "name": "account_computers_current_installation_id_computers_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "current_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_connect_codes": {
+      "name": "computer_connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "computer_connect_code_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_computer_id": {
+          "name": "target_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_workspace_computer_id": {
+          "name": "consumed_workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_computer_id": {
+          "name": "consumed_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_connect_codes_workspace_created_idx": {
+          "name": "computer_connect_codes_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_target_computer_id_idx": {
+          "name": "computer_connect_codes_target_computer_id_idx",
+          "columns": [
+            {
+              "expression": "target_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_consumed_computer_id_idx": {
+          "name": "computer_connect_codes_consumed_computer_id_idx",
+          "columns": [
+            {
+              "expression": "consumed_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_connect_codes_workspace_id_workspaces_id_fk": {
+          "name": "computer_connect_codes_workspace_id_workspaces_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_account_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_account_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_target_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_target_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "target_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_consumed_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_consumed_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "consumed_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_revoked_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_workspace_enrollment_fk": {
+          "name": "computer_connect_codes_workspace_enrollment_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "consumed_workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_connect_codes_token_hash_unique": {
+          "name": "computer_connect_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_connect_codes_expiry": {
+          "name": "computer_connect_codes_expiry",
+          "value": "\"computer_connect_codes\".\"expires_at\" > \"computer_connect_codes\".\"created_at\""
+        },
+        "computer_connect_codes_consumption_pair": {
+          "name": "computer_connect_codes_consumption_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_workspace_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_revocation_pair": {
+          "name": "computer_connect_codes_revocation_pair",
+          "value": "(\"computer_connect_codes\".\"revoked_by_user_id\" is null) = (\"computer_connect_codes\".\"revoked_at\" is null)"
+        },
+        "computer_connect_codes_terminal_state": {
+          "name": "computer_connect_codes_terminal_state",
+          "value": "not (\"computer_connect_codes\".\"consumed_at\" is not null and \"computer_connect_codes\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computer_credentials": {
+      "name": "computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_credentials_active_computer_unique": {
+          "name": "computer_credentials_active_computer_unique",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_credentials_computer_issued_idx": {
+          "name": "computer_credentials_computer_issued_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_credentials_computer_id_account_computers_id_fk": {
+          "name": "computer_credentials_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_credentials_secret_hash_unique": {
+          "name": "computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_credentials_revocation_pair": {
+          "name": "computer_credentials_revocation_pair",
+          "value": "(\"computer_credentials\".\"revoked_by_user_id\" is null) = (\"computer_credentials\".\"revoked_at\" is null)"
+        },
+        "computer_credentials_revoked_after_issued": {
+          "name": "computer_credentials_revoked_after_issued",
+          "value": "\"computer_credentials\".\"revoked_at\" is null or \"computer_credentials\".\"revoked_at\" >= \"computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computers": {
+      "name": "computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_computer_credentials": {
+      "name": "workspace_computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_computer_credentials_active_enrollment_unique": {
+          "name": "workspace_computer_credentials_active_enrollment_unique",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computer_credentials_enrollment_issued_idx": {
+          "name": "workspace_computer_credentials_enrollment_issued_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computer_credentials_secret_hash_unique": {
+          "name": "workspace_computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computer_credentials_revocation_pair": {
+          "name": "workspace_computer_credentials_revocation_pair",
+          "value": "(\"workspace_computer_credentials\".\"revoked_by_user_id\" is null) = (\"workspace_computer_credentials\".\"revoked_at\" is null)"
+        },
+        "workspace_computer_credentials_revoked_after_issued": {
+          "name": "workspace_computer_credentials_revoked_after_issued",
+          "value": "\"workspace_computer_credentials\".\"revoked_at\" is null or \"workspace_computer_credentials\".\"revoked_at\" >= \"workspace_computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_computers": {
+      "name": "workspace_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_by_user_id": {
+          "name": "enrolled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_computers_active_workspace_computer_unique": {
+          "name": "workspace_computers_active_workspace_computer_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_active_workspace_idx": {
+          "name": "workspace_computers_active_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_computer_id_idx": {
+          "name": "workspace_computers_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computers_workspace_id_workspaces_id_fk": {
+          "name": "workspace_computers_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_computer_id_computers_id_fk": {
+          "name": "workspace_computers_computer_id_computers_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_enrolled_by_user_id_users_id_fk": {
+          "name": "workspace_computers_enrolled_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enrolled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computers_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computers_workspace_id_id_unique": {
+          "name": "workspace_computers_workspace_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computers_revocation_pair": {
+          "name": "workspace_computers_revocation_pair",
+          "value": "(\"workspace_computers\".\"revoked_by_user_id\" is null) = (\"workspace_computers\".\"revoked_at\" is null)"
+        },
+        "workspace_computers_revoked_after_enrolled": {
+          "name": "workspace_computers_revoked_after_enrolled",
+          "value": "\"workspace_computers\".\"revoked_at\" is null or \"workspace_computers\".\"revoked_at\" >= \"workspace_computers\".\"enrolled_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_bindings": {
+      "name": "im_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "im_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "im_binding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_brand": {
+          "name": "external_team_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "setup_attempt_id": {
+          "name": "setup_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_intent": {
+          "name": "setup_intent",
+          "type": "feishu_setup_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_state": {
+          "name": "setup_state",
+          "type": "feishu_setup_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_instance_id": {
+          "name": "setup_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_heartbeat_at": {
+          "name": "setup_owner_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_setup_context": {
+          "name": "encrypted_setup_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_expires_at": {
+          "name": "setup_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_route_kind": {
+          "name": "slack_route_kind",
+          "type": "slack_route_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_im_binding_id": {
+          "name": "replacement_im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_owner_instance_id": {
+          "name": "connection_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_fencing_epoch": {
+          "name": "connection_fencing_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_lease_expires_at": {
+          "name": "connection_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_bindings_agent_current_unique": {
+          "name": "im_bindings_agent_current_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_feishu_app_current_unique": {
+          "name": "im_bindings_feishu_app_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_current_unique": {
+          "name": "im_bindings_slack_installation_current_unique",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_id_idx": {
+          "name": "im_bindings_slack_installation_id_idx",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_agent_id_agents_id_fk": {
+          "name": "im_bindings_agent_id_agents_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_id_slack_installations_id_fk": {
+          "name": "im_bindings_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_replacement_im_binding_id_im_bindings_id_fk": {
+          "name": "im_bindings_replacement_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "replacement_im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_bindings_credential_generation_nonnegative": {
+          "name": "im_bindings_credential_generation_nonnegative",
+          "value": "\"im_bindings\".\"credential_generation\" >= 0"
+        },
+        "im_bindings_connection_epoch_nonnegative": {
+          "name": "im_bindings_connection_epoch_nonnegative",
+          "value": "\"im_bindings\".\"connection_fencing_epoch\" >= 0"
+        },
+        "im_bindings_active_binding_shape": {
+          "name": "im_bindings_active_binding_shape",
+          "value": "\"im_bindings\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"im_bindings\".\"external_app_id\" is not null and\n        (\"im_bindings\".\"provider\" = 'feishu' or \"im_bindings\".\"external_team_id\" is not null) and\n        \"im_bindings\".\"external_bot_id\" is not null and \"im_bindings\".\"credential_schema_version\" is not null and\n        \"im_bindings\".\"credential_generation\" >= 1 and\n        \"im_bindings\".\"activated_at\" is not null and \"im_bindings\".\"disabled_at\" is null and\n        (\n          (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"encrypted_credential\" is not null and\n            \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null) or\n          (\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"encrypted_credential\" is null and\n            \"im_bindings\".\"slack_installation_id\" is not null and \"im_bindings\".\"slack_route_kind\" is not null)\n        )\n      )"
+        },
+        "im_bindings_disabled_secret_shape": {
+          "name": "im_bindings_disabled_secret_shape",
+          "value": "\"im_bindings\".\"status\" <> 'disabled' or (\n        \"im_bindings\".\"encrypted_credential\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"connection_owner_instance_id\" is null and\n        \"im_bindings\".\"connection_lease_expires_at\" is null and \"im_bindings\".\"disabled_at\" is not null\n      )"
+        },
+        "im_bindings_setup_owner_shape": {
+          "name": "im_bindings_setup_owner_shape",
+          "value": "(\"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"setup_owner_heartbeat_at\" is null and\n        \"im_bindings\".\"encrypted_setup_context\" is null and \"im_bindings\".\"setup_expires_at\" is null)\n        or (\"im_bindings\".\"setup_attempt_id\" is not null and \"im_bindings\".\"setup_intent\" is not null and\n        \"im_bindings\".\"setup_state\" is not null and \"im_bindings\".\"setup_owner_instance_id\" is not null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is not null and \"im_bindings\".\"encrypted_setup_context\" is not null and\n        \"im_bindings\".\"setup_expires_at\" is not null)"
+        },
+        "im_bindings_connection_owner_shape": {
+          "name": "im_bindings_connection_owner_shape",
+          "value": "(\"im_bindings\".\"connection_owner_instance_id\" is null and \"im_bindings\".\"connection_lease_expires_at\" is null)\n        or (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"connection_owner_instance_id\" is not null and\n        \"im_bindings\".\"connection_lease_expires_at\" is not null)"
+        },
+        "im_bindings_slack_setup_fields_null": {
+          "name": "im_bindings_slack_setup_fields_null",
+          "value": "\"im_bindings\".\"provider\" <> 'slack' or (\n        \"im_bindings\".\"setup_attempt_id\" is null and \"im_bindings\".\"setup_intent\" is null and\n        \"im_bindings\".\"setup_state\" is null and \"im_bindings\".\"setup_owner_instance_id\" is null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_expires_at\" is null\n      )"
+        },
+        "im_bindings_slack_route_fields": {
+          "name": "im_bindings_slack_route_fields",
+          "value": "\"im_bindings\".\"provider\" = 'slack' or (\n        \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_message_deliveries": {
+      "name": "im_message_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attention": {
+          "name": "attention",
+          "type": "im_delivery_attention",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "im_delivery_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_request_id": {
+          "name": "dispatch_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_input_hash": {
+          "name": "dispatch_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_payload": {
+          "name": "dispatch_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steer_target_delivery_id": {
+          "name": "steer_target_delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steered_at": {
+          "name": "steered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_owner_instance_id": {
+          "name": "report_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_hash": {
+          "name": "result_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_report": {
+          "name": "turn_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "im_message_deliveries_message_session_unique": {
+          "name": "im_message_deliveries_message_session_unique",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_session_id_idx": {
+          "name": "im_message_deliveries_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_steer_target_idx": {
+          "name": "im_message_deliveries_steer_target_idx",
+          "columns": [
+            {
+              "expression": "steer_target_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_pending_idx": {
+          "name": "im_message_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_dispatch_request_unique": {
+          "name": "im_message_deliveries_dispatch_request_unique",
+          "columns": [
+            {
+              "expression": "dispatch_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"dispatch_request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_turn_id_unique": {
+          "name": "im_message_deliveries_turn_id_unique",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"turn_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_deliveries_message_id_im_messages_id_fk": {
+          "name": "im_message_deliveries_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_session_id_sessions_id_fk": {
+          "name": "im_message_deliveries_session_id_sessions_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk": {
+          "name": "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_message_deliveries",
+          "columnsFrom": [
+            "steer_target_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_message_deliveries_dispatch_shape": {
+          "name": "im_message_deliveries_dispatch_shape",
+          "value": "(\"im_message_deliveries\".\"dispatch_request_id\" is null and \"im_message_deliveries\".\"dispatch_input_hash\" is null and \"im_message_deliveries\".\"dispatch_payload\" is null)\n        or (\"im_message_deliveries\".\"dispatch_request_id\" is not null and \"im_message_deliveries\".\"dispatch_input_hash\" is not null\n          and (\"im_message_deliveries\".\"dispatch_payload\" is not null or \"im_message_deliveries\".\"state\" = 'accepted'))"
+        },
+        "im_message_deliveries_custody_shape": {
+          "name": "im_message_deliveries_custody_shape",
+          "value": "(\"im_message_deliveries\".\"state\" = 'accepted' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"turn_id\" is not null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is not null and \"im_message_deliveries\".\"accepted_at\" is not null\n          and \"im_message_deliveries\".\"steer_target_delivery_id\" is null and \"im_message_deliveries\".\"steered_at\" is null)\n        or (\"im_message_deliveries\".\"state\" = 'steered' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"steer_target_delivery_id\" is not null\n          and \"im_message_deliveries\".\"steered_at\" is not null and \"im_message_deliveries\".\"turn_id\" is null and \"im_message_deliveries\".\"report_owner_instance_id\" is null\n          and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null\n          and \"im_message_deliveries\".\"result_hash\" is null)\n        or (\"im_message_deliveries\".\"state\" not in ('accepted', 'steered') and \"im_message_deliveries\".\"input_hash\" is null and \"im_message_deliveries\".\"turn_id\" is null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is null and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"steered_at\" is null\n          and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null and \"im_message_deliveries\".\"result_hash\" is null)"
+        },
+        "im_message_deliveries_report_shape": {
+          "name": "im_message_deliveries_report_shape",
+          "value": "(\"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null)\n        or (\"im_message_deliveries\".\"reported_at\" is not null and \"im_message_deliveries\".\"turn_report\" is not null and \"im_message_deliveries\".\"result_hash\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_messages": {
+      "name": "im_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_revision_key": {
+          "name": "provider_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "im_message_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "im_message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_external_id": {
+          "name": "reply_to_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "im_author_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_external_id": {
+          "name": "author_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_context": {
+          "name": "provider_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_messages_provider_event_unique": {
+          "name": "im_messages_provider_event_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_messages\".\"provider_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_semantic_revision_unique": {
+          "name": "im_messages_semantic_revision_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_revision_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_scope_occurred_idx": {
+          "name": "im_messages_scope_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_external_occurred_idx": {
+          "name": "im_messages_external_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_messages_im_binding_id_im_bindings_id_fk": {
+          "name": "im_messages_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invitations": {
+      "name": "admin_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_invitations_workspace_created_idx": {
+          "name": "admin_invitations_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_invitations_workspace_id_workspaces_id_fk": {
+          "name": "admin_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_created_by_user_id_users_id_fk": {
+          "name": "admin_invitations_created_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_accepted_by_user_id_users_id_fk": {
+          "name": "admin_invitations_accepted_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_revoked_by_user_id_users_id_fk": {
+          "name": "admin_invitations_revoked_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invitations_token_hash_unique": {
+          "name": "admin_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invitations_expiry": {
+          "name": "admin_invitations_expiry",
+          "value": "\"admin_invitations\".\"expires_at\" > \"admin_invitations\".\"created_at\""
+        },
+        "admin_invitations_acceptance_pair": {
+          "name": "admin_invitations_acceptance_pair",
+          "value": "(\"admin_invitations\".\"accepted_by_user_id\" is null) = (\"admin_invitations\".\"accepted_at\" is null)"
+        },
+        "admin_invitations_revocation_pair": {
+          "name": "admin_invitations_revocation_pair",
+          "value": "(\"admin_invitations\".\"revoked_by_user_id\" is null) = (\"admin_invitations\".\"revoked_at\" is null)"
+        },
+        "admin_invitations_terminal_state": {
+          "name": "admin_invitations_terminal_state",
+          "value": "not (\"admin_invitations\".\"accepted_at\" is not null and \"admin_invitations\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_cli_proofs": {
+      "name": "session_cli_proofs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proof_id": {
+          "name": "proof_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_instance_id": {
+          "name": "connection_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_cli_proofs_computer_id_idx": {
+          "name": "session_cli_proofs_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_cli_proofs_session_id_sessions_id_fk": {
+          "name": "session_cli_proofs_session_id_sessions_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_computer_id_account_computers_id_fk": {
+          "name": "session_cli_proofs_computer_id_account_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_cli_proofs_proof_id_unique": {
+          "name": "session_cli_proofs_proof_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proof_id"
+          ]
+        },
+        "session_cli_proofs_token_hash_unique": {
+          "name": "session_cli_proofs_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_cli_proofs_token_hash_shape": {
+          "name": "session_cli_proofs_token_hash_shape",
+          "value": "\"session_cli_proofs\".\"token_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_cli_proofs_generation_positive": {
+          "name": "session_cli_proofs_generation_positive",
+          "value": "\"session_cli_proofs\".\"placement_generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_messages": {
+      "name": "session_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_outcome": {
+          "name": "last_outcome",
+          "type": "session_message_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_messages_target_created_idx": {
+          "name": "session_messages_target_created_idx",
+          "columns": [
+            {
+              "expression": "target_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_messages_source_created_idx": {
+          "name": "session_messages_source_created_idx",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_messages_source_session_id_sessions_id_fk": {
+          "name": "session_messages_source_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "source_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_messages_target_session_id_sessions_id_fk": {
+          "name": "session_messages_target_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_messages_content_hash_shape": {
+          "name": "session_messages_content_hash_shape",
+          "value": "\"session_messages\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_messages_content_bounds": {
+          "name": "session_messages_content_bounds",
+          "value": "octet_length(\"session_messages\".\"content\") between 1 and 16384"
+        },
+        "session_messages_error_code_shape": {
+          "name": "session_messages_error_code_shape",
+          "value": "\"session_messages\".\"last_error_code\" is null or (\"session_messages\".\"last_error_code\" ~ '^[a-z][a-z0-9_]{0,127}$')"
+        },
+        "session_messages_attempt_count_nonnegative": {
+          "name": "session_messages_attempt_count_nonnegative",
+          "value": "\"session_messages\".\"attempt_count\" >= 0"
+        },
+        "session_messages_attempt_shape": {
+          "name": "session_messages_attempt_shape",
+          "value": "(\"session_messages\".\"attempt_count\" = 0 and \"session_messages\".\"last_attempt_at\" is null)\n        or (\"session_messages\".\"attempt_count\" > 0 and \"session_messages\".\"last_attempt_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_descendants": {
+      "name": "session_descendants",
+      "schema": "",
+      "columns": {
+        "ancestor_session_id": {
+          "name": "ancestor_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_session_id": {
+          "name": "descendant_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_created_at": {
+          "name": "last_message_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_delivery_outcome": {
+          "name": "last_delivery_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_preview": {
+          "name": "task_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_descendants_ancestor_activity_idx": {
+          "name": "session_descendants_ancestor_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_ancestor_depth_activity_idx": {
+          "name": "session_descendants_ancestor_depth_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_descendant_ancestor_idx": {
+          "name": "session_descendants_descendant_ancestor_idx",
+          "columns": [
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_last_message_idx": {
+          "name": "session_descendants_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_descendants_ancestor_session_id_sessions_id_fk": {
+          "name": "session_descendants_ancestor_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "ancestor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_descendants_descendant_session_id_sessions_id_fk": {
+          "name": "session_descendants_descendant_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "descendant_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_descendants_ancestor_session_id_descendant_session_id_pk": {
+          "name": "session_descendants_ancestor_session_id_descendant_session_id_pk",
+          "columns": [
+            "ancestor_session_id",
+            "descendant_session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_descendants_depth_positive": {
+          "name": "session_descendants_depth_positive",
+          "value": "\"session_descendants\".\"depth\" >= 1"
+        },
+        "session_descendants_outcome_valid": {
+          "name": "session_descendants_outcome_valid",
+          "value": "\"session_descendants\".\"last_delivery_outcome\" in ('accepted', 'unreachable', 'unknown', 'rejected')"
+        },
+        "session_descendants_preview_bounds": {
+          "name": "session_descendants_preview_bounds",
+          "value": "char_length(\"session_descendants\".\"task_preview\") between 1 and 256"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_placements": {
+      "name": "session_placements",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_placements_workspace_computer_id_idx": {
+          "name": "session_placements_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_placements_computer_id_idx": {
+          "name": "session_placements_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_placements_session_id_sessions_id_fk": {
+          "name": "session_placements_session_id_sessions_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_placements_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_placements_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_placements_computer_id_account_computers_id_fk": {
+          "name": "session_placements_computer_id_account_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_placements_generation_positive": {
+          "name": "session_placements_generation_positive",
+          "value": "\"session_placements\".\"generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_kind": {
+          "name": "conversation_kind",
+          "type": "im_conversation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "session_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_model": {
+          "name": "runtime_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_reasoning_effort": {
+          "name": "runtime_reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_max_duration_ms": {
+          "name": "runtime_max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_active_channel_unique": {
+          "name": "sessions_active_channel_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'channel' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_active_thread_unique": {
+          "name": "sessions_active_thread_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'thread' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_im_binding_scope_idx": {
+          "name": "sessions_im_binding_scope_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_creator_created_idx": {
+          "name": "sessions_creator_created_idx",
+          "columns": [
+            {
+              "expression": "created_by_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_im_binding_id_im_bindings_id_fk": {
+          "name": "sessions_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sessions_created_by_session_id_sessions_id_fk": {
+          "name": "sessions_created_by_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "created_by_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sessions_shape_check": {
+          "name": "sessions_shape_check",
+          "value": "(\"sessions\".\"kind\" = 'channel' and \"sessions\".\"thread_key\" is null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'thread' and \"sessions\".\"thread_key\" is not null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'internal' and \"sessions\".\"created_by_session_id\" is not null)"
+        },
+        "sessions_runtime_max_duration_valid": {
+          "name": "sessions_runtime_max_duration_valid",
+          "value": "\"sessions\".\"runtime_max_duration_ms\" is null or (\"sessions\".\"runtime_max_duration_ms\" > 0 and \"sessions\".\"runtime_max_duration_ms\" <= 86400000)"
+        },
+        "sessions_runtime_model_bounds": {
+          "name": "sessions_runtime_model_bounds",
+          "value": "\"sessions\".\"runtime_model\" is null or octet_length(\"sessions\".\"runtime_model\") between 1 and 128"
+        },
+        "sessions_runtime_reasoning_effort_bounds": {
+          "name": "sessions_runtime_reasoning_effort_bounds",
+          "value": "\"sessions\".\"runtime_reasoning_effort\" is null or octet_length(\"sessions\".\"runtime_reasoning_effort\") between 1 and 64"
+        },
+        "sessions_revision_positive": {
+          "name": "sessions_revision_positive",
+          "value": "\"sessions\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "slack_installation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "replacement_slack_installation_id": {
+          "name": "replacement_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installations_app_team_current_unique": {
+          "name": "slack_installations_app_team_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_installations\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_workspace_current_unique": {
+          "name": "slack_installations_workspace_current_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_installations\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_workspace_id_idx": {
+          "name": "slack_installations_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_agent_id_idx": {
+          "name": "slack_installations_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_app_team_idx": {
+          "name": "slack_installations_app_team_idx",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_workspace_id_workspaces_id_fk": {
+          "name": "slack_installations_workspace_id_workspaces_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_agent_id_agents_id_fk": {
+          "name": "slack_installations_agent_id_agents_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_replacement_slack_installation_id_slack_installations_id_fk": {
+          "name": "slack_installations_replacement_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "replacement_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_installations_credential_generation_nonnegative": {
+          "name": "slack_installations_credential_generation_nonnegative",
+          "value": "\"slack_installations\".\"credential_generation\" >= 0"
+        },
+        "slack_installations_active_shape": {
+          "name": "slack_installations_active_shape",
+          "value": "\"slack_installations\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"slack_installations\".\"credential_schema_version\" is not null and\n        \"slack_installations\".\"credential_generation\" >= 1 and \"slack_installations\".\"encrypted_credential\" is not null and\n        \"slack_installations\".\"activated_at\" is not null and \"slack_installations\".\"disabled_at\" is null\n      )"
+        },
+        "slack_installations_disabled_secret_shape": {
+          "name": "slack_installations_disabled_secret_shape",
+          "value": "\"slack_installations\".\"status\" <> 'disabled' or (\n        \"slack_installations\".\"encrypted_credential\" is null and \"slack_installations\".\"disabled_at\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_oauth_nonces": {
+      "name": "slack_oauth_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_binding_id": {
+          "name": "expected_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_credential_generation": {
+          "name": "expected_credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_binding_hash": {
+          "name": "session_binding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_oauth_nonces_user_agent_idx": {
+          "name": "slack_oauth_nonces_user_agent_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_oauth_nonces_expires_idx": {
+          "name": "slack_oauth_nonces_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_oauth_nonces_user_id_users_id_fk": {
+          "name": "slack_oauth_nonces_user_id_users_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_oauth_nonces_agent_id_agents_id_fk": {
+          "name": "slack_oauth_nonces_agent_id_agents_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_oauth_nonces_nonce_hash_unique": {
+          "name": "slack_oauth_nonces_nonce_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_oauth_nonces_intent": {
+          "name": "slack_oauth_nonces_intent",
+          "value": "\"slack_oauth_nonces\".\"intent\" in ('create', 'reauthorize')"
+        },
+        "slack_oauth_nonces_expiry": {
+          "name": "slack_oauth_nonces_expiry",
+          "value": "\"slack_oauth_nonces\".\"expires_at\" > \"slack_oauth_nonces\".\"created_at\""
+        },
+        "slack_oauth_nonces_expected_binding_pair": {
+          "name": "slack_oauth_nonces_expected_binding_pair",
+          "value": "(\"slack_oauth_nonces\".\"expected_binding_id\" is null) = (\"slack_oauth_nonces\".\"expected_credential_generation\" is null)"
+        },
+        "slack_oauth_nonces_generation_positive": {
+          "name": "slack_oauth_nonces_generation_positive",
+          "value": "\"slack_oauth_nonces\".\"expected_credential_generation\" is null or \"slack_oauth_nonces\".\"expected_credential_generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_receive_mode": {
+      "name": "agent_receive_mode",
+      "schema": "public",
+      "values": [
+        "all_message",
+        "mention_only"
+      ]
+    },
+    "public.agent_runtime_provider": {
+      "name": "agent_runtime_provider",
+      "schema": "public",
+      "values": [
+        "codex",
+        "claude-code"
+      ]
+    },
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "suspended",
+        "deleted"
+      ]
+    },
+    "public.computer_connect_code_mode": {
+      "name": "computer_connect_code_mode",
+      "schema": "public",
+      "values": [
+        "create",
+        "repair"
+      ]
+    },
+    "public.computer_platform": {
+      "name": "computer_platform",
+      "schema": "public",
+      "values": [
+        "darwin",
+        "linux",
+        "win32"
+      ]
+    },
+    "public.feishu_setup_intent": {
+      "name": "feishu_setup_intent",
+      "schema": "public",
+      "values": [
+        "create",
+        "reauthorize",
+        "replace"
+      ]
+    },
+    "public.feishu_setup_state": {
+      "name": "feishu_setup_state",
+      "schema": "public",
+      "values": [
+        "awaiting_user",
+        "validating",
+        "succeeded",
+        "failed",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.im_binding_status": {
+      "name": "im_binding_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "active",
+        "reauthorization_required",
+        "error",
+        "disabled"
+      ]
+    },
+    "public.im_conversation_kind": {
+      "name": "im_conversation_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "dm",
+        "group_dm"
+      ]
+    },
+    "public.im_provider": {
+      "name": "im_provider",
+      "schema": "public",
+      "values": [
+        "feishu",
+        "slack"
+      ]
+    },
+    "public.slack_route_kind": {
+      "name": "slack_route_kind",
+      "schema": "public",
+      "values": [
+        "default"
+      ]
+    },
+    "public.im_author_kind": {
+      "name": "im_author_kind",
+      "schema": "public",
+      "values": [
+        "human",
+        "bot",
+        "system"
+      ]
+    },
+    "public.im_delivery_attention": {
+      "name": "im_delivery_attention",
+      "schema": "public",
+      "values": [
+        "direct",
+        "ambient"
+      ]
+    },
+    "public.im_delivery_state": {
+      "name": "im_delivery_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "steered",
+        "terminal_rejected",
+        "expired"
+      ]
+    },
+    "public.im_message_direction": {
+      "name": "im_message_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.im_message_operation": {
+      "name": "im_message_operation",
+      "schema": "public",
+      "values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "public.session_message_outcome": {
+      "name": "session_message_outcome",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "accepted",
+        "unreachable",
+        "rejected"
+      ]
+    },
+    "public.session_kind": {
+      "name": "session_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "thread",
+        "internal"
+      ]
+    },
+    "public.slack_installation_status": {
+      "name": "slack_installation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "reauthorization_required",
+        "disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {
+    "public.runtime_config_revision_sequence": {
+      "name": "runtime_config_revision_sequence",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1787976615603,
       "tag": "0025_retire_legacy_credentials",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1787995618306,
+      "tag": "0026_wakeful_wildside",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/integration/account-ownership-expansion.test.ts
+++ b/packages/server/src/__tests__/integration/account-ownership-expansion.test.ts
@@ -1,0 +1,1034 @@
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { RUNTIME_PROTOCOL_V2 } from "@opentag/shared";
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import { eq } from "drizzle-orm";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
+import { createDatabaseClient } from "../../db/client.js";
+import { migrateDatabase, verifyDatabaseMigrations } from "../../db/migrate.js";
+import {
+  accountComputers,
+  agents,
+  computerConnectCodes,
+  computerCredentials,
+  sessionCliProofs,
+  sessionPlacements,
+  workspaceComputerCredentials,
+  workspaceComputers,
+} from "../../db/schema/index.js";
+import { AgentService } from "../../services/agents/index.js";
+import { ComputerService, MachineAuthService } from "../../services/computers/index.js";
+import { SessionCliProofService, SessionService } from "../../services/sessions/index.js";
+
+const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
+
+const OWNER_ID = "00000000-0000-4000-8000-000000000001";
+const CREATOR_ID = "00000000-0000-4000-8000-000000000002";
+const WORKSPACE_ID = "00000000-0000-4000-8000-000000000003";
+const INSTALLATION_ID = "00000000-0000-4000-8000-000000000004";
+const ACTIVE_ENROLLMENT_ID = "00000000-0000-4000-8000-000000000005";
+const REVOKED_ENROLLMENT_ID = "00000000-0000-4000-8000-000000000006";
+const ACTIVE_CREDENTIAL_ID = "00000000-0000-4000-8000-000000000007";
+const REVOKED_CREDENTIAL_ID = "00000000-0000-4000-8000-000000000008";
+const UNCONSUMED_CODE_ID = "00000000-0000-4000-8000-000000000009";
+const CONSUMED_CODE_ID = "00000000-0000-4000-8000-00000000000a";
+const AGENT_ID = "00000000-0000-4000-8000-00000000000b";
+const BINDING_ID = "00000000-0000-4000-8000-00000000000c";
+const ACTIVE_SESSION_ID = "00000000-0000-4000-8000-00000000000d";
+const ENDED_SESSION_ID = "00000000-0000-4000-8000-00000000000e";
+const SLACK_ACTIVE_ID = "00000000-0000-4000-8000-00000000000f";
+const SLACK_DISABLED_ID = "00000000-0000-4000-8000-000000000010";
+const MESSAGE_ID = "00000000-0000-4000-8000-000000000011";
+const PENDING_DELIVERY_ID = "00000000-0000-4000-8000-000000000012";
+const ACCEPTED_DELIVERY_ID = "00000000-0000-4000-8000-000000000013";
+const CURRENT_INSTANCE_ID = "00000000-0000-4000-8000-000000000014";
+const STALE_INSTANCE_ID = "00000000-0000-4000-8000-000000000015";
+
+type Journal = {
+  version: string;
+  dialect: string;
+  entries: Array<{ idx: number; version: string; when: number; tag: string; breakpoints: boolean }>;
+};
+
+let container: StartedPostgreSqlContainer;
+let databaseUrl: string;
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("postgres:17-alpine").start();
+  databaseUrl = container.getConnectionUri();
+}, 120_000);
+
+afterAll(async () => {
+  await container.stop();
+});
+
+beforeEach(async () => {
+  const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+  try {
+    await sql.unsafe("drop schema if exists public cascade");
+    await sql.unsafe("drop schema if exists drizzle cascade");
+    await sql.unsafe("create schema public");
+  } finally {
+    await sql.end();
+  }
+});
+
+async function readJournal(): Promise<Journal> {
+  return JSON.parse(await readFile(join(migrationsFolder, "meta/_journal.json"), "utf8")) as Journal;
+}
+
+async function truncatedMigrations(lastIndex: number): Promise<string> {
+  const journal = await readJournal();
+  const folder = await mkdtemp(join(tmpdir(), `opentag-${lastIndex}-migrations-`));
+  await mkdir(join(folder, "meta"));
+  const entries = journal.entries.filter(({ idx }) => idx <= lastIndex);
+  for (const entry of entries) {
+    await copyFile(join(migrationsFolder, `${entry.tag}.sql`), join(folder, `${entry.tag}.sql`));
+  }
+  await writeFile(join(folder, "meta/_journal.json"), JSON.stringify({ ...journal, entries }, null, 2));
+  return folder;
+}
+
+function postgresError(error: unknown): { code?: string; constraint_name?: string } {
+  if (typeof error !== "object" || error === null) return {};
+  return error as { code?: string; constraint_name?: string };
+}
+
+const HAZARD_CONSTRAINTS = [
+  "computer_connect_codes_workspace_enrollment_fk",
+  "agents_workspace_enrollment_fk",
+] as const;
+const HAZARD_INDEXES = [
+  "slack_installations_workspace_current_unique",
+  "session_placements_workspace_computer_id_idx",
+] as const;
+
+async function expansionSchema(sql: postgres.Sql) {
+  const [row] = await sql<
+    {
+      migrations: number;
+      account_computers: string | null;
+      computer_credentials: string | null;
+      agents_computer_id: boolean;
+      placements_computer_id: boolean;
+      proofs_computer_id: boolean;
+      slack_agent_id: boolean;
+      connect_mode: boolean;
+      hazards: string[];
+      hazard_indexes: string[];
+    }[]
+  >`
+    select
+      (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+      to_regclass('public.account_computers')::text as account_computers,
+      to_regclass('public.computer_credentials')::text as computer_credentials,
+      exists(
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'agents' and column_name = 'computer_id'
+      ) as agents_computer_id,
+      exists(
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'session_placements' and column_name = 'computer_id'
+      ) as placements_computer_id,
+      exists(
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'session_cli_proofs' and column_name = 'computer_id'
+      ) as proofs_computer_id,
+      exists(
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'slack_installations' and column_name = 'agent_id'
+      ) as slack_agent_id,
+      exists(
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'computer_connect_codes' and column_name = 'mode'
+      ) as connect_mode,
+      array(
+        select conname::text from pg_constraint
+        where conname in ('computer_connect_codes_workspace_enrollment_fk', 'agents_workspace_enrollment_fk')
+        order by conname
+      ) as hazards,
+      array(
+        select indexname::text from pg_indexes
+        where indexname in (
+          'slack_installations_workspace_current_unique',
+          'session_placements_workspace_computer_id_idx'
+        )
+        order by indexname
+      ) as hazard_indexes
+  `;
+  return row;
+}
+
+async function populateLegacyOwnership(sql: postgres.Sql): Promise<void> {
+  const now = new Date("2026-08-20T00:00:00.000Z");
+  const later = new Date("2026-08-21T00:00:00.000Z");
+  await sql`
+    insert into users (id, email, display_name)
+    values
+      (${OWNER_ID}, 'owner@example.com', 'Owner'),
+      (${CREATOR_ID}, 'creator@example.com', 'Creator')
+  `;
+  await sql`
+    insert into workspaces (id, name, display_name)
+    values (${WORKSPACE_ID}, 'legacy', 'Legacy')
+  `;
+  await sql`
+    insert into workspace_admin_grants (workspace_id, user_id, granted_by_user_id, granted_at)
+    values
+      (${WORKSPACE_ID}, ${OWNER_ID}, ${OWNER_ID}, ${now}),
+      (${WORKSPACE_ID}, ${CREATOR_ID}, ${OWNER_ID}, ${now})
+  `;
+  await sql`insert into computers (id, created_at) values (${INSTALLATION_ID}, ${now})`;
+  await sql`
+    insert into workspace_computers (
+      id, workspace_id, computer_id, display_name, platform, arch, client_version,
+      enrolled_by_user_id, enrolled_at, current_instance_id, connected_at, last_seen_at, updated_at
+    )
+    values (
+      ${ACTIVE_ENROLLMENT_ID}, ${WORKSPACE_ID}, ${INSTALLATION_ID}, 'active-box', 'linux', 'x64', '0.0.1',
+      ${OWNER_ID}, ${now}, ${CURRENT_INSTANCE_ID}, ${now}, ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into workspace_computers (
+      id, workspace_id, computer_id, display_name, platform, arch, client_version,
+      enrolled_by_user_id, enrolled_at, revoked_by_user_id, revoked_at, updated_at
+    )
+    values (
+      ${REVOKED_ENROLLMENT_ID}, ${WORKSPACE_ID}, ${INSTALLATION_ID}, 'revoked-box', 'linux', 'x64', '0.0.1',
+      ${OWNER_ID}, ${now}, ${OWNER_ID}, ${later}, ${later}
+    )
+  `;
+  await sql`
+    insert into workspace_computer_credentials (
+      id, workspace_computer_id, secret_hash, issued_by_user_id, issued_at
+    )
+    values (
+      ${ACTIVE_CREDENTIAL_ID}, ${ACTIVE_ENROLLMENT_ID}, ${"a".repeat(64)}, ${OWNER_ID}, ${now}
+    )
+  `;
+  await sql`
+    insert into workspace_computer_credentials (
+      id, workspace_computer_id, secret_hash, issued_by_user_id, issued_at, revoked_by_user_id, revoked_at
+    )
+    values (
+      ${REVOKED_CREDENTIAL_ID}, ${ACTIVE_ENROLLMENT_ID}, ${"b".repeat(64)}, ${OWNER_ID}, ${now}, ${OWNER_ID}, ${later}
+    )
+  `;
+  await sql`
+    insert into computer_connect_codes (
+      id, workspace_id, token_hash, issued_by_user_id, created_at, expires_at
+    )
+    values (
+      ${UNCONSUMED_CODE_ID}, ${WORKSPACE_ID}, ${"c".repeat(64)}, ${OWNER_ID}, ${now}, ${later}
+    )
+  `;
+  await sql`
+    insert into computer_connect_codes (
+      id, workspace_id, token_hash, issued_by_user_id, created_at, expires_at,
+      consumed_workspace_computer_id, consumed_at
+    )
+    values (
+      ${CONSUMED_CODE_ID}, ${WORKSPACE_ID}, ${"d".repeat(64)}, ${OWNER_ID}, ${now}, ${later},
+      ${ACTIVE_ENROLLMENT_ID}, ${now}
+    )
+  `;
+  await sql`
+    insert into agents (
+      id, workspace_id, created_by_user_id, workspace_computer_id, name, display_name, runtime_provider
+    )
+    values (
+      ${AGENT_ID}, ${WORKSPACE_ID}, ${CREATOR_ID}, ${ACTIVE_ENROLLMENT_ID},
+      'mismatched', 'Mismatched', 'codex'
+    )
+  `;
+  await sql`
+    insert into im_bindings (
+      id, agent_id, provider, status, external_app_id, external_bot_id,
+      credential_schema_version, credential_generation, encrypted_credential, activated_at
+    )
+    values (
+      ${BINDING_ID}, ${AGENT_ID}, 'feishu', 'active', 'cli_legacy', 'ou_legacy',
+      1, 1, 'encrypted', ${now}
+    )
+  `;
+  await sql`
+    insert into sessions (id, im_binding_id, channel_id, conversation_kind, kind, created_at)
+    values
+      (${ACTIVE_SESSION_ID}, ${BINDING_ID}, 'C-active', 'channel', 'channel', ${now}),
+      (${ENDED_SESSION_ID}, ${BINDING_ID}, 'C-ended', 'channel', 'channel', ${now})
+  `;
+  await sql`update sessions set ended_at = ${later} where id = ${ENDED_SESSION_ID}`;
+  await sql`
+    insert into session_placements (session_id, workspace_computer_id, generation, updated_at)
+    values
+      (${ACTIVE_SESSION_ID}, ${ACTIVE_ENROLLMENT_ID}, 2, ${later}),
+      (${ENDED_SESSION_ID}, ${REVOKED_ENROLLMENT_ID}, 1, ${now})
+  `;
+  await sql`
+    insert into session_cli_proofs (
+      session_id, proof_id, token_hash, workspace_computer_id, placement_generation,
+      connection_instance_id, created_at, updated_at
+    )
+    values (
+      ${ACTIVE_SESSION_ID}, ${crypto.randomUUID()}, ${"e".repeat(64)}, ${ACTIVE_ENROLLMENT_ID}, 1,
+      ${STALE_INSTANCE_ID}, ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into slack_installations (
+      id, workspace_id, status, external_app_id, external_team_id, external_bot_id,
+      credential_schema_version, credential_generation, encrypted_credential, activated_at, created_at, updated_at
+    )
+    values (
+      ${SLACK_ACTIVE_ID}, ${WORKSPACE_ID}, 'active', 'A_LEGACY', 'T_LEGACY', 'U_BOT',
+      1, 1, 'encrypted-slack', ${now}, ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into slack_installations (
+      id, workspace_id, status, external_app_id, external_team_id, external_bot_id,
+      credential_generation, encrypted_credential, replacement_slack_installation_id,
+      disabled_at, created_at, updated_at
+    )
+    values (
+      ${SLACK_DISABLED_ID}, ${WORKSPACE_ID}, 'disabled', 'A_OLD', 'T_OLD', 'U_OLD',
+      1, null, ${SLACK_ACTIVE_ID}, ${later}, ${now}, ${later}
+    )
+  `;
+  await sql`
+    insert into im_messages (
+      id, im_binding_id, channel_id, external_message_id, provider_revision_key, operation, direction,
+      author_kind, author_external_id, content, provider_context, occurred_at, received_at
+    )
+    values (
+      ${MESSAGE_ID}, ${BINDING_ID}, 'C-active', 'om_legacy', '1', 'created', 'inbound',
+      'human', 'ou_human',
+      '{"version":1,"fallbackText":"hi","blocks":[],"truncated":false}'::jsonb,
+      '{"provider":"feishu","chatType":"p2p"}'::jsonb,
+      ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into im_message_deliveries (
+      id, message_id, session_id, attention, state, placement_generation, attempt_count,
+      next_attempt_at, expires_at
+    )
+    values (
+      ${PENDING_DELIVERY_ID}, ${MESSAGE_ID}, ${ACTIVE_SESSION_ID}, 'direct', 'pending', 2, 0,
+      ${now}, ${later}
+    )
+  `;
+  await sql`
+    insert into im_message_deliveries (
+      id, message_id, session_id, attention, state, placement_generation, attempt_count,
+      next_attempt_at, expires_at, accepted_at, turn_id, input_hash, report_owner_instance_id
+    )
+    values (
+      ${ACCEPTED_DELIVERY_ID}, ${MESSAGE_ID}, ${ENDED_SESSION_ID}, 'direct', 'accepted', 1, 1,
+      ${now}, ${later}, ${now}, 'turn-legacy', ${"a".repeat(64)}, ${CURRENT_INSTANCE_ID}
+    )
+  `;
+}
+
+describe("account-owned computer expansion migrations", () => {
+  it("orders the expansion schema immediately after credential retirement", async () => {
+    const journal = await readJournal();
+    expect(journal.entries.slice(25, 27).map(({ idx, tag }) => ({ idx, tag }))).toEqual([
+      { idx: 25, tag: "0025_retire_legacy_credentials" },
+      { idx: 26, tag: "0026_wakeful_wildside" },
+    ]);
+  });
+
+  it("migrates an empty database to 0026 and reruns idempotently", async () => {
+    const journal = await readJournal();
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+
+    const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+    try {
+      const schema = await expansionSchema(sql);
+      expect(schema).toMatchObject({
+        migrations: journal.entries.length,
+        account_computers: "account_computers",
+        computer_credentials: "computer_credentials",
+        agents_computer_id: true,
+        placements_computer_id: true,
+        proofs_computer_id: true,
+        slack_agent_id: true,
+        connect_mode: true,
+        hazards: [...HAZARD_CONSTRAINTS].sort(),
+        hazard_indexes: [...HAZARD_INDEXES].sort(),
+      });
+      const [counts] = await sql<{ account_computers: number; computer_credentials: number }[]>`
+        select
+          (select count(*)::int from account_computers) as account_computers,
+          (select count(*)::int from computer_credentials) as computer_credentials
+      `;
+      expect(counts).toEqual({ account_computers: 0, computer_credentials: 0 });
+    } finally {
+      await sql.end();
+    }
+  });
+
+  it("upgrades populated 0025 data to 0026 without backfilling target projections", async () => {
+    const journal = await readJournal();
+    const legacyFolder = await truncatedMigrations(25);
+    try {
+      await migrateDatabase(databaseUrl, legacyFolder);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateLegacyOwnership(sql);
+        const [before] = await sql<
+          {
+            migrations: number;
+            workspace_computers: number;
+            credentials: number;
+            codes: number;
+            agents: number;
+            placements: number;
+            proofs: number;
+            slack: number;
+            deliveries: number;
+          }[]
+        >`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (select count(*)::int from workspace_computers) as workspace_computers,
+            (select count(*)::int from workspace_computer_credentials) as credentials,
+            (select count(*)::int from computer_connect_codes) as codes,
+            (select count(*)::int from agents) as agents,
+            (select count(*)::int from session_placements) as placements,
+            (select count(*)::int from session_cli_proofs) as proofs,
+            (select count(*)::int from slack_installations) as slack,
+            (select count(*)::int from im_message_deliveries) as deliveries
+        `;
+        expect(before).toEqual({
+          migrations: 26,
+          workspace_computers: 2,
+          credentials: 2,
+          codes: 2,
+          agents: 1,
+          placements: 2,
+          proofs: 1,
+          slack: 2,
+          deliveries: 2,
+        });
+
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+
+        const [after] = await sql<
+          {
+            migrations: number;
+            workspace_computers: number;
+            credentials: number;
+            codes: number;
+            agents: number;
+            placements: number;
+            proofs: number;
+            slack: number;
+            deliveries: number;
+            account_computers: number;
+            computer_credentials: number;
+            agents_computer_id: number;
+            placement_computer_id: number;
+            proof_computer_id: number;
+            slack_agent_id: number;
+            code_projections: number;
+            owner_mismatch: number;
+            active_credentials: number;
+            revoked_credentials: number;
+            unconsumed_codes: number;
+            consumed_codes: number;
+            ended_sessions: number;
+            pending_deliveries: number;
+            accepted_unreported: number;
+            replaced_slack: number;
+          }[]
+        >`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (select count(*)::int from workspace_computers) as workspace_computers,
+            (select count(*)::int from workspace_computer_credentials) as credentials,
+            (select count(*)::int from computer_connect_codes) as codes,
+            (select count(*)::int from agents) as agents,
+            (select count(*)::int from session_placements) as placements,
+            (select count(*)::int from session_cli_proofs) as proofs,
+            (select count(*)::int from slack_installations) as slack,
+            (select count(*)::int from im_message_deliveries) as deliveries,
+            (select count(*)::int from account_computers) as account_computers,
+            (select count(*)::int from computer_credentials) as computer_credentials,
+            (select count(*)::int from agents where computer_id is not null) as agents_computer_id,
+            (select count(*)::int from session_placements where computer_id is not null) as placement_computer_id,
+            (select count(*)::int from session_cli_proofs where computer_id is not null) as proof_computer_id,
+            (select count(*)::int from slack_installations where agent_id is not null) as slack_agent_id,
+            (
+              select count(*)::int from computer_connect_codes
+              where issued_by_account_id is not null or mode is not null
+                or target_computer_id is not null or consumed_computer_id is not null
+            ) as code_projections,
+            (
+              select count(*)::int from agents
+              inner join workspace_computers on workspace_computers.id = agents.workspace_computer_id
+              where agents.created_by_user_id <> workspace_computers.enrolled_by_user_id
+            ) as owner_mismatch,
+            (select count(*)::int from workspace_computer_credentials where revoked_at is null) as active_credentials,
+            (select count(*)::int from workspace_computer_credentials where revoked_at is not null) as revoked_credentials,
+            (select count(*)::int from computer_connect_codes where consumed_at is null and revoked_at is null) as unconsumed_codes,
+            (select count(*)::int from computer_connect_codes where consumed_at is not null) as consumed_codes,
+            (select count(*)::int from sessions where ended_at is not null) as ended_sessions,
+            (select count(*)::int from im_message_deliveries where state = 'pending') as pending_deliveries,
+            (
+              select count(*)::int from im_message_deliveries
+              where state = 'accepted' and reported_at is null
+            ) as accepted_unreported,
+            (
+              select count(*)::int from slack_installations
+              where status = 'disabled' and replacement_slack_installation_id = ${SLACK_ACTIVE_ID}
+            ) as replaced_slack
+        `;
+        expect(after).toEqual({
+          migrations: journal.entries.length,
+          workspace_computers: 2,
+          credentials: 2,
+          codes: 2,
+          agents: 1,
+          placements: 2,
+          proofs: 1,
+          slack: 2,
+          deliveries: 2,
+          account_computers: 0,
+          computer_credentials: 0,
+          agents_computer_id: 0,
+          placement_computer_id: 0,
+          proof_computer_id: 0,
+          slack_agent_id: 0,
+          code_projections: 0,
+          owner_mismatch: 1,
+          active_credentials: 1,
+          revoked_credentials: 1,
+          unconsumed_codes: 1,
+          consumed_codes: 1,
+          ended_sessions: 1,
+          pending_deliveries: 1,
+          accepted_unreported: 1,
+          replaced_slack: 1,
+        });
+        const schema = await expansionSchema(sql);
+        expect(schema?.hazards).toEqual([...HAZARD_CONSTRAINTS].sort());
+        expect(schema?.hazard_indexes).toEqual([...HAZARD_INDEXES].sort());
+        const [stable] = await sql<{ enrollment_id: string; credential_hash: string; agent_creator: string }[]>`
+          select
+            ${ACTIVE_ENROLLMENT_ID}::text as enrollment_id,
+            (select secret_hash from workspace_computer_credentials where id = ${ACTIVE_CREDENTIAL_ID}) as credential_hash,
+            (select created_by_user_id::text from agents where id = ${AGENT_ID}) as agent_creator
+        `;
+        expect(stable).toEqual({
+          enrollment_id: ACTIVE_ENROLLMENT_ID,
+          credential_hash: "a".repeat(64),
+          agent_creator: CREATOR_ID,
+        });
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(legacyFolder, { force: true, recursive: true });
+    }
+  });
+
+  it("upgrades representative 0024 Slack-install history through 0026 without filling agent_id", async () => {
+    const journal = await readJournal();
+    const legacyFolder = await truncatedMigrations(24);
+    try {
+      await migrateDatabase(databaseUrl, legacyFolder);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        const userId = crypto.randomUUID();
+        const workspaceId = crypto.randomUUID();
+        await sql`insert into users (id, email, display_name) values (${userId}, 'hist@example.com', 'Hist')`;
+        await sql`insert into workspaces (id, name, display_name) values (${workspaceId}, 'hist', 'Hist')`;
+        await sql`
+          insert into slack_installations (
+            workspace_id, status, external_app_id, external_team_id, external_bot_id,
+            credential_schema_version, credential_generation, encrypted_credential, activated_at
+          )
+          values (
+            ${workspaceId}, 'active', 'A_HIST', 'T_HIST', 'U_HIST', 1, 1, 'encrypted', now()
+          )
+        `;
+        const [before] = await sql<{ migrations: number; slack: number }[]>`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (select count(*)::int from slack_installations) as slack
+        `;
+        expect(before).toEqual({ migrations: 25, slack: 1 });
+
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        const [after] = await sql<{ migrations: number; slack: number; filled: number; installation: string }[]>`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (select count(*)::int from slack_installations) as slack,
+            (select count(*)::int from slack_installations where agent_id is not null) as filled,
+            (select external_app_id from slack_installations limit 1) as installation
+        `;
+        expect(after).toEqual({
+          migrations: journal.entries.length,
+          slack: 1,
+          filled: 0,
+          installation: "A_HIST",
+        });
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(legacyFolder, { force: true, recursive: true });
+    }
+  });
+
+  it("rolls back a failed 0026 transaction and retries the checked-in migration", async () => {
+    const journal = await readJournal();
+    const through0025 = await truncatedMigrations(25);
+    try {
+      await migrateDatabase(databaseUrl, through0025);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await sql`insert into users (id, email, display_name) values (${OWNER_ID}, 'retry@example.com', 'Retry')`;
+        await sql.unsafe("create table computer_credentials (id integer primary key)");
+        await sql.unsafe("insert into computer_credentials (id) values (1)");
+
+        await expect(migrateDatabase(databaseUrl, migrationsFolder)).rejects.toThrow(/computer_credentials/);
+        const [failed] = await sql<
+          {
+            migrations: number;
+            account_computers: string | null;
+            mode_enum: boolean;
+            agents_computer_id: boolean;
+            dummy_type: string | null;
+            dummy_rows: number;
+            users: number;
+          }[]
+        >`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            to_regclass('public.account_computers')::text as account_computers,
+            exists(select 1 from pg_type where typname = 'computer_connect_code_mode') as mode_enum,
+            exists(
+              select 1 from information_schema.columns
+              where table_schema = 'public' and table_name = 'agents' and column_name = 'computer_id'
+            ) as agents_computer_id,
+            (
+              select data_type from information_schema.columns
+              where table_schema = 'public' and table_name = 'computer_credentials' and column_name = 'id'
+            ) as dummy_type,
+            (select count(*)::int from computer_credentials) as dummy_rows,
+            (select count(*)::int from users) as users
+        `;
+        expect(failed).toEqual({
+          migrations: 26,
+          account_computers: null,
+          mode_enum: false,
+          agents_computer_id: false,
+          dummy_type: "integer",
+          dummy_rows: 1,
+          users: 1,
+        });
+
+        await sql.unsafe("drop table computer_credentials");
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+        const [retried] = await sql<
+          {
+            migrations: number;
+            account_computers: string | null;
+            mode_enum: boolean;
+            credential_id_type: string | null;
+            users: number;
+            account_rows: number;
+            credential_rows: number;
+          }[]
+        >`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            to_regclass('public.account_computers')::text as account_computers,
+            exists(select 1 from pg_type where typname = 'computer_connect_code_mode') as mode_enum,
+            (
+              select data_type from information_schema.columns
+              where table_schema = 'public' and table_name = 'computer_credentials' and column_name = 'id'
+            ) as credential_id_type,
+            (select count(*)::int from users) as users,
+            (select count(*)::int from account_computers) as account_rows,
+            (select count(*)::int from computer_credentials) as credential_rows
+        `;
+        expect(retried).toEqual({
+          migrations: journal.entries.length,
+          account_computers: "account_computers",
+          mode_enum: true,
+          credential_id_type: "uuid",
+          users: 1,
+          account_rows: 0,
+          credential_rows: 0,
+        });
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(through0025, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves legacy enrollment hazards and fail-closes new projection constraints", async () => {
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    const client = createDatabaseClient(databaseUrl);
+    try {
+      const bootstrap = await bootstrapInitialAdmin(client.database, {
+        displayName: "Admin",
+        email: "admin@example.com",
+        workspaceDisplayName: "Example",
+        workspaceName: "example",
+      });
+      const sql = client.sql;
+      const [hazards] = await sql<{ constraints: string[]; indexes: string[] }[]>`
+        select
+          array(
+            select conname::text from pg_constraint
+            where conname in ('computer_connect_codes_workspace_enrollment_fk', 'agents_workspace_enrollment_fk')
+            order by conname
+          ) as constraints,
+          array(
+            select indexname::text from pg_indexes
+            where indexname in (
+              'slack_installations_workspace_current_unique',
+              'session_placements_workspace_computer_id_idx'
+            )
+            order by indexname
+          ) as indexes
+      `;
+      expect(hazards).toEqual({
+        constraints: [...HAZARD_CONSTRAINTS].sort(),
+        indexes: [...HAZARD_INDEXES].sort(),
+      });
+
+      const computerId = crypto.randomUUID();
+      await sql`insert into computers (id) values (${computerId})`;
+      const [enrollment] = await sql<{ id: string }[]>`
+        insert into workspace_computers (
+          workspace_id, computer_id, display_name, platform, arch, client_version, enrolled_by_user_id
+        )
+        values (${bootstrap.workspaceId}, ${computerId}, 'box', 'linux', 'x64', '0.0.1', ${bootstrap.userId})
+        returning id::text
+      `;
+      if (!enrollment) throw new Error("Enrollment fixture was not created");
+      await sql`
+        insert into account_computers (
+          id, owner_account_id, current_installation_id, display_name, platform, arch, client_version
+        )
+        values (${enrollment.id}, ${bootstrap.userId}, ${computerId}, 'box', 'linux', 'x64', '0.0.1')
+      `;
+
+      const orphan = await sql`
+        insert into agents (workspace_id, created_by_user_id, workspace_computer_id, computer_id, name, display_name, runtime_provider)
+        values (
+          ${bootstrap.workspaceId}, ${bootstrap.userId}, ${enrollment.id}, ${crypto.randomUUID()},
+          'orphan', 'Orphan', 'codex'
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(orphan)).toMatchObject({
+        code: "23503",
+        constraint_name: "agents_computer_id_account_computers_id_fk",
+      });
+
+      await sql`
+        insert into computer_credentials (computer_id, secret_hash, issued_by_user_id)
+        values (${enrollment.id}, ${"f".repeat(64)}, ${bootstrap.userId})
+      `;
+      const duplicateActive = await sql`
+        insert into computer_credentials (computer_id, secret_hash, issued_by_user_id)
+        values (${enrollment.id}, ${"0".repeat(64)}, ${bootstrap.userId})
+      `.catch((error: unknown) => error);
+      expect(postgresError(duplicateActive)).toMatchObject({
+        code: "23505",
+        constraint_name: "computer_credentials_active_computer_unique",
+      });
+
+      const revocationPair = await sql`
+        insert into computer_credentials (computer_id, secret_hash, issued_by_user_id, revoked_at)
+        values (${enrollment.id}, ${"1".repeat(64)}, ${bootstrap.userId}, now())
+      `.catch((error: unknown) => error);
+      expect(postgresError(revocationPair)).toMatchObject({
+        code: "23514",
+        constraint_name: "computer_credentials_revocation_pair",
+      });
+
+      const otherWorkspace = crypto.randomUUID();
+      await sql`insert into workspaces (id, name, display_name) values (${otherWorkspace}, 'other', 'Other')`;
+      const crossCode = await sql`
+        insert into computer_connect_codes (
+          workspace_id, token_hash, issued_by_user_id, expires_at, consumed_workspace_computer_id, consumed_at
+        )
+        values (
+          ${otherWorkspace}, ${"2".repeat(64)}, ${bootstrap.userId}, now() + interval '15 minutes',
+          ${enrollment.id}, now()
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(crossCode)).toMatchObject({
+        code: "23503",
+        constraint_name: "computer_connect_codes_workspace_enrollment_fk",
+      });
+
+      await sql`
+        insert into slack_installations (
+          workspace_id, status, external_app_id, external_team_id, external_bot_id,
+          credential_schema_version, credential_generation, encrypted_credential, activated_at
+        )
+        values (
+          ${bootstrap.workspaceId}, 'active', 'A1', 'T1', 'U1', 1, 1, 'secret', now()
+        )
+      `;
+      const duplicateSlack = await sql`
+        insert into slack_installations (
+          workspace_id, status, external_app_id, external_team_id, external_bot_id,
+          credential_schema_version, credential_generation, encrypted_credential, activated_at
+        )
+        values (
+          ${bootstrap.workspaceId}, 'active', 'A2', 'T2', 'U2', 1, 1, 'secret-2', now()
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(duplicateSlack)).toMatchObject({
+        code: "23505",
+        constraint_name: "slack_installations_workspace_current_unique",
+      });
+
+      const [otherEnrollment] = await sql<{ id: string }[]>`
+        insert into workspace_computers (
+          workspace_id, computer_id, display_name, platform, arch, client_version, enrolled_by_user_id
+        )
+        values (${otherWorkspace}, ${computerId}, 'other-box', 'linux', 'x64', '0.0.1', ${bootstrap.userId})
+        returning id::text
+      `;
+      if (!otherEnrollment) throw new Error("Cross-workspace enrollment fixture was not created");
+      const crossAgent = await sql`
+        insert into agents (workspace_id, created_by_user_id, workspace_computer_id, name, display_name, runtime_provider)
+        values (
+          ${bootstrap.workspaceId}, ${bootstrap.userId}, ${otherEnrollment.id},
+          'cross', 'Cross', 'codex'
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(crossAgent)).toMatchObject({
+        code: "23503",
+        constraint_name: "agents_workspace_enrollment_fk",
+      });
+    } finally {
+      await client.sql.end();
+    }
+  });
+
+  it("accepts representative reads and dual-writes after the real migration runner", async () => {
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+    const client = createDatabaseClient(databaseUrl);
+    try {
+      const bootstrap = await bootstrapInitialAdmin(client.database, {
+        displayName: "Admin",
+        email: "admin@example.com",
+        workspaceDisplayName: "Example",
+        workspaceName: "example",
+      });
+      const machineAuth = new MachineAuthService(client.database);
+      const computers = new ComputerService(client.database, {
+        getActiveUserById: async () => {
+          throw new Error("unused");
+        },
+      });
+      const issued = await machineAuth.issueForWorkspaceAdmin(bootstrap.userId, bootstrap.workspaceId);
+      const enrollment = await machineAuth.exchangeConnectCode({
+        code: issued.code,
+        computerId: crypto.randomUUID(),
+        displayName: "workstation",
+        platform: "linux",
+        arch: "x64",
+        clientVersion: "0.0.1",
+      });
+      const instanceId = crypto.randomUUID();
+      await computers.register(enrollment, {
+        type: "computer:register",
+        requestId: crypto.randomUUID(),
+        computerId: enrollment.computerId,
+        instanceId,
+        displayName: "workstation",
+        platform: "linux",
+        arch: "x64",
+        clientVersion: "0.0.1",
+        capabilities: { imCredentialGrant: 0 as const },
+        protocolVersion: RUNTIME_PROTOCOL_V2,
+        supportedCapabilities: { imCredentialGrant: { min: 1, max: 1 } },
+        requiredServerCapabilities: [],
+      });
+
+      const [legacy] = await client.database
+        .select()
+        .from(workspaceComputers)
+        .where(eq(workspaceComputers.id, enrollment.workspaceComputerId));
+      const [target] = await client.database
+        .select()
+        .from(accountComputers)
+        .where(eq(accountComputers.id, enrollment.workspaceComputerId));
+      expect(target).toMatchObject({
+        id: enrollment.workspaceComputerId,
+        ownerAccountId: bootstrap.userId,
+        currentInstallationId: enrollment.computerId,
+        currentInstanceId: instanceId,
+        displayName: legacy?.displayName,
+      });
+      const [legacyCredential] = await client.database
+        .select()
+        .from(workspaceComputerCredentials)
+        .where(eq(workspaceComputerCredentials.id, enrollment.credentialId));
+      const [targetCredential] = await client.database
+        .select()
+        .from(computerCredentials)
+        .where(eq(computerCredentials.id, enrollment.credentialId));
+      expect(targetCredential).toMatchObject({
+        id: enrollment.credentialId,
+        computerId: enrollment.workspaceComputerId,
+        secretHash: legacyCredential?.secretHash,
+        issuedByUserId: bootstrap.userId,
+        revokedAt: null,
+      });
+      const codes = await client.database.select().from(computerConnectCodes);
+      expect(codes).toHaveLength(1);
+      expect(codes[0]).toMatchObject({
+        issuedByAccountId: bootstrap.userId,
+        mode: "create",
+        consumedComputerId: enrollment.workspaceComputerId,
+        consumedWorkspaceComputerId: enrollment.workspaceComputerId,
+      });
+
+      const agent = await new AgentService(client.database).createForWorkspace(
+        bootstrap.userId,
+        bootstrap.workspaceId,
+        {
+          name: "assistant",
+          displayName: "Assistant",
+          runtimeProvider: "codex",
+          computerId: enrollment.computerId,
+        },
+      );
+      const [agentRow] = await client.database.select().from(agents).where(eq(agents.id, agent.id));
+      expect(agentRow).toMatchObject({
+        createdByUserId: bootstrap.userId,
+        workspaceComputerId: enrollment.workspaceComputerId,
+        computerId: enrollment.workspaceComputerId,
+      });
+
+      const [binding] = await client.sql<{ id: string }[]>`
+        insert into im_bindings (
+          agent_id, provider, status, external_app_id, external_bot_id,
+          credential_schema_version, credential_generation, encrypted_credential, activated_at
+        )
+        values (
+          ${agent.id}, 'feishu', 'active', 'cli_boot', 'ou_boot', 1, 1, 'encrypted', now()
+        )
+        returning id::text
+      `;
+      if (!binding) throw new Error("IM binding was not created");
+      const sessions = new SessionService(client.database);
+      const chat = await sessions.ensureChatSession(
+        { imBindingId: binding.id, channelId: "C-boot", conversationKind: "channel" },
+        "channel",
+      );
+      expect(chat.placement.workspaceComputerId).toBe(enrollment.workspaceComputerId);
+      const [placement] = await client.database
+        .select()
+        .from(sessionPlacements)
+        .where(eq(sessionPlacements.sessionId, chat.session.id));
+      expect(placement).toMatchObject({
+        workspaceComputerId: enrollment.workspaceComputerId,
+        computerId: enrollment.workspaceComputerId,
+        generation: 1,
+      });
+
+      const proofs = new SessionCliProofService(
+        client.database,
+        {
+          currentInstanceId: (workspaceComputerId: string) =>
+            workspaceComputerId === enrollment.workspaceComputerId ? instanceId : undefined,
+          supportsCapability: (workspaceComputerId: string, connectionInstanceId: string) =>
+            workspaceComputerId === enrollment.workspaceComputerId && connectionInstanceId === instanceId,
+        },
+        new Uint8Array(32).fill(3),
+      );
+      const minted = await proofs.mint({
+        sessionId: chat.session.id,
+        workspaceComputerId: enrollment.workspaceComputerId,
+        placementGeneration: 1,
+        connectionInstanceId: instanceId,
+      });
+      const [proof] = await client.database
+        .select()
+        .from(sessionCliProofs)
+        .where(eq(sessionCliProofs.sessionId, chat.session.id));
+      expect(proof).toMatchObject({
+        proofId: minted.proofId,
+        workspaceComputerId: enrollment.workspaceComputerId,
+        computerId: enrollment.workspaceComputerId,
+      });
+
+      const moved = await sessions.movePlacement(chat.session.id, enrollment.workspaceComputerId);
+      expect(moved).toMatchObject({
+        workspaceComputerId: enrollment.workspaceComputerId,
+        generation: 2,
+      });
+      const [movedRow] = await client.database
+        .select()
+        .from(sessionPlacements)
+        .where(eq(sessionPlacements.sessionId, chat.session.id));
+      expect(movedRow?.computerId).toBe(enrollment.workspaceComputerId);
+
+      const [message] = await client.sql<{ id: string }[]>`
+        insert into im_messages (
+          im_binding_id, channel_id, external_message_id, provider_revision_key, operation, direction,
+          author_kind, author_external_id, content, provider_context, occurred_at
+        )
+        values (
+          ${binding.id}, 'C-boot', 'om_boot', '1', 'created', 'inbound',
+          'human', 'ou_boot',
+          '{"version":1,"fallbackText":"custody","blocks":[],"truncated":false}'::jsonb,
+          '{"provider":"feishu","chatType":"p2p"}'::jsonb,
+          now()
+        )
+        returning id::text
+      `;
+      if (!message) throw new Error("Custody message was not created");
+      await client.sql`
+        insert into im_message_deliveries (
+          message_id, session_id, attention, state, placement_generation, attempt_count,
+          next_attempt_at, expires_at, accepted_at, turn_id, input_hash, report_owner_instance_id
+        )
+        values (
+          ${message.id}, ${chat.session.id}, 'direct', 'accepted', 2, 1,
+          now(), now() + interval '1 day', now(), 'turn-boot', ${"b".repeat(64)}, ${instanceId}
+        )
+      `;
+      await expect(sessions.movePlacement(chat.session.id, enrollment.workspaceComputerId)).rejects.toMatchObject({
+        code: "SESSION_PLACEMENT_CUSTODY_PENDING",
+      });
+      const [blocked] = await client.database
+        .select()
+        .from(sessionPlacements)
+        .where(eq(sessionPlacements.sessionId, chat.session.id));
+      expect(blocked).toMatchObject({
+        generation: 2,
+        computerId: enrollment.workspaceComputerId,
+        workspaceComputerId: enrollment.workspaceComputerId,
+      });
+    } finally {
+      await client.sql.end();
+    }
+  });
+});

--- a/packages/server/src/__tests__/integration/agents.test.ts
+++ b/packages/server/src/__tests__/integration/agents.test.ts
@@ -17,6 +17,7 @@ import {
   workspaces,
 } from "../../db/schema/index.js";
 import { AgentService } from "../../services/agents/index.js";
+import { MachineAuthService } from "../../services/computers/index.js";
 import { DEFAULT_AGENT_RUNTIME_CONFIG } from "../../services/runtime-config/index.js";
 import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
 
@@ -256,6 +257,8 @@ describe("Agent persistence and authorization", () => {
           computer: expect.objectContaining({ computerId: computer.id }),
         }),
       ]);
+      const [stored] = await value.database.select().from(agents).where(eq(agents.id, created.id));
+      expect(stored?.computerId).toBeNull();
       await expect(value.service.getById(value.bootstrap.userId, created.id)).resolves.toMatchObject({
         id: created.id,
       });
@@ -1103,6 +1106,61 @@ describe("Agent persistence and authorization", () => {
         name: "assistant",
         runtimeProvider: "claude-code",
         workspaceId: otherWorkspace.id,
+      });
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("projects the stable Computer id when the account-owned row exists", async () => {
+    const value = await fixture();
+    try {
+      const machineAuth = new MachineAuthService(value.database);
+      const issued = await machineAuth.issueForWorkspaceAdmin(value.bootstrap.userId, value.bootstrap.workspaceId);
+      const enrollment = await machineAuth.exchangeConnectCode({
+        code: issued.code,
+        computerId: crypto.randomUUID(),
+        displayName: "workstation",
+        platform: "linux",
+        arch: "x64",
+        clientVersion: "0.0.1",
+      });
+      const created = await value.service.createForWorkspace(
+        value.bootstrap.userId,
+        value.bootstrap.workspaceId,
+        createInput(enrollment.computerId),
+      );
+      const [stored] = await value.database.select().from(agents).where(eq(agents.id, created.id));
+      expect(stored).toMatchObject({
+        workspaceComputerId: enrollment.workspaceComputerId,
+        computerId: enrollment.workspaceComputerId,
+        createdByUserId: value.bootstrap.userId,
+      });
+      expect(created.computerId).toBe(enrollment.computerId);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("keeps an Agent whose creator differs from the Computer owner", async () => {
+    const value = await fixture();
+    try {
+      const computer = await createComputer(value.database, value.bootstrap.userId, value.bootstrap.workspaceId);
+      const other = await createUser(value.database, value.bootstrap.workspaceId, "other-admin@example.com", "admin");
+      const created = await value.service.createForWorkspace(
+        other.id,
+        value.bootstrap.workspaceId,
+        createInput(computer.id, "foreign-owner"),
+      );
+      expect(created).toMatchObject({
+        createdByUserId: other.id,
+        computerId: computer.id,
+      });
+      const [stored] = await value.database.select().from(agents).where(eq(agents.id, created.id));
+      expect(stored).toMatchObject({
+        createdByUserId: other.id,
+        workspaceComputerId: computer.workspaceComputerId,
+        computerId: null,
       });
     } finally {
       await value.sql.end();

--- a/packages/server/src/__tests__/integration/auth-migrations.test.ts
+++ b/packages/server/src/__tests__/integration/auth-migrations.test.ts
@@ -1062,6 +1062,26 @@ describe("database migrations", () => {
           select id from agents where id in (${activeAgentId}, ${deletedAgentId})
         `;
         expect(preservedAgentIds).toHaveLength(2);
+        const [expansion] = await sql<
+          {
+            account_computers: number;
+            computer_credentials: number;
+            agents_filled: number;
+            placements_filled: number;
+          }[]
+        >`
+          select
+            (select count(*)::int from account_computers) as account_computers,
+            (select count(*)::int from computer_credentials) as computer_credentials,
+            (select count(*)::int from agents where computer_id is not null) as agents_filled,
+            (select count(*)::int from session_placements where computer_id is not null) as placements_filled
+        `;
+        expect(expansion).toEqual({
+          account_computers: 0,
+          computer_credentials: 0,
+          agents_filled: 0,
+          placements_filled: 0,
+        });
         const repairedWorkspaces = await sql<{ completed: boolean; name: string }[]>`
           select name, setup_completed_at is not null as completed
           from workspaces

--- a/packages/server/src/__tests__/integration/computers.test.ts
+++ b/packages/server/src/__tests__/integration/computers.test.ts
@@ -14,7 +14,17 @@ import { createApp } from "../../app.js";
 import { createBetterAuth } from "../../auth/better-auth.js";
 import { BetterAuthSessionTokens } from "../../auth/session-tokens.js";
 import { createDatabaseClient } from "../../db/client.js";
-import { computers, workspaceAdminGrants, workspaceComputers, workspaces } from "../../db/schema/index.js";
+import {
+  accountComputers,
+  computerConnectCodes,
+  computerCredentials,
+  computers,
+  users,
+  workspaceAdminGrants,
+  workspaceComputerCredentials,
+  workspaceComputers,
+  workspaces,
+} from "../../db/schema/index.js";
 import { ConnectionRegistry } from "../../runtime/connection-registry.js";
 import { AuthService } from "../../services/auth/index.js";
 import { ComputerService, MachineAuthService } from "../../services/computers/index.js";
@@ -114,6 +124,31 @@ describe("Computer enrollment persistence", () => {
       expect(await value.service.heartbeat(enrollment, second)).toBe(true);
       expect(await value.database.select().from(computers)).toHaveLength(1);
       expect(await value.database.select().from(workspaceComputers)).toHaveLength(1);
+      const [legacy] = await value.database.select().from(workspaceComputers);
+      const [projected] = await value.database.select().from(accountComputers);
+      expect(projected).toMatchObject({
+        id: enrollment.workspaceComputerId,
+        ownerAccountId: value.bootstrap.userId,
+        currentInstallationId: enrollment.computerId,
+        currentInstanceId: second,
+        displayName: legacy?.displayName,
+        platform: legacy?.platform,
+      });
+      const [legacyCredential] = await value.database
+        .select()
+        .from(workspaceComputerCredentials)
+        .where(eq(workspaceComputerCredentials.id, enrollment.credentialId));
+      const [targetCredential] = await value.database
+        .select()
+        .from(computerCredentials)
+        .where(eq(computerCredentials.id, enrollment.credentialId));
+      expect(targetCredential).toMatchObject({
+        id: enrollment.credentialId,
+        computerId: enrollment.workspaceComputerId,
+        secretHash: legacyCredential?.secretHash,
+        issuedByUserId: value.bootstrap.userId,
+        revokedAt: null,
+      });
     } finally {
       await value.sql.end();
     }
@@ -188,6 +223,86 @@ describe("Computer enrollment persistence", () => {
       });
       await expect(value.machineAuth.verifyMachineToken(rotated.machineToken)).resolves.toMatchObject({
         workspaceComputerId: first.workspaceComputerId,
+      });
+      const credentials = await value.database
+        .select()
+        .from(computerCredentials)
+        .where(eq(computerCredentials.computerId, first.workspaceComputerId));
+      expect(credentials).toHaveLength(2);
+      expect(credentials.find((row) => row.id === first.credentialId)).toMatchObject({
+        revokedAt: expect.any(Date),
+        revokedByUserId: value.bootstrap.userId,
+      });
+      expect(credentials.find((row) => row.id === rotated.credentialId)).toMatchObject({
+        secretHash: (
+          await value.database
+            .select()
+            .from(workspaceComputerCredentials)
+            .where(eq(workspaceComputerCredentials.id, rotated.credentialId))
+        )[0]?.secretHash,
+        revokedAt: null,
+      });
+      const [accountComputer] = await value.database
+        .select()
+        .from(accountComputers)
+        .where(eq(accountComputers.id, first.workspaceComputerId));
+      expect(accountComputer).toMatchObject({
+        id: first.workspaceComputerId,
+        ownerAccountId: value.bootstrap.userId,
+        currentInstallationId: computerId,
+      });
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("rolls back Computer exchange when the account-owned identity diverges", async () => {
+    const value = await fixture();
+    try {
+      const computerId = crypto.randomUUID();
+      const first = await enroll(value, value.bootstrap.workspaceId, value.bootstrap.userId, computerId);
+      const [otherUser] = await value.database
+        .insert(users)
+        .values({ email: "other-owner@example.com", displayName: "Other" })
+        .returning();
+      if (!otherUser) throw new Error("Other Account fixture was not created");
+      await value.database
+        .update(accountComputers)
+        .set({ ownerAccountId: otherUser.id })
+        .where(eq(accountComputers.id, first.workspaceComputerId));
+
+      const issued = await value.machineAuth.issueForWorkspaceAdmin(
+        value.bootstrap.userId,
+        value.bootstrap.workspaceId,
+      );
+      const before = {
+        enrollments: await value.database.select().from(workspaceComputers),
+        accountComputers: await value.database.select().from(accountComputers),
+        legacyCredentials: await value.database.select().from(workspaceComputerCredentials),
+        targetCredentials: await value.database.select().from(computerCredentials),
+        codes: await value.database.select().from(computerConnectCodes),
+      };
+
+      await expect(
+        value.machineAuth.exchangeConnectCode({
+          code: issued.code,
+          computerId,
+          displayName: "mutated",
+          platform: "darwin",
+          arch: "arm64",
+          clientVersion: "9.9.9",
+        }),
+      ).rejects.toThrow(/does not match the enrollment identity/);
+
+      expect(await value.database.select().from(workspaceComputers)).toEqual(before.enrollments);
+      expect(await value.database.select().from(accountComputers)).toEqual(before.accountComputers);
+      expect(await value.database.select().from(workspaceComputerCredentials)).toEqual(before.legacyCredentials);
+      expect(await value.database.select().from(computerCredentials)).toEqual(before.targetCredentials);
+      expect(await value.database.select().from(computerConnectCodes)).toEqual(before.codes);
+      expect(before.codes.filter((row) => row.consumedAt === null)).toHaveLength(1);
+      expect(before.accountComputers[0]).toMatchObject({
+        ownerAccountId: otherUser.id,
+        currentInstallationId: computerId,
       });
     } finally {
       await value.sql.end();

--- a/packages/server/src/__tests__/integration/session-collaboration.test.ts
+++ b/packages/server/src/__tests__/integration/session-collaboration.test.ts
@@ -101,6 +101,12 @@ describe("Session collaboration authority", () => {
       expect((await fixture.database.select().from(sessions)).filter(({ kind }) => kind === "internal")).toHaveLength(
         1,
       );
+      const placements = await fixture.database.select().from(sessionPlacements);
+      expect(placements.every((row) => row.computerId === null)).toBe(true);
+      expect(placements.map((row) => row.workspaceComputerId)).toEqual([
+        fixture.workspaceComputerId,
+        fixture.workspaceComputerId,
+      ]);
 
       await expect(
         fixture.sessions.createInternalSessionWithMessage({ ...input, initialMessage: "Conflicting task" }),
@@ -479,6 +485,11 @@ describe("Session collaboration authority", () => {
 
       const moved = await fixture.sessions.movePlacement(source.session.id, fixture.workspaceComputerId);
       expect(moved.generation).toBe(2);
+      const [movedRow] = await fixture.database
+        .select()
+        .from(sessionPlacements)
+        .where(eq(sessionPlacements.sessionId, source.session.id));
+      expect(movedRow).toMatchObject({ computerId: null, generation: 2 });
       const current = await proofs.mint({
         ...input,
         placementGeneration: 2,

--- a/packages/server/src/__tests__/integration/slack-oauth.test.ts
+++ b/packages/server/src/__tests__/integration/slack-oauth.test.ts
@@ -202,6 +202,7 @@ describe("Slack distributed OAuth adapter", () => {
       expect(installation?.encryptedCredential).toEqual(expect.any(String));
       expect(installation?.encryptedCredential).not.toContain("xoxb-distributed");
       expect(installation?.encryptedCredential).not.toContain(slackApp.signingSecret);
+      expect(installation?.agentId).toBe(value.first.id);
 
       await expect(
         value.oauth.callback({
@@ -275,6 +276,7 @@ describe("Slack distributed OAuth adapter", () => {
         externalAppId: "A_OPENTAG",
         externalTeamId: "T_TEAM",
         externalBotId: "U_BOT",
+        agentId: value.first.id,
       });
       const bindings = await value.database.select().from(imBindings);
       expect(bindings.find((row) => row.id === migrated.imBindingId)).toMatchObject({
@@ -341,6 +343,7 @@ describe("Slack distributed OAuth adapter", () => {
         workspaceId: value.bootstrap.workspaceId,
         credentialGeneration: 2,
         status: "active",
+        agentId: value.second.id,
       });
       expect(installations[0]?.encryptedCredential).not.toContain("xoxb-distributed");
     } finally {

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -12,7 +12,7 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 import { users, workspaces } from "./auth.js";
-import { workspaceComputers } from "./computers.js";
+import { accountComputers, workspaceComputers } from "./computers.js";
 
 export const agentRuntimeProvider = pgEnum("agent_runtime_provider", ["codex", "claude-code"]);
 export const agentReceiveMode = pgEnum("agent_receive_mode", ["all_message", "mention_only"]);
@@ -31,6 +31,7 @@ export const agents = pgTable(
     creationIntentId: uuid("creation_intent_id"),
     creationIntentFingerprint: text("creation_intent_fingerprint"),
     workspaceComputerId: uuid("workspace_computer_id").notNull(),
+    computerId: uuid("computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
     name: text("name").notNull(),
     displayName: text("display_name").notNull(),
     runtimeProvider: agentRuntimeProvider("runtime_provider").notNull(),
@@ -50,6 +51,7 @@ export const agents = pgTable(
     index("agents_workspace_id_idx").on(table.workspaceId),
     index("agents_created_by_user_id_idx").on(table.createdByUserId),
     index("agents_workspace_computer_id_idx").on(table.workspaceComputerId),
+    index("agents_computer_id_idx").on(table.computerId),
     foreignKey({
       columns: [table.workspaceId, table.workspaceComputerId],
       foreignColumns: [workspaceComputers.workspaceId, workspaceComputers.id],
@@ -69,5 +71,9 @@ export const agentsRelations = relations(agents, ({ one }) => ({
   workspaceComputer: one(workspaceComputers, {
     fields: [agents.workspaceComputerId],
     references: [workspaceComputers.id],
+  }),
+  computer: one(accountComputers, {
+    fields: [agents.computerId],
+    references: [accountComputers.id],
   }),
 }));

--- a/packages/server/src/db/schema/computers.ts
+++ b/packages/server/src/db/schema/computers.ts
@@ -14,6 +14,7 @@ import {
 import { users, workspaces } from "./auth.js";
 
 export const computerPlatform = pgEnum("computer_platform", ["darwin", "linux", "win32"]);
+export const computerConnectCodeMode = pgEnum("computer_connect_code_mode", ["create", "repair"]);
 
 export const computers = pgTable(
   "computers",
@@ -67,6 +68,36 @@ export const workspaceComputers = pgTable(
   ],
 );
 
+/**
+ * Account-owned Computer projection. Named `account_computers` because the thin `computers` table occupies the final
+ * name until that identity table is dropped.
+ */
+export const accountComputers = pgTable(
+  "account_computers",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    ownerAccountId: uuid("owner_account_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    currentInstallationId: uuid("current_installation_id")
+      .notNull()
+      .references(() => computers.id, { onDelete: "restrict" }),
+    displayName: text("display_name").notNull(),
+    platform: computerPlatform("platform").notNull(),
+    arch: text("arch").notNull(),
+    clientVersion: text("client_version").notNull(),
+    currentInstanceId: uuid("current_instance_id"),
+    connectedAt: timestamp("connected_at", { withTimezone: true }),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("account_computers_owner_account_id_idx").on(table.ownerAccountId),
+    index("account_computers_current_installation_id_idx").on(table.currentInstallationId),
+  ],
+);
+
 export const workspaceComputerCredentials = pgTable(
   "workspace_computer_credentials",
   {
@@ -98,6 +129,37 @@ export const workspaceComputerCredentials = pgTable(
   ],
 );
 
+export const computerCredentials = pgTable(
+  "computer_credentials",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    computerId: uuid("computer_id")
+      .notNull()
+      .references(() => accountComputers.id, { onDelete: "restrict" }),
+    secretHash: text("secret_hash").notNull().unique(),
+    issuedByUserId: uuid("issued_by_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    issuedAt: timestamp("issued_at", { withTimezone: true }).notNull().defaultNow(),
+    revokedByUserId: uuid("revoked_by_user_id").references(() => users.id, { onDelete: "restrict" }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex("computer_credentials_active_computer_unique")
+      .on(table.computerId)
+      .where(sql`${table.revokedAt} is null`),
+    index("computer_credentials_computer_issued_idx").on(table.computerId, table.issuedAt),
+    check(
+      "computer_credentials_revocation_pair",
+      sql`(${table.revokedByUserId} is null) = (${table.revokedAt} is null)`,
+    ),
+    check(
+      "computer_credentials_revoked_after_issued",
+      sql`${table.revokedAt} is null or ${table.revokedAt} >= ${table.issuedAt}`,
+    ),
+  ],
+);
+
 export const computerConnectCodes = pgTable(
   "computer_connect_codes",
   {
@@ -109,9 +171,13 @@ export const computerConnectCodes = pgTable(
     issuedByUserId: uuid("issued_by_user_id")
       .notNull()
       .references(() => users.id, { onDelete: "restrict" }),
+    issuedByAccountId: uuid("issued_by_account_id").references(() => users.id, { onDelete: "restrict" }),
+    mode: computerConnectCodeMode("mode"),
+    targetComputerId: uuid("target_computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     consumedWorkspaceComputerId: uuid("consumed_workspace_computer_id"),
+    consumedComputerId: uuid("consumed_computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
     consumedAt: timestamp("consumed_at", { withTimezone: true }),
     revokedByUserId: uuid("revoked_by_user_id").references(() => users.id, { onDelete: "restrict" }),
     revokedAt: timestamp("revoked_at", { withTimezone: true }),
@@ -123,6 +189,8 @@ export const computerConnectCodes = pgTable(
       name: "computer_connect_codes_workspace_enrollment_fk",
     }).onDelete("restrict"),
     index("computer_connect_codes_workspace_created_idx").on(table.workspaceId, table.createdAt),
+    index("computer_connect_codes_target_computer_id_idx").on(table.targetComputerId),
+    index("computer_connect_codes_consumed_computer_id_idx").on(table.consumedComputerId),
     check("computer_connect_codes_expiry", sql`${table.expiresAt} > ${table.createdAt}`),
     check(
       "computer_connect_codes_consumption_pair",

--- a/packages/server/src/db/schema/session-cli-proofs.ts
+++ b/packages/server/src/db/schema/session-cli-proofs.ts
@@ -1,6 +1,6 @@
 import { sql } from "drizzle-orm";
-import { bigint, check, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
-import { workspaceComputers } from "./computers.js";
+import { bigint, check, index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { accountComputers, workspaceComputers } from "./computers.js";
 import { sessions } from "./sessions.js";
 
 export const sessionCliProofs = pgTable(
@@ -14,12 +14,14 @@ export const sessionCliProofs = pgTable(
     workspaceComputerId: uuid("workspace_computer_id")
       .notNull()
       .references(() => workspaceComputers.id, { onDelete: "cascade" }),
+    computerId: uuid("computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
     placementGeneration: bigint("placement_generation", { mode: "number" }).notNull(),
     connectionInstanceId: uuid("connection_instance_id").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
+    index("session_cli_proofs_computer_id_idx").on(table.computerId),
     check("session_cli_proofs_token_hash_shape", sql`${table.tokenHash} ~ '^[0-9a-f]{64}$'`),
     check("session_cli_proofs_generation_positive", sql`${table.placementGeneration} >= 1`),
   ],

--- a/packages/server/src/db/schema/sessions.ts
+++ b/packages/server/src/db/schema/sessions.ts
@@ -13,7 +13,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
-import { workspaceComputers } from "./computers.js";
+import { accountComputers, workspaceComputers } from "./computers.js";
 import { imBindings, imConversationKind } from "./im-bindings.js";
 
 export const sessionKind = pgEnum("session_kind", ["channel", "thread", "internal"]);
@@ -79,11 +79,13 @@ export const sessionPlacements = pgTable(
     workspaceComputerId: uuid("workspace_computer_id")
       .notNull()
       .references(() => workspaceComputers.id, { onDelete: "restrict" }),
+    computerId: uuid("computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
     generation: bigint("generation", { mode: "number" }).notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     index("session_placements_workspace_computer_id_idx").on(table.workspaceComputerId),
+    index("session_placements_computer_id_idx").on(table.computerId),
     check("session_placements_generation_positive", sql`${table.generation} >= 1`),
   ],
 );

--- a/packages/server/src/db/schema/slack-installations.ts
+++ b/packages/server/src/db/schema/slack-installations.ts
@@ -11,6 +11,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
 import { workspaces } from "./auth.js";
 
 export const slackInstallationStatus = pgEnum("slack_installation_status", [
@@ -26,6 +27,7 @@ export const slackInstallations = pgTable(
     workspaceId: uuid("workspace_id")
       .notNull()
       .references(() => workspaces.id, { onDelete: "restrict" }),
+    agentId: uuid("agent_id").references(() => agents.id, { onDelete: "restrict" }),
     status: slackInstallationStatus("status").notNull().default("active"),
 
     externalAppId: text("external_app_id").notNull(),
@@ -63,6 +65,7 @@ export const slackInstallations = pgTable(
       .on(table.workspaceId)
       .where(sql`${table.status} <> 'disabled'`),
     index("slack_installations_workspace_id_idx").on(table.workspaceId),
+    index("slack_installations_agent_id_idx").on(table.agentId),
     index("slack_installations_app_team_idx").on(table.externalAppId, table.externalTeamId),
     check("slack_installations_credential_generation_nonnegative", sql`${table.credentialGeneration} >= 0`),
     check(
@@ -84,6 +87,7 @@ export const slackInstallations = pgTable(
 
 export const slackInstallationsRelations = relations(slackInstallations, ({ one, many }) => ({
   workspace: one(workspaces, { fields: [slackInstallations.workspaceId], references: [workspaces.id] }),
+  agent: one(agents, { fields: [slackInstallations.agentId], references: [agents.id] }),
   replacement: one(slackInstallations, {
     fields: [slackInstallations.replacementSlackInstallationId],
     references: [slackInstallations.id],

--- a/packages/server/src/services/agents/agent-service.ts
+++ b/packages/server/src/services/agents/agent-service.ts
@@ -34,6 +34,7 @@ import {
   workspaceComputers,
 } from "../../db/schema/index.js";
 import { AuthServiceError } from "../auth/index.js";
+import { projectedComputerId } from "../computers/ownership-projections.js";
 import { disableImBindingInTransaction } from "../im-bindings/index.js";
 import { resolveAgentRuntimeConfig } from "../runtime-config/index.js";
 import { WorkspaceAdminAccess } from "../workspace-admin-access/index.js";
@@ -337,6 +338,7 @@ export class AgentService {
             creationIntentId: input.creationIntentId,
             creationIntentFingerprint: intentFingerprint,
             workspaceComputerId: computerEnrollment.id,
+            computerId: await projectedComputerId(transaction, computerEnrollment.id),
             name: input.name,
             displayName: input.displayName,
             runtimeProvider: input.runtimeProvider,

--- a/packages/server/src/services/computers/computer-service.ts
+++ b/packages/server/src/services/computers/computer-service.ts
@@ -1,7 +1,12 @@
 import type { ComputerRegisterFrame, MeResponse } from "@opentag/shared";
 import { and, eq, isNull } from "drizzle-orm";
 import type { DatabaseClient, DatabaseTransaction } from "../../db/client.js";
-import { workspaceComputerCredentials, workspaceComputers, workspaces } from "../../db/schema/index.js";
+import {
+  accountComputers,
+  workspaceComputerCredentials,
+  workspaceComputers,
+  workspaces,
+} from "../../db/schema/index.js";
 import { AuthServiceError } from "../auth/index.js";
 import type { ComputerAuthContext } from "./machine-auth-service.js";
 
@@ -34,18 +39,19 @@ export class ComputerService {
     const now = this.#now();
     await this.#database.transaction(async (transaction) => {
       await this.#lockActiveCredential(transaction, context);
+      const observation = {
+        displayName: frame.displayName,
+        platform: frame.platform,
+        arch: frame.arch,
+        clientVersion: frame.clientVersion,
+        currentInstanceId: frame.instanceId,
+        connectedAt: now,
+        lastSeenAt: now,
+        updatedAt: now,
+      };
       const updated = await transaction
         .update(workspaceComputers)
-        .set({
-          displayName: frame.displayName,
-          platform: frame.platform,
-          arch: frame.arch,
-          clientVersion: frame.clientVersion,
-          currentInstanceId: frame.instanceId,
-          connectedAt: now,
-          lastSeenAt: now,
-          updatedAt: now,
-        })
+        .set(observation)
         .where(
           and(
             eq(workspaceComputers.id, context.workspaceComputerId),
@@ -56,6 +62,10 @@ export class ComputerService {
         )
         .returning({ id: workspaceComputers.id });
       if (updated.length !== 1) throw unavailableEnrollment();
+      await transaction
+        .update(accountComputers)
+        .set(observation)
+        .where(eq(accountComputers.id, context.workspaceComputerId));
     });
   }
 
@@ -63,9 +73,10 @@ export class ComputerService {
     const now = this.#now();
     return this.#database.transaction(async (transaction) => {
       await this.#lockActiveCredential(transaction, context);
+      const heartbeat = { lastSeenAt: now, updatedAt: now };
       const updated = await transaction
         .update(workspaceComputers)
-        .set({ lastSeenAt: now, updatedAt: now })
+        .set(heartbeat)
         .where(
           and(
             eq(workspaceComputers.id, context.workspaceComputerId),
@@ -76,7 +87,12 @@ export class ComputerService {
           ),
         )
         .returning({ id: workspaceComputers.id });
-      return updated.length === 1;
+      if (updated.length !== 1) return false;
+      await transaction
+        .update(accountComputers)
+        .set(heartbeat)
+        .where(eq(accountComputers.id, context.workspaceComputerId));
+      return true;
     });
   }
 
@@ -86,12 +102,24 @@ export class ComputerService {
 
   async disconnect(workspaceComputerId: string, instanceId: string): Promise<boolean> {
     const now = this.#now();
-    const updated = await this.#database
-      .update(workspaceComputers)
-      .set({ currentInstanceId: null, connectedAt: null, lastSeenAt: now, updatedAt: now })
-      .where(and(eq(workspaceComputers.id, workspaceComputerId), eq(workspaceComputers.currentInstanceId, instanceId)))
-      .returning({ id: workspaceComputers.id });
-    return updated.length === 1;
+    return this.#database.transaction(async (transaction) => {
+      const disconnection = {
+        currentInstanceId: null,
+        connectedAt: null,
+        lastSeenAt: now,
+        updatedAt: now,
+      };
+      const updated = await transaction
+        .update(workspaceComputers)
+        .set(disconnection)
+        .where(
+          and(eq(workspaceComputers.id, workspaceComputerId), eq(workspaceComputers.currentInstanceId, instanceId)),
+        )
+        .returning({ id: workspaceComputers.id });
+      if (updated.length !== 1) return false;
+      await transaction.update(accountComputers).set(disconnection).where(eq(accountComputers.id, workspaceComputerId));
+      return true;
+    });
   }
 
   async #lockActiveCredential(transaction: DatabaseTransaction, context: ComputerAuthContext): Promise<void> {

--- a/packages/server/src/services/computers/machine-auth-service.ts
+++ b/packages/server/src/services/computers/machine-auth-service.ts
@@ -3,7 +3,9 @@ import { type ChannelName, getChannelConfig } from "@opentag/shared";
 import { and, eq, isNull } from "drizzle-orm";
 import type { DatabaseClient } from "../../db/client.js";
 import {
+  accountComputers,
   computerConnectCodes,
+  computerCredentials,
   computers,
   workspaceComputerCredentials,
   workspaceComputers,
@@ -83,6 +85,8 @@ export class MachineAuthService implements ComputerAuthVerifier, MachineConnectC
         workspaceId,
         tokenHash: hashSecret(code),
         issuedByUserId: accountId,
+        issuedByAccountId: accountId,
+        mode: "create",
         createdAt: now,
         expiresAt,
       });
@@ -134,8 +138,22 @@ export class MachineAuthService implements ComputerAuthVerifier, MachineConnectC
         })
         .onConflictDoNothing({ target: computers.id });
 
+      const enrollmentColumns = {
+        id: workspaceComputers.id,
+        computerId: workspaceComputers.computerId,
+        displayName: workspaceComputers.displayName,
+        platform: workspaceComputers.platform,
+        arch: workspaceComputers.arch,
+        clientVersion: workspaceComputers.clientVersion,
+        enrolledByUserId: workspaceComputers.enrolledByUserId,
+        enrolledAt: workspaceComputers.enrolledAt,
+        currentInstanceId: workspaceComputers.currentInstanceId,
+        connectedAt: workspaceComputers.connectedAt,
+        lastSeenAt: workspaceComputers.lastSeenAt,
+        updatedAt: workspaceComputers.updatedAt,
+      };
       let [enrollment] = await transaction
-        .select({ id: workspaceComputers.id })
+        .select(enrollmentColumns)
         .from(workspaceComputers)
         .where(
           and(
@@ -160,9 +178,9 @@ export class MachineAuthService implements ComputerAuthVerifier, MachineConnectC
             enrolledAt: now,
             updatedAt: now,
           })
-          .returning({ id: workspaceComputers.id });
+          .returning(enrollmentColumns);
       } else {
-        await transaction
+        [enrollment] = await transaction
           .update(workspaceComputers)
           .set({
             displayName: input.displayName,
@@ -174,9 +192,55 @@ export class MachineAuthService implements ComputerAuthVerifier, MachineConnectC
             lastSeenAt: null,
             updatedAt: now,
           })
-          .where(eq(workspaceComputers.id, enrollment.id));
+          .where(eq(workspaceComputers.id, enrollment.id))
+          .returning(enrollmentColumns);
       }
       if (!enrollment) throw new Error("Computer enrollment was not created");
+
+      const [accountComputer] = await transaction
+        .select({
+          ownerAccountId: accountComputers.ownerAccountId,
+          currentInstallationId: accountComputers.currentInstallationId,
+        })
+        .from(accountComputers)
+        .where(eq(accountComputers.id, enrollment.id))
+        .limit(1)
+        .for("update");
+      if (!accountComputer) {
+        await transaction.insert(accountComputers).values({
+          id: enrollment.id,
+          ownerAccountId: enrollment.enrolledByUserId,
+          currentInstallationId: enrollment.computerId,
+          displayName: enrollment.displayName,
+          platform: enrollment.platform,
+          arch: enrollment.arch,
+          clientVersion: enrollment.clientVersion,
+          currentInstanceId: enrollment.currentInstanceId,
+          connectedAt: enrollment.connectedAt,
+          lastSeenAt: enrollment.lastSeenAt,
+          createdAt: enrollment.enrolledAt,
+          updatedAt: enrollment.updatedAt,
+        });
+      } else if (
+        accountComputer.ownerAccountId !== enrollment.enrolledByUserId ||
+        accountComputer.currentInstallationId !== enrollment.computerId
+      ) {
+        throw new Error("The account-owned Computer projection does not match the enrollment identity");
+      } else {
+        await transaction
+          .update(accountComputers)
+          .set({
+            displayName: enrollment.displayName,
+            platform: enrollment.platform,
+            arch: enrollment.arch,
+            clientVersion: enrollment.clientVersion,
+            currentInstanceId: enrollment.currentInstanceId,
+            connectedAt: enrollment.connectedAt,
+            lastSeenAt: enrollment.lastSeenAt,
+            updatedAt: enrollment.updatedAt,
+          })
+          .where(eq(accountComputers.id, enrollment.id));
+      }
 
       await transaction
         .update(workspaceComputerCredentials)
@@ -187,18 +251,34 @@ export class MachineAuthService implements ComputerAuthVerifier, MachineConnectC
             isNull(workspaceComputerCredentials.revokedAt),
           ),
         );
+      await transaction
+        .update(computerCredentials)
+        .set({ revokedByUserId: connectCode.issuedByUserId, revokedAt: now })
+        .where(and(eq(computerCredentials.computerId, enrollment.id), isNull(computerCredentials.revokedAt)));
       const credentialId = randomUUID();
       const secret = generateSecret(32);
+      const secretHash = hashSecret(secret);
       await transaction.insert(workspaceComputerCredentials).values({
         id: credentialId,
         workspaceComputerId: enrollment.id,
-        secretHash: hashSecret(secret),
+        secretHash,
+        issuedByUserId: connectCode.issuedByUserId,
+        issuedAt: now,
+      });
+      await transaction.insert(computerCredentials).values({
+        id: credentialId,
+        computerId: enrollment.id,
+        secretHash,
         issuedByUserId: connectCode.issuedByUserId,
         issuedAt: now,
       });
       const [consumed] = await transaction
         .update(computerConnectCodes)
-        .set({ consumedWorkspaceComputerId: enrollment.id, consumedAt: now })
+        .set({
+          consumedWorkspaceComputerId: enrollment.id,
+          consumedComputerId: enrollment.id,
+          consumedAt: now,
+        })
         .where(and(eq(computerConnectCodes.id, connectCode.id), isNull(computerConnectCodes.consumedAt)))
         .returning({ id: computerConnectCodes.id });
       if (!consumed) {

--- a/packages/server/src/services/computers/ownership-projections.ts
+++ b/packages/server/src/services/computers/ownership-projections.ts
@@ -1,0 +1,16 @@
+import { eq } from "drizzle-orm";
+import type { DatabaseTransaction } from "../../db/client.js";
+import { accountComputers } from "../../db/schema/index.js";
+
+/** Returns the stable Computer id when the account-owned projection row already exists. */
+export async function projectedComputerId(
+  transaction: DatabaseTransaction,
+  workspaceComputerId: string,
+): Promise<string | undefined> {
+  const [row] = await transaction
+    .select({ id: accountComputers.id })
+    .from(accountComputers)
+    .where(eq(accountComputers.id, workspaceComputerId))
+    .limit(1);
+  return row?.id;
+}

--- a/packages/server/src/services/im-bindings/im-binding-service.ts
+++ b/packages/server/src/services/im-bindings/im-binding-service.ts
@@ -1558,6 +1558,7 @@ export class ImBindingService {
           .update(slackInstallations)
           .set({
             status: "active",
+            agentId: input.agentId,
             externalAppId: input.appId,
             externalTeamId: input.teamId,
             externalEnterpriseId: input.enterpriseId ?? null,
@@ -1646,6 +1647,7 @@ export class ImBindingService {
       .insert(slackInstallations)
       .values({
         workspaceId: input.workspaceId,
+        agentId: input.agentId,
         status: "active",
         externalAppId: input.appId,
         externalTeamId: input.teamId,

--- a/packages/server/src/services/onboarding-lab/onboarding-reset-service.ts
+++ b/packages/server/src/services/onboarding-lab/onboarding-reset-service.ts
@@ -2,8 +2,10 @@ import type { ChannelName } from "@opentag/shared";
 import { and, count, eq, gt, inArray, isNull, ne } from "drizzle-orm";
 import type { DatabaseClient } from "../../db/client.js";
 import {
+  accountComputers,
   agents,
   computerConnectCodes,
+  computerCredentials,
   imBindings,
   workspaceAdminGrants,
   workspaceComputerCredentials,
@@ -211,6 +213,10 @@ export class OnboardingResetService {
           ),
         );
       await transaction
+        .update(computerCredentials)
+        .set({ revokedByUserId: accountId, revokedAt: now })
+        .where(and(inArray(computerCredentials.computerId, enrollmentIds), isNull(computerCredentials.revokedAt)));
+      await transaction
         .update(workspaceComputers)
         .set({
           revokedByUserId: accountId,
@@ -220,6 +226,14 @@ export class OnboardingResetService {
           updatedAt: now,
         })
         .where(and(inArray(workspaceComputers.id, enrollmentIds), isNull(workspaceComputers.revokedAt)));
+      await transaction
+        .update(accountComputers)
+        .set({
+          currentInstanceId: null,
+          connectedAt: null,
+          updatedAt: now,
+        })
+        .where(inArray(accountComputers.id, enrollmentIds));
       return enrollmentIds;
     });
   }

--- a/packages/server/src/services/sessions/session-cli-proof-service.ts
+++ b/packages/server/src/services/sessions/session-cli-proof-service.ts
@@ -11,6 +11,7 @@ import {
   workspaceComputers,
 } from "../../db/schema/index.js";
 import type { ConnectionRegistry } from "../../runtime/connection-registry.js";
+import { projectedComputerId } from "../computers/ownership-projections.js";
 
 export interface SessionCliSourceContext {
   agentId: string;
@@ -94,6 +95,7 @@ export class SessionCliProofService {
       const proofId = randomUUID();
       const token = this.#deriveToken({ ...input, proofId });
       const now = this.#now();
+      const computerId = (await projectedComputerId(transaction, input.workspaceComputerId)) ?? null;
       await transaction
         .insert(sessionCliProofs)
         .values({
@@ -101,6 +103,7 @@ export class SessionCliProofService {
           proofId,
           tokenHash: hashToken(token),
           workspaceComputerId: input.workspaceComputerId,
+          computerId,
           placementGeneration: input.placementGeneration,
           connectionInstanceId: input.connectionInstanceId,
           createdAt: now,
@@ -112,6 +115,7 @@ export class SessionCliProofService {
             proofId,
             tokenHash: hashToken(token),
             workspaceComputerId: input.workspaceComputerId,
+            computerId,
             placementGeneration: input.placementGeneration,
             connectionInstanceId: input.connectionInstanceId,
             updatedAt: now,

--- a/packages/server/src/services/sessions/session-service.ts
+++ b/packages/server/src/services/sessions/session-service.ts
@@ -21,6 +21,7 @@ import {
   sessions,
   workspaceComputers,
 } from "../../db/schema/index.js";
+import { projectedComputerId } from "../computers/ownership-projections.js";
 
 type SessionRow = typeof sessions.$inferSelect;
 type PlacementRow = typeof sessionPlacements.$inferSelect;
@@ -264,6 +265,7 @@ export class SessionService {
         .values({
           sessionId: created.id,
           workspaceComputerId: creator.placement.workspaceComputerId,
+          computerId: await projectedComputerId(transaction, creator.placement.workspaceComputerId),
           generation: 1,
           updatedAt: now,
         })
@@ -649,7 +651,12 @@ export class SessionService {
         .where(and(eq(imMessageDeliveries.sessionId, sessionId), eq(imMessageDeliveries.state, "pending")));
       const [placement] = await transaction
         .update(sessionPlacements)
-        .set({ workspaceComputerId, generation, updatedAt: now })
+        .set({
+          workspaceComputerId,
+          computerId: (await projectedComputerId(transaction, workspaceComputerId)) ?? null,
+          generation,
+          updatedAt: now,
+        })
         .where(eq(sessionPlacements.sessionId, sessionId))
         .returning();
       if (!placement) throw new SessionServiceError("SESSION_NOT_FOUND", "The Session placement was not found");
@@ -890,7 +897,13 @@ export class SessionService {
       (
         await transaction
           .insert(sessionPlacements)
-          .values({ sessionId: session.id, workspaceComputerId, generation: 1, updatedAt: now })
+          .values({
+            sessionId: session.id,
+            workspaceComputerId,
+            computerId: await projectedComputerId(transaction, workspaceComputerId),
+            generation: 1,
+            updatedAt: now,
+          })
           .onConflictDoNothing()
           .returning()
       )[0];


### PR DESCRIPTION
## Summary

PR 1 of the approved Issue #227 sequence. This is expansion schema and dual writes only:

- adds nullable Account-owned Computer projections (`account_computers`, `computer_credentials`, and target columns on connect codes, Agents, Session placements/proofs, and Slack installations);
- dual-writes legacy and target projections in the same database transaction for Computer exchange/credential rotation/observations, Agent creation, Session placement/proof writes, Slack installation, and onboarding reset;
- keeps all canonical reads and user-visible behavior on the legacy model;
- deliberately performs no historical backfill (that is PR 2) and does not inherit `workspace_admin_grants` into ownership.

Issue: #227. This PR does not close the Issue.

Exact source/base: `430302903596c0763ffc8e034bbf496424b1803f`  
Exact accepted head: `8170b99b5542b6d00b1e87a618b9ce5074e64867`

## Gate 0 readiness

- Node `v24.7.0`; pnpm `10.12.1`; `pnpm install --frozen-lockfile` passed with the lockfile current (571 packages reused, 0 downloaded).
- Docker client/server `29.4.1`; cached `postgres:17-alpine`; Testcontainers and the repository `migrateDatabase`/`verifyDatabaseMigrations` path were exercised successfully.
- GitHub CLI is authenticated as `yuezengwu`; repository fetch/push/PR and coordinating-task merge capabilities were verified without printing credentials. This implementation task remains non-merging.
- Staging observation was verified without writes: CapRover deployment/revision and sanitized logs were readable; `https://dev.opentag.build/healthz` returned healthy; the deployed image was the planned base revision `430302903596c0763ffc8e034bbf496424b1803f`.
- pgAdmin access was verified with the existing `opentag_staging` identity inside `REPEATABLE READ, READ ONLY`; `transaction_read_only=on`, 26 migration rows through 0025 were observed, and the session ended with `ROLLBACK`/no active transaction.
- No staging smoke-test writes were performed. The deferred CapRover App-token rotation and dedicated DB observer role were not changed.
- Repository-managed Pi provider smoke passed for Grok, Kimi, and DeepSeek; the implementation session settled successfully on the pinned Grok provider.

## Gate 1 migration matrix

All migration scenarios run the checked-in production migration runner against PostgreSQL 17. Fixtures may select an exact checked-in starting journal (for example, through 0025), but no migration SQL is modified and no fixture repairs data that 0026 is expected to reject.

| Scenario | Start → target | Result / invariant evidence |
| --- | --- | --- |
| Empty database and restart | empty → 0026 | PASS; 27 journal rows, all additive objects present, 0 target rows; a second runner invocation is idempotent. |
| Immediately previous populated schema | 0025 → 0026 | PASS; legacy counts remained Computers 2, credentials 2, codes 2, Agents 1, placements 2, proofs 1, Slack 2, deliveries 2; target tables remained empty and nullable projections remained null, as PR 1 requires. |
| Representative historical upgrades | 0024 and deployed 0005/0006 histories → 0026 | PASS; Slack history and previous migration semantics were preserved; historical Slack `agent_id` remained null pending PR 2. |
| Normal and terminal records | 0025 → 0026 | PASS; active/revoked credentials 1/1, unconsumed/consumed codes 1/1, active/ended Sessions 1/1, current/replaced Slack chain 1/1, pending delivery 1, accepted-unreported custody 1, and stale proof/connection data all survived unchanged. |
| Missing and owner-mismatched target data | 0025 → 0026 | PASS; absent target parents remain nullable; an Agent creator vs enrollment-owner mismatch remained exactly 1 and was not inferred from Workspace admin grants. |
| Orphan/duplicate/constraint violations | current 0026 | PASS, fail closed; target orphan FK, duplicate active credential, invalid revocation pair, consumed-code composite FK, duplicate current Slack installation, and Agent/enrollment composite FK were all rejected by their expected constraints. |
| Transactional failure and retry | 0025 → 0026 | PASS; a fixture-only conflicting `computer_credentials` relation made the checked-in 0026 fail. The ledger stayed at 26, earlier 0026 enum/table/column work rolled back, and legacy data remained. After dropping only the intentional obstruction, the same checked-in runner reached 0026 with 27 journal rows. |
| Post-migration startup/reads/writes | empty → 0026 | PASS; startup ordering tests require migration/verification before listen, migrated HTTP/service flows remained healthy, and representative Computer, credential, code, Agent, placement, proof, Slack, observation, reset, and custody operations preserved legacy behavior while writing target projections where a target parent exists. |

The realistic populated fixture also verifies that expansion adds no hidden backfill: `account_computers=0`, `computer_credentials=0`, and non-null target Agent/placement/proof/Slack/code projections are all 0 immediately after 0025 → 0026.

## Testing

- `pnpm check` — pass; 470 files and third-party notices verified.
- `pnpm build` — pass; 5/5 package builds.
- `pnpm typecheck` — pass; 7/7 tasks.
- `pnpm test` — pass; repository script tests 66/66 and Turbo 7/7 tasks.
- `pnpm --filter @opentag/server test` — pass; 41 files, 292 tests (includes Server startup migration-before-listen behavior).
- `pnpm --filter @opentag/server test:integration` — pass; 13 files, 240 tests.
- `pnpm --filter @opentag/server exec vitest run src/__tests__/integration/account-ownership-expansion.test.ts --maxWorkers=1` — pass; 7/7 migration scenarios.
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — pass; 20 files, 289 tests, 100% statements/branches/functions/lines.
- `pnpm --filter @opentag/server db:generate` — pass; `No schema changes, nothing to migrate`.
- `git diff --check` — pass.

## Migration risk and rollback compatibility

The four known migration hazards remain intact and are asserted by tests:

1. the consumed connect-code `(workspace_id, consumed_workspace_computer_id)` composite FK;
2. Slack installation Workspace binding/routing and current-installation uniqueness;
3. Workspace-qualified Session placement joins/indexes;
4. the non-deferrable Agent/enrollment composite FK.

Application rollback remains compatible: every legacy table, column, index, FK, read path, and behavior remains present; the target fields are nullable; and historical rows are intentionally not backfilled. Rolling back the Server can safely ignore the additive target schema/rows. The database migration itself remains installed and additive; no destructive down migration is proposed.

## Breaking changes

None. No user-visible behavior change is expected.

## Merge and progression boundary

This implementation task must not merge this PR. The coordinating task may merge only after re-reading the live PR head and proving all required GitHub CI checks on this exact head. Any synchronize/head change invalidates the acceptance evidence above and requires a fresh exact-head Gate 1 run. PR 2 must not start until that merge and staging Gate 2 pass.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (not applicable; no docs changed).
