### PR TITLE
fix(web): label onboarding Kumo input

### DIFF
--- a/apps/web/src/onboarding-v2/page.test.tsx
+++ b/apps/web/src/onboarding-v2/page.test.tsx
@@ -106,6 +106,17 @@ describe("OnboardingV2Page", () => {
     expect(screen.getByText("More runtimes coming soon.")).toBeTruthy();
   });
 
+  it("gives the Kumo agent name input an explicit accessible label", () => {
+    render(<OnboardingV2Page />);
+    fireEvent.click(screen.getByRole("button", { name: /Local computer/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    const input = screen.getByRole("textbox", { name: "Agent name" });
+    const labelId = input.getAttribute("aria-labelledby");
+    expect(labelId).toBeTruthy();
+    expect(document.getElementById(labelId ?? "")?.textContent).toBe("Agent name");
+  });
+
   it("explains an invalid name instead of advancing", () => {
     render(<OnboardingV2Page />);
     fireEvent.click(screen.getByRole("button", { name: /Local computer/ }));

--- a/apps/web/src/onboarding-v2/steps.tsx
+++ b/apps/web/src/onboarding-v2/steps.tsx
@@ -165,6 +165,7 @@ function AgentNameField({
   showError: boolean;
 }) {
   const nameId = useId();
+  const labelId = `${nameId}-label`;
   const hintId = `${nameId}-hint`;
   const errorId = `${nameId}-error`;
   const error = showError ? validateAgentName(draft.name) : undefined;
@@ -179,7 +180,7 @@ function AgentNameField({
 
   return (
     <div className="otv2-fieldset">
-      <label className="otv2-fieldset__label" htmlFor={nameId}>
+      <label className="otv2-fieldset__label" htmlFor={nameId} id={labelId}>
         {COPY.agent.nameLabel}
       </label>
       <p className="otv2-fieldset__hint" id={hintId}>
@@ -188,6 +189,7 @@ function AgentNameField({
       <KumoInputControl
         aria-describedby={errorText ? `${hintId} ${errorId}` : hintId}
         aria-invalid={errorText ? true : undefined}
+        aria-labelledby={labelId}
         autoComplete="off"
         className="otv2-name"
         id={nameId}


### PR DESCRIPTION
Provide an explicit accessible name for the onboarding Agent name Kumo input and add a regression assertion for aria-labelledby. Local checks passed; CI will verify the branch.