### PR TITLE
fix(client): harden Runtime CLI discovery fallback

### DIFF
--- a/docs/design/doctor-product-spec.md
+++ b/docs/design/doctor-product-spec.md
@@ -306,19 +306,13 @@ Resolver 必须由生产 Client Runtime 与 doctor 共用，避免两套解析�
   Provider override；
 - 搜索诊断进程的 `PATH`；
 - 搜索经过评审的 well-known 安装目录；
-- 仅为 Codex 搜索经过验证的 macOS ChatGPT/Codex App bundle 位置；这仍是启动 shell 前的
-  廉价存在检查，并保持 #249 已有的相对优先级；
-- 在以上所有廉价存在检查之后，搜索登录 shell `PATH`，再搜索 nvm/fnm 的 version-manager
-  目录；不得在两个 manager 同时出现、或同一 manager 存在多个已安装版本时猜测版本；
+- 仅为 Codex 搜索经过验证的 macOS ChatGPT/Codex App bundle 位置；
 - 不得把具有执行位的目录、broken link、不可执行文件或不安全的自动候选项当成已安装；
 - 在 `stat`、`access`、`realpath`、目录枚举或其他会跟随路径的读取之前，应用相同的
-  macOS protected-root 策略，包括 version-manager 根目录及其符号链接版本条目；
-- 返回选中的规范路径及来源：`caller-path`、`well-known`、`desktop-app`、
-  `login-shell`、`version-manager`，或未来真实存在的配置来源；
+  macOS protected-root 策略；
+- 返回选中的规范路径及来源：`caller-path`、`well-known`、`desktop-app`，或未来真实
+  存在的配置来源；
 - 每个 Provider 独立失败，单个 detector 错误不能隐藏另一个 Provider 的结果。
-- Doctor 与生产 Client Runtime 共用 install-only resolver，只取第一个可执行候选项，
-  不执行 readiness fallback；它不得启动 Provider，也不得把同一 Provider 的后续候选项
-  当作已安装。登录 shell 探测属于内部能力，不是用户配置、环境变量、flag 或 schema。
 
 P0 不得启动 `codex` 或 `claude`，不得请求 `--version`/`--help`，不得检查认证、初始化
 app server、发起模型请求、安装 binary 或修改 Provider 配置。

--- a/docs/design/doctor-product-spec.md
+++ b/docs/design/doctor-product-spec.md
@@ -306,13 +306,19 @@ Resolver 必须由生产 Client Runtime 与 doctor 共用，避免两套解析�
   Provider override；
 - 搜索诊断进程的 `PATH`；
 - 搜索经过评审的 well-known 安装目录；
-- 仅为 Codex 搜索经过验证的 macOS ChatGPT/Codex App bundle 位置；
+- 仅为 Codex 搜索经过验证的 macOS ChatGPT/Codex App bundle 位置；这仍是启动 shell 前的
+  廉价存在检查，并保持 #249 已有的相对优先级；
+- 在以上所有廉价存在检查之后，搜索登录 shell `PATH`，再搜索 nvm/fnm 的 version-manager
+  目录；不得在两个 manager 同时出现、或同一 manager 存在多个已安装版本时猜测版本；
 - 不得把具有执行位的目录、broken link、不可执行文件或不安全的自动候选项当成已安装；
 - 在 `stat`、`access`、`realpath`、目录枚举或其他会跟随路径的读取之前，应用相同的
-  macOS protected-root 策略；
-- 返回选中的规范路径及来源：`caller-path`、`well-known`、`desktop-app`，或未来真实
-  存在的配置来源；
+  macOS protected-root 策略，包括 version-manager 根目录及其符号链接版本条目；
+- 返回选中的规范路径及来源：`caller-path`、`well-known`、`desktop-app`、
+  `login-shell`、`version-manager`，或未来真实存在的配置来源；
 - 每个 Provider 独立失败，单个 detector 错误不能隐藏另一个 Provider 的结果。
+- Doctor 与生产 Client Runtime 共用 install-only resolver，只取第一个可执行候选项，
+  不执行 readiness fallback；它不得启动 Provider，也不得把同一 Provider 的后续候选项
+  当作已安装。登录 shell 探测属于内部能力，不是用户配置、环境变量、flag 或 schema。
 
 P0 不得启动 `codex` 或 `claude`，不得请求 `--version`/`--help`，不得检查认证、初始化
 app server、发起模型请求、安装 binary 或修改 Provider 配置。

--- a/packages/client/src/__tests__/agent-runtime-installation.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-installation.test.ts
@@ -30,6 +30,7 @@ describe("Agent Runtime CLI installation discovery", () => {
     ).resolves.toEqual({
       path: await realpath(executable),
       provider: "codex",
+      searchDir: bin,
       source: "caller-path",
     });
   });

--- a/packages/client/src/__tests__/agent-runtime-installation.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-installation.test.ts
@@ -4,6 +4,8 @@ import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AgentRuntimeExecutableNotFoundError,
+  canAdvanceRuntimeCandidate,
+  iterateAgentRuntimeExecutables,
   probeAgentRuntimeCliInstallations,
   resolveAgentRuntimeExecutable,
 } from "../runtime/agent-runtime-installation.js";
