### PR TITLE
fix(tasks): recover paginated task loading

### DIFF
--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -144,6 +144,21 @@ describe("Tasks debug view", () => {
     expect(taskRequest).toHaveBeenLastCalledWith({ cursor: "next-page" });
   });
 
+  it("retries an initial Tasks load after displaying the request error", async () => {
+    const taskRequest = vi
+      .spyOn(browserApi, "tasks")
+      .mockRejectedValueOnce(new Error("Temporary initial load failure"))
+      .mockResolvedValueOnce({ tasks: [task], nextCursor: null });
+
+    await renderInRouter(<TasksPage />);
+
+    expect(await screen.findByText("Temporary initial load failure")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(await screen.findByRole("link", { name: task.title })).toBeTruthy();
+    expect(taskRequest).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+
   it("renders the stored inbound message and runtime report without claiming an outbound record", async () => {
     vi.spyOn(browserApi, "task").mockResolvedValue(detail);
     await renderInRouter(<TaskDetailPage taskId={sessionId} />, { path: `/tasks/${sessionId}` });

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderInRouter } from "../__tests__/support/router.js";
 import { browserApi } from "../api.js";
-import { TaskDetailPage, TasksPage } from "./tasks-page.js";
+import { AgentTasksSection, TaskDetailPage, TasksPage } from "./tasks-page.js";
 
 const sessionId = "11111111-1111-4111-8111-111111111111";
 const agentId = "22222222-2222-4222-8222-222222222222";
@@ -115,6 +115,69 @@ describe("Tasks debug view", () => {
     fireEvent.change(screen.getByLabelText("Search Tasks"), { target: { value: sessionId } });
     expect(screen.getAllByRole("row")).toHaveLength(2);
     expect(screen.getByText("Investigate the failed deployment")).toBeTruthy();
+  });
+
+  it("keeps the loaded rows and retries a failed page append", async () => {
+    const second = {
+      ...task,
+      id: "66666666-6666-4666-8666-666666666666",
+      title: "Review onboarding",
+    } satisfies TaskSummary;
+    const taskRequest = vi
+      .spyOn(browserApi, "tasks")
+      .mockResolvedValueOnce({ tasks: [task], nextCursor: "next-page" })
+      .mockRejectedValueOnce(new Error("Temporary pagination failure"))
+      .mockResolvedValueOnce({ tasks: [second], nextCursor: null });
+
+    await renderInRouter(<TasksPage />);
+    expect(await screen.findByRole("link", { name: task.title })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    expect(taskRequest).toHaveBeenCalledTimes(2);
+    expect(await screen.findByText("Temporary pagination failure")).toBeTruthy();
+    expect(screen.getByRole("link", { name: task.title })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(await screen.findByRole("link", { name: second.title })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    expect(taskRequest).toHaveBeenLastCalledWith({ cursor: "next-page" });
+  });
+
+  it("does not let a late page for one Agent land on another Agent's Tasks", async () => {
+    const secondAgentId = "44444444-4444-4444-8444-444444444444";
+    const secondTask = {
+      ...task,
+      id: "55555555-5555-4555-8555-555555555555",
+      title: "Draft the release notes",
+    } satisfies TaskSummary;
+    let releaseOldPage: (value: { tasks: TaskSummary[]; nextCursor: string | null }) => void = () => undefined;
+    vi.spyOn(browserApi, "tasks").mockImplementation((input = {}) => {
+      if (input.cursor) {
+        return new Promise((resolve) => {
+          releaseOldPage = resolve;
+        });
+      }
+      return Promise.resolve(
+        input.agentId === secondAgentId
+          ? { tasks: [secondTask], nextCursor: null }
+          : { tasks: [task], nextCursor: "next-page" },
+      );
+    });
+
+    const view = await renderInRouter(<AgentTasksSection agentId={agentId} />);
+    expect(await screen.findByRole("link", { name: task.title })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    view.rerender(<AgentTasksSection agentId={secondAgentId} />);
+    expect(await screen.findByRole("link", { name: secondTask.title })).toBeTruthy();
+
+    releaseOldPage({
+      tasks: [{ ...task, id: "66666666-6666-4666-8666-666666666666", title: "Stale Task" }],
+      nextCursor: null,
+    });
+    await waitFor(() => expect(screen.getByRole("link", { name: secondTask.title })).toBeTruthy());
+    expect(screen.queryByText("Stale Task")).toBeNull();
   });
 
   it("renders the stored inbound message and runtime report without claiming an outbound record", async () => {

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -1,5 +1,5 @@
 import type { TaskDetail, TaskSummary } from "@opentag/shared/browser";
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderInRouter } from "../__tests__/support/router.js";
 import { browserApi } from "../api.js";
@@ -232,6 +232,85 @@ describe("Tasks debug view", () => {
     expect(await screen.findByText("This is an older inbound message.")).toBeTruthy();
     expect(taskRequest).toHaveBeenLastCalledWith(sessionId, "older-turns");
     expect(screen.queryByRole("button", { name: "Load more Turns" })).toBeNull();
+  });
+
+  it.each(["success", "error"] as const)(
+    "ignores a delayed Task A append %s after switching to Task B",
+    async (outcome) => {
+      const firstPage = { ...detail, nextCursor: "older-turns" } satisfies TaskDetail;
+      const secondTaskId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+      const secondDetail = {
+        ...detail,
+        task: { ...detail.task, id: secondTaskId, title: "Task B" },
+        nextCursor: "task-b-older-turns",
+      } satisfies TaskDetail;
+      const baseTurn = detail.turns[0];
+      if (!baseTurn) throw new Error("Expected the Task fixture to include a Turn");
+      const staleTurn = {
+        ...baseTurn,
+        deliveryId: "88888888-8888-4888-8888-888888888888",
+        message: {
+          ...baseTurn.message,
+          id: "99999999-9999-4999-8999-999999999999",
+          externalMessageId: "om_stale",
+          fallbackText: "Stale Task A Turn",
+        },
+      } satisfies TaskDetail["turns"][number];
+      let resolveTaskA: (value: TaskDetail) => void = () => undefined;
+      let rejectTaskA: (reason: Error) => void = () => undefined;
+      vi.spyOn(browserApi, "task").mockImplementation((requestedTaskId, cursor) => {
+        if (requestedTaskId === sessionId && !cursor) return Promise.resolve(firstPage);
+        if (requestedTaskId === sessionId && cursor === "older-turns") {
+          return new Promise((resolve, reject) => {
+            resolveTaskA = resolve;
+            rejectTaskA = reject;
+          });
+        }
+        if (requestedTaskId === secondTaskId && !cursor) return Promise.resolve(secondDetail);
+        return Promise.reject(new Error("Unexpected Task request"));
+      });
+
+      const view = await renderInRouter(<TaskDetailPage taskId={sessionId} />, { path: `/tasks/${sessionId}` });
+      fireEvent.click(await screen.findByRole("button", { name: "Load more Turns" }));
+
+      view.rerender(<TaskDetailPage taskId={secondTaskId} />);
+      expect(await screen.findByRole("heading", { name: "Task B" })).toBeTruthy();
+      expect((screen.getByRole("button", { name: "Load more Turns" }) as HTMLButtonElement).disabled).toBe(false);
+
+      await act(async () => {
+        if (outcome === "success") {
+          resolveTaskA({ ...detail, turns: [staleTurn], nextCursor: null });
+        } else {
+          rejectTaskA(new Error("Stale Task A pagination failure"));
+        }
+      });
+
+      expect(screen.getByRole("heading", { name: "Task B" })).toBeTruthy();
+      expect(screen.queryByText("Stale Task A Turn")).toBeNull();
+      expect(screen.queryByText("Stale Task A pagination failure")).toBeNull();
+    },
+  );
+
+  it("clears a Task append error when taskId changes", async () => {
+    const firstPage = { ...detail, nextCursor: "older-turns" } satisfies TaskDetail;
+    const secondTaskId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const secondDetail = {
+      ...detail,
+      task: { ...detail.task, id: secondTaskId, title: "Task B" },
+      nextCursor: null,
+    } satisfies TaskDetail;
+    vi.spyOn(browserApi, "task")
+      .mockResolvedValueOnce(firstPage)
+      .mockRejectedValueOnce(new Error("Task A pagination failure"))
+      .mockResolvedValueOnce(secondDetail);
+
+    const view = await renderInRouter(<TaskDetailPage taskId={sessionId} />, { path: `/tasks/${sessionId}` });
+    fireEvent.click(await screen.findByRole("button", { name: "Load more Turns" }));
+    expect(await screen.findByText("Task A pagination failure")).toBeTruthy();
+
+    view.rerender(<TaskDetailPage taskId={secondTaskId} />);
+    expect(await screen.findByRole("heading", { name: "Task B" })).toBeTruthy();
+    expect(screen.queryByText("Task A pagination failure")).toBeNull();
   });
 
   it("shows loading and empty states from the API", async () => {

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderInRouter } from "../__tests__/support/router.js";
 import { browserApi } from "../api.js";
-import { AgentTasksSection, TaskDetailPage, TasksPage } from "./tasks-page.js";
+import { TaskDetailPage, TasksPage } from "./tasks-page.js";
 
 const sessionId = "11111111-1111-4111-8111-111111111111";
 const agentId = "22222222-2222-4222-8222-222222222222";
@@ -142,42 +142,6 @@ describe("Tasks debug view", () => {
     expect(await screen.findByRole("link", { name: second.title })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
     expect(taskRequest).toHaveBeenLastCalledWith({ cursor: "next-page" });
-  });
-
-  it("does not let a late page for one Agent land on another Agent's Tasks", async () => {
-    const secondAgentId = "44444444-4444-4444-8444-444444444444";
-    const secondTask = {
-      ...task,
-      id: "55555555-5555-4555-8555-555555555555",
-      title: "Draft the release notes",
-    } satisfies TaskSummary;
-    let releaseOldPage: (value: { tasks: TaskSummary[]; nextCursor: string | null }) => void = () => undefined;
-    vi.spyOn(browserApi, "tasks").mockImplementation((input = {}) => {
-      if (input.cursor) {
-        return new Promise((resolve) => {
-          releaseOldPage = resolve;
-        });
-      }
-      return Promise.resolve(
-        input.agentId === secondAgentId
-          ? { tasks: [secondTask], nextCursor: null }
-          : { tasks: [task], nextCursor: "next-page" },
-      );
-    });
-
-    const view = await renderInRouter(<AgentTasksSection agentId={agentId} />);
-    expect(await screen.findByRole("link", { name: task.title })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
-
-    view.rerender(<AgentTasksSection agentId={secondAgentId} />);
-    expect(await screen.findByRole("link", { name: secondTask.title })).toBeTruthy();
-
-    releaseOldPage({
-      tasks: [{ ...task, id: "66666666-6666-4666-8666-666666666666", title: "Stale Task" }],
-      nextCursor: null,
-    });
-    await waitFor(() => expect(screen.getByRole("link", { name: secondTask.title })).toBeTruthy());
-    expect(screen.queryByText("Stale Task")).toBeNull();
   });
 
   it("renders the stored inbound message and runtime report without claiming an outbound record", async () => {

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -224,30 +224,41 @@ export function TaskDetailPage({ taskId }: { taskId?: string }) {
   const [state, setState] = useState<LoadState<TaskDetail>>({ kind: "loading" });
   const [loadingMore, setLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<Error | null>(null);
+  const taskLoadGeneration = useRef(0);
 
   useEffect(() => {
-    let active = true;
+    const generation = taskLoadGeneration.current + 1;
+    taskLoadGeneration.current = generation;
+    setState({ kind: "loading" });
+    setLoadingMore(false);
+    setLoadMoreError(null);
     if (!taskId) {
       setState({ kind: "error", error: new Error("Task not found") });
-      return () => undefined;
+      return () => {
+        if (taskLoadGeneration.current === generation) taskLoadGeneration.current += 1;
+      };
     }
     browserApi.task(taskId).then(
-      (value) => active && setState({ kind: "ready", value }),
-      (error: unknown) => active && setState({ kind: "error", error: asError(error) }),
+      (value) => taskLoadGeneration.current === generation && setState({ kind: "ready", value }),
+      (error: unknown) =>
+        taskLoadGeneration.current === generation && setState({ kind: "error", error: asError(error) }),
     );
     return () => {
-      active = false;
+      if (taskLoadGeneration.current === generation) taskLoadGeneration.current += 1;
     };
   }, [taskId]);
 
   async function loadMoreTurns(): Promise<void> {
     if (!taskId || state.kind !== "ready" || !state.value.nextCursor || loadingMore) return;
+    const generation = taskLoadGeneration.current;
+    const cursor = state.value.nextCursor;
     setLoadingMore(true);
     setLoadMoreError(null);
     try {
-      const next = await browserApi.task(taskId, state.value.nextCursor);
+      const next = await browserApi.task(taskId, cursor);
+      if (taskLoadGeneration.current !== generation) return;
       setState((current) =>
-        current.kind === "ready"
+        current.kind === "ready" && current.value.task.id === taskId
           ? {
               kind: "ready",
               value: {
@@ -259,9 +270,10 @@ export function TaskDetailPage({ taskId }: { taskId?: string }) {
           : current,
       );
     } catch (error) {
+      if (taskLoadGeneration.current !== generation) return;
       setLoadMoreError(asError(error));
     } finally {
-      setLoadingMore(false);
+      if (taskLoadGeneration.current === generation) setLoadingMore(false);
     }
   }
 

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -1,6 +1,6 @@
 import type { TaskDetail, TaskStatus, TaskSummary, TaskTurn } from "@opentag/shared/browser";
 import { Link } from "@tanstack/react-router";
-import { type ChangeEventHandler, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ChangeEventHandler, type ReactNode, useEffect, useMemo, useState } from "react";
 import { ApiError, browserApi } from "../api.js";
 import feishuIconUrl from "../assets/feishu.svg";
 import { PageHeader } from "../components/kumo/page-header/page-header.js";
@@ -193,110 +193,6 @@ export function TasksPage() {
       ) : null}
       {state.kind === "ready" && tasks.length === 0 ? (
         <TaskNotice heading="No Tasks found" detail="Try a different search or filter." />
-      ) : null}
-    </section>
-  );
-}
-
-/**
- * The Agent home list reads the Agent's own Tasks from the server. It keeps pagination scoped to
- * that Agent and protects each append from a response belonging to an older load.
- */
-export function AgentTasksSection({ agentId }: { agentId: string }) {
-  const [state, setState] = useState<LoadState<TaskCollection>>({ kind: "loading" });
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [loadMoreError, setLoadMoreError] = useState<Error | null>(null);
-  const loadGeneration = useRef(0);
-
-  useEffect(() => {
-    let active = true;
-    loadGeneration.current += 1;
-    setState({ kind: "loading" });
-    setLoadMoreError(null);
-    setLoadingMore(false);
-    browserApi.tasks({ agentId }).then(
-      (value) =>
-        active && setState({ kind: "ready", value: { tasks: [...value.tasks], nextCursor: value.nextCursor } }),
-      (error: unknown) => active && setState({ kind: "error", error: asError(error) }),
-    );
-    return () => {
-      active = false;
-    };
-  }, [agentId]);
-
-  async function loadMore(): Promise<void> {
-    if (state.kind !== "ready" || !state.value.nextCursor || loadingMore) return;
-    const pagedGeneration = loadGeneration.current;
-    setLoadingMore(true);
-    setLoadMoreError(null);
-    try {
-      const next = await browserApi.tasks({ agentId, cursor: state.value.nextCursor });
-      if (loadGeneration.current !== pagedGeneration) return;
-      setState((current) =>
-        current.kind === "ready"
-          ? { kind: "ready", value: { tasks: [...current.value.tasks, ...next.tasks], nextCursor: next.nextCursor } }
-          : current,
-      );
-    } catch (error) {
-      if (loadGeneration.current !== pagedGeneration) return;
-      // Keep the rows already on screen so a transient page failure has a safe retry path.
-      setLoadMoreError(asError(error));
-    } finally {
-      if (loadGeneration.current === pagedGeneration) setLoadingMore(false);
-    }
-  }
-
-  return (
-    <section className="grid gap-4" aria-labelledby="agent-tasks-heading" data-ui="agent-tasks">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <Text as="h2" id="agent-tasks-heading" variant="heading">
-          Tasks
-        </Text>
-        <Link to="/tasks">All Tasks</Link>
-      </div>
-      {state.kind === "loading" ? (
-        <TaskNotice heading="Loading Tasks" detail="Reading stored Sessions and Turns." />
-      ) : null}
-      {state.kind === "error" ? <TaskNotice heading="Tasks unavailable" detail={state.error.message} /> : null}
-      {state.kind === "ready" && state.value.tasks.length === 0 ? (
-        <TaskNotice heading="No Tasks found" detail="Work this Agent handles in Feishu or Slack appears here." />
-      ) : null}
-      {state.kind === "ready" && state.value.tasks.length > 0 ? (
-        <>
-          <div className="overflow-x-auto">
-            <Table className="w-full" aria-label="Agent Tasks" data-ui="task-table">
-              <thead>
-                <tr className="border-b border-kumo-line text-left text-sm text-kumo-subtle">
-                  <th scope="col">Task</th>
-                  <th scope="col">Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {state.value.tasks.map((task) => (
-                  <TaskRow key={task.id} showAgent={false} task={task} />
-                ))}
-              </tbody>
-            </Table>
-          </div>
-          {state.value.nextCursor ? (
-            <div className="flex flex-wrap items-center gap-3">
-              <Button
-                disabled={loadingMore}
-                loading={loadingMore}
-                type="button"
-                variant="secondary"
-                onClick={() => void loadMore()}
-              >
-                {loadingMore ? "Loading more Tasks…" : loadMoreError ? "Try again" : "Load more"}
-              </Button>
-              {loadMoreError ? (
-                <span className="text-sm text-kumo-danger" role="alert">
-                  {loadMoreError.message}
-                </span>
-              ) : null}
-            </div>
-          ) : null}
-        </>
       ) : null}
     </section>
   );
@@ -589,7 +485,7 @@ function TaskSelect({
   );
 }
 
-function TaskRow({ showAgent = true, task }: { showAgent?: boolean; task: TaskSummary }) {
+function TaskRow({ task }: { task: TaskSummary }) {
   const status = statusPresentation[task.status];
   return (
     <tr className="border-b border-kumo-line align-top" data-ui="task-table-row">
@@ -598,17 +494,13 @@ function TaskRow({ showAgent = true, task }: { showAgent?: boolean; task: TaskSu
           {task.title}
         </Link>
         <span className="mt-1 block text-sm text-kumo-subtle" data-ui="task-list-metadata">
-          {showAgent ? (
-            <>
-              <span>{task.agent.displayName}</span>
-              <span aria-hidden="true"> · </span>
-            </>
-          ) : null}
+          <span>{task.agent.displayName}</span>
+          <span aria-hidden="true">·</span>
           <ProviderIcon provider={task.source.provider} compact />
-          <span> {task.source.provider}</span>
-          <span aria-hidden="true"> · </span>
+          <span>{task.source.provider}</span>
+          <span aria-hidden="true">·</span>
           <span>{task.sessionKind}</span>
-          <span aria-hidden="true"> · </span>
+          <span aria-hidden="true">·</span>
           <span>{shortId(task.source.threadKey ?? task.source.channelId)}</span>
         </span>
       </td>

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -1,6 +1,6 @@
 import type { TaskDetail, TaskStatus, TaskSummary, TaskTurn } from "@opentag/shared/browser";
 import { Link } from "@tanstack/react-router";
-import { type ChangeEventHandler, type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ChangeEventHandler, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { ApiError, browserApi } from "../api.js";
 import feishuIconUrl from "../assets/feishu.svg";
 import { PageHeader } from "../components/kumo/page-header/page-header.js";
@@ -20,6 +20,7 @@ import {
 
 type TaskFilter = "all" | TaskStatus;
 type LoadState<T> = { kind: "loading" } | { kind: "error"; error: Error } | { kind: "ready"; value: T };
+type TaskCollection = { tasks: TaskSummary[]; nextCursor: string | null };
 
 const statusPresentation: Record<TaskStatus, { readonly label: string; readonly tone: StatusTone }> = {
   queued: { label: "Queued", tone: "info" },
@@ -32,12 +33,12 @@ const statusPresentation: Record<TaskStatus, { readonly label: string; readonly 
 };
 
 export function TasksPage() {
-  const [state, setState] = useState<LoadState<{ tasks: TaskSummary[]; nextCursor: string | null }>>({
-    kind: "loading",
-  });
+  const [state, setState] = useState<LoadState<TaskCollection>>({ kind: "loading" });
   const [query, setQuery] = useState("");
   const [agentId, setAgentId] = useState("all");
   const [status, setStatus] = useState<TaskFilter>("all");
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -82,12 +83,22 @@ export function TasksPage() {
   }, [agentId, query, state, status]);
 
   async function loadMore(): Promise<void> {
-    if (state.kind !== "ready" || !state.value.nextCursor) return;
+    if (state.kind !== "ready" || !state.value.nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    setLoadMoreError(null);
     try {
       const next = await browserApi.tasks({ cursor: state.value.nextCursor });
-      setState({ kind: "ready", value: { tasks: [...state.value.tasks, ...next.tasks], nextCursor: next.nextCursor } });
+      setState((current) =>
+        current.kind === "ready"
+          ? { kind: "ready", value: { tasks: [...current.value.tasks, ...next.tasks], nextCursor: next.nextCursor } }
+          : current,
+      );
     } catch (error) {
-      setState({ kind: "error", error: asError(error) });
+      // Keep the rows already on screen. A failed append should be recoverable without making the
+      // viewer lose the page that was loaded successfully.
+      setLoadMoreError(asError(error));
+    } finally {
+      setLoadingMore(false);
     }
   }
 
@@ -161,14 +172,131 @@ export function TasksPage() {
             </tbody>
           </Table>
           {state.value.nextCursor ? (
-            <Button type="button" variant="secondary" onClick={() => void loadMore()}>
-              Load more
-            </Button>
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                disabled={loadingMore}
+                loading={loadingMore}
+                type="button"
+                variant="secondary"
+                onClick={() => void loadMore()}
+              >
+                {loadingMore ? "Loading more Tasks…" : loadMoreError ? "Try again" : "Load more"}
+              </Button>
+              {loadMoreError ? (
+                <span className="text-sm text-kumo-danger" role="alert">
+                  {loadMoreError.message}
+                </span>
+              ) : null}
+            </div>
           ) : null}
         </>
       ) : null}
       {state.kind === "ready" && tasks.length === 0 ? (
         <TaskNotice heading="No Tasks found" detail="Try a different search or filter." />
+      ) : null}
+    </section>
+  );
+}
+
+/**
+ * The Agent home list reads the Agent's own Tasks from the server. It keeps pagination scoped to
+ * that Agent and protects each append from a response belonging to an older load.
+ */
+export function AgentTasksSection({ agentId }: { agentId: string }) {
+  const [state, setState] = useState<LoadState<TaskCollection>>({ kind: "loading" });
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | null>(null);
+  const loadGeneration = useRef(0);
+
+  useEffect(() => {
+    let active = true;
+    loadGeneration.current += 1;
+    setState({ kind: "loading" });
+    setLoadMoreError(null);
+    setLoadingMore(false);
+    browserApi.tasks({ agentId }).then(
+      (value) =>
+        active && setState({ kind: "ready", value: { tasks: [...value.tasks], nextCursor: value.nextCursor } }),
+      (error: unknown) => active && setState({ kind: "error", error: asError(error) }),
+    );
+    return () => {
+      active = false;
+    };
+  }, [agentId]);
+
+  async function loadMore(): Promise<void> {
+    if (state.kind !== "ready" || !state.value.nextCursor || loadingMore) return;
+    const pagedGeneration = loadGeneration.current;
+    setLoadingMore(true);
+    setLoadMoreError(null);
+    try {
+      const next = await browserApi.tasks({ agentId, cursor: state.value.nextCursor });
+      if (loadGeneration.current !== pagedGeneration) return;
+      setState((current) =>
+        current.kind === "ready"
+          ? { kind: "ready", value: { tasks: [...current.value.tasks, ...next.tasks], nextCursor: next.nextCursor } }
+          : current,
+      );
+    } catch (error) {
+      if (loadGeneration.current !== pagedGeneration) return;
+      // Keep the rows already on screen so a transient page failure has a safe retry path.
+      setLoadMoreError(asError(error));
+    } finally {
+      if (loadGeneration.current === pagedGeneration) setLoadingMore(false);
+    }
+  }
+
+  return (
+    <section className="grid gap-4" aria-labelledby="agent-tasks-heading" data-ui="agent-tasks">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <Text as="h2" id="agent-tasks-heading" variant="heading">
+          Tasks
+        </Text>
+        <Link to="/tasks">All Tasks</Link>
+      </div>
+      {state.kind === "loading" ? (
+        <TaskNotice heading="Loading Tasks" detail="Reading stored Sessions and Turns." />
+      ) : null}
+      {state.kind === "error" ? <TaskNotice heading="Tasks unavailable" detail={state.error.message} /> : null}
+      {state.kind === "ready" && state.value.tasks.length === 0 ? (
+        <TaskNotice heading="No Tasks found" detail="Work this Agent handles in Feishu or Slack appears here." />
+      ) : null}
+      {state.kind === "ready" && state.value.tasks.length > 0 ? (
+        <>
+          <div className="overflow-x-auto">
+            <Table className="w-full" aria-label="Agent Tasks" data-ui="task-table">
+              <thead>
+                <tr className="border-b border-kumo-line text-left text-sm text-kumo-subtle">
+                  <th scope="col">Task</th>
+                  <th scope="col">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {state.value.tasks.map((task) => (
+                  <TaskRow key={task.id} showAgent={false} task={task} />
+                ))}
+              </tbody>
+            </Table>
+          </div>
+          {state.value.nextCursor ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                disabled={loadingMore}
+                loading={loadingMore}
+                type="button"
+                variant="secondary"
+                onClick={() => void loadMore()}
+              >
+                {loadingMore ? "Loading more Tasks…" : loadMoreError ? "Try again" : "Load more"}
+              </Button>
+              {loadMoreError ? (
+                <span className="text-sm text-kumo-danger" role="alert">
+                  {loadMoreError.message}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+        </>
       ) : null}
     </section>
   );
@@ -461,7 +589,7 @@ function TaskSelect({
   );
 }
 
-function TaskRow({ task }: { task: TaskSummary }) {
+function TaskRow({ showAgent = true, task }: { showAgent?: boolean; task: TaskSummary }) {
   const status = statusPresentation[task.status];
   return (
     <tr className="border-b border-kumo-line align-top" data-ui="task-table-row">
@@ -470,13 +598,17 @@ function TaskRow({ task }: { task: TaskSummary }) {
           {task.title}
         </Link>
         <span className="mt-1 block text-sm text-kumo-subtle" data-ui="task-list-metadata">
-          <span>{task.agent.displayName}</span>
-          <span aria-hidden="true">·</span>
+          {showAgent ? (
+            <>
+              <span>{task.agent.displayName}</span>
+              <span aria-hidden="true"> · </span>
+            </>
+          ) : null}
           <ProviderIcon provider={task.source.provider} compact />
-          <span>{task.source.provider}</span>
-          <span aria-hidden="true">·</span>
+          <span> {task.source.provider}</span>
+          <span aria-hidden="true"> · </span>
           <span>{task.sessionKind}</span>
-          <span aria-hidden="true">·</span>
+          <span aria-hidden="true"> · </span>
           <span>{shortId(task.source.threadKey ?? task.source.channelId)}</span>
         </span>
       </td>

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -1,6 +1,6 @@
 import type { TaskDetail, TaskStatus, TaskSummary, TaskTurn } from "@opentag/shared/browser";
 import { Link } from "@tanstack/react-router";
-import { type ChangeEventHandler, type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ChangeEventHandler, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ApiError, browserApi } from "../api.js";
 import feishuIconUrl from "../assets/feishu.svg";
 import { PageHeader } from "../components/kumo/page-header/page-header.js";
@@ -39,18 +39,30 @@ export function TasksPage() {
   const [status, setStatus] = useState<TaskFilter>("all");
   const [loadingMore, setLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<Error | null>(null);
+  const initialLoadGeneration = useRef(0);
+
+  const loadTasks = useCallback(async (): Promise<void> => {
+    const generation = initialLoadGeneration.current + 1;
+    initialLoadGeneration.current = generation;
+    setState({ kind: "loading" });
+    setLoadMoreError(null);
+    try {
+      const value = await browserApi.tasks();
+      if (initialLoadGeneration.current !== generation) return;
+      setState({ kind: "ready", value: { tasks: [...value.tasks], nextCursor: value.nextCursor } });
+    } catch (error) {
+      if (initialLoadGeneration.current !== generation) return;
+      setState({ kind: "error", error: asError(error) });
+    }
+  }, []);
 
   useEffect(() => {
-    let active = true;
-    browserApi.tasks().then(
-      (value) =>
-        active && setState({ kind: "ready", value: { tasks: [...value.tasks], nextCursor: value.nextCursor } }),
-      (error: unknown) => active && setState({ kind: "error", error: asError(error) }),
-    );
+    void loadTasks();
     return () => {
-      active = false;
+      // Invalidate an in-flight request when this page unmounts.
+      initialLoadGeneration.current += 1;
     };
-  }, []);
+  }, [loadTasks]);
 
   const agents = useMemo(() => {
     if (state.kind !== "ready") return [];
@@ -155,7 +167,17 @@ export function TasksPage() {
       {state.kind === "loading" ? (
         <TaskNotice heading="Loading Tasks" detail="Reading stored Sessions and Turns." />
       ) : null}
-      {state.kind === "error" ? <TaskNotice heading="Tasks unavailable" detail={state.error.message} /> : null}
+      {state.kind === "error" ? (
+        <TaskNotice
+          action={
+            <Button type="button" variant="secondary" onClick={() => void loadTasks()}>
+              Try again
+            </Button>
+          }
+          heading="Tasks unavailable"
+          detail={state.error.message}
+        />
+      ) : null}
       {state.kind === "ready" && tasks.length > 0 ? (
         <>
           <Table className="w-full" aria-label="Tasks" data-ui="task-table">
@@ -560,7 +582,7 @@ function DebugValue({ label, value }: { label: string; value: string }) {
   );
 }
 
-function TaskNotice({ heading, detail }: { heading: string; detail: string }) {
+function TaskNotice({ action, heading, detail }: { action?: ReactNode; heading: string; detail: string }) {
   return (
     <section
       className="grid gap-2 rounded-lg bg-kumo-base p-8 text-center ring ring-kumo-line"
@@ -576,6 +598,7 @@ function TaskNotice({ heading, detail }: { heading: string; detail: string }) {
       <Text as="p" variant="secondary">
         {detail}
       </Text>
+      {action ? <div className="flex justify-center">{action}</div> : null}
     </section>
   );
 }

--- a/packages/server/src/__tests__/integration/tasks.test.ts
+++ b/packages/server/src/__tests__/integration/tasks.test.ts
@@ -262,6 +262,78 @@ describe("Task debug queries", () => {
     }
   });
 
+  it("follows list and Turn cursors past the first page", async () => {
+    const value = await fixture();
+    try {
+      const [secondSession] = await value.database
+        .insert(sessions)
+        .values({
+          imBindingId: value.binding.id,
+          channelId: "oc_second",
+          conversationKind: "dm",
+          kind: "channel",
+          createdAt: new Date("2026-08-26T01:00:00.000Z"),
+        })
+        .returning();
+      if (!secondSession) throw new Error("Second Session fixture was not created");
+
+      const firstPage = await value.service.list(value.bootstrap.userId, { limit: 1 });
+      expect(firstPage.tasks).toHaveLength(1);
+      expect(firstPage.nextCursor).not.toBeNull();
+      if (!firstPage.nextCursor) throw new Error("The first Task page did not issue a cursor");
+
+      const secondPage = await value.service.list(value.bootstrap.userId, {
+        cursor: firstPage.nextCursor,
+        limit: 1,
+      });
+      expect(secondPage.tasks.map((task) => task.id)).toEqual([secondSession.id]);
+      expect(secondPage.nextCursor).toBeNull();
+
+      const [followUpMessage] = await value.database
+        .insert(imMessages)
+        .values({
+          imBindingId: value.binding.id,
+          providerEventId: "event-second",
+          channelId: "oc_debug",
+          externalMessageId: "om_second",
+          providerRevisionKey: "1",
+          operation: "created",
+          direction: "inbound",
+          authorKind: "human",
+          authorExternalId: "ou_debug",
+          authorDisplayName: "Mia",
+          content: { version: 1, fallbackText: "And once more.", blocks: [], truncated: false },
+          providerContext: { provider: "feishu", chatType: "p2p" },
+          occurredAt: new Date("2026-08-27T02:01:00.000Z"),
+        })
+        .returning();
+      if (!followUpMessage) throw new Error("Second IM Message fixture was not created");
+      await value.database.insert(imMessageDeliveries).values({
+        messageId: followUpMessage.id,
+        sessionId: value.session.id,
+        attention: "direct",
+        state: "pending",
+        placementGeneration: 1,
+        expiresAt: new Date("2026-08-28T02:00:00.000Z"),
+      });
+
+      const firstTurnPage = await value.service.get(value.bootstrap.userId, value.session.id, { limit: 1 });
+      expect(firstTurnPage.turns).toHaveLength(1);
+      expect(firstTurnPage.nextCursor).not.toBeNull();
+      if (!firstTurnPage.nextCursor) throw new Error("The first Turn page did not issue a cursor");
+
+      const secondTurnPage = await value.service.get(value.bootstrap.userId, value.session.id, {
+        cursor: firstTurnPage.nextCursor,
+        limit: 1,
+      });
+      expect(secondTurnPage.turns).toHaveLength(1);
+      expect(secondTurnPage.turns[0]?.deliveryId).toBe(value.deliveryId);
+      expect(secondTurnPage.nextCursor).toBeNull();
+    } finally {
+      await value.sql.end();
+    }
+  });
+
   it("titles a Session from a follow-up message that no longer addresses the Agent", async () => {
     const value = await fixture();
     try {

--- a/packages/server/src/services/tasks/task-service.ts
+++ b/packages/server/src/services/tasks/task-service.ts
@@ -93,6 +93,15 @@ function parseCursor(cursor: string | undefined): { at: Date; id: string } | und
   }
 }
 
+/**
+ * Keep cursor timestamps explicit when they cross the SQL boundary. The postgres driver rejects
+ * binding the decoded Date directly in a tuple comparison, which only affects requests after the
+ * first page. An ISO value with a timestamptz cast preserves the cursor's instant and its ordering.
+ */
+function cursorTimestamp(cursor: { at: Date; id: string }): string {
+  return cursor.at.toISOString();
+}
+
 function toIso(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
@@ -256,7 +265,7 @@ export class TaskService {
       inner join im_messages m on m.id = d.message_id
       left join im_message_deliveries root on root.id = d.steer_target_delivery_id
       where d.session_id = ${sessionId}::uuid
-        ${cursor ? sql`and (m.occurred_at, d.id) < (${cursor.at}, ${cursor.id}::uuid)` : sql``}
+        ${cursor ? sql`and (m.occurred_at, d.id) < (${cursorTimestamp(cursor)}::timestamptz, ${cursor.id}::uuid)` : sql``}
       order by m.occurred_at desc, d.id desc
       limit ${options.limit + 1}
     `);
@@ -387,7 +396,7 @@ export class TaskService {
         ${options.kind ? sql`and s.kind = ${options.kind}` : sql``}
         ${
           options.cursor
-            ? sql`and (greatest(s.created_at, coalesce(ld.activity_at, s.created_at)), s.id) < (${options.cursor.at}, ${options.cursor.id}::uuid)`
+            ? sql`and (greatest(s.created_at, coalesce(ld.activity_at, s.created_at)), s.id) < (${cursorTimestamp(options.cursor)}::timestamptz, ${options.cursor.id}::uuid)`
             : sql``
         }
       order by "lastActivityAt" desc, s.id desc


### PR DESCRIPTION
Make Tasks pagination race-safe with loading state, functional page appends, retryable append errors, and initial-load recovery. Includes the server cursor timestamp fix and integration coverage required for second-page requests. Local web/server checks passed.