### PR TITLE
fix(web): add route error recovery boundary

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -32,6 +32,17 @@ body {
   display: flex;
 }
 
+.app-error-boundary {
+  min-height: 100%;
+  place-items: center;
+}
+
+.app-error-boundary__card {
+  width: 100%;
+  max-width: 36rem;
+  margin-inline: auto;
+}
+
 @media (min-width: 48rem) {
   .app-mobile-header {
     display: none;

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,6 +1,7 @@
 import { type LinkComponentProps, LinkProvider, TooltipProvider } from "@cloudflare/kumo";
 import { Link as RouterLink, RouterProvider } from "@tanstack/react-router";
 import { forwardRef, useEffect, useState } from "react";
+import { AppErrorBoundary } from "./features/error-boundary.js";
 import { type AppRouter, createAppRouter } from "./router.js";
 
 const AppLink = forwardRef<HTMLAnchorElement, LinkComponentProps>(function AppLink({ href, ...props }, ref) {
@@ -27,10 +28,12 @@ export function App({ router }: { router?: AppRouter } = {}) {
     return () => instance.history.destroy();
   }, [instance, owned]);
   return (
-    <LinkProvider component={AppLink}>
-      <TooltipProvider>
-        <RouterProvider router={instance} />
-      </TooltipProvider>
-    </LinkProvider>
+    <AppErrorBoundary>
+      <LinkProvider component={AppLink}>
+        <TooltipProvider>
+          <RouterProvider router={instance} />
+        </TooltipProvider>
+      </LinkProvider>
+    </AppErrorBoundary>
   );
 }

--- a/apps/web/src/features/error-boundary.test.tsx
+++ b/apps/web/src/features/error-boundary.test.tsx
@@ -11,7 +11,7 @@ import { StandaloneNotFoundPage } from "./not-found.js";
 
 function ExplodingChild(): never {
   throw new Error(
-    'Authorization: Bearer root-bearer-secret; Authorization: Basic dXNlcjpwYXNz; "token": "json-token-secret"; password: \'quoted-password-secret\'',
+    'Authorization: Bearer root-bearer-secret\nAuthorization: Basic dXNlcjpwYXNz\n"token": "json-token-secret"; password: \'quoted-password-secret\'',
   );
 }
 
@@ -92,6 +92,37 @@ describe("application error boundaries", () => {
       }),
     );
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain("dXNlcjpwYXNz");
+  });
+
+  it("redacts complete Digest authorization parameters", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportBoundaryError(
+      "app",
+      new Error('Authorization: Digest username="u", response="secret-response", nonce="secret-nonce"'),
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[OpenTag] Unhandled UI error",
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "Authorization: [REDACTED]" }),
+      }),
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("secret-response");
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("secret-nonce");
+  });
+
+  it("preserves JSON structure after a quoted authorization value", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportBoundaryError("app", new Error('{"authorization": "Bearer x", "safe": true}'));
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[OpenTag] Unhandled UI error",
+      expect.objectContaining({
+        error: expect.objectContaining({ message: '{"authorization": "Bearer [REDACTED]", "safe": true}' }),
+      }),
+    );
   });
 
   it("redacts complete multi-cookie and Set-Cookie header values", () => {

--- a/apps/web/src/features/error-boundary.test.tsx
+++ b/apps/web/src/features/error-boundary.test.tsx
@@ -1,12 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { act, within } from "@testing-library/react";
+import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppRouter } from "../router.js";
 import { Route } from "../routes/__root.js";
-import { AppErrorBoundary } from "./error-boundary.js";
+import { AppErrorBoundary, rootErrorHandlers } from "./error-boundary.js";
 import { StandaloneNotFoundPage } from "./not-found.js";
 
 function ExplodingChild(): never {
-  throw new Error("token: secret-value");
+  throw new Error(
+    'Authorization: Bearer root-bearer-secret; "token": "json-token-secret"; password: \'quoted-password-secret\'',
+  );
 }
 
 describe("application error boundaries", () => {
@@ -14,25 +20,48 @@ describe("application error boundaries", () => {
     vi.restoreAllMocks();
   });
 
-  it("keeps an unexpected render failure recoverable and redacts credential-shaped diagnostics", () => {
+  it("keeps root and custom boundary diagnostics free of credential-shaped values", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container, rootErrorHandlers);
 
-    render(
-      <AppErrorBoundary>
-        <ExplodingChild />
-      </AppErrorBoundary>,
-    );
+    act(() => {
+      root.render(
+        <AppErrorBoundary>
+          <ExplodingChild />
+        </AppErrorBoundary>,
+      );
+    });
 
-    expect(screen.getByRole("heading", { name: "Something went wrong" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Back to Agents" }).getAttribute("href")).toBe("/agents");
-    expect(consoleError).toHaveBeenCalledWith(
-      "[OpenTag] Unhandled UI error",
-      expect.objectContaining({
-        boundary: "app",
-        error: expect.objectContaining({ message: "token=[REDACTED]" }),
-      }),
-    );
+    try {
+      const view = within(container);
+      expect(view.getByRole("heading", { name: "Something went wrong" })).toBeTruthy();
+      expect(view.getByRole("button", { name: "Try again" })).toBeTruthy();
+      expect(view.getByRole("link", { name: "Back to Agents" }).getAttribute("href")).toBe("/agents");
+
+      const logged = consoleError.mock.calls.map((args) => JSON.stringify(args)).join("\n");
+      expect(logged).not.toContain("root-bearer-secret");
+      expect(logged).not.toContain("json-token-secret");
+      expect(logged).not.toContain("quoted-password-secret");
+      expect(consoleError).toHaveBeenCalledWith(
+        "[OpenTag] Unhandled UI error",
+        expect.objectContaining({
+          boundary: "root",
+          error: expect.objectContaining({ message: expect.stringContaining("Bearer [REDACTED]") }),
+        }),
+      );
+      expect(consoleError).toHaveBeenCalledWith(
+        "[OpenTag] Unhandled UI error",
+        expect.objectContaining({
+          boundary: "app",
+          error: expect.objectContaining({ message: expect.stringContaining('"token": [REDACTED]') }),
+        }),
+      );
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
   });
 
   it("takes ownership of route error and not-found fallbacks", () => {
@@ -44,5 +73,12 @@ describe("application error boundaries", () => {
     expect(router.options.defaultOnCatch).toEqual(expect.any(Function));
 
     router.history.destroy();
+  });
+
+  it("keeps the standalone fallback centered and bounded in production CSS", () => {
+    const css = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), "../app.css"), "utf8");
+
+    expect(css).toMatch(/\.app-error-boundary\s*\{[^}]*min-height:\s*100%;[^}]*place-items:\s*center;/s);
+    expect(css).toMatch(/\.app-error-boundary__card\s*\{[^}]*max-width:\s*36rem;/s);
   });
 });

--- a/apps/web/src/features/error-boundary.test.tsx
+++ b/apps/web/src/features/error-boundary.test.tsx
@@ -94,6 +94,24 @@ describe("application error boundaries", () => {
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain("dXNlcjpwYXNz");
   });
 
+  it("redacts complete multi-cookie and Set-Cookie header values", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportBoundaryError(
+      "app",
+      new Error("Cookie: theme=dark; sid=session-secret\nSet-Cookie: sid=set-session-secret; Path=/; HttpOnly"),
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[OpenTag] Unhandled UI error",
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "Cookie: [REDACTED]\nSet-Cookie: [REDACTED]" }),
+      }),
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("session-secret");
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("set-session-secret");
+  });
+
   it("keeps the standalone fallback centered and bounded in production CSS", () => {
     const css = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), "../app.css"), "utf8");
 

