### PR TITLE
test(web): make the account menu tests assert what their names claim

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -2687,7 +2687,6 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("menu")).toBeTruthy();
     account.focus();
     note("after focus");
-    expect("x").toBe("forced-failure");
     fireEvent.keyDown(account, { key: "Escape" });
     note("after escape");
     expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1,7 +1,7 @@
 import type { AgentUsageDetail } from "@opentag/shared/browser";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { StrictMode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, onTestFailed, vi } from "vitest";
 import { App } from "../app.js";
 import { PasswordSignInForm } from "../features/auth/password-sign-in-form.js";
 
@@ -2645,6 +2645,41 @@ describe("OpenTag Web App Shell", () => {
   });
 
   it("moves focus into account actions and returns it to the trigger on Escape", async () => {
+    /*
+     * This one fails intermittently — once in 41 whole-file runs, on two different machines, and
+     * not reproduced in isolation (opentag#273). Chasing another failure costs dozens of runs, so
+     * instead the next one describes itself.
+     *
+     * Only on the failure path: `onTestFailed` runs before the DOM is torn down, and printing on
+     * every run would put noise back into a file we just finished clearing it out of.
+     */
+    onTestFailed(() => {
+      const active = document.activeElement;
+      const menus = [...document.querySelectorAll('[role="menu"]')];
+      // eslint-disable-next-line no-console -- diagnostic for a failure we cannot reproduce on demand
+      console.log(
+        "[opentag#273]",
+        JSON.stringify(
+          {
+            activeElement: active
+              ? {
+                  tag: active.tagName,
+                  role: active.getAttribute("role"),
+                  name: active.getAttribute("aria-label") ?? active.textContent?.slice(0, 40),
+                }
+              : null,
+            menus: menus.map((menu) => ({
+              name: menu.getAttribute("aria-label") ?? menu.getAttribute("aria-labelledby"),
+              items: menu.querySelectorAll('[role="menuitem"]').length,
+            })),
+            menuitems: document.querySelectorAll('[role="menuitem"]').length,
+          },
+          null,
+          1,
+        ),
+      );
+    });
+
     installApi({ multipleMemberships: true });
     render(<App />);
     const trigger = await screen.findByRole("button", { name: "Account menu" });

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1,7 +1,7 @@
 import type { AgentUsageDetail } from "@opentag/shared/browser";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { StrictMode } from "react";
-import { beforeEach, describe, expect, it, onTestFailed, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app.js";
 import { PasswordSignInForm } from "../features/auth/password-sign-in-form.js";
 

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -2645,51 +2645,28 @@ describe("OpenTag Web App Shell", () => {
   });
 
   it("moves focus into account actions and returns it to the trigger on Escape", async () => {
-    /*
-     * This one fails intermittently — once in about forty whole-file runs, on two machines, and
-     * never reproduced in isolation (opentag#273). Chasing another failure costs dozens of runs, so
-     * the next one describes itself instead.
-     *
-     * The record is taken *during* the test rather than after it. `onTestFailed` runs after this
-     * suite's `afterEach(cleanup)`, so by then the DOM is gone: a handler that inspects it there
-     * reports an empty document no matter what actually happened.
-     *
-     * It is a trail rather than a snapshot because we do not know which line gives way first. Menu
-     * never opened, opened and did not close, focus never landed — each leaves a different
-     * sequence, and one occurrence should be enough to tell them apart.
-     */
-    const trail: string[] = [];
-    const note = (label: string) => {
-      const active = document.activeElement;
-      /*
-       * The record asks the question the assertion asks — a menu accessibly named "Account" —
-       * rather than a bare count of menus. A menu element stays in the document after Escape and
-       * only stops matching that name, so a count reads identically on a passing run and explains
-       * nothing about a failing one.
-       */
-      trail.push(
-        `${label}: active=${active?.tagName}/${active?.getAttribute("role") ?? "-"} ` +
-          `accountMenus=${screen.queryAllByRole("menu", { name: "Account" }).length} ` +
-          `menus=${document.querySelectorAll('[role="menu"]').length} ` +
-          `items=${document.querySelectorAll('[role="menuitem"]').length}`,
-      );
-    };
-    // Nothing is printed on a green run; the trail is a few strings that go out of scope.
-    onTestFailed(() => console.log(`[opentag#273]\n${trail.join("\n")}`));
-
     installApi({ multipleMemberships: true });
     render(<App />);
     const trigger = await screen.findByRole("button", { name: "Account menu" });
-    note("before open");
     fireEvent.click(trigger);
-    note("after open");
     const account = screen.getByRole("menuitem", { name: "Account" });
     expect(screen.getByRole("menu")).toBeTruthy();
     account.focus();
-    note("after focus");
     fireEvent.keyDown(account, { key: "Escape" });
-    note("after escape");
-    expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();
+
+    /*
+     * Closing is asynchronous: the menu is still in the document on the tick after Escape and
+     * leaves a frame or two later. This waits for it rather than asserting immediately, which also
+     * means the close finishes inside the test instead of racing whatever runs next.
+     *
+     * The old assertion asked for a menu accessibly named "Account" and got null at every moment,
+     * open or closed — so it passed with the Escape line deleted entirely, and never checked the
+     * focus return its name promises.
+     */
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).toBeNull();
+    });
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("supports arrow-key navigation and focus return in the account menu", async () => {
@@ -2706,7 +2683,11 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.keyDown(signOut, { key: "ArrowDown" });
     fireEvent.keyDown(account, { key: "End" });
     fireEvent.keyDown(signOut, { key: "Escape" });
-    expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();
+    // Same as above: closing is asynchronous, and a menu named "Account" never existed to be null.
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).toBeNull();
+    });
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("removes the old admin product shell without a redirect", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -2646,48 +2646,50 @@ describe("OpenTag Web App Shell", () => {
 
   it("moves focus into account actions and returns it to the trigger on Escape", async () => {
     /*
-     * This one fails intermittently — once in 41 whole-file runs, on two different machines, and
-     * not reproduced in isolation (opentag#273). Chasing another failure costs dozens of runs, so
-     * instead the next one describes itself.
+     * This one fails intermittently — once in about forty whole-file runs, on two machines, and
+     * never reproduced in isolation (opentag#273). Chasing another failure costs dozens of runs, so
+     * the next one describes itself instead.
      *
-     * Only on the failure path: `onTestFailed` runs before the DOM is torn down, and printing on
-     * every run would put noise back into a file we just finished clearing it out of.
+     * The record is taken *during* the test rather than after it. `onTestFailed` runs after this
+     * suite's `afterEach(cleanup)`, so by then the DOM is gone: a handler that inspects it there
+     * reports an empty document no matter what actually happened.
+     *
+     * It is a trail rather than a snapshot because we do not know which line gives way first. Menu
+     * never opened, opened and did not close, focus never landed — each leaves a different
+     * sequence, and one occurrence should be enough to tell them apart.
      */
-    onTestFailed(() => {
+    const trail: string[] = [];
+    const note = (label: string) => {
       const active = document.activeElement;
-      const menus = [...document.querySelectorAll('[role="menu"]')];
-      // eslint-disable-next-line no-console -- diagnostic for a failure we cannot reproduce on demand
-      console.log(
-        "[opentag#273]",
-        JSON.stringify(
-          {
-            activeElement: active
-              ? {
-                  tag: active.tagName,
-                  role: active.getAttribute("role"),
-                  name: active.getAttribute("aria-label") ?? active.textContent?.slice(0, 40),
-                }
-              : null,
-            menus: menus.map((menu) => ({
-              name: menu.getAttribute("aria-label") ?? menu.getAttribute("aria-labelledby"),
-              items: menu.querySelectorAll('[role="menuitem"]').length,
-            })),
-            menuitems: document.querySelectorAll('[role="menuitem"]').length,
-          },
-          null,
-          1,
-        ),
+      /*
+       * The record asks the question the assertion asks — a menu accessibly named "Account" —
+       * rather than a bare count of menus. A menu element stays in the document after Escape and
+       * only stops matching that name, so a count reads identically on a passing run and explains
+       * nothing about a failing one.
+       */
+      trail.push(
+        `${label}: active=${active?.tagName}/${active?.getAttribute("role") ?? "-"} ` +
+          `accountMenus=${screen.queryAllByRole("menu", { name: "Account" }).length} ` +
+          `menus=${document.querySelectorAll('[role="menu"]').length} ` +
+          `items=${document.querySelectorAll('[role="menuitem"]').length}`,
       );
-    });
+    };
+    // Nothing is printed on a green run; the trail is a few strings that go out of scope.
+    onTestFailed(() => console.log(`[opentag#273]\n${trail.join("\n")}`));
 
     installApi({ multipleMemberships: true });
     render(<App />);
     const trigger = await screen.findByRole("button", { name: "Account menu" });
+    note("before open");
     fireEvent.click(trigger);
+    note("after open");
     const account = screen.getByRole("menuitem", { name: "Account" });
     expect(screen.getByRole("menu")).toBeTruthy();
     account.focus();
+    note("after focus");
+    expect("x").toBe("forced-failure");
     fireEvent.keyDown(account, { key: "Escape" });
+    note("after escape");
     expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();
   });
 


### PR DESCRIPTION
## What

Two account-menu tests now assert what their names claim. This started as a diagnostic for #273 and became the fix, because building the diagnostic found the cause.

## The tests were not testing

Both asserted `queryByRole("menu", { name: "Account" })` is null. **No such menu ever exists.** `aria-label="Account"` is applied to the popup wrapper, which base-ui renders with `role="presentation"` — so it is ignored, and the menu takes its name from `aria-labelledby` pointing at the trigger. Under jsdom that name resolves to `"AAda"`; in Chrome it resolves to `"Account menu"`. Either way it is never `"Account"`, so the assertion was null with the menu open and null with it closed.

The plainest statement of what that was worth: **deleting the `fireEvent.keyDown(…, "Escape")` line entirely left the test passing.** Neither test checked the focus return both are named for.

## What is actually happening

Escape works. Closing is **asynchronous** — the menu is still in the document on the tick after the keydown and gone a few milliseconds later:

```
after focus:        active=DIV/menuitem  menus=1 items=2
escape on item:     active=DIV/menuitem  menus=1 items=2
after 50ms settle:  active=BUTTON/-      menus=0 items=0
```

So the tests ended with that work still outstanding, to land against whatever ran next.

## The change

Wait for the close, assert it, and assert focus returns to the trigger. Both new assertions verified by removing what they depend on: drop the Escape dispatch → red; expect focus elsewhere → red.

## On #273

⚠️ **This is not claimed as the fix.** Awaiting the close means it now completes inside the test rather than escaping its boundary, which makes it a candidate cause for an intermittent failure in this file — but 12 clean runs afterwards say nothing either way. At the observed ~2.4% rate that outcome is likelier than not regardless, which is the same arithmetic that invalidated our earlier isolation runs.

The diagnostic that was here is gone: it existed to find a cause that is now found.

## Note for a separate change

**`aria-label="Account"` in `app-shell.tsx` does nothing** — it lands on the presentation wrapper, so the menu is named through `aria-labelledby` pointing at the trigger instead.

That turns out to be harmless. Chrome resolves the trigger to its own `aria-label="Account menu"`, so the menu's accessible name is **"Account menu"**, which is correct. Verified in headless Chrome against the real components and confirmed by mutation: removing the trigger's `aria-label` makes the name fall back to the trigger's text, `"AAda"`.

⚠️ An earlier revision of this section claimed a screen reader announces the menu as *"AAda"* and called it an accessibility defect. That came from `dom-accessibility-api` under jsdom, whose name computation stops at the referenced element's text where Chrome first consults its `aria-label`. The DOM wiring was right; the conclusion drawn from a test library's approximation was not.

What remains is a no-op attribute that misleads the reader. Tracked in #275 as cosmetic cleanup; this PR is tests only. It is the only place in the app where a label sits on a base-ui `Content`.

## Verification

`pnpm check`, typecheck clean; web tests **366 passed**; 12 consecutive whole-file runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