@@ -74,6 +76,7 @@ describe("Agent Runtime CLI installation discovery", () => {
           candidateAllowed: () => true,
           desktopAppDirs: () => [],
           home: root,
+          includeLoginShell: false,
           platform: "linux",
           wellKnownDirs: () => [bin],
         },
@@ -97,6 +100,7 @@ describe("Agent Runtime CLI installation discovery", () => {
           candidateAllowed: () => false,
           desktopAppDirs: () => [],
           home: "/Users/alice",
+          includeLoginShell: false,
           platform: "darwin",
           realpath: resolvePath,
           stat,
@@ -137,6 +141,7 @@ describe("Agent Runtime CLI installation discovery", () => {
       desktopAppDirs: () => [],
       environment: { PATH: `/runtime${delimiter}/unused` },
       home: "/home/alice",
+      includeLoginShell: false,
       platform: "linux" as const,
       realpath: vi.fn(async (path: string) => path),
       stat: vi.fn(async (path: string) => {
@@ -170,6 +175,7 @@ describe("Agent Runtime CLI installation discovery", () => {
       desktopAppDirs: () => [],
       environment: { PATH: "/runtime" },
       home: "/home/alice",
+      includeLoginShell: false,
       platform: "linux",
       stat: async () => {
         throw Object.assign(new Error("permission denied"), { code: "EACCES" });
@@ -181,11 +187,263 @@ describe("Agent Runtime CLI installation discovery", () => {
   });
 });
 
+describe("Agent Runtime CLI candidate sequence", () => {
+  it("preserves source order and does not evaluate later layers after a hit", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    const wellKnown = join(root, "well-known");
+    const login = join(root, "login");
+    const version = join(root, "version");
+    const desktop = join(root, "desktop");
+    await Promise.all([caller, wellKnown, login, version, desktop].map((dir) => mkdir(dir)));
+    const executable = join(caller, "codex");
+    await writeFile(executable, "#!/bin/sh\n", { mode: 0o700 });
+    const loginShellPathDirs = vi.fn(async () => [login]);
+    const versionManagerDirs = vi.fn(() => [version]);
+    const desktopAppDirs = vi.fn(() => [desktop]);
+
+    await expect(
+      resolveAgentRuntimeExecutable(
+        "codex",
+        "codex",
+        { PATH: caller },
+        {
+          candidateAllowed: () => true,
+          desktopAppDirs,
+          home: root,
+          includeLoginShell: true,
+          loginShellPathDirs,
+          platform: "linux",
+          versionManagerDirs,
+          wellKnownDirs: () => [wellKnown],
+        },
+      ),
+    ).resolves.toMatchObject({ path: await realpath(executable), source: "caller-path" });
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+    expect(versionManagerDirs).not.toHaveBeenCalled();
+    expect(desktopAppDirs).not.toHaveBeenCalled();
+  });
+
+  it("yields later sources only when the consumer asks for the next candidate", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    const wellKnown = join(root, "well-known");
+    const login = join(root, "login");
+    const version = join(root, "version");
+    const desktop = join(root, "desktop");
+    await Promise.all([caller, wellKnown, login, version, desktop].map((dir) => mkdir(dir)));
+    await Promise.all(
+      [caller, wellKnown, login, version, desktop].map((dir) =>
+        writeFile(join(dir, "codex"), "#!/bin/sh\n", { mode: 0o700 }),
+      ),
+    );
+    const loginShellPathDirs = vi.fn(async () => [login]);
+    const versionManagerDirs = vi.fn(() => [version]);
+    const desktopAppDirs = vi.fn(() => [desktop]);
+    const iterator = iterateAgentRuntimeExecutables(
+      "codex",
+      "codex",
+      { PATH: caller },
+      {
+        candidateAllowed: () => true,
+        desktopAppDirs,
+        home: root,
+        includeLoginShell: true,
+        loginShellPathDirs,
+        platform: "linux",
+        versionManagerDirs,
+        wellKnownDirs: () => [wellKnown],
+      },
+    );
+    await expect(iterator.next()).resolves.toMatchObject({ value: { source: "caller-path" } });
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+    expect(desktopAppDirs).not.toHaveBeenCalled();
+    await expect(iterator.next()).resolves.toMatchObject({ value: { source: "well-known" } });
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+    await expect(iterator.next()).resolves.toMatchObject({ value: { source: "desktop-app" } });
+    expect(desktopAppDirs).toHaveBeenCalledOnce();
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+    await expect(iterator.next()).resolves.toMatchObject({ value: { source: "login-shell" } });
+    expect(loginShellPathDirs).toHaveBeenCalledOnce();
+    expect(versionManagerDirs).toHaveBeenCalledOnce();
+    await expect(iterator.next()).resolves.toMatchObject({ value: { source: "version-manager" } });
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+
+  it("keeps an absolute explicit command as a single candidate without fallback sources", async () => {
+    const root = await temporaryRoot();
+    const explicit = join(root, "explicit-codex");
+    const other = join(root, "other");
+    await mkdir(other);
+    await writeFile(explicit, "#!/bin/sh\n", { mode: 0o700 });
+    await writeFile(join(other, "codex"), "#!/bin/sh\n", { mode: 0o700 });
+    const loginShellPathDirs = vi.fn(async () => [other]);
+    const iterator = iterateAgentRuntimeExecutables(
+      "codex",
+      explicit,
+      { PATH: other },
+      {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [other],
+        home: root,
+        includeLoginShell: true,
+        loginShellPathDirs,
+        platform: "linux",
+        wellKnownDirs: () => [other],
+      },
+    );
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { path: await realpath(explicit), source: "explicit" },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+  });
+
+  it("skips login-shell and version-manager layers on the pre-connect path", async () => {
+    const root = await temporaryRoot();
+    const login = join(root, "login");
+    await mkdir(login);
+    await writeFile(join(login, "codex"), "#!/bin/sh\n", { mode: 0o700 });
+    const loginShellPathDirs = vi.fn(async () => [login]);
+    const versionManagerDirs = vi.fn(() => [login]);
+    await expect(
+      resolveAgentRuntimeExecutable(
+        "codex",
+        "codex",
+        { PATH: "" },
+        {
+          candidateAllowed: () => true,
+          desktopAppDirs: () => [],
+          home: root,
+          includeLoginShell: false,
+          loginShellPathDirs,
+          platform: "linux",
+          versionManagerDirs,
+          wellKnownDirs: () => [],
+        },
+      ),
+    ).rejects.toBeInstanceOf(AgentRuntimeExecutableNotFoundError);
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+    expect(versionManagerDirs).not.toHaveBeenCalled();
+  });
+
+  it("labels a login-shell hit after cheap sources miss", async () => {
+    const root = await temporaryRoot();
+    const login = join(root, "login");
+    await mkdir(login);
+    const executable = join(login, "claude");
+    await writeFile(executable, "#!/bin/sh\n", { mode: 0o700 });
+    await expect(
+      resolveAgentRuntimeExecutable(
+        "claude-code",
+        "claude",
+        { PATH: "" },
+        {
+          candidateAllowed: () => true,
+          desktopAppDirs: () => [],
+          home: root,
+          includeLoginShell: true,
+          loginShellPathDirs: async () => [login],
+          platform: "linux",
+          versionManagerDirs: () => [],
+          wellKnownDirs: () => [],
+        },
+      ),
+    ).resolves.toMatchObject({ path: await realpath(executable), source: "login-shell" });
+  });
+
+  it("keeps the existing desktop-app source ahead of the expensive login-shell layer", async () => {
+    const root = await temporaryRoot();
+    const desktop = join(root, "desktop");
+    await mkdir(desktop);
+    const executable = join(desktop, "codex");
+    await writeFile(executable, "#!/bin/sh\n", { mode: 0o700 });
+    await expect(
+      resolveAgentRuntimeExecutable(
+        "codex",
+        "codex",
+        { PATH: "" },
+        {
+          candidateAllowed: () => true,
+          desktopAppDirs: () => [desktop],
+          home: root,
+          includeLoginShell: true,
+          loginShellPathDirs: () => {
+            throw new Error("login shell must remain lazy after a cheap desktop hit");
+          },
+          platform: "linux",
+          versionManagerDirs: () => [],
+          wellKnownDirs: () => [],
+        },
+      ),
+    ).resolves.toMatchObject({ path: await realpath(executable), source: "desktop-app" });
+  });
+
+  it("deduplicates the same canonical executable reached through a symlink or a later source", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    const alias = join(root, "alias");
+    const wellKnown = join(root, "well-known");
+    await mkdir(caller);
+    await mkdir(alias);
+    await mkdir(wellKnown);
+    const executable = join(caller, "codex");
+    await writeFile(executable, "#!/bin/sh\n", { mode: 0o700 });
+    await symlink(executable, join(alias, "codex"));
+    await symlink(executable, join(wellKnown, "codex"));
+    const yielded: string[] = [];
+    for await (const candidate of iterateAgentRuntimeExecutables(
+      "codex",
+      "codex",
+      { PATH: `${caller}${delimiter}${alias}` },
+      {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [wellKnown],
+      },
+    )) {
+      yielded.push(candidate.path);
+    }
+    expect(yielded).toEqual([await realpath(executable)]);
+  });
+});
+
+describe("same-Provider candidate fallback taxonomy", () => {
+  it("advances only when every issue is artifact_missing or version_incompatible", () => {
+    expect(canAdvanceRuntimeCandidate({ ready: false, issues: [{ code: "artifact_missing" }] })).toBe(true);
+    expect(
+      canAdvanceRuntimeCandidate({
+        ready: false,
+        issues: [{ code: "version_incompatible" }, { code: "artifact_missing" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("never advances on ready, empty, mixed, credential, configuration, or transient results", () => {
+    expect(canAdvanceRuntimeCandidate({ ready: true, issues: [] })).toBe(false);
+    expect(canAdvanceRuntimeCandidate({ ready: false, issues: [] })).toBe(false);
+    expect(canAdvanceRuntimeCandidate({ ready: false, issues: [{ code: "credential_missing" }] })).toBe(false);
+    expect(canAdvanceRuntimeCandidate({ ready: false, issues: [{ code: "configuration_invalid" }] })).toBe(false);
+    expect(canAdvanceRuntimeCandidate({ ready: false, issues: [{ code: "temporarily_unavailable" }] })).toBe(false);
+    expect(
+      canAdvanceRuntimeCandidate({
+        ready: false,
+        issues: [{ code: "version_incompatible" }, { code: "credential_missing" }],
+      }),
+    ).toBe(false);
+    expect(canAdvanceRuntimeCandidate({ ready: false, issues: [{ code: "other" }] })).toBe(false);
+  });
+});
+
 function emptyAutomaticLocations(home: string) {
   return {
     candidateAllowed: () => true,
     desktopAppDirs: () => [],
     home,
+    includeLoginShell: false,
     platform: "linux" as const,
     wellKnownDirs: () => [],
   };

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -407,13 +407,7 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
         throw new Error("missing");
       },
     });
-    await expect(probe.probe({ configuration: { reasoningEffort: "bad" } })).resolves.toEqual({
-      ready: false,
-      issues: [
-        { code: "configuration_invalid", message: "Claude Code reasoning effort is unsupported" },
-        { code: "artifact_missing", message: "Claude Code CLI could not be executed" },
-      ],
-    });
+    await expect(probe.probe({ configuration: { reasoningEffort: "bad" } })).rejects.toThrow("missing");
     await expect(
       new ClaudeCodeAgentRuntimeFactory({
         probeRunner: async () => {
@@ -661,7 +655,7 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
       new ClaudeCodeAgentRuntimeFactory({ process: { command: brokenCommand, env: { PATH: process.env.PATH } } }).probe(
         {},
       ),
-    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    ).rejects.toThrow("Claude Code CLI returned no version");
 
     const authStarted = join(directory, "auth-started");
     const hangingAuthCommand = join(directory, "claude-hanging-auth");

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -414,6 +414,20 @@ describe("ClaudeCodeAgentRuntime exhaustive behavior", () => {
         { code: "artifact_missing", message: "Claude Code CLI could not be executed" },
       ],
     });
+    await expect(
+      new ClaudeCodeAgentRuntimeFactory({
+        probeRunner: async () => {
+          throw Object.assign(new Error("timeout"), { code: "ETIMEDOUT" });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "temporarily_unavailable" }] });
+    await expect(
+      new ClaudeCodeAgentRuntimeFactory({
+        probeRunner: async () => {
+          throw Object.assign(new Error("crash"), { signal: "SIGSEGV" });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
   });
 
   it("maps unrestricted policy and configuration override arguments", async () => {

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -372,6 +372,27 @@ describe("createClientRuntime production composition", () => {
     await expect(factory.probe({ signal: aborted.signal })).rejects.toThrow("stop resolution");
   });
 
+  it("does not execute a login shell during pre-connect createClientRuntime readiness", async () => {
+    const home = await temporaryDirectory("opentag-client-preconnect-shell-");
+    const empty = resolve(home, "empty-bin");
+    await mkdir(empty);
+    const marker = resolve(home, "login-shell-invoked");
+    const fakeShell = resolve(home, "fake-shell");
+    await writeFile(fakeShell, `#!/bin/sh\nprintf invoked > ${JSON.stringify(marker)}\nexit 0\n`, "utf8");
+    await chmod(fakeShell, 0o755);
+    const runtime = await createClientRuntime(runtimeConnection(), {
+      clientVersion: "0.0.1",
+      claudeCodeCommand: "claude",
+      codexCommand: "codex",
+      environment: { HOME: home, PATH: empty, SHELL: fakeShell },
+      home,
+      larkCliCommand: resolve(empty, "missing-lark"),
+      slackCliCommand: resolve(empty, "missing-slack"),
+    });
+    runtime.stop();
+    await expect(readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("resolves the production Claude Code factory and enforces its reviewed runtime policy", async () => {
     const home = await temporaryDirectory("opentag-client-claude-factory-");
     const command = resolve(home, "claude-fixture");

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -1092,10 +1092,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
         throw new Error("missing");
       },
     });
-    await expect(missing.probe({})).resolves.toEqual({
-      ready: false,
-      issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }],
-    });
+    await expect(missing.probe({})).rejects.toThrow("missing");
     await expect(
       new CodexAgentRuntimeFactory({
         clientVersion: "test",
@@ -1103,7 +1100,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
           throw "bare-string";
         },
       }).probe({}),
-    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    ).rejects.toBe("bare-string");
     await expect(
       new CodexAgentRuntimeFactory({
         clientVersion: "test",
@@ -1111,7 +1108,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
           throw null;
         },
       }).probe({}),
-    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    ).rejects.toBeNull();
     const transientCases = [
       { code: "ETIMEDOUT" },
       { code: "EAGAIN" },
@@ -1145,7 +1142,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
           throw new CodexAppServerError("spawn", "missing");
         },
       }).probe({}),
-    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    ).rejects.toMatchObject({ code: "spawn", message: "missing" });
     await expect(
       new CodexAgentRuntimeFactory({
         clientVersion: "test",
@@ -1161,7 +1158,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
           throw new CodexAppServerError("exited", "clean", { exitCode: 0, signal: null });
         },
       }).probe({}),
-    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    ).rejects.toMatchObject({ code: "exited", exitCode: 0 });
     await expect(
       new CodexAgentRuntimeFactory({
         clientVersion: "test",
@@ -1502,10 +1499,7 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
       clientVersion: "test",
       process: { command: emptyVersionCommand, env: { PATH: process.env.PATH, OPENAI_API_KEY: "key" } },
     });
-    await expect(emptyVersion.probe({})).resolves.toMatchObject({
-      ready: false,
-      issues: [{ code: "artifact_missing" }],
-    });
+    await expect(emptyVersion.probe({})).rejects.toThrow("Codex CLI returned no version");
 
     const loginStarted = join(directory, "login-started");
     const hangingLoginCommand = join(directory, "codex-hanging-login");

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -1096,6 +1096,132 @@ describe("CodexAgentRuntime exhaustive behavior", () => {
       ready: false,
       issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }],
     });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw "bare-string";
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw null;
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    const transientCases = [
+      { code: "ETIMEDOUT" },
+      { code: "EAGAIN" },
+      { code: "ENOMEM" },
+      { killed: true, signal: "SIGKILL" },
+    ];
+    for (const extra of transientCases) {
+      const transient = new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw Object.assign(new Error("busy"), extra);
+        },
+      });
+      await expect(transient.probe({})).resolves.toMatchObject({
+        ready: false,
+        issues: [{ code: "temporarily_unavailable" }],
+      });
+    }
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw Object.assign(new Error("crash-killed"), { killed: true, signal: "SIGSEGV" });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw new CodexAppServerError("spawn", "missing");
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw new CodexAppServerError("spawn", "enoent", { errno: "ENOENT" });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw new CodexAppServerError("exited", "clean", { exitCode: 0, signal: null });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw new CodexAppServerError("exited", "timeout-kill", { killed: true, signal: "SIGKILL" });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "temporarily_unavailable" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw new CodexAppServerError("spawn", "busy", { errno: "EAGAIN" });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "temporarily_unavailable" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw new CodexAppServerError("exited", "dead", { exitCode: 1, signal: null });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "version_incompatible" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw new CodexAppServerError("exited", "fault", { exitCode: null, signal: "SIGABRT" });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "artifact_missing" }] });
+    await expect(
+      new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw new CodexAppServerError("exited", "host", { signal: "SIGUSR1" });
+        },
+      }).probe({}),
+    ).resolves.toMatchObject({ ready: false, issues: [{ code: "temporarily_unavailable" }] });
+    const crashCases = [
+      { signal: "SIGSEGV" },
+      { signal: "SIGABRT" },
+      { signal: "SIGILL" },
+      { signal: "SIGBUS" },
+      { signal: "SIGFPE" },
+      { code: 1 },
+    ];
+    for (const extra of crashCases) {
+      const crashed = new CodexAgentRuntimeFactory({
+        clientVersion: "test",
+        probeRunner: async () => {
+          throw Object.assign(new Error("broken"), extra);
+        },
+      });
+      await expect(crashed.probe({})).resolves.toMatchObject({
+        ready: false,
+        issues: [{ code: "artifact_missing" }],
+      });
+    }
     const incompatibleProtocol = new CodexAgentRuntimeFactory({
       clientVersion: "test",
       probeRunner: async () => {

--- a/packages/client/src/__tests__/codex-app-server-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-exhaustive.test.ts
@@ -41,6 +41,16 @@ describe("CodexAppServerProcess exhaustive behavior", () => {
           },
         }),
     ).toThrowError(expect.objectContaining({ code: "spawn", message: "Codex could not be started" }));
+    expect(
+      () =>
+        new CodexAppServerProcess({
+          cwd: "/tmp",
+          env: {},
+          spawnProcess: () => {
+            throw Object.assign(new Error("again"), { code: "EAGAIN" });
+          },
+        }),
+    ).toThrowError(expect.objectContaining({ code: "spawn", errno: "EAGAIN" }));
   });
 
   it("uses default process options, exposes pid, initializes, notifies, interrupts, and rejects request errors", async () => {
@@ -384,6 +394,30 @@ describe("CodexAppServerProcess exhaustive behavior", () => {
     await failureProcess.close();
   });
 
+  it("records exit code, crash signal, and spawn errno on App Server failures", async () => {
+    const exited = new FakeChild({ exitOnEnd: false });
+    const exitedProcess = processWith(exited);
+    const exitedFailure = processFailure(exitedProcess);
+    exited.exit(1, null);
+    await expect(exitedFailure).resolves.toMatchObject({ code: "exited", exitCode: 1, signal: null });
+    await exitedProcess.close();
+
+    const crashed = new FakeChild({ exitOnEnd: false });
+    const crashedProcess = processWith(crashed);
+    const crashedFailure = processFailure(crashedProcess);
+    crashed.exit(null, "SIGSEGV");
+    await expect(crashedFailure).resolves.toMatchObject({ code: "exited", signal: "SIGSEGV" });
+    await crashedProcess.close();
+
+    const busy = new FakeChild({ exitOnEnd: false });
+    const busyProcess = processWith(busy);
+    const busyFailure = processFailure(busyProcess);
+    busy.emit("error", Object.assign(new Error("again"), { code: "ENOMEM" }));
+    await expect(busyFailure).resolves.toMatchObject({ code: "spawn", errno: "ENOMEM" });
+    busy.exit();
+    await busyProcess.close();
+  });
+
   it("distinguishes clean exit, truncated exit, child errors, forced kill, and unkillable process trees", async () => {
     for (const truncated of [false, true]) {
       const child = new FakeChild({ exitOnEnd: false });
@@ -490,10 +524,10 @@ class FakeChild extends EventEmitter {
     for (const write of this.#heldWrites.splice(0)) write();
   }
 
-  exit(): void {
+  exit(code: number | null = 0, signal: NodeJS.Signals | null = null): void {
     if (this.#exited) return;
     this.#exited = true;
-    this.emit("exit", 0, null);
+    this.emit("exit", code, signal);
   }
 
   send(message: unknown): void {

--- a/packages/client/src/__tests__/install-locations.test.ts
+++ b/packages/client/src/__tests__/install-locations.test.ts
@@ -1,0 +1,168 @@
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { wellKnownAgentRuntimeBinDirs } from "../runtime/agent-runtime-installation.js";
+import { versionManagerBinDirs } from "../runtime/install-locations.js";
+
+const NEVER_LISTED = (path: string): string[] => {
+  throw new Error(`unexpected readdir: ${path}`);
+};
+
+const linux = { platform: "linux" as const, env: {} as NodeJS.ProcessEnv };
+
+describe("versionManagerBinDirs", () => {
+  it("returns the sole candidate when exactly one root holds exactly one version", () => {
+    const home = "/home/u";
+    const versions = join(home, ".nvm", "versions", "node");
+    expect(
+      versionManagerBinDirs(home, { ...linux, readDir: (path) => (path === versions ? ["v22.2.0"] : []) }),
+    ).toEqual([join(versions, "v22.2.0", "bin")]);
+  });
+
+  it("contributes nothing from a root holding more than one version", () => {
+    const home = "/home/u";
+    const versions = join(home, ".local", "share", "fnm", "node-versions");
+    expect(
+      versionManagerBinDirs(home, {
+        ...linux,
+        readDir: (path) => (path === versions ? ["v20.11.0", "v22.2.0"] : []),
+      }),
+    ).toEqual([]);
+  });
+
+  it("fails closed globally when any scanned safe root has multiple versions even if another root is unique", () => {
+    const home = "/home/u";
+    const nvm = join(home, ".nvm", "versions", "node");
+    const fnm = join(home, ".local", "share", "fnm", "node-versions");
+    expect(
+      versionManagerBinDirs(home, {
+        ...linux,
+        readDir: (path) => (path === nvm ? ["v20.11.0", "v22.2.0"] : path === fnm ? ["v18.0.0"] : []),
+      }),
+    ).toEqual([]);
+  });
+
+  it("contributes nothing when two roots each hold one version", () => {
+    const home = "/home/u";
+    const nvm = join(home, ".nvm", "versions", "node");
+    const fnm = join(home, ".local", "share", "fnm", "node-versions");
+    expect(
+      versionManagerBinDirs(home, {
+        ...linux,
+        readDir: (path) => (path === nvm ? ["v22.2.0"] : path === fnm ? ["v18.0.0"] : []),
+      }),
+    ).toEqual([]);
+  });
+
+  it("uses only the active $FNM_DIR the shell reported, and only when it is unambiguous", () => {
+    const home = "/home/u";
+    const activeVersions = join("/opt/fnm", "node-versions");
+    const staleNvm = join(home, ".nvm", "versions", "node");
+    const readDir = (path: string): string[] =>
+      path === activeVersions ? ["v20.11.0", "v22.2.0"] : path === staleNvm ? ["v18.0.0"] : [];
+
+    expect(versionManagerBinDirs(home, { ...linux, readDir, active: { fnmDir: "/opt/fnm" } })).toEqual([]);
+    expect(
+      versionManagerBinDirs(home, {
+        ...linux,
+        readDir: (path) => (path === activeVersions ? ["v20.11.0"] : path === staleNvm ? ["v18.0.0"] : []),
+        active: { fnmDir: "/opt/fnm" },
+      }),
+    ).toEqual([join(activeVersions, "v20.11.0", "installation", "bin")]);
+  });
+
+  it("takes $NVM_BIN as authoritative instead of enumerating nvm", () => {
+    const home = "/home/u";
+    const active = join(home, ".nvm", "versions", "node", "v20.11.0", "bin");
+    expect(
+      versionManagerBinDirs(home, {
+        ...linux,
+        readDir: () => ["v20.11.0", "v22.2.0"],
+        active: { nvmBin: active },
+      }),
+    ).toEqual([active]);
+  });
+
+  it("fails closed when the shell reported both managers", () => {
+    const home = "/home/u";
+    const nvmBin = join(home, ".nvm", "versions", "node", "v20.11.0", "bin");
+    const fnmVersions = join("/opt/fnm", "node-versions");
+    expect(
+      versionManagerBinDirs(home, {
+        ...linux,
+        readDir: (path) => (path === fnmVersions ? ["v18.0.0"] : []),
+        active: { nvmBin, fnmDir: "/opt/fnm" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("rejects relative active manager paths before any filesystem read", () => {
+    const readDir = (path: string): string[] => {
+      throw new Error(`must not inspect relative path: ${path}`);
+    };
+    expect(versionManagerBinDirs("/home/u", { ...linux, active: { fnmDir: "relative-fnm" }, readDir })).toEqual([]);
+    expect(versionManagerBinDirs("/home/u", { ...linux, active: { nvmBin: "relative-nvm/bin" }, readDir })).toEqual([]);
+  });
+
+  it("returns nothing when no version manager is installed", () => {
+    expect(
+      versionManagerBinDirs("/home/u", {
+        ...linux,
+        readDir: () => {
+          throw new Error("ENOENT");
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps version dirs out of well-known dirs, whose precedence is above the login shell", () => {
+    const dirs = wellKnownAgentRuntimeBinDirs("/home/u", "linux");
+    expect(dirs.some((dir) => dir.includes(".nvm"))).toBe(false);
+    expect(dirs.some((dir) => dir.includes("fnm"))).toBe(false);
+  });
+});
+
+describe("versionManagerBinDirs protected-root vetting (macOS)", () => {
+  function macHome(): string {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ot-vm-")));
+    const home = join(root, "home");
+    mkdirSync(join(home, "Documents"), { recursive: true });
+    return home;
+  }
+
+  it("never lists a $FNM_DIR pointing into a protected folder", () => {
+    const home = macHome();
+    expect(
+      versionManagerBinDirs(home, {
+        platform: "darwin",
+        home,
+        readDir: NEVER_LISTED,
+        env: { FNM_DIR: join(home, "Documents", "fnm") },
+      }),
+    ).toEqual([]);
+  });
+
+  it("never lists a default root symlinked into a protected folder", () => {
+    const home = macHome();
+    mkdirSync(join(home, "Documents", "nvm", "versions", "node"), { recursive: true });
+    symlinkSync(join(home, "Documents", "nvm"), join(home, ".nvm"));
+    expect(versionManagerBinDirs(home, { platform: "darwin", home, readDir: NEVER_LISTED, env: {} })).toEqual([]);
+  });
+
+  it("drops a version entry symlinked into a protected folder", () => {
+    const home = macHome();
+    const versions = join(home, ".nvm", "versions", "node");
+    mkdirSync(versions, { recursive: true });
+    mkdirSync(join(home, "Documents", "sneaky", "bin"), { recursive: true });
+    symlinkSync(join(home, "Documents", "sneaky"), join(versions, "v23.0.0"));
+    expect(
+      versionManagerBinDirs(home, {
+        platform: "darwin",
+        home,
+        readDir: (path) => (path === versions ? ["v23.0.0"] : []),
+        env: {},
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -1,0 +1,368 @@
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, readlinkSync, realpathSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildProbeScript,
+  defaultRunShell,
+  getLoginShellPathDirs,
+  LOGIN_SHELL_ENV_DELIM,
+  LOGIN_SHELL_PATH_DELIM,
+  LOGIN_SHELL_PROBE_KILL_SIGNAL,
+  LOGIN_SHELL_PROBE_MAX_ATTEMPTS,
+  LOGIN_SHELL_PROBE_MAX_STDOUT_BYTES,
+  LOGIN_SHELL_PROBE_TIMEOUT_MS,
+  probeLoginShellPath,
+  type RunShell,
+  resetLoginShellPathDirsCache,
+} from "../runtime/login-shell-path.js";
+
+function wrap(dirs: string[], env: { fnmDir?: string; nvmBin?: string } = {}): string {
+  const envBody = `${env.fnmDir ?? ""}\n${env.nvmBin ?? ""}\n`;
+  return `some prompt noise\n${LOGIN_SHELL_PATH_DELIM}${dirs.join("\n")}${LOGIN_SHELL_PATH_DELIM}${LOGIN_SHELL_ENV_DELIM}${envBody}${LOGIN_SHELL_ENV_DELIM}\n`;
+}
+
+const linux = { platform: "linux" as const, home: "/home/u" };
+
+describe("getLoginShellPathDirs", () => {
+  afterEach(() => {
+    resetLoginShellPathDirsCache();
+    vi.useRealTimers();
+  });
+
+  it("parses delimiter-bracketed canonical dirs, dropping empty lines", async () => {
+    await expect(
+      getLoginShellPathDirs({ ...linux, runShell: () => wrap(["/home/u/.nvm/v/bin", "", "/usr/local/bin", ""]) }),
+    ).resolves.toEqual(["/home/u/.nvm/v/bin", "/usr/local/bin"]);
+  });
+
+  it("returns [] when the shell output is null (probe failure)", async () => {
+    await expect(getLoginShellPathDirs({ ...linux, runShell: () => null })).resolves.toEqual([]);
+  });
+
+  it("returns [] when the delimiters are missing (parse miss)", async () => {
+    await expect(getLoginShellPathDirs({ ...linux, runShell: () => "no markers here" })).resolves.toEqual([]);
+  });
+
+  it("treats a successfully-parsed empty PATH as success (cached, no retry)", async () => {
+    const runShell = vi.fn(() => wrap([]));
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual([]);
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual([]);
+    expect(runShell).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns [] on win32 without invoking the shell", async () => {
+    const runShell = vi.fn(() => wrap(["/should/not/be/used"]));
+    await expect(getLoginShellPathDirs({ platform: "win32", home: "/Users/x", runShell })).resolves.toEqual([]);
+    expect(runShell).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when the shell seam throws", async () => {
+    await expect(
+      getLoginShellPathDirs({
+        ...linux,
+        runShell: () => {
+          throw new Error("spawn failed");
+        },
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("memoizes a successful probe across calls", async () => {
+    const runShell = vi.fn(() => wrap(["/a/bin"]));
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual(["/a/bin"]);
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual(["/a/bin"]);
+    expect(runShell).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one in-flight probe across concurrent callers", async () => {
+    let release!: (value: string | null) => void;
+    const runShell = vi.fn(
+      () =>
+        new Promise<string | null>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const first = getLoginShellPathDirs({ ...linux, runShell });
+    const second = getLoginShellPathDirs({ ...linux, runShell });
+    expect(runShell).toHaveBeenCalledTimes(1);
+    release(wrap(["/shared/bin"]));
+    await expect(first).resolves.toEqual(["/shared/bin"]);
+    await expect(second).resolves.toEqual(["/shared/bin"]);
+    expect(runShell).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes a failing shell up to the cap, then settles to [] cached", async () => {
+    const runShell = vi.fn(() => null);
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual([]);
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual([]);
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual([]);
+    expect(runShell).toHaveBeenCalledTimes(LOGIN_SHELL_PROBE_MAX_ATTEMPTS);
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual([]);
+    expect(runShell).toHaveBeenCalledTimes(LOGIN_SHELL_PROBE_MAX_ATTEMPTS);
+  });
+
+  it("recovers: a success after transient failures caches and stops retrying", async () => {
+    const runShell = vi
+      .fn<RunShell>()
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(wrap(["/late/bin"]))
+      .mockReturnValue(wrap(["/unused/bin"]));
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual([]);
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual(["/late/bin"]);
+    await expect(getLoginShellPathDirs({ ...linux, runShell })).resolves.toEqual(["/late/bin"]);
+    expect(runShell).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops macOS TCC-protected dirs using injected platform/home, not process globals", async () => {
+    await expect(
+      getLoginShellPathDirs({
+        platform: "darwin",
+        home: "/Users/tester",
+        environment: { HOME: "/Users/tester" },
+        runShell: () =>
+          wrap([
+            "/opt/homebrew/bin",
+            "/Users/tester/Documents/bin",
+            "/Users/tester/Desktop",
+            "/Users/tester/Downloads/tools/bin",
+            "/Users/tester/Library/Mobile Documents/com~apple~CloudDocs/bin",
+            "/Users/tester/Library/CloudStorage/OneDrive/bin",
+            "/Users/tester/.nvm/versions/node/v22.0.0/bin",
+            "/Users/tester/Documents-archive/bin",
+          ]),
+      }),
+    ).resolves.toEqual([
+      "/opt/homebrew/bin",
+      "/Users/tester/.nvm/versions/node/v22.0.0/bin",
+      "/Users/tester/Documents-archive/bin",
+    ]);
+  });
+
+  it.skipIf(process.platform === "win32")("rejects symlinks into a protected root without entering them", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ot-symlink-")));
+    const home = join(root, "home");
+    mkdirSync(join(home, "Documents", "real", "bin"), { recursive: true });
+    mkdirSync(join(home, "deep"), { recursive: true });
+    mkdirSync(join(home, "safe", "bin"), { recursive: true });
+    symlinkSync(join(home, "Documents", "real"), join(home, "bin"));
+    symlinkSync(join(home, "Documents"), join(home, "deep", "mid"));
+    symlinkSync(join(home, "safe", "bin"), join(home, "safe-link"));
+
+    await expect(
+      getLoginShellPathDirs({
+        platform: "darwin",
+        home,
+        environment: { HOME: home },
+        runShell: () =>
+          wrap([join(home, "bin", "bin"), join(home, "deep", "mid", "real", "bin"), join(home, "safe-link")]),
+      }),
+    ).resolves.toEqual([join(home, "safe", "bin")]);
+  });
+
+  it("matches protected roots regardless of case", async () => {
+    await expect(
+      getLoginShellPathDirs({
+        platform: "darwin",
+        home: "/Users/tester",
+        environment: { HOME: "/Users/tester" },
+        runShell: () =>
+          wrap([
+            "/Users/tester/documents/bin",
+            "/Users/tester/DOWNLOADS/bin",
+            "/Users/tester/Library/mobile documents/bin",
+            "/opt/homebrew/bin",
+          ]),
+      }),
+    ).resolves.toEqual(["/opt/homebrew/bin"]);
+  });
+
+  it.skipIf(process.platform === "win32")("never passes a protected path to readlink", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ot-touch-")));
+    const home = join(root, "home");
+    mkdirSync(join(home, "Documents", "real", "bin"), { recursive: true });
+    mkdirSync(join(home, "deep"), { recursive: true });
+    symlinkSync(join(home, "Documents", "real"), join(home, "bin"));
+    symlinkSync(join(home, "Documents"), join(home, "deep", "mid"));
+    const touched: string[] = [];
+    const readLink = (path: string): string => {
+      touched.push(path);
+      return readlinkSync(path);
+    };
+
+    await getLoginShellPathDirs({
+      platform: "darwin",
+      home,
+      environment: { HOME: home },
+      readLink,
+      runShell: () =>
+        wrap([
+          join(home, "Documents", "bin"),
+          join(home, "documents", "bin"),
+          join(home, "bin", "bin"),
+          join(home, "deep", "mid", "real", "bin"),
+        ]),
+    });
+
+    expect(touched.length).toBeGreaterThan(0);
+    expect(touched.filter((path) => path.toLowerCase().startsWith(join(home, "documents")))).toEqual([]);
+  });
+
+  it("keeps protected-looking dirs on non-macOS hosts", async () => {
+    await expect(
+      getLoginShellPathDirs({
+        platform: "linux",
+        home: "/home/tester",
+        runShell: () => wrap(["/home/tester/Documents/bin", "/usr/local/bin"]),
+      }),
+    ).resolves.toEqual(["/home/tester/Documents/bin", "/usr/local/bin"]);
+  });
+
+  it("drops both manager trees from live dirs when macOS sees both managers", async () => {
+    const nvmBin = "/Users/tester/.nvm/versions/node/v22.2.0/bin";
+    const fnmDir = "/opt/fnm";
+    await expect(
+      getLoginShellPathDirs({
+        platform: "darwin",
+        home: "/Users/tester",
+        environment: { HOME: "/Users/tester" },
+        runShell: () => wrap(["/opt/fnm-multishells/1/bin", nvmBin, "/opt/homebrew/bin"], { fnmDir, nvmBin }),
+      }),
+    ).resolves.toEqual(["/opt/fnm-multishells/1/bin", "/opt/homebrew/bin"]);
+  });
+
+  it("keeps a dual-manager PATH intact where the shell already canonicalized it", async () => {
+    const nvmBin = "/home/u/.nvm/versions/node/v22.2.0/bin";
+    const fnmDir = "/opt/fnm";
+    const fnmTarget = "/opt/fnm/node-versions/v20.11.0/installation/bin";
+    await expect(
+      getLoginShellPathDirs({
+        ...linux,
+        runShell: () => wrap([fnmTarget, nvmBin], { fnmDir, nvmBin }),
+      }),
+    ).resolves.toEqual([fnmTarget, nvmBin]);
+  });
+
+  it("captures active NVM_BIN and FNM_DIR evidence from the login shell", async () => {
+    const env = { fnmDir: "/opt/fnm", nvmBin: "/home/u/.nvm/versions/node/v20/bin" };
+    await expect(
+      probeLoginShellPath({ ...linux, runShell: () => wrap(["/usr/local/bin"], env) }),
+    ).resolves.toMatchObject({
+      ok: true,
+      dirs: ["/usr/local/bin"],
+      env,
+    });
+  });
+});
+
+describe("defaultRunShell timeout, kill, and source environment", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("kills a hanging child with SIGKILL and settles null even when close is never emitted", async () => {
+    vi.useFakeTimers();
+    const kill = vi.fn(() => true);
+    const spawnFn = () => {
+      const child = new EventEmitter();
+      Object.assign(child, {
+        stdout: new PassThrough(),
+        kill,
+      });
+      return child;
+    };
+    const pending = defaultRunShell({
+      platform: "linux",
+      environment: { SHELL: "/bin/bash" },
+      spawn: spawnFn as never,
+    });
+    await vi.advanceTimersByTimeAsync(LOGIN_SHELL_PROBE_TIMEOUT_MS);
+    await expect(pending).resolves.toBeNull();
+    expect(kill).toHaveBeenCalledWith(LOGIN_SHELL_PROBE_KILL_SIGNAL);
+  });
+
+  it("selects the source-environment shell and passes that environment to spawn", async () => {
+    const spawn = vi.fn((_command: string, _args: readonly string[], _options: unknown) => {
+      const child = new EventEmitter();
+      const stdout = new PassThrough();
+      Object.assign(child, { stdout, kill: vi.fn() });
+      queueMicrotask(() => {
+        stdout.end();
+        child.emit("close", 0, null);
+      });
+      return child;
+    });
+    const environment = { SHELL: "/custom/shell", HOME: "/Users/x", PATH: "/bin" };
+    await defaultRunShell({ platform: "darwin", environment, spawn: spawn as never });
+    expect(spawn).toHaveBeenCalledWith("/custom/shell", ["-lic", expect.any(String)], {
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+      env: environment,
+    });
+  });
+
+  it("inherits the current process environment when no source environment is supplied", async () => {
+    vi.stubEnv("SHELL", "/process/shell");
+    const spawn = vi.fn((_command: string, _args: readonly string[], _options: unknown) => {
+      const child = new EventEmitter();
+      const stdout = new PassThrough();
+      Object.assign(child, { stdout, kill: vi.fn() });
+      queueMicrotask(() => child.emit("close", 1, null));
+      return child;
+    });
+    await defaultRunShell({ platform: "linux", spawn: spawn as never });
+    expect(spawn).toHaveBeenCalledWith("/process/shell", ["-lic", expect.any(String)], {
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+      env: process.env,
+    });
+  });
+
+  it("defaults to zsh on darwin and bash elsewhere when SHELL is unset", async () => {
+    const spawn = vi.fn((_command: string) => {
+      const child = new EventEmitter();
+      Object.assign(child, { stdout: new PassThrough(), kill: vi.fn() });
+      queueMicrotask(() => child.emit("close", 1, null));
+      return child;
+    });
+    await defaultRunShell({ platform: "darwin", environment: {}, spawn: spawn as never });
+    expect(spawn.mock.calls[0]?.[0]).toBe("/bin/zsh");
+    await defaultRunShell({ platform: "linux", environment: {}, spawn: spawn as never });
+    expect(spawn.mock.calls[1]?.[0]).toBe("/bin/bash");
+  });
+
+  it("kills and fails closed when stdout exceeds the bounded limit", async () => {
+    const kill = vi.fn(() => true);
+    const spawnFn = () => {
+      const child = new EventEmitter();
+      const stdout = new PassThrough();
+      Object.assign(child, { stdout, kill });
+      queueMicrotask(() => {
+        stdout.write("x".repeat(LOGIN_SHELL_PROBE_MAX_STDOUT_BYTES + 1));
+      });
+      return child;
+    };
+    await expect(
+      defaultRunShell({ platform: "linux", environment: { SHELL: "/bin/bash" }, spawn: spawnFn as never }),
+    ).resolves.toBeNull();
+    expect(kill).toHaveBeenCalledWith(LOGIN_SHELL_PROBE_KILL_SIGNAL);
+  });
+});
+
+describe("probe script shape", () => {
+  it("emits a script with no filesystem access on macOS", () => {
+    const darwin = buildProbeScript("darwin");
+    expect(darwin).not.toContain("cd ");
+    expect(darwin).not.toContain("pwd");
+    expect(darwin).not.toContain("readlink");
+  });
+
+  it("keeps shell canonicalization on non-macOS platforms", () => {
+    const linuxScript = buildProbeScript("linux");
+    expect(linuxScript).toContain('(cd "$d" 2>/dev/null && pwd -P)');
+    expect(buildProbeScript("win32")).toBe(linuxScript);
+  });
+});

--- a/packages/client/src/__tests__/probe-failure.test.ts
+++ b/packages/client/src/__tests__/probe-failure.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  artifactOrTransientProbeIssue,
+  classifiedProviderProbeIssue,
   isBinaryShapedProviderProbeFailure,
   isTransientProviderProbeFailure,
   readProbeFailureEvidence,
@@ -28,13 +28,20 @@ describe("provider probe failure taxonomy", () => {
     expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("usr"), { signal: "SIGUSR1" }))).toBe(false);
   });
 
-  it("treats clean non-zero exits and ENOENT as binary-shaped", () => {
+  it("treats only known artifact errno, clean non-zero exits, and crash signals as binary-shaped", () => {
     expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("exit"), { code: 1 }))).toBe(true);
     expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("missing"), { code: "ENOENT" }))).toBe(true);
+    expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("denied"), { code: "EACCES" }))).toBe(true);
+    expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("format"), { code: "ENOEXEC" }))).toBe(true);
+    expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("loop"), { code: "ELOOP" }))).toBe(true);
+    expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("io"), { code: "EIO" }))).toBe(false);
+    expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("ok"), { exitCode: 0 }))).toBe(false);
     expect(isBinaryShapedProviderProbeFailure(new Error("plain"))).toBe(false);
-    expect(artifactOrTransientProbeIssue(Object.assign(new Error("busy"), { code: "EAGAIN" }), "x")).toEqual({
+    expect(classifiedProviderProbeIssue(Object.assign(new Error("busy"), { code: "EAGAIN" }), "x")).toEqual({
       code: "temporarily_unavailable",
       message: "x",
     });
+    expect(classifiedProviderProbeIssue(new Error("plain"), "x")).toBeUndefined();
+    expect(classifiedProviderProbeIssue("bare", "x")).toBeUndefined();
   });
 });

--- a/packages/client/src/__tests__/probe-failure.test.ts
+++ b/packages/client/src/__tests__/probe-failure.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  artifactOrTransientProbeIssue,
+  isBinaryShapedProviderProbeFailure,
+  isTransientProviderProbeFailure,
+  readProbeFailureEvidence,
+} from "../agent-runtime/probe-failure.js";
+
+describe("provider probe failure taxonomy", () => {
+  it("reads no evidence from non-object values", () => {
+    expect(readProbeFailureEvidence(null)).toEqual({});
+    expect(readProbeFailureEvidence("timeout")).toEqual({});
+    expect(isTransientProviderProbeFailure(null)).toBe(false);
+    expect(isBinaryShapedProviderProbeFailure("x")).toBe(false);
+  });
+
+  it("treats crash signals as binary even when killed is set", () => {
+    const error = Object.assign(new Error("crash"), { killed: true, signal: "SIGSEGV" });
+    expect(isTransientProviderProbeFailure(error)).toBe(false);
+    expect(isBinaryShapedProviderProbeFailure(error)).toBe(true);
+  });
+
+  it("treats unknown non-crash signals and timeout kills as transient", () => {
+    expect(isTransientProviderProbeFailure(Object.assign(new Error("usr"), { signal: "SIGUSR1" }))).toBe(true);
+    expect(isTransientProviderProbeFailure(Object.assign(new Error("kill"), { killed: true, signal: "SIGKILL" }))).toBe(
+      true,
+    );
+    expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("usr"), { signal: "SIGUSR1" }))).toBe(false);
+  });
+
+  it("treats clean non-zero exits and ENOENT as binary-shaped", () => {
+    expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("exit"), { code: 1 }))).toBe(true);
+    expect(isBinaryShapedProviderProbeFailure(Object.assign(new Error("missing"), { code: "ENOENT" }))).toBe(true);
+    expect(isBinaryShapedProviderProbeFailure(new Error("plain"))).toBe(false);
+    expect(artifactOrTransientProbeIssue(Object.assign(new Error("busy"), { code: "EAGAIN" }), "x")).toEqual({
+      code: "temporarily_unavailable",
+      message: "x",
+    });
+  });
+});

