### PR TITLE
chore: add lefthook gates and worktree bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ coverage/
 *.tsbuildinfo
 .portable-release/
 
+# Local tooling overrides
+lefthook-local.yml
+
 # Local environment and logs
 .env
 .env.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ historical feature with the same name in the First Tree repository. Do not copy 
 - Node.js `^22.13.0 || ^24.0.0 || ^26.0.0` (Node.js 24 primary), ESM, strict TypeScript
 - pnpm 10.12.1 and Turborepo
 - Biome for formatting and linting
+- lefthook for the local `pre-commit` and `pre-push` gates, installed by `pnpm install`
 - tsdown for ESM builds and Vitest for tests
 - Fastify for the server and Zod for shared runtime schemas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,9 @@ product capabilities without an agreed design.
 ## Workflow
 
 1. Create a branch with one of these prefixes: `feat/`, `fix/`, `refactor/`, `test/`, `docs/`, `chore/`, or `merge/`.
-2. Install dependencies with `pnpm install`.
+2. Install dependencies with `pnpm install`. This also installs the Git hooks that lint and format staged files before a
+   commit and re-check the repository before a push, described in
+   [DEVELOPMENT.md](./DEVELOPMENT.md#git-hooks-and-worktrees).
 3. Make the smallest coherent change and update relevant tests and documentation.
 4. Run `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test`.
 5. Open a pull request using the repository template.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,14 +1,15 @@
 # 为 OpenTag 贡献
 
 > Canonical source: [CONTRIBUTING.md](./CONTRIBUTING.md)
-> Last synced with: 2026-08-17
+> Last synced with: 2026-08-29
 
 OpenTag 处于 pre-alpha 阶段。请保持改动聚焦，说明其解决的用户或贡献者问题，并避免在没有既定设计时增加产品能力。
 
 ## 工作流
 
 1. 使用以下前缀创建分支：`feat/`、`fix/`、`refactor/`、`test/`、`docs/`、`chore/` 或 `merge/`。
-2. 运行 `pnpm install` 安装依赖。
+2. 运行 `pnpm install` 安装依赖。该命令同时会安装 Git hooks：commit 前对暂存文件执行 lint 与格式化，push 前重新检查
+   整个仓库，详见 [DEVELOPMENT.zh-CN.md](./DEVELOPMENT.zh-CN.md#git-hooks-与-worktree)。
 3. 完成最小且完整的改动，并更新相关测试和文档。
 4. 运行 `pnpm check`、`pnpm build`、`pnpm typecheck` 和 `pnpm test`。
 5. 使用仓库模板创建 Pull Request。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,6 +17,37 @@ pnpm install
 
 The repository pins pnpm in `package.json`. Do not use npm or Yarn to update dependencies.
 
+## Git hooks and worktrees
+
+`pnpm install` runs the root `prepare` script, which installs three hooks into the clone's hooks directory:
+
+- `pre-commit` runs Biome over the staged files, applies the fixes it can make safely, and stages the result.
+- `pre-push` runs `biome lint .` and `biome format .` over the whole repository.
+- `post-checkout` prepares a worktree that `git worktree add` has just created: it runs `pnpm install` inside the new
+  worktree and reinstalls the hooks, so the worktree is ready to commit and push.
+
+Git shares one hooks directory between a clone and all of its linked worktrees, so a single installation covers every
+worktree. The `post-checkout` payload in `scripts/git-hooks/` is installed by `scripts/install-git-hooks.mjs` rather than
+by lefthook, because it has to run before the new worktree has a `node_modules` directory. Prepare a worktree by hand
+when it was created by a tool that bypasses Git hooks:
+
+```bash
+pnpm worktree:setup
+```
+
+`lefthook.yml` holds the shared configuration; personal overrides belong in an untracked `lefthook-local.yml`. The hooks
+stay out of the way when they are not wanted:
+
+| Variable | Effect |
+| --- | --- |
+| `LEFTHOOK=0` | skip the lefthook gates for one command |
+| `OPENTAG_SKIP_WORKTREE_BOOTSTRAP=1` | skip the worktree bootstrap |
+| `OPENTAG_SKIP_GIT_HOOKS=1` | skip hook installation during `pnpm install` |
+| `OPENTAG_HOOKS_LOG_LEVEL=debug` | print every decision the hook scripts make |
+
+A set `CI` variable disables the bootstrap and the installation as well, so automated checkouts never install local
+hooks.
+
 ## Validation
 
 ```bash

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -1,7 +1,7 @@
 # OpenTag 开发指南
 
 > Canonical source: [DEVELOPMENT.md](./DEVELOPMENT.md)
-> Last synced with: 2026-08-26
+> Last synced with: 2026-08-29
 
 ## 前置要求
 
@@ -17,6 +17,34 @@ pnpm install
 ```
 
 仓库已在 `package.json` 中固定 pnpm 版本。请勿使用 npm 或 Yarn 更新依赖。
+
+## Git hooks 与 worktree
+
+`pnpm install` 会执行根目录的 `prepare` 脚本，将三个 hook 安装到该 clone 的 hooks 目录：
+
+- `pre-commit` 对暂存文件运行 Biome，应用可安全自动修复的改动并重新暂存结果。
+- `pre-push` 对整个仓库运行 `biome lint .` 和 `biome format .`。
+- `post-checkout` 负责准备 `git worktree add` 刚创建的 worktree：在新 worktree 中执行 `pnpm install` 并重新安装
+  hooks，使该 worktree 可以直接 commit 和 push。
+
+Git 的 hooks 目录由 clone 及其全部 linked worktree 共享，因此安装一次即可覆盖所有 worktree。`scripts/git-hooks/` 中的
+`post-checkout` 由 `scripts/install-git-hooks.mjs` 安装，而不是交给 lefthook，因为它必须在新 worktree 还没有
+`node_modules` 时就能运行。如果 worktree 由绕过 Git hooks 的工具创建，可手动准备：
+
+```bash
+pnpm worktree:setup
+```
+
+共享配置位于 `lefthook.yml`；个人覆盖配置应放在未纳入版本控制的 `lefthook-local.yml`。在不需要时，这些 hook 可以让开：
+
+| 变量 | 作用 |
+| --- | --- |
+| `LEFTHOOK=0` | 跳过本次命令的 lefthook 检查 |
+| `OPENTAG_SKIP_WORKTREE_BOOTSTRAP=1` | 跳过 worktree 引导 |
+| `OPENTAG_SKIP_GIT_HOOKS=1` | 跳过 `pnpm install` 期间的 hook 安装 |
+| `OPENTAG_HOOKS_LOG_LEVEL=debug` | 打印 hook 脚本的全部判断过程 |
+
+设置 `CI` 变量同样会禁用引导与安装，因此自动化 checkout 不会安装本地 hooks。
 
 ## 验证
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/server/package.json packages/server/package.json
 COPY apps/web/package.json apps/web/package.json
-RUN pnpm install --frozen-lockfile --config.engine-strict=true --filter @opentag/server... --filter @opentag/web...
+# The image build copies manifests only, so lifecycle scripts are skipped: the root `prepare` installs
+# local Git hooks from `scripts/`, which the image neither ships nor needs.
+RUN pnpm install --frozen-lockfile --config.engine-strict=true --ignore-scripts --filter @opentag/server... --filter @opentag/web...
 
 FROM deps AS build
 
@@ -27,7 +29,7 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/server/package.json packages/server/package.json
-RUN pnpm install --frozen-lockfile --config.engine-strict=true --prod --filter @opentag/server...
+RUN pnpm install --frozen-lockfile --config.engine-strict=true --ignore-scripts --prod --filter @opentag/server...
 
 FROM node:24-alpine AS runtime
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,33 @@
+# Local Git quality gates.
+#
+# Hooks are written into the shared Git hooks directory by `scripts/install-git-hooks.mjs`, which the
+# root `prepare` lifecycle runs on every `pnpm install`. Create `lefthook-local.yml` for personal
+# overrides; set `LEFTHOOK=0` to bypass a single command.
+#
+# `post-checkout` is deliberately absent: it bootstraps a brand new worktree before its `node_modules`
+# exists, so it cannot depend on the lefthook binary. It lives in `scripts/git-hooks/post-checkout`.
+
+assert_lefthook_installed: true
+
+pre-commit:
+  parallel: false
+  skip:
+    - merge
+    - rebase
+  jobs:
+    - name: biome
+      glob:
+        - "*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,json,jsonc,css}"
+      run: pnpm exec biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      stage_fixed: true
+      fail_text: "Biome reported problems it cannot fix automatically. Fix them and stage the result."
+
+pre-push:
+  parallel: true
+  jobs:
+    - name: lint
+      run: pnpm exec biome lint .
+      fail_text: "Lint rules failed. Run `pnpm lint` for details."
+    - name: format
+      run: pnpm exec biome format .
+      fail_text: "Formatting drifted. Run `pnpm format` and commit the result."

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
   },
   "scripts": {
+    "prepare": "node scripts/install-git-hooks.mjs",
+    "worktree:setup": "node scripts/worktree-bootstrap.mjs --force",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "check": "biome check . && node scripts/third-party-notices.mjs --check",
@@ -24,6 +26,7 @@
     "@biomejs/biome": "^2.4.0",
     "@types/node": "^22.15.0",
     "@vitest/coverage-v8": "3.2.7",
+    "lefthook": "^2.1.12",
     "tsdown": "^0.21.4",
     "tsx": "^4.21.0",
     "turbo": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 3.2.7
         version: 3.2.7(vitest@3.2.7(@types/node@22.20.1)(jsdom@26.1.0)(tsx@4.23.12)(yaml@2.9.0))
+      lefthook:
+        specifier: ^2.1.12
+        version: 2.1.12
       tsdown:
         specifier: 0.21.4
         version: 0.21.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)
@@ -2758,6 +2761,60 @@ packages:
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
+
+  lefthook-darwin-arm64@2.1.12:
+    resolution: {integrity: sha512-GSUjqaCuxAYlPOovbjXEWE3HAIa/xOQkTTmZ937zieQldjPLTaC7+s5FHoxKywn+D9riBlofkDqG7Z4f5zzmPA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.12:
+    resolution: {integrity: sha512-qAUHSSw/7Afi5wxkoLkxORxSicCeTBXyVLnRgD6YZra6udviozpK3Aok9Z6FIWeKc5FBijRMSNDxGPTREhsjcQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.12:
+    resolution: {integrity: sha512-FHZRfKliFNbyz54zsoGdVe9muq67cNjBTZ6jrPPUjI7xUuyCwSpzA+1OpiwJT00L9pP5ZGONBqnGZKnrpC+7Uw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.12:
+    resolution: {integrity: sha512-HYQZPGy2DDEx7dbuotusJpujY5q9igOLgx36qeeQcNQuvvdGHPj2ZGSIsGKhoJ0dw5Qa4knKJoPAHEZQWdV/og==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.12:
+    resolution: {integrity: sha512-ipjOri2PB/sk4noPrHQuM5fcpNBjmlKo4qMtXyLnxeOxGYHWZzf0Xi0OtrXHQ//tOprcv40ADvhUuSdcGqigLw==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.12:
+    resolution: {integrity: sha512-DmU6xfvqVoFdW+STyc70YI4Ry8vkHGKHx+IJ1Js/Gacq5dv+fiwNzwle3bi28EkL6P8xY67B/CfQfRj4SRU4tg==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.12:
+    resolution: {integrity: sha512-vb0J7bElLvoaCWQmna3HntsvoNqMsGAhfjjC99ss1OdCteufZKM3RxCVoMBEbD50Itv2c1Ua2AFVToltVFTy1Q==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.12:
+    resolution: {integrity: sha512-QOmhDWqPPK4+99scanfEmbJjUR+JYC93qhr/0bp5Dj3LaR3kVFNWc6zOQUsOTPy/LC6PG759Lej/mr/BtjUL2Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.12:
+    resolution: {integrity: sha512-eErEyr9AHkRFj6TxpCQeKGd0s6IrtL/VEIZ/ssg8dNfG+ycR4jAW/IAlrJSw6/ZQXb3WtWLaQ6QA5c+TLh7vmg==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.12:
+    resolution: {integrity: sha512-0h+WmDVdDriTjloD/UbjPq/ZtqaaJlPAdGcVwMCEdAxfbF0FTgDbKX3igui9g2U/qG2y6QpVhtz1jeiRe7ctaw==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.12:
+    resolution: {integrity: sha512-2uOexfsrrRhCiTUWdGyDySxVHHhOFJ8MQejs27dM3hugrQB48/z1ZVlaNoxpZ1SnzQ1GaDIbO5rAvicwyiknYQ==}
+    hasBin: true
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
@@ -6079,6 +6136,49 @@ snapshots:
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
+
+  lefthook-darwin-arm64@2.1.12:
+    optional: true
+
+  lefthook-darwin-x64@2.1.12:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.12:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.12:
+    optional: true
+
+  lefthook-linux-arm64@2.1.12:
+    optional: true
+
+  lefthook-linux-x64@2.1.12:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.12:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.12:
+    optional: true
+
+  lefthook-windows-arm64@2.1.12:
+    optional: true
+
+  lefthook-windows-x64@2.1.12:
+    optional: true
+
+  lefthook@2.1.12:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.12
+      lefthook-darwin-x64: 2.1.12
+      lefthook-freebsd-arm64: 2.1.12
+      lefthook-freebsd-x64: 2.1.12
+      lefthook-linux-arm64: 2.1.12
+      lefthook-linux-x64: 2.1.12
+      lefthook-openbsd-arm64: 2.1.12
+      lefthook-openbsd-x64: 2.1.12
+      lefthook-windows-arm64: 2.1.12
+      lefthook-windows-x64: 2.1.12
 
   light-my-request@6.6.0:
     dependencies:

--- a/scripts/__tests__/git-hooks.test.mjs
+++ b/scripts/__tests__/git-hooks.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { constants } from "node:fs";
+import { access, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createLogger, resolveLogLevel } from "../hook-logging.mjs";
+import {
+  classifyInstallation,
+  installManagedHook,
+  MANAGED_HOOK_MARKER,
+  MANAGED_HOOKS,
+  resolveHooksDirectory,
+} from "../install-git-hooks.mjs";
+import { childEnvironment, classifyCheckout } from "../worktree-bootstrap.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const silentLogger = { debug() {}, info() {}, warn() {}, error() {} };
+
+const NULL_OBJECT_ID = "0".repeat(40);
+const HEAD_OBJECT_ID = "1".repeat(40);
+
+async function withTemporaryDirectory(run) {
+  const directory = await mkdtemp(join(tmpdir(), "opentag-hooks-"));
+  try {
+    return await run(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("only a checkout without a previous HEAD bootstraps a worktree", () => {
+  assert.equal(classifyCheckout({ argv: [NULL_OBJECT_ID, HEAD_OBJECT_ID, "1"], env: {} }).bootstrap, true);
+  assert.equal(classifyCheckout({ argv: [HEAD_OBJECT_ID, HEAD_OBJECT_ID, "1"], env: {} }).bootstrap, false);
+  assert.equal(classifyCheckout({ argv: [NULL_OBJECT_ID, HEAD_OBJECT_ID, "0"], env: {} }).bootstrap, false);
+  assert.equal(classifyCheckout({ argv: [], env: {} }).bootstrap, false);
+});
+
+test("the worktree bootstrap stays out of automated and opted-out environments", () => {
+  const worktreeArguments = [NULL_OBJECT_ID, HEAD_OBJECT_ID, "1"];
+  assert.equal(classifyCheckout({ argv: worktreeArguments, env: { CI: "true" } }).bootstrap, false);
+  assert.equal(
+    classifyCheckout({ argv: worktreeArguments, env: { OPENTAG_SKIP_WORKTREE_BOOTSTRAP: "1" } }).bootstrap,
+    false,
+  );
+  assert.equal(classifyCheckout({ argv: ["--force"], env: { CI: "true" } }).bootstrap, true);
+});
+
+test("nested commands do not inherit the hook's Git environment", () => {
+  const childEnv = childEnvironment({
+    GIT_DIR: "/repo/.git/worktrees/feature",
+    GIT_INDEX_FILE: "/repo/.git/worktrees/feature/index",
+    GIT_COMMON_DIR: "/repo/.git",
+    PATH: "/usr/bin",
+  });
+  assert.deepEqual(childEnv, { PATH: "/usr/bin" });
+});
+
+test("hook installation is skipped where local hooks are pointless", () => {
+  assert.equal(classifyInstallation({ env: {} }).install, true);
+  assert.equal(classifyInstallation({ env: { CI: "true" } }).install, false);
+  assert.equal(classifyInstallation({ env: { OPENTAG_SKIP_GIT_HOOKS: "1" } }).install, false);
+});
+
+test("core.hooksPath wins and relative paths resolve against the working tree", () => {
+  assert.equal(
+    resolveHooksDirectory({ repositoryRoot: "/repo", configuredHooksPath: "", gitHooksPath: ".git/hooks" }),
+    "/repo/.git/hooks",
+  );
+  assert.equal(
+    resolveHooksDirectory({ repositoryRoot: "/repo", configuredHooksPath: ".githooks", gitHooksPath: ".git/hooks" }),
+    "/repo/.githooks",
+  );
+  assert.equal(
+    resolveHooksDirectory({ repositoryRoot: "/repo", gitHooksPath: "/repo/.git/worktrees/feature/hooks" }),
+    "/repo/.git/worktrees/feature/hooks",
+  );
+  assert.throws(() => resolveHooksDirectory({ repositoryRoot: "/repo", gitHooksPath: "  " }), /hooks directory/);
+});
+
+test("a managed hook is installed executable and refreshed in place", async () => {
+  await withTemporaryDirectory(async (hooksDirectory) => {
+    const source = `#!/bin/sh\n# ${MANAGED_HOOK_MARKER}\nexit 0\n`;
+    const created = await installManagedHook({
+      hooksDirectory,
+      name: "post-checkout",
+      source,
+      logger: silentLogger,
+    });
+    assert.equal(created, "created");
+
+    const target = join(hooksDirectory, "post-checkout");
+    await access(target, constants.X_OK);
+    assert.equal(await readFile(target, "utf8"), source);
+    assert.equal(
+      await installManagedHook({ hooksDirectory, name: "post-checkout", source, logger: silentLogger }),
+      "unchanged",
+    );
+
+    const updatedSource = `${source}# revised\n`;
+    assert.equal(
+      await installManagedHook({ hooksDirectory, name: "post-checkout", source: updatedSource, logger: silentLogger }),
+      "updated",
+    );
+    assert.equal(await readFile(target, "utf8"), updatedSource);
+    await assert.rejects(stat(`${target}.old`));
+  });
+});
+
+test("an unrelated hook is preserved instead of being overwritten", async () => {
+  await withTemporaryDirectory(async (hooksDirectory) => {
+    const target = join(hooksDirectory, "post-checkout");
+    await writeFile(target, "#!/bin/sh\necho mine\n", "utf8");
+
+    const outcome = await installManagedHook({
+      hooksDirectory,
+      name: "post-checkout",
+      source: `#!/bin/sh\n# ${MANAGED_HOOK_MARKER}\nexit 0\n`,
+      logger: silentLogger,
+    });
+
+    assert.equal(outcome, "updated");
+    assert.equal(await readFile(`${target}.old`, "utf8"), "#!/bin/sh\necho mine\n");
+  });
+});
+
+test("the post-checkout payload bootstraps without depending on node_modules", async () => {
+  const hookPath = join(repoRoot, "scripts", "git-hooks", "post-checkout");
+  assert.deepEqual(MANAGED_HOOKS, ["post-checkout"]);
+
+  const source = await readFile(hookPath, "utf8");
+  assert.ok(source.includes(MANAGED_HOOK_MARKER), "the payload must identify itself as managed");
+  assert.match(source, /exec node "\$bootstrap_script" "\$@"/);
+  assert.doesNotMatch(source, /lefthook|pnpm|npx/);
+});
+
+test("lefthook owns the commit and push gates and leaves post-checkout alone", async () => {
+  const config = await readFile(join(repoRoot, "lefthook.yml"), "utf8");
+  assert.match(config, /^pre-commit:$/m);
+  assert.match(config, /^pre-push:$/m);
+  assert.doesNotMatch(config, /^post-checkout:$/m);
+  assert.match(config, /biome check --write .* \{staged_files\}/);
+  assert.match(config, /stage_fixed: true/);
+  assert.match(config, /biome lint \./);
+  assert.match(config, /biome format \./);
+});
+
+test("image builds install without the hook-installing prepare lifecycle", async () => {
+  const dockerfiles = ["Dockerfile", join("scripts", "e2e", "doctor-docker", "Dockerfile")];
+  for (const dockerfile of dockerfiles) {
+    const source = await readFile(join(repoRoot, dockerfile), "utf8");
+    const installations = source.split("\n").filter((line) => line.includes("pnpm install"));
+    assert.ok(installations.length > 0, `${dockerfile} should install dependencies`);
+    for (const installation of installations) {
+      assert.ok(
+        installation.includes("--ignore-scripts"),
+        `${dockerfile} copies manifests only, so "${installation.trim()}" must not run the root prepare script`,
+      );
+    }
+  }
+});
+
+test("hook logging honors the configured level", () => {
+  assert.equal(resolveLogLevel(undefined), "info");
+  assert.equal(resolveLogLevel("DEBUG"), "debug");
+  assert.equal(resolveLogLevel("nonsense"), "info");
+
+  const lines = [];
+  const logger = createLogger({
+    scope: "test",
+    env: { OPENTAG_HOOKS_LOG_LEVEL: "warn" },
+    streams: { out: (line) => lines.push(`out:${line}`), error: (line) => lines.push(`err:${line}`) },
+  });
+  logger.debug("hidden");
+  logger.info("hidden");
+  logger.warn("shown");
+  logger.error("shown too");
+  assert.deepEqual(lines, ["err:[test] shown", "err:[test] shown too"]);
+});

--- a/scripts/e2e/doctor-docker/Dockerfile
+++ b/scripts/e2e/doctor-docker/Dockerfile
@@ -9,7 +9,9 @@ COPY apps/web/package.json apps/web/package.json
 COPY packages/client/package.json packages/client/package.json
 COPY packages/server/package.json packages/server/package.json
 COPY packages/shared/package.json packages/shared/package.json
-RUN pnpm install --frozen-lockfile --config.engine-strict=true
+# Manifests only, so lifecycle scripts stay off: the root `prepare` installs local Git hooks from
+# `scripts/`, which this image neither ships nor needs.
+RUN pnpm install --frozen-lockfile --config.engine-strict=true --ignore-scripts
 
 COPY tsconfig.json ./
 COPY apps/cli apps/cli

--- a/scripts/git-hooks/post-checkout
+++ b/scripts/git-hooks/post-checkout
@@ -1,0 +1,23 @@
+#!/bin/sh
+# opentag-managed-hook: installed from scripts/git-hooks/post-checkout by scripts/install-git-hooks.mjs.
+#
+# Git shares one hooks directory across every worktree, so this file is the only entry point that is
+# guaranteed to exist inside a worktree that `git worktree add` has just created. At that moment the
+# worktree has no `node_modules`, so the hook must depend on nothing but `git` and `node`.
+#
+# Arguments: <previous HEAD> <new HEAD> <branch checkout flag>. The bootstrap script decides which
+# checkouts deserve work; a post-checkout hook can never change the outcome of the checkout itself.
+
+set -u
+
+repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+bootstrap_script="$repository_root/scripts/worktree-bootstrap.mjs"
+
+[ -f "$bootstrap_script" ] || exit 0
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "[worktree-bootstrap] node is not on PATH; skipping worktree bootstrap" >&2
+  exit 0
+fi
+
+exec node "$bootstrap_script" "$@"

--- a/scripts/hook-logging.mjs
+++ b/scripts/hook-logging.mjs
@@ -1,0 +1,42 @@
+/**
+ * Leveled logging for the Git hook scripts.
+ *
+ * Hook output is interleaved with Git's own output, so the default level stays quiet enough to read
+ * while `OPENTAG_HOOKS_LOG_LEVEL=debug` exposes every decision the scripts make.
+ */
+
+export const LOG_LEVELS = ["error", "warn", "info", "debug"];
+
+export const DEFAULT_LOG_LEVEL = "info";
+
+export function resolveLogLevel(rawLevel) {
+  const normalized = rawLevel?.trim().toLowerCase();
+  return normalized && LOG_LEVELS.includes(normalized) ? normalized : DEFAULT_LOG_LEVEL;
+}
+
+export function createLogger({ scope, env = process.env, streams = {} } = {}) {
+  const level = resolveLogLevel(env.OPENTAG_HOOKS_LOG_LEVEL);
+  const threshold = LOG_LEVELS.indexOf(level);
+  const out = streams.out ?? ((line) => console.log(line));
+  const error = streams.error ?? ((line) => console.error(line));
+
+  const emit = (messageLevel, message) => {
+    if (LOG_LEVELS.indexOf(messageLevel) > threshold) {
+      return;
+    }
+    const line = `[${scope}] ${message}`;
+    if (messageLevel === "error" || messageLevel === "warn") {
+      error(line);
+      return;
+    }
+    out(line);
+  };
+
+  return {
+    level,
+    debug: (message) => emit("debug", message),
+    info: (message) => emit("info", message),
+    warn: (message) => emit("warn", message),
+    error: (message) => emit("error", message),
+  };
+}

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+/**
+ * Installs the local Git hooks.
+ *
+ * Two mechanisms share one hooks directory:
+ *
+ * - lefthook owns the quality gates declared in `lefthook.yml` (`pre-commit`, `pre-push`).
+ * - This script owns `scripts/git-hooks/*`, hooks that must run before `node_modules` exists and
+ *   therefore cannot go through the lefthook binary. They are written last so they win.
+ *
+ * Git keeps a single hooks directory per clone and shares it with every linked worktree, so one
+ * installation covers all of them. The root `prepare` lifecycle runs this on every `pnpm install`.
+ */
+
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createLogger } from "./hook-logging.mjs";
+
+const require = createRequire(import.meta.url);
+const scriptsDirectory = dirname(fileURLToPath(import.meta.url));
+
+/** Marker that identifies a hook this script owns and may overwrite without warning. */
+export const MANAGED_HOOK_MARKER = "opentag-managed-hook";
+
+/** Hooks copied verbatim from `scripts/git-hooks/` into the Git hooks directory. */
+export const MANAGED_HOOKS = ["post-checkout"];
+
+export function classifyInstallation({ env }) {
+  if (env.OPENTAG_SKIP_GIT_HOOKS === "1") {
+    return { install: false, reason: "OPENTAG_SKIP_GIT_HOOKS=1" };
+  }
+  if (env.CI) {
+    return { install: false, reason: "CI environment" };
+  }
+  return { install: true, reason: "local checkout" };
+}
+
+/**
+ * `core.hooksPath` wins when set, and Git resolves a relative value against the working tree root.
+ * Otherwise `git rev-parse --git-path hooks` already points at the directory shared by all worktrees.
+ */
+export function resolveHooksDirectory({ repositoryRoot, configuredHooksPath, gitHooksPath }) {
+  const candidate = configuredHooksPath?.trim() || gitHooksPath?.trim();
+  if (!candidate) {
+    throw new Error("unable to determine the Git hooks directory");
+  }
+  return isAbsolute(candidate) ? candidate : resolve(repositoryRoot, candidate);
+}
+
+function runGit(arguments_, { cwd }) {
+  const result = spawnSync("git", arguments_, { cwd, encoding: "utf8" });
+  if (result.error) {
+    // A container image can install dependencies without shipping Git; that is not a failure here.
+    if (result.error.code === "ENOENT") {
+      return { status: null, stdout: "", stderr: "git is not on PATH" };
+    }
+    throw new Error(`git ${arguments_.join(" ")} failed to start: ${result.error.message}`, { cause: result.error });
+  }
+  return { status: result.status, stdout: result.stdout?.trim() ?? "", stderr: result.stderr?.trim() ?? "" };
+}
+
+export function readRepositoryRoot(cwd) {
+  const result = runGit(["rev-parse", "--show-toplevel"], { cwd });
+  return result.status === 0 && result.stdout ? result.stdout : undefined;
+}
+
+function readConfiguredHooksPath(repositoryRoot) {
+  const result = runGit(["config", "--get", "core.hooksPath"], { cwd: repositoryRoot });
+  return result.status === 0 ? result.stdout : "";
+}
+
+function runLefthookInstall({ repositoryRoot, logger }) {
+  let lefthookEntry;
+  try {
+    lefthookEntry = require.resolve("lefthook/bin/index.js");
+  } catch (error) {
+    throw new Error("lefthook is not installed; run `pnpm install` first", { cause: error });
+  }
+
+  logger.debug(`running lefthook install from ${lefthookEntry}`);
+  const result = spawnSync(process.execPath, [lefthookEntry, "install"], {
+    cwd: repositoryRoot,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    throw new Error(`lefthook install failed to start: ${result.error.message}`, { cause: result.error });
+  }
+  if (result.status !== 0) {
+    throw new Error(`lefthook install exited with status ${result.status ?? "unknown"}`);
+  }
+}
+
+async function readIfPresent(path) {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Writes one managed hook, preserving a foreign hook of the same name as `<hook>.old` the way
+ * lefthook does, so no unrelated automation is lost silently.
+ */
+export async function installManagedHook({ hooksDirectory, name, source, logger }) {
+  const target = join(hooksDirectory, name);
+  const existing = await readIfPresent(target);
+
+  if (existing === source) {
+    logger.debug(`${name} is already up to date`);
+    await chmod(target, 0o755);
+    return "unchanged";
+  }
+
+  if (existing !== undefined && !existing.includes(MANAGED_HOOK_MARKER)) {
+    const backup = `${target}.old`;
+    await rename(target, backup);
+    logger.warn(`kept the previous ${name} hook as ${backup}`);
+  }
+
+  await writeFile(target, source, "utf8");
+  await chmod(target, 0o755);
+  return existing === undefined ? "created" : "updated";
+}
+
+export async function installGitHooks({ cwd = process.cwd(), env = process.env, logger } = {}) {
+  const log = logger ?? createLogger({ scope: "git-hooks", env });
+
+  const classification = classifyInstallation({ env });
+  if (!classification.install) {
+    log.info(`skipping hook installation (${classification.reason})`);
+    return { installed: false, reason: classification.reason };
+  }
+
+  const repositoryRoot = readRepositoryRoot(cwd);
+  if (!repositoryRoot) {
+    log.info("skipping hook installation (not a Git repository)");
+    return { installed: false, reason: "not a Git repository" };
+  }
+
+  runLefthookInstall({ repositoryRoot, logger: log });
+
+  const hooksDirectory = resolveHooksDirectory({
+    repositoryRoot,
+    configuredHooksPath: readConfiguredHooksPath(repositoryRoot),
+    gitHooksPath: runGit(["rev-parse", "--git-path", "hooks"], { cwd: repositoryRoot }).stdout,
+  });
+  log.debug(`hooks directory: ${hooksDirectory}`);
+  await mkdir(hooksDirectory, { recursive: true });
+
+  const outcomes = {};
+  for (const name of MANAGED_HOOKS) {
+    const source = await readFile(join(scriptsDirectory, "git-hooks", name), "utf8");
+    outcomes[name] = await installManagedHook({ hooksDirectory, name, source, logger: log });
+  }
+
+  log.info(
+    `hooks ready in ${hooksDirectory} (lefthook: pre-commit, pre-push; managed: ${MANAGED_HOOKS.map((name) => `${name} ${outcomes[name]}`).join(", ")})`,
+  );
+  return { installed: true, hooksDirectory, outcomes };
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  installGitHooks().catch((error) => {
+    console.error(`[git-hooks] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/worktree-bootstrap.mjs
+++ b/scripts/worktree-bootstrap.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/**
+ * Prepares a freshly created worktree.
+ *
+ * `git worktree add` checks the branch out inside the new directory and then runs the shared
+ * `post-checkout` hook there, with the previous HEAD reported as the null object id. That is the one
+ * moment where the worktree exists but has no dependencies, so this script installs them and then
+ * installs the Git hooks, leaving the worktree ready to commit and push.
+ *
+ * Git ignores the exit status of `post-checkout`, so failures are reported and never left implicit,
+ * but they cannot break the checkout itself.
+ */
+
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createLogger } from "./hook-logging.mjs";
+import { installGitHooks, readRepositoryRoot } from "./install-git-hooks.mjs";
+
+/** Git reports an all-zero object id when a checkout has no previous HEAD. */
+const NULL_OBJECT_ID = /^0+$/;
+
+/** Git environment that belongs to the invoking hook and must not leak into nested commands. */
+const INHERITED_GIT_VARIABLES = [
+  "GIT_DIR",
+  "GIT_COMMON_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_PREFIX",
+  "GIT_REFLOG_ACTION",
+];
+
+/**
+ * @param argv hook arguments: `<previous HEAD> <new HEAD> <branch checkout flag>`, or `--force`
+ *             when a developer runs the bootstrap by hand.
+ */
+export function classifyCheckout({ argv, env }) {
+  if (argv.includes("--force")) {
+    return { bootstrap: true, reason: "forced by --force" };
+  }
+  if (env.OPENTAG_SKIP_WORKTREE_BOOTSTRAP === "1") {
+    return { bootstrap: false, reason: "OPENTAG_SKIP_WORKTREE_BOOTSTRAP=1" };
+  }
+  if (env.CI) {
+    return { bootstrap: false, reason: "CI environment" };
+  }
+
+  const [previousHead, , branchCheckout] = argv;
+  if (branchCheckout !== "1") {
+    return { bootstrap: false, reason: "file checkout" };
+  }
+  if (!previousHead || !NULL_OBJECT_ID.test(previousHead)) {
+    return { bootstrap: false, reason: "branch switch in an existing worktree" };
+  }
+  return { bootstrap: true, reason: "checkout without a previous HEAD" };
+}
+
+export function childEnvironment(env) {
+  const childEnv = { ...env };
+  for (const variable of INHERITED_GIT_VARIABLES) {
+    delete childEnv[variable];
+  }
+  return childEnv;
+}
+
+function installDependencies({ repositoryRoot, env, logger }) {
+  logger.info(`installing dependencies in ${repositoryRoot}`);
+  const result = spawnSync("pnpm", ["install"], {
+    cwd: repositoryRoot,
+    env: childEnvironment(env),
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      throw new Error("pnpm is not on PATH; run `corepack enable` and then `pnpm install` in this worktree");
+    }
+    throw new Error(`pnpm install failed to start: ${result.error.message}`, { cause: result.error });
+  }
+  if (result.status !== 0) {
+    throw new Error(`pnpm install exited with status ${result.status ?? "unknown"}`);
+  }
+}
+
+export async function bootstrapWorktree({ argv = [], cwd = process.cwd(), env = process.env, logger } = {}) {
+  const log = logger ?? createLogger({ scope: "worktree-bootstrap", env });
+
+  const classification = classifyCheckout({ argv, env });
+  if (!classification.bootstrap) {
+    log.debug(`no bootstrap needed (${classification.reason})`);
+    return { bootstrapped: false, reason: classification.reason };
+  }
+
+  const repositoryRoot = readRepositoryRoot(cwd);
+  if (!repositoryRoot) {
+    log.warn("skipping bootstrap (not a Git repository)");
+    return { bootstrapped: false, reason: "not a Git repository" };
+  }
+
+  log.info(`preparing worktree ${repositoryRoot} (${classification.reason})`);
+  installDependencies({ repositoryRoot, env, logger: log });
+  // `pnpm install` already runs the `prepare` lifecycle, but a developer may have disabled install
+  // scripts, and the hooks are the whole point of the bootstrap.
+  await installGitHooks({ cwd: repositoryRoot, env: childEnvironment(env), logger: log });
+
+  log.info("worktree is ready");
+  return { bootstrapped: true, repositoryRoot };
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  bootstrapWorktree({ argv: process.argv.slice(2) }).catch((error) => {
+    console.error(`[worktree-bootstrap] ${error instanceof Error ? error.message : String(error)}`);
+    console.error("[worktree-bootstrap] run `pnpm install` in this worktree to finish the setup");
+  });
+}


### PR DESCRIPTION
## Summary

Adds lefthook and wires the local Git hooks so a clone and every worktree share one setup.

- `pnpm install` runs the root `prepare` script (`scripts/install-git-hooks.mjs`), which installs the lefthook gates and the repository's own hook payloads into the clone's hooks directory. Git shares that directory with all linked worktrees, so one installation covers them all.
- `pre-commit` runs Biome over the staged files, applies the fixes it can make safely, and stages the result. `pre-push` re-runs `biome lint .` and `biome format .` over the repository.
- `post-checkout` prepares a worktree that `git worktree add` has just created: it runs `pnpm install` there and reinstalls the hooks. It is installed by `scripts/install-git-hooks.mjs` instead of lefthook because it has to run before the new worktree has a `node_modules` directory, and it is a no-op for ordinary branch switches, `CI`, and branches that do not carry the script. `pnpm worktree:setup` does the same by hand for tools that bypass Git hooks.
- Image builds now install with `--ignore-scripts`. They copy manifests only, so the root `prepare` would otherwise look for a `scripts/` directory the image never receives. No workspace defines a lifecycle script, so nothing else changes.
- Escape hatches: `LEFTHOOK=0`, `OPENTAG_SKIP_WORKTREE_BOOTSTRAP=1`, `OPENTAG_SKIP_GIT_HOOKS=1`, `OPENTAG_HOOKS_LOG_LEVEL=debug`, and an untracked `lefthook-local.yml`.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test`
- New unit tests in `scripts/__tests__/git-hooks.test.mjs` cover the checkout classification, the hooks-directory resolution, the managed-hook installation including the backup of a foreign hook, and the Dockerfile coupling.
- Manual: `git worktree add` installed the dependencies and the hooks in the new worktree in ~5s; a plain branch switch skipped the bootstrap; a deliberately unformatted staged file was fixed and restaged by `pre-commit`; `pre-push` ran both jobs while pushing this branch.

## Breaking changes

None. Contributors get the hooks on their next `pnpm install`; `CI` and image builds are unaffected.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.