--- a/apps/web/src/features/error-boundary.test.tsx
+++ b/apps/web/src/features/error-boundary.test.tsx
@@ -11,7 +11,7 @@ import { StandaloneNotFoundPage } from "./not-found.js";
 
 function ExplodingChild(): never {
   throw new Error(
-    'Authorization: Bearer root-bearer-secret; "token": "json-token-secret"; password: \'quoted-password-secret\'',
+    'Authorization: Bearer root-bearer-secret; Authorization: Basic dXNlcjpwYXNz; "token": "json-token-secret"; password: \'quoted-password-secret\'',
   );
 }
 
@@ -42,20 +42,25 @@ describe("application error boundaries", () => {
 
       const logged = consoleError.mock.calls.map((args) => JSON.stringify(args)).join("\n");
       expect(logged).not.toContain("root-bearer-secret");
+      expect(logged).not.toContain("dXNlcjpwYXNz");
       expect(logged).not.toContain("json-token-secret");
       expect(logged).not.toContain("quoted-password-secret");
       expect(consoleError).toHaveBeenCalledWith(
         "[OpenTag] Unhandled UI error",
         expect.objectContaining({
           boundary: "root",
-          error: expect.objectContaining({ message: expect.stringContaining("Bearer [REDACTED]") }),
+          error: expect.objectContaining({
+            message: expect.stringContaining("Authorization: Bearer [REDACTED]"),
+          }),
         }),
       );
       expect(consoleError).toHaveBeenCalledWith(
         "[OpenTag] Unhandled UI error",
         expect.objectContaining({
           boundary: "app",
-          error: expect.objectContaining({ message: expect.stringContaining('"token": [REDACTED]') }),
+          error: expect.objectContaining({
+            message: expect.stringContaining("Authorization: [REDACTED]"),
+          }),
         }),
       );
     } finally {

--- a/apps/web/src/features/error-boundary.test.tsx
+++ b/apps/web/src/features/error-boundary.test.tsx
@@ -112,6 +112,33 @@ describe("application error boundaries", () => {
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain("set-session-secret");
   });
 
+  it("redacts serialized cookie collections without swallowing enclosing delimiters", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportBoundaryError(
+      "app",
+      new Error('{"Set-Cookie":["sid=first-session-secret", "refresh=second-session-secret"],"safe":true}'),
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[OpenTag] Unhandled UI error",
+      expect.objectContaining({
+        error: expect.objectContaining({ message: '{"Set-Cookie":[REDACTED],"safe":true}' }),
+      }),
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("first-session-secret");
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("second-session-secret");
+  });
+
+  it("redacts comma-separated Set-Cookie values as one field", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportBoundaryError("app", new Error("Set-Cookie: sid=first-session-secret, refresh=second-session-secret"));
+
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("first-session-secret");
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("second-session-secret");
+  });
+
   it("keeps the standalone fallback centered and bounded in production CSS", () => {
     const css = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), "../app.css"), "utf8");
 