--- a/packages/client/src/__tests__/resolved-runtime-factory.test.ts
+++ b/packages/client/src/__tests__/resolved-runtime-factory.test.ts
@@ -1,0 +1,412 @@
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentRuntimeProbeResult } from "../agent-runtime/types.js";
+import { ClaudeCodeAgentRuntimeFactory } from "../providers/claude-code/agent-runtime.js";
+import { CodexAgentRuntimeFactory } from "../providers/codex/agent-runtime.js";
+import { resolvedClaudeCodeFactory, resolvedCodexFactory } from "../runtime/client-runtime-composition.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "opentag-resolved-factory-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+async function executable(dir: string, name: string): Promise<string> {
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, name);
+  await writeFile(path, "#!/bin/sh\n", { mode: 0o700 });
+  await chmod(path, 0o700);
+  return path;
+}
+
+function issues(result: AgentRuntimeProbeResult): string[] {
+  return result.issues.map((issue) => issue.code);
+}
+
+describe("resolved provider factories candidate fallback", () => {
+  it("advances to the next same-Provider candidate on version_incompatible and does not spawn login-shell", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    const wellKnown = join(root, "well-known");
+    const stale = await realpath(await executable(caller, "codex"));
+    const working = await realpath(await executable(wellKnown, "codex"));
+    const loginShellPathDirs = vi.fn(async () => [join(root, "login")]);
+    const probed: string[] = [];
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: "codex",
+      codexHome: root,
+      environment: {},
+      sourceEnvironment: { PATH: caller },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: true,
+        loginShellPathDirs,
+        platform: "linux",
+        wellKnownDirs: () => [wellKnown],
+      },
+      createCandidateFactory: (command) => {
+        probed.push(command);
+        return new CodexAgentRuntimeFactory({
+          clientVersion: "test",
+          probeRunner: async () => {
+            if (command === stale) {
+              throw Object.assign(new Error("old"), { code: 1 });
+            }
+            return { appServer: true, credential: true, experimentalTools: true, version: "new" };
+          },
+        });
+      },
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({ ready: true, version: "new" });
+    expect(probed).toEqual([stale, working]);
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+  });
+
+  it("advances Claude Code to the next same-Provider candidate after a deterministic binary failure", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    const wellKnown = join(root, "well-known");
+    const stale = await realpath(await executable(caller, "claude"));
+    const working = await realpath(await executable(wellKnown, "claude"));
+    const probed: string[] = [];
+    const factory = resolvedClaudeCodeFactory({
+      claudeCodeHome: root,
+      command: "claude",
+      environment: {},
+      sourceEnvironment: { PATH: caller },
+      discovery: {
+        candidateAllowed: () => true,
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [wellKnown],
+      },
+      createCandidateFactory: (command) => {
+        probed.push(command);
+        return new ClaudeCodeAgentRuntimeFactory({
+          probeRunner: async () => {
+            if (command === stale) throw Object.assign(new Error("fault"), { signal: "SIGSEGV" });
+            return { credential: true, streamJson: true, version: "new" };
+          },
+        });
+      },
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({ ready: true, version: "new" });
+    expect(probed).toEqual([stale, working]);
+  });
+
+  it("does not advance on credential_missing, mixed issues, or temporarily_unavailable", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    const wellKnown = join(root, "well-known");
+    const first = await realpath(await executable(caller, "codex"));
+    await executable(wellKnown, "codex");
+    const cases: Array<{ result: AgentRuntimeProbeResult; expected: string }> = [
+      {
+        result: { ready: false, issues: [{ code: "credential_missing", message: "logged out" }] },
+        expected: "credential_missing",
+      },
+      {
+        result: {
+          ready: false,
+          issues: [
+            { code: "version_incompatible", message: "old" },
+            { code: "credential_missing", message: "logged out" },
+          ],
+        },
+        expected: "version_incompatible",
+      },
+      {
+        result: { ready: false, issues: [{ code: "temporarily_unavailable", message: "timeout" }] },
+        expected: "temporarily_unavailable",
+      },
+      {
+        result: { ready: false, issues: [{ code: "configuration_invalid", message: "bad" }] },
+        expected: "configuration_invalid",
+      },
+    ];
+    for (const testCase of cases) {
+      const probed: string[] = [];
+      const canned = resolvedCodexFactory({
+        clientVersion: "test",
+        command: "codex",
+        codexHome: root,
+        environment: {},
+        sourceEnvironment: { PATH: caller },
+        discovery: {
+          candidateAllowed: () => true,
+          desktopAppDirs: () => [],
+          home: root,
+          includeLoginShell: false,
+          platform: "linux",
+          wellKnownDirs: () => [wellKnown],
+        },
+        createCandidateFactory: (command) => {
+          probed.push(command);
+          return {
+            manifest: new CodexAgentRuntimeFactory({ clientVersion: "test" }).manifest,
+            probe: async () => testCase.result,
+            create: async () => {
+              throw new Error("unused");
+            },
+            resume: async () => {
+              throw new Error("unused");
+            },
+          } as unknown as CodexAgentRuntimeFactory;
+        },
+      });
+      const result = await canned.probe({});
+      expect(issues(result)).toContain(testCase.expected);
+      expect(probed).toEqual([first]);
+    }
+  });
+
+  it("does not give an absolute explicit command fallback semantics", async () => {
+    const root = await temporaryRoot();
+    const explicit = await realpath(await executable(root, "explicit-codex"));
+    const other = join(root, "other");
+    await executable(other, "codex");
+    const loginShellPathDirs = vi.fn(async () => [other]);
+    const probed: string[] = [];
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: explicit,
+      codexHome: root,
+      environment: {},
+      sourceEnvironment: { PATH: other },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [other],
+        home: root,
+        includeLoginShell: true,
+        loginShellPathDirs,
+        platform: "linux",
+        wellKnownDirs: () => [other],
+      },
+      createCandidateFactory: (command) => {
+        probed.push(command);
+        return new CodexAgentRuntimeFactory({
+          clientVersion: "test",
+          probeRunner: async () => {
+            throw Object.assign(new Error("old"), { code: 1 });
+          },
+        });
+      },
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "artifact_missing" }],
+    });
+    expect(probed).toEqual([explicit]);
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+  });
+
+  it("skips login-shell on pre-connect and consults it when includeLoginShell becomes true", async () => {
+    const root = await temporaryRoot();
+    const login = join(root, "login");
+    const working = await realpath(await executable(login, "claude"));
+    let includeLoginShell = false;
+    const loginShellPathDirs = vi.fn(async () => [login]);
+    const factory = resolvedClaudeCodeFactory({
+      claudeCodeHome: root,
+      command: "claude",
+      environment: {},
+      sourceEnvironment: { PATH: "" },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: () => includeLoginShell,
+        loginShellPathDirs,
+        platform: "linux",
+        wellKnownDirs: () => [],
+      },
+      createCandidateFactory: (command) =>
+        new ClaudeCodeAgentRuntimeFactory({
+          probeRunner: async () => {
+            if (command !== working) throw new Error("missing");
+            return { credential: true, streamJson: true, version: "2" };
+          },
+        }),
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "artifact_missing" }],
+    });
+    expect(loginShellPathDirs).not.toHaveBeenCalled();
+    includeLoginShell = true;
+    await expect(factory.probe({})).resolves.toMatchObject({ ready: true, version: "2" });
+    expect(loginShellPathDirs).toHaveBeenCalledOnce();
+  });
+
+  it("never substitutes another Provider when Codex candidates are exhausted", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    await executable(caller, "codex");
+    await executable(caller, "claude");
+    const probed: string[] = [];
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: "codex",
+      codexHome: root,
+      environment: {},
+      sourceEnvironment: { PATH: caller },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [],
+      },
+      createCandidateFactory: (command) => {
+        probed.push(command);
+        return new CodexAgentRuntimeFactory({
+          clientVersion: "test",
+          probeRunner: async () => {
+            throw Object.assign(new Error("old"), { code: 1 });
+          },
+        });
+      },
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "artifact_missing" }],
+    });
+    expect(probed.every((command) => command.endsWith("codex"))).toBe(true);
+    expect(probed.some((command) => command.endsWith("claude"))).toBe(false);
+  });
+
+  it("returns artifact_missing when discovery yields no candidates", async () => {
+    const root = await temporaryRoot();
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: "codex",
+      codexHome: root,
+      environment: {},
+      sourceEnvironment: { PATH: "" },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [],
+      },
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "artifact_missing" }],
+    });
+  });
+
+  it("returns the last Claude binary-shaped result after same-Provider candidate fallback", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    await realpath(await executable(caller, "claude"));
+    const factory = resolvedClaudeCodeFactory({
+      claudeCodeHome: root,
+      command: "claude",
+      environment: {},
+      sourceEnvironment: { PATH: caller },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [],
+      },
+      createCandidateFactory: () =>
+        new ClaudeCodeAgentRuntimeFactory({
+          probeRunner: async () => {
+            throw Object.assign(new Error("old"), { code: 1 });
+          },
+        }),
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "artifact_missing" }],
+    });
+  });
+
+  it("maps a missing absolute Claude command through discovery failure without fallback", async () => {
+    const root = await temporaryRoot();
+    const factory = resolvedClaudeCodeFactory({
+      claudeCodeHome: root,
+      command: join(root, "missing-claude"),
+      environment: {},
+      sourceEnvironment: {},
+      discovery: {
+        includeLoginShell: false,
+        platform: "linux",
+        home: root,
+        wellKnownDirs: () => [],
+        desktopAppDirs: () => [],
+      },
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "artifact_missing" }],
+    });
+  });
+
+  it("rethrows an aborted Codex discovery failure", async () => {
+    const root = await temporaryRoot();
+    const controller = new AbortController();
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: "codex",
+      codexHome: root,
+      environment: {},
+      sourceEnvironment: { PATH: join(root, "bin") },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [],
+        stat: async () => {
+          controller.abort(new Error("stop discovery"));
+          throw Object.assign(new Error("io"), { code: "EIO" });
+        },
+      },
+    });
+    await expect(factory.probe({ signal: controller.signal })).rejects.toThrow();
+  });
+
+  it("rethrows an aborted Claude discovery failure", async () => {
+    const root = await temporaryRoot();
+    const controller = new AbortController();
+    const factory = resolvedClaudeCodeFactory({
+      claudeCodeHome: root,
+      command: "claude",
+      environment: {},
+      sourceEnvironment: { PATH: "" },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => {
+          controller.abort(new Error("stop Claude discovery"));
+          throw new Error("well-known failed");
+        },
+      },
+    });
+    await expect(factory.probe({ signal: controller.signal })).rejects.toThrow("well-known failed");
+  });
+});

