### PR TITLE
feat(server): backfill account-owned resources

### DIFF
--- a/packages/server/drizzle/0027_backfill_account_owned_resources.sql
+++ b/packages/server/drizzle/0027_backfill_account_owned_resources.sql
@@ -1,0 +1,332 @@
+-- Backfill account-owned Computer projections from Workspace enrollments.
+-- Data-only: target columns stay nullable until the constraint migration.
+DO $$
+BEGIN
+	LOCK TABLE
+		"computer_connect_codes",
+		"workspace_computers",
+		"workspace_computer_credentials",
+		"account_computers",
+		"computer_credentials",
+		"agents",
+		"session_placements",
+		"session_cli_proofs",
+		"slack_installations",
+		"im_bindings"
+	IN SHARE ROW EXCLUSIVE MODE;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "account_computers" AS "account_computer"
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM "workspace_computers" AS "workspace_computer"
+			WHERE "workspace_computer"."id" = "account_computer"."id"
+		)
+	) THEN
+		RAISE EXCEPTION 'Account Computer backfill found a target Computer that does not match a Workspace enrollment';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "account_computers" AS "account_computer"
+		INNER JOIN "workspace_computers" AS "workspace_computer" ON "workspace_computer"."id" = "account_computer"."id"
+		WHERE "account_computer"."owner_account_id" IS DISTINCT FROM "workspace_computer"."enrolled_by_user_id"
+			OR "account_computer"."current_installation_id" IS DISTINCT FROM "workspace_computer"."computer_id"
+	) THEN
+		RAISE EXCEPTION 'Account Computer backfill found a Computer whose owner or installation does not match the enrollment';
+	END IF;
+
+	INSERT INTO "account_computers" (
+		"id",
+		"owner_account_id",
+		"current_installation_id",
+		"display_name",
+		"platform",
+		"arch",
+		"client_version",
+		"current_instance_id",
+		"connected_at",
+		"last_seen_at",
+		"created_at",
+		"updated_at"
+	)
+	SELECT
+		"workspace_computer"."id",
+		"workspace_computer"."enrolled_by_user_id",
+		"workspace_computer"."computer_id",
+		"workspace_computer"."display_name",
+		"workspace_computer"."platform",
+		"workspace_computer"."arch",
+		"workspace_computer"."client_version",
+		"workspace_computer"."current_instance_id",
+		"workspace_computer"."connected_at",
+		"workspace_computer"."last_seen_at",
+		"workspace_computer"."enrolled_at",
+		"workspace_computer"."updated_at"
+	FROM "workspace_computers" AS "workspace_computer"
+	WHERE NOT EXISTS (
+		SELECT 1
+		FROM "account_computers" AS "account_computer"
+		WHERE "account_computer"."id" = "workspace_computer"."id"
+	);
+
+	IF EXISTS (
+		SELECT 1
+		FROM "workspace_computers" AS "workspace_computer"
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM "account_computers" AS "account_computer"
+			WHERE "account_computer"."id" = "workspace_computer"."id"
+		)
+	) THEN
+		RAISE EXCEPTION 'Account Computer backfill could not project every Workspace enrollment';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "computer_credentials" AS "computer_credential"
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM "workspace_computer_credentials" AS "workspace_credential"
+			WHERE "workspace_credential"."id" = "computer_credential"."id"
+		)
+	) THEN
+		RAISE EXCEPTION 'Computer credential backfill found a target credential that does not match a Workspace enrollment credential';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "computer_credentials" AS "computer_credential"
+		INNER JOIN "workspace_computer_credentials" AS "workspace_credential"
+			ON "workspace_credential"."id" = "computer_credential"."id"
+		WHERE "computer_credential"."computer_id" IS DISTINCT FROM "workspace_credential"."workspace_computer_id"
+			OR "computer_credential"."secret_hash" IS DISTINCT FROM "workspace_credential"."secret_hash"
+			OR "computer_credential"."issued_by_user_id" IS DISTINCT FROM "workspace_credential"."issued_by_user_id"
+			OR "computer_credential"."issued_at" IS DISTINCT FROM "workspace_credential"."issued_at"
+			OR "computer_credential"."revoked_by_user_id" IS DISTINCT FROM "workspace_credential"."revoked_by_user_id"
+			OR "computer_credential"."revoked_at" IS DISTINCT FROM "workspace_credential"."revoked_at"
+	) THEN
+		RAISE EXCEPTION 'Computer credential backfill found a credential whose identity or audit history does not match the enrollment credential';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "workspace_computer_credentials" AS "workspace_credential"
+		INNER JOIN "computer_credentials" AS "computer_credential"
+			ON "computer_credential"."secret_hash" = "workspace_credential"."secret_hash"
+		WHERE "computer_credential"."id" IS DISTINCT FROM "workspace_credential"."id"
+	) THEN
+		RAISE EXCEPTION 'Computer credential backfill found a credential hash that belongs to a different credential';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "workspace_computer_credentials" AS "workspace_credential"
+		INNER JOIN "computer_credentials" AS "computer_credential"
+			ON "computer_credential"."computer_id" = "workspace_credential"."workspace_computer_id"
+			AND "computer_credential"."revoked_at" IS NULL
+			AND "workspace_credential"."revoked_at" IS NULL
+		WHERE "computer_credential"."id" IS DISTINCT FROM "workspace_credential"."id"
+	) THEN
+		RAISE EXCEPTION 'Computer credential backfill found a conflicting active credential for a Computer';
+	END IF;
+
+	INSERT INTO "computer_credentials" (
+		"id",
+		"computer_id",
+		"secret_hash",
+		"issued_by_user_id",
+		"issued_at",
+		"revoked_by_user_id",
+		"revoked_at"
+	)
+	SELECT
+		"workspace_credential"."id",
+		"workspace_credential"."workspace_computer_id",
+		"workspace_credential"."secret_hash",
+		"workspace_credential"."issued_by_user_id",
+		"workspace_credential"."issued_at",
+		"workspace_credential"."revoked_by_user_id",
+		"workspace_credential"."revoked_at"
+	FROM "workspace_computer_credentials" AS "workspace_credential"
+	WHERE NOT EXISTS (
+		SELECT 1
+		FROM "computer_credentials" AS "computer_credential"
+		WHERE "computer_credential"."id" = "workspace_credential"."id"
+	);
+
+	IF EXISTS (
+		SELECT 1
+		FROM "workspace_computer_credentials" AS "workspace_credential"
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM "computer_credentials" AS "computer_credential"
+			WHERE "computer_credential"."id" = "workspace_credential"."id"
+		)
+	) THEN
+		RAISE EXCEPTION 'Computer credential backfill could not project every Workspace enrollment credential';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "agents"
+		WHERE "computer_id" IS NOT NULL
+			AND "computer_id" IS DISTINCT FROM "workspace_computer_id"
+	) THEN
+		RAISE EXCEPTION 'Agent Computer backfill found an Agent whose Computer does not match its enrollment';
+	END IF;
+
+	UPDATE "agents"
+	SET "computer_id" = "workspace_computer_id"
+	WHERE "computer_id" IS NULL;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "agents"
+		WHERE "computer_id" IS DISTINCT FROM "workspace_computer_id"
+	) THEN
+		RAISE EXCEPTION 'Agent Computer backfill could not project every Agent enrollment';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "session_placements"
+		WHERE "computer_id" IS NOT NULL
+			AND "computer_id" IS DISTINCT FROM "workspace_computer_id"
+	) THEN
+		RAISE EXCEPTION 'Session placement backfill found a placement whose Computer does not match its enrollment';
+	END IF;
+
+	UPDATE "session_placements"
+	SET "computer_id" = "workspace_computer_id"
+	WHERE "computer_id" IS NULL;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "session_placements"
+		WHERE "computer_id" IS DISTINCT FROM "workspace_computer_id"
+	) THEN
+		RAISE EXCEPTION 'Session placement backfill could not project every Session placement';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "session_cli_proofs"
+		WHERE "computer_id" IS NOT NULL
+			AND "computer_id" IS DISTINCT FROM "workspace_computer_id"
+	) THEN
+		RAISE EXCEPTION 'Session CLI proof backfill found a proof whose Computer does not match its enrollment';
+	END IF;
+
+	UPDATE "session_cli_proofs"
+	SET "computer_id" = "workspace_computer_id"
+	WHERE "computer_id" IS NULL;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "session_cli_proofs"
+		WHERE "computer_id" IS DISTINCT FROM "workspace_computer_id"
+	) THEN
+		RAISE EXCEPTION 'Session CLI proof backfill could not project every Session CLI proof';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "computer_connect_codes"
+		WHERE (
+			"mode" IS NOT NULL
+			AND "mode" IS DISTINCT FROM 'create'::"computer_connect_code_mode"
+		) OR "target_computer_id" IS NOT NULL
+	) THEN
+		RAISE EXCEPTION 'Computer connect-code backfill found a repair-shaped code; historical codes must be create codes without a target Computer';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "computer_connect_codes"
+		WHERE "issued_by_account_id" IS NOT NULL
+			AND "issued_by_account_id" IS DISTINCT FROM "issued_by_user_id"
+	) THEN
+		RAISE EXCEPTION 'Computer connect-code backfill found an issuing Account that does not match the issuing user';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "computer_connect_codes"
+		WHERE "consumed_computer_id" IS NOT NULL
+			AND "consumed_computer_id" IS DISTINCT FROM "consumed_workspace_computer_id"
+	) THEN
+		RAISE EXCEPTION 'Computer connect-code backfill found a consumed Computer that does not match the enrollment';
+	END IF;
+
+	UPDATE "computer_connect_codes"
+	SET
+		"issued_by_account_id" = "issued_by_user_id",
+		"mode" = 'create',
+		"consumed_computer_id" = "consumed_workspace_computer_id";
+
+	IF EXISTS (
+		SELECT 1
+		FROM "slack_installations" AS "installation"
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM "im_bindings" AS "binding"
+			WHERE "binding"."provider" = 'slack'
+				AND "binding"."slack_installation_id" = "installation"."id"
+		)
+	) THEN
+		RAISE EXCEPTION 'Slack installation backfill found an installation with no Slack binding';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "slack_installations" AS "installation"
+		INNER JOIN "im_bindings" AS "binding"
+			ON "binding"."provider" = 'slack'
+			AND "binding"."slack_installation_id" = "installation"."id"
+		GROUP BY "installation"."id"
+		HAVING count(DISTINCT "binding"."agent_id") > 1
+	) THEN
+		RAISE EXCEPTION 'Slack installation backfill found an installation bound to more than one Agent';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "slack_installations" AS "installation"
+		INNER JOIN "im_bindings" AS "binding"
+			ON "binding"."provider" = 'slack'
+			AND "binding"."slack_installation_id" = "installation"."id"
+		INNER JOIN "agents" AS "agent" ON "agent"."id" = "binding"."agent_id"
+		WHERE "agent"."workspace_id" IS DISTINCT FROM "installation"."workspace_id"
+	) THEN
+		RAISE EXCEPTION 'Slack installation backfill found a binding whose Agent is not in the installation Workspace';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "slack_installations" AS "installation"
+		INNER JOIN "im_bindings" AS "binding"
+			ON "binding"."provider" = 'slack'
+			AND "binding"."slack_installation_id" = "installation"."id"
+		WHERE "installation"."agent_id" IS NOT NULL
+			AND "installation"."agent_id" IS DISTINCT FROM "binding"."agent_id"
+	) THEN
+		RAISE EXCEPTION 'Slack installation backfill found an Agent owner that does not match the bound Agent';
+	END IF;
+
+	UPDATE "slack_installations" AS "installation"
+	SET "agent_id" = "binding"."agent_id"
+	FROM "im_bindings" AS "binding"
+	WHERE "binding"."provider" = 'slack'
+		AND "binding"."slack_installation_id" = "installation"."id"
+		AND "installation"."agent_id" IS NULL;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "slack_installations"
+		WHERE "agent_id" IS NULL
+	) THEN
+		RAISE EXCEPTION 'Slack installation backfill could not project every installation owner';
+	END IF;
+END $$;