--- a/apps/web/src/features/error-boundary.test.tsx
+++ b/apps/web/src/features/error-boundary.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAppRouter } from "../router.js";
+import { Route } from "../routes/__root.js";
+import { AppErrorBoundary } from "./error-boundary.js";
+import { StandaloneNotFoundPage } from "./not-found.js";
+
+function ExplodingChild(): never {
+  throw new Error("token: secret-value");
+}
+
+describe("application error boundaries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps an unexpected render failure recoverable and redacts credential-shaped diagnostics", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <AppErrorBoundary>
+        <ExplodingChild />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Something went wrong" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Back to Agents" }).getAttribute("href")).toBe("/agents");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[OpenTag] Unhandled UI error",
+      expect.objectContaining({
+        boundary: "app",
+        error: expect.objectContaining({ message: "token=[REDACTED]" }),
+      }),
+    );
+  });
+
+  it("takes ownership of route error and not-found fallbacks", () => {
+    const router = createAppRouter();
+
+    expect(Route.options.errorComponent).toBe(router.options.defaultErrorComponent);
+    expect(Route.options.notFoundComponent).toBe(StandaloneNotFoundPage);
+    expect(router.options.defaultNotFoundComponent).toBe(StandaloneNotFoundPage);
+    expect(router.options.defaultOnCatch).toEqual(expect.any(Function));
+
+    router.history.destroy();
+  });
+});

--- a/apps/web/src/features/error-boundary.test.tsx
+++ b/apps/web/src/features/error-boundary.test.tsx
@@ -6,7 +6,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppRouter } from "../router.js";
 import { Route } from "../routes/__root.js";