--- a/packages/client/src/__tests__/resolved-runtime-factory.test.ts
+++ b/packages/client/src/__tests__/resolved-runtime-factory.test.ts
@@ -1,8 +1,10 @@
-import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AgentRuntimeProbeResult } from "../agent-runtime/types.js";
+import type { AgentRuntimeProbeResult, CreateAgentRuntimeRequest } from "../agent-runtime/types.js";
 import { ClaudeCodeAgentRuntimeFactory } from "../providers/claude-code/agent-runtime.js";
 import { CodexAgentRuntimeFactory } from "../providers/codex/agent-runtime.js";
 import { resolvedClaudeCodeFactory, resolvedCodexFactory } from "../runtime/client-runtime-composition.js";
@@ -409,4 +411,283 @@ describe("resolved provider factories candidate fallback", () => {
     });
     await expect(factory.probe({ signal: controller.signal })).rejects.toThrow("well-known failed");
   });
+
+  it("maps discovery-unknown to non-advancing temporarily_unavailable", async () => {
+    const root = await temporaryRoot();
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: "codex",
+      codexHome: root,
+      environment: {},
+      sourceEnvironment: { PATH: join(root, "bin") },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [],
+        stat: async () => {
+          throw Object.assign(new Error("io"), { code: "EIO" });
+        },
+      },
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({
+      ready: false,
+      issues: [{ code: "temporarily_unavailable" }],
+    });
+  });
+
+  it("propagates candidate factory construction errors", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    await executable(caller, "codex");
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: "codex",
+      codexHome: root,
+      environment: {},
+      sourceEnvironment: { PATH: caller },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [],
+      },
+      createCandidateFactory: () => {
+        throw new Error("factory exploded");
+      },
+    });
+    await expect(factory.probe({})).rejects.toThrow("factory exploded");
+  });
+
+  it("propagates candidate probe errors outside the discovery catch", async () => {
+    const root = await temporaryRoot();
+    const caller = join(root, "caller");
+    await executable(caller, "claude");
+    const factory = resolvedClaudeCodeFactory({
+      claudeCodeHome: root,
+      command: "claude",
+      environment: {},
+      sourceEnvironment: { PATH: caller },
+      discovery: {
+        candidateAllowed: () => true,
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => [],
+      },
+      createCandidateFactory: () =>
+        ({
+          manifest: new ClaudeCodeAgentRuntimeFactory().manifest,
+          probe: async () => {
+            throw new Error("probe exploded");
+          },
+        }) as unknown as ClaudeCodeAgentRuntimeFactory,
+    });
+    await expect(factory.probe({})).rejects.toThrow("probe exploded");
+  });
+
+  it("propagates discovery programming errors instead of translating them", async () => {
+    const root = await temporaryRoot();
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: "codex",
+      codexHome: root,
+      environment: {},
+      sourceEnvironment: { PATH: "" },
+      discovery: {
+        candidateAllowed: () => true,
+        desktopAppDirs: () => [],
+        home: root,
+        includeLoginShell: false,
+        platform: "linux",
+        wellKnownDirs: () => {
+          throw new Error("well-known failed");
+        },
+      },
+    });
+    await expect(factory.probe({})).rejects.toThrow("well-known failed");
+  });
+
+  it("does not prepend a search bin for an explicit command", async () => {
+    const root = await temporaryRoot();
+    const empty = join(root, "empty");
+    await mkdir(empty);
+    const explicit = await realpath(await executable(root, "explicit-codex"));
+    let capturedEnv: NodeJS.ProcessEnv | undefined;
+    const factory = resolvedCodexFactory({
+      clientVersion: "test",
+      command: explicit,
+      codexHome: root,
+      environment: { PATH: empty },
+      sourceEnvironment: {},
+      createCandidateFactory: (_command, environment) => {
+        capturedEnv = environment;
+        return new CodexAgentRuntimeFactory({
+          clientVersion: "test",
+          probeRunner: async () => ({ appServer: true, credential: true, experimentalTools: true, version: "1" }),
+        });
+      },
+    });
+    await expect(factory.probe({})).resolves.toMatchObject({ ready: true });
+    expect(capturedEnv?.PATH).toBe(empty);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "executes an env-node Codex candidate by prepending its search bin, which is absent from the frozen PATH",
+    async () => {
+      const root = await temporaryRoot();
+      const home = join(root, "home");
+      const empty = join(root, "empty");
+      const version = join(home, ".nvm", "versions", "node", "v22.13.0");
+      const bin = join(version, "bin");
+      const scriptDir = join(version, "lib", "node_modules", "@openai", "codex", "bin");
+      const script = join(scriptDir, "codex.js");
+      const invocationLog = join(root, "codex-invocations.jsonl");
+      await mkdir(empty);
+      await mkdir(bin, { recursive: true });
+      await mkdir(scriptDir, { recursive: true });
+      await writeFile(
+        script,
+        [
+          "#!/usr/bin/env node",
+          'const { appendFileSync } = require("node:fs");',
+          'const { createInterface } = require("node:readline");',
+          "const args = process.argv.slice(2);",
+          'appendFileSync(process.env.FIXTURE_LOG, JSON.stringify({ args, path: process.env.PATH }) + "\\n");',
+          'if (args[0] === "--version") { process.stdout.write("codex-env-node\\n"); process.exit(0); }',
+          'if (args[0] === "login" && args[1] === "status") process.exit(0);',
+          'if (args[0] === "app-server" && args[1] === "--help") { process.stdout.write("app-server\\n"); process.exit(0); }',
+          'if (args[0] !== "app-server") process.exit(1);',
+          "const lines = createInterface({ input: process.stdin });",
+          'lines.on("line", (line) => {',
+          "  const message = JSON.parse(line);",
+          '  if (!("id" in message)) return;',
+          "  let result;",
+          '  if (message.method === "initialize") {',
+          '    result = { userAgent: "fixture", platformFamily: process.platform, platformOs: process.platform, codexHome: process.env.CODEX_HOME };',
+          '  } else if (message.method === "thread/start") {',
+          '    result = { thread: { id: "fixture-thread" } };',
+          '  } else if (message.method === "thread/resume") {',
+          "    result = { thread: { id: message.params.threadId } };",
+          "  } else {",
+          "    result = {};",
+          "  }",
+          '  process.stdout.write(JSON.stringify({ id: message.id, result }) + "\\n");',
+          "});",
+          "",
+        ].join("\n"),
+      );
+      await chmod(script, 0o755);
+      await symlink(script, join(bin, "codex"));
+      await symlink(process.execPath, join(bin, "node"));
+      const canonical = await realpath(join(bin, "codex"));
+      const frozen = { CODEX_HOME: root, FIXTURE_LOG: invocationLog, PATH: empty };
+      const execFileAsync = promisify(execFile);
+      await expect(execFileAsync(canonical, ["--version"], { env: frozen, timeout: 5_000 })).rejects.toThrow();
+      const factory = resolvedCodexFactory({
+        clientVersion: "test",
+        command: "codex",
+        codexHome: root,
+        environment: frozen,
+        sourceEnvironment: { PATH: empty },
+        discovery: {
+          candidateAllowed: () => true,
+          desktopAppDirs: () => [],
+          home: root,
+          includeLoginShell: true,
+          loginShellEnv: () => ({ nvmBin: bin }),
+          loginShellPathDirs: () => [],
+          platform: "linux",
+          wellKnownDirs: () => [],
+        },
+      });
+      await expect(factory.probe({})).resolves.toMatchObject({ ready: true, version: "codex-env-node" });
+      expect(canonical).toBe(await realpath(script));
+      const request: CreateAgentRuntimeRequest = {
+        eventSink: async () => undefined,
+        systemPrompt: "OpenTag managed system prompt",
+        workspace: { cwd: root },
+        policy: {
+          approvals: "on-request",
+          fileSystem: "workspace-write",
+          network: "disabled",
+          tools: { mode: "provider-default" },
+        },
+      };
+      const created = await factory.create(request);
+      expect(created.binding).toMatchObject({ providerId: "codex" });
+      const binding = created.binding;
+      await created.close();
+      if (!binding) throw new Error("fixture Codex binding is unavailable");
+      const resumed = await factory.resume({ ...request, binding });
+      expect(resumed.binding).toEqual(binding);
+      await resumed.close();
+      const invocations = (await readFile(invocationLog, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { args: string[]; path?: string });
+      expect(invocations.length).toBeGreaterThanOrEqual(8);
+      expect(invocations.every((invocation) => invocation.path?.split(delimiter)[0] === bin)).toBe(true);
+
+      let missingPath: NodeJS.ProcessEnv | undefined;
+      const noPath = resolvedCodexFactory({
+        clientVersion: "test",
+        command: "codex",
+        codexHome: root,
+        environment: {},
+        sourceEnvironment: { PATH: empty },
+        discovery: {
+          candidateAllowed: () => true,
+          desktopAppDirs: () => [],
+          home: root,
+          includeLoginShell: true,
+          loginShellEnv: () => ({ nvmBin: bin }),
+          loginShellPathDirs: () => [],
+          platform: "linux",
+          wellKnownDirs: () => [],
+        },
+        createCandidateFactory: (_command, environment) => {
+          missingPath = environment;
+          return new CodexAgentRuntimeFactory({
+            clientVersion: "test",
+            probeRunner: async () => ({ appServer: true, credential: true, experimentalTools: true, version: "1" }),
+          });
+        },
+      });
+      await noPath.probe({});
+      expect(missingPath?.PATH).toBe(bin);
+
+      let alreadyFirst: NodeJS.ProcessEnv | undefined;
+      const prepended = resolvedCodexFactory({
+        clientVersion: "test",
+        command: "codex",
+        codexHome: root,
+        environment: { PATH: `${bin}${delimiter}${empty}` },
+        sourceEnvironment: { PATH: empty },
+        discovery: {
+          candidateAllowed: () => true,
+          desktopAppDirs: () => [],
+          home: root,
+          includeLoginShell: true,
+          loginShellEnv: () => ({ nvmBin: bin }),
+          loginShellPathDirs: () => [],
+          platform: "linux",
+          wellKnownDirs: () => [],
+        },
+        createCandidateFactory: (_command, environment) => {
+          alreadyFirst = environment;
+          return new CodexAgentRuntimeFactory({
+            clientVersion: "test",
+            probeRunner: async () => ({ appServer: true, credential: true, experimentalTools: true, version: "1" }),
+          });
+        },
+      });
+      await prepended.probe({});
+      expect(alreadyFirst?.PATH).toBe(`${bin}${delimiter}${empty}`);
+    },
+  );
 });