--- a/packages/server/drizzle/0028_overjoyed_speedball.sql
+++ b/packages/server/drizzle/0028_overjoyed_speedball.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "agents" ALTER COLUMN "computer_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ALTER COLUMN "issued_by_account_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ALTER COLUMN "mode" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "session_cli_proofs" ALTER COLUMN "computer_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "session_placements" ALTER COLUMN "computer_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "slack_installations" ALTER COLUMN "agent_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "slack_installations" ADD CONSTRAINT "slack_installations_agent_id_id_unique" UNIQUE("agent_id","id");--> statement-breakpoint
+ALTER TABLE "im_bindings" ADD CONSTRAINT "im_bindings_slack_installation_owner_fk" FOREIGN KEY ("agent_id","slack_installation_id") REFERENCES "public"."slack_installations"("agent_id","id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "agents" ADD CONSTRAINT "agents_computer_matches_enrollment" CHECK ("agents"."computer_id" = "agents"."workspace_computer_id");--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD CONSTRAINT "computer_connect_codes_issued_by_account_pair" CHECK ("computer_connect_codes"."issued_by_account_id" = "computer_connect_codes"."issued_by_user_id");--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD CONSTRAINT "computer_connect_codes_consumed_computer_identity" CHECK ("computer_connect_codes"."consumed_computer_id" is not distinct from "computer_connect_codes"."consumed_workspace_computer_id");--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD CONSTRAINT "computer_connect_codes_consumed_computer_pair" CHECK (("computer_connect_codes"."consumed_computer_id" is null) = ("computer_connect_codes"."consumed_at" is null));--> statement-breakpoint
+ALTER TABLE "computer_connect_codes" ADD CONSTRAINT "computer_connect_codes_repair_target_pair" CHECK (("computer_connect_codes"."mode" = 'create') = ("computer_connect_codes"."target_computer_id" is null));--> statement-breakpoint
+ALTER TABLE "session_cli_proofs" ADD CONSTRAINT "session_cli_proofs_computer_matches_enrollment" CHECK ("session_cli_proofs"."computer_id" = "session_cli_proofs"."workspace_computer_id");--> statement-breakpoint
+ALTER TABLE "session_placements" ADD CONSTRAINT "session_placements_computer_matches_enrollment" CHECK ("session_placements"."computer_id" = "session_placements"."workspace_computer_id");

--- a/packages/server/drizzle/meta/0028_snapshot.json
+++ b/packages/server/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,4991 @@
+{
+  "id": "de8f2afe-d3c0-4eac-900b-513c8d1b2026",
+  "prevId": "aee65499-5dbd-4025-b1be-0b47d7a1de69",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_runtime_configs": {
+      "name": "agent_runtime_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('runtime_config_revision_sequence')"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_duration_ms": {
+          "name": "max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_runtime_configs_agent_id_agents_id_fk": {
+          "name": "agent_runtime_configs_agent_id_agents_id_fk",
+          "tableFrom": "agent_runtime_configs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runtime_configs_revision_safe_positive": {
+          "name": "agent_runtime_configs_revision_safe_positive",
+          "value": "\"agent_runtime_configs\".\"revision\" > 0 and \"agent_runtime_configs\".\"revision\" <= 9007199254740991"
+        },
+        "agent_runtime_configs_max_duration_valid": {
+          "name": "agent_runtime_configs_max_duration_valid",
+          "value": "\"agent_runtime_configs\".\"max_duration_ms\" is null or (\"agent_runtime_configs\".\"max_duration_ms\" > 0 and \"agent_runtime_configs\".\"max_duration_ms\" <= 86400000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_intent_id": {
+          "name": "creation_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_intent_fingerprint": {
+          "name": "creation_intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "agent_runtime_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_mode": {
+          "name": "receive_mode",
+          "type": "agent_receive_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_message'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_workspace_name_active_unique": {
+          "name": "agents_workspace_name_active_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_creation_intent_unique": {
+          "name": "agents_creation_intent_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"creation_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_id_idx": {
+          "name": "agents_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_created_by_user_id_idx": {
+          "name": "agents_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_computer_id_idx": {
+          "name": "agents_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_computer_id_idx": {
+          "name": "agents_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_workspace_id_workspaces_id_fk": {
+          "name": "agents_workspace_id_workspaces_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_created_by_user_id_users_id_fk": {
+          "name": "agents_created_by_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_computer_id_account_computers_id_fk": {
+          "name": "agents_computer_id_account_computers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_workspace_enrollment_fk": {
+          "name": "agents_workspace_enrollment_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_creation_intent_pair": {
+          "name": "agents_creation_intent_pair",
+          "value": "(\"agents\".\"creation_intent_id\" is null) = (\"agents\".\"creation_intent_fingerprint\" is null)"
+        },
+        "agents_revision_positive": {
+          "name": "agents_revision_positive",
+          "value": "\"agents\".\"revision\" >= 1"
+        },
+        "agents_computer_matches_enrollment": {
+          "name": "agents_computer_matches_enrollment",
+          "value": "\"agents\".\"computer_id\" = \"agents\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_cli_login_codes": {
+      "name": "account_cli_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_cli_login_codes_user_created_idx": {
+          "name": "account_cli_login_codes_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_cli_login_codes_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_cli_login_codes_issued_by_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_cli_login_codes_token_hash_unique": {
+          "name": "account_cli_login_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_cli_login_codes_expiry": {
+          "name": "account_cli_login_codes_expiry",
+          "value": "\"account_cli_login_codes\".\"expires_at\" > \"account_cli_login_codes\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_admin_grants": {
+      "name": "workspace_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_admin_grants_active_workspace_user_unique": {
+          "name": "workspace_admin_grants_active_workspace_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_active_user_workspace_idx": {
+          "name": "workspace_admin_grants_active_user_workspace_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_workspace_granted_idx": {
+          "name": "workspace_admin_grants_workspace_granted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_admin_grants_workspace_id_workspaces_id_fk": {
+          "name": "workspace_admin_grants_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_admin_grants_revocation_pair": {
+          "name": "workspace_admin_grants_revocation_pair",
+          "value": "(\"workspace_admin_grants\".\"revoked_by_user_id\" is null) = (\"workspace_admin_grants\".\"revoked_at\" is null)"
+        },
+        "workspace_admin_grants_revoked_after_granted": {
+          "name": "workspace_admin_grants_revoked_after_granted",
+          "value": "\"workspace_admin_grants\".\"revoked_at\" is null or \"workspace_admin_grants\".\"revoked_at\" >= \"workspace_admin_grants\".\"granted_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_name_unique": {
+          "name": "workspaces_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_identities_provider_subject_unique": {
+          "name": "auth_identities_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_provider_unique": {
+          "name": "auth_identities_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_issuer_subject_unique": {
+          "name": "auth_identities_issuer_subject_unique",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_id_idx": {
+          "name": "auth_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_user_id_idx": {
+          "name": "auth_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expires_at_idx": {
+          "name": "auth_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_verifications_expires_at_idx": {
+          "name": "auth_verifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_computers": {
+      "name": "account_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_installation_id": {
+          "name": "current_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_computers_owner_account_id_idx": {
+          "name": "account_computers_owner_account_id_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_computers_current_installation_id_idx": {
+          "name": "account_computers_current_installation_id_idx",
+          "columns": [
+            {
+              "expression": "current_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_computers_owner_account_id_users_id_fk": {
+          "name": "account_computers_owner_account_id_users_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_computers_current_installation_id_computers_id_fk": {
+          "name": "account_computers_current_installation_id_computers_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "current_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_connect_codes": {
+      "name": "computer_connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "computer_connect_code_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_computer_id": {
+          "name": "target_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_workspace_computer_id": {
+          "name": "consumed_workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_computer_id": {
+          "name": "consumed_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_connect_codes_workspace_created_idx": {
+          "name": "computer_connect_codes_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_target_computer_id_idx": {
+          "name": "computer_connect_codes_target_computer_id_idx",
+          "columns": [
+            {
+              "expression": "target_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_consumed_computer_id_idx": {
+          "name": "computer_connect_codes_consumed_computer_id_idx",
+          "columns": [
+            {
+              "expression": "consumed_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_connect_codes_workspace_id_workspaces_id_fk": {
+          "name": "computer_connect_codes_workspace_id_workspaces_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_account_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_account_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_target_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_target_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "target_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_consumed_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_consumed_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "consumed_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_revoked_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_workspace_enrollment_fk": {
+          "name": "computer_connect_codes_workspace_enrollment_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "consumed_workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_connect_codes_token_hash_unique": {
+          "name": "computer_connect_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_connect_codes_expiry": {
+          "name": "computer_connect_codes_expiry",
+          "value": "\"computer_connect_codes\".\"expires_at\" > \"computer_connect_codes\".\"created_at\""
+        },
+        "computer_connect_codes_consumption_pair": {
+          "name": "computer_connect_codes_consumption_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_workspace_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_revocation_pair": {
+          "name": "computer_connect_codes_revocation_pair",
+          "value": "(\"computer_connect_codes\".\"revoked_by_user_id\" is null) = (\"computer_connect_codes\".\"revoked_at\" is null)"
+        },
+        "computer_connect_codes_terminal_state": {
+          "name": "computer_connect_codes_terminal_state",
+          "value": "not (\"computer_connect_codes\".\"consumed_at\" is not null and \"computer_connect_codes\".\"revoked_at\" is not null)"
+        },
+        "computer_connect_codes_issued_by_account_pair": {
+          "name": "computer_connect_codes_issued_by_account_pair",
+          "value": "\"computer_connect_codes\".\"issued_by_account_id\" = \"computer_connect_codes\".\"issued_by_user_id\""
+        },
+        "computer_connect_codes_consumed_computer_identity": {
+          "name": "computer_connect_codes_consumed_computer_identity",
+          "value": "\"computer_connect_codes\".\"consumed_computer_id\" is not distinct from \"computer_connect_codes\".\"consumed_workspace_computer_id\""
+        },
+        "computer_connect_codes_consumed_computer_pair": {
+          "name": "computer_connect_codes_consumed_computer_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_repair_target_pair": {
+          "name": "computer_connect_codes_repair_target_pair",
+          "value": "(\"computer_connect_codes\".\"mode\" = 'create') = (\"computer_connect_codes\".\"target_computer_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computer_credentials": {
+      "name": "computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_credentials_active_computer_unique": {
+          "name": "computer_credentials_active_computer_unique",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_credentials_computer_issued_idx": {
+          "name": "computer_credentials_computer_issued_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_credentials_computer_id_account_computers_id_fk": {
+          "name": "computer_credentials_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_credentials_secret_hash_unique": {
+          "name": "computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_credentials_revocation_pair": {
+          "name": "computer_credentials_revocation_pair",
+          "value": "(\"computer_credentials\".\"revoked_by_user_id\" is null) = (\"computer_credentials\".\"revoked_at\" is null)"
+        },
+        "computer_credentials_revoked_after_issued": {
+          "name": "computer_credentials_revoked_after_issued",
+          "value": "\"computer_credentials\".\"revoked_at\" is null or \"computer_credentials\".\"revoked_at\" >= \"computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computers": {
+      "name": "computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_computer_credentials": {
+      "name": "workspace_computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_computer_credentials_active_enrollment_unique": {
+          "name": "workspace_computer_credentials_active_enrollment_unique",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computer_credentials_enrollment_issued_idx": {
+          "name": "workspace_computer_credentials_enrollment_issued_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computer_credentials_secret_hash_unique": {
+          "name": "workspace_computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computer_credentials_revocation_pair": {
+          "name": "workspace_computer_credentials_revocation_pair",
+          "value": "(\"workspace_computer_credentials\".\"revoked_by_user_id\" is null) = (\"workspace_computer_credentials\".\"revoked_at\" is null)"
+        },
+        "workspace_computer_credentials_revoked_after_issued": {
+          "name": "workspace_computer_credentials_revoked_after_issued",
+          "value": "\"workspace_computer_credentials\".\"revoked_at\" is null or \"workspace_computer_credentials\".\"revoked_at\" >= \"workspace_computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_computers": {
+      "name": "workspace_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_by_user_id": {
+          "name": "enrolled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_computers_active_workspace_computer_unique": {
+          "name": "workspace_computers_active_workspace_computer_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_active_workspace_idx": {
+          "name": "workspace_computers_active_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_computer_id_idx": {
+          "name": "workspace_computers_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computers_workspace_id_workspaces_id_fk": {
+          "name": "workspace_computers_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_computer_id_computers_id_fk": {
+          "name": "workspace_computers_computer_id_computers_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_enrolled_by_user_id_users_id_fk": {
+          "name": "workspace_computers_enrolled_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enrolled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computers_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computers_workspace_id_id_unique": {
+          "name": "workspace_computers_workspace_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computers_revocation_pair": {
+          "name": "workspace_computers_revocation_pair",
+          "value": "(\"workspace_computers\".\"revoked_by_user_id\" is null) = (\"workspace_computers\".\"revoked_at\" is null)"
+        },
+        "workspace_computers_revoked_after_enrolled": {
+          "name": "workspace_computers_revoked_after_enrolled",
+          "value": "\"workspace_computers\".\"revoked_at\" is null or \"workspace_computers\".\"revoked_at\" >= \"workspace_computers\".\"enrolled_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_bindings": {
+      "name": "im_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "im_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "im_binding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_brand": {
+          "name": "external_team_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "setup_attempt_id": {
+          "name": "setup_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_intent": {
+          "name": "setup_intent",
+          "type": "feishu_setup_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_state": {
+          "name": "setup_state",
+          "type": "feishu_setup_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_instance_id": {
+          "name": "setup_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_heartbeat_at": {
+          "name": "setup_owner_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_setup_context": {
+          "name": "encrypted_setup_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_expires_at": {
+          "name": "setup_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_route_kind": {
+          "name": "slack_route_kind",
+          "type": "slack_route_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_im_binding_id": {
+          "name": "replacement_im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_owner_instance_id": {
+          "name": "connection_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_fencing_epoch": {
+          "name": "connection_fencing_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_lease_expires_at": {
+          "name": "connection_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_bindings_agent_current_unique": {
+          "name": "im_bindings_agent_current_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_feishu_app_current_unique": {
+          "name": "im_bindings_feishu_app_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_current_unique": {
+          "name": "im_bindings_slack_installation_current_unique",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_id_idx": {
+          "name": "im_bindings_slack_installation_id_idx",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_agent_id_agents_id_fk": {
+          "name": "im_bindings_agent_id_agents_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_id_slack_installations_id_fk": {
+          "name": "im_bindings_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_replacement_im_binding_id_im_bindings_id_fk": {
+          "name": "im_bindings_replacement_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "replacement_im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_owner_fk": {
+          "name": "im_bindings_slack_installation_owner_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "agent_id",
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "agent_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_bindings_credential_generation_nonnegative": {
+          "name": "im_bindings_credential_generation_nonnegative",
+          "value": "\"im_bindings\".\"credential_generation\" >= 0"
+        },
+        "im_bindings_connection_epoch_nonnegative": {
+          "name": "im_bindings_connection_epoch_nonnegative",
+          "value": "\"im_bindings\".\"connection_fencing_epoch\" >= 0"
+        },
+        "im_bindings_active_binding_shape": {
+          "name": "im_bindings_active_binding_shape",
+          "value": "\"im_bindings\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"im_bindings\".\"external_app_id\" is not null and\n        (\"im_bindings\".\"provider\" = 'feishu' or \"im_bindings\".\"external_team_id\" is not null) and\n        \"im_bindings\".\"external_bot_id\" is not null and \"im_bindings\".\"credential_schema_version\" is not null and\n        \"im_bindings\".\"credential_generation\" >= 1 and\n        \"im_bindings\".\"activated_at\" is not null and \"im_bindings\".\"disabled_at\" is null and\n        (\n          (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"encrypted_credential\" is not null and\n            \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null) or\n          (\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"encrypted_credential\" is null and\n            \"im_bindings\".\"slack_installation_id\" is not null and \"im_bindings\".\"slack_route_kind\" is not null)\n        )\n      )"
+        },
+        "im_bindings_disabled_secret_shape": {
+          "name": "im_bindings_disabled_secret_shape",
+          "value": "\"im_bindings\".\"status\" <> 'disabled' or (\n        \"im_bindings\".\"encrypted_credential\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"connection_owner_instance_id\" is null and\n        \"im_bindings\".\"connection_lease_expires_at\" is null and \"im_bindings\".\"disabled_at\" is not null\n      )"
+        },
+        "im_bindings_setup_owner_shape": {
+          "name": "im_bindings_setup_owner_shape",
+          "value": "(\"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"setup_owner_heartbeat_at\" is null and\n        \"im_bindings\".\"encrypted_setup_context\" is null and \"im_bindings\".\"setup_expires_at\" is null)\n        or (\"im_bindings\".\"setup_attempt_id\" is not null and \"im_bindings\".\"setup_intent\" is not null and\n        \"im_bindings\".\"setup_state\" is not null and \"im_bindings\".\"setup_owner_instance_id\" is not null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is not null and \"im_bindings\".\"encrypted_setup_context\" is not null and\n        \"im_bindings\".\"setup_expires_at\" is not null)"
+        },
+        "im_bindings_connection_owner_shape": {
+          "name": "im_bindings_connection_owner_shape",
+          "value": "(\"im_bindings\".\"connection_owner_instance_id\" is null and \"im_bindings\".\"connection_lease_expires_at\" is null)\n        or (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"connection_owner_instance_id\" is not null and\n        \"im_bindings\".\"connection_lease_expires_at\" is not null)"
+        },
+        "im_bindings_slack_setup_fields_null": {
+          "name": "im_bindings_slack_setup_fields_null",
+          "value": "\"im_bindings\".\"provider\" <> 'slack' or (\n        \"im_bindings\".\"setup_attempt_id\" is null and \"im_bindings\".\"setup_intent\" is null and\n        \"im_bindings\".\"setup_state\" is null and \"im_bindings\".\"setup_owner_instance_id\" is null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_expires_at\" is null\n      )"
+        },
+        "im_bindings_slack_route_fields": {
+          "name": "im_bindings_slack_route_fields",
+          "value": "\"im_bindings\".\"provider\" = 'slack' or (\n        \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_message_deliveries": {
+      "name": "im_message_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attention": {
+          "name": "attention",
+          "type": "im_delivery_attention",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "im_delivery_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_request_id": {
+          "name": "dispatch_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_input_hash": {
+          "name": "dispatch_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_payload": {
+          "name": "dispatch_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steer_target_delivery_id": {
+          "name": "steer_target_delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steered_at": {
+          "name": "steered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_owner_instance_id": {
+          "name": "report_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_hash": {
+          "name": "result_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_report": {
+          "name": "turn_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "im_message_deliveries_message_session_unique": {
+          "name": "im_message_deliveries_message_session_unique",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_session_id_idx": {
+          "name": "im_message_deliveries_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_steer_target_idx": {
+          "name": "im_message_deliveries_steer_target_idx",
+          "columns": [
+            {
+              "expression": "steer_target_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_pending_idx": {
+          "name": "im_message_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_dispatch_request_unique": {
+          "name": "im_message_deliveries_dispatch_request_unique",
+          "columns": [
+            {
+              "expression": "dispatch_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"dispatch_request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_turn_id_unique": {
+          "name": "im_message_deliveries_turn_id_unique",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"turn_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_deliveries_message_id_im_messages_id_fk": {
+          "name": "im_message_deliveries_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_session_id_sessions_id_fk": {
+          "name": "im_message_deliveries_session_id_sessions_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk": {
+          "name": "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_message_deliveries",
+          "columnsFrom": [
+            "steer_target_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_message_deliveries_dispatch_shape": {
+          "name": "im_message_deliveries_dispatch_shape",
+          "value": "(\"im_message_deliveries\".\"dispatch_request_id\" is null and \"im_message_deliveries\".\"dispatch_input_hash\" is null and \"im_message_deliveries\".\"dispatch_payload\" is null)\n        or (\"im_message_deliveries\".\"dispatch_request_id\" is not null and \"im_message_deliveries\".\"dispatch_input_hash\" is not null\n          and (\"im_message_deliveries\".\"dispatch_payload\" is not null or \"im_message_deliveries\".\"state\" = 'accepted'))"
+        },
+        "im_message_deliveries_custody_shape": {
+          "name": "im_message_deliveries_custody_shape",
+          "value": "(\"im_message_deliveries\".\"state\" = 'accepted' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"turn_id\" is not null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is not null and \"im_message_deliveries\".\"accepted_at\" is not null\n          and \"im_message_deliveries\".\"steer_target_delivery_id\" is null and \"im_message_deliveries\".\"steered_at\" is null)\n        or (\"im_message_deliveries\".\"state\" = 'steered' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"steer_target_delivery_id\" is not null\n          and \"im_message_deliveries\".\"steered_at\" is not null and \"im_message_deliveries\".\"turn_id\" is null and \"im_message_deliveries\".\"report_owner_instance_id\" is null\n          and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null\n          and \"im_message_deliveries\".\"result_hash\" is null)\n        or (\"im_message_deliveries\".\"state\" not in ('accepted', 'steered') and \"im_message_deliveries\".\"input_hash\" is null and \"im_message_deliveries\".\"turn_id\" is null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is null and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"steered_at\" is null\n          and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null and \"im_message_deliveries\".\"result_hash\" is null)"
+        },
+        "im_message_deliveries_report_shape": {
+          "name": "im_message_deliveries_report_shape",
+          "value": "(\"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null)\n        or (\"im_message_deliveries\".\"reported_at\" is not null and \"im_message_deliveries\".\"turn_report\" is not null and \"im_message_deliveries\".\"result_hash\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_messages": {
+      "name": "im_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_revision_key": {
+          "name": "provider_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "im_message_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "im_message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_external_id": {
+          "name": "reply_to_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "im_author_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_external_id": {
+          "name": "author_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_context": {
+          "name": "provider_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_messages_provider_event_unique": {
+          "name": "im_messages_provider_event_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_messages\".\"provider_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_semantic_revision_unique": {
+          "name": "im_messages_semantic_revision_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_revision_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_scope_occurred_idx": {
+          "name": "im_messages_scope_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_external_occurred_idx": {
+          "name": "im_messages_external_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_messages_im_binding_id_im_bindings_id_fk": {
+          "name": "im_messages_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invitations": {
+      "name": "admin_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_invitations_workspace_created_idx": {
+          "name": "admin_invitations_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_invitations_workspace_id_workspaces_id_fk": {
+          "name": "admin_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_created_by_user_id_users_id_fk": {
+          "name": "admin_invitations_created_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_accepted_by_user_id_users_id_fk": {
+          "name": "admin_invitations_accepted_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_revoked_by_user_id_users_id_fk": {
+          "name": "admin_invitations_revoked_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invitations_token_hash_unique": {
+          "name": "admin_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invitations_expiry": {
+          "name": "admin_invitations_expiry",
+          "value": "\"admin_invitations\".\"expires_at\" > \"admin_invitations\".\"created_at\""
+        },
+        "admin_invitations_acceptance_pair": {
+          "name": "admin_invitations_acceptance_pair",
+          "value": "(\"admin_invitations\".\"accepted_by_user_id\" is null) = (\"admin_invitations\".\"accepted_at\" is null)"
+        },
+        "admin_invitations_revocation_pair": {
+          "name": "admin_invitations_revocation_pair",
+          "value": "(\"admin_invitations\".\"revoked_by_user_id\" is null) = (\"admin_invitations\".\"revoked_at\" is null)"
+        },
+        "admin_invitations_terminal_state": {
+          "name": "admin_invitations_terminal_state",
+          "value": "not (\"admin_invitations\".\"accepted_at\" is not null and \"admin_invitations\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_cli_proofs": {
+      "name": "session_cli_proofs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proof_id": {
+          "name": "proof_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_instance_id": {
+          "name": "connection_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_cli_proofs_computer_id_idx": {
+          "name": "session_cli_proofs_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_cli_proofs_session_id_sessions_id_fk": {
+          "name": "session_cli_proofs_session_id_sessions_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_computer_id_account_computers_id_fk": {
+          "name": "session_cli_proofs_computer_id_account_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_cli_proofs_proof_id_unique": {
+          "name": "session_cli_proofs_proof_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proof_id"
+          ]
+        },
+        "session_cli_proofs_token_hash_unique": {
+          "name": "session_cli_proofs_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_cli_proofs_token_hash_shape": {
+          "name": "session_cli_proofs_token_hash_shape",
+          "value": "\"session_cli_proofs\".\"token_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_cli_proofs_generation_positive": {
+          "name": "session_cli_proofs_generation_positive",
+          "value": "\"session_cli_proofs\".\"placement_generation\" >= 1"
+        },
+        "session_cli_proofs_computer_matches_enrollment": {
+          "name": "session_cli_proofs_computer_matches_enrollment",
+          "value": "\"session_cli_proofs\".\"computer_id\" = \"session_cli_proofs\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_messages": {
+      "name": "session_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_outcome": {
+          "name": "last_outcome",
+          "type": "session_message_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_messages_target_created_idx": {
+          "name": "session_messages_target_created_idx",
+          "columns": [
+            {
+              "expression": "target_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_messages_source_created_idx": {
+          "name": "session_messages_source_created_idx",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_messages_source_session_id_sessions_id_fk": {
+          "name": "session_messages_source_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "source_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_messages_target_session_id_sessions_id_fk": {
+          "name": "session_messages_target_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_messages_content_hash_shape": {
+          "name": "session_messages_content_hash_shape",
+          "value": "\"session_messages\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_messages_content_bounds": {
+          "name": "session_messages_content_bounds",
+          "value": "octet_length(\"session_messages\".\"content\") between 1 and 16384"
+        },
+        "session_messages_error_code_shape": {
+          "name": "session_messages_error_code_shape",
+          "value": "\"session_messages\".\"last_error_code\" is null or (\"session_messages\".\"last_error_code\" ~ '^[a-z][a-z0-9_]{0,127}$')"
+        },
+        "session_messages_attempt_count_nonnegative": {
+          "name": "session_messages_attempt_count_nonnegative",
+          "value": "\"session_messages\".\"attempt_count\" >= 0"
+        },
+        "session_messages_attempt_shape": {
+          "name": "session_messages_attempt_shape",
+          "value": "(\"session_messages\".\"attempt_count\" = 0 and \"session_messages\".\"last_attempt_at\" is null)\n        or (\"session_messages\".\"attempt_count\" > 0 and \"session_messages\".\"last_attempt_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_descendants": {
+      "name": "session_descendants",
+      "schema": "",
+      "columns": {
+        "ancestor_session_id": {
+          "name": "ancestor_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_session_id": {
+          "name": "descendant_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_created_at": {
+          "name": "last_message_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_delivery_outcome": {
+          "name": "last_delivery_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_preview": {
+          "name": "task_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_descendants_ancestor_activity_idx": {
+          "name": "session_descendants_ancestor_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_ancestor_depth_activity_idx": {
+          "name": "session_descendants_ancestor_depth_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_descendant_ancestor_idx": {
+          "name": "session_descendants_descendant_ancestor_idx",
+          "columns": [
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_last_message_idx": {
+          "name": "session_descendants_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_descendants_ancestor_session_id_sessions_id_fk": {
+          "name": "session_descendants_ancestor_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "ancestor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_descendants_descendant_session_id_sessions_id_fk": {
+          "name": "session_descendants_descendant_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "descendant_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_descendants_ancestor_session_id_descendant_session_id_pk": {
+          "name": "session_descendants_ancestor_session_id_descendant_session_id_pk",
+          "columns": [
+            "ancestor_session_id",
+            "descendant_session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_descendants_depth_positive": {
+          "name": "session_descendants_depth_positive",
+          "value": "\"session_descendants\".\"depth\" >= 1"
+        },
+        "session_descendants_outcome_valid": {
+          "name": "session_descendants_outcome_valid",
+          "value": "\"session_descendants\".\"last_delivery_outcome\" in ('accepted', 'unreachable', 'unknown', 'rejected')"
+        },
+        "session_descendants_preview_bounds": {
+          "name": "session_descendants_preview_bounds",
+          "value": "char_length(\"session_descendants\".\"task_preview\") between 1 and 256"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_placements": {
+      "name": "session_placements",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_placements_workspace_computer_id_idx": {
+          "name": "session_placements_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_placements_computer_id_idx": {
+          "name": "session_placements_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_placements_session_id_sessions_id_fk": {
+          "name": "session_placements_session_id_sessions_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_placements_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_placements_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_placements_computer_id_account_computers_id_fk": {
+          "name": "session_placements_computer_id_account_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_placements_generation_positive": {
+          "name": "session_placements_generation_positive",
+          "value": "\"session_placements\".\"generation\" >= 1"
+        },
+        "session_placements_computer_matches_enrollment": {
+          "name": "session_placements_computer_matches_enrollment",
+          "value": "\"session_placements\".\"computer_id\" = \"session_placements\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_kind": {
+          "name": "conversation_kind",
+          "type": "im_conversation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "session_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_model": {
+          "name": "runtime_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_reasoning_effort": {
+          "name": "runtime_reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_max_duration_ms": {
+          "name": "runtime_max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_active_channel_unique": {
+          "name": "sessions_active_channel_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'channel' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_active_thread_unique": {
+          "name": "sessions_active_thread_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'thread' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_im_binding_scope_idx": {
+          "name": "sessions_im_binding_scope_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_creator_created_idx": {
+          "name": "sessions_creator_created_idx",
+          "columns": [
+            {
+              "expression": "created_by_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_im_binding_id_im_bindings_id_fk": {
+          "name": "sessions_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sessions_created_by_session_id_sessions_id_fk": {
+          "name": "sessions_created_by_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "created_by_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sessions_shape_check": {
+          "name": "sessions_shape_check",
+          "value": "(\"sessions\".\"kind\" = 'channel' and \"sessions\".\"thread_key\" is null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'thread' and \"sessions\".\"thread_key\" is not null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'internal' and \"sessions\".\"created_by_session_id\" is not null)"
+        },
+        "sessions_runtime_max_duration_valid": {
+          "name": "sessions_runtime_max_duration_valid",
+          "value": "\"sessions\".\"runtime_max_duration_ms\" is null or (\"sessions\".\"runtime_max_duration_ms\" > 0 and \"sessions\".\"runtime_max_duration_ms\" <= 86400000)"
+        },
+        "sessions_runtime_model_bounds": {
+          "name": "sessions_runtime_model_bounds",
+          "value": "\"sessions\".\"runtime_model\" is null or octet_length(\"sessions\".\"runtime_model\") between 1 and 128"
+        },
+        "sessions_runtime_reasoning_effort_bounds": {
+          "name": "sessions_runtime_reasoning_effort_bounds",
+          "value": "\"sessions\".\"runtime_reasoning_effort\" is null or octet_length(\"sessions\".\"runtime_reasoning_effort\") between 1 and 64"
+        },
+        "sessions_revision_positive": {
+          "name": "sessions_revision_positive",
+          "value": "\"sessions\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "slack_installation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "replacement_slack_installation_id": {
+          "name": "replacement_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installations_app_team_current_unique": {
+          "name": "slack_installations_app_team_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_installations\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_workspace_current_unique": {
+          "name": "slack_installations_workspace_current_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_installations\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_workspace_id_idx": {
+          "name": "slack_installations_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_agent_id_idx": {
+          "name": "slack_installations_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_app_team_idx": {
+          "name": "slack_installations_app_team_idx",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_workspace_id_workspaces_id_fk": {
+          "name": "slack_installations_workspace_id_workspaces_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_agent_id_agents_id_fk": {
+          "name": "slack_installations_agent_id_agents_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_replacement_slack_installation_id_slack_installations_id_fk": {
+          "name": "slack_installations_replacement_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "replacement_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_agent_id_id_unique": {
+          "name": "slack_installations_agent_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_installations_credential_generation_nonnegative": {
+          "name": "slack_installations_credential_generation_nonnegative",
+          "value": "\"slack_installations\".\"credential_generation\" >= 0"
+        },
+        "slack_installations_active_shape": {
+          "name": "slack_installations_active_shape",
+          "value": "\"slack_installations\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"slack_installations\".\"credential_schema_version\" is not null and\n        \"slack_installations\".\"credential_generation\" >= 1 and \"slack_installations\".\"encrypted_credential\" is not null and\n        \"slack_installations\".\"activated_at\" is not null and \"slack_installations\".\"disabled_at\" is null\n      )"
+        },
+        "slack_installations_disabled_secret_shape": {
+          "name": "slack_installations_disabled_secret_shape",
+          "value": "\"slack_installations\".\"status\" <> 'disabled' or (\n        \"slack_installations\".\"encrypted_credential\" is null and \"slack_installations\".\"disabled_at\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_oauth_nonces": {
+      "name": "slack_oauth_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_binding_id": {
+          "name": "expected_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_credential_generation": {
+          "name": "expected_credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_binding_hash": {
+          "name": "session_binding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_oauth_nonces_user_agent_idx": {
+          "name": "slack_oauth_nonces_user_agent_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_oauth_nonces_expires_idx": {
+          "name": "slack_oauth_nonces_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_oauth_nonces_user_id_users_id_fk": {
+          "name": "slack_oauth_nonces_user_id_users_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_oauth_nonces_agent_id_agents_id_fk": {
+          "name": "slack_oauth_nonces_agent_id_agents_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_oauth_nonces_nonce_hash_unique": {
+          "name": "slack_oauth_nonces_nonce_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_oauth_nonces_intent": {
+          "name": "slack_oauth_nonces_intent",
+          "value": "\"slack_oauth_nonces\".\"intent\" in ('create', 'reauthorize')"
+        },
+        "slack_oauth_nonces_expiry": {
+          "name": "slack_oauth_nonces_expiry",
+          "value": "\"slack_oauth_nonces\".\"expires_at\" > \"slack_oauth_nonces\".\"created_at\""
+        },
+        "slack_oauth_nonces_expected_binding_pair": {
+          "name": "slack_oauth_nonces_expected_binding_pair",
+          "value": "(\"slack_oauth_nonces\".\"expected_binding_id\" is null) = (\"slack_oauth_nonces\".\"expected_credential_generation\" is null)"
+        },
+        "slack_oauth_nonces_generation_positive": {
+          "name": "slack_oauth_nonces_generation_positive",
+          "value": "\"slack_oauth_nonces\".\"expected_credential_generation\" is null or \"slack_oauth_nonces\".\"expected_credential_generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_receive_mode": {
+      "name": "agent_receive_mode",
+      "schema": "public",
+      "values": [
+        "all_message",
+        "mention_only"
+      ]
+    },
+    "public.agent_runtime_provider": {
+      "name": "agent_runtime_provider",
+      "schema": "public",
+      "values": [
+        "codex",
+        "claude-code"
+      ]
+    },
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "suspended",
+        "deleted"
+      ]
+    },
+    "public.computer_connect_code_mode": {
+      "name": "computer_connect_code_mode",
+      "schema": "public",
+      "values": [
+        "create",
+        "repair"
+      ]
+    },
+    "public.computer_platform": {
+      "name": "computer_platform",
+      "schema": "public",
+      "values": [
+        "darwin",
+        "linux",
+        "win32"
+      ]
+    },
+    "public.feishu_setup_intent": {
+      "name": "feishu_setup_intent",
+      "schema": "public",
+      "values": [
+        "create",
+        "reauthorize",
+        "replace"
+      ]
+    },
+    "public.feishu_setup_state": {
+      "name": "feishu_setup_state",
+      "schema": "public",
+      "values": [
+        "awaiting_user",
+        "validating",
+        "succeeded",
+        "failed",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.im_binding_status": {
+      "name": "im_binding_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "active",
+        "reauthorization_required",
+        "error",
+        "disabled"
+      ]
+    },
+    "public.im_conversation_kind": {
+      "name": "im_conversation_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "dm",
+        "group_dm"
+      ]
+    },
+    "public.im_provider": {
+      "name": "im_provider",
+      "schema": "public",
+      "values": [
+        "feishu",
+        "slack"
+      ]
+    },
+    "public.slack_route_kind": {
+      "name": "slack_route_kind",
+      "schema": "public",
+      "values": [
+        "default"
+      ]
+    },
+    "public.im_author_kind": {
+      "name": "im_author_kind",
+      "schema": "public",
+      "values": [
+        "human",
+        "bot",
+        "system"
+      ]
+    },
+    "public.im_delivery_attention": {
+      "name": "im_delivery_attention",
+      "schema": "public",
+      "values": [
+        "direct",
+        "ambient"
+      ]
+    },
+    "public.im_delivery_state": {
+      "name": "im_delivery_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "steered",
+        "terminal_rejected",
+        "expired"
+      ]
+    },
+    "public.im_message_direction": {
+      "name": "im_message_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.im_message_operation": {
+      "name": "im_message_operation",
+      "schema": "public",
+      "values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "public.session_message_outcome": {
+      "name": "session_message_outcome",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "accepted",
+        "unreachable",
+        "rejected"
+      ]
+    },
+    "public.session_kind": {
+      "name": "session_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "thread",
+        "internal"
+      ]
+    },
+    "public.slack_installation_status": {
+      "name": "slack_installation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "reauthorization_required",
+        "disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {
+    "public.runtime_config_revision_sequence": {
+      "name": "runtime_config_revision_sequence",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1788005515125,
       "tag": "0027_backfill_account_owned_resources",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1788005894809,
+      "tag": "0028_overjoyed_speedball",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1787995618306,
       "tag": "0026_wakeful_wildside",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1788005515125,
+      "tag": "0027_backfill_account_owned_resources",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/integration/account-ownership-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/account-ownership-backfill.test.ts
@@ -1,0 +1,1500 @@
+import { access, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { RUNTIME_PROTOCOL_V2 } from "@opentag/shared";
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import { eq } from "drizzle-orm";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
+import { createDatabaseClient } from "../../db/client.js";
+import { migrateDatabase, verifyDatabaseMigrations } from "../../db/migrate.js";
+import {
+  accountComputers,
+  agents,
+  computerConnectCodes,
+  computerCredentials,
+  sessionCliProofs,
+  sessionPlacements,
+  workspaceComputerCredentials,
+  workspaceComputers,
+} from "../../db/schema/index.js";
+import { AgentService } from "../../services/agents/index.js";
+import { ComputerService, MachineAuthService } from "../../services/computers/index.js";
+import { SessionCliProofService, SessionService } from "../../services/sessions/index.js";
+
+const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
+
+const OWNER_ID = "00000000-0000-4000-8000-000000000001";
+const CREATOR_ID = "00000000-0000-4000-8000-000000000002";
+const EXTRA_ADMIN_ID = "00000000-0000-4000-8000-000000000016";
+const WORKSPACE_ID = "00000000-0000-4000-8000-000000000003";
+const INSTALLATION_ID = "00000000-0000-4000-8000-000000000004";
+const ACTIVE_ENROLLMENT_ID = "00000000-0000-4000-8000-000000000005";
+const REVOKED_ENROLLMENT_ID = "00000000-0000-4000-8000-000000000006";
+const ACTIVE_CREDENTIAL_ID = "00000000-0000-4000-8000-000000000007";
+const REVOKED_CREDENTIAL_ID = "00000000-0000-4000-8000-000000000008";
+const UNCONSUMED_CODE_ID = "00000000-0000-4000-8000-000000000009";
+const CONSUMED_CODE_ID = "00000000-0000-4000-8000-00000000000a";
+const AGENT_ID = "00000000-0000-4000-8000-00000000000b";
+const BINDING_ID = "00000000-0000-4000-8000-00000000000c";
+const ACTIVE_SESSION_ID = "00000000-0000-4000-8000-00000000000d";
+const ENDED_SESSION_ID = "00000000-0000-4000-8000-00000000000e";
+const SLACK_ACTIVE_ID = "00000000-0000-4000-8000-00000000000f";
+const SLACK_DISABLED_ID = "00000000-0000-4000-8000-000000000010";
+const MESSAGE_ID = "00000000-0000-4000-8000-000000000011";
+const PENDING_DELIVERY_ID = "00000000-0000-4000-8000-000000000012";
+const ACCEPTED_DELIVERY_ID = "00000000-0000-4000-8000-000000000013";
+const CURRENT_INSTANCE_ID = "00000000-0000-4000-8000-000000000014";
+const STALE_INSTANCE_ID = "00000000-0000-4000-8000-000000000015";
+const SLACK_AGENT_ID = "00000000-0000-4000-8000-000000000017";
+const SLACK_BINDING_ID = "00000000-0000-4000-8000-000000000018";
+const SLACK_DISABLED_BINDING_ID = "00000000-0000-4000-8000-000000000019";
+
+const THROUGH_0026_COUNT = 27;
+const THROUGH_0027_COUNT = 28;
+
+type Journal = {
+  version: string;
+  dialect: string;
+  entries: Array<{ idx: number; version: string; when: number; tag: string; breakpoints: boolean }>;
+};
+
+let container: StartedPostgreSqlContainer;
+let databaseUrl: string;
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("postgres:17-alpine").start();
+  databaseUrl = container.getConnectionUri();
+}, 120_000);
+
+afterAll(async () => {
+  await container.stop();
+});
+
+beforeEach(async () => {
+  const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+  try {
+    await sql.unsafe("drop schema if exists public cascade");
+    await sql.unsafe("drop schema if exists drizzle cascade");
+    await sql.unsafe("create schema public");
+  } finally {
+    await sql.end();
+  }
+});
+
+async function readJournal(): Promise<Journal> {
+  return JSON.parse(await readFile(join(migrationsFolder, "meta/_journal.json"), "utf8")) as Journal;
+}
+
+async function truncatedMigrations(lastIndex: number): Promise<string> {
+  const journal = await readJournal();
+  const folder = await mkdtemp(join(tmpdir(), `opentag-${lastIndex}-migrations-`));
+  await mkdir(join(folder, "meta"));
+  const entries = journal.entries.filter(({ idx }) => idx <= lastIndex);
+  for (const entry of entries) {
+    await copyFile(join(migrationsFolder, `${entry.tag}.sql`), join(folder, `${entry.tag}.sql`));
+  }
+  await writeFile(join(folder, "meta/_journal.json"), JSON.stringify({ ...journal, entries }, null, 2));
+  return folder;
+}
+
+function postgresError(error: unknown): { code?: string; constraint_name?: string } {
+  if (typeof error !== "object" || error === null) return {};
+  return error as { code?: string; constraint_name?: string };
+}
+
+async function populateLegacyOwnership(sql: postgres.Sql): Promise<void> {
+  const now = new Date("2026-08-20T00:00:00.000Z");
+  const later = new Date("2026-08-21T00:00:00.000Z");
+  await sql`
+    insert into users (id, email, display_name)
+    values
+      (${OWNER_ID}, 'owner@example.com', 'Owner'),
+      (${CREATOR_ID}, 'creator@example.com', 'Creator'),
+      (${EXTRA_ADMIN_ID}, 'extra-admin@example.com', 'Extra Admin')
+  `;
+  await sql`
+    insert into workspaces (id, name, display_name)
+    values (${WORKSPACE_ID}, 'legacy', 'Legacy')
+  `;
+  await sql`
+    insert into workspace_admin_grants (workspace_id, user_id, granted_by_user_id, granted_at)
+    values
+      (${WORKSPACE_ID}, ${OWNER_ID}, ${OWNER_ID}, ${now}),
+      (${WORKSPACE_ID}, ${CREATOR_ID}, ${OWNER_ID}, ${now}),
+      (${WORKSPACE_ID}, ${EXTRA_ADMIN_ID}, ${OWNER_ID}, ${now})
+  `;
+  await sql`insert into computers (id, created_at) values (${INSTALLATION_ID}, ${now})`;
+  await sql`
+    insert into workspace_computers (
+      id, workspace_id, computer_id, display_name, platform, arch, client_version,
+      enrolled_by_user_id, enrolled_at, current_instance_id, connected_at, last_seen_at, updated_at
+    )
+    values (
+      ${ACTIVE_ENROLLMENT_ID}, ${WORKSPACE_ID}, ${INSTALLATION_ID}, 'active-box', 'linux', 'x64', '0.0.1',
+      ${OWNER_ID}, ${now}, ${CURRENT_INSTANCE_ID}, ${now}, ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into workspace_computers (
+      id, workspace_id, computer_id, display_name, platform, arch, client_version,
+      enrolled_by_user_id, enrolled_at, revoked_by_user_id, revoked_at, updated_at
+    )
+    values (
+      ${REVOKED_ENROLLMENT_ID}, ${WORKSPACE_ID}, ${INSTALLATION_ID}, 'revoked-box', 'linux', 'x64', '0.0.1',
+      ${OWNER_ID}, ${now}, ${OWNER_ID}, ${later}, ${later}
+    )
+  `;
+  await sql`
+    insert into workspace_computer_credentials (
+      id, workspace_computer_id, secret_hash, issued_by_user_id, issued_at
+    )
+    values (
+      ${ACTIVE_CREDENTIAL_ID}, ${ACTIVE_ENROLLMENT_ID}, ${"a".repeat(64)}, ${OWNER_ID}, ${now}
+    )
+  `;
+  await sql`
+    insert into workspace_computer_credentials (
+      id, workspace_computer_id, secret_hash, issued_by_user_id, issued_at, revoked_by_user_id, revoked_at
+    )
+    values (
+      ${REVOKED_CREDENTIAL_ID}, ${ACTIVE_ENROLLMENT_ID}, ${"b".repeat(64)}, ${OWNER_ID}, ${now}, ${OWNER_ID}, ${later}
+    )
+  `;
+  await sql`
+    insert into computer_connect_codes (
+      id, workspace_id, token_hash, issued_by_user_id, created_at, expires_at
+    )
+    values (
+      ${UNCONSUMED_CODE_ID}, ${WORKSPACE_ID}, ${"c".repeat(64)}, ${OWNER_ID}, ${now}, ${later}
+    )
+  `;
+  await sql`
+    insert into computer_connect_codes (
+      id, workspace_id, token_hash, issued_by_user_id, created_at, expires_at,
+      consumed_workspace_computer_id, consumed_at
+    )
+    values (
+      ${CONSUMED_CODE_ID}, ${WORKSPACE_ID}, ${"d".repeat(64)}, ${OWNER_ID}, ${now}, ${later},
+      ${ACTIVE_ENROLLMENT_ID}, ${now}
+    )
+  `;
+  await sql`
+    insert into agents (
+      id, workspace_id, created_by_user_id, workspace_computer_id, name, display_name, runtime_provider
+    )
+    values
+      (
+        ${AGENT_ID}, ${WORKSPACE_ID}, ${CREATOR_ID}, ${ACTIVE_ENROLLMENT_ID},
+        'mismatched', 'Mismatched', 'codex'
+      ),
+      (
+        ${SLACK_AGENT_ID}, ${WORKSPACE_ID}, ${CREATOR_ID}, ${ACTIVE_ENROLLMENT_ID},
+        'slack-owner', 'Slack Owner', 'codex'
+      )
+  `;
+  await sql`
+    insert into im_bindings (
+      id, agent_id, provider, status, external_app_id, external_bot_id,
+      credential_schema_version, credential_generation, encrypted_credential, activated_at
+    )
+    values (
+      ${BINDING_ID}, ${AGENT_ID}, 'feishu', 'active', 'cli_legacy', 'ou_legacy',
+      1, 1, 'encrypted', ${now}
+    )
+  `;
+  await sql`
+    insert into sessions (id, im_binding_id, channel_id, conversation_kind, kind, created_at)
+    values
+      (${ACTIVE_SESSION_ID}, ${BINDING_ID}, 'C-active', 'channel', 'channel', ${now}),
+      (${ENDED_SESSION_ID}, ${BINDING_ID}, 'C-ended', 'channel', 'channel', ${now})
+  `;
+  await sql`update sessions set ended_at = ${later} where id = ${ENDED_SESSION_ID}`;
+  await sql`
+    insert into session_placements (session_id, workspace_computer_id, generation, updated_at)
+    values
+      (${ACTIVE_SESSION_ID}, ${ACTIVE_ENROLLMENT_ID}, 2, ${later}),
+      (${ENDED_SESSION_ID}, ${REVOKED_ENROLLMENT_ID}, 1, ${now})
+  `;
+  await sql`
+    insert into session_cli_proofs (
+      session_id, proof_id, token_hash, workspace_computer_id, placement_generation,
+      connection_instance_id, created_at, updated_at
+    )
+    values (
+      ${ACTIVE_SESSION_ID}, ${crypto.randomUUID()}, ${"e".repeat(64)}, ${ACTIVE_ENROLLMENT_ID}, 1,
+      ${STALE_INSTANCE_ID}, ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into slack_installations (
+      id, workspace_id, status, external_app_id, external_team_id, external_bot_id,
+      credential_schema_version, credential_generation, encrypted_credential, activated_at, created_at, updated_at
+    )
+    values (
+      ${SLACK_ACTIVE_ID}, ${WORKSPACE_ID}, 'active', 'A_LEGACY', 'T_LEGACY', 'U_BOT',
+      1, 1, 'encrypted-slack', ${now}, ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into slack_installations (
+      id, workspace_id, status, external_app_id, external_team_id, external_bot_id,
+      credential_generation, encrypted_credential, replacement_slack_installation_id,
+      disabled_at, created_at, updated_at
+    )
+    values (
+      ${SLACK_DISABLED_ID}, ${WORKSPACE_ID}, 'disabled', 'A_OLD', 'T_OLD', 'U_OLD',
+      1, null, ${SLACK_ACTIVE_ID}, ${later}, ${now}, ${later}
+    )
+  `;
+  await sql`
+    insert into im_bindings (
+      id, agent_id, provider, status, external_app_id, external_team_id, external_bot_id,
+      credential_schema_version, credential_generation, slack_installation_id, slack_route_kind, activated_at
+    )
+    values (
+      ${SLACK_BINDING_ID}, ${SLACK_AGENT_ID}, 'slack', 'active', 'A_LEGACY', 'T_LEGACY', 'U_BOT',
+      1, 1, ${SLACK_ACTIVE_ID}, 'default', ${now}
+    )
+  `;
+  await sql`
+    insert into im_bindings (
+      id, agent_id, provider, status, external_app_id, external_team_id, external_bot_id,
+      credential_generation, slack_installation_id, disabled_at
+    )
+    values (
+      ${SLACK_DISABLED_BINDING_ID}, ${SLACK_AGENT_ID}, 'slack', 'disabled', 'A_OLD', 'T_OLD', 'U_OLD',
+      1, ${SLACK_DISABLED_ID}, ${later}
+    )
+  `;
+  await sql`
+    insert into im_messages (
+      id, im_binding_id, channel_id, external_message_id, provider_revision_key, operation, direction,
+      author_kind, author_external_id, content, provider_context, occurred_at, received_at
+    )
+    values (
+      ${MESSAGE_ID}, ${BINDING_ID}, 'C-active', 'om_legacy', '1', 'created', 'inbound',
+      'human', 'ou_human',
+      '{"version":1,"fallbackText":"hi","blocks":[],"truncated":false}'::jsonb,
+      '{"provider":"feishu","chatType":"p2p"}'::jsonb,
+      ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into im_message_deliveries (
+      id, message_id, session_id, attention, state, placement_generation, attempt_count,
+      next_attempt_at, expires_at
+    )
+    values (
+      ${PENDING_DELIVERY_ID}, ${MESSAGE_ID}, ${ACTIVE_SESSION_ID}, 'direct', 'pending', 2, 0,
+      ${now}, ${later}
+    )
+  `;
+  await sql`
+    insert into im_message_deliveries (
+      id, message_id, session_id, attention, state, placement_generation, attempt_count,
+      next_attempt_at, expires_at, accepted_at, turn_id, input_hash, report_owner_instance_id
+    )
+    values (
+      ${ACCEPTED_DELIVERY_ID}, ${MESSAGE_ID}, ${ENDED_SESSION_ID}, 'direct', 'accepted', 1, 1,
+      ${now}, ${later}, ${now}, 'turn-legacy', ${"a".repeat(64)}, ${CURRENT_INSTANCE_ID}
+    )
+  `;
+}
+
+async function insertMatchingAccountComputer(
+  sql: postgres.Sql,
+  enrollmentId: string,
+  displayName = "active-box",
+): Promise<void> {
+  const now = new Date("2026-08-20T00:00:00.000Z");
+  await sql`
+    insert into account_computers (
+      id, owner_account_id, current_installation_id, display_name, platform, arch, client_version,
+      current_instance_id, connected_at, last_seen_at, created_at, updated_at
+    )
+    values (
+      ${enrollmentId}, ${OWNER_ID}, ${INSTALLATION_ID}, ${displayName}, 'linux', 'x64', '0.0.1',
+      ${CURRENT_INSTANCE_ID}, ${now}, ${now}, ${now}, ${now}
+    )
+  `;
+}
+
+async function insertExtraEnrollment(sql: postgres.Sql): Promise<string> {
+  const extraInstallation = crypto.randomUUID();
+  const extraEnrollment = crypto.randomUUID();
+  const now = new Date("2026-08-20T00:00:00.000Z");
+  await sql`insert into computers (id, created_at) values (${extraInstallation}, ${now})`;
+  await sql`
+    insert into workspace_computers (
+      id, workspace_id, computer_id, display_name, platform, arch, client_version,
+      enrolled_by_user_id, enrolled_at, updated_at
+    )
+    values (
+      ${extraEnrollment}, ${WORKSPACE_ID}, ${extraInstallation}, 'extra-box', 'linux', 'x64', '0.0.1',
+      ${OWNER_ID}, ${now}, ${now}
+    )
+  `;
+  await insertMatchingAccountComputer(sql, extraEnrollment, "extra-box");
+  await sql`
+    update account_computers
+    set current_installation_id = ${extraInstallation}, current_instance_id = null, connected_at = null, last_seen_at = null
+    where id = ${extraEnrollment}
+  `;
+  return extraEnrollment;
+}
+
+const FAIL_CASES: Array<{ name: string; error: RegExp; inject: (sql: postgres.Sql) => Promise<void> }> = [
+  {
+    name: "orphan account Computer",
+    error: /target Computer that does not match a Workspace enrollment/,
+    inject: async (sql) => {
+      const orphanId = crypto.randomUUID();
+      const now = new Date("2026-08-20T00:00:00.000Z");
+      await sql`
+        insert into account_computers (
+          id, owner_account_id, current_installation_id, display_name, platform, arch, client_version, created_at, updated_at
+        )
+        values (
+          ${orphanId}, ${OWNER_ID}, ${INSTALLATION_ID}, 'orphan', 'linux', 'x64', '0.0.1', ${now}, ${now}
+        )
+      `;
+    },
+  },
+  {
+    name: "account Computer owner mismatch",
+    error: /owner or installation does not match the enrollment/,
+    inject: async (sql) => {
+      await insertMatchingAccountComputer(sql, ACTIVE_ENROLLMENT_ID);
+      await sql`update account_computers set owner_account_id = ${CREATOR_ID} where id = ${ACTIVE_ENROLLMENT_ID}`;
+    },
+  },
+  {
+    name: "target credential without a legacy source",
+    error: /target credential that does not match a Workspace enrollment credential/,
+    inject: async (sql) => {
+      await insertMatchingAccountComputer(sql, ACTIVE_ENROLLMENT_ID);
+      const now = new Date("2026-08-20T00:00:00.000Z");
+      await sql`
+        insert into computer_credentials (id, computer_id, secret_hash, issued_by_user_id, issued_at)
+        values (${crypto.randomUUID()}, ${ACTIVE_ENROLLMENT_ID}, ${"f".repeat(64)}, ${OWNER_ID}, ${now})
+      `;
+    },
+  },
+  {
+    name: "credential hash mismatch",
+    error: /identity or audit history does not match the enrollment credential/,
+    inject: async (sql) => {
+      await insertMatchingAccountComputer(sql, ACTIVE_ENROLLMENT_ID);
+      const now = new Date("2026-08-20T00:00:00.000Z");
+      await sql`
+        insert into computer_credentials (id, computer_id, secret_hash, issued_by_user_id, issued_at)
+        values (${ACTIVE_CREDENTIAL_ID}, ${ACTIVE_ENROLLMENT_ID}, ${"f".repeat(64)}, ${OWNER_ID}, ${now})
+      `;
+    },
+  },
+  {
+    name: "credential issued-at audit mismatch",
+    error: /identity or audit history does not match the enrollment credential/,
+    inject: async (sql) => {
+      await insertMatchingAccountComputer(sql, ACTIVE_ENROLLMENT_ID);
+      const later = new Date("2026-08-21T00:00:00.000Z");
+      await sql`
+        insert into computer_credentials (id, computer_id, secret_hash, issued_by_user_id, issued_at)
+        values (${ACTIVE_CREDENTIAL_ID}, ${ACTIVE_ENROLLMENT_ID}, ${"a".repeat(64)}, ${OWNER_ID}, ${later})
+      `;
+    },
+  },
+  {
+    name: "credential revoked-at audit mismatch",
+    error: /identity or audit history does not match the enrollment credential/,
+    inject: async (sql) => {
+      await insertMatchingAccountComputer(sql, ACTIVE_ENROLLMENT_ID);
+      const now = new Date("2026-08-20T00:00:00.000Z");
+      const divergent = new Date("2026-08-22T00:00:00.000Z");
+      await sql`
+        insert into computer_credentials (
+          id, computer_id, secret_hash, issued_by_user_id, issued_at, revoked_by_user_id, revoked_at
+        )
+        values (
+          ${REVOKED_CREDENTIAL_ID}, ${ACTIVE_ENROLLMENT_ID}, ${"b".repeat(64)},
+          ${OWNER_ID}, ${now}, ${OWNER_ID}, ${divergent}
+        )
+      `;
+    },
+  },
+  {
+    name: "divergent Agent projection",
+    error: /Agent whose Computer does not match its enrollment/,
+    inject: async (sql) => {
+      const extraEnrollment = await insertExtraEnrollment(sql);
+      await sql`update agents set computer_id = ${extraEnrollment} where id = ${AGENT_ID}`;
+    },
+  },
+  {
+    name: "divergent Session placement projection",
+    error: /placement whose Computer does not match its enrollment/,
+    inject: async (sql) => {
+      const extraEnrollment = await insertExtraEnrollment(sql);
+      await sql`update session_placements set computer_id = ${extraEnrollment} where session_id = ${ACTIVE_SESSION_ID}`;
+    },
+  },
+  {
+    name: "divergent Session CLI proof projection",
+    error: /proof whose Computer does not match its enrollment/,
+    inject: async (sql) => {
+      const extraEnrollment = await insertExtraEnrollment(sql);
+      await sql`update session_cli_proofs set computer_id = ${extraEnrollment} where session_id = ${ACTIVE_SESSION_ID}`;
+    },
+  },
+  {
+    name: "repair-shaped historical connect code",
+    error: /repair-shaped code/,
+    inject: async (sql) => {
+      await sql`update computer_connect_codes set mode = 'repair' where id = ${UNCONSUMED_CODE_ID}`;
+    },
+  },
+  {
+    name: "connect-code issuing Account conflict",
+    error: /issuing Account that does not match the issuing user/,
+    inject: async (sql) => {
+      await sql`update computer_connect_codes set issued_by_account_id = ${CREATOR_ID} where id = ${UNCONSUMED_CODE_ID}`;
+    },
+  },
+  {
+    name: "consumed Computer conflict",
+    error: /consumed Computer that does not match the enrollment/,
+    inject: async (sql) => {
+      await insertMatchingAccountComputer(sql, ACTIVE_ENROLLMENT_ID);
+      await sql`
+        update computer_connect_codes
+        set consumed_computer_id = ${ACTIVE_ENROLLMENT_ID}
+        where id = ${UNCONSUMED_CODE_ID}
+      `;
+    },
+  },
+  {
+    name: "Slack installation with zero bindings",
+    error: /installation with no Slack binding/,
+    inject: async (sql) => {
+      const orphanInstallation = crypto.randomUUID();
+      const later = new Date("2026-08-21T00:00:00.000Z");
+      await sql`
+        insert into slack_installations (
+          id, workspace_id, status, external_app_id, external_team_id, external_bot_id,
+          credential_generation, disabled_at, created_at, updated_at
+        )
+        values (
+          ${orphanInstallation}, ${WORKSPACE_ID}, 'disabled', 'A_ORPHAN', 'T_ORPHAN', 'U_ORPHAN',
+          1, ${later}, ${later}, ${later}
+        )
+      `;
+    },
+  },
+  {
+    name: "Slack installation bound to multiple Agents",
+    error: /installation bound to more than one Agent/,
+    inject: async (sql) => {
+      const later = new Date("2026-08-21T00:00:00.000Z");
+      await sql`
+        insert into im_bindings (
+          agent_id, provider, status, slack_installation_id, disabled_at
+        )
+        values (
+          ${AGENT_ID}, 'slack', 'disabled', ${SLACK_ACTIVE_ID}, ${later}
+        )
+      `;
+    },
+  },
+  {
+    name: "Slack binding whose Agent is in another Workspace",
+    error: /Agent is not in the installation Workspace/,
+    inject: async (sql) => {
+      const otherWorkspace = crypto.randomUUID();
+      const otherUser = EXTRA_ADMIN_ID;
+      const otherInstallation = crypto.randomUUID();
+      const otherEnrollment = crypto.randomUUID();
+      const otherAgent = crypto.randomUUID();
+      const now = new Date("2026-08-20T00:00:00.000Z");
+      await sql`delete from im_bindings where id = ${SLACK_BINDING_ID}`;
+      await sql`insert into workspaces (id, name, display_name) values (${otherWorkspace}, 'other', 'Other')`;
+      await sql`insert into computers (id, created_at) values (${otherInstallation}, ${now})`;
+      await sql`
+        insert into workspace_computers (
+          id, workspace_id, computer_id, display_name, platform, arch, client_version,
+          enrolled_by_user_id, enrolled_at, updated_at
+        )
+        values (
+          ${otherEnrollment}, ${otherWorkspace}, ${otherInstallation}, 'other-box', 'linux', 'x64', '0.0.1',
+          ${otherUser}, ${now}, ${now}
+        )
+      `;
+      await sql`
+        insert into agents (
+          id, workspace_id, created_by_user_id, workspace_computer_id, name, display_name, runtime_provider
+        )
+        values (
+          ${otherAgent}, ${otherWorkspace}, ${otherUser}, ${otherEnrollment}, 'outsider', 'Outsider', 'codex'
+        )
+      `;
+      await sql`
+        insert into im_bindings (
+          agent_id, provider, status, external_app_id, external_team_id, external_bot_id,
+          credential_schema_version, credential_generation, slack_installation_id, slack_route_kind, activated_at
+        )
+        values (
+          ${otherAgent}, 'slack', 'active', 'A_LEGACY', 'T_LEGACY', 'U_BOT',
+          1, 1, ${SLACK_ACTIVE_ID}, 'default', ${now}
+        )
+      `;
+    },
+  },
+  {
+    name: "prefilled Slack owner conflict",
+    error: /Agent owner that does not match the bound Agent/,
+    inject: async (sql) => {
+      await sql`update slack_installations set agent_id = ${AGENT_ID} where id = ${SLACK_ACTIVE_ID}`;
+    },
+  },
+];
+
+async function expectBackfillProjections(sql: postgres.Sql, migrations: number): Promise<void> {
+  const computers = await sql<
+    {
+      id: string;
+      owner_account_id: string;
+      current_installation_id: string;
+      display_name: string;
+      platform: string;
+      arch: string;
+      client_version: string;
+      current_instance_id: string | null;
+      connected_at: Date | null;
+      last_seen_at: Date | null;
+      created_at: Date;
+      updated_at: Date;
+    }[]
+  >`
+    select id::text, owner_account_id::text, current_installation_id::text, display_name, platform::text, arch,
+           client_version, current_instance_id::text, connected_at, last_seen_at, created_at, updated_at
+    from account_computers
+    order by display_name
+  `;
+  expect(computers).toEqual([
+    expect.objectContaining({
+      id: ACTIVE_ENROLLMENT_ID,
+      owner_account_id: OWNER_ID,
+      current_installation_id: INSTALLATION_ID,
+      display_name: "active-box",
+      platform: "linux",
+      arch: "x64",
+      client_version: "0.0.1",
+      current_instance_id: CURRENT_INSTANCE_ID,
+      connected_at: new Date("2026-08-20T00:00:00.000Z"),
+      last_seen_at: new Date("2026-08-20T00:00:00.000Z"),
+      created_at: new Date("2026-08-20T00:00:00.000Z"),
+      updated_at: new Date("2026-08-20T00:00:00.000Z"),
+    }),
+    expect.objectContaining({
+      id: REVOKED_ENROLLMENT_ID,
+      owner_account_id: OWNER_ID,
+      current_installation_id: INSTALLATION_ID,
+      display_name: "revoked-box",
+      current_instance_id: null,
+      connected_at: null,
+      last_seen_at: null,
+      created_at: new Date("2026-08-20T00:00:00.000Z"),
+      updated_at: new Date("2026-08-21T00:00:00.000Z"),
+    }),
+  ]);
+
+  const credentials = await sql<
+    {
+      id: string;
+      computer_id: string;
+      secret_hash: string;
+      issued_by_user_id: string;
+      issued_at: Date;
+      revoked_by_user_id: string | null;
+      revoked_at: Date | null;
+    }[]
+  >`
+    select id::text, computer_id::text, secret_hash, issued_by_user_id::text, issued_at,
+           revoked_by_user_id::text, revoked_at
+    from computer_credentials
+    order by secret_hash
+  `;
+  const legacyCredentials = await sql<
+    {
+      id: string;
+      workspace_computer_id: string;
+      secret_hash: string;
+      issued_by_user_id: string;
+      issued_at: Date;
+      revoked_by_user_id: string | null;
+      revoked_at: Date | null;
+    }[]
+  >`
+    select id::text, workspace_computer_id::text, secret_hash, issued_by_user_id::text, issued_at,
+           revoked_by_user_id::text, revoked_at
+    from workspace_computer_credentials
+    order by secret_hash
+  `;
+  expect(credentials).toEqual(
+    legacyCredentials.map((row) => ({
+      id: row.id,
+      computer_id: row.workspace_computer_id,
+      secret_hash: row.secret_hash,
+      issued_by_user_id: row.issued_by_user_id,
+      issued_at: row.issued_at,
+      revoked_by_user_id: row.revoked_by_user_id,
+      revoked_at: row.revoked_at,
+    })),
+  );
+  expect(credentials).toEqual([
+    {
+      id: ACTIVE_CREDENTIAL_ID,
+      computer_id: ACTIVE_ENROLLMENT_ID,
+      secret_hash: "a".repeat(64),
+      issued_by_user_id: OWNER_ID,
+      issued_at: new Date("2026-08-20T00:00:00.000Z"),
+      revoked_by_user_id: null,
+      revoked_at: null,
+    },
+    {
+      id: REVOKED_CREDENTIAL_ID,
+      computer_id: ACTIVE_ENROLLMENT_ID,
+      secret_hash: "b".repeat(64),
+      issued_by_user_id: OWNER_ID,
+      issued_at: new Date("2026-08-20T00:00:00.000Z"),
+      revoked_by_user_id: OWNER_ID,
+      revoked_at: new Date("2026-08-21T00:00:00.000Z"),
+    },
+  ]);
+
+  const [ownership] = await sql<
+    {
+      migrations: number;
+      agent_computer: string;
+      agent_creator: string;
+      slack_agent_computer: string;
+      extra_admin_owns_computer: number;
+      active_placement: string;
+      ended_placement: string;
+      proof_computer: string;
+      unconsumed_mode: string;
+      unconsumed_account: string;
+      unconsumed_consumed: string | null;
+      consumed_computer: string;
+      slack_active_owner: string;
+      slack_disabled_owner: string;
+      owner_mismatch: number;
+    }[]
+  >`
+    select
+      (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+      (select computer_id::text from agents where id = ${AGENT_ID}) as agent_computer,
+      (select created_by_user_id::text from agents where id = ${AGENT_ID}) as agent_creator,
+      (select computer_id::text from agents where id = ${SLACK_AGENT_ID}) as slack_agent_computer,
+      (
+        select count(*)::int from account_computers
+        where owner_account_id = ${EXTRA_ADMIN_ID}
+      ) as extra_admin_owns_computer,
+      (select computer_id::text from session_placements where session_id = ${ACTIVE_SESSION_ID}) as active_placement,
+      (select computer_id::text from session_placements where session_id = ${ENDED_SESSION_ID}) as ended_placement,
+      (select computer_id::text from session_cli_proofs where session_id = ${ACTIVE_SESSION_ID}) as proof_computer,
+      (select mode::text from computer_connect_codes where id = ${UNCONSUMED_CODE_ID}) as unconsumed_mode,
+      (select issued_by_account_id::text from computer_connect_codes where id = ${UNCONSUMED_CODE_ID}) as unconsumed_account,
+      (select consumed_computer_id::text from computer_connect_codes where id = ${UNCONSUMED_CODE_ID}) as unconsumed_consumed,
+      (select consumed_computer_id::text from computer_connect_codes where id = ${CONSUMED_CODE_ID}) as consumed_computer,
+      (select agent_id::text from slack_installations where id = ${SLACK_ACTIVE_ID}) as slack_active_owner,
+      (select agent_id::text from slack_installations where id = ${SLACK_DISABLED_ID}) as slack_disabled_owner,
+      (
+        select count(*)::int from agents
+        inner join workspace_computers on workspace_computers.id = agents.workspace_computer_id
+        where agents.created_by_user_id <> workspace_computers.enrolled_by_user_id
+      ) as owner_mismatch
+  `;
+  expect(ownership).toEqual({
+    migrations,
+    agent_computer: ACTIVE_ENROLLMENT_ID,
+    agent_creator: CREATOR_ID,
+    slack_agent_computer: ACTIVE_ENROLLMENT_ID,
+    extra_admin_owns_computer: 0,
+    active_placement: ACTIVE_ENROLLMENT_ID,
+    ended_placement: REVOKED_ENROLLMENT_ID,
+    proof_computer: ACTIVE_ENROLLMENT_ID,
+    unconsumed_mode: "create",
+    unconsumed_account: OWNER_ID,
+    unconsumed_consumed: null,
+    consumed_computer: ACTIVE_ENROLLMENT_ID,
+    slack_active_owner: SLACK_AGENT_ID,
+    slack_disabled_owner: SLACK_AGENT_ID,
+    owner_mismatch: 2,
+  });
+
+  const [preserved] = await sql<
+    {
+      stale_proof_instance: string;
+      pending_deliveries: number;
+      accepted_unreported: number;
+      ended_sessions: number;
+      revoked_enrollments: number;
+    }[]
+  >`
+    select
+      (
+        select connection_instance_id::text from session_cli_proofs
+        where session_id = ${ACTIVE_SESSION_ID}
+      ) as stale_proof_instance,
+      (
+        select count(*)::int from im_message_deliveries
+        where id = ${PENDING_DELIVERY_ID} and state = 'pending' and placement_generation = 2
+      ) as pending_deliveries,
+      (
+        select count(*)::int from im_message_deliveries
+        where id = ${ACCEPTED_DELIVERY_ID} and state = 'accepted' and reported_at is null
+          and report_owner_instance_id = ${CURRENT_INSTANCE_ID}
+      ) as accepted_unreported,
+      (
+        select count(*)::int from sessions where id = ${ENDED_SESSION_ID} and ended_at is not null
+      ) as ended_sessions,
+      (
+        select count(*)::int from workspace_computers
+        where id = ${REVOKED_ENROLLMENT_ID} and revoked_at is not null
+      ) as revoked_enrollments
+  `;
+  expect(preserved).toEqual({
+    stale_proof_instance: STALE_INSTANCE_ID,
+    pending_deliveries: 1,
+    accepted_unreported: 1,
+    ended_sessions: 1,
+    revoked_enrollments: 1,
+  });
+}
+
+describe("account-owned resource backfill migrations", () => {
+  it("journals 0027 without a snapshot immediately before 0028", async () => {
+    const journal = await readJournal();
+    expect(journal.entries.slice(26, 29).map(({ idx, tag }) => ({ idx, tag }))).toEqual([
+      { idx: 26, tag: "0026_wakeful_wildside" },
+      { idx: 27, tag: "0027_backfill_account_owned_resources" },
+      { idx: 28, tag: "0028_overjoyed_speedball" },
+    ]);
+    await expect(access(join(migrationsFolder, "meta/0027_snapshot.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(join(migrationsFolder, "meta/0028_snapshot.json"))).resolves.toBeUndefined();
+  });
+
+  it("migrates an empty database to current and reruns idempotently", async () => {
+    const journal = await readJournal();
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+
+    const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+    try {
+      const [row] = await sql<
+        {
+          migrations: number;
+          account_computers: number;
+          computer_credentials: number;
+          agents_nullable: string | null;
+          slack_nullable: string | null;
+        }[]
+      >`
+        select
+          (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+          (select count(*)::int from account_computers) as account_computers,
+          (select count(*)::int from computer_credentials) as computer_credentials,
+          (
+            select is_nullable from information_schema.columns
+            where table_schema = 'public' and table_name = 'agents' and column_name = 'computer_id'
+          ) as agents_nullable,
+          (
+            select is_nullable from information_schema.columns
+            where table_schema = 'public' and table_name = 'slack_installations' and column_name = 'agent_id'
+          ) as slack_nullable
+      `;
+      expect(row).toEqual({
+        migrations: journal.entries.length,
+        account_computers: 0,
+        computer_credentials: 0,
+        agents_nullable: "NO",
+        slack_nullable: "NO",
+      });
+    } finally {
+      await sql.end();
+    }
+  });
+
+  it("backfills populated 0026 data onto matching account-owned projections", async () => {
+    const journal = await readJournal();
+    const through0026 = await truncatedMigrations(26);
+    try {
+      await migrateDatabase(databaseUrl, through0026);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateLegacyOwnership(sql);
+        const [before] = await sql<{ migrations: number; account_computers: number; slack_filled: number }[]>`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (select count(*)::int from account_computers) as account_computers,
+            (select count(*)::int from slack_installations where agent_id is not null) as slack_filled
+        `;
+        expect(before).toEqual({ migrations: THROUGH_0026_COUNT, account_computers: 0, slack_filled: 0 });
+
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+        await expectBackfillProjections(sql, journal.entries.length);
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(through0026, { force: true, recursive: true });
+    }
+  });
+
+  it("upgrades representative 0025 history through current when Slack bindings exist", async () => {
+    const journal = await readJournal();
+    const through0025 = await truncatedMigrations(25);
+    try {
+      await migrateDatabase(databaseUrl, through0025);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateLegacyOwnership(sql);
+        const [before] = await sql<{ migrations: number; slack: number }[]>`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (select count(*)::int from slack_installations) as slack
+        `;
+        expect(before).toEqual({ migrations: 26, slack: 2 });
+
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+        await expectBackfillProjections(sql, journal.entries.length);
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(through0025, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps already matching rows and fills remaining projections retry-safely", async () => {
+    const journal = await readJournal();
+    const through0026 = await truncatedMigrations(26);
+    try {
+      await migrateDatabase(databaseUrl, through0026);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateLegacyOwnership(sql);
+        await insertMatchingAccountComputer(sql, ACTIVE_ENROLLMENT_ID, "already-projected");
+        await sql`update agents set computer_id = ${ACTIVE_ENROLLMENT_ID} where id = ${AGENT_ID}`;
+        await sql`
+          update computer_connect_codes
+          set issued_by_account_id = issued_by_user_id, mode = 'create'
+          where id = ${UNCONSUMED_CODE_ID}
+        `;
+        await sql`update slack_installations set agent_id = ${SLACK_AGENT_ID} where id = ${SLACK_ACTIVE_ID}`;
+
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+
+        const [row] = await sql<
+          {
+            migrations: number;
+            prefilled_name: string;
+            revoked_name: string;
+            slack_agent: string;
+            proof_computer: string;
+            consumed_computer: string;
+          }[]
+        >`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (select display_name from account_computers where id = ${ACTIVE_ENROLLMENT_ID}) as prefilled_name,
+            (select display_name from account_computers where id = ${REVOKED_ENROLLMENT_ID}) as revoked_name,
+            (select agent_id::text from slack_installations where id = ${SLACK_DISABLED_ID}) as slack_agent,
+            (select computer_id::text from session_cli_proofs where session_id = ${ACTIVE_SESSION_ID}) as proof_computer,
+            (select consumed_computer_id::text from computer_connect_codes where id = ${CONSUMED_CODE_ID}) as consumed_computer
+        `;
+        expect(row).toEqual({
+          migrations: journal.entries.length,
+          prefilled_name: "already-projected",
+          revoked_name: "revoked-box",
+          slack_agent: SLACK_AGENT_ID,
+          proof_computer: ACTIVE_ENROLLMENT_ID,
+          consumed_computer: ACTIVE_ENROLLMENT_ID,
+        });
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(through0026, { force: true, recursive: true });
+    }
+  });
+
+  it.each(FAIL_CASES)("fail-closes 0027 for $name and leaves the journal at 0026", async ({ error, inject }) => {
+    const through0026 = await truncatedMigrations(26);
+    try {
+      await migrateDatabase(databaseUrl, through0026);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateLegacyOwnership(sql);
+        await inject(sql);
+        await expect(migrateDatabase(databaseUrl, migrationsFolder)).rejects.toThrow(error);
+        const [failed] = await sql<{ migrations: number; agents_nullable: string | null }[]>`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (
+              select is_nullable from information_schema.columns
+              where table_schema = 'public' and table_name = 'agents' and column_name = 'computer_id'
+            ) as agents_nullable
+        `;
+        expect(failed).toEqual({ migrations: THROUGH_0026_COUNT, agents_nullable: "YES" });
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(through0026, { force: true, recursive: true });
+    }
+  });
+
+  it("rolls back a late 0027 failure and retries after the external orphan is removed", async () => {
+    const journal = await readJournal();
+    const through0026 = await truncatedMigrations(26);
+    try {
+      await migrateDatabase(databaseUrl, through0026);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateLegacyOwnership(sql);
+        const orphanInstallation = crypto.randomUUID();
+        const later = new Date("2026-08-21T00:00:00.000Z");
+        await sql`
+          insert into slack_installations (
+            id, workspace_id, status, external_app_id, external_team_id, external_bot_id,
+            credential_generation, disabled_at, created_at, updated_at
+          )
+          values (
+            ${orphanInstallation}, ${WORKSPACE_ID}, 'disabled', 'A_RETRY_ORPHAN', 'T_RETRY_ORPHAN', 'U_RETRY_ORPHAN',
+            1, ${later}, ${later}, ${later}
+          )
+        `;
+
+        await expect(migrateDatabase(databaseUrl, migrationsFolder)).rejects.toThrow(
+          /installation with no Slack binding/,
+        );
+        const [rolledBack] = await sql<
+          {
+            migrations: number;
+            account_computers: number;
+            credentials: number;
+            projected_agents: number;
+            projected_placements: number;
+            projected_proofs: number;
+            projected_slack: number;
+          }[]
+        >`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (select count(*)::int from account_computers) as account_computers,
+            (select count(*)::int from computer_credentials) as credentials,
+            (select count(*)::int from agents where computer_id is not null) as projected_agents,
+            (select count(*)::int from session_placements where computer_id is not null) as projected_placements,
+            (select count(*)::int from session_cli_proofs where computer_id is not null) as projected_proofs,
+            (select count(*)::int from slack_installations where agent_id is not null) as projected_slack
+        `;
+        expect(rolledBack).toEqual({
+          migrations: THROUGH_0026_COUNT,
+          account_computers: 0,
+          credentials: 0,
+          projected_agents: 0,
+          projected_placements: 0,
+          projected_proofs: 0,
+          projected_slack: 0,
+        });
+
+        await sql`delete from slack_installations where id = ${orphanInstallation}`;
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+        await expectBackfillProjections(sql, journal.entries.length);
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(through0026, { force: true, recursive: true });
+    }
+  });
+
+  it("enforces 0028 NOT NULL, identity checks, and the Slack ownership FK", async () => {
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    const client = createDatabaseClient(databaseUrl);
+    try {
+      const bootstrap = await bootstrapInitialAdmin(client.database, {
+        displayName: "Admin",
+        email: "admin@example.com",
+        workspaceDisplayName: "Example",
+        workspaceName: "example",
+      });
+      const machineAuth = new MachineAuthService(client.database);
+      const issued = await machineAuth.issueForWorkspaceAdmin(bootstrap.userId, bootstrap.workspaceId);
+      const enrollment = await machineAuth.exchangeConnectCode({
+        code: issued.code,
+        computerId: crypto.randomUUID(),
+        displayName: "workstation",
+        platform: "linux",
+        arch: "x64",
+        clientVersion: "0.0.1",
+      });
+      const secondIssued = await machineAuth.issueForWorkspaceAdmin(bootstrap.userId, bootstrap.workspaceId);
+      const second = await machineAuth.exchangeConnectCode({
+        code: secondIssued.code,
+        computerId: crypto.randomUUID(),
+        displayName: "other-box",
+        platform: "linux",
+        arch: "x64",
+        clientVersion: "0.0.1",
+      });
+      const sql = client.sql;
+      const missingComputer = await sql`
+        insert into agents (
+          workspace_id, created_by_user_id, workspace_computer_id, name, display_name, runtime_provider
+        )
+        values (
+          ${bootstrap.workspaceId}, ${bootstrap.userId}, ${enrollment.workspaceComputerId},
+          'missing', 'Missing', 'codex'
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(missingComputer)).toMatchObject({ code: "23502" });
+
+      const mismatchedAgent = await sql`
+        insert into agents (
+          workspace_id, created_by_user_id, workspace_computer_id, computer_id, name, display_name, runtime_provider
+        )
+        values (
+          ${bootstrap.workspaceId}, ${bootstrap.userId}, ${enrollment.workspaceComputerId}, ${second.workspaceComputerId},
+          'mismatch', 'Mismatch', 'codex'
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(mismatchedAgent)).toMatchObject({
+        code: "23514",
+        constraint_name: "agents_computer_matches_enrollment",
+      });
+
+      const [agent] = await sql<{ id: string }[]>`
+        insert into agents (
+          workspace_id, created_by_user_id, workspace_computer_id, computer_id, name, display_name, runtime_provider
+        )
+        values (
+          ${bootstrap.workspaceId}, ${bootstrap.userId}, ${enrollment.workspaceComputerId}, ${enrollment.workspaceComputerId},
+          'bound', 'Bound', 'codex'
+        )
+        returning id::text
+      `;
+      if (!agent) throw new Error("Agent fixture was not created");
+      const [binding] = await sql<{ id: string }[]>`
+        insert into im_bindings (
+          agent_id, provider, status, external_app_id, external_bot_id,
+          credential_schema_version, credential_generation, encrypted_credential, activated_at
+        )
+        values (
+          ${agent.id}, 'feishu', 'active', 'cli_bound', 'ou_bound', 1, 1, 'encrypted', now()
+        )
+        returning id::text
+      `;
+      if (!binding) throw new Error("IM binding fixture was not created");
+      const [session] = await sql<{ id: string }[]>`
+        insert into sessions (im_binding_id, channel_id, conversation_kind, kind)
+        values (${binding.id}, 'C-bound', 'channel', 'channel')
+        returning id::text
+      `;
+      if (!session) throw new Error("Session fixture was not created");
+
+      const mismatchedPlacement = await sql`
+        insert into session_placements (session_id, workspace_computer_id, computer_id, generation)
+        values (${session.id}, ${enrollment.workspaceComputerId}, ${second.workspaceComputerId}, 1)
+      `.catch((error: unknown) => error);
+      expect(postgresError(mismatchedPlacement)).toMatchObject({
+        code: "23514",
+        constraint_name: "session_placements_computer_matches_enrollment",
+      });
+      await sql`
+        insert into session_placements (session_id, workspace_computer_id, computer_id, generation)
+        values (${session.id}, ${enrollment.workspaceComputerId}, ${enrollment.workspaceComputerId}, 1)
+      `;
+
+      const mismatchedProof = await sql`
+        insert into session_cli_proofs (
+          session_id, proof_id, token_hash, workspace_computer_id, computer_id, placement_generation, connection_instance_id
+        )
+        values (
+          ${session.id}, ${crypto.randomUUID()}, ${"1".repeat(64)},
+          ${enrollment.workspaceComputerId}, ${second.workspaceComputerId}, 1, ${crypto.randomUUID()}
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(mismatchedProof)).toMatchObject({
+        code: "23514",
+        constraint_name: "session_cli_proofs_computer_matches_enrollment",
+      });
+
+      const [otherUser] = await sql<{ id: string }[]>`
+        insert into users (email, display_name) values ('other-issuer@example.com', 'Other')
+        returning id::text
+      `;
+      if (!otherUser) throw new Error("Other user fixture was not created");
+      const issuedAccountPair = await sql`
+        insert into computer_connect_codes (
+          workspace_id, token_hash, issued_by_user_id, issued_by_account_id, mode, expires_at
+        )
+        values (
+          ${bootstrap.workspaceId}, ${"3".repeat(64)}, ${bootstrap.userId}, ${otherUser.id}, 'create',
+          now() + interval '15 minutes'
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(issuedAccountPair)).toMatchObject({
+        code: "23514",
+        constraint_name: "computer_connect_codes_issued_by_account_pair",
+      });
+
+      const consumedIdentity = await sql`
+        insert into computer_connect_codes (
+          workspace_id, token_hash, issued_by_user_id, issued_by_account_id, mode, expires_at,
+          consumed_workspace_computer_id, consumed_computer_id, consumed_at
+        )
+        values (
+          ${bootstrap.workspaceId}, ${"4".repeat(64)}, ${bootstrap.userId}, ${bootstrap.userId}, 'create',
+          now() + interval '15 minutes',
+          ${enrollment.workspaceComputerId}, ${second.workspaceComputerId}, now()
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(consumedIdentity)).toMatchObject({
+        code: "23514",
+        constraint_name: "computer_connect_codes_consumed_computer_identity",
+      });
+
+      const repairPair = await sql`
+        insert into computer_connect_codes (
+          workspace_id, token_hash, issued_by_user_id, issued_by_account_id, mode, expires_at, target_computer_id
+        )
+        values (
+          ${bootstrap.workspaceId}, ${"5".repeat(64)}, ${bootstrap.userId}, ${bootstrap.userId}, 'create',
+          now() + interval '15 minutes', ${enrollment.workspaceComputerId}
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(repairPair)).toMatchObject({
+        code: "23514",
+        constraint_name: "computer_connect_codes_repair_target_pair",
+      });
+
+      const missingSlackOwner = await sql`
+        insert into slack_installations (
+          workspace_id, status, external_app_id, external_team_id, external_bot_id,
+          credential_schema_version, credential_generation, encrypted_credential, activated_at
+        )
+        values (
+          ${bootstrap.workspaceId}, 'active', 'A_MISSING', 'T_MISSING', 'U_MISSING', 1, 1, 'secret', now()
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(missingSlackOwner)).toMatchObject({ code: "23502" });
+
+      const [installation] = await sql<{ id: string }[]>`
+        insert into slack_installations (
+          workspace_id, agent_id, status, external_app_id, external_team_id, external_bot_id,
+          credential_schema_version, credential_generation, encrypted_credential, activated_at
+        )
+        values (
+          ${bootstrap.workspaceId}, ${agent.id}, 'active', 'A_OWNED', 'T_OWNED', 'U_OWNED', 1, 1, 'secret', now()
+        )
+        returning id::text
+      `;
+      if (!installation) throw new Error("Slack installation fixture was not created");
+      const [otherAgent] = await sql<{ id: string }[]>`
+        insert into agents (
+          workspace_id, created_by_user_id, workspace_computer_id, computer_id, name, display_name, runtime_provider
+        )
+        values (
+          ${bootstrap.workspaceId}, ${bootstrap.userId}, ${enrollment.workspaceComputerId}, ${enrollment.workspaceComputerId},
+          'other-bound', 'Other Bound', 'codex'
+        )
+        returning id::text
+      `;
+      if (!otherAgent) throw new Error("Other Agent fixture was not created");
+      const ownerFk = await sql`
+        insert into im_bindings (
+          agent_id, provider, status, slack_installation_id, slack_route_kind, disabled_at
+        )
+        values (
+          ${otherAgent.id}, 'slack', 'disabled', ${installation.id}, 'default', now()
+        )
+      `.catch((error: unknown) => error);
+      expect(postgresError(ownerFk)).toMatchObject({
+        code: "23503",
+        constraint_name: "im_bindings_slack_installation_owner_fk",
+      });
+    } finally {
+      await client.sql.end();
+    }
+  });
+
+  it("rolls back a failed 0028 and retries after removing the obstruction", async () => {
+    const journal = await readJournal();
+    const through0026 = await truncatedMigrations(26);
+    const through0027 = await truncatedMigrations(27);
+    try {
+      await migrateDatabase(databaseUrl, through0026);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateLegacyOwnership(sql);
+        await migrateDatabase(databaseUrl, through0027);
+        const [filled] = await sql<{ migrations: number; agents_nullable: string | null; null_agents: number }[]>`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (
+              select is_nullable from information_schema.columns
+              where table_schema = 'public' and table_name = 'agents' and column_name = 'computer_id'
+            ) as agents_nullable,
+            (select count(*)::int from agents where computer_id is null) as null_agents
+        `;
+        expect(filled).toEqual({
+          migrations: THROUGH_0027_COUNT,
+          agents_nullable: "YES",
+          null_agents: 0,
+        });
+
+        await sql`update agents set computer_id = null`;
+        await expect(migrateDatabase(databaseUrl, migrationsFolder)).rejects.toThrow(
+          /ALTER TABLE "agents" ALTER COLUMN "computer_id" SET NOT NULL/,
+        );
+        const [failed] = await sql<
+          {
+            migrations: number;
+            agents_nullable: string | null;
+            identity_check: boolean;
+            slack_unique: boolean;
+            owner_fk: boolean;
+          }[]
+        >`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (
+              select is_nullable from information_schema.columns
+              where table_schema = 'public' and table_name = 'agents' and column_name = 'computer_id'
+            ) as agents_nullable,
+            exists(select 1 from pg_constraint where conname = 'agents_computer_matches_enrollment') as identity_check,
+            exists(select 1 from pg_constraint where conname = 'slack_installations_agent_id_id_unique') as slack_unique,
+            exists(select 1 from pg_constraint where conname = 'im_bindings_slack_installation_owner_fk') as owner_fk
+        `;
+        expect(failed).toEqual({
+          migrations: THROUGH_0027_COUNT,
+          agents_nullable: "YES",
+          identity_check: false,
+          slack_unique: false,
+          owner_fk: false,
+        });
+
+        await sql`update agents set computer_id = workspace_computer_id`;
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+        const [retried] = await sql<
+          {
+            migrations: number;
+            agents_nullable: string | null;
+            identity_check: boolean;
+            slack_unique: boolean;
+            owner_fk: boolean;
+          }[]
+        >`
+          select
+            (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
+            (
+              select is_nullable from information_schema.columns
+              where table_schema = 'public' and table_name = 'agents' and column_name = 'computer_id'
+            ) as agents_nullable,
+            exists(select 1 from pg_constraint where conname = 'agents_computer_matches_enrollment') as identity_check,
+            exists(select 1 from pg_constraint where conname = 'slack_installations_agent_id_id_unique') as slack_unique,
+            exists(select 1 from pg_constraint where conname = 'im_bindings_slack_installation_owner_fk') as owner_fk
+        `;
+        expect(retried).toEqual({
+          migrations: journal.entries.length,
+          agents_nullable: "NO",
+          identity_check: true,
+          slack_unique: true,
+          owner_fk: true,
+        });
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(through0026, { force: true, recursive: true });
+      await rm(through0027, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts representative reads and dual-writes after the real migration runner", async () => {
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+    const client = createDatabaseClient(databaseUrl);
+    try {
+      const bootstrap = await bootstrapInitialAdmin(client.database, {
+        displayName: "Admin",
+        email: "admin@example.com",
+        workspaceDisplayName: "Example",
+        workspaceName: "example",
+      });
+      const machineAuth = new MachineAuthService(client.database);
+      const computers = new ComputerService(client.database, {
+        getActiveUserById: async () => {
+          throw new Error("unused");
+        },
+      });
+      const issued = await machineAuth.issueForWorkspaceAdmin(bootstrap.userId, bootstrap.workspaceId);
+      const enrollment = await machineAuth.exchangeConnectCode({
+        code: issued.code,
+        computerId: crypto.randomUUID(),
+        displayName: "workstation",
+        platform: "linux",
+        arch: "x64",
+        clientVersion: "0.0.1",
+      });
+      const instanceId = crypto.randomUUID();
+      await computers.register(enrollment, {
+        type: "computer:register",
+        requestId: crypto.randomUUID(),
+        computerId: enrollment.computerId,
+        instanceId,
+        displayName: "workstation",
+        platform: "linux",
+        arch: "x64",
+        clientVersion: "0.0.1",
+        capabilities: { imCredentialGrant: 0 as const },
+        protocolVersion: RUNTIME_PROTOCOL_V2,
+        supportedCapabilities: { imCredentialGrant: { min: 1, max: 1 } },
+        requiredServerCapabilities: [],
+      });
+
+      const [legacy] = await client.database
+        .select()
+        .from(workspaceComputers)
+        .where(eq(workspaceComputers.id, enrollment.workspaceComputerId));
+      const [target] = await client.database
+        .select()
+        .from(accountComputers)
+        .where(eq(accountComputers.id, enrollment.workspaceComputerId));
+      expect(target).toMatchObject({
+        id: enrollment.workspaceComputerId,
+        ownerAccountId: bootstrap.userId,
+        currentInstallationId: enrollment.computerId,
+        currentInstanceId: instanceId,
+        displayName: legacy?.displayName,
+      });
+      const [legacyCredential] = await client.database
+        .select()
+        .from(workspaceComputerCredentials)
+        .where(eq(workspaceComputerCredentials.id, enrollment.credentialId));
+      const [targetCredential] = await client.database
+        .select()
+        .from(computerCredentials)
+        .where(eq(computerCredentials.id, enrollment.credentialId));
+      expect(targetCredential).toMatchObject({
+        id: enrollment.credentialId,
+        computerId: enrollment.workspaceComputerId,
+        secretHash: legacyCredential?.secretHash,
+        issuedByUserId: bootstrap.userId,
+        revokedAt: null,
+      });
+      const codes = await client.database.select().from(computerConnectCodes);
+      expect(codes).toHaveLength(1);
+      expect(codes[0]).toMatchObject({
+        issuedByAccountId: bootstrap.userId,
+        mode: "create",
+        consumedComputerId: enrollment.workspaceComputerId,
+        consumedWorkspaceComputerId: enrollment.workspaceComputerId,
+      });
+
+      const agent = await new AgentService(client.database).createForWorkspace(
+        bootstrap.userId,
+        bootstrap.workspaceId,
+        {
+          name: "assistant",
+          displayName: "Assistant",
+          runtimeProvider: "codex",
+          computerId: enrollment.computerId,
+        },
+      );
+      const [agentRow] = await client.database.select().from(agents).where(eq(agents.id, agent.id));
+      expect(agentRow).toMatchObject({
+        createdByUserId: bootstrap.userId,
+        workspaceComputerId: enrollment.workspaceComputerId,
+        computerId: enrollment.workspaceComputerId,
+      });
+
+      const [binding] = await client.sql<{ id: string }[]>`
+        insert into im_bindings (
+          agent_id, provider, status, external_app_id, external_bot_id,
+          credential_schema_version, credential_generation, encrypted_credential, activated_at
+        )
+        values (
+          ${agent.id}, 'feishu', 'active', 'cli_boot', 'ou_boot', 1, 1, 'encrypted', now()
+        )
+        returning id::text
+      `;
+      if (!binding) throw new Error("IM binding was not created");
+      const sessions = new SessionService(client.database);
+      const chat = await sessions.ensureChatSession(
+        { imBindingId: binding.id, channelId: "C-boot", conversationKind: "channel" },
+        "channel",
+      );
+      expect(chat.placement.workspaceComputerId).toBe(enrollment.workspaceComputerId);
+      const [placement] = await client.database
+        .select()
+        .from(sessionPlacements)
+        .where(eq(sessionPlacements.sessionId, chat.session.id));
+      expect(placement).toMatchObject({
+        workspaceComputerId: enrollment.workspaceComputerId,
+        computerId: enrollment.workspaceComputerId,
+        generation: 1,
+      });
+
+      const proofs = new SessionCliProofService(
+        client.database,
+        {
+          currentInstanceId: (workspaceComputerId: string) =>
+            workspaceComputerId === enrollment.workspaceComputerId ? instanceId : undefined,
+          supportsCapability: (workspaceComputerId: string, connectionInstanceId: string) =>
+            workspaceComputerId === enrollment.workspaceComputerId && connectionInstanceId === instanceId,
+        },
+        new Uint8Array(32).fill(3),
+      );
+      const minted = await proofs.mint({
+        sessionId: chat.session.id,
+        workspaceComputerId: enrollment.workspaceComputerId,
+        placementGeneration: 1,
+        connectionInstanceId: instanceId,
+      });
+      const [proof] = await client.database
+        .select()
+        .from(sessionCliProofs)
+        .where(eq(sessionCliProofs.sessionId, chat.session.id));
+      expect(proof).toMatchObject({
+        proofId: minted.proofId,
+        workspaceComputerId: enrollment.workspaceComputerId,
+        computerId: enrollment.workspaceComputerId,
+      });
+
+      const moved = await sessions.movePlacement(chat.session.id, enrollment.workspaceComputerId);
+      expect(moved).toMatchObject({
+        workspaceComputerId: enrollment.workspaceComputerId,
+        generation: 2,
+      });
+      const [movedRow] = await client.database
+        .select()
+        .from(sessionPlacements)
+        .where(eq(sessionPlacements.sessionId, chat.session.id));
+      expect(movedRow?.computerId).toBe(enrollment.workspaceComputerId);
+    } finally {
+      await client.sql.end();
+    }
+  });
+});

--- a/packages/server/src/__tests__/integration/account-ownership-expansion.test.ts
+++ b/packages/server/src/__tests__/integration/account-ownership-expansion.test.ts
@@ -377,7 +377,6 @@ describe("account-owned computer expansion migrations", () => {
   });
 
   it("upgrades populated 0025 data to 0026 without backfilling target projections", async () => {
-    const journal = await readJournal();
     const legacyFolder = await truncatedMigrations(25);
     try {
       await migrateDatabase(databaseUrl, legacyFolder);
@@ -420,8 +419,12 @@ describe("account-owned computer expansion migrations", () => {
           deliveries: 2,
         });
 
-        await migrateDatabase(databaseUrl, migrationsFolder);
-        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+        const through0026 = await truncatedMigrations(26);
+        try {
+          await migrateDatabase(databaseUrl, through0026);
+        } finally {
+          await rm(through0026, { force: true, recursive: true });
+        }
 
         const [after] = await sql<
           {
@@ -494,7 +497,7 @@ describe("account-owned computer expansion migrations", () => {
             ) as replaced_slack
         `;
         expect(after).toEqual({
-          migrations: journal.entries.length,
+          migrations: 27,
           workspace_computers: 2,
           credentials: 2,
           codes: 2,
@@ -543,8 +546,8 @@ describe("account-owned computer expansion migrations", () => {
   });
 
   it("upgrades representative 0024 Slack-install history through 0026 without filling agent_id", async () => {
-    const journal = await readJournal();
     const legacyFolder = await truncatedMigrations(24);
+    const through0026 = await truncatedMigrations(26);
     try {
       await migrateDatabase(databaseUrl, legacyFolder);
       const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
@@ -569,7 +572,7 @@ describe("account-owned computer expansion migrations", () => {
         `;
         expect(before).toEqual({ migrations: 25, slack: 1 });
 
-        await migrateDatabase(databaseUrl, migrationsFolder);
+        await migrateDatabase(databaseUrl, through0026);
         const [after] = await sql<{ migrations: number; slack: number; filled: number; installation: string }[]>`
           select
             (select count(*)::int from drizzle.__drizzle_migrations) as migrations,
@@ -578,7 +581,7 @@ describe("account-owned computer expansion migrations", () => {
             (select external_app_id from slack_installations limit 1) as installation
         `;
         expect(after).toEqual({
-          migrations: journal.entries.length,
+          migrations: 27,
           slack: 1,
           filled: 0,
           installation: "A_HIST",
@@ -588,6 +591,7 @@ describe("account-owned computer expansion migrations", () => {
       }
     } finally {
       await rm(legacyFolder, { force: true, recursive: true });
+      await rm(through0026, { force: true, recursive: true });
     }
   });
 
@@ -683,7 +687,12 @@ describe("account-owned computer expansion migrations", () => {
   });
 
   it("preserves legacy enrollment hazards and fail-closes new projection constraints", async () => {
-    await migrateDatabase(databaseUrl, migrationsFolder);
+    const through0026 = await truncatedMigrations(26);
+    try {
+      await migrateDatabase(databaseUrl, through0026);
+    } finally {
+      await rm(through0026, { force: true, recursive: true });
+    }
     const client = createDatabaseClient(databaseUrl);
     try {
       const bootstrap = await bootstrapInitialAdmin(client.database, {

--- a/packages/server/src/__tests__/integration/agents.test.ts
+++ b/packages/server/src/__tests__/integration/agents.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient, type DatabaseClient } from "../../db/client.js";
 import {
+  accountComputers,
   agents,
   computers,
   imBindings,
@@ -81,6 +82,12 @@ async function createComputer(database: DatabaseClient, ownerUserId: string, wor
     })
     .returning();
   if (!workspaceComputer) throw new Error("Workspace Computer fixture was not created");
+  await database.insert(accountComputers).values({
+    id: workspaceComputer.id,
+    ownerAccountId: ownerUserId,
+    currentInstallationId: computer.id,
+    ...profile,
+  });
   return { ...computer, ...profile, workspaceComputerId: workspaceComputer.id };
 }
 
@@ -258,7 +265,7 @@ describe("Agent persistence and authorization", () => {
         }),
       ]);
       const [stored] = await value.database.select().from(agents).where(eq(agents.id, created.id));
-      expect(stored?.computerId).toBeNull();
+      expect(stored?.computerId).toBe(computer.workspaceComputerId);
       await expect(value.service.getById(value.bootstrap.userId, created.id)).resolves.toMatchObject({
         id: created.id,
       });
@@ -1089,14 +1096,27 @@ describe("Agent persistence and authorization", () => {
           runtimeProvider: "claude-code",
         }),
       ).rejects.toMatchObject({ code: "COMPUTER_NOT_FOUND", statusCode: 404 });
-      await value.database.insert(workspaceComputers).values({
-        workspaceId: otherWorkspace.id,
-        computerId: computer.id,
+      const [otherEnrollment] = await value.database
+        .insert(workspaceComputers)
+        .values({
+          workspaceId: otherWorkspace.id,
+          computerId: computer.id,
+          displayName: computer.displayName,
+          platform: computer.platform,
+          arch: computer.arch,
+          clientVersion: computer.clientVersion,
+          enrolledByUserId: value.bootstrap.userId,
+        })
+        .returning();
+      if (!otherEnrollment) throw new Error("Other Workspace Computer fixture was not created");
+      await value.database.insert(accountComputers).values({
+        id: otherEnrollment.id,
+        ownerAccountId: value.bootstrap.userId,
+        currentInstallationId: computer.id,
         displayName: computer.displayName,
         platform: computer.platform,
         arch: computer.arch,
         clientVersion: computer.clientVersion,
-        enrolledByUserId: value.bootstrap.userId,
       });
       const created = await value.service.createForWorkspace(value.bootstrap.userId, otherWorkspace.id, {
         ...createInput(computer.id, "assistant"),
@@ -1160,7 +1180,7 @@ describe("Agent persistence and authorization", () => {
       expect(stored).toMatchObject({
         createdByUserId: other.id,
         workspaceComputerId: computer.workspaceComputerId,
-        computerId: null,
+        computerId: computer.workspaceComputerId,
       });
     } finally {
       await value.sql.end();

--- a/packages/server/src/__tests__/integration/auth-migrations.test.ts
+++ b/packages/server/src/__tests__/integration/auth-migrations.test.ts
@@ -1077,10 +1077,10 @@ describe("database migrations", () => {
             (select count(*)::int from session_placements where computer_id is not null) as placements_filled
         `;
         expect(expansion).toEqual({
-          account_computers: 0,
+          account_computers: 4,
           computer_credentials: 0,
-          agents_filled: 0,
-          placements_filled: 0,
+          agents_filled: 2,
+          placements_filled: 2,
         });
         const repairedWorkspaces = await sql<{ completed: boolean; name: string }[]>`
           select name, setup_completed_at is not null as completed

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -24,6 +24,7 @@ import WebSocket from "ws";
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient } from "../../db/client.js";
 import {
+  accountComputers,
   agentRuntimeConfigs,
   agents,
   computers,
@@ -129,6 +130,12 @@ async function fixture() {
     })
     .returning();
   if (!workspaceComputer) throw new Error("Workspace Computer fixture was not created");
+  await client.database.insert(accountComputers).values({
+    id: workspaceComputer.id,
+    ownerAccountId: bootstrap.userId,
+    currentInstallationId: computer.id,
+    ...computerProfile,
+  });
   const agent = await new AgentService(client.database).createForWorkspace(bootstrap.userId, bootstrap.workspaceId, {
     name: "assistant",
     displayName: "Assistant",
@@ -201,6 +208,12 @@ async function unboundFixture() {
     })
     .returning();
   if (!workspaceComputer) throw new Error("Workspace Computer fixture was not created");
+  await client.database.insert(accountComputers).values({
+    id: workspaceComputer.id,
+    ownerAccountId: bootstrap.userId,
+    currentInstallationId: computer.id,
+    ...computerProfile,
+  });
   const created = await new AgentService(client.database).createForWorkspace(bootstrap.userId, bootstrap.workspaceId, {
     name: "assistant",
     displayName: "Assistant",
@@ -6476,6 +6489,7 @@ describe("IM binding persistence", () => {
             workspaceId: value.bootstrap.workspaceId,
             createdByUserId: value.bootstrap.userId,
             workspaceComputerId: value.workspaceComputer.id,
+            computerId: value.workspaceComputer.id,
             name: `feishu-${String(index).padStart(3, "0")}`,
             displayName: `Feishu ${index}`,
             runtimeProvider: "codex" as const,

--- a/packages/server/src/__tests__/integration/onboarding-lab-reset.test.ts
+++ b/packages/server/src/__tests__/integration/onboarding-lab-reset.test.ts
@@ -144,9 +144,12 @@ async function seedAccount(
     .values({ imBindingId: imBinding.id, channelId: "channel-1", conversationKind: "channel", kind: "channel" })
     .returning({ id: sessions.id });
   if (!session) throw new Error("Session fixture was not created");
-  await database
-    .insert(sessionPlacements)
-    .values({ sessionId: session.id, workspaceComputerId: enrollment.workspaceComputerId, generation: 1 });
+  await database.insert(sessionPlacements).values({
+    sessionId: session.id,
+    workspaceComputerId: enrollment.workspaceComputerId,
+    computerId: enrollment.workspaceComputerId,
+    generation: 1,
+  });
   await database.update(workspaces).set({ setupCompletedAt: now }).where(eq(workspaces.id, input.workspaceId));
   return {
     accountId: input.accountId,

--- a/packages/server/src/__tests__/integration/session-collaboration.test.ts
+++ b/packages/server/src/__tests__/integration/session-collaboration.test.ts
@@ -14,6 +14,7 @@ import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient } from "../../db/client.js";
 import { migrateDatabase } from "../../db/migrate.js";
 import {
+  accountComputers,
   agents,
   computers,
   imBindings,
@@ -102,7 +103,7 @@ describe("Session collaboration authority", () => {
         1,
       );
       const placements = await fixture.database.select().from(sessionPlacements);
-      expect(placements.every((row) => row.computerId === null)).toBe(true);
+      expect(placements.every((row) => row.computerId === fixture.workspaceComputerId)).toBe(true);
       expect(placements.map((row) => row.workspaceComputerId)).toEqual([
         fixture.workspaceComputerId,
         fixture.workspaceComputerId,
@@ -489,7 +490,7 @@ describe("Session collaboration authority", () => {
         .select()
         .from(sessionPlacements)
         .where(eq(sessionPlacements.sessionId, source.session.id));
-      expect(movedRow).toMatchObject({ computerId: null, generation: 2 });
+      expect(movedRow).toMatchObject({ computerId: fixture.workspaceComputerId, generation: 2 });
       const current = await proofs.mint({
         ...input,
         placementGeneration: 2,
@@ -586,10 +587,20 @@ describe("Session collaboration authority", () => {
         })
         .returning({ id: workspaceComputers.id });
       if (!otherWorkspaceComputer) throw new Error("Second Workspace Computer fixture was not created");
+      await fixture.database.insert(accountComputers).values({
+        id: otherWorkspaceComputer.id,
+        ownerAccountId: fixture.userId,
+        currentInstallationId: otherComputerId,
+        displayName: "other-workstation",
+        platform: "linux",
+        arch: "x64",
+        clientVersion: "0.0.1",
+        currentInstanceId: connectionInstanceId,
+      });
       proof = await mint();
       await fixture.database
         .update(sessionPlacements)
-        .set({ workspaceComputerId: otherWorkspaceComputer.id })
+        .set({ workspaceComputerId: otherWorkspaceComputer.id, computerId: otherWorkspaceComputer.id })
         .where(eq(sessionPlacements.sessionId, source.session.id));
       await expect(proofs.authenticate(proof.token)).rejects.toMatchObject({ code: "invalid_proof" });
     } finally {
@@ -836,6 +847,16 @@ async function createFixture() {
     })
     .returning({ id: workspaceComputers.id });
   if (!workspaceComputer) throw new Error("Workspace Computer fixture was not created");
+  await client.database.insert(accountComputers).values({
+    id: workspaceComputer.id,
+    ownerAccountId: bootstrap.userId,
+    currentInstallationId: computerId,
+    displayName: "workstation",
+    platform: "linux",
+    arch: "x64",
+    clientVersion: "0.0.1",
+    currentInstanceId: connectionInstanceId,
+  });
   const agent = await new AgentService(client.database).createForWorkspace(bootstrap.userId, bootstrap.workspaceId, {
     name: "assistant",
     displayName: "Assistant",

--- a/packages/server/src/__tests__/integration/slack-oauth.test.ts
+++ b/packages/server/src/__tests__/integration/slack-oauth.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient } from "../../db/client.js";
 import {
+  accountComputers,
   agents,
   computers,
   imBindings,
@@ -64,6 +65,15 @@ async function fixture() {
     })
     .returning();
   if (!workspaceComputer) throw new Error("Workspace Computer fixture was not created");
+  await client.database.insert(accountComputers).values({
+    id: workspaceComputer.id,
+    ownerAccountId: bootstrap.userId,
+    currentInstallationId: computer.id,
+    displayName: "workstation",
+    platform: "linux",
+    arch: "x64",
+    clientVersion: "0.0.1",
+  });
   const agentsService = new AgentService(client.database);
   const first = await agentsService.createForWorkspace(bootstrap.userId, bootstrap.workspaceId, {
     name: "assistant",
@@ -295,57 +305,52 @@ describe("Slack distributed OAuth adapter", () => {
     }
   });
 
-  it("installs one workspace Slack installation and transfers its only current route to a second Agent", async () => {
+  it("rejects cross-Agent OAuth for a current installation without changing its owner or route", async () => {
     const value = await fixture();
     try {
-      await value.slack.configure(value.bootstrap.userId, value.first.id, {
+      const firstConfigured = await value.slack.configure(value.bootstrap.userId, value.first.id, {
         intent: "create",
         expectedBinding: null,
         appId: "A_OPENTAG",
         botAccessToken: "xoxb-first",
         signingSecret: slackApp.signingSecret,
       });
+      const [installationBefore] = await value.database.select().from(slackInstallations);
+      if (!installationBefore) throw new Error("First installation fixture was not created");
       const started = await value.oauth.start(value.bootstrap.userId, value.second.id, "create");
       const state = new URL(started.authorizationUrl).searchParams.get("state");
       if (!state) throw new Error("OAuth start did not return state");
-      const completed = await value.oauth.callback({
-        authenticatedUserId: value.bootstrap.userId,
-        code: "slack-oauth-code",
-        sessionBinding: started.sessionBinding,
-        state,
-      });
-      expect(completed.result).toMatchObject({
-        agentId: value.second.id,
-        appId: "A_OPENTAG",
-        teamId: "T_TEAM",
-        credentialGeneration: 2,
-        bindingState: "active",
-      });
+      await expect(
+        value.oauth.callback({
+          authenticatedUserId: value.bootstrap.userId,
+          code: "slack-oauth-code",
+          sessionBinding: started.sessionBinding,
+          state,
+        }),
+      ).rejects.toMatchObject({ code: "SLACK_APP_TEAM_ALREADY_BOUND", statusCode: 409 });
+
       const rows = await value.database.select().from(imBindings);
-      expect(rows).toHaveLength(2);
-      expect(rows.find((row) => row.agentId === value.first.id)).toMatchObject({
-        status: "disabled",
-        replacementImBindingId: completed.result.imBindingId,
-        credentialGeneration: 2,
-        encryptedCredential: null,
-      });
-      expect(rows.find((row) => row.agentId === value.second.id)).toMatchObject({
-        status: "active",
-        slackRouteKind: "default",
-        credentialGeneration: 2,
-        encryptedCredential: null,
-      });
-      expect(rows.filter((row) => row.status !== "disabled")).toHaveLength(1);
-      expect(new Set(rows.map((row) => row.slackInstallationId)).size).toBe(1);
+      expect(rows).toEqual([
+        expect.objectContaining({
+          id: firstConfigured.imBindingId,
+          agentId: value.first.id,
+          status: "active",
+          slackRouteKind: "default",
+          slackInstallationId: installationBefore.id,
+          credentialGeneration: 1,
+          encryptedCredential: null,
+        }),
+      ]);
       const installations = await value.database.select().from(slackInstallations);
-      expect(installations).toHaveLength(1);
-      expect(installations[0]).toMatchObject({
-        workspaceId: value.bootstrap.workspaceId,
-        credentialGeneration: 2,
-        status: "active",
-        agentId: value.second.id,
-      });
-      expect(installations[0]?.encryptedCredential).not.toContain("xoxb-distributed");
+      expect(installations).toEqual([
+        expect.objectContaining({
+          id: installationBefore.id,
+          workspaceId: value.bootstrap.workspaceId,
+          credentialGeneration: 1,
+          status: "active",
+          agentId: value.first.id,
+        }),
+      ]);
     } finally {
       await value.sql.end();
     }

--- a/packages/server/src/__tests__/integration/slack-workspace-routing.test.ts
+++ b/packages/server/src/__tests__/integration/slack-workspace-routing.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient } from "../../db/client.js";
 import {
+  accountComputers,
   agents,
   computers,
   imBindings,
@@ -55,6 +56,15 @@ async function fixture() {
     })
     .returning();
   if (!workspaceComputer) throw new Error("Workspace Computer fixture was not created");
+  await client.database.insert(accountComputers).values({
+    id: workspaceComputer.id,
+    ownerAccountId: bootstrap.userId,
+    currentInstallationId: computer.id,
+    displayName: "workstation",
+    platform: "linux",
+    arch: "x64",
+    clientVersion: "0.0.1",
+  });
   const agentsService = new AgentService(client.database);
   const first = await agentsService.createForWorkspace(bootstrap.userId, bootstrap.workspaceId, {
     name: "assistant",
@@ -103,10 +113,12 @@ async function activate(
 }
 
 describe("Slack workspace installation routing", () => {
-  it("atomically transfers the one current workspace route to the selected Agent", async () => {
+  it("rejects cross-Agent create on a current installation without side effects", async () => {
     const value = await fixture();
     try {
       const first = await activate(value.imBindingsService, value.first.id, "create");
+      const [installationBefore] = await value.database.select().from(slackInstallations);
+      if (!installationBefore) throw new Error("First installation fixture was not created");
       const [firstSession] = await value.database
         .insert(sessions)
         .values({
@@ -117,49 +129,50 @@ describe("Slack workspace installation routing", () => {
         })
         .returning();
       if (!firstSession) throw new Error("First route Session fixture was not created");
-      const second = await activate(value.imBindingsService, value.second.id, "create", { token: "xoxb-second" });
-      expect(second.credentialGeneration).toBe(2);
+      await expect(
+        activate(value.imBindingsService, value.second.id, "create", { token: "xoxb-second" }),
+      ).rejects.toMatchObject({ code: "SLACK_APP_TEAM_ALREADY_BOUND", statusCode: 409 });
+
       const installations = await value.database.select().from(slackInstallations);
-      expect(installations).toHaveLength(1);
-      expect(installations[0]).toMatchObject({
-        workspaceId: value.bootstrap.workspaceId,
-        credentialGeneration: 2,
-        status: "active",
-      });
-      expect(installations[0]?.encryptedCredential).not.toContain("xoxb-secret");
-      expect(installations[0]?.encryptedCredential).not.toContain("signing-secret");
+      expect(installations).toEqual([
+        expect.objectContaining({
+          id: installationBefore.id,
+          agentId: value.first.id,
+          workspaceId: value.bootstrap.workspaceId,
+          credentialGeneration: 1,
+          status: "active",
+        }),
+      ]);
       const routes = await value.database.select().from(imBindings);
-      expect(routes.every((row) => row.encryptedCredential === null)).toBe(true);
-      expect(routes.find((row) => row.agentId === value.first.id)).toMatchObject({
-        status: "disabled",
-        replacementImBindingId: second.imBindingId,
+      expect(routes).toEqual([
+        expect.objectContaining({
+          id: first.imBindingId,
+          agentId: value.first.id,
+          status: "active",
+          slackRouteKind: "default",
+          slackInstallationId: installationBefore.id,
+        }),
+      ]);
+      const [unchangedSession] = await value.database.select().from(sessions).where(eq(sessions.id, firstSession.id));
+      expect(unchangedSession).toMatchObject({ endedAt: null, revision: 1 });
+      await expect(value.imBindingsService.getForAgent(value.bootstrap.userId, value.first.id)).resolves.toMatchObject({
+        id: first.imBindingId,
       });
-      expect(routes.find((row) => row.agentId === value.second.id)).toMatchObject({
-        status: "active",
-        slackRouteKind: "default",
-      });
-      expect(routes.filter((row) => row.status !== "disabled")).toHaveLength(1);
-      const [endedSession] = await value.database.select().from(sessions).where(eq(sessions.id, firstSession.id));
-      expect(endedSession).toMatchObject({ endedAt: now, revision: 2 });
       await expect(
-        value.imBindingsService.getForAgent(value.bootstrap.userId, value.first.id),
-      ).resolves.toBeUndefined();
-      await expect(
-        value.imBindingsService.getHandoffForAgent(value.bootstrap.userId, value.first.id),
+        value.imBindingsService.getForAgent(value.bootstrap.userId, value.second.id),
       ).resolves.toBeUndefined();
       await expect(value.imBindingsService.findSlackIngressBinding("A_OPENTAG", "T_TEAM")).resolves.toMatchObject({
-        imBindingId: second.imBindingId,
-        installationId: installations[0]?.id,
-        generation: 2,
+        imBindingId: first.imBindingId,
+        installationId: installationBefore.id,
+        generation: 1,
       });
-      await expect(value.imBindingsService.resolveSlackDefaultRoute(installations[0]?.id as string)).resolves.toEqual({
-        imBindingId: second.imBindingId,
-        agentId: value.second.id,
-        installationId: installations[0]?.id,
-        generation: 2,
+      await expect(value.imBindingsService.resolveSlackDefaultRoute(installationBefore.id)).resolves.toEqual({
+        imBindingId: first.imBindingId,
+        agentId: value.first.id,
+        installationId: installationBefore.id,
+        generation: 1,
         routeKind: "default",
       });
-      expect(first.imBindingId).not.toBe(second.imBindingId);
     } finally {
       await value.sql.end();
     }
@@ -191,14 +204,27 @@ describe("Slack workspace installation routing", () => {
       });
       const [otherComputer] = await value.database.insert(computers).values({ id: crypto.randomUUID() }).returning();
       if (!otherComputer) throw new Error("Other computer fixture was not created");
-      await value.database.insert(workspaceComputers).values({
-        workspaceId: otherWorkspace.id,
-        computerId: otherComputer.id,
+      const [otherEnrollment] = await value.database
+        .insert(workspaceComputers)
+        .values({
+          workspaceId: otherWorkspace.id,
+          computerId: otherComputer.id,
+          displayName: "other-workstation",
+          platform: "linux",
+          arch: "x64",
+          clientVersion: "0.0.1",
+          enrolledByUserId: otherUser.id,
+        })
+        .returning();
+      if (!otherEnrollment) throw new Error("Other Workspace Computer fixture was not created");
+      await value.database.insert(accountComputers).values({
+        id: otherEnrollment.id,
+        ownerAccountId: otherUser.id,
+        currentInstallationId: otherComputer.id,
         displayName: "other-workstation",
         platform: "linux",
         arch: "x64",
         clientVersion: "0.0.1",
-        enrolledByUserId: otherUser.id,
       });
       const outsider = await new AgentService(value.database).createForWorkspace(otherUser.id, otherWorkspace.id, {
         name: "outsider",
@@ -218,14 +244,27 @@ describe("Slack workspace installation routing", () => {
         installationId: installation.id,
       });
 
-      await activate(value.imBindingsService, value.second.id, "create", { token: "xoxb-second" });
-      await value.imBindingsService.disable(
-        value.bootstrap.userId,
-        (await value.database.select().from(imBindings)).find((row) => row.agentId === value.second.id)?.id as string,
+      await expect(
+        activate(value.imBindingsService, value.second.id, "create", { token: "xoxb-second" }),
+      ).rejects.toMatchObject({ code: "SLACK_APP_TEAM_ALREADY_BOUND", statusCode: 409 });
+      expect(await value.database.select().from(slackInstallations)).toEqual([
+        expect.objectContaining({ id: installation.id, agentId: value.first.id, status: "active" }),
+      ]);
+      expect(await value.database.select().from(imBindings)).toEqual([
+        expect.objectContaining({ agentId: value.first.id, slackInstallationId: installation.id, status: "active" }),
+      ]);
+
+      await expect(value.imBindingsService.disableSlackInstallationFromProvider(installation.id, 1)).resolves.toBe(
+        true,
       );
       await expect(value.imBindingsService.resolveSlackDefaultRoute(installation.id)).resolves.toBeUndefined();
       const remaining = await value.database.select().from(slackInstallations);
-      expect(remaining[0]).toMatchObject({ status: "disabled", id: installation.id, encryptedCredential: null });
+      expect(remaining[0]).toMatchObject({
+        status: "disabled",
+        id: installation.id,
+        agentId: value.first.id,
+        encryptedCredential: null,
+      });
     } finally {
       await value.sql.end();
     }
@@ -263,6 +302,19 @@ describe("Slack workspace installation routing", () => {
         .from(slackInstallations)
         .where(eq(slackInstallations.id, installation.id));
       expect(revoked).toMatchObject({ status: "reauthorization_required", lastErrorCode: "SLACK_TOKEN_REVOKED" });
+      await expect(
+        activate(value.imBindingsService, value.second.id, "create", { token: "xoxb-second" }),
+      ).rejects.toMatchObject({ code: "SLACK_APP_TEAM_ALREADY_BOUND", statusCode: 409 });
+      const [stillRevoked] = await value.database
+        .select()
+        .from(slackInstallations)
+        .where(eq(slackInstallations.id, installation.id));
+      expect(stillRevoked).toMatchObject({
+        agentId: value.first.id,
+        status: "reauthorization_required",
+        credentialGeneration: 2,
+        lastErrorCode: "SLACK_TOKEN_REVOKED",
+      });
       await expect(value.imBindingsService.disableSlackInstallationFromProvider(installation.id, 2)).resolves.toBe(
         true,
       );
@@ -346,7 +398,7 @@ describe("Slack workspace installation routing", () => {
     }
   });
 
-  it("releases the installation on last-route disconnect so a different Slack workspace can be installed", async () => {
+  it("supports manual transfer only after explicit removal creates a fresh installation for the new Agent", async () => {
     const value = await fixture();
     try {
       const created = await activate(value.imBindingsService, value.first.id, "create");
@@ -358,26 +410,54 @@ describe("Slack workspace installation routing", () => {
         .select()
         .from(slackInstallations)
         .where(eq(slackInstallations.id, originalInstallation.id));
-      expect(disabledInstallation).toMatchObject({ status: "disabled", encryptedCredential: null, disabledAt: now });
-
-      const reinstalled = await activate(value.imBindingsService, value.first.id, "create", {
-        appId: "A_OPENTAG_NEW",
-        teamId: "T_TEAM_NEW",
-        botUserId: "U_BOT_NEW",
-        botId: "B_BOT_NEW",
-        token: "xoxb-new",
+      expect(disabledInstallation).toMatchObject({
+        id: originalInstallation.id,
+        agentId: value.first.id,
+        status: "disabled",
+        encryptedCredential: null,
+        disabledAt: now,
       });
-      expect(reinstalled).toMatchObject({ credentialGeneration: 1, agentId: value.first.id });
-      const currentInstallations = (await value.database.select().from(slackInstallations)).filter(
-        (row) => row.status !== "disabled",
-      );
-      expect(currentInstallations).toEqual([
-        expect.objectContaining({
-          externalAppId: "A_OPENTAG_NEW",
-          externalTeamId: "T_TEAM_NEW",
-          externalBotId: "U_BOT_NEW",
-        }),
-      ]);
+      const [disabledRoute] = await value.database
+        .select()
+        .from(imBindings)
+        .where(eq(imBindings.id, created.imBindingId));
+      expect(disabledRoute).toMatchObject({
+        agentId: value.first.id,
+        slackInstallationId: originalInstallation.id,
+        status: "disabled",
+      });
+
+      const reinstalled = await activate(value.imBindingsService, value.second.id, "create", {
+        token: "xoxb-second",
+      });
+      expect(reinstalled).toMatchObject({ credentialGeneration: 1, agentId: value.second.id });
+      const installations = await value.database.select().from(slackInstallations);
+      const oldInstallation = installations.find((row) => row.id === originalInstallation.id);
+      const newInstallation = installations.find((row) => row.id !== originalInstallation.id);
+      expect(installations).toHaveLength(2);
+      expect(oldInstallation).toMatchObject({ agentId: value.first.id, status: "disabled" });
+      expect(newInstallation).toMatchObject({
+        agentId: value.second.id,
+        status: "active",
+        externalAppId: "A_OPENTAG",
+        externalTeamId: "T_TEAM",
+      });
+      expect(newInstallation?.id).not.toBe(originalInstallation.id);
+      expect(
+        installations.filter(
+          (row) => row.externalAppId === "A_OPENTAG" && row.externalTeamId === "T_TEAM" && row.status !== "disabled",
+        ),
+      ).toHaveLength(1);
+      const [newRoute] = await value.database
+        .select()
+        .from(imBindings)
+        .where(eq(imBindings.id, reinstalled.imBindingId));
+      expect(newRoute).toMatchObject({
+        agentId: value.second.id,
+        slackInstallationId: newInstallation?.id,
+        status: "active",
+        slackRouteKind: "default",
+      });
     } finally {
       await value.sql.end();
     }
@@ -390,6 +470,7 @@ describe("Slack workspace installation routing", () => {
         .insert(slackInstallations)
         .values({
           workspaceId: value.bootstrap.workspaceId,
+          agentId: value.first.id,
           status: "active",
           externalAppId: "A_STRANDED",
           externalTeamId: "T_STRANDED",
@@ -432,15 +513,22 @@ describe("Slack workspace installation routing", () => {
         botAccessToken: "xoxb-secret",
       });
       expect(JSON.stringify(material)).not.toContain("signing-secret");
-      await activate(value.imBindingsService, value.second.id, "create", { token: "xoxb-second" });
-      const secondRoute = (await value.database.select().from(imBindings)).find(
-        (row) => row.agentId === value.second.id,
+      await expect(
+        activate(value.imBindingsService, value.second.id, "create", { token: "xoxb-second" }),
+      ).rejects.toMatchObject({ code: "SLACK_APP_TEAM_ALREADY_BOUND", statusCode: 409 });
+      const unchangedMaterial = await value.imBindingsService.getSlackConnectionMaterial(created.imBindingId);
+      expect(unchangedMaterial).toMatchObject({
+        imBindingId: created.imBindingId,
+        installationId: material?.installationId,
+        generation: 1,
+        botAccessToken: "xoxb-secret",
+      });
+      expect((await value.database.select().from(imBindings)).filter((row) => row.agentId === value.second.id)).toEqual(
+        [],
       );
-      if (!secondRoute) throw new Error("Second route was not created");
-      await value.imBindingsService.recordSlackIdentityClosure(secondRoute.id, 2);
-      const secondMaterial = await value.imBindingsService.getSlackConnectionMaterial(secondRoute.id);
-      expect(secondMaterial).toMatchObject({ generation: 2, botAccessToken: "xoxb-second" });
-      expect(secondMaterial?.installationId).toBe(material?.installationId);
+      expect(await value.database.select().from(slackInstallations)).toEqual([
+        expect.objectContaining({ agentId: value.first.id, credentialGeneration: 1, status: "active" }),
+      ]);
     } finally {
       await value.sql.end();
     }

--- a/packages/server/src/__tests__/integration/tasks.test.ts
+++ b/packages/server/src/__tests__/integration/tasks.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { bootstrapInitialAdmin } from "../../admin/bootstrap.js";
 import { createDatabaseClient } from "../../db/client.js";
 import {
+  accountComputers,
   agents,
   computers,
   imBindings,
@@ -52,12 +53,22 @@ async function fixture() {
     })
     .returning();
   if (!workspaceComputer) throw new Error("Workspace Computer fixture was not created");
+  await client.database.insert(accountComputers).values({
+    id: workspaceComputer.id,
+    ownerAccountId: bootstrap.userId,
+    currentInstallationId: computer.id,
+    displayName: "workstation",
+    platform: "linux",
+    arch: "x64",
+    clientVersion: "0.0.1",
+  });
   const [agent] = await client.database
     .insert(agents)
     .values({
       workspaceId: bootstrap.workspaceId,
       createdByUserId: bootstrap.userId,
       workspaceComputerId: workspaceComputer.id,
+      computerId: workspaceComputer.id,
       name: "atlas",
       displayName: "Atlas",
       runtimeProvider: "codex",

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -31,7 +31,9 @@ export const agents = pgTable(
     creationIntentId: uuid("creation_intent_id"),
     creationIntentFingerprint: text("creation_intent_fingerprint"),
     workspaceComputerId: uuid("workspace_computer_id").notNull(),
-    computerId: uuid("computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
+    computerId: uuid("computer_id")
+      .notNull()
+      .references(() => accountComputers.id, { onDelete: "restrict" }),
     name: text("name").notNull(),
     displayName: text("display_name").notNull(),
     runtimeProvider: agentRuntimeProvider("runtime_provider").notNull(),
@@ -62,6 +64,7 @@ export const agents = pgTable(
       sql`(${table.creationIntentId} is null) = (${table.creationIntentFingerprint} is null)`,
     ),
     check("agents_revision_positive", sql`${table.revision} >= 1`),
+    check("agents_computer_matches_enrollment", sql`${table.computerId} = ${table.workspaceComputerId}`),
   ],
 );
 

--- a/packages/server/src/db/schema/computers.ts
+++ b/packages/server/src/db/schema/computers.ts
@@ -171,8 +171,10 @@ export const computerConnectCodes = pgTable(
     issuedByUserId: uuid("issued_by_user_id")
       .notNull()
       .references(() => users.id, { onDelete: "restrict" }),
-    issuedByAccountId: uuid("issued_by_account_id").references(() => users.id, { onDelete: "restrict" }),
-    mode: computerConnectCodeMode("mode"),
+    issuedByAccountId: uuid("issued_by_account_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    mode: computerConnectCodeMode("mode").notNull(),
     targetComputerId: uuid("target_computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
@@ -203,6 +205,19 @@ export const computerConnectCodes = pgTable(
     check(
       "computer_connect_codes_terminal_state",
       sql`not (${table.consumedAt} is not null and ${table.revokedAt} is not null)`,
+    ),
+    check("computer_connect_codes_issued_by_account_pair", sql`${table.issuedByAccountId} = ${table.issuedByUserId}`),
+    check(
+      "computer_connect_codes_consumed_computer_identity",
+      sql`${table.consumedComputerId} is not distinct from ${table.consumedWorkspaceComputerId}`,
+    ),
+    check(
+      "computer_connect_codes_consumed_computer_pair",
+      sql`(${table.consumedComputerId} is null) = (${table.consumedAt} is null)`,
+    ),
+    check(
+      "computer_connect_codes_repair_target_pair",
+      sql`(${table.mode} = 'create') = (${table.targetComputerId} is null)`,
     ),
   ],
 );

--- a/packages/server/src/db/schema/im-bindings.ts
+++ b/packages/server/src/db/schema/im-bindings.ts
@@ -3,6 +3,7 @@ import {
   type AnyPgColumn,
   bigint,
   check,
+  foreignKey,
   index,
   pgEnum,
   pgTable,
@@ -95,6 +96,11 @@ export const imBindings = pgTable(
       .on(table.slackInstallationId)
       .where(sql`${table.provider} = 'slack' and ${table.status} <> 'disabled'`),
     index("im_bindings_slack_installation_id_idx").on(table.slackInstallationId),
+    foreignKey({
+      columns: [table.agentId, table.slackInstallationId],
+      foreignColumns: [slackInstallations.agentId, slackInstallations.id],
+      name: "im_bindings_slack_installation_owner_fk",
+    }).onDelete("restrict"),
     check("im_bindings_credential_generation_nonnegative", sql`${table.credentialGeneration} >= 0`),
     check("im_bindings_connection_epoch_nonnegative", sql`${table.connectionFencingEpoch} >= 0`),
     check(

--- a/packages/server/src/db/schema/session-cli-proofs.ts
+++ b/packages/server/src/db/schema/session-cli-proofs.ts
@@ -14,7 +14,9 @@ export const sessionCliProofs = pgTable(
     workspaceComputerId: uuid("workspace_computer_id")
       .notNull()
       .references(() => workspaceComputers.id, { onDelete: "cascade" }),
-    computerId: uuid("computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
+    computerId: uuid("computer_id")
+      .notNull()
+      .references(() => accountComputers.id, { onDelete: "restrict" }),
     placementGeneration: bigint("placement_generation", { mode: "number" }).notNull(),
     connectionInstanceId: uuid("connection_instance_id").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -24,5 +26,6 @@ export const sessionCliProofs = pgTable(
     index("session_cli_proofs_computer_id_idx").on(table.computerId),
     check("session_cli_proofs_token_hash_shape", sql`${table.tokenHash} ~ '^[0-9a-f]{64}$'`),
     check("session_cli_proofs_generation_positive", sql`${table.placementGeneration} >= 1`),
+    check("session_cli_proofs_computer_matches_enrollment", sql`${table.computerId} = ${table.workspaceComputerId}`),
   ],
 );

--- a/packages/server/src/db/schema/sessions.ts
+++ b/packages/server/src/db/schema/sessions.ts
@@ -79,7 +79,9 @@ export const sessionPlacements = pgTable(
     workspaceComputerId: uuid("workspace_computer_id")
       .notNull()
       .references(() => workspaceComputers.id, { onDelete: "restrict" }),
-    computerId: uuid("computer_id").references(() => accountComputers.id, { onDelete: "restrict" }),
+    computerId: uuid("computer_id")
+      .notNull()
+      .references(() => accountComputers.id, { onDelete: "restrict" }),
     generation: bigint("generation", { mode: "number" }).notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -87,6 +89,7 @@ export const sessionPlacements = pgTable(
     index("session_placements_workspace_computer_id_idx").on(table.workspaceComputerId),
     index("session_placements_computer_id_idx").on(table.computerId),
     check("session_placements_generation_positive", sql`${table.generation} >= 1`),
+    check("session_placements_computer_matches_enrollment", sql`${table.computerId} = ${table.workspaceComputerId}`),
   ],
 );
 

--- a/packages/server/src/db/schema/slack-installations.ts
+++ b/packages/server/src/db/schema/slack-installations.ts
@@ -8,6 +8,7 @@ import {
   pgTable,
   text,
   timestamp,
+  unique,
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
@@ -27,7 +28,9 @@ export const slackInstallations = pgTable(
     workspaceId: uuid("workspace_id")
       .notNull()
       .references(() => workspaces.id, { onDelete: "restrict" }),
-    agentId: uuid("agent_id").references(() => agents.id, { onDelete: "restrict" }),
+    agentId: uuid("agent_id")
+      .notNull()
+      .references(() => agents.id, { onDelete: "restrict" }),
     status: slackInstallationStatus("status").notNull().default("active"),
 
     externalAppId: text("external_app_id").notNull(),
@@ -58,6 +61,7 @@ export const slackInstallations = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
+    unique("slack_installations_agent_id_id_unique").on(table.agentId, table.id),
     uniqueIndex("slack_installations_app_team_current_unique")
       .on(table.externalAppId, table.externalTeamId)
       .where(sql`${table.status} <> 'disabled'`),

--- a/packages/server/src/services/computers/ownership-projections.ts
+++ b/packages/server/src/services/computers/ownership-projections.ts
@@ -2,15 +2,18 @@ import { eq } from "drizzle-orm";
 import type { DatabaseTransaction } from "../../db/client.js";
 import { accountComputers } from "../../db/schema/index.js";
 
-/** Returns the stable Computer id when the account-owned projection row already exists. */
+/** Returns the stable Computer id for a Workspace enrollment. Missing projections fail closed. */
 export async function projectedComputerId(
   transaction: DatabaseTransaction,
   workspaceComputerId: string,
-): Promise<string | undefined> {
+): Promise<string> {
   const [row] = await transaction
     .select({ id: accountComputers.id })
     .from(accountComputers)
     .where(eq(accountComputers.id, workspaceComputerId))
     .limit(1);
-  return row?.id;
+  if (!row) {
+    throw new Error("The account-owned Computer projection is missing");
+  }
+  return row.id;
 }

--- a/packages/server/src/services/im-bindings/im-binding-service.ts
+++ b/packages/server/src/services/im-bindings/im-binding-service.ts
@@ -1514,6 +1514,13 @@ export class ImBindingService {
       }
       const existingInstallation = currentAppTeamInstallation ?? currentWorkspaceInstallation;
       if (existingInstallation) {
+        if (existingInstallation.agentId !== input.agentId) {
+          throw new ImBindingServiceError(
+            "SLACK_APP_TEAM_ALREADY_BOUND",
+            409,
+            "This Slack App installation is already bound to another OpenTag Agent",
+          );
+        }
         const currentCredential = this.#decodeSlackCredential(existingInstallation.encryptedCredential);
         const sameIdentity =
           existingInstallation.externalAppId === input.appId &&

--- a/packages/server/src/services/sessions/session-cli-proof-service.ts
+++ b/packages/server/src/services/sessions/session-cli-proof-service.ts
@@ -95,7 +95,7 @@ export class SessionCliProofService {
       const proofId = randomUUID();
       const token = this.#deriveToken({ ...input, proofId });
       const now = this.#now();
-      const computerId = (await projectedComputerId(transaction, input.workspaceComputerId)) ?? null;
+      const computerId = await projectedComputerId(transaction, input.workspaceComputerId);
       await transaction
         .insert(sessionCliProofs)
         .values({

--- a/packages/server/src/services/sessions/session-service.ts
+++ b/packages/server/src/services/sessions/session-service.ts
@@ -653,7 +653,7 @@ export class SessionService {
         .update(sessionPlacements)
         .set({
           workspaceComputerId,
-          computerId: (await projectedComputerId(transaction, workspaceComputerId)) ?? null,
+          computerId: await projectedComputerId(transaction, workspaceComputerId),
           generation,
           updatedAt: now,
         })


### PR DESCRIPTION
## Scope

Issue #227 PR 2 only (Stages C-D): deterministic account-ownership backfill plus validation constraints.

- Backfills `account_computers.id = workspace_computers.id`, `owner_account_id = enrolled_by_user_id`, and `current_installation_id = workspace_computers.computer_id`.
- Preserves credential IDs, hashes, issuers, issuance timestamps, revocation actors, and revocation timestamps exactly.
- Backfills the approved Agent, Session placement, Session CLI proof, connect-code, and Slack installation projections.
- Does not use `workspace_admin_grants` to infer ownership.
- Keeps application reads on the legacy model and retains PR 1 dual writes; this PR does not perform the PR 3 behavior cutover.
- Keeps Agent/enrollment owner mismatches as expected rebind-required state; it does not silently repair them.

Exact base: `ee3863d12f59e1a50a6a5a5a6b72a9957d374fb5`

Exact head: `2dca71c338854b30fd91d16175befc27fb2da54e`

Commits:

1. `d380228 feat(server): backfill account-owned resources`
2. `67b9321 feat(server): validate account ownership constraints`
3. `2dca71c test(server): cover account ownership backfill migrations`

## Slack ownership decision

- The 0028 composite ownership FK is retained. It is neither deferred nor configured with `ON UPDATE CASCADE`.
- A current `(OpenTag Slack App, Slack Team)` installation has an immutable Agent owner.
- Same-owner reauthorization updates the current installation. Cross-Agent create/OAuth while it remains current returns stable HTTP 409 (`SLACK_APP_TEAM_ALREADY_BOUND`) before mutation.
- `reauthorization_required` and transient delivery failures are not removal states.
- Manual transfer remains the existing explicit two-step path: remove/uninstall disables the old installation/routes without rewriting its owner, then installing from another Agent creates a different installation ID owned by that Agent. Tests prove one current row per App/Team and routing to the new row.

## Gate 0

- Source refreshed from live GitHub; PR 1 merge `1d876f33f6bc1bfd3edcb4dec9b5209acb107b11` is an ancestor of the base.
- Node `v24.7.0`; pnpm `10.12.1`; Docker `29.4.1`; `postgres:17-alpine` available.
- Frozen dependency install reused 571 packages with zero downloads.
- Repository-supervised Pi smoke settled successfully for Grok, Kimi, and DeepSeek; the implementation/audit session also ended with `agent_settled` and `stopReason=stop`.
- GitHub authentication verified as `yuezengwu`, including pull, push, PR, and admin capabilities. This implementation task will not merge the PR.
- Staging GitHub/deploy/health and bounded pgAdmin read-only observation capabilities were verified without exposing secrets and without staging writes.
- Staging pre-backfill snapshot: 7 legacy computers, 8 legacy credentials, 0 target computers/credentials; migration ledger through 0026. Slack: 2 installations, both current, 2 unique routes, 0 unrouted, 2 missing `agent_id`; the observed state is deterministically backfillable.
- CapRover App-token rotation and a dedicated DB read-only role remain explicitly deferred until the six-PR task completes.

## Gate 1: production migration matrix

The checked-in production migration runner is used throughout; fixtures do not pre-repair corruption that the migration must reject.

| Scenario | Evidence / invariant |
| --- | --- |
| Empty / current / repeat | Empty DB migrates through 0028, verifies the full journal, and a second runner invocation is a no-op. |
| Immediately previous (0026) | Populated legacy state starts with no target rows and finishes with exact deterministic projections. |
| Representative historical (0025) | Historical schema plus Slack bindings upgrades through 0026, journal-only 0027, and 0028. |
| Populated normal | Produces 2 account computers, 2 exact credentials, 2 Agent projections, 2 placements, 1 proof, 2 connect codes, and 2 Slack owner projections. Active/revoked credentials and enrollments, consumed/unconsumed codes, active/ended Sessions, pending/accepted custody, and stale proof custody are preserved. |
| Matching / partial retry | Matching pre-existing projections remain unchanged; missing projections are filled deterministically. |
| Ownership mismatch | Two fixture Agents whose creators differ from enrollment owners remain mismatched and are treated as rebind-required. An additional workspace admin owns 0 computers. |
| Orphan / ambiguous Slack | Zero-binding, multiple-binding, cross-workspace binding, and conflicting prefilled-owner fixtures fail closed. |
| Credential corruption | Extra target credential plus ID/computer/hash/issuer/issued-at/revocation conflicts fail closed. |
| Connect-code corruption | Repair-shaped target, issuer mismatch, and consumed-computer mismatch fail closed. |
| Agent / Session divergence | Conflicting Agent, placement, and CLI-proof target projections fail closed. |
| 0027 failure + retry | A late Slack orphan aborts all DML and leaves the journal at 0026; removing only the external obstruction permits a clean retry. |
| 0028 failure + retry | NOT NULL obstruction rolls back every 0028 constraint and leaves the journal at 0027; removing the obstruction permits a clean retry. |
| Constraint validation | Validates target NOT NULL, identity checks, connect-code pair constraints, Slack `(agent_id, id)` uniqueness, and binding-to-installation composite ownership FK. |
| Post-migration startup/read/write | Server services start against current schema; legacy reads and PR 1 dual writes create matching legacy/target computers and credentials. Missing target projections fail closed. |
| Slack reauth / conflict / transfer | Same-owner reauth reuses the current row; cross-Agent current attempts return 409 with no side effects; explicit removal followed by new-Agent install creates a distinct current row, leaves the old owner/history disabled, and repoints the unique route. |

The current journal contains 29 entries (indices 0-28), including journal-only 0027 and schema snapshot 0028.

## Gate 1: commands

- `pnpm --filter @opentag/server db:generate` — PASS, no schema changes / no drift; worktree remained clean.
- `pnpm check` — PASS, 479 files checked.
- `pnpm build` — PASS, 5/5 tasks.
- `pnpm typecheck` — PASS, 7/7 tasks.
- `pnpm test` — PASS for the complete workspace test command; server 41 files / 292 tests and scripts 66 tests included.
- `pnpm --filter @opentag/server test` — PASS, 41 files / 292 tests.
- `pnpm --filter @opentag/server test:integration` — PASS, 14 files / 265 tests, including the focused migration matrix (25 tests), Slack OAuth/routing (11), auth migrations (29), IM binding (90), Agents (24), Sessions (15), onboarding (15), expansion (7), computers (10), auth (27), and directly affected runtime/service suites.
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — PASS, 20 files / 289 tests; 100% statements, branches, functions, and lines.
- `git diff --check` and `git diff --cached --check` — PASS.
- Final `git status --short` — clean.

All commands above ran on exact head `2dca71c338854b30fd91d16175befc27fb2da54e` after the final rebase onto the exact base shown above. A final `git fetch --prune origin` confirmed that `origin/main` had not moved.

## Known migration risks

1. Consumed connect-code composite-FK identity is preserved and validated; conflicting consumed projections fail closed.
2. Slack installation ownership/routing uses the composite ownership FK and immutable current owner; only explicit remove/uninstall enables a fresh installation for another Agent.
3. Workspace-qualified Session placement and CLI-proof identifiers are backfilled and equality-constrained while legacy joins/read behavior remain in place.
4. The non-deferrable Agent/enrollment composite FK remains; the migration preserves owner mismatch as rebind-required rather than attempting an unsafe repair.

The data migration takes deterministic `SHARE ROW EXCLUSIVE` locks in legacy-first writer order. This serializes affected writes and may briefly block them during deployment, while avoiding opposite-order lock acquisition with the existing legacy-first dual-write services.

## Rollback / rolling-deploy boundary

- No legacy column/table is dropped and no read path is cut over. The previous application remains compatible with the expanded schema and continues operating on legacy data.
- PR 1 dual writes remain active, so rolling old/new application instances keep both projections aligned after backfill.
- The DB migration is forward-only: reverting application code is compatible, but reversing the schema/data migration would require an explicit follow-up rather than ad-hoc destructive rollback.
- Corrupt or ambiguous source/target state aborts atomically and leaves the migration journal at the prior completed stage.

Do not merge from this implementation task. The coordinating task owns exact-head CI acceptance, merge, and staging Gate 2 before PR 3 may begin.
