### PR TITLE
perf(web): split routes and tree-shake echarts

### DIFF
--- a/apps/web/src/features/agent-usage-echarts.ts
+++ b/apps/web/src/features/agent-usage-echarts.ts
@@ -1,0 +1,15 @@
+import { LineChart } from "echarts/charts";
+import { BrushComponent, GridComponent, ToolboxComponent, TooltipComponent } from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+
+/*
+ * The chart's echarts registration lives in a module of its own so the imports above can be static.
+ * Awaiting `import("echarts/charts")` directly asks for the whole module namespace, and Rollup cannot
+ * prove which of its bindings a caller reads, so it keeps every one — all 22 chart types and every
+ * component, map projections included. Static named imports are traceable, so only what is named here
+ * survives; the lazy boundary moves out to whoever imports this module.
+ */
+echarts.use([LineChart, BrushComponent, GridComponent, ToolboxComponent, TooltipComponent, CanvasRenderer]);
+
+export { echarts };

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -10,18 +10,7 @@ import { browserApi } from "../api.js";
 import { ChartPalette, KumoSelectControl, Loader, Meter, Text, TimeseriesChart } from "../ui/design-system.js";
 
 const LazyTimeseriesChart = lazy(async () => {
-  const [
-    { LineChart },
-    { BrushComponent, GridComponent, ToolboxComponent, TooltipComponent },
-    { CanvasRenderer },
-    echarts,
-  ] = await Promise.all([
-    import("echarts/charts"),
-    import("echarts/components"),
-    import("echarts/renderers"),
-    import("echarts/core"),
-  ]);
-  echarts.use([LineChart, BrushComponent, GridComponent, ToolboxComponent, TooltipComponent, CanvasRenderer]);
+  const { echarts } = await import("./agent-usage-echarts.js");
   return {
     default: (props: Omit<ComponentProps<typeof TimeseriesChart>, "echarts">) => (
       <TimeseriesChart {...props} echarts={echarts} />

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,17 +3,16 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 /**
- * Regenerating the route tree is only useful while serving or building; a test run imports the
- * committed `src/routeTree.gen.ts`. Keeping the generator out of the test transform also keeps its
- * Babel pass out of it, which matters because this repository pins @babel/parser and @babel/types
- * to 8.x while @babel/core stays on 7.x — a combination that crashes on TypeScript function types.
+ * Regenerating the route tree, and splitting each route's component out of the entry, is only useful
+ * while serving or building; a test run imports the committed `src/routeTree.gen.ts`, which the
+ * splitter never rewrites — it transforms the route modules themselves, in memory.
  */
 const generateRoutes = !process.env.VITEST;
 
 export default defineConfig({
   base: "/",
   // The route generator must run before the React plugin so the generated tree is transformed too.
-  plugins: [...(generateRoutes ? [tanstackRouter({ autoCodeSplitting: false, target: "react" })] : []), react()],
+  plugins: [...(generateRoutes ? [tanstackRouter({ autoCodeSplitting: true, target: "react" })] : []), react()],
   server: {
     proxy: {
       "/api": "http://localhost:8000",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,6 @@
   },
   "pnpm": {
     "overrides": {
-      "@babel/helper-string-parser": "8.0.0-rc.2",
-      "@babel/helper-validator-identifier": "8.0.0-rc.2",
-      "@babel/parser": "8.0.0-rc.2",
-      "@babel/types": "8.0.0-rc.2",
       "ast-kit": "3.0.0-beta.1",
       "rollup": "4.59.0",
       "tsdown": "0.21.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@babel/helper-string-parser': 8.0.0-rc.2
-  '@babel/helper-validator-identifier': 8.0.0-rc.2
-  '@babel/parser': 8.0.0-rc.2
-  '@babel/types': 8.0.0-rc.2
   ast-kit: 3.0.0-beta.1
   rollup: 4.59.0
   tsdown: 0.21.4
@@ -267,9 +263,17 @@ packages:
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@8.0.0-rc.2':
     resolution: {integrity: sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@8.0.0-rc.2':
     resolution: {integrity: sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==}
@@ -282,6 +286,11 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   '@babel/parser@8.0.0-rc.2':
     resolution: {integrity: sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ==}
@@ -310,6 +319,10 @@ packages:
 
   '@babel/traverse@7.29.8':
     resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.0-rc.2':
@@ -4037,7 +4050,7 @@ snapshots:
 
   '@babel/code-frame@7.29.7':
     dependencies:
-      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -4050,10 +4063,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
-      '@babel/parser': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.8
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -4065,8 +4078,8 @@ snapshots:
 
   '@babel/generator@7.29.8':
     dependencies:
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -4093,7 +4106,7 @@ snapshots:
   '@babel/helper-module-imports@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.8
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4101,14 +4114,18 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-string-parser@8.0.0-rc.2': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.2': {}
 
@@ -4117,7 +4134,11 @@ snapshots:
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
 
   '@babel/parser@8.0.0-rc.2':
     dependencies:
@@ -4138,20 +4159,25 @@ snapshots:
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/traverse@7.29.8':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-globals': 7.29.7
-      '@babel/parser': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@8.0.0-rc.2':
     dependencies:
@@ -5144,7 +5170,7 @@ snapshots:
 
   '@tanstack/router-generator@1.167.33':
     dependencies:
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
       '@tanstack/router-core': 1.171.27
       '@tanstack/router-utils': 1.162.2
       '@tanstack/virtual-file-routes': 1.162.0
@@ -5159,7 +5185,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
       '@tanstack/router-core': 1.171.27
       '@tanstack/router-generator': 1.167.33
       '@tanstack/router-utils': 1.162.2
@@ -5182,8 +5208,8 @@ snapshots:
   '@tanstack/router-utils@1.162.2':
     dependencies:
       '@babel/generator': 7.29.8
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       ansis: 4.3.1
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
@@ -5253,24 +5279,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5544,9 +5570,9 @@ snapshots:
   babel-dead-code-elimination@1.0.12:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
       '@babel/traverse': 7.29.8
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -6454,8 +6480,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       source-map-js: 1.2.1
 
   make-dir@4.0.0:


### PR DESCRIPTION
## Summary

Three independent bundle-size changes, one commit each so they can be reviewed and reverted separately.

**`perf(web): tree-shake echarts by registering it in a static module`**
`await import("echarts/charts")` asks for the whole module namespace, and Rollup cannot prove which bindings the caller reads, so it kept all 22 chart types and every component, map projections included. Registration moves into `features/agent-usage-echarts.ts` behind static named imports, which are traceable; the lazy boundary stays at the importer. The lazy chart graph goes from 8 chunks totalling 1,096 kB (365 kB gzip) to one 563 kB chunk (190 kB gzip). The entry chunk is unaffected — echarts was already lazy.

**`chore: drop the repository-wide Babel 8 overrides`**
`rolldown-plugin-dts` declares `@babel/generator`, `@babel/parser`, `@babel/types` and `@babel/helper-validator-identifier` as exact `8.0.0-rc.2` dependencies of its own, and pnpm resolves per package, so it receives them with or without an override. The overrides did nothing for the one consumer that needs a Babel 8 prerelease, and forced it on every consumer that asked for Babel 7 — `@babel/core@7.29.7` wants `@babel/parser@^7.29.7`, `@tanstack/router-plugin` wants `^7.28.5`, and `magicast` wants `^7.25.4`. A Babel 7 traverse, template and generator were being handed a Babel 8 AST, which is the mismatch the comment in `apps/web/vite.config.ts` warned about. After this, `apps/web` resolves a consistent Babel 7 while tsdown's dts chain keeps `8.0.0-rc.2`.

**`perf(web): split route components out of the entry chunk`**
`autoCodeSplitting` was off, so a visitor who only wanted to sign in downloaded onboarding, agent creation, tasks and settings first. **The entry chunk drops from 1,219 kB to 572 kB (382 kB → 186 kB gzip), across 49 chunks.** This one needed the overrides gone first: the splitter runs a full parse-and-generate pass over route TSX, which is the workload the mismatch would have crashed on.

`src/routeTree.gen.ts` is byte-for-byte unchanged — the splitter rewrites the route modules in memory, not the generated tree.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test` all pass (7/7 tasks; web 366 tests, server 292, client 491, shared 84, cli 152).
- Full `pnpm build` exercises `packages/*` `.d.mts` generation, which is the tsdown → rolldown-plugin-dts → Babel 8 chain the overrides used to cover.
- echarts tree-shaking verified in the build output: of the series type ids only `series.line` survives; no component install ids (`dataZoom.slider`, `timeline.slider`, `visualMap.continuous`, `legend.plain`) remain. The residual `polar`/`parallel`/`geo` strings are echarts core's coordinate-system registry, not installed components.
- Route splitting verified by literal probe, since minification renames identifiers but not JSX text: `"Loading Agent usage"`, `"Read-only debug view"` and `"Welcome back"` each left the entry chunk for `agents._agentId.usage-*.js`, `tasks-page-*.js` and `login-*.js`.
- `vite dev` smoke-tested separately, since CI never runs it and the splitter also transforms in dev: server starts, `/` returns 200, and route modules come back rewritten to `lazyRouteComponent` over a `?tsr-split=component` import.

## Breaking changes

None. No runtime behavior changes; no API or schema changes.

## Follow-ups (not in this PR)

- `apps/web/src/router.ts` has no `defaultPendingComponent`. Now that route components load asynchronously, a slow connection may flash blank during a transition.
- `rolldown-plugin-dts@0.28.3` drops Babel entirely. Upgrading `tsdown` past it would let the remaining `ast-kit` pin go too.
- The entry is now dominated by vendor code (React, the router runtime, Kumo, icons) pulled in eagerly through `ui/design-system.tsx`'s barrel. Restructuring that barrel is the next lever.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