--- a/packages/client/src/agent-runtime/probe-failure.ts
+++ b/packages/client/src/agent-runtime/probe-failure.ts
@@ -1,0 +1,83 @@
+import type { AgentRuntimeProbeIssue } from "./types.js";
+
+/**
+ * Spawn errnos that mean "the machine could not run the check right now", not
+ * "the binary is broken or absent". These map to `temporarily_unavailable` and
+ * must not advance same-Provider candidate fallback.
+ */
+const TRANSIENT_SPAWN_CODES: ReadonlySet<string> = new Set(["ETIMEDOUT", "EAGAIN", "ENOMEM"]);
+
+/**
+ * Kill signals that mean the binary crashed deterministically — a broken or
+ * incompatible native install that will fault the same way on every retry.
+ * These stay binary-shaped so a later same-Provider candidate may be tried.
+ * Deterministic crash signals take precedence over a generic `killed` flag.
+ */
+const DETERMINISTIC_CRASH_SIGNALS: ReadonlySet<string> = new Set(["SIGSEGV", "SIGABRT", "SIGILL", "SIGBUS", "SIGFPE"]);
+
+export type ProbeFailureEvidence = {
+  readonly errno?: string;
+  readonly exitCode?: number | null;
+  readonly signal?: string;
+  readonly killed?: boolean;
+};
+
+export function readProbeFailureEvidence(error: unknown): ProbeFailureEvidence {
+  if (!error || typeof error !== "object") return {};
+  const err = error as NodeJS.ErrnoException & {
+    errno?: unknown;
+    exitCode?: unknown;
+    signal?: unknown;
+    killed?: unknown;
+  };
+  const errno =
+    typeof err.errno === "string"
+      ? err.errno
+      : typeof err.code === "string" && err.code.startsWith("E")
+        ? err.code
+        : undefined;
+  const exitCode =
+    typeof err.exitCode === "number"
+      ? err.exitCode
+      : err.exitCode === null
+        ? null
+        : typeof err.code === "number"
+          ? err.code
+          : undefined;
+  const signal = typeof err.signal === "string" ? err.signal : undefined;
+  return {
+    ...(errno ? { errno } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    ...(signal ? { signal } : {}),
+    ...(err.killed === true ? { killed: true } : {}),
+  };
+}
+
+export function isDeterministicCrashSignal(signal: string | undefined): boolean {
+  return signal !== undefined && DETERMINISTIC_CRASH_SIGNALS.has(signal);
+}
+
+export function isTransientProviderProbeFailure(error: unknown): boolean {
+  const evidence = readProbeFailureEvidence(error);
+  if (isDeterministicCrashSignal(evidence.signal)) return false;
+  if (evidence.errno && TRANSIENT_SPAWN_CODES.has(evidence.errno)) return true;
+  if (evidence.killed) return true;
+  if (evidence.signal) return true;
+  return false;
+}
+
+export function isBinaryShapedProviderProbeFailure(error: unknown): boolean {
+  const evidence = readProbeFailureEvidence(error);
+  if (isDeterministicCrashSignal(evidence.signal)) return true;
+  if (isTransientProviderProbeFailure(error)) return false;
+  if (typeof evidence.exitCode === "number" && evidence.exitCode !== 0) return true;
+  if (typeof evidence.errno === "string") return true;
+  return false;
+}
+
+export function artifactOrTransientProbeIssue(error: unknown, artifactMessage: string): AgentRuntimeProbeIssue {
+  if (isTransientProviderProbeFailure(error)) {
+    return { code: "temporarily_unavailable", message: artifactMessage };
+  }
+  return { code: "artifact_missing", message: artifactMessage };
+}

--- a/packages/client/src/agent-runtime/probe-failure.ts
+++ b/packages/client/src/agent-runtime/probe-failure.ts
@@ -8,9 +8,15 @@ import type { AgentRuntimeProbeIssue } from "./types.js";
 const TRANSIENT_SPAWN_CODES: ReadonlySet<string> = new Set(["ETIMEDOUT", "EAGAIN", "ENOMEM"]);
 
 /**
+ * Errnos that mean the selected file is missing or not an executable artifact.
+ * Only these, together with a clean non-zero exit or a deterministic crash
+ * signal, are binary-shaped. Any other errno is unknown and must propagate.
+ */
+const ARTIFACT_ERRNOS: ReadonlySet<string> = new Set(["ENOENT", "ENOTDIR", "EISDIR", "EACCES", "ENOEXEC", "ELOOP"]);
+
+/**
  * Kill signals that mean the binary crashed deterministically — a broken or
  * incompatible native install that will fault the same way on every retry.
- * These stay binary-shaped so a later same-Provider candidate may be tried.
  * Deterministic crash signals take precedence over a generic `killed` flag.
  */
 const DETERMINISTIC_CRASH_SIGNALS: ReadonlySet<string> = new Set(["SIGSEGV", "SIGABRT", "SIGILL", "SIGBUS", "SIGFPE"]);
@@ -71,13 +77,19 @@ export function isBinaryShapedProviderProbeFailure(error: unknown): boolean {
   if (isDeterministicCrashSignal(evidence.signal)) return true;
   if (isTransientProviderProbeFailure(error)) return false;
   if (typeof evidence.exitCode === "number" && evidence.exitCode !== 0) return true;
-  if (typeof evidence.errno === "string") return true;
+  if (evidence.errno && ARTIFACT_ERRNOS.has(evidence.errno)) return true;
   return false;
 }
 
-export function artifactOrTransientProbeIssue(error: unknown, artifactMessage: string): AgentRuntimeProbeIssue {
+export function classifiedProviderProbeIssue(
+  error: unknown,
+  artifactMessage: string,
+): AgentRuntimeProbeIssue | undefined {
   if (isTransientProviderProbeFailure(error)) {
     return { code: "temporarily_unavailable", message: artifactMessage };
   }
-  return { code: "artifact_missing", message: artifactMessage };
+  if (isBinaryShapedProviderProbeFailure(error)) {
+    return { code: "artifact_missing", message: artifactMessage };
+  }
+  return undefined;
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -157,6 +157,7 @@ export {
   AgentRuntimeExecutableNotFoundError,
   type AgentRuntimeExecutableSource,
   codexDesktopAppBinDirs,
+  iterateAgentRuntimeExecutables,
   type ProbeAgentRuntimeCliInstallationsOptions,
   probeAgentRuntimeCliInstallations,
   type ResolveAgentRuntimeExecutableOptions,

--- a/packages/client/src/providers/claude-code/agent-runtime.ts
+++ b/packages/client/src/providers/claude-code/agent-runtime.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import { getRuntimeConfigurationOptions } from "@opentag/shared";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
+import { artifactOrTransientProbeIssue } from "../../agent-runtime/probe-failure.js";
 import {
   AGENT_RUNTIME_CONTRACT_VERSION,
   type AgentAbortRequest,
@@ -622,7 +623,7 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
       }
     } catch (error) {
       if (request.signal?.aborted) throw error;
-      issues.push({ code: "artifact_missing", message: "Claude Code CLI could not be executed" });
+      issues.push(artifactOrTransientProbeIssue(error, "Claude Code CLI could not be executed"));
     }
     return { ready: issues.length === 0, ...(version ? { version } : {}), issues };
   }

--- a/packages/client/src/providers/claude-code/agent-runtime.ts
+++ b/packages/client/src/providers/claude-code/agent-runtime.ts
@@ -5,7 +5,7 @@ import { promisify } from "node:util";
 import { getRuntimeConfigurationOptions } from "@opentag/shared";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
-import { artifactOrTransientProbeIssue } from "../../agent-runtime/probe-failure.js";
+import { classifiedProviderProbeIssue } from "../../agent-runtime/probe-failure.js";
 import {
   AGENT_RUNTIME_CONTRACT_VERSION,
   type AgentAbortRequest,
@@ -623,7 +623,9 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
       }
     } catch (error) {
       if (request.signal?.aborted) throw error;
-      issues.push(artifactOrTransientProbeIssue(error, "Claude Code CLI could not be executed"));
+      const issue = classifiedProviderProbeIssue(error, "Claude Code CLI could not be executed");
+      if (!issue) throw error;
+      issues.push(issue);
     }
     return { ready: issues.length === 0, ...(version ? { version } : {}), issues };
   }

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -7,6 +7,11 @@ import { getRuntimeConfigurationOptions, hashTuple } from "@opentag/shared";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
 import {
+  artifactOrTransientProbeIssue,
+  isBinaryShapedProviderProbeFailure,
+  isTransientProviderProbeFailure,
+} from "../../agent-runtime/probe-failure.js";
+import {
   AGENT_RUNTIME_CONTRACT_VERSION,
   type AgentAbortRequest,
   type AgentApprovalResponse,
@@ -1004,9 +1009,20 @@ function probeIssue(error: unknown): AgentRuntimeProbeResult["issues"][number] {
     if (error.code === "protocol") {
       return { code: "version_incompatible", message: `Codex App Server protocol is incompatible: ${error.message}` };
     }
-    return { code: "temporarily_unavailable", message: `Codex App Server is unavailable: ${error.message}` };
+    if (error.code === "timeout" || error.code === "aborted" || error.code === "write") {
+      return { code: "temporarily_unavailable", message: `Codex App Server is unavailable: ${error.message}` };
+    }
+    if (isTransientProviderProbeFailure(error)) {
+      return { code: "temporarily_unavailable", message: `Codex App Server is unavailable: ${error.message}` };
+    }
+    if (isBinaryShapedProviderProbeFailure(error)) {
+      return typeof error.exitCode === "number" && error.exitCode !== 0 && !error.signal
+        ? { code: "version_incompatible", message: `Codex App Server protocol is incompatible: ${error.message}` }
+        : { code: "artifact_missing", message: "Codex CLI could not be executed" };
+    }
+    return { code: "artifact_missing", message: "Codex CLI could not be executed" };
   }
-  return { code: "artifact_missing", message: "Codex CLI could not be executed" };
+  return artifactOrTransientProbeIssue(error, "Codex CLI could not be executed");
 }
 
 async function probeCodex(

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -7,7 +7,7 @@ import { getRuntimeConfigurationOptions, hashTuple } from "@opentag/shared";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
 import {
-  artifactOrTransientProbeIssue,
+  classifiedProviderProbeIssue,
   isBinaryShapedProviderProbeFailure,
   isTransientProviderProbeFailure,
 } from "../../agent-runtime/probe-failure.js";
@@ -870,7 +870,9 @@ export class CodexAgentRuntimeFactory implements AgentRuntimeFactory {
       }
     } catch (error) {
       if (request.signal?.aborted) throw error;
-      issues.push(probeIssue(error));
+      const issue = probeIssue(error);
+      if (!issue) throw error;
+      issues.push(issue);
     }
     return { ready: issues.length === 0, ...(version ? { version } : {}), issues };
   }
@@ -1001,7 +1003,7 @@ export function codexAgentRuntimeEnvironment(source: NodeJS.ProcessEnv = process
   return environment;
 }
 
-function probeIssue(error: unknown): AgentRuntimeProbeResult["issues"][number] {
+function probeIssue(error: unknown): AgentRuntimeProbeResult["issues"][number] | undefined {
   if (error instanceof AgentProviderError && error.code === "provider_protocol_error") {
     return { code: "version_incompatible", message: `Codex App Server protocol is incompatible: ${error.message}` };
   }
@@ -1020,9 +1022,9 @@ function probeIssue(error: unknown): AgentRuntimeProbeResult["issues"][number] {
         ? { code: "version_incompatible", message: `Codex App Server protocol is incompatible: ${error.message}` }
         : { code: "artifact_missing", message: "Codex CLI could not be executed" };
     }
-    return { code: "artifact_missing", message: "Codex CLI could not be executed" };
+    return undefined;
   }
-  return artifactOrTransientProbeIssue(error, "Codex CLI could not be executed");
+  return classifiedProviderProbeIssue(error, "Codex CLI could not be executed");
 }
 
 async function probeCodex(

--- a/packages/client/src/providers/codex/app-server-wire.ts
+++ b/packages/client/src/providers/codex/app-server-wire.ts
@@ -5,12 +5,27 @@ export const CODEX_APP_SERVER_MAX_LINE_BYTES = 1024 * 1024;
 export const CODEX_APP_SERVER_REQUEST_TIMEOUT_MS = 60_000;
 
 export class CodexAppServerError extends Error {
+  readonly errno?: string;
+  readonly exitCode?: number | null;
+  readonly signal?: NodeJS.Signals | null;
+  readonly killed?: boolean;
+
   constructor(
     readonly code: "aborted" | "exited" | "protocol" | "spawn" | "timeout" | "write",
     message: string,
+    evidence: {
+      readonly errno?: string;
+      readonly exitCode?: number | null;
+      readonly signal?: NodeJS.Signals | null;
+      readonly killed?: boolean;
+    } = {},
   ) {
     super(message);
     this.name = "CodexAppServerError";
+    if (evidence.errno !== undefined) this.errno = evidence.errno;
+    if (evidence.exitCode !== undefined) this.exitCode = evidence.exitCode;
+    if (evidence.signal !== undefined) this.signal = evidence.signal;
+    if (evidence.killed !== undefined) this.killed = evidence.killed;
   }
 }
 
@@ -126,12 +141,18 @@ export class CodexAppServerProcess implements InteractiveCodexAppServerClient {
         { cwd: options.cwd, env: options.env, detached: process.platform !== "win32" },
       );
     } catch (error) {
-      throw new CodexAppServerError("spawn", error instanceof Error ? error.message : "Codex could not be started");
+      throw new CodexAppServerError(
+        "spawn",
+        error instanceof Error ? error.message : "Codex could not be started",
+        spawnEvidence(error),
+      );
     }
     this.#child.stdout.on("data", (chunk: Buffer) => this.#onStdout(chunk));
     this.#child.stderr.on("data", () => undefined);
-    this.#child.on("error", (error) => this.#fail(new CodexAppServerError("spawn", error.message)));
-    this.#child.on("exit", () => {
+    this.#child.on("error", (error) =>
+      this.#fail(new CodexAppServerError("spawn", error.message, spawnEvidence(error))),
+    );
+    this.#child.on("exit", (exitCode, signal) => {
       this.#closed = true;
       this.#resolveExit?.();
       this.#resolveExit = undefined;
@@ -139,7 +160,7 @@ export class CodexAppServerProcess implements InteractiveCodexAppServerClient {
         const error =
           this.#buffer.byteLength > 0
             ? new CodexAppServerError("protocol", "Codex exited with a truncated JSONL line")
-            : new CodexAppServerError("exited", "Codex App Server exited");
+            : new CodexAppServerError("exited", "Codex App Server exited", { exitCode, signal });
         this.#fail(error);
       }
     });