-import { AppErrorBoundary, rootErrorHandlers } from "./error-boundary.js";
+import { AppErrorBoundary, reportBoundaryError, rootErrorHandlers } from "./error-boundary.js";
 import { StandaloneNotFoundPage } from "./not-found.js";
 
 function ExplodingChild(): never {
@@ -78,6 +78,20 @@ describe("application error boundaries", () => {
     expect(router.options.defaultOnCatch).toEqual(expect.any(Function));
 
     router.history.destroy();
+  });
+
+  it("redacts the complete credential for non-Bearer authorization schemes", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportBoundaryError("app", new Error("Authorization: Basic dXNlcjpwYXNz"));
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[OpenTag] Unhandled UI error",
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "Authorization: [REDACTED]" }),
+      }),
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("dXNlcjpwYXNz");
   });
 
   it("keeps the standalone fallback centered and bounded in production CSS", () => {

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -141,10 +141,16 @@ export const rootErrorHandlers = {
 };
 
 const credentialKey =
-  "(?:authorization|cookie|password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
+  "(?:cookie|password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
+const authorizationField = /(["']?authorization["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^,;}\n]+)/gi;
 
 function redactErrorMessage(message: string): string {
   return message
+    .replace(
+      authorizationField,
+      (_match, prefix: string, value: string) =>
+        `${prefix}${/^['"]?Bearer\s/i.test(value.trim()) ? "Bearer [REDACTED]" : "[REDACTED]"}`,
+    )
     .replace(
       new RegExp(
         `(["']?${credentialKey}["']?\\s*[:=]\\s*)(Bearer\\s+(?:"[^"]*"|'[^']*'|[^\\s,;}\\]]+)|"[^"]*"|'[^']*'|[^\\s,;}\\]]+)`,

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -141,12 +141,17 @@ export const rootErrorHandlers = {
 };
 
 const credentialKey = "(?:password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
-const authorizationField = /(["']?authorization["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\n,;}]*?\S)(?=\s*(?:[,;}\n]|$))/gi;
-const cookieQuotedValue = String.raw`(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`;
-const cookieArrayValue = String.raw`\[(?:${cookieQuotedValue}|[^\[\]"'])*\]`;
-const cookieObjectValue = String.raw`\{(?:${cookieQuotedValue}|[^{}"'])*\}`;
+const quotedValue = String.raw`(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`;
+const arrayValue = String.raw`\[(?:${quotedValue}|[^\[\]"'])*\]`;
+const objectValue = String.raw`\{(?:${quotedValue}|[^{}"'])*\}`;
+const structuredValue = `(?:${arrayValue}|${objectValue}|${quotedValue})`;
+const structuredValueWithBoundary = String.raw`${structuredValue}(?=\s*(?:[,}\n]|$))`;
+const authorizationField = new RegExp(
+  String.raw`(["']?authorization["']?\s*[:=]\s*)(${structuredValueWithBoundary}|[^\r\n]*)`,
+  "gi",
+);
 const cookieField = new RegExp(
-  String.raw`(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*)(?:${cookieArrayValue}(?=\s*(?:[,}\n]|$))|${cookieObjectValue}(?=\s*(?:[,}\n]|$))|${cookieQuotedValue}(?=\s*(?:[,}\n]|$))|[^\r\n]*)`,
+  String.raw`(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*)(${structuredValueWithBoundary}|[^\r\n]*)`,
   "gi",
 );
 
@@ -154,8 +159,7 @@ function redactErrorMessage(message: string): string {
   return message
     .replace(
       authorizationField,
-      (_match, prefix: string, value: string) =>
-        `${prefix}${/^['"]?Bearer\s/i.test(value.trim()) ? "Bearer [REDACTED]" : "[REDACTED]"}`,
+      (_match, prefix: string, value: string) => `${prefix}${redactAuthorizationValue(value)}`,
     )
     .replace(cookieField, (_match, prefix: string) => `${prefix}[REDACTED]`)
     .replace(
@@ -166,6 +170,13 @@ function redactErrorMessage(message: string): string {
       (_match, prefix: string, value: string) =>
         `${prefix}${/^Bearer\s/i.test(value) ? "Bearer [REDACTED]" : "[REDACTED]"}`,
     )
-    .replace(/\bBearer\s+(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)/gi, "Bearer [REDACTED]")
+    .replace(/\bBearer\s+(?!\[REDACTED\])(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)/gi, "Bearer [REDACTED]")
     .replace(/([?&](?:code|client_secret|token|secret|password|key)=)[^&#\s]+/gi, "$1[REDACTED]");
+}
+
+function redactAuthorizationValue(value: string): string {
+  const trimmed = value.trim();
+  const quote = /^(["'])Bearer\s/i.exec(trimmed)?.[1] ?? "";
+  if (!/^['"]?Bearer\s/i.test(trimmed)) return "[REDACTED]";
+  return `${quote}Bearer [REDACTED]${quote && trimmed.endsWith(quote) ? quote : ""}`;
 }

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -142,7 +142,7 @@ export const rootErrorHandlers = {
 
 const credentialKey =
   "(?:cookie|password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
-const authorizationField = /(["']?authorization["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^,;}\n]+)/gi;
+const authorizationField = /(["']?authorization["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\n,;}]*?\S)(?=\s*(?:[,;}\n]|$))/gi;
 
 function redactErrorMessage(message: string): string {
   return message

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -1,0 +1,141 @@
+import { type ErrorComponentProps, Link, useRouter } from "@tanstack/react-router";
+import { Component, type ErrorInfo, type HTMLAttributes, type ReactNode } from "react";
+import { Button, Text } from "../ui/design-system.js";
+
+type BoundaryError = Error & { digest?: string };
+
+export type AppErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type AppErrorBoundaryState = {
+  error?: BoundaryError;
+};
+
+/**
+ * Keeps an unexpected render failure from leaving the application root blank.
+ *
+ * TanStack Router catches errors thrown while rendering a route. This boundary is still needed
+ * around the router itself because providers, the router boot process, and non-route UI can fail
+ * before a route match has a chance to install its own boundary.
+ */
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = {};
+
+  static getDerivedStateFromError(error: unknown): AppErrorBoundaryState {
+    return { error: normalizeError(error) };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    reportBoundaryError("app", error, errorInfo);
+  }
+
+  private readonly reload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.error) {
+      return <StandaloneErrorPage actionLabel="Try again" onAction={this.reload} />;
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Error component used by route matches and as the router-wide fallback. It intentionally does not
+ * display the thrown message: route errors can contain request URLs or provider details that are
+ * useful in a local log but are not safe to put in a shared browser surface.
+ */
+export function RouteErrorPage({ reset }: ErrorComponentProps) {
+  const router = useRouter();
+
+  const retry = () => {
+    // Reset the local boundary immediately, then invalidate the match so loaders and beforeLoad
+    // handlers run again. reset() alone would only replay the same failed render.
+    reset();
+    void router.invalidate();
+  };
+
+  return (
+    <BoundaryCard data-ui="route-error">
+      <Text as="span" variant="secondary">
+        OpenTag
+      </Text>
+      <Text as="h1" size="lg" variant="heading">
+        Something went wrong
+      </Text>
+      <Text as="p" variant="secondary">
+        OpenTag could not load this page. Try again, or return to Agents and continue from there.
+      </Text>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button onClick={retry}>Try again</Button>
+        <Link className="text-sm font-medium text-kumo-brand underline-offset-4 hover:underline" to="/agents">
+          Back to Agents
+        </Link>
+      </div>
+    </BoundaryCard>
+  );
+}
+
+export function StandaloneErrorPage({ actionLabel, onAction }: { actionLabel: string; onAction: () => void }) {
+  return (
+    <main className="grid min-h-full place-items-center bg-kumo-canvas p-6" data-ui="app-error-boundary">
+      <BoundaryCard>
+        <Text as="span" variant="secondary">
+          OpenTag
+        </Text>
+        <Text as="h1" size="lg" variant="heading">
+          Something went wrong
+        </Text>
+        <Text as="p" variant="secondary">
+          OpenTag could not load the application. Reload the page and try again.
+        </Text>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button onClick={onAction}>{actionLabel}</Button>
+          <a className="text-sm font-medium text-kumo-brand underline-offset-4 hover:underline" href="/agents">
+            Back to Agents
+          </a>
+        </div>
+      </BoundaryCard>
+    </main>
+  );
+}
+
+function BoundaryCard({ children, ...props }: { children: ReactNode } & HTMLAttributes<HTMLElement>) {
+  return (
+    <section
+      {...props}
+      className="grid w-full max-w-xl gap-3 rounded-lg bg-kumo-base p-6 shadow-sm ring ring-kumo-line"
+    >
+      {children}
+    </section>
+  );
+}
+
+function normalizeError(value: unknown): BoundaryError {
+  if (value instanceof Error) return value;
+  return new Error(typeof value === "string" ? value : "Unknown application error");
+}
+
+/** Logs diagnostics without copying credential-shaped values into the browser console. */
+export function reportBoundaryError(boundary: "app" | "route", error: unknown, errorInfo?: ErrorInfo) {
+  const normalized = normalizeError(error);
+  console.error("[OpenTag] Unhandled UI error", {
+    boundary,
+    error: {
+      name: normalized.name,
+      message: redactErrorMessage(normalized.message),
+    },
+    componentStack: errorInfo?.componentStack ? redactErrorMessage(errorInfo.componentStack) : undefined,
+  });
+}
+
+function redactErrorMessage(message: string): string {
+  return message
+    .replace(
+      /\b(authorization|cookie|password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token)\b\s*[:=]\s*[^\s,;]+/gi,
+      "$1=[REDACTED]",
+    )
+    .replace(/([?&](?:code|client_secret|token|secret|password|key)=)[^&#\s]+/gi, "$1[REDACTED]");
+}

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -142,7 +142,13 @@ export const rootErrorHandlers = {
 
 const credentialKey = "(?:password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
 const authorizationField = /(["']?authorization["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\n,;}]*?\S)(?=\s*(?:[,;}\n]|$))/gi;
-const cookieField = /(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\n,}]*?\S)(?=\s*(?:[,}\n]|$))/gi;
+const cookieQuotedValue = String.raw`(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`;
+const cookieArrayValue = String.raw`\[(?:${cookieQuotedValue}|[^\[\]"'])*\]`;
+const cookieObjectValue = String.raw`\{(?:${cookieQuotedValue}|[^{}"'])*\}`;
+const cookieField = new RegExp(
+  String.raw`(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*)(?:${cookieArrayValue}(?=\s*(?:[,}\n]|$))|${cookieObjectValue}(?=\s*(?:[,}\n]|$))|${cookieQuotedValue}(?=\s*(?:[,}\n]|$))|[^\r\n]*)`,
+  "gi",
+);
 
 function redactErrorMessage(message: string): string {
   return message

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -3,6 +3,8 @@ import { Component, type ErrorInfo, type HTMLAttributes, type ReactNode } from "
 import { Button, Text } from "../ui/design-system.js";
 
 type BoundaryError = Error & { digest?: string };
+type BoundaryErrorInfo = { componentStack?: string | null };
+type BoundaryName = "app" | "route" | "root";
 
 export type AppErrorBoundaryProps = {
   children: ReactNode;
@@ -80,7 +82,7 @@ export function RouteErrorPage({ reset }: ErrorComponentProps) {
 
 export function StandaloneErrorPage({ actionLabel, onAction }: { actionLabel: string; onAction: () => void }) {
   return (
-    <main className="grid min-h-full place-items-center bg-kumo-canvas p-6" data-ui="app-error-boundary">
+    <main className="app-error-boundary grid bg-kumo-canvas p-6" data-ui="app-error-boundary">
       <BoundaryCard>
         <Text as="span" variant="secondary">
           OpenTag
@@ -106,7 +108,7 @@ function BoundaryCard({ children, ...props }: { children: ReactNode } & HTMLAttr
   return (
     <section
       {...props}
-      className="grid w-full max-w-xl gap-3 rounded-lg bg-kumo-base p-6 shadow-sm ring ring-kumo-line"
+      className="app-error-boundary__card grid w-full gap-3 rounded-lg bg-kumo-base p-6 shadow-sm ring ring-kumo-line"
     >
       {children}
     </section>
@@ -119,23 +121,38 @@ function normalizeError(value: unknown): BoundaryError {
 }
 
 /** Logs diagnostics without copying credential-shaped values into the browser console. */
-export function reportBoundaryError(boundary: "app" | "route", error: unknown, errorInfo?: ErrorInfo) {
+export function reportBoundaryError(boundary: BoundaryName, error: unknown, errorInfo?: BoundaryErrorInfo) {
   const normalized = normalizeError(error);
   console.error("[OpenTag] Unhandled UI error", {
     boundary,
     error: {
-      name: normalized.name,
+      name: redactErrorMessage(normalized.name),
       message: redactErrorMessage(normalized.message),
     },
     componentStack: errorInfo?.componentStack ? redactErrorMessage(errorInfo.componentStack) : undefined,
   });
 }
 
+/** Replaces React 19's default root reporting so caught and uncaught errors stay sanitized. */
+export const rootErrorHandlers = {
+  onCaughtError: (error: unknown, errorInfo: BoundaryErrorInfo) => reportBoundaryError("root", error, errorInfo),
+  onRecoverableError: (error: unknown, errorInfo: BoundaryErrorInfo) => reportBoundaryError("root", error, errorInfo),
+  onUncaughtError: (error: unknown, errorInfo: BoundaryErrorInfo) => reportBoundaryError("root", error, errorInfo),
+};
+
+const credentialKey =
+  "(?:authorization|cookie|password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
+
 function redactErrorMessage(message: string): string {
   return message
     .replace(
-      /\b(authorization|cookie|password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token)\b\s*[:=]\s*[^\s,;]+/gi,
-      "$1=[REDACTED]",
+      new RegExp(
+        `(["']?${credentialKey}["']?\\s*[:=]\\s*)(Bearer\\s+(?:"[^"]*"|'[^']*'|[^\\s,;}\\]]+)|"[^"]*"|'[^']*'|[^\\s,;}\\]]+)`,
+        "gi",
+      ),
+      (_match, prefix: string, value: string) =>
+        `${prefix}${/^Bearer\s/i.test(value) ? "Bearer [REDACTED]" : "[REDACTED]"}`,
     )
+    .replace(/\bBearer\s+(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)/gi, "Bearer [REDACTED]")
     .replace(/([?&](?:code|client_secret|token|secret|password|key)=)[^&#\s]+/gi, "$1[REDACTED]");
 }

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -140,9 +140,9 @@ export const rootErrorHandlers = {
   onUncaughtError: (error: unknown, errorInfo: BoundaryErrorInfo) => reportBoundaryError("root", error, errorInfo),
 };
 
-const credentialKey =
-  "(?:cookie|password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
+const credentialKey = "(?:password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
 const authorizationField = /(["']?authorization["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\n,;}]*?\S)(?=\s*(?:[,;}\n]|$))/gi;
+const cookieField = /(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^\n,}]*?\S)(?=\s*(?:[,}\n]|$))/gi;
 
 function redactErrorMessage(message: string): string {
   return message
@@ -151,6 +151,7 @@ function redactErrorMessage(message: string): string {
       (_match, prefix: string, value: string) =>
         `${prefix}${/^['"]?Bearer\s/i.test(value.trim()) ? "Bearer [REDACTED]" : "[REDACTED]"}`,
     )
+    .replace(cookieField, (_match, prefix: string) => `${prefix}[REDACTED]`)
     .replace(
       new RegExp(
         `(["']?${credentialKey}["']?\\s*[:=]\\s*)(Bearer\\s+(?:"[^"]*"|'[^']*'|[^\\s,;}\\]]+)|"[^"]*"|'[^']*'|[^\\s,;}\\]]+)`,

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,10 +4,11 @@ import "@cloudflare/kumo/styles/standalone";
 import "./ui/kumo-theme.css";
 import { App } from "./app.js";
 import "./app.css";
+import { rootErrorHandlers } from "./features/error-boundary.js";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("OpenTag root element is missing");
-createRoot(root).render(
+createRoot(root, rootErrorHandlers).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -1,10 +1,18 @@
 import { createRouter } from "@tanstack/react-router";
 import type { AgentDetailView } from "./features/agents/agent-model.js";
+import { RouteErrorPage, reportBoundaryError } from "./features/error-boundary.js";
+import { StandaloneNotFoundPage } from "./features/not-found.js";
 import { routeTree } from "./routeTree.gen.js";
 
 export function createAppRouter() {
   // The shell owns its own scrolling region, so the router must not drive window scroll.
-  return createRouter({ routeTree, scrollRestoration: false });
+  return createRouter({
+    defaultErrorComponent: RouteErrorPage,
+    defaultNotFoundComponent: StandaloneNotFoundPage,
+    defaultOnCatch: (error, errorInfo) => reportBoundaryError("route", error, errorInfo),
+    routeTree,
+    scrollRestoration: false,
+  });
 }
 
 export type AppRouter = ReturnType<typeof createAppRouter>;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,8 +1,10 @@
 import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { RouteErrorPage } from "../features/error-boundary.js";
 import { StandaloneNotFoundPage } from "../features/not-found.js";
 
 export const Route = createRootRoute({
   component: RootRoute,
+  errorComponent: RouteErrorPage,
   // The catch-all sits outside every gate, so an unknown path answers without asking for a session.
   notFoundComponent: StandaloneNotFoundPage,
 });


### PR DESCRIPTION
Add a root React error boundary and TanStack Router error component with sanitized diagnostics, retry/reset behavior, and a navigation fallback. Includes focused regression coverage. Local checks passed; CI will verify the branch.