@@ -489,6 +510,11 @@ async function settlesWithin(promise: Promise<void>, milliseconds: number): Prom
   const settled = await Promise.race([promise.then(() => true as const), timeout]);
   if (timer) clearTimeout(timer);
   return settled;
+}
+
+function spawnEvidence(error: unknown): { readonly errno?: string } {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return typeof code === "string" ? { errno: code } : {};
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/client/src/runtime/agent-runtime-installation.ts
+++ b/packages/client/src/runtime/agent-runtime-installation.ts
@@ -1,7 +1,7 @@
 import { constants, type Stats } from "node:fs";
 import { access, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { delimiter, isAbsolute, join } from "node:path";
+import { delimiter, dirname, isAbsolute, join } from "node:path";
 import type { AgentRuntimeProvider } from "@opentag/shared";
 import { type ActiveVersionManager, versionManagerBinDirs } from "./install-locations.js";
 import { type LoginShellPathDeps, probeLoginShellPath } from "./login-shell-path.js";
@@ -19,6 +19,8 @@ export interface ResolvedAgentRuntimeExecutable {
   provider: AgentRuntimeProvider;
   path: string;
   source: AgentRuntimeExecutableSource;
+  /** Directory of the search hit; used to prepend PATH for automatic candidates. */
+  searchDir?: string;
 }
 
 export type AgentRuntimeCliInstallation =
@@ -203,7 +205,7 @@ export async function* iterateAgentRuntimeExecutables(
         if (seenResolvedPaths.has(outcome.path)) continue;
         seenResolvedPaths.add(outcome.path);
         yielded = true;
-        yield { provider, path: outcome.path, source: candidate.source };
+        yield { provider, path: outcome.path, source: candidate.source, searchDir: dirname(candidate.path) };
         continue;
       }
       if (outcome.status === "unknown") firstUnknown ??= outcome.detail;

--- a/packages/client/src/runtime/agent-runtime-installation.ts
+++ b/packages/client/src/runtime/agent-runtime-installation.ts
@@ -3,9 +3,17 @@ import { access, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { delimiter, isAbsolute, join } from "node:path";
 import type { AgentRuntimeProvider } from "@opentag/shared";
+import { type ActiveVersionManager, versionManagerBinDirs } from "./install-locations.js";
+import { type LoginShellPathDeps, probeLoginShellPath } from "./login-shell-path.js";
 import { automaticCandidateAllowed } from "./protected-paths.js";
 
-export type AgentRuntimeExecutableSource = "explicit" | "caller-path" | "well-known" | "desktop-app";
+export type AgentRuntimeExecutableSource =
+  | "explicit"
+  | "caller-path"
+  | "well-known"
+  | "login-shell"
+  | "version-manager"
+  | "desktop-app";
 
 export interface ResolvedAgentRuntimeExecutable {
   provider: AgentRuntimeProvider;
@@ -45,6 +53,18 @@ export interface ResolveAgentRuntimeExecutableOptions {
   wellKnownDirs?: (home: string, platform: NodeJS.Platform) => readonly string[];
   desktopAppDirs?: (home: string, platform: NodeJS.Platform) => readonly string[];
   candidateAllowed?: (path: string, options: { platform: NodeJS.Platform; home: string }) => boolean;
+  /**
+   * Whether to consult the login-shell PATH (which may spawn a shell) and the
+   * version-manager fallback that depends on it. Default `true`. Set `false` on
+   * the daemon's pre-connect readiness path so startup never blocks on a login
+   * shell. Later refresh and Turn-triggered readiness pass `true`.
+   */
+  includeLoginShell?: boolean | (() => boolean);
+  loginShellPathDirs?: () => Promise<readonly string[]> | readonly string[];
+  loginShellEnv?: () => ActiveVersionManager | Promise<ActiveVersionManager>;
+  runShell?: LoginShellPathDeps["runShell"];
+  loginShellSpawn?: LoginShellPathDeps["spawn"];
+  versionManagerDirs?: (home: string, active: ActiveVersionManager) => readonly string[];
 }
 
 export interface ProbeAgentRuntimeCliInstallationsOptions extends ResolveAgentRuntimeExecutableOptions {
@@ -94,12 +114,50 @@ export function codexDesktopAppBinDirs(home: string, platform: NodeJS.Platform =
   ];
 }
 
+export function includeLoginShellEnabled(options: ResolveAgentRuntimeExecutableOptions = {}): boolean {
+  const value = options.includeLoginShell;
+  if (typeof value === "function") return value();
+  return value !== false;
+}
+
+/**
+ * Same-Provider candidate fallback is allowed only when the full readiness
+ * result contains at least one issue and every issue is binary-shaped.
+ * Credential, configuration, transient, mixed, or empty results must not
+ * advance, and another Provider must never be substituted.
+ */
+export function canAdvanceRuntimeCandidate(result: {
+  readonly ready: boolean;
+  readonly issues: readonly { readonly code: string }[];
+}): boolean {
+  if (result.ready || result.issues.length === 0) return false;
+  return result.issues.every((issue) => issue.code === "artifact_missing" || issue.code === "version_incompatible");
+}
+
 export async function resolveAgentRuntimeExecutable(
   provider: AgentRuntimeProvider,
   command: string,
   environment: NodeJS.ProcessEnv,
   options: ResolveAgentRuntimeExecutableOptions = {},
 ): Promise<ResolvedAgentRuntimeExecutable> {
+  for await (const candidate of iterateAgentRuntimeExecutables(provider, command, environment, options)) {
+    return candidate;
+  }
+  throw new AgentRuntimeExecutableNotFoundError(`The ${provider} Agent Runtime CLI is not installed`);
+}
+
+/**
+ * Lazy installed-candidate sequence. Later, more expensive sources are only
+ * evaluated when the consumer asks for the next candidate — the common case of
+ * a single working hit therefore keeps today's cost. An absolute explicit
+ * command remains one candidate and never gains fallback sources.
+ */
+export async function* iterateAgentRuntimeExecutables(
+  provider: AgentRuntimeProvider,
+  command: string,
+  environment: NodeJS.ProcessEnv,
+  options: ResolveAgentRuntimeExecutableOptions = {},
+): AsyncGenerator<ResolvedAgentRuntimeExecutable> {
   const dependencies = {
     access: options.access ?? access,
     realpath: options.realpath ?? realpath,
@@ -111,7 +169,8 @@ export async function resolveAgentRuntimeExecutable(
       if (outcome.status === "unknown") throw new AgentRuntimeExecutableDiscoveryError(outcome.detail);
       throw new AgentRuntimeExecutableNotFoundError(`The ${provider} Agent Runtime CLI is not installed`);
     }
-    return { provider, path: outcome.path, source: "explicit" };
+    yield { provider, path: outcome.path, source: "explicit" };
+    return;
   }
 
   const platform = options.platform ?? process.platform;
@@ -121,32 +180,52 @@ export async function resolveAgentRuntimeExecutable(
   const desktopAppDirs = options.desktopAppDirs ?? codexDesktopAppBinDirs;
   const candidateAllowed = options.candidateAllowed ?? automaticCandidateAllowed;
   const extensions = platform === "win32" ? (environment.PATHEXT ?? ".EXE;.CMD;.BAT").split(";") : [""];
-  const seen = new Set<string>();
+  const seenSearchPaths = new Set<string>();
+  const seenResolvedPaths = new Set<string>();
   let firstUnknown: string | undefined;
+  let yielded = false;
 
-  for (const candidate of executableCandidates({
-    command,
-    desktopAppDirs: provider === "codex" ? desktopAppDirs(home, platform) : [],
-    extensions,
-    pathDirs: (environment.PATH ?? "").split(pathDelimiter).filter(Boolean),
-    wellKnownDirs: wellKnownDirs(home, platform),
-  })) {
-    if (seen.has(candidate.path)) continue;
-    seen.add(candidate.path);
-    try {
-      if (!candidateAllowed(candidate.path, { platform, home })) continue;
-    } catch {
-      firstUnknown ??= "An automatic Runtime candidate could not be inspected safely";
-      continue;
+  const fromDirectories = async function* (
+    directories: readonly string[],
+    source: Exclude<AgentRuntimeExecutableSource, "explicit">,
+  ): AsyncGenerator<ResolvedAgentRuntimeExecutable> {
+    for (const candidate of executableCandidatesFrom({ command, directories, extensions, source })) {
+      if (seenSearchPaths.has(candidate.path)) continue;
+      seenSearchPaths.add(candidate.path);
+      try {
+        if (!candidateAllowed(candidate.path, { platform, home })) continue;
+      } catch {
+        firstUnknown ??= "An automatic Runtime candidate could not be inspected safely";
+        continue;
+      }
+      const outcome = await inspectExecutableCandidate(candidate.path, dependencies);
+      if (outcome.status === "installed") {
+        if (seenResolvedPaths.has(outcome.path)) continue;
+        seenResolvedPaths.add(outcome.path);
+        yielded = true;
+        yield { provider, path: outcome.path, source: candidate.source };
+        continue;
+      }
+      if (outcome.status === "unknown") firstUnknown ??= outcome.detail;
     }
-    const outcome = await inspectExecutableCandidate(candidate.path, dependencies);
-    if (outcome.status === "installed") {
-      return { provider, path: outcome.path, source: candidate.source };
-    }
-    if (outcome.status === "unknown") firstUnknown ??= outcome.detail;
+  };
+
+  yield* fromDirectories((environment.PATH ?? "").split(pathDelimiter).filter(Boolean), "caller-path");
+  yield* fromDirectories(wellKnownDirs(home, platform), "well-known");
+
+  if (provider === "codex") {
+    yield* fromDirectories(desktopAppDirs(home, platform), "desktop-app");
   }
-  if (firstUnknown) throw new AgentRuntimeExecutableDiscoveryError(firstUnknown);
-  throw new AgentRuntimeExecutableNotFoundError(`The ${provider} Agent Runtime CLI is not installed`);
+
+  if (includeLoginShellEnabled(options) && platform !== "win32") {
+    const login = await resolveLoginShellLayer(home, platform, environment, options);
+    if (login) {
+      yield* fromDirectories(login.dirs, "login-shell");
+      yield* fromDirectories(login.versionManagerDirs, "version-manager");
+    }
+  }
+
+  if (!yielded && firstUnknown) throw new AgentRuntimeExecutableDiscoveryError(firstUnknown);
 }
 
 export async function probeAgentRuntimeCliInstallations(
@@ -176,6 +255,35 @@ export async function probeAgentRuntimeCliInstallations(
       }
     }),
   );
+}
+
+async function resolveLoginShellLayer(
+  home: string,
+  platform: NodeJS.Platform,
+  environment: NodeJS.ProcessEnv,
+  options: ResolveAgentRuntimeExecutableOptions,
+): Promise<{ dirs: readonly string[]; versionManagerDirs: readonly string[] } | undefined> {
+  const versionManagerOptions = { env: environment, home, platform } as const;
+  if (options.loginShellPathDirs) {
+    const dirs = await options.loginShellPathDirs();
+    const active = (await options.loginShellEnv?.()) ?? {};
+    const versionDirs = options.versionManagerDirs
+      ? options.versionManagerDirs(home, active)
+      : versionManagerBinDirs(home, { ...versionManagerOptions, active });
+    return { dirs, versionManagerDirs: versionDirs };
+  }
+  const probed = await probeLoginShellPath({
+    environment,
+    home,
+    platform,
+    runShell: options.runShell,
+    spawn: options.loginShellSpawn,
+  });
+  if (!probed.ok) return undefined;
+  const versionDirs = options.versionManagerDirs
+    ? options.versionManagerDirs(home, probed.env)
+    : versionManagerBinDirs(home, { ...versionManagerOptions, active: probed.env });
+  return { dirs: probed.dirs, versionManagerDirs: versionDirs };
 }
 
 async function inspectExecutableCandidate(
@@ -218,23 +326,16 @@ function safeErrorDetail(error: unknown, fallback: string): string {
   return error.message.slice(0, 300);
 }
 
-function* executableCandidates(options: {
+function* executableCandidatesFrom(options: {
   command: string;
   extensions: readonly string[];
-  pathDirs: readonly string[];
-  wellKnownDirs: readonly string[];
-  desktopAppDirs: readonly string[];
+  directories: readonly string[];
+  source: Exclude<AgentRuntimeExecutableSource, "explicit">;
 }): Generator<Candidate> {
-  for (const [source, directories] of [
-    ["caller-path", options.pathDirs],
-    ["well-known", options.wellKnownDirs],
-    ["desktop-app", options.desktopAppDirs],
-  ] as const) {
-    for (const directory of directories) {
-      if (!isAbsolute(directory)) continue;
-      for (const extension of options.extensions) {
-        yield { path: join(directory, `${options.command}${extension}`), source };
-      }
+  for (const directory of options.directories) {
+    if (!isAbsolute(directory)) continue;
+    for (const extension of options.extensions) {
+      yield { path: join(directory, `${options.command}${extension}`), source: options.source };
     }
   }
 }

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -38,9 +38,12 @@ import { codexRuntimePolicy, validateCodexRuntimePolicy } from "../providers/cod
 import { RuntimeStorageError } from "../storage/durable-file.js";
 import { AdmissionController } from "./admission-controller.js";
 import {
+  AgentRuntimeExecutableDiscoveryError,
+  AgentRuntimeExecutableNotFoundError,
   canAdvanceRuntimeCandidate,
   iterateAgentRuntimeExecutables,
   type ResolveAgentRuntimeExecutableOptions,
+  type ResolvedAgentRuntimeExecutable,
 } from "./agent-runtime-installation.js";
 import {
   type AgentRuntimeProviderRegistration,
@@ -598,7 +601,7 @@ export interface ResolvedCodexFactoryOptions {
   readonly environment: NodeJS.ProcessEnv;
   readonly sourceEnvironment: NodeJS.ProcessEnv;
   readonly discovery?: ResolveAgentRuntimeExecutableOptions;
-  readonly createCandidateFactory?: (command: string) => CodexAgentRuntimeFactory;
+  readonly createCandidateFactory?: (command: string, environment: NodeJS.ProcessEnv) => CodexAgentRuntimeFactory;
 }
 
 function claudeCodeProcessEnvironment(
@@ -649,40 +652,83 @@ function productionProviderRegistration(
     : { ...common, policy: claudeCodeRuntimePolicy, validate: validateClaudeCodeRuntimePolicy };
 }
 
+function withSearchBinOnPath(
+  environment: NodeJS.ProcessEnv,
+  resolved: ResolvedAgentRuntimeExecutable,
+  pathDelimiter: string = delimiter,
+): NodeJS.ProcessEnv {
+  if (resolved.source === "explicit" || !resolved.searchDir) return environment;
+  const current = environment.PATH;
+  if (!current) return { ...environment, PATH: resolved.searchDir };
+  if (current === resolved.searchDir || current.startsWith(`${resolved.searchDir}${pathDelimiter}`)) {
+    return environment;
+  }
+  return { ...environment, PATH: `${resolved.searchDir}${pathDelimiter}${current}` };
+}
+
+function translateExecutableDiscoveryError(
+  error: unknown,
+  signal: AbortSignal | undefined,
+  artifactMessage: string,
+): AgentRuntimeProbeResult {
+  if (signal?.aborted) throw error;
+  if (error instanceof AgentRuntimeExecutableNotFoundError) {
+    return {
+      ready: false,
+      issues: [{ code: "artifact_missing", message: artifactMessage }],
+    };
+  }
+  if (error instanceof AgentRuntimeExecutableDiscoveryError) {
+    return {
+      ready: false,
+      issues: [{ code: "temporarily_unavailable", message: artifactMessage }],
+    };
+  }
+  throw error;
+}
+
 export function resolvedCodexFactory(options: ResolvedCodexFactoryOptions): AgentRuntimeFactory {
   let readyFactory: CodexAgentRuntimeFactory | undefined;
   const createCandidate =
     options.createCandidateFactory ??
-    ((command: string) =>
+    ((command: string, environment: NodeJS.ProcessEnv) =>
       new CodexAgentRuntimeFactory({
         clientVersion: options.clientVersion,
-        process: { command, env: options.environment, expectedCodexHome: options.codexHome },
+        process: { command, env: environment, expectedCodexHome: options.codexHome },
       }));
   return {
     manifest: CODEX_AGENT_RUNTIME_MANIFEST,
     async probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult> {
       request.signal?.throwIfAborted();
       let lastBinaryResult: AgentRuntimeProbeResult | undefined;
-      try {
-        for await (const resolved of iterateAgentRuntimeExecutables(
-          "codex",
-          options.command,
-          options.sourceEnvironment,
-          options.discovery,
-        )) {
-          request.signal?.throwIfAborted();
-          const candidate = createCandidate(resolved.path);
-          const result = await candidate.probe(request);
-          if (result.ready) {
-            readyFactory = candidate;
-            return result;
-          }
-          if (!canAdvanceRuntimeCandidate(result)) return result;
-          lastBinaryResult = result;
+      const candidates = iterateAgentRuntimeExecutables(
+        "codex",
+        options.command,
+        options.sourceEnvironment,
+        options.discovery,
+      );
+      while (true) {
+        let step: IteratorResult<ResolvedAgentRuntimeExecutable>;
+        try {
+          step = await candidates.next();
+        } catch (error) {
+          return translateExecutableDiscoveryError(error, request.signal, "Codex CLI could not be executed");
         }
-      } catch (error) {
-        if (request.signal?.aborted) throw error;
-        return { ready: false, issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }] };
+        if (step.done) break;
+        request.signal?.throwIfAborted();
+        const environment = withSearchBinOnPath(
+          options.environment,
+          step.value,
+          options.discovery?.pathDelimiter ?? delimiter,
+        );
+        const candidate = createCandidate(step.value.path, environment);
+        const result = await candidate.probe(request);
+        if (result.ready) {
+          readyFactory = candidate;
+          return result;
+        }
+        if (!canAdvanceRuntimeCandidate(result)) return result;
+        lastBinaryResult = result;
       }
       return (
         lastBinaryResult ?? {
@@ -711,45 +757,50 @@ export interface ResolvedClaudeCodeFactoryOptions {
   readonly environment: NodeJS.ProcessEnv;
   readonly sourceEnvironment: NodeJS.ProcessEnv;
   readonly discovery?: ResolveAgentRuntimeExecutableOptions;
-  readonly createCandidateFactory?: (command: string) => ClaudeCodeAgentRuntimeFactory;
+  readonly createCandidateFactory?: (command: string, environment: NodeJS.ProcessEnv) => ClaudeCodeAgentRuntimeFactory;
 }
 
 export function resolvedClaudeCodeFactory(options: ResolvedClaudeCodeFactoryOptions): AgentRuntimeFactory {
   let readyFactory: ClaudeCodeAgentRuntimeFactory | undefined;
   const createCandidate =
     options.createCandidateFactory ??
-    ((command: string) =>
+    ((command: string, environment: NodeJS.ProcessEnv) =>
       new ClaudeCodeAgentRuntimeFactory({
-        process: { command, env: options.environment },
+        process: { command, env: environment },
       }));
   return {
     manifest: CLAUDE_CODE_AGENT_RUNTIME_MANIFEST,
     async probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult> {
       request.signal?.throwIfAborted();
       let lastBinaryResult: AgentRuntimeProbeResult | undefined;
-      try {
-        for await (const resolved of iterateAgentRuntimeExecutables(
-          "claude-code",
-          options.command,
-          options.sourceEnvironment,
-          options.discovery,
-        )) {
-          request.signal?.throwIfAborted();
-          const candidate = createCandidate(resolved.path);
-          const result = await candidate.probe(request);
-          if (result.ready) {
-            readyFactory = candidate;
-            return result;
-          }
-          if (!canAdvanceRuntimeCandidate(result)) return result;
-          lastBinaryResult = result;
+      const candidates = iterateAgentRuntimeExecutables(
+        "claude-code",
+        options.command,
+        options.sourceEnvironment,
+        options.discovery,
+      );
+      while (true) {
+        let step: IteratorResult<ResolvedAgentRuntimeExecutable>;
+        try {
+          step = await candidates.next();
+        } catch (error) {
+          return translateExecutableDiscoveryError(error, request.signal, "Claude Code CLI could not be executed");
         }
-      } catch (error) {
-        if (request.signal?.aborted) throw error;
-        return {
-          ready: false,
-          issues: [{ code: "artifact_missing", message: "Claude Code CLI could not be executed" }],
-        };
+        if (step.done) break;
+        request.signal?.throwIfAborted();
+        const environment = withSearchBinOnPath(
+          options.environment,
+          step.value,
+          options.discovery?.pathDelimiter ?? delimiter,
+        );
+        const candidate = createCandidate(step.value.path, environment);
+        const result = await candidate.probe(request);
+        if (result.ready) {
+          readyFactory = candidate;
+          return result;
+        }
+        if (!canAdvanceRuntimeCandidate(result)) return result;
+        lastBinaryResult = result;
       }
       return (
         lastBinaryResult ?? {

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -37,7 +37,11 @@ import {
 import { codexRuntimePolicy, validateCodexRuntimePolicy } from "../providers/codex/runtime-policy.js";
 import { RuntimeStorageError } from "../storage/durable-file.js";
 import { AdmissionController } from "./admission-controller.js";
-import { resolveAgentRuntimeExecutable } from "./agent-runtime-installation.js";
+import {
+  canAdvanceRuntimeCandidate,
+  iterateAgentRuntimeExecutables,
+  type ResolveAgentRuntimeExecutableOptions,
+} from "./agent-runtime-installation.js";
 import {
   type AgentRuntimeProviderRegistration,
   AgentRuntimeProviderRegistry,
@@ -247,6 +251,10 @@ export async function createClientRuntime(
     codex: createHash("sha256").update(codexHome, "utf8").digest("hex"),
     "claude-code": createHash("sha256").update(claudeCodeHome, "utf8").digest("hex"),
   };
+  let includeLoginShell = false;
+  const discovery: ResolveAgentRuntimeExecutableOptions = {
+    includeLoginShell: () => includeLoginShell,
+  };
   const factories =
     options.factories ??
     (options.factory
@@ -256,12 +264,14 @@ export async function createClientRuntime(
             clientVersion: options.clientVersion,
             command: codexCommand,
             codexHome,
+            discovery,
             environment: codexEnvironment,
             sourceEnvironment,
           }),
           resolvedClaudeCodeFactory({
             claudeCodeHome,
             command: claudeCodeCommand,
+            discovery,
             environment: claudeCodeEnvironment,
             sourceEnvironment,
           }),
@@ -407,6 +417,7 @@ export async function createClientRuntime(
     capabilityAbort.abort(error);
     throw error;
   }
+  includeLoginShell = true;
 
   const bindingStore = new SessionBindingStore({
     home: options.home,
@@ -586,6 +597,8 @@ export interface ResolvedCodexFactoryOptions {
   readonly command: string;
   readonly environment: NodeJS.ProcessEnv;
   readonly sourceEnvironment: NodeJS.ProcessEnv;
+  readonly discovery?: ResolveAgentRuntimeExecutableOptions;
+  readonly createCandidateFactory?: (command: string) => CodexAgentRuntimeFactory;
 }
 
 function claudeCodeProcessEnvironment(
@@ -638,24 +651,45 @@ function productionProviderRegistration(
 
 export function resolvedCodexFactory(options: ResolvedCodexFactoryOptions): AgentRuntimeFactory {
   let readyFactory: CodexAgentRuntimeFactory | undefined;
+  const createCandidate =
+    options.createCandidateFactory ??
+    ((command: string) =>
+      new CodexAgentRuntimeFactory({
+        clientVersion: options.clientVersion,
+        process: { command, env: options.environment, expectedCodexHome: options.codexHome },
+      }));
   return {
     manifest: CODEX_AGENT_RUNTIME_MANIFEST,
     async probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult> {
-      let command: string;
+      request.signal?.throwIfAborted();
+      let lastBinaryResult: AgentRuntimeProbeResult | undefined;
       try {
-        request.signal?.throwIfAborted();
-        command = (await resolveAgentRuntimeExecutable("codex", options.command, options.sourceEnvironment)).path;
+        for await (const resolved of iterateAgentRuntimeExecutables(
+          "codex",
+          options.command,
+          options.sourceEnvironment,
+          options.discovery,
+        )) {
+          request.signal?.throwIfAborted();
+          const candidate = createCandidate(resolved.path);
+          const result = await candidate.probe(request);
+          if (result.ready) {
+            readyFactory = candidate;
+            return result;
+          }
+          if (!canAdvanceRuntimeCandidate(result)) return result;
+          lastBinaryResult = result;
+        }
       } catch (error) {
         if (request.signal?.aborted) throw error;
         return { ready: false, issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }] };
       }
-      const candidate = new CodexAgentRuntimeFactory({
-        clientVersion: options.clientVersion,
-        process: { command, env: options.environment, expectedCodexHome: options.codexHome },
-      });
-      const result = await candidate.probe(request);
-      if (result.ready) readyFactory = candidate;
-      return result;
+      return (
+        lastBinaryResult ?? {
+          ready: false,
+          issues: [{ code: "artifact_missing", message: "Codex CLI could not be executed" }],
+        }
+      );
     },
     create(request: CreateAgentRuntimeRequest) {
       return requireReadyCodexFactory(readyFactory).create(request);
@@ -676,17 +710,40 @@ export interface ResolvedClaudeCodeFactoryOptions {
   readonly command: string;
   readonly environment: NodeJS.ProcessEnv;
   readonly sourceEnvironment: NodeJS.ProcessEnv;
+  readonly discovery?: ResolveAgentRuntimeExecutableOptions;
+  readonly createCandidateFactory?: (command: string) => ClaudeCodeAgentRuntimeFactory;
 }
 
 export function resolvedClaudeCodeFactory(options: ResolvedClaudeCodeFactoryOptions): AgentRuntimeFactory {
   let readyFactory: ClaudeCodeAgentRuntimeFactory | undefined;
+  const createCandidate =
+    options.createCandidateFactory ??
+    ((command: string) =>
+      new ClaudeCodeAgentRuntimeFactory({
+        process: { command, env: options.environment },
+      }));
   return {
     manifest: CLAUDE_CODE_AGENT_RUNTIME_MANIFEST,
     async probe(request: AgentRuntimeProbeRequest): Promise<AgentRuntimeProbeResult> {
-      let command: string;
+      request.signal?.throwIfAborted();
+      let lastBinaryResult: AgentRuntimeProbeResult | undefined;
       try {
-        request.signal?.throwIfAborted();
-        command = (await resolveAgentRuntimeExecutable("claude-code", options.command, options.sourceEnvironment)).path;
+        for await (const resolved of iterateAgentRuntimeExecutables(
+          "claude-code",
+          options.command,
+          options.sourceEnvironment,
+          options.discovery,
+        )) {
+          request.signal?.throwIfAborted();
+          const candidate = createCandidate(resolved.path);
+          const result = await candidate.probe(request);
+          if (result.ready) {
+            readyFactory = candidate;
+            return result;
+          }
+          if (!canAdvanceRuntimeCandidate(result)) return result;
+          lastBinaryResult = result;
+        }
       } catch (error) {
         if (request.signal?.aborted) throw error;
         return {
@@ -694,12 +751,12 @@ export function resolvedClaudeCodeFactory(options: ResolvedClaudeCodeFactoryOpti
           issues: [{ code: "artifact_missing", message: "Claude Code CLI could not be executed" }],
         };
       }
-      const candidate = new ClaudeCodeAgentRuntimeFactory({
-        process: { command, env: options.environment },
-      });
-      const result = await candidate.probe(request);
-      if (result.ready) readyFactory = candidate;
-      return result;
+      return (
+        lastBinaryResult ?? {
+          ready: false,
+          issues: [{ code: "artifact_missing", message: "Claude Code CLI could not be executed" }],
+        }
+      );
     },
     create(request: CreateAgentRuntimeRequest) {
       return requireReadyClaudeCodeFactory(readyFactory).create(request);

--- a/packages/client/src/runtime/install-locations.ts
+++ b/packages/client/src/runtime/install-locations.ts
@@ -1,0 +1,130 @@
+import { readdirSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { protectedRoots, type ReadLink, resolveOutsideProtectedRoots } from "./protected-paths.js";
+
+/** Injectable directory listing so tests need no real version-manager install. */
+export type ReadDirNames = (path: string) => string[];
+
+/**
+ * What the login shell reported about the version manager it had active.
+ * `nvmBin` names the selected version outright; `fnmDir` names only the root it
+ * was selected from, leaving the version still to be determined.
+ */
+export type ActiveVersionManager = { fnmDir?: string; nvmBin?: string };
+
+/** Injectable seams so tests need neither a real install nor a real filesystem. */
+export type VersionManagerDirDeps = {
+  active?: ActiveVersionManager;
+  readDir?: ReadDirNames;
+  readLink?: ReadLink;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  home?: string;
+};
+
+type RootScan = { kind: "skip" } | { kind: "ambiguous" } | { kind: "one"; dir: string };
+
+/**
+ * The `bin` dir to fall back to when a version manager's per-session `$PATH`
+ * entry is gone, or nothing when the selected version cannot be established.
+ *
+ * The answer must never be a guess. Resolving a version the user did not select
+ * silently swaps the executable and its context, which is worse than reporting
+ * the provider as not found, so the decision is made across the complete state
+ * rather than per root:
+ *
+ *   - The login shell reported exactly one manager. Only that is used.
+ *     `$NVM_BIN` names the selected version outright and is authoritative,
+ *     replacing any nvm enumeration. `$FNM_DIR` names only the active root, so
+ *     that root — and no other — is consulted, and it answers only if it holds
+ *     exactly one version. Default roots are not scanned at all: if we know
+ *     which manager is active and it cannot answer, an unrelated installation
+ *     is not a better answer.
+ *   - The login shell reported BOTH managers. Which one was active was decided
+ *     by the live `$PATH` order, which is exactly what is no longer available,
+ *     so neither answers.
+ *   - The login shell reported nothing. The default roots are scanned and the
+ *     result is used only when there is exactly ONE safe candidate in total.
+ *     Any safe root holding more than one version, or two single-version roots,
+ *     is globally ambiguous.
+ *
+ * It is a FALLBACK, not a preference: callers search it only after the
+ * login-shell dirs, so a live selection always wins.
+ *
+ * Every root is vetted with the injected platform/home protected roots before
+ * it is listed, and every candidate before it is returned. Nothing is trusted
+ * for being spelled like a version manager.
+ */
+export function versionManagerBinDirs(home: string, deps: VersionManagerDirDeps = {}): string[] {
+  const readDir = deps.readDir ?? ((path: string) => readdirSync(path));
+  const readLink = deps.readLink;
+  const env = deps.env ?? process.env;
+  const active = deps.active ?? {};
+  const platform = deps.platform ?? process.platform;
+  const rootsHome = deps.home ?? home;
+  const protectedRootList = protectedRoots(platform, rootsHome);
+
+  const safe = (path: string): string | null => {
+    if (!isAbsolute(path)) return null;
+    if (protectedRootList.length === 0) return path;
+    return resolveOutsideProtectedRoots(path, protectedRootList, readLink);
+  };
+
+  const scanRoot = (root: string, layout: (versionsRoot: string, version: string) => string): RootScan => {
+    const vetted = safe(root);
+    if (vetted === null) return { kind: "skip" };
+    let entries: string[];
+    try {
+      entries = readDir(vetted);
+    } catch {
+      return { kind: "skip" };
+    }
+    if (entries.length === 0) return { kind: "skip" };
+    if (entries.length !== 1 || entries[0] === undefined) return { kind: "ambiguous" };
+    const candidate = layout(vetted, entries[0]);
+    const vettedCandidate = safe(candidate);
+    if (vettedCandidate === null) return { kind: "skip" };
+    return { kind: "one", dir: vettedCandidate };
+  };
+
+  const nvmLayout = (versionsRoot: string, version: string): string => join(versionsRoot, version, "bin");
+  const fnmLayout = (versionsRoot: string, version: string): string =>
+    join(versionsRoot, version, "installation", "bin");
+
+  if (active.nvmBin !== undefined || active.fnmDir !== undefined) {
+    if (active.nvmBin !== undefined && active.fnmDir !== undefined) return [];
+    if (active.nvmBin !== undefined) {
+      const vetted = safe(active.nvmBin);
+      return vetted === null ? [] : [vetted];
+    }
+    const scanned = scanRoot(join(active.fnmDir ?? "", "node-versions"), fnmLayout);
+    return scanned.kind === "one" ? [scanned.dir] : [];
+  }
+
+  const defaultRoots: Array<[string, (versionsRoot: string, version: string) => string]> = [
+    [join(home, ".nvm", "versions", "node"), nvmLayout],
+    ...[
+      env.FNM_DIR,
+      join(home, ".local", "share", "fnm"),
+      join(home, "Library", "Application Support", "fnm"),
+      join(home, ".fnm"),
+    ]
+      .filter((root): root is string => typeof root === "string" && root.length > 0)
+      .map((root): [string, (versionsRoot: string, version: string) => string] => [
+        join(root, "node-versions"),
+        fnmLayout,
+      ]),
+  ];
+
+  const seen = new Set<string>();
+  const scans: RootScan[] = [];
+  for (const [root, layout] of defaultRoots) {
+    if (seen.has(root)) continue;
+    seen.add(root);
+    scans.push(scanRoot(root, layout));
+  }
+  if (scans.some((scan) => scan.kind === "ambiguous")) return [];
+  const ones = scans.filter((scan): scan is { kind: "one"; dir: string } => scan.kind === "one");
+  const only = ones.length === 1 ? ones[0] : undefined;
+  return only ? [only.dir] : [];
+}

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -1,0 +1,252 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { sep } from "node:path";
+import type { ActiveVersionManager } from "./install-locations.js";
+import { protectedRoots, type ReadLink, resolveOutsideProtectedRoots } from "./protected-paths.js";
+
+/**
+ * Unique marker that brackets the canonical dir list in the probe output so we
+ * can isolate it from any prompt / rc-file noise the interactive login shell
+ * prints. Chosen to be vanishingly unlikely to appear in a real PATH entry.
+ */
+export const LOGIN_SHELL_PATH_DELIM = "__OT_SHELL_PATH__";
+
+/**
+ * Brackets a second section carrying the version-manager variables the login
+ * shell exported. Reading an environment variable costs no filesystem access at
+ * all, which is why these can be captured here while a symlink target cannot.
+ */
+export const LOGIN_SHELL_ENV_DELIM = "__OT_SHELL_ENV__";
+
+export const LOGIN_SHELL_PROBE_TIMEOUT_MS = 4_000;
+export const LOGIN_SHELL_PROBE_KILL_SIGNAL = "SIGKILL" as const;
+export const LOGIN_SHELL_PROBE_MAX_ATTEMPTS = 3;
+export const LOGIN_SHELL_PROBE_MAX_STDOUT_BYTES = 64 * 1024;
+
+/** The version-manager environment the login shell reported, if it reported any. */
+export type ProbedShellEnv = ActiveVersionManager;
+
+/** Injectable seam for hermetic tests — returns the raw shell stdout, or null on failure. */
+export type RunShell = () => Promise<string | null> | string | null;
+
+export type LoginShellSpawn = (
+  command: string,
+  args: readonly string[],
+  options: {
+    stdio: ["ignore", "pipe", "ignore"];
+    windowsHide: boolean;
+    env?: NodeJS.ProcessEnv;
+  },
+) => ChildProcess;
+
+export type LoginShellPathDeps = {
+  runShell?: RunShell;
+  readLink?: ReadLink;
+  platform?: NodeJS.Platform;
+  home?: string;
+  environment?: NodeJS.ProcessEnv;
+  spawn?: LoginShellSpawn;
+};
+
+export type LoginShellPathProbe = {
+  readonly ok: boolean;
+  readonly dirs: string[];
+  readonly env: ProbedShellEnv;
+};
+
+type Memo = LoginShellPathProbe;
+
+/** Cached successful probe or the settled skip, kept for the process. */
+let memo: Memo | undefined;
+/** In-flight probe shared by concurrent callers so one spawn serves them all. */
+let inFlight: Promise<Memo> | undefined;
+/** Count of probe spawns that did NOT succeed, used to enforce the attempt cap. */
+let failedAttempts = 0;
+
+export async function getLoginShellPathDirs(deps: LoginShellPathDeps = {}): Promise<string[]> {
+  return (await probeLoginShellPath(deps)).dirs;
+}
+
+export async function probeLoginShellPath(deps: LoginShellPathDeps = {}): Promise<LoginShellPathProbe> {
+  if (memo) return memo;
+  if (inFlight) return inFlight;
+  const pending = runProbe(deps);
+  inFlight = pending;
+  try {
+    return await pending;
+  } finally {
+    if (inFlight === pending) inFlight = undefined;
+  }
+}
+
+/** Reset the memoized result, in-flight probe, and attempt counter. Tests only. */
+export function resetLoginShellPathDirsCache(): void {
+  memo = undefined;
+  inFlight = undefined;
+  failedAttempts = 0;
+}
+
+async function runProbe(deps: LoginShellPathDeps): Promise<LoginShellPathProbe> {
+  const platform = deps.platform ?? process.platform;
+  if (platform === "win32") {
+    memo = { ok: false, dirs: [], env: {} };
+    return memo;
+  }
+  const runShell = deps.runShell ?? (() => defaultRunShell(deps));
+  const probed = await readProbe(runShell);
+  if (probed) {
+    const result = interpretProbe(probed, deps);
+    memo = result;
+    return result;
+  }
+  failedAttempts += 1;
+  if (failedAttempts >= LOGIN_SHELL_PROBE_MAX_ATTEMPTS) {
+    memo = { ok: false, dirs: [], env: {} };
+    return memo;
+  }
+  return { ok: false, dirs: [], env: {} };
+}
+
+async function readProbe(runShell: RunShell): Promise<{ dirs: string[]; env: ProbedShellEnv } | null> {
+  let output: string | null;
+  try {
+    output = await runShell();
+  } catch {
+    return null;
+  }
+  if (!output) return null;
+  const dirs = parsePathFromShellOutput(output);
+  if (dirs === null) return null;
+  return { dirs, env: parseShellEnv(output) };
+}
+
+function interpretProbe(
+  probed: { dirs: string[]; env: ProbedShellEnv },
+  deps: LoginShellPathDeps,
+): LoginShellPathProbe {
+  const platform = deps.platform ?? process.platform;
+  const environment = deps.environment ?? {};
+  const home =
+    deps.home ??
+    (environment.HOME && environment.HOME.length > 0 ? environment.HOME : undefined) ??
+    (process.env.HOME && process.env.HOME.length > 0 ? process.env.HOME : homedir());
+  const roots = protectedRoots(platform, home);
+  const vet = (dir: string): string | null =>
+    roots.length === 0 ? dir : resolveOutsideProtectedRoots(dir, roots, deps.readLink);
+  const resolutionDeferredPastShellExit = platform === "darwin";
+  const untrusted =
+    resolutionDeferredPastShellExit && probed.env.nvmBin !== undefined && probed.env.fnmDir !== undefined
+      ? [probed.env.nvmBin, probed.env.fnmDir].map(vet).filter((dir): dir is string => dir !== null)
+      : [];
+  const trusted = (dir: string): boolean => !untrusted.some((root) => dir === root || dir.startsWith(`${root}${sep}`));
+  const live = probed.dirs
+    .map(vet)
+    .filter((dir): dir is string => dir !== null)
+    .filter(trusted);
+  return { ok: true, dirs: live, env: probed.env };
+}
+
+/**
+ * Build the probe command the login shell launches: it prints, bracketed by
+ * {@link LOGIN_SHELL_PATH_DELIM}, the dirs of `$PATH` — one per line.
+ *
+ * The login shell is used only as a launcher: it runs a single opaque
+ * `/bin/sh -c '…'` token, and ALL of the `$PATH` splitting and canonicalization
+ * happens inside that nested POSIX `sh`.
+ *
+ * Off macOS each dir is canonicalized with `(cd "$d" && pwd -P)` while the
+ * login shell — and any per-session fnm/nvm multishell symlink — is still
+ * alive. On macOS this script performs no filesystem access at all: it only
+ * prints `$PATH`, and {@link probeLoginShellPath} resolves via
+ * {@link resolveOutsideProtectedRoots} so a dir that lands in a TCC-protected
+ * root is dropped without being entered.
+ */
+export function buildProbeScript(platform: NodeJS.Platform = process.platform): string {
+  const body = platform === "darwin" ? 'printf "%s\\n" "$d"' : '(cd "$d" 2>/dev/null && pwd -P)';
+  const posix =
+    `printf %s ${LOGIN_SHELL_PATH_DELIM}; ` +
+    `set -f; IFS=:; for d in $PATH; do [ -n "$d" ] || continue; ${body}; done; ` +
+    `printf %s ${LOGIN_SHELL_PATH_DELIM}; ` +
+    `printf %s ${LOGIN_SHELL_ENV_DELIM}; printf "%s\n%s\n" "$FNM_DIR" "$NVM_BIN"; printf %s ${LOGIN_SHELL_ENV_DELIM}`;
+  return `/bin/sh -c '${posix}'`;
+}
+
+export function defaultRunShell(deps: LoginShellPathDeps = {}): Promise<string | null> {
+  const platform = deps.platform ?? process.platform;
+  const environment = deps.environment ?? process.env;
+  const spawnFn = deps.spawn ?? spawn;
+  const shell = pickShell(environment, platform);
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(value);
+    };
+    let child: ChildProcess;
+    try {
+      child = spawnFn(shell, ["-lic", buildProbeScript(platform)], {
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+        env: environment,
+      });
+    } catch {
+      finish(null);
+      return;
+    }
+    const killAndSettle = () => {
+      try {
+        child.kill(LOGIN_SHELL_PROBE_KILL_SIGNAL);
+      } catch {
+        // The child may already be gone.
+      }
+      child.stdout?.destroy();
+      finish(null);
+    };
+    timer = setTimeout(killAndSettle, LOGIN_SHELL_PROBE_TIMEOUT_MS);
+    timer.unref();
+    let stdout = "";
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      if (settled) return;
+      stdout += chunk;
+      if (Buffer.byteLength(stdout, "utf8") > LOGIN_SHELL_PROBE_MAX_STDOUT_BYTES) {
+        killAndSettle();
+      }
+    });
+    child.on("error", () => finish(null));
+    child.on("close", (status, signal) => {
+      if (signal || status !== 0) finish(null);
+      else finish(stdout);
+    });
+  });
+}
+
+function pickShell(environment: NodeJS.ProcessEnv, platform: NodeJS.Platform): string {
+  const shell = environment.SHELL;
+  if (shell && shell.length > 0) return shell;
+  return platform === "darwin" ? "/bin/zsh" : "/bin/bash";
+}
+
+function parseShellEnv(output: string): ProbedShellEnv {
+  const start = output.indexOf(LOGIN_SHELL_ENV_DELIM);
+  if (start < 0) return {};
+  const end = output.indexOf(LOGIN_SHELL_ENV_DELIM, start + LOGIN_SHELL_ENV_DELIM.length);
+  if (end < 0) return {};
+  const [fnmDir, nvmBin] = output.slice(start + LOGIN_SHELL_ENV_DELIM.length, end).split("\n");
+  return {
+    ...(fnmDir ? { fnmDir } : {}),
+    ...(nvmBin ? { nvmBin } : {}),
+  };
+}
+
+function parsePathFromShellOutput(output: string): string[] | null {
+  const start = output.indexOf(LOGIN_SHELL_PATH_DELIM);
+  if (start < 0) return null;
+  const end = output.indexOf(LOGIN_SHELL_PATH_DELIM, start + LOGIN_SHELL_PATH_DELIM.length);
+  if (end < 0) return null;
+  const inner = output.slice(start + LOGIN_SHELL_PATH_DELIM.length, end);
+  return inner.split("\n").filter((dir) => dir.length > 0);
+}

--- a/packages/client/vitest.agent-runtime.config.ts
+++ b/packages/client/vitest.agent-runtime.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
       "src/__tests__/pi-rpc-wire.test.ts",
       "src/__tests__/client-turn.integration.test.ts",
       "src/__tests__/client-runtime-composition.test.ts",
+      "src/__tests__/probe-failure.test.ts",
+      "src/__tests__/resolved-runtime-factory.test.ts",
       "src/__tests__/runtime-tool-host.test.ts",
       "src/__tests__/session-runtime-manager.test.ts",
     ],

--- a/scripts/e2e/doctor-docker/README.md
+++ b/scripts/e2e/doctor-docker/README.md
@@ -22,8 +22,10 @@ then creates an isolated Docker network containing:
 
 The scenarios execute the built CLI entrypoint and assert the command's process
 exit status, stdout/stderr contract, filesystem immutability, network request
-counts, response redaction, wall-clock deadline, Runtime artifact rules, and
-systemd service state. The systemd scenarios perform a real `daemon install`,
+counts, response redaction, wall-clock deadline, Runtime artifact rules
+(including a login-shell-only Codex fixture that is absent from caller `PATH`),
+and systemd service state. Doctor reports the first install-only candidate and
+does not run readiness fallback. The systemd scenarios perform a real `daemon install`,
 reach a fully passing P0 baseline, and then inject wrong-Home, drifted,
 malformed, and stopped-service failures.
 

--- a/scripts/e2e/doctor-docker/scenario-runner.mjs
+++ b/scripts/e2e/doctor-docker/scenario-runner.mjs
@@ -46,10 +46,11 @@ async function record(name, operation) {
 function doctorEnvironment(home, options = {}) {
   return {
     ...process.env,
-    HOME: process.env.HOME ?? "/home/node",
+    HOME: options.userHome ?? process.env.HOME ?? "/home/node",
     OPENTAG_HOME: home,
     OPENTAG_SERVER_URL: "http://caller-controlled.invalid:65535",
     PATH: options.path ?? defaultPath,
+    ...(options.shell ? { SHELL: options.shell } : {}),
   };
 }
 
@@ -247,7 +248,7 @@ async function runCoreSuite() {
       }),
     ]);
     const result = runDoctor(home);
-    expectIncludes(result.stdout, "more than one Server origin", "binding result", result);
+    expectIncludes(result.stdout, "multiple enrollments", "binding result", result);
     expect((await requestCount(18081)) === beforeA, "doctor contacted the first ambiguous Server");
     expect((await requestCount(18082)) === beforeB, "doctor contacted the second ambiguous Server");
   });
@@ -335,6 +336,33 @@ async function runCoreSuite() {
       "runtime result",
       result,
     );
+  });
+
+  await record("login-shell-only Runtime artifact is reported as login-shell", async () => {
+    const userHome = join(root, "login-shell-home");
+    const loginBin = join(userHome, "login-bin");
+    await mkdir(loginBin, { mode: 0o700, recursive: true });
+    const executable = join(loginBin, "codex");
+    await writeFile(executable, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    await chmod(executable, 0o755);
+    const exportLine = `export PATH="${loginBin}:$PATH"
+`;
+    await writeFile(join(userHome, ".bash_profile"), exportLine, { mode: 0o644 });
+    await writeFile(join(userHome, ".bashrc"), exportLine, { mode: 0o644 });
+    await writeFile(join(userHome, ".profile"), exportLine, { mode: 0o644 });
+    const home = await createHome("runtime-login-shell");
+    const result = runDoctor(home, {
+      path: "/usr/bin:/bin",
+      shell: "/bin/bash",
+      userHome,
+    });
+    expectIncludes(
+      result.stdout,
+      "Agent Runtime CLI: at least one supported Runtime is installed",
+      "runtime result",
+      result,
+    );
+    expectIncludes(result.stdout, `${executable} (login-shell)`, "runtime result", result);
   });
 
   await record("executable directory is not a Runtime artifact", async () => {


### PR DESCRIPTION
## Summary

Implements the two confirmed Runtime CLI discovery follow-ups in order:

- Related to #257: exposes installed executables as a lazy, canonical, same-Provider candidate sequence. Codex and Claude Code advance only when the complete readiness result contains exclusively `artifact_missing` and/or `version_incompatible` backed by positive deterministic binary evidence; credential, configuration, mixed, empty, transient, and unknown failures never authorize fallback.
- Related to #256: after the existing cheap `PATH` → well-known → macOS app-bundle order, adds a memoized login-shell PATH probe and fail-closed nvm/fnm candidates. The shell probe has a 4 second deadline, SIGKILL timeout handling, one shared in-flight probe, and a maximum of three failed attempts. The daemon pre-connect refresh sets `includeLoginShell=false`.
- Preserves the protected-root and symlink policy introduced by #249, including manager roots and version entries.
- Splits transient probe failures (`ETIMEDOUT`, `EAGAIN`, `ENOMEM`, non-crash signals, timeout kills) from positively binary-shaped deterministic failures (known executable-artifact errnos, clean non-zero exit, and `SIGSEGV`/`SIGABRT`/`SIGILL`/`SIGBUS`/`SIGFPE`).

The doctor contract remains install-only: it takes the first executable artifact and never runs Provider readiness fallback.

## Requested-changes repair

Addresses [review 5059191388](https://github.com/first-tree-ai/opentag/pull/265#pullrequestreview-5059191388) on exact repaired head `69a3fd395fecbf6160c9ef8904b51f543be2f397`:

- **Decision authority:** removes this PR's durable design additions from source-repo `docs/design`. The unmerged design now lives as a non-canonical [Context Tree proposal](https://github.com/first-tree-ai/opentag-context-tree/blob/d0c621c2b75f27edd178dbb27ecd9a270e5f94bf/raw-context/proposals/runtime-cli-discovery-fallback.md) with an explicit source-rollout/review promotion gate; active Agent Runtime truth is unchanged until adoption.
- **Failure visibility:** resolved factories catch only executable-discovery iterator reads. `AgentRuntimeExecutableNotFoundError` maps to `artifact_missing`, discovery-unknown maps to non-advancing `temporarily_unavailable`, and unknown discovery dependency, candidate construction, probe, programming, parse, and non-`Error` failures propagate.
- **Runnable nvm/npm entrypoints:** canonical realpath remains candidate identity, while every automatic candidate carries its inspected search bin and prepends that bin to the Provider process PATH. The same resolved factory instance owns readiness, create, resume, and Turns; explicit overrides keep their existing environment and single-candidate semantics.
- **Fail-closed taxonomy:** only allow-listed executable-artifact errnos, clean non-zero exits, or deterministic crash signals become fallback-eligible. Unknown errno/errors and clean exit 0 remain visible and non-advancing.
- **Real env-node fixture:** a hermetic nvm-layout Codex symlink resolves to `codex.js` with `#!/usr/bin/env node`, fails under the frozen PATH, then passes the default Codex readiness probe (including App Server capability create/exact-resume) through real `versionManagerBinDirs`. Resolved create/resume also run with the selected nvm bin first in PATH.

## Validation

- `git diff --check`
- focused Runtime discovery/probe/factory suites — 6 files / 127 tests
- `pnpm check` — passes; pre-existing onboarding lint notices remain informational
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — 22 files / 315 tests, 100% statements, branches, functions, and lines
- `pnpm --filter @opentag/server test:integration` — 15 files / 276 tests
- `pnpm test:e2e:doctor-docker` — 21/21 scenarios

## Scope and remaining platform limits

- No schema or database migration, Provider admission change, CLI install/download/substitution, or cross-Provider fallback.
- No config/env/flag or explicit-override semantic change from #258; no readiness path/source or privacy API from #259.
- Discovery still does not establish authentication, subscription/token usability, protocol readiness, or end-to-end Turn delivery.
- Docker black-box coverage is Linux/bash. macOS protected-root behavior, post-shell canonicalization policy, ambiguity, and symlink handling are covered hermetically, but a physical macOS release-QA pass is still separate. Windows intentionally skips the login-shell/version-manager layer and retains the existing cheap discovery sources.
