### PR TITLE
refactor: cut management surfaces over to Accounts

### DIFF
--- a/apps/cli/src/__tests__/agent.test.ts
+++ b/apps/cli/src/__tests__/agent.test.ts
@@ -20,16 +20,9 @@ const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const workspaceId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
 const computerId = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
-const workspace = {
-  id: workspaceId,
-  name: "example",
-  displayName: "Example",
-  setupCompletedAt: null,
-  grantedAt: "2026-08-19T00:00:00.000Z",
-};
 const me = {
   user: { id: userId, email: "admin@example.com", displayName: "Admin" },
-  workspaces: [workspace],
+  setupCompletedAt: null,
 };
 const computer = {
   computerId,
@@ -90,7 +83,7 @@ const agentSummary = {
 function api() {
   return {
     me: vi.fn().mockResolvedValue(me),
-    listWorkspaceComputers: vi.fn().mockResolvedValue({ computers: [computer] }),
+    listAccountComputers: vi.fn().mockResolvedValue({ computers: [computer] }),
     createAgent: vi.fn().mockResolvedValue(agent),
     listAgents: vi.fn().mockResolvedValue({ agents: [agentSummary] }),
     getAgent: vi.fn().mockResolvedValue(agent),
@@ -149,7 +142,7 @@ describe("Agent CLI core", () => {
     const client = api();
     client.me = vi.fn().mockResolvedValue({
       ...me,
-      workspaces: [workspace, { ...workspace, id: crypto.randomUUID(), name: "second" }],
+      setupCompletedAt: "2026-08-19T00:00:00.000Z",
     });
 
     await runAgentList({ accessToken: "access", api: client });
@@ -162,7 +155,7 @@ describe("Agent CLI core", () => {
     });
 
     expect(client.listAgents).toHaveBeenCalledWith("access");
-    expect(client.listWorkspaceComputers).toHaveBeenCalledWith("access");
+    expect(client.listAccountComputers).toHaveBeenCalledWith("access");
     expect(client.createAgent).toHaveBeenCalledWith("access", expect.objectContaining({ name: "code-reviewer" }));
     expect(client.me).not.toHaveBeenCalled();
   });
@@ -185,7 +178,7 @@ describe("Agent CLI core", () => {
 
   it("creates without a management scope and preserves an offline warning", async () => {
     const client = api();
-    client.listWorkspaceComputers.mockResolvedValue({
+    client.listAccountComputers.mockResolvedValue({
       computers: [{ ...computer, connectionStatus: "offline" as const }],
     });
     const result = await runAgentCreate({

--- a/apps/cli/src/core/agent/context.ts
+++ b/apps/cli/src/core/agent/context.ts
@@ -11,7 +11,7 @@ export interface AgentApiClient
     | "suspendAgent"
     | "reactivateAgent"
     | "deleteAgent"
-    | "listWorkspaceComputers"
+    | "listAccountComputers"
     | "me"
     | "getAgentImBinding"
     | "getAgentImBindingConfig"

--- a/apps/cli/src/core/agent/mutations.ts
+++ b/apps/cli/src/core/agent/mutations.ts
@@ -59,7 +59,7 @@ export function selectComputer(
 export async function runAgentCreate(options: AgentCreateOptions): Promise<AgentCreateResult> {
   const runtimeConfig = await createRuntimeConfig(options);
   const { api, accessToken } = await resolveAgentCommandContext(options);
-  const computers = await api.listWorkspaceComputers(accessToken);
+  const computers = await api.listAccountComputers(accessToken);
   const computer = selectComputer(computers, options.computerId);
   const input = CreateAgentRequestSchema.parse({
     name: options.name,

--- a/apps/cli/src/core/computer/queries.ts
+++ b/apps/cli/src/core/computer/queries.ts
@@ -6,5 +6,5 @@ export async function listComputers(home = resolveOpenTagHome()): Promise<ListWo
   if (!credentials) throw new Error("OpenTag is not logged in; run login first");
   const accessToken = await new AccessTokenProvider({ home }).getAccessToken();
   const api = new OpenTagApi(credentials.serverUrl);
-  return api.listWorkspaceComputers(accessToken);
+  return api.listAccountComputers(accessToken);
 }

--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -122,7 +122,7 @@ describe("BrowserApi", () => {
               email: "admin@example.com",
               displayName: "Admin",
             },
-            workspaces: [],
+            setupCompletedAt: null,
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         ),

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1,12 +1,10 @@
 import type { AgentUsageDetail } from "@opentag/shared/browser";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app.js";
 import { PasswordSignInForm } from "../features/auth/password-sign-in-form.js";
 
 const workspaceId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
-const secondaryWorkspaceId = "3928e3dc-99b0-4a79-97c8-bf9c26b91add";
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const memberUserId = "63e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
@@ -177,33 +175,9 @@ function installApi(
           503,
         );
       }
-      const existing = options.workspaceless
-        ? []
-        : [
-            {
-              id: workspaceId,
-              name: "example",
-              displayName: "Example",
-              setupCompletedAt,
-              grantedAt: "2026-08-20T00:00:00.000Z",
-            },
-          ];
       return json({
         user: { id: userId, email: "ada@example.com", displayName: currentDisplayName },
-        workspaces: [
-          ...existing,
-          ...(options.multipleMemberships
-            ? [
-                {
-                  id: secondaryWorkspaceId,
-                  name: "secondary",
-                  displayName: "Secondary",
-                  setupCompletedAt: "2026-08-20T00:00:00.000Z",
-                  grantedAt: "2026-08-20T00:00:00.000Z",
-                },
-              ]
-            : []),
-        ],
+        setupCompletedAt: options.workspaceless ? null : setupCompletedAt,
       });
     }
     if (path === "/api/v1/me/setup/complete" && init?.method === "POST") {
@@ -844,7 +818,7 @@ describe("OpenTag Web App Shell", () => {
     expect(trigger).toBe(document.activeElement);
   });
 
-  it("lets a Workspace Admin connect another Computer from New Agent", async () => {
+  it("lets the Account owner connect another Computer from New Agent", async () => {
     installApi();
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "New Agent" }));
@@ -2545,38 +2519,29 @@ describe("OpenTag Web App Shell", () => {
     expect(within(dialog).queryByRole("button", { name: "Create Agent" })).toBeNull();
   });
 
-  it("keeps an unprovisioned authenticated account read-only while the server finishes setup", async () => {
+  it("routes an Account with incomplete setup into onboarding without a Workspace grant", async () => {
     installApi({ workspaceless: true });
-    render(
-      <StrictMode>
-        <App />
-      </StrictMode>,
-    );
-    expect(await screen.findByRole("heading", { name: "OpenTag is not ready for this account" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/agents");
-    expect(screen.getByRole("status").textContent).toContain("Retry after provisioning finishes");
-    expect(screen.getByText(/contact an operator/)).toBeTruthy();
-    expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
-    const initialMeReads = vi.mocked(fetch).mock.calls.filter(([path]) => path === "/api/v1/me").length;
-    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
-    await waitFor(() =>
-      expect(vi.mocked(fetch).mock.calls.filter(([path]) => path === "/api/v1/me")).toHaveLength(initialMeReads + 1),
-    );
-    expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "Set up OpenTag" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/onboarding");
+    expect(screen.queryByRole("heading", { name: "OpenTag is not ready for this account" })).toBeNull();
+    expect(
+      vi.mocked(fetch).mock.calls.some(([path, init]) => path === "/api/v1/workspaces" && init?.method === "POST"),
+    ).toBe(false);
   });
 
-  it("keeps standalone onboarding behind the read-only Workspace setup gate", async () => {
+  it("keeps standalone onboarding reachable without a management Workspace", async () => {
     installApi({ workspaceless: true });
     window.history.replaceState({}, "", "/onboarding");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "OpenTag is not ready for this account" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Set up OpenTag" })).toBeTruthy();
     expect(window.location.pathname).toBe("/onboarding");
     expect(
       vi.mocked(fetch).mock.calls.some(([path, init]) => path === "/api/v1/workspaces" && init?.method === "POST"),
     ).toBe(false);
   });
 
-  it("routes an admin with incomplete Workspace setup into onboarding", async () => {
+  it("routes an Account with incomplete setup into onboarding", async () => {
     installApi({ setupCompletedAt: null });
     render(<App />);
     expect(await screen.findByRole("heading", { name: "Set up OpenTag" })).toBeTruthy();
@@ -2596,7 +2561,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getAllByRole("link", { name: "OpenTag" })).toHaveLength(1);
   });
 
-  it("keeps completed Workspaces out of onboarding even when it is requested directly", async () => {
+  it("keeps completed Accounts out of onboarding even when it is requested directly", async () => {
     installApi();
     window.history.replaceState({}, "", "/onboarding");
     render(<App />);

--- a/apps/web/src/features/account/account-page.tsx
+++ b/apps/web/src/features/account/account-page.tsx
@@ -3,10 +3,10 @@ import { type FormEvent, useEffect, useRef, useState } from "react";
 import { browserApi } from "../../api.js";
 import { Button, Field, KumoInputControl, SettingsList, SettingsRow, Text } from "../../ui/design-system.js";
 import { Page } from "../layout/page.js";
-import { useWorkspace } from "../session/session-context.js";
+import { useAccount } from "../session/session-context.js";
 
 export function AccountPage() {
-  const { me, refreshMe } = useWorkspace();
+  const { me, refreshMe } = useAccount();
   return (
     <Page title="Account" description="Manage your personal account details.">
       <AccountSettings refreshMe={refreshMe} user={me.user} />

--- a/apps/web/src/features/agents/agent-detail-page.tsx
+++ b/apps/web/src/features/agents/agent-detail-page.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { buttonClassName, Icon, StatusIndicator, Text } from "../../ui/design-system.js";
 import { AsyncState, useResource } from "../resource/use-resource.js";
-import { useWorkspace } from "../session/session-context.js";
+import { useAccount } from "../session/session-context.js";
 import type { AgentDetailView } from "./agent-model.js";
 import { loadAgentDetail, markAgentDetailUnconfirmed } from "./agent-model.js";
 import {
@@ -38,7 +38,7 @@ export function AgentDetailPage({ agentId }: { agentId: string }) {
 }
 
 export function AgentObjectHeader({ agent, backToSettings }: { agent: AgentDetailView; backToSettings?: boolean }) {
-  const { me } = useWorkspace();
+  const { me } = useAccount();
   const showCreator = agent.createdBy.userId !== me.user.id;
   return (
     <header className="grid gap-4">

--- a/apps/web/src/features/agents/agents-page.tsx
+++ b/apps/web/src/features/agents/agents-page.tsx
@@ -4,7 +4,7 @@ import { orderAgentIds } from "../../features/agent-list-order.js";
 import { Button, buttonClassName, Icon, StatusIndicator } from "../../ui/design-system.js";
 import { EmptyState, Page } from "../layout/page.js";
 import { AsyncState, useResource } from "../resource/use-resource.js";
-import { useWorkspace } from "../session/session-context.js";
+import { useAccount } from "../session/session-context.js";
 import type { AgentListItem } from "./agent-model.js";
 import { loadAgentList, markAgentListUnconfirmed } from "./agent-model.js";
 import {
@@ -18,7 +18,7 @@ import { agentDetailLink, agentSettingsSectionLink } from "./agent-routes.js";
 import { NewAgentDialog } from "./new-agent-page.js";
 
 export function AgentsPage() {
-  const { me } = useWorkspace();
+  const { me } = useAccount();
   const [createOpen, setCreateOpen] = useState(false);
   const createTriggerRef = useRef<HTMLButtonElement>(null);
   const state = useResource(() => loadAgentList(), me.user.id, {

--- a/apps/web/src/features/agents/new-agent-page.tsx
+++ b/apps/web/src/features/agents/new-agent-page.tsx
@@ -8,7 +8,7 @@ import { Button, Dialog, Text } from "../../ui/design-system.js";
 import { Page } from "../layout/page.js";
 import type { LoadState } from "../resource/use-resource.js";
 import { AsyncState, useResource } from "../resource/use-resource.js";
-import { useWorkspace } from "../session/session-context.js";
+import { useAccount } from "../session/session-context.js";
 import { agentDetailLink } from "./agent-routes.js";
 
 export function useOwnComputersResource(accountId: string, refreshVersion = 0) {
@@ -20,7 +20,7 @@ export function useOwnComputersResource(accountId: string, refreshVersion = 0) {
 }
 
 export function NewAgentPage() {
-  const { me } = useWorkspace();
+  const { me } = useAccount();
   const navigate = useNavigate();
   const [computerRefreshVersion, setComputerRefreshVersion] = useState(0);
   const [created, setCreated] = useState<AgentAdminConfig>();
@@ -57,7 +57,7 @@ export function NewAgentDialog({
   onClose: () => void;
   returnFocusRef: { current: HTMLButtonElement | null };
 }) {
-  const { me } = useWorkspace();
+  const { me } = useAccount();
   const navigate = useNavigate();
   const [computerRefreshVersion, setComputerRefreshVersion] = useState(0);
   const computers = useOwnComputersResource(me.user.id, computerRefreshVersion);

--- a/apps/web/src/features/session/session-context.tsx
+++ b/apps/web/src/features/session/session-context.tsx
@@ -1,10 +1,9 @@
-import type { MeResponse, MeWorkspace } from "@opentag/shared/browser";
+import type { MeResponse } from "@opentag/shared/browser";
 import { createContext, useContext } from "react";
 
 /**
- * Authentication proves the Account identity and nothing more. The Server says the same: an Account
- * may hold no active resource grant and still be signed in, so a page that needs only the Account
- * reads this rather than the Workspace session below.
+ * Authentication proves the Account identity and nothing more. Resource pages use the same Account
+ * session; they no longer depend on a management Workspace membership.
  */
 export interface AccountSession {
   me: MeResponse;
@@ -14,26 +13,12 @@ export interface AccountSession {
   refreshMe: () => Promise<MeResponse>;
 }
 
-export interface WorkspaceSession extends AccountSession {
-  membership: MeWorkspace;
-}
-
 export const accountContext = createContext<AccountSession | undefined>(undefined);
 
 export const AccountContext = accountContext.Provider;
 
-export const workspaceContext = createContext<WorkspaceSession | undefined>(undefined);
-
-export const WorkspaceContext = workspaceContext.Provider;
-
 export function useAccount(): AccountSession {
   const value = useContext(accountContext);
   if (!value) throw new Error("Account context is missing");
-  return value;
-}
-
-export function useWorkspace(): WorkspaceSession {
-  const value = useContext(workspaceContext);
-  if (!value) throw new Error("Workspace context is missing");
   return value;
 }

--- a/apps/web/src/im/slack-configuration.tsx
+++ b/apps/web/src/im/slack-configuration.tsx
@@ -10,7 +10,7 @@ const SLACK_CONFIGURATION_MESSAGES: Record<string, string> = {
   IM_BINDING_PROVIDER_IMMUTABLE:
     "This Agent is connected to a different IM provider. Disable that binding before connecting Slack.",
   SLACK_APP_TEAM_ALREADY_BOUND:
-    "This Slack App installation is already connected to another OpenTag workspace. Disconnect that workspace first, or use a different Slack workspace.",
+    "This Slack App installation is already connected to another OpenTag Agent. Disconnect that Agent first, or use a different Slack workspace.",
   SLACK_AUTH_IDENTITY_INCOMPLETE:
     "Slack did not identify this authorization as an installed Bot. Start OpenTag Slack again from this Agent.",
   SLACK_AUTH_INVALID: "Slack rejected this authorization. Start OpenTag Slack again from this Agent.",

--- a/apps/web/src/internal/onboarding-lab.test.tsx
+++ b/apps/web/src/internal/onboarding-lab.test.tsx
@@ -6,7 +6,6 @@ import { App } from "../app.js";
 import { OnboardingLabPage } from "./onboarding-lab-page.js";
 import { ONBOARDING_SCENARIOS } from "./onboarding-lab-scenarios.js";
 
-const workspaceId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const user: UserProfile = { id: userId, email: "onboarding-test@company.example", displayName: "Onboarding Test" };
 
@@ -253,18 +252,10 @@ describe("Onboarding Lab route", () => {
           );
         }
         if (options.meDelayMs) await new Promise((resolve) => setTimeout(resolve, options.meDelayMs));
-        if (options.workspaces === "none") return json({ user, workspaces: [] });
+        if (options.workspaces === "none") return json({ user, setupCompletedAt: null });
         return json({
           user,
-          workspaces: [
-            {
-              id: workspaceId,
-              name: "lab",
-              displayName: "Lab",
-              setupCompletedAt: resetRequests > 0 ? afterReset : completed,
-              grantedAt: "2026-08-20T00:00:00.000Z",
-            },
-          ],
+          setupCompletedAt: resetRequests > 0 ? afterReset : completed,
         });
       }
       if (path === "/api/v1/internal/onboarding-lab") {

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -11,8 +11,8 @@ export const Route = createFileRoute("/_authenticated")({
 });
 
 /**
- * Resolves the authenticated Account and publishes it. Workspace authority is a separate question,
- * asked below only by the routes that act on stored resources.
+ * Resolves the authenticated Account and publishes it. Resource pages use this Account session; they
+ * no longer depend on a management Workspace membership.
  *
  * The Account is read while rendering rather than in `beforeLoad` because the application has no
  * request cache: a loader would re-request /me on every navigation.

--- a/apps/web/src/routes/_authenticated/_workspace.tsx
+++ b/apps/web/src/routes/_authenticated/_workspace.tsx
@@ -1,40 +1,13 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
-import { useAccount, WorkspaceContext } from "../../features/session/session-context.js";
-import { Button, Text } from "../../ui/design-system.js";
 
 export const Route = createFileRoute("/_authenticated/_workspace")({
-  component: WorkspaceAuthorityGate,
+  component: AuthenticatedResourceLayout,
 });
 
-/** Refuses the Account-shaped dead end to the routes that act on stored resources. */
-function WorkspaceAuthorityGate() {
-  const { me, refreshMe, reloadMe } = useAccount();
-  const membership = me.workspaces[0];
-  if (!membership) return <NoWorkspaceAccess onRetry={reloadMe} />;
-  return (
-    <WorkspaceContext value={{ me, membership, refreshMe, reloadMe }}>
-      <Outlet />
-    </WorkspaceContext>
-  );
-}
-
-function NoWorkspaceAccess({ onRetry }: { onRetry: () => void }) {
-  return (
-    <main
-      className="mx-auto grid max-w-xl gap-4 rounded-lg bg-kumo-base p-6 ring ring-kumo-line"
-      data-ui="account-access"
-    >
-      <span className="text-xs font-medium uppercase text-kumo-subtle">Account access</span>
-      <Text as="h1" size="lg" variant="heading">
-        OpenTag is not ready for this account
-      </Text>
-      <Text as="p" variant="secondary">
-        The server has not assigned the internal access needed to use OpenTag.
-      </Text>
-      <div className="rounded-md bg-kumo-info-tint p-3 text-sm" role="status">
-        Retry after provisioning finishes, or contact an operator if this continues.
-      </div>
-      <Button onClick={onRetry}>Check again</Button>
-    </main>
-  );
+/**
+ * Pathless layout for Account-owned resource pages. Workspace membership is no longer an
+ * authority gate; setup completion is enforced by the onboarding and shell routes.
+ */
+function AuthenticatedResourceLayout() {
+  return <Outlet />;
 }

--- a/apps/web/src/routes/_authenticated/_workspace/_shell.tsx
+++ b/apps/web/src/routes/_authenticated/_workspace/_shell.tsx
@@ -1,18 +1,18 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Redirect } from "../../../features/navigation/redirect.js";
-import { useWorkspace } from "../../../features/session/session-context.js";
+import { useAccount } from "../../../features/session/session-context.js";
 import { AppShell } from "../../../features/shell/app-shell.js";
 
 export const Route = createFileRoute("/_authenticated/_workspace/_shell")({
-  component: WorkspaceShell,
+  component: AccountShell,
 });
 
 /**
  * The application surface. An Account that has not finished setup is sent back to onboarding, which
  * is the direction the onboarding route mirrors.
  */
-function WorkspaceShell() {
-  const { membership } = useWorkspace();
-  if (!membership.setupCompletedAt) return <Redirect replace to="/onboarding" />;
+function AccountShell() {
+  const { me } = useAccount();
+  if (!me.setupCompletedAt) return <Redirect replace to="/onboarding" />;
   return <AppShell />;
 }

--- a/apps/web/src/routes/_authenticated/_workspace/onboarding.tsx
+++ b/apps/web/src/routes/_authenticated/_workspace/onboarding.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { browserApi } from "../../../api.js";
 import { Redirect } from "../../../features/navigation/redirect.js";
-import { useWorkspace } from "../../../features/session/session-context.js";
+import { useAccount } from "../../../features/session/session-context.js";
 import { OnboardingPage } from "../../../onboarding/page.js";
 
 export const Route = createFileRoute("/_authenticated/_workspace/onboarding")({
@@ -17,10 +17,10 @@ export const Route = createFileRoute("/_authenticated/_workspace/onboarding")({
  * brand mark beside the one onboarding renders itself.
  */
 function OnboardingRoute() {
-  const { me, membership, refreshMe } = useWorkspace();
+  const { me, refreshMe } = useAccount();
   const navigate = useNavigate();
   const { agentId: targetAgentId } = Route.useSearch();
-  if (membership.setupCompletedAt) return <Redirect replace to="/agents" />;
+  if (me.setupCompletedAt) return <Redirect replace to="/agents" />;
   return (
     <OnboardingPage
       targetAgentId={targetAgentId}

--- a/apps/web/src/routes/_authenticated/internal.onboarding-lab.tsx
+++ b/apps/web/src/routes/_authenticated/internal.onboarding-lab.tsx
@@ -36,7 +36,7 @@ function OnboardingLabRoute() {
               // The Lab never infers success from client state: it enters onboarding only once the
               // refreshed Account actually reports incomplete setup.
               const account = await refreshMe();
-              if (account.workspaces[0]?.setupCompletedAt) {
+              if (account.setupCompletedAt) {
                 throw new Error("The Account still reports completed setup; retry the reset.");
               }
               await navigate({ replace: true, to: "/onboarding" });

--- a/packages/client/src/__tests__/workspace-api.test.ts
+++ b/packages/client/src/__tests__/workspace-api.test.ts
@@ -18,6 +18,7 @@ describe("OpenTagApi Workspace surface", () => {
     expect("previewAdminInvitation" in api).toBe(false);
     expect("acceptAdminInvitation" in api).toBe(false);
     expect("issueComputerConnectCode" in api).toBe(true);
+    expect("listAccountComputers" in api).toBe(true);
     expect("listWorkspaceComputers" in api).toBe(true);
     expect("createAgent" in api).toBe(true);
     expect("listAgents" in api).toBe(true);

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -126,10 +126,15 @@ export class OpenTagApi {
     });
   }
 
-  listWorkspaceComputers(accessToken: string): Promise<ListWorkspaceComputersResponse> {
+  listAccountComputers(accessToken: string): Promise<ListWorkspaceComputersResponse> {
     return this.#request(HTTP_PATHS.accountComputers, ListWorkspaceComputersResponseSchema, {
       headers: { authorization: `Bearer ${accessToken}`, [PROVIDER_READINESS_V1_HEADER]: "1" },
     });
+  }
+
+  /** @deprecated Use `listAccountComputers`; retained for the rolling client compatibility window. */
+  listWorkspaceComputers(accessToken: string): Promise<ListWorkspaceComputersResponse> {
+    return this.listAccountComputers(accessToken);
   }
 
   createAgent(accessToken: string, input: CreateAgentRequest): Promise<AgentAdminConfig> {

--- a/packages/server/drizzle/0029_tiresome_bedlam.sql
+++ b/packages/server/drizzle/0029_tiresome_bedlam.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "users" ADD COLUMN "setup_completed_at" timestamp with time zone;--> statement-breakpoint
+-- Backfill Account onboarding from the earliest Workspace completion reachable through an Agent
+-- this Account created, including deleted Agents. Grants never contribute. Retry-safe: already
+-- populated Account rows are left unchanged.
+DO $$
+BEGIN
+	LOCK TABLE "users", "agents", "workspaces" IN SHARE ROW EXCLUSIVE MODE;
+
+	UPDATE "users" AS "account"
+	SET "setup_completed_at" = "source"."setup_completed_at"
+	FROM (
+		SELECT
+			"agent"."created_by_user_id" AS "account_id",
+			min("workspace"."setup_completed_at") AS "setup_completed_at"
+		FROM "agents" AS "agent"
+		INNER JOIN "workspaces" AS "workspace" ON "workspace"."id" = "agent"."workspace_id"
+		WHERE "workspace"."setup_completed_at" IS NOT NULL
+		GROUP BY "agent"."created_by_user_id"
+	) AS "source"
+	WHERE "account"."id" = "source"."account_id"
+		AND "account"."setup_completed_at" IS NULL;
+END
+$$;

--- a/packages/server/drizzle/0030_low_ulik.sql
+++ b/packages/server/drizzle/0030_low_ulik.sql
@@ -1,0 +1,1 @@
+DROP INDEX "slack_installations_workspace_current_unique";

--- a/packages/server/drizzle/meta/0029_snapshot.json
+++ b/packages/server/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,4997 @@
+{
+  "id": "7ee11b26-91e4-4201-9bee-9d88ad8ca6c9",
+  "prevId": "de8f2afe-d3c0-4eac-900b-513c8d1b2026",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_runtime_configs": {
+      "name": "agent_runtime_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('runtime_config_revision_sequence')"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_duration_ms": {
+          "name": "max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_runtime_configs_agent_id_agents_id_fk": {
+          "name": "agent_runtime_configs_agent_id_agents_id_fk",
+          "tableFrom": "agent_runtime_configs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runtime_configs_revision_safe_positive": {
+          "name": "agent_runtime_configs_revision_safe_positive",
+          "value": "\"agent_runtime_configs\".\"revision\" > 0 and \"agent_runtime_configs\".\"revision\" <= 9007199254740991"
+        },
+        "agent_runtime_configs_max_duration_valid": {
+          "name": "agent_runtime_configs_max_duration_valid",
+          "value": "\"agent_runtime_configs\".\"max_duration_ms\" is null or (\"agent_runtime_configs\".\"max_duration_ms\" > 0 and \"agent_runtime_configs\".\"max_duration_ms\" <= 86400000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_intent_id": {
+          "name": "creation_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_intent_fingerprint": {
+          "name": "creation_intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "agent_runtime_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_mode": {
+          "name": "receive_mode",
+          "type": "agent_receive_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_message'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_workspace_name_active_unique": {
+          "name": "agents_workspace_name_active_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_creation_intent_unique": {
+          "name": "agents_creation_intent_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"creation_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_id_idx": {
+          "name": "agents_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_created_by_user_id_idx": {
+          "name": "agents_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_computer_id_idx": {
+          "name": "agents_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_computer_id_idx": {
+          "name": "agents_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_workspace_id_workspaces_id_fk": {
+          "name": "agents_workspace_id_workspaces_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_created_by_user_id_users_id_fk": {
+          "name": "agents_created_by_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_computer_id_account_computers_id_fk": {
+          "name": "agents_computer_id_account_computers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_workspace_enrollment_fk": {
+          "name": "agents_workspace_enrollment_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_creation_intent_pair": {
+          "name": "agents_creation_intent_pair",
+          "value": "(\"agents\".\"creation_intent_id\" is null) = (\"agents\".\"creation_intent_fingerprint\" is null)"
+        },
+        "agents_revision_positive": {
+          "name": "agents_revision_positive",
+          "value": "\"agents\".\"revision\" >= 1"
+        },
+        "agents_computer_matches_enrollment": {
+          "name": "agents_computer_matches_enrollment",
+          "value": "\"agents\".\"computer_id\" = \"agents\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_cli_login_codes": {
+      "name": "account_cli_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_cli_login_codes_user_created_idx": {
+          "name": "account_cli_login_codes_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_cli_login_codes_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_cli_login_codes_issued_by_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_cli_login_codes_token_hash_unique": {
+          "name": "account_cli_login_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_cli_login_codes_expiry": {
+          "name": "account_cli_login_codes_expiry",
+          "value": "\"account_cli_login_codes\".\"expires_at\" > \"account_cli_login_codes\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_admin_grants": {
+      "name": "workspace_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_admin_grants_active_workspace_user_unique": {
+          "name": "workspace_admin_grants_active_workspace_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_active_user_workspace_idx": {
+          "name": "workspace_admin_grants_active_user_workspace_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_workspace_granted_idx": {
+          "name": "workspace_admin_grants_workspace_granted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_admin_grants_workspace_id_workspaces_id_fk": {
+          "name": "workspace_admin_grants_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_admin_grants_revocation_pair": {
+          "name": "workspace_admin_grants_revocation_pair",
+          "value": "(\"workspace_admin_grants\".\"revoked_by_user_id\" is null) = (\"workspace_admin_grants\".\"revoked_at\" is null)"
+        },
+        "workspace_admin_grants_revoked_after_granted": {
+          "name": "workspace_admin_grants_revoked_after_granted",
+          "value": "\"workspace_admin_grants\".\"revoked_at\" is null or \"workspace_admin_grants\".\"revoked_at\" >= \"workspace_admin_grants\".\"granted_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_name_unique": {
+          "name": "workspaces_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_identities_provider_subject_unique": {
+          "name": "auth_identities_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_provider_unique": {
+          "name": "auth_identities_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_issuer_subject_unique": {
+          "name": "auth_identities_issuer_subject_unique",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_id_idx": {
+          "name": "auth_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_user_id_idx": {
+          "name": "auth_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expires_at_idx": {
+          "name": "auth_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_verifications_expires_at_idx": {
+          "name": "auth_verifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_computers": {
+      "name": "account_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_installation_id": {
+          "name": "current_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_computers_owner_account_id_idx": {
+          "name": "account_computers_owner_account_id_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_computers_current_installation_id_idx": {
+          "name": "account_computers_current_installation_id_idx",
+          "columns": [
+            {
+              "expression": "current_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_computers_owner_account_id_users_id_fk": {
+          "name": "account_computers_owner_account_id_users_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_computers_current_installation_id_computers_id_fk": {
+          "name": "account_computers_current_installation_id_computers_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "current_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_connect_codes": {
+      "name": "computer_connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "computer_connect_code_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_computer_id": {
+          "name": "target_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_workspace_computer_id": {
+          "name": "consumed_workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_computer_id": {
+          "name": "consumed_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_connect_codes_workspace_created_idx": {
+          "name": "computer_connect_codes_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_target_computer_id_idx": {
+          "name": "computer_connect_codes_target_computer_id_idx",
+          "columns": [
+            {
+              "expression": "target_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_consumed_computer_id_idx": {
+          "name": "computer_connect_codes_consumed_computer_id_idx",
+          "columns": [
+            {
+              "expression": "consumed_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_connect_codes_workspace_id_workspaces_id_fk": {
+          "name": "computer_connect_codes_workspace_id_workspaces_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_account_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_account_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_target_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_target_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "target_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_consumed_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_consumed_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "consumed_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_revoked_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_workspace_enrollment_fk": {
+          "name": "computer_connect_codes_workspace_enrollment_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "consumed_workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_connect_codes_token_hash_unique": {
+          "name": "computer_connect_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_connect_codes_expiry": {
+          "name": "computer_connect_codes_expiry",
+          "value": "\"computer_connect_codes\".\"expires_at\" > \"computer_connect_codes\".\"created_at\""
+        },
+        "computer_connect_codes_consumption_pair": {
+          "name": "computer_connect_codes_consumption_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_workspace_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_revocation_pair": {
+          "name": "computer_connect_codes_revocation_pair",
+          "value": "(\"computer_connect_codes\".\"revoked_by_user_id\" is null) = (\"computer_connect_codes\".\"revoked_at\" is null)"
+        },
+        "computer_connect_codes_terminal_state": {
+          "name": "computer_connect_codes_terminal_state",
+          "value": "not (\"computer_connect_codes\".\"consumed_at\" is not null and \"computer_connect_codes\".\"revoked_at\" is not null)"
+        },
+        "computer_connect_codes_issued_by_account_pair": {
+          "name": "computer_connect_codes_issued_by_account_pair",
+          "value": "\"computer_connect_codes\".\"issued_by_account_id\" = \"computer_connect_codes\".\"issued_by_user_id\""
+        },
+        "computer_connect_codes_consumed_computer_identity": {
+          "name": "computer_connect_codes_consumed_computer_identity",
+          "value": "\"computer_connect_codes\".\"consumed_computer_id\" is not distinct from \"computer_connect_codes\".\"consumed_workspace_computer_id\""
+        },
+        "computer_connect_codes_consumed_computer_pair": {
+          "name": "computer_connect_codes_consumed_computer_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_repair_target_pair": {
+          "name": "computer_connect_codes_repair_target_pair",
+          "value": "(\"computer_connect_codes\".\"mode\" = 'create') = (\"computer_connect_codes\".\"target_computer_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computer_credentials": {
+      "name": "computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_credentials_active_computer_unique": {
+          "name": "computer_credentials_active_computer_unique",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_credentials_computer_issued_idx": {
+          "name": "computer_credentials_computer_issued_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_credentials_computer_id_account_computers_id_fk": {
+          "name": "computer_credentials_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_credentials_secret_hash_unique": {
+          "name": "computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_credentials_revocation_pair": {
+          "name": "computer_credentials_revocation_pair",
+          "value": "(\"computer_credentials\".\"revoked_by_user_id\" is null) = (\"computer_credentials\".\"revoked_at\" is null)"
+        },
+        "computer_credentials_revoked_after_issued": {
+          "name": "computer_credentials_revoked_after_issued",
+          "value": "\"computer_credentials\".\"revoked_at\" is null or \"computer_credentials\".\"revoked_at\" >= \"computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computers": {
+      "name": "computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_computer_credentials": {
+      "name": "workspace_computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_computer_credentials_active_enrollment_unique": {
+          "name": "workspace_computer_credentials_active_enrollment_unique",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computer_credentials_enrollment_issued_idx": {
+          "name": "workspace_computer_credentials_enrollment_issued_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computer_credentials_secret_hash_unique": {
+          "name": "workspace_computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computer_credentials_revocation_pair": {
+          "name": "workspace_computer_credentials_revocation_pair",
+          "value": "(\"workspace_computer_credentials\".\"revoked_by_user_id\" is null) = (\"workspace_computer_credentials\".\"revoked_at\" is null)"
+        },
+        "workspace_computer_credentials_revoked_after_issued": {
+          "name": "workspace_computer_credentials_revoked_after_issued",
+          "value": "\"workspace_computer_credentials\".\"revoked_at\" is null or \"workspace_computer_credentials\".\"revoked_at\" >= \"workspace_computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_computers": {
+      "name": "workspace_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_by_user_id": {
+          "name": "enrolled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_computers_active_workspace_computer_unique": {
+          "name": "workspace_computers_active_workspace_computer_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_active_workspace_idx": {
+          "name": "workspace_computers_active_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_computer_id_idx": {
+          "name": "workspace_computers_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computers_workspace_id_workspaces_id_fk": {
+          "name": "workspace_computers_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_computer_id_computers_id_fk": {
+          "name": "workspace_computers_computer_id_computers_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_enrolled_by_user_id_users_id_fk": {
+          "name": "workspace_computers_enrolled_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enrolled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computers_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computers_workspace_id_id_unique": {
+          "name": "workspace_computers_workspace_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computers_revocation_pair": {
+          "name": "workspace_computers_revocation_pair",
+          "value": "(\"workspace_computers\".\"revoked_by_user_id\" is null) = (\"workspace_computers\".\"revoked_at\" is null)"
+        },
+        "workspace_computers_revoked_after_enrolled": {
+          "name": "workspace_computers_revoked_after_enrolled",
+          "value": "\"workspace_computers\".\"revoked_at\" is null or \"workspace_computers\".\"revoked_at\" >= \"workspace_computers\".\"enrolled_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_bindings": {
+      "name": "im_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "im_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "im_binding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_brand": {
+          "name": "external_team_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "setup_attempt_id": {
+          "name": "setup_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_intent": {
+          "name": "setup_intent",
+          "type": "feishu_setup_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_state": {
+          "name": "setup_state",
+          "type": "feishu_setup_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_instance_id": {
+          "name": "setup_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_heartbeat_at": {
+          "name": "setup_owner_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_setup_context": {
+          "name": "encrypted_setup_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_expires_at": {
+          "name": "setup_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_route_kind": {
+          "name": "slack_route_kind",
+          "type": "slack_route_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_im_binding_id": {
+          "name": "replacement_im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_owner_instance_id": {
+          "name": "connection_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_fencing_epoch": {
+          "name": "connection_fencing_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_lease_expires_at": {
+          "name": "connection_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_bindings_agent_current_unique": {
+          "name": "im_bindings_agent_current_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_feishu_app_current_unique": {
+          "name": "im_bindings_feishu_app_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_current_unique": {
+          "name": "im_bindings_slack_installation_current_unique",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_id_idx": {
+          "name": "im_bindings_slack_installation_id_idx",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_agent_id_agents_id_fk": {
+          "name": "im_bindings_agent_id_agents_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_id_slack_installations_id_fk": {
+          "name": "im_bindings_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_replacement_im_binding_id_im_bindings_id_fk": {
+          "name": "im_bindings_replacement_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "replacement_im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_owner_fk": {
+          "name": "im_bindings_slack_installation_owner_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "agent_id",
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "agent_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_bindings_credential_generation_nonnegative": {
+          "name": "im_bindings_credential_generation_nonnegative",
+          "value": "\"im_bindings\".\"credential_generation\" >= 0"
+        },
+        "im_bindings_connection_epoch_nonnegative": {
+          "name": "im_bindings_connection_epoch_nonnegative",
+          "value": "\"im_bindings\".\"connection_fencing_epoch\" >= 0"
+        },
+        "im_bindings_active_binding_shape": {
+          "name": "im_bindings_active_binding_shape",
+          "value": "\"im_bindings\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"im_bindings\".\"external_app_id\" is not null and\n        (\"im_bindings\".\"provider\" = 'feishu' or \"im_bindings\".\"external_team_id\" is not null) and\n        \"im_bindings\".\"external_bot_id\" is not null and \"im_bindings\".\"credential_schema_version\" is not null and\n        \"im_bindings\".\"credential_generation\" >= 1 and\n        \"im_bindings\".\"activated_at\" is not null and \"im_bindings\".\"disabled_at\" is null and\n        (\n          (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"encrypted_credential\" is not null and\n            \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null) or\n          (\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"encrypted_credential\" is null and\n            \"im_bindings\".\"slack_installation_id\" is not null and \"im_bindings\".\"slack_route_kind\" is not null)\n        )\n      )"
+        },
+        "im_bindings_disabled_secret_shape": {
+          "name": "im_bindings_disabled_secret_shape",
+          "value": "\"im_bindings\".\"status\" <> 'disabled' or (\n        \"im_bindings\".\"encrypted_credential\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"connection_owner_instance_id\" is null and\n        \"im_bindings\".\"connection_lease_expires_at\" is null and \"im_bindings\".\"disabled_at\" is not null\n      )"
+        },
+        "im_bindings_setup_owner_shape": {
+          "name": "im_bindings_setup_owner_shape",
+          "value": "(\"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"setup_owner_heartbeat_at\" is null and\n        \"im_bindings\".\"encrypted_setup_context\" is null and \"im_bindings\".\"setup_expires_at\" is null)\n        or (\"im_bindings\".\"setup_attempt_id\" is not null and \"im_bindings\".\"setup_intent\" is not null and\n        \"im_bindings\".\"setup_state\" is not null and \"im_bindings\".\"setup_owner_instance_id\" is not null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is not null and \"im_bindings\".\"encrypted_setup_context\" is not null and\n        \"im_bindings\".\"setup_expires_at\" is not null)"
+        },
+        "im_bindings_connection_owner_shape": {
+          "name": "im_bindings_connection_owner_shape",
+          "value": "(\"im_bindings\".\"connection_owner_instance_id\" is null and \"im_bindings\".\"connection_lease_expires_at\" is null)\n        or (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"connection_owner_instance_id\" is not null and\n        \"im_bindings\".\"connection_lease_expires_at\" is not null)"
+        },
+        "im_bindings_slack_setup_fields_null": {
+          "name": "im_bindings_slack_setup_fields_null",
+          "value": "\"im_bindings\".\"provider\" <> 'slack' or (\n        \"im_bindings\".\"setup_attempt_id\" is null and \"im_bindings\".\"setup_intent\" is null and\n        \"im_bindings\".\"setup_state\" is null and \"im_bindings\".\"setup_owner_instance_id\" is null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_expires_at\" is null\n      )"
+        },
+        "im_bindings_slack_route_fields": {
+          "name": "im_bindings_slack_route_fields",
+          "value": "\"im_bindings\".\"provider\" = 'slack' or (\n        \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_message_deliveries": {
+      "name": "im_message_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attention": {
+          "name": "attention",
+          "type": "im_delivery_attention",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "im_delivery_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_request_id": {
+          "name": "dispatch_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_input_hash": {
+          "name": "dispatch_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_payload": {
+          "name": "dispatch_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steer_target_delivery_id": {
+          "name": "steer_target_delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steered_at": {
+          "name": "steered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_owner_instance_id": {
+          "name": "report_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_hash": {
+          "name": "result_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_report": {
+          "name": "turn_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "im_message_deliveries_message_session_unique": {
+          "name": "im_message_deliveries_message_session_unique",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_session_id_idx": {
+          "name": "im_message_deliveries_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_steer_target_idx": {
+          "name": "im_message_deliveries_steer_target_idx",
+          "columns": [
+            {
+              "expression": "steer_target_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_pending_idx": {
+          "name": "im_message_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_dispatch_request_unique": {
+          "name": "im_message_deliveries_dispatch_request_unique",
+          "columns": [
+            {
+              "expression": "dispatch_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"dispatch_request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_turn_id_unique": {
+          "name": "im_message_deliveries_turn_id_unique",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"turn_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_deliveries_message_id_im_messages_id_fk": {
+          "name": "im_message_deliveries_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_session_id_sessions_id_fk": {
+          "name": "im_message_deliveries_session_id_sessions_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk": {
+          "name": "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_message_deliveries",
+          "columnsFrom": [
+            "steer_target_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_message_deliveries_dispatch_shape": {
+          "name": "im_message_deliveries_dispatch_shape",
+          "value": "(\"im_message_deliveries\".\"dispatch_request_id\" is null and \"im_message_deliveries\".\"dispatch_input_hash\" is null and \"im_message_deliveries\".\"dispatch_payload\" is null)\n        or (\"im_message_deliveries\".\"dispatch_request_id\" is not null and \"im_message_deliveries\".\"dispatch_input_hash\" is not null\n          and (\"im_message_deliveries\".\"dispatch_payload\" is not null or \"im_message_deliveries\".\"state\" = 'accepted'))"
+        },
+        "im_message_deliveries_custody_shape": {
+          "name": "im_message_deliveries_custody_shape",
+          "value": "(\"im_message_deliveries\".\"state\" = 'accepted' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"turn_id\" is not null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is not null and \"im_message_deliveries\".\"accepted_at\" is not null\n          and \"im_message_deliveries\".\"steer_target_delivery_id\" is null and \"im_message_deliveries\".\"steered_at\" is null)\n        or (\"im_message_deliveries\".\"state\" = 'steered' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"steer_target_delivery_id\" is not null\n          and \"im_message_deliveries\".\"steered_at\" is not null and \"im_message_deliveries\".\"turn_id\" is null and \"im_message_deliveries\".\"report_owner_instance_id\" is null\n          and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null\n          and \"im_message_deliveries\".\"result_hash\" is null)\n        or (\"im_message_deliveries\".\"state\" not in ('accepted', 'steered') and \"im_message_deliveries\".\"input_hash\" is null and \"im_message_deliveries\".\"turn_id\" is null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is null and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"steered_at\" is null\n          and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null and \"im_message_deliveries\".\"result_hash\" is null)"
+        },
+        "im_message_deliveries_report_shape": {
+          "name": "im_message_deliveries_report_shape",
+          "value": "(\"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null)\n        or (\"im_message_deliveries\".\"reported_at\" is not null and \"im_message_deliveries\".\"turn_report\" is not null and \"im_message_deliveries\".\"result_hash\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_messages": {
+      "name": "im_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_revision_key": {
+          "name": "provider_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "im_message_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "im_message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_external_id": {
+          "name": "reply_to_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "im_author_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_external_id": {
+          "name": "author_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_context": {
+          "name": "provider_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_messages_provider_event_unique": {
+          "name": "im_messages_provider_event_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_messages\".\"provider_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_semantic_revision_unique": {
+          "name": "im_messages_semantic_revision_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_revision_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_scope_occurred_idx": {
+          "name": "im_messages_scope_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_external_occurred_idx": {
+          "name": "im_messages_external_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_messages_im_binding_id_im_bindings_id_fk": {
+          "name": "im_messages_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invitations": {
+      "name": "admin_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_invitations_workspace_created_idx": {
+          "name": "admin_invitations_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_invitations_workspace_id_workspaces_id_fk": {
+          "name": "admin_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_created_by_user_id_users_id_fk": {
+          "name": "admin_invitations_created_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_accepted_by_user_id_users_id_fk": {
+          "name": "admin_invitations_accepted_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_revoked_by_user_id_users_id_fk": {
+          "name": "admin_invitations_revoked_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invitations_token_hash_unique": {
+          "name": "admin_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invitations_expiry": {
+          "name": "admin_invitations_expiry",
+          "value": "\"admin_invitations\".\"expires_at\" > \"admin_invitations\".\"created_at\""
+        },
+        "admin_invitations_acceptance_pair": {
+          "name": "admin_invitations_acceptance_pair",
+          "value": "(\"admin_invitations\".\"accepted_by_user_id\" is null) = (\"admin_invitations\".\"accepted_at\" is null)"
+        },
+        "admin_invitations_revocation_pair": {
+          "name": "admin_invitations_revocation_pair",
+          "value": "(\"admin_invitations\".\"revoked_by_user_id\" is null) = (\"admin_invitations\".\"revoked_at\" is null)"
+        },
+        "admin_invitations_terminal_state": {
+          "name": "admin_invitations_terminal_state",
+          "value": "not (\"admin_invitations\".\"accepted_at\" is not null and \"admin_invitations\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_cli_proofs": {
+      "name": "session_cli_proofs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proof_id": {
+          "name": "proof_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_instance_id": {
+          "name": "connection_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_cli_proofs_computer_id_idx": {
+          "name": "session_cli_proofs_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_cli_proofs_session_id_sessions_id_fk": {
+          "name": "session_cli_proofs_session_id_sessions_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_computer_id_account_computers_id_fk": {
+          "name": "session_cli_proofs_computer_id_account_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_cli_proofs_proof_id_unique": {
+          "name": "session_cli_proofs_proof_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proof_id"
+          ]
+        },
+        "session_cli_proofs_token_hash_unique": {
+          "name": "session_cli_proofs_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_cli_proofs_token_hash_shape": {
+          "name": "session_cli_proofs_token_hash_shape",
+          "value": "\"session_cli_proofs\".\"token_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_cli_proofs_generation_positive": {
+          "name": "session_cli_proofs_generation_positive",
+          "value": "\"session_cli_proofs\".\"placement_generation\" >= 1"
+        },
+        "session_cli_proofs_computer_matches_enrollment": {
+          "name": "session_cli_proofs_computer_matches_enrollment",
+          "value": "\"session_cli_proofs\".\"computer_id\" = \"session_cli_proofs\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_messages": {
+      "name": "session_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_outcome": {
+          "name": "last_outcome",
+          "type": "session_message_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_messages_target_created_idx": {
+          "name": "session_messages_target_created_idx",
+          "columns": [
+            {
+              "expression": "target_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_messages_source_created_idx": {
+          "name": "session_messages_source_created_idx",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_messages_source_session_id_sessions_id_fk": {
+          "name": "session_messages_source_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "source_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_messages_target_session_id_sessions_id_fk": {
+          "name": "session_messages_target_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_messages_content_hash_shape": {
+          "name": "session_messages_content_hash_shape",
+          "value": "\"session_messages\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_messages_content_bounds": {
+          "name": "session_messages_content_bounds",
+          "value": "octet_length(\"session_messages\".\"content\") between 1 and 16384"
+        },
+        "session_messages_error_code_shape": {
+          "name": "session_messages_error_code_shape",
+          "value": "\"session_messages\".\"last_error_code\" is null or (\"session_messages\".\"last_error_code\" ~ '^[a-z][a-z0-9_]{0,127}$')"
+        },
+        "session_messages_attempt_count_nonnegative": {
+          "name": "session_messages_attempt_count_nonnegative",
+          "value": "\"session_messages\".\"attempt_count\" >= 0"
+        },
+        "session_messages_attempt_shape": {
+          "name": "session_messages_attempt_shape",
+          "value": "(\"session_messages\".\"attempt_count\" = 0 and \"session_messages\".\"last_attempt_at\" is null)\n        or (\"session_messages\".\"attempt_count\" > 0 and \"session_messages\".\"last_attempt_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_descendants": {
+      "name": "session_descendants",
+      "schema": "",
+      "columns": {
+        "ancestor_session_id": {
+          "name": "ancestor_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_session_id": {
+          "name": "descendant_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_created_at": {
+          "name": "last_message_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_delivery_outcome": {
+          "name": "last_delivery_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_preview": {
+          "name": "task_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_descendants_ancestor_activity_idx": {
+          "name": "session_descendants_ancestor_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_ancestor_depth_activity_idx": {
+          "name": "session_descendants_ancestor_depth_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_descendant_ancestor_idx": {
+          "name": "session_descendants_descendant_ancestor_idx",
+          "columns": [
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_last_message_idx": {
+          "name": "session_descendants_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_descendants_ancestor_session_id_sessions_id_fk": {
+          "name": "session_descendants_ancestor_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "ancestor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_descendants_descendant_session_id_sessions_id_fk": {
+          "name": "session_descendants_descendant_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "descendant_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_descendants_ancestor_session_id_descendant_session_id_pk": {
+          "name": "session_descendants_ancestor_session_id_descendant_session_id_pk",
+          "columns": [
+            "ancestor_session_id",
+            "descendant_session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_descendants_depth_positive": {
+          "name": "session_descendants_depth_positive",
+          "value": "\"session_descendants\".\"depth\" >= 1"
+        },
+        "session_descendants_outcome_valid": {
+          "name": "session_descendants_outcome_valid",
+          "value": "\"session_descendants\".\"last_delivery_outcome\" in ('accepted', 'unreachable', 'unknown', 'rejected')"
+        },
+        "session_descendants_preview_bounds": {
+          "name": "session_descendants_preview_bounds",
+          "value": "char_length(\"session_descendants\".\"task_preview\") between 1 and 256"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_placements": {
+      "name": "session_placements",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_placements_workspace_computer_id_idx": {
+          "name": "session_placements_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_placements_computer_id_idx": {
+          "name": "session_placements_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_placements_session_id_sessions_id_fk": {
+          "name": "session_placements_session_id_sessions_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_placements_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_placements_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_placements_computer_id_account_computers_id_fk": {
+          "name": "session_placements_computer_id_account_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_placements_generation_positive": {
+          "name": "session_placements_generation_positive",
+          "value": "\"session_placements\".\"generation\" >= 1"
+        },
+        "session_placements_computer_matches_enrollment": {
+          "name": "session_placements_computer_matches_enrollment",
+          "value": "\"session_placements\".\"computer_id\" = \"session_placements\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_kind": {
+          "name": "conversation_kind",
+          "type": "im_conversation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "session_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_model": {
+          "name": "runtime_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_reasoning_effort": {
+          "name": "runtime_reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_max_duration_ms": {
+          "name": "runtime_max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_active_channel_unique": {
+          "name": "sessions_active_channel_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'channel' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_active_thread_unique": {
+          "name": "sessions_active_thread_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'thread' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_im_binding_scope_idx": {
+          "name": "sessions_im_binding_scope_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_creator_created_idx": {
+          "name": "sessions_creator_created_idx",
+          "columns": [
+            {
+              "expression": "created_by_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_im_binding_id_im_bindings_id_fk": {
+          "name": "sessions_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sessions_created_by_session_id_sessions_id_fk": {
+          "name": "sessions_created_by_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "created_by_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sessions_shape_check": {
+          "name": "sessions_shape_check",
+          "value": "(\"sessions\".\"kind\" = 'channel' and \"sessions\".\"thread_key\" is null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'thread' and \"sessions\".\"thread_key\" is not null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'internal' and \"sessions\".\"created_by_session_id\" is not null)"
+        },
+        "sessions_runtime_max_duration_valid": {
+          "name": "sessions_runtime_max_duration_valid",
+          "value": "\"sessions\".\"runtime_max_duration_ms\" is null or (\"sessions\".\"runtime_max_duration_ms\" > 0 and \"sessions\".\"runtime_max_duration_ms\" <= 86400000)"
+        },
+        "sessions_runtime_model_bounds": {
+          "name": "sessions_runtime_model_bounds",
+          "value": "\"sessions\".\"runtime_model\" is null or octet_length(\"sessions\".\"runtime_model\") between 1 and 128"
+        },
+        "sessions_runtime_reasoning_effort_bounds": {
+          "name": "sessions_runtime_reasoning_effort_bounds",
+          "value": "\"sessions\".\"runtime_reasoning_effort\" is null or octet_length(\"sessions\".\"runtime_reasoning_effort\") between 1 and 64"
+        },
+        "sessions_revision_positive": {
+          "name": "sessions_revision_positive",
+          "value": "\"sessions\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "slack_installation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "replacement_slack_installation_id": {
+          "name": "replacement_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installations_app_team_current_unique": {
+          "name": "slack_installations_app_team_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_installations\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_workspace_current_unique": {
+          "name": "slack_installations_workspace_current_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_installations\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_workspace_id_idx": {
+          "name": "slack_installations_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_agent_id_idx": {
+          "name": "slack_installations_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_app_team_idx": {
+          "name": "slack_installations_app_team_idx",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_workspace_id_workspaces_id_fk": {
+          "name": "slack_installations_workspace_id_workspaces_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_agent_id_agents_id_fk": {
+          "name": "slack_installations_agent_id_agents_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_replacement_slack_installation_id_slack_installations_id_fk": {
+          "name": "slack_installations_replacement_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "replacement_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_agent_id_id_unique": {
+          "name": "slack_installations_agent_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_installations_credential_generation_nonnegative": {
+          "name": "slack_installations_credential_generation_nonnegative",
+          "value": "\"slack_installations\".\"credential_generation\" >= 0"
+        },
+        "slack_installations_active_shape": {
+          "name": "slack_installations_active_shape",
+          "value": "\"slack_installations\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"slack_installations\".\"credential_schema_version\" is not null and\n        \"slack_installations\".\"credential_generation\" >= 1 and \"slack_installations\".\"encrypted_credential\" is not null and\n        \"slack_installations\".\"activated_at\" is not null and \"slack_installations\".\"disabled_at\" is null\n      )"
+        },
+        "slack_installations_disabled_secret_shape": {
+          "name": "slack_installations_disabled_secret_shape",
+          "value": "\"slack_installations\".\"status\" <> 'disabled' or (\n        \"slack_installations\".\"encrypted_credential\" is null and \"slack_installations\".\"disabled_at\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_oauth_nonces": {
+      "name": "slack_oauth_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_binding_id": {
+          "name": "expected_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_credential_generation": {
+          "name": "expected_credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_binding_hash": {
+          "name": "session_binding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_oauth_nonces_user_agent_idx": {
+          "name": "slack_oauth_nonces_user_agent_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_oauth_nonces_expires_idx": {
+          "name": "slack_oauth_nonces_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_oauth_nonces_user_id_users_id_fk": {
+          "name": "slack_oauth_nonces_user_id_users_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_oauth_nonces_agent_id_agents_id_fk": {
+          "name": "slack_oauth_nonces_agent_id_agents_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_oauth_nonces_nonce_hash_unique": {
+          "name": "slack_oauth_nonces_nonce_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_oauth_nonces_intent": {
+          "name": "slack_oauth_nonces_intent",
+          "value": "\"slack_oauth_nonces\".\"intent\" in ('create', 'reauthorize')"
+        },
+        "slack_oauth_nonces_expiry": {
+          "name": "slack_oauth_nonces_expiry",
+          "value": "\"slack_oauth_nonces\".\"expires_at\" > \"slack_oauth_nonces\".\"created_at\""
+        },
+        "slack_oauth_nonces_expected_binding_pair": {
+          "name": "slack_oauth_nonces_expected_binding_pair",
+          "value": "(\"slack_oauth_nonces\".\"expected_binding_id\" is null) = (\"slack_oauth_nonces\".\"expected_credential_generation\" is null)"
+        },
+        "slack_oauth_nonces_generation_positive": {
+          "name": "slack_oauth_nonces_generation_positive",
+          "value": "\"slack_oauth_nonces\".\"expected_credential_generation\" is null or \"slack_oauth_nonces\".\"expected_credential_generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_receive_mode": {
+      "name": "agent_receive_mode",
+      "schema": "public",
+      "values": [
+        "all_message",
+        "mention_only"
+      ]
+    },
+    "public.agent_runtime_provider": {
+      "name": "agent_runtime_provider",
+      "schema": "public",
+      "values": [
+        "codex",
+        "claude-code"
+      ]
+    },
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "suspended",
+        "deleted"
+      ]
+    },
+    "public.computer_connect_code_mode": {
+      "name": "computer_connect_code_mode",
+      "schema": "public",
+      "values": [
+        "create",
+        "repair"
+      ]
+    },
+    "public.computer_platform": {
+      "name": "computer_platform",
+      "schema": "public",
+      "values": [
+        "darwin",
+        "linux",
+        "win32"
+      ]
+    },
+    "public.feishu_setup_intent": {
+      "name": "feishu_setup_intent",
+      "schema": "public",
+      "values": [
+        "create",
+        "reauthorize",
+        "replace"
+      ]
+    },
+    "public.feishu_setup_state": {
+      "name": "feishu_setup_state",
+      "schema": "public",
+      "values": [
+        "awaiting_user",
+        "validating",
+        "succeeded",
+        "failed",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.im_binding_status": {
+      "name": "im_binding_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "active",
+        "reauthorization_required",
+        "error",
+        "disabled"
+      ]
+    },
+    "public.im_conversation_kind": {
+      "name": "im_conversation_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "dm",
+        "group_dm"
+      ]
+    },
+    "public.im_provider": {
+      "name": "im_provider",
+      "schema": "public",
+      "values": [
+        "feishu",
+        "slack"
+      ]
+    },
+    "public.slack_route_kind": {
+      "name": "slack_route_kind",
+      "schema": "public",
+      "values": [
+        "default"
+      ]
+    },
+    "public.im_author_kind": {
+      "name": "im_author_kind",
+      "schema": "public",
+      "values": [
+        "human",
+        "bot",
+        "system"
+      ]
+    },
+    "public.im_delivery_attention": {
+      "name": "im_delivery_attention",
+      "schema": "public",
+      "values": [
+        "direct",
+        "ambient"
+      ]
+    },
+    "public.im_delivery_state": {
+      "name": "im_delivery_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "steered",
+        "terminal_rejected",
+        "expired"
+      ]
+    },
+    "public.im_message_direction": {
+      "name": "im_message_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.im_message_operation": {
+      "name": "im_message_operation",
+      "schema": "public",
+      "values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "public.session_message_outcome": {
+      "name": "session_message_outcome",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "accepted",
+        "unreachable",
+        "rejected"
+      ]
+    },
+    "public.session_kind": {
+      "name": "session_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "thread",
+        "internal"
+      ]
+    },
+    "public.slack_installation_status": {
+      "name": "slack_installation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "reauthorization_required",
+        "disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {
+    "public.runtime_config_revision_sequence": {
+      "name": "runtime_config_revision_sequence",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/0030_snapshot.json
+++ b/packages/server/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,4981 @@
+{
+  "id": "4393adc9-0b9e-49e0-9114-95a761365550",
+  "prevId": "7ee11b26-91e4-4201-9bee-9d88ad8ca6c9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_runtime_configs": {
+      "name": "agent_runtime_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('runtime_config_revision_sequence')"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_duration_ms": {
+          "name": "max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_runtime_configs_agent_id_agents_id_fk": {
+          "name": "agent_runtime_configs_agent_id_agents_id_fk",
+          "tableFrom": "agent_runtime_configs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runtime_configs_revision_safe_positive": {
+          "name": "agent_runtime_configs_revision_safe_positive",
+          "value": "\"agent_runtime_configs\".\"revision\" > 0 and \"agent_runtime_configs\".\"revision\" <= 9007199254740991"
+        },
+        "agent_runtime_configs_max_duration_valid": {
+          "name": "agent_runtime_configs_max_duration_valid",
+          "value": "\"agent_runtime_configs\".\"max_duration_ms\" is null or (\"agent_runtime_configs\".\"max_duration_ms\" > 0 and \"agent_runtime_configs\".\"max_duration_ms\" <= 86400000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_intent_id": {
+          "name": "creation_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_intent_fingerprint": {
+          "name": "creation_intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "agent_runtime_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_mode": {
+          "name": "receive_mode",
+          "type": "agent_receive_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_message'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_workspace_name_active_unique": {
+          "name": "agents_workspace_name_active_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_creation_intent_unique": {
+          "name": "agents_creation_intent_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"creation_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_id_idx": {
+          "name": "agents_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_created_by_user_id_idx": {
+          "name": "agents_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_computer_id_idx": {
+          "name": "agents_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_computer_id_idx": {
+          "name": "agents_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_workspace_id_workspaces_id_fk": {
+          "name": "agents_workspace_id_workspaces_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_created_by_user_id_users_id_fk": {
+          "name": "agents_created_by_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_computer_id_account_computers_id_fk": {
+          "name": "agents_computer_id_account_computers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_workspace_enrollment_fk": {
+          "name": "agents_workspace_enrollment_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_creation_intent_pair": {
+          "name": "agents_creation_intent_pair",
+          "value": "(\"agents\".\"creation_intent_id\" is null) = (\"agents\".\"creation_intent_fingerprint\" is null)"
+        },
+        "agents_revision_positive": {
+          "name": "agents_revision_positive",
+          "value": "\"agents\".\"revision\" >= 1"
+        },
+        "agents_computer_matches_enrollment": {
+          "name": "agents_computer_matches_enrollment",
+          "value": "\"agents\".\"computer_id\" = \"agents\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_cli_login_codes": {
+      "name": "account_cli_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_cli_login_codes_user_created_idx": {
+          "name": "account_cli_login_codes_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_cli_login_codes_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_cli_login_codes_issued_by_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_cli_login_codes_token_hash_unique": {
+          "name": "account_cli_login_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_cli_login_codes_expiry": {
+          "name": "account_cli_login_codes_expiry",
+          "value": "\"account_cli_login_codes\".\"expires_at\" > \"account_cli_login_codes\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_admin_grants": {
+      "name": "workspace_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_admin_grants_active_workspace_user_unique": {
+          "name": "workspace_admin_grants_active_workspace_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_active_user_workspace_idx": {
+          "name": "workspace_admin_grants_active_user_workspace_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_workspace_granted_idx": {
+          "name": "workspace_admin_grants_workspace_granted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_admin_grants_workspace_id_workspaces_id_fk": {
+          "name": "workspace_admin_grants_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_admin_grants_revocation_pair": {
+          "name": "workspace_admin_grants_revocation_pair",
+          "value": "(\"workspace_admin_grants\".\"revoked_by_user_id\" is null) = (\"workspace_admin_grants\".\"revoked_at\" is null)"
+        },
+        "workspace_admin_grants_revoked_after_granted": {
+          "name": "workspace_admin_grants_revoked_after_granted",
+          "value": "\"workspace_admin_grants\".\"revoked_at\" is null or \"workspace_admin_grants\".\"revoked_at\" >= \"workspace_admin_grants\".\"granted_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_name_unique": {
+          "name": "workspaces_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_identities_provider_subject_unique": {
+          "name": "auth_identities_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_provider_unique": {
+          "name": "auth_identities_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_issuer_subject_unique": {
+          "name": "auth_identities_issuer_subject_unique",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_id_idx": {
+          "name": "auth_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_user_id_idx": {
+          "name": "auth_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expires_at_idx": {
+          "name": "auth_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_verifications_expires_at_idx": {
+          "name": "auth_verifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_computers": {
+      "name": "account_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_installation_id": {
+          "name": "current_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_computers_owner_account_id_idx": {
+          "name": "account_computers_owner_account_id_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_computers_current_installation_id_idx": {
+          "name": "account_computers_current_installation_id_idx",
+          "columns": [
+            {
+              "expression": "current_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_computers_owner_account_id_users_id_fk": {
+          "name": "account_computers_owner_account_id_users_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_computers_current_installation_id_computers_id_fk": {
+          "name": "account_computers_current_installation_id_computers_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "current_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_connect_codes": {
+      "name": "computer_connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "computer_connect_code_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_computer_id": {
+          "name": "target_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_workspace_computer_id": {
+          "name": "consumed_workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_computer_id": {
+          "name": "consumed_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_connect_codes_workspace_created_idx": {
+          "name": "computer_connect_codes_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_target_computer_id_idx": {
+          "name": "computer_connect_codes_target_computer_id_idx",
+          "columns": [
+            {
+              "expression": "target_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_consumed_computer_id_idx": {
+          "name": "computer_connect_codes_consumed_computer_id_idx",
+          "columns": [
+            {
+              "expression": "consumed_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_connect_codes_workspace_id_workspaces_id_fk": {
+          "name": "computer_connect_codes_workspace_id_workspaces_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_account_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_account_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_target_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_target_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "target_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_consumed_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_consumed_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "consumed_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_revoked_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_workspace_enrollment_fk": {
+          "name": "computer_connect_codes_workspace_enrollment_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "consumed_workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_connect_codes_token_hash_unique": {
+          "name": "computer_connect_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_connect_codes_expiry": {
+          "name": "computer_connect_codes_expiry",
+          "value": "\"computer_connect_codes\".\"expires_at\" > \"computer_connect_codes\".\"created_at\""
+        },
+        "computer_connect_codes_consumption_pair": {
+          "name": "computer_connect_codes_consumption_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_workspace_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_revocation_pair": {
+          "name": "computer_connect_codes_revocation_pair",
+          "value": "(\"computer_connect_codes\".\"revoked_by_user_id\" is null) = (\"computer_connect_codes\".\"revoked_at\" is null)"
+        },
+        "computer_connect_codes_terminal_state": {
+          "name": "computer_connect_codes_terminal_state",
+          "value": "not (\"computer_connect_codes\".\"consumed_at\" is not null and \"computer_connect_codes\".\"revoked_at\" is not null)"
+        },
+        "computer_connect_codes_issued_by_account_pair": {
+          "name": "computer_connect_codes_issued_by_account_pair",
+          "value": "\"computer_connect_codes\".\"issued_by_account_id\" = \"computer_connect_codes\".\"issued_by_user_id\""
+        },
+        "computer_connect_codes_consumed_computer_identity": {
+          "name": "computer_connect_codes_consumed_computer_identity",
+          "value": "\"computer_connect_codes\".\"consumed_computer_id\" is not distinct from \"computer_connect_codes\".\"consumed_workspace_computer_id\""
+        },
+        "computer_connect_codes_consumed_computer_pair": {
+          "name": "computer_connect_codes_consumed_computer_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_repair_target_pair": {
+          "name": "computer_connect_codes_repair_target_pair",
+          "value": "(\"computer_connect_codes\".\"mode\" = 'create') = (\"computer_connect_codes\".\"target_computer_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computer_credentials": {
+      "name": "computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_credentials_active_computer_unique": {
+          "name": "computer_credentials_active_computer_unique",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_credentials_computer_issued_idx": {
+          "name": "computer_credentials_computer_issued_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_credentials_computer_id_account_computers_id_fk": {
+          "name": "computer_credentials_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_credentials_secret_hash_unique": {
+          "name": "computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_credentials_revocation_pair": {
+          "name": "computer_credentials_revocation_pair",
+          "value": "(\"computer_credentials\".\"revoked_by_user_id\" is null) = (\"computer_credentials\".\"revoked_at\" is null)"
+        },
+        "computer_credentials_revoked_after_issued": {
+          "name": "computer_credentials_revoked_after_issued",
+          "value": "\"computer_credentials\".\"revoked_at\" is null or \"computer_credentials\".\"revoked_at\" >= \"computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computers": {
+      "name": "computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_computer_credentials": {
+      "name": "workspace_computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_computer_credentials_active_enrollment_unique": {
+          "name": "workspace_computer_credentials_active_enrollment_unique",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computer_credentials_enrollment_issued_idx": {
+          "name": "workspace_computer_credentials_enrollment_issued_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computer_credentials_secret_hash_unique": {
+          "name": "workspace_computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computer_credentials_revocation_pair": {
+          "name": "workspace_computer_credentials_revocation_pair",
+          "value": "(\"workspace_computer_credentials\".\"revoked_by_user_id\" is null) = (\"workspace_computer_credentials\".\"revoked_at\" is null)"
+        },
+        "workspace_computer_credentials_revoked_after_issued": {
+          "name": "workspace_computer_credentials_revoked_after_issued",
+          "value": "\"workspace_computer_credentials\".\"revoked_at\" is null or \"workspace_computer_credentials\".\"revoked_at\" >= \"workspace_computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_computers": {
+      "name": "workspace_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_by_user_id": {
+          "name": "enrolled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_computers_active_workspace_computer_unique": {
+          "name": "workspace_computers_active_workspace_computer_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_active_workspace_idx": {
+          "name": "workspace_computers_active_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_computer_id_idx": {
+          "name": "workspace_computers_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computers_workspace_id_workspaces_id_fk": {
+          "name": "workspace_computers_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_computer_id_computers_id_fk": {
+          "name": "workspace_computers_computer_id_computers_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_enrolled_by_user_id_users_id_fk": {
+          "name": "workspace_computers_enrolled_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enrolled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computers_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computers_workspace_id_id_unique": {
+          "name": "workspace_computers_workspace_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computers_revocation_pair": {
+          "name": "workspace_computers_revocation_pair",
+          "value": "(\"workspace_computers\".\"revoked_by_user_id\" is null) = (\"workspace_computers\".\"revoked_at\" is null)"
+        },
+        "workspace_computers_revoked_after_enrolled": {
+          "name": "workspace_computers_revoked_after_enrolled",
+          "value": "\"workspace_computers\".\"revoked_at\" is null or \"workspace_computers\".\"revoked_at\" >= \"workspace_computers\".\"enrolled_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_bindings": {
+      "name": "im_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "im_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "im_binding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_brand": {
+          "name": "external_team_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "setup_attempt_id": {
+          "name": "setup_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_intent": {
+          "name": "setup_intent",
+          "type": "feishu_setup_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_state": {
+          "name": "setup_state",
+          "type": "feishu_setup_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_instance_id": {
+          "name": "setup_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_heartbeat_at": {
+          "name": "setup_owner_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_setup_context": {
+          "name": "encrypted_setup_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_expires_at": {
+          "name": "setup_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_route_kind": {
+          "name": "slack_route_kind",
+          "type": "slack_route_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_im_binding_id": {
+          "name": "replacement_im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_owner_instance_id": {
+          "name": "connection_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_fencing_epoch": {
+          "name": "connection_fencing_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_lease_expires_at": {
+          "name": "connection_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_bindings_agent_current_unique": {
+          "name": "im_bindings_agent_current_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_feishu_app_current_unique": {
+          "name": "im_bindings_feishu_app_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_current_unique": {
+          "name": "im_bindings_slack_installation_current_unique",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_id_idx": {
+          "name": "im_bindings_slack_installation_id_idx",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_agent_id_agents_id_fk": {
+          "name": "im_bindings_agent_id_agents_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_id_slack_installations_id_fk": {
+          "name": "im_bindings_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_replacement_im_binding_id_im_bindings_id_fk": {
+          "name": "im_bindings_replacement_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "replacement_im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_owner_fk": {
+          "name": "im_bindings_slack_installation_owner_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "agent_id",
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "agent_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_bindings_credential_generation_nonnegative": {
+          "name": "im_bindings_credential_generation_nonnegative",
+          "value": "\"im_bindings\".\"credential_generation\" >= 0"
+        },
+        "im_bindings_connection_epoch_nonnegative": {
+          "name": "im_bindings_connection_epoch_nonnegative",
+          "value": "\"im_bindings\".\"connection_fencing_epoch\" >= 0"
+        },
+        "im_bindings_active_binding_shape": {
+          "name": "im_bindings_active_binding_shape",
+          "value": "\"im_bindings\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"im_bindings\".\"external_app_id\" is not null and\n        (\"im_bindings\".\"provider\" = 'feishu' or \"im_bindings\".\"external_team_id\" is not null) and\n        \"im_bindings\".\"external_bot_id\" is not null and \"im_bindings\".\"credential_schema_version\" is not null and\n        \"im_bindings\".\"credential_generation\" >= 1 and\n        \"im_bindings\".\"activated_at\" is not null and \"im_bindings\".\"disabled_at\" is null and\n        (\n          (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"encrypted_credential\" is not null and\n            \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null) or\n          (\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"encrypted_credential\" is null and\n            \"im_bindings\".\"slack_installation_id\" is not null and \"im_bindings\".\"slack_route_kind\" is not null)\n        )\n      )"
+        },
+        "im_bindings_disabled_secret_shape": {
+          "name": "im_bindings_disabled_secret_shape",
+          "value": "\"im_bindings\".\"status\" <> 'disabled' or (\n        \"im_bindings\".\"encrypted_credential\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"connection_owner_instance_id\" is null and\n        \"im_bindings\".\"connection_lease_expires_at\" is null and \"im_bindings\".\"disabled_at\" is not null\n      )"
+        },
+        "im_bindings_setup_owner_shape": {
+          "name": "im_bindings_setup_owner_shape",
+          "value": "(\"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"setup_owner_heartbeat_at\" is null and\n        \"im_bindings\".\"encrypted_setup_context\" is null and \"im_bindings\".\"setup_expires_at\" is null)\n        or (\"im_bindings\".\"setup_attempt_id\" is not null and \"im_bindings\".\"setup_intent\" is not null and\n        \"im_bindings\".\"setup_state\" is not null and \"im_bindings\".\"setup_owner_instance_id\" is not null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is not null and \"im_bindings\".\"encrypted_setup_context\" is not null and\n        \"im_bindings\".\"setup_expires_at\" is not null)"
+        },
+        "im_bindings_connection_owner_shape": {
+          "name": "im_bindings_connection_owner_shape",
+          "value": "(\"im_bindings\".\"connection_owner_instance_id\" is null and \"im_bindings\".\"connection_lease_expires_at\" is null)\n        or (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"connection_owner_instance_id\" is not null and\n        \"im_bindings\".\"connection_lease_expires_at\" is not null)"
+        },
+        "im_bindings_slack_setup_fields_null": {
+          "name": "im_bindings_slack_setup_fields_null",
+          "value": "\"im_bindings\".\"provider\" <> 'slack' or (\n        \"im_bindings\".\"setup_attempt_id\" is null and \"im_bindings\".\"setup_intent\" is null and\n        \"im_bindings\".\"setup_state\" is null and \"im_bindings\".\"setup_owner_instance_id\" is null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_expires_at\" is null\n      )"
+        },
+        "im_bindings_slack_route_fields": {
+          "name": "im_bindings_slack_route_fields",
+          "value": "\"im_bindings\".\"provider\" = 'slack' or (\n        \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_message_deliveries": {
+      "name": "im_message_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attention": {
+          "name": "attention",
+          "type": "im_delivery_attention",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "im_delivery_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_request_id": {
+          "name": "dispatch_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_input_hash": {
+          "name": "dispatch_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_payload": {
+          "name": "dispatch_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steer_target_delivery_id": {
+          "name": "steer_target_delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steered_at": {
+          "name": "steered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_owner_instance_id": {
+          "name": "report_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_hash": {
+          "name": "result_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_report": {
+          "name": "turn_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "im_message_deliveries_message_session_unique": {
+          "name": "im_message_deliveries_message_session_unique",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_session_id_idx": {
+          "name": "im_message_deliveries_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_steer_target_idx": {
+          "name": "im_message_deliveries_steer_target_idx",
+          "columns": [
+            {
+              "expression": "steer_target_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_pending_idx": {
+          "name": "im_message_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_dispatch_request_unique": {
+          "name": "im_message_deliveries_dispatch_request_unique",
+          "columns": [
+            {
+              "expression": "dispatch_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"dispatch_request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_turn_id_unique": {
+          "name": "im_message_deliveries_turn_id_unique",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"turn_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_deliveries_message_id_im_messages_id_fk": {
+          "name": "im_message_deliveries_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_session_id_sessions_id_fk": {
+          "name": "im_message_deliveries_session_id_sessions_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk": {
+          "name": "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_message_deliveries",
+          "columnsFrom": [
+            "steer_target_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_message_deliveries_dispatch_shape": {
+          "name": "im_message_deliveries_dispatch_shape",
+          "value": "(\"im_message_deliveries\".\"dispatch_request_id\" is null and \"im_message_deliveries\".\"dispatch_input_hash\" is null and \"im_message_deliveries\".\"dispatch_payload\" is null)\n        or (\"im_message_deliveries\".\"dispatch_request_id\" is not null and \"im_message_deliveries\".\"dispatch_input_hash\" is not null\n          and (\"im_message_deliveries\".\"dispatch_payload\" is not null or \"im_message_deliveries\".\"state\" = 'accepted'))"
+        },
+        "im_message_deliveries_custody_shape": {
+          "name": "im_message_deliveries_custody_shape",
+          "value": "(\"im_message_deliveries\".\"state\" = 'accepted' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"turn_id\" is not null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is not null and \"im_message_deliveries\".\"accepted_at\" is not null\n          and \"im_message_deliveries\".\"steer_target_delivery_id\" is null and \"im_message_deliveries\".\"steered_at\" is null)\n        or (\"im_message_deliveries\".\"state\" = 'steered' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"steer_target_delivery_id\" is not null\n          and \"im_message_deliveries\".\"steered_at\" is not null and \"im_message_deliveries\".\"turn_id\" is null and \"im_message_deliveries\".\"report_owner_instance_id\" is null\n          and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null\n          and \"im_message_deliveries\".\"result_hash\" is null)\n        or (\"im_message_deliveries\".\"state\" not in ('accepted', 'steered') and \"im_message_deliveries\".\"input_hash\" is null and \"im_message_deliveries\".\"turn_id\" is null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is null and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"steered_at\" is null\n          and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null and \"im_message_deliveries\".\"result_hash\" is null)"
+        },
+        "im_message_deliveries_report_shape": {
+          "name": "im_message_deliveries_report_shape",
+          "value": "(\"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null)\n        or (\"im_message_deliveries\".\"reported_at\" is not null and \"im_message_deliveries\".\"turn_report\" is not null and \"im_message_deliveries\".\"result_hash\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_messages": {
+      "name": "im_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_revision_key": {
+          "name": "provider_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "im_message_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "im_message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_external_id": {
+          "name": "reply_to_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "im_author_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_external_id": {
+          "name": "author_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_context": {
+          "name": "provider_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_messages_provider_event_unique": {
+          "name": "im_messages_provider_event_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_messages\".\"provider_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_semantic_revision_unique": {
+          "name": "im_messages_semantic_revision_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_revision_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_scope_occurred_idx": {
+          "name": "im_messages_scope_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_external_occurred_idx": {
+          "name": "im_messages_external_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_messages_im_binding_id_im_bindings_id_fk": {
+          "name": "im_messages_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invitations": {
+      "name": "admin_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_invitations_workspace_created_idx": {
+          "name": "admin_invitations_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_invitations_workspace_id_workspaces_id_fk": {
+          "name": "admin_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_created_by_user_id_users_id_fk": {
+          "name": "admin_invitations_created_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_accepted_by_user_id_users_id_fk": {
+          "name": "admin_invitations_accepted_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_revoked_by_user_id_users_id_fk": {
+          "name": "admin_invitations_revoked_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invitations_token_hash_unique": {
+          "name": "admin_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invitations_expiry": {
+          "name": "admin_invitations_expiry",
+          "value": "\"admin_invitations\".\"expires_at\" > \"admin_invitations\".\"created_at\""
+        },
+        "admin_invitations_acceptance_pair": {
+          "name": "admin_invitations_acceptance_pair",
+          "value": "(\"admin_invitations\".\"accepted_by_user_id\" is null) = (\"admin_invitations\".\"accepted_at\" is null)"
+        },
+        "admin_invitations_revocation_pair": {
+          "name": "admin_invitations_revocation_pair",
+          "value": "(\"admin_invitations\".\"revoked_by_user_id\" is null) = (\"admin_invitations\".\"revoked_at\" is null)"
+        },
+        "admin_invitations_terminal_state": {
+          "name": "admin_invitations_terminal_state",
+          "value": "not (\"admin_invitations\".\"accepted_at\" is not null and \"admin_invitations\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_cli_proofs": {
+      "name": "session_cli_proofs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proof_id": {
+          "name": "proof_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_instance_id": {
+          "name": "connection_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_cli_proofs_computer_id_idx": {
+          "name": "session_cli_proofs_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_cli_proofs_session_id_sessions_id_fk": {
+          "name": "session_cli_proofs_session_id_sessions_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_computer_id_account_computers_id_fk": {
+          "name": "session_cli_proofs_computer_id_account_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_cli_proofs_proof_id_unique": {
+          "name": "session_cli_proofs_proof_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proof_id"
+          ]
+        },
+        "session_cli_proofs_token_hash_unique": {
+          "name": "session_cli_proofs_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_cli_proofs_token_hash_shape": {
+          "name": "session_cli_proofs_token_hash_shape",
+          "value": "\"session_cli_proofs\".\"token_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_cli_proofs_generation_positive": {
+          "name": "session_cli_proofs_generation_positive",
+          "value": "\"session_cli_proofs\".\"placement_generation\" >= 1"
+        },
+        "session_cli_proofs_computer_matches_enrollment": {
+          "name": "session_cli_proofs_computer_matches_enrollment",
+          "value": "\"session_cli_proofs\".\"computer_id\" = \"session_cli_proofs\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_messages": {
+      "name": "session_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_outcome": {
+          "name": "last_outcome",
+          "type": "session_message_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_messages_target_created_idx": {
+          "name": "session_messages_target_created_idx",
+          "columns": [
+            {
+              "expression": "target_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_messages_source_created_idx": {
+          "name": "session_messages_source_created_idx",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_messages_source_session_id_sessions_id_fk": {
+          "name": "session_messages_source_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "source_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_messages_target_session_id_sessions_id_fk": {
+          "name": "session_messages_target_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_messages_content_hash_shape": {
+          "name": "session_messages_content_hash_shape",
+          "value": "\"session_messages\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_messages_content_bounds": {
+          "name": "session_messages_content_bounds",
+          "value": "octet_length(\"session_messages\".\"content\") between 1 and 16384"
+        },
+        "session_messages_error_code_shape": {
+          "name": "session_messages_error_code_shape",
+          "value": "\"session_messages\".\"last_error_code\" is null or (\"session_messages\".\"last_error_code\" ~ '^[a-z][a-z0-9_]{0,127}$')"
+        },
+        "session_messages_attempt_count_nonnegative": {
+          "name": "session_messages_attempt_count_nonnegative",
+          "value": "\"session_messages\".\"attempt_count\" >= 0"
+        },
+        "session_messages_attempt_shape": {
+          "name": "session_messages_attempt_shape",
+          "value": "(\"session_messages\".\"attempt_count\" = 0 and \"session_messages\".\"last_attempt_at\" is null)\n        or (\"session_messages\".\"attempt_count\" > 0 and \"session_messages\".\"last_attempt_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_descendants": {
+      "name": "session_descendants",
+      "schema": "",
+      "columns": {
+        "ancestor_session_id": {
+          "name": "ancestor_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_session_id": {
+          "name": "descendant_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_created_at": {
+          "name": "last_message_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_delivery_outcome": {
+          "name": "last_delivery_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_preview": {
+          "name": "task_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_descendants_ancestor_activity_idx": {
+          "name": "session_descendants_ancestor_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_ancestor_depth_activity_idx": {
+          "name": "session_descendants_ancestor_depth_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_descendant_ancestor_idx": {
+          "name": "session_descendants_descendant_ancestor_idx",
+          "columns": [
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_last_message_idx": {
+          "name": "session_descendants_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_descendants_ancestor_session_id_sessions_id_fk": {
+          "name": "session_descendants_ancestor_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "ancestor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_descendants_descendant_session_id_sessions_id_fk": {
+          "name": "session_descendants_descendant_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "descendant_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_descendants_ancestor_session_id_descendant_session_id_pk": {
+          "name": "session_descendants_ancestor_session_id_descendant_session_id_pk",
+          "columns": [
+            "ancestor_session_id",
+            "descendant_session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_descendants_depth_positive": {
+          "name": "session_descendants_depth_positive",
+          "value": "\"session_descendants\".\"depth\" >= 1"
+        },
+        "session_descendants_outcome_valid": {
+          "name": "session_descendants_outcome_valid",
+          "value": "\"session_descendants\".\"last_delivery_outcome\" in ('accepted', 'unreachable', 'unknown', 'rejected')"
+        },
+        "session_descendants_preview_bounds": {
+          "name": "session_descendants_preview_bounds",
+          "value": "char_length(\"session_descendants\".\"task_preview\") between 1 and 256"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_placements": {
+      "name": "session_placements",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_placements_workspace_computer_id_idx": {
+          "name": "session_placements_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_placements_computer_id_idx": {
+          "name": "session_placements_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_placements_session_id_sessions_id_fk": {
+          "name": "session_placements_session_id_sessions_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_placements_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_placements_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_placements_computer_id_account_computers_id_fk": {
+          "name": "session_placements_computer_id_account_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_placements_generation_positive": {
+          "name": "session_placements_generation_positive",
+          "value": "\"session_placements\".\"generation\" >= 1"
+        },
+        "session_placements_computer_matches_enrollment": {
+          "name": "session_placements_computer_matches_enrollment",
+          "value": "\"session_placements\".\"computer_id\" = \"session_placements\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_kind": {
+          "name": "conversation_kind",
+          "type": "im_conversation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "session_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_model": {
+          "name": "runtime_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_reasoning_effort": {
+          "name": "runtime_reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_max_duration_ms": {
+          "name": "runtime_max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_active_channel_unique": {
+          "name": "sessions_active_channel_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'channel' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_active_thread_unique": {
+          "name": "sessions_active_thread_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'thread' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_im_binding_scope_idx": {
+          "name": "sessions_im_binding_scope_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_creator_created_idx": {
+          "name": "sessions_creator_created_idx",
+          "columns": [
+            {
+              "expression": "created_by_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_im_binding_id_im_bindings_id_fk": {
+          "name": "sessions_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sessions_created_by_session_id_sessions_id_fk": {
+          "name": "sessions_created_by_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "created_by_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sessions_shape_check": {
+          "name": "sessions_shape_check",
+          "value": "(\"sessions\".\"kind\" = 'channel' and \"sessions\".\"thread_key\" is null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'thread' and \"sessions\".\"thread_key\" is not null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'internal' and \"sessions\".\"created_by_session_id\" is not null)"
+        },
+        "sessions_runtime_max_duration_valid": {
+          "name": "sessions_runtime_max_duration_valid",
+          "value": "\"sessions\".\"runtime_max_duration_ms\" is null or (\"sessions\".\"runtime_max_duration_ms\" > 0 and \"sessions\".\"runtime_max_duration_ms\" <= 86400000)"
+        },
+        "sessions_runtime_model_bounds": {
+          "name": "sessions_runtime_model_bounds",
+          "value": "\"sessions\".\"runtime_model\" is null or octet_length(\"sessions\".\"runtime_model\") between 1 and 128"
+        },
+        "sessions_runtime_reasoning_effort_bounds": {
+          "name": "sessions_runtime_reasoning_effort_bounds",
+          "value": "\"sessions\".\"runtime_reasoning_effort\" is null or octet_length(\"sessions\".\"runtime_reasoning_effort\") between 1 and 64"
+        },
+        "sessions_revision_positive": {
+          "name": "sessions_revision_positive",
+          "value": "\"sessions\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "slack_installation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "replacement_slack_installation_id": {
+          "name": "replacement_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installations_app_team_current_unique": {
+          "name": "slack_installations_app_team_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_installations\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_workspace_id_idx": {
+          "name": "slack_installations_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_agent_id_idx": {
+          "name": "slack_installations_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_app_team_idx": {
+          "name": "slack_installations_app_team_idx",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_workspace_id_workspaces_id_fk": {
+          "name": "slack_installations_workspace_id_workspaces_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_agent_id_agents_id_fk": {
+          "name": "slack_installations_agent_id_agents_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_replacement_slack_installation_id_slack_installations_id_fk": {
+          "name": "slack_installations_replacement_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "replacement_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_agent_id_id_unique": {
+          "name": "slack_installations_agent_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_installations_credential_generation_nonnegative": {
+          "name": "slack_installations_credential_generation_nonnegative",
+          "value": "\"slack_installations\".\"credential_generation\" >= 0"
+        },
+        "slack_installations_active_shape": {
+          "name": "slack_installations_active_shape",
+          "value": "\"slack_installations\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"slack_installations\".\"credential_schema_version\" is not null and\n        \"slack_installations\".\"credential_generation\" >= 1 and \"slack_installations\".\"encrypted_credential\" is not null and\n        \"slack_installations\".\"activated_at\" is not null and \"slack_installations\".\"disabled_at\" is null\n      )"
+        },
+        "slack_installations_disabled_secret_shape": {
+          "name": "slack_installations_disabled_secret_shape",
+          "value": "\"slack_installations\".\"status\" <> 'disabled' or (\n        \"slack_installations\".\"encrypted_credential\" is null and \"slack_installations\".\"disabled_at\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_oauth_nonces": {
+      "name": "slack_oauth_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_binding_id": {
+          "name": "expected_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_credential_generation": {
+          "name": "expected_credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_binding_hash": {
+          "name": "session_binding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_oauth_nonces_user_agent_idx": {
+          "name": "slack_oauth_nonces_user_agent_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_oauth_nonces_expires_idx": {
+          "name": "slack_oauth_nonces_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_oauth_nonces_user_id_users_id_fk": {
+          "name": "slack_oauth_nonces_user_id_users_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_oauth_nonces_agent_id_agents_id_fk": {
+          "name": "slack_oauth_nonces_agent_id_agents_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_oauth_nonces_nonce_hash_unique": {
+          "name": "slack_oauth_nonces_nonce_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_oauth_nonces_intent": {
+          "name": "slack_oauth_nonces_intent",
+          "value": "\"slack_oauth_nonces\".\"intent\" in ('create', 'reauthorize')"
+        },
+        "slack_oauth_nonces_expiry": {
+          "name": "slack_oauth_nonces_expiry",
+          "value": "\"slack_oauth_nonces\".\"expires_at\" > \"slack_oauth_nonces\".\"created_at\""
+        },
+        "slack_oauth_nonces_expected_binding_pair": {
+          "name": "slack_oauth_nonces_expected_binding_pair",
+          "value": "(\"slack_oauth_nonces\".\"expected_binding_id\" is null) = (\"slack_oauth_nonces\".\"expected_credential_generation\" is null)"
+        },
+        "slack_oauth_nonces_generation_positive": {
+          "name": "slack_oauth_nonces_generation_positive",
+          "value": "\"slack_oauth_nonces\".\"expected_credential_generation\" is null or \"slack_oauth_nonces\".\"expected_credential_generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_receive_mode": {
+      "name": "agent_receive_mode",
+      "schema": "public",
+      "values": [
+        "all_message",
+        "mention_only"
+      ]
+    },
+    "public.agent_runtime_provider": {
+      "name": "agent_runtime_provider",
+      "schema": "public",
+      "values": [
+        "codex",
+        "claude-code"
+      ]
+    },
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "suspended",
+        "deleted"
+      ]
+    },
+    "public.computer_connect_code_mode": {
+      "name": "computer_connect_code_mode",
+      "schema": "public",
+      "values": [
+        "create",
+        "repair"
+      ]
+    },
+    "public.computer_platform": {
+      "name": "computer_platform",
+      "schema": "public",
+      "values": [
+        "darwin",
+        "linux",
+        "win32"
+      ]
+    },
+    "public.feishu_setup_intent": {
+      "name": "feishu_setup_intent",
+      "schema": "public",
+      "values": [
+        "create",
+        "reauthorize",
+        "replace"
+      ]
+    },
+    "public.feishu_setup_state": {
+      "name": "feishu_setup_state",
+      "schema": "public",
+      "values": [
+        "awaiting_user",
+        "validating",
+        "succeeded",
+        "failed",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.im_binding_status": {
+      "name": "im_binding_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "active",
+        "reauthorization_required",
+        "error",
+        "disabled"
+      ]
+    },
+    "public.im_conversation_kind": {
+      "name": "im_conversation_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "dm",
+        "group_dm"
+      ]
+    },
+    "public.im_provider": {
+      "name": "im_provider",
+      "schema": "public",
+      "values": [
+        "feishu",
+        "slack"
+      ]
+    },
+    "public.slack_route_kind": {
+      "name": "slack_route_kind",
+      "schema": "public",
+      "values": [
+        "default"
+      ]
+    },
+    "public.im_author_kind": {
+      "name": "im_author_kind",
+      "schema": "public",
+      "values": [
+        "human",
+        "bot",
+        "system"
+      ]
+    },
+    "public.im_delivery_attention": {
+      "name": "im_delivery_attention",
+      "schema": "public",
+      "values": [
+        "direct",
+        "ambient"
+      ]
+    },
+    "public.im_delivery_state": {
+      "name": "im_delivery_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "steered",
+        "terminal_rejected",
+        "expired"
+      ]
+    },
+    "public.im_message_direction": {
+      "name": "im_message_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.im_message_operation": {
+      "name": "im_message_operation",
+      "schema": "public",
+      "values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "public.session_message_outcome": {
+      "name": "session_message_outcome",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "accepted",
+        "unreachable",
+        "rejected"
+      ]
+    },
+    "public.session_kind": {
+      "name": "session_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "thread",
+        "internal"
+      ]
+    },
+    "public.slack_installation_status": {
+      "name": "slack_installation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "reauthorization_required",
+        "disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {
+    "public.runtime_config_revision_sequence": {
+      "name": "runtime_config_revision_sequence",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1788076586983,
       "tag": "0029_tiresome_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1788077592745,
+      "tag": "0030_low_ulik",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1788005894809,
       "tag": "0028_overjoyed_speedball",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1788076586983,
+      "tag": "0029_tiresome_bedlam",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/account-api.test.ts
+++ b/packages/server/src/__tests__/account-api.test.ts
@@ -102,15 +102,7 @@ function authService(): UserAuthService {
       tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
       me: {
         user: { id: userId, email: "admin@example.com", displayName: "Admin" },
-        workspaces: [
-          {
-            id: workspaceId,
-            name: "example",
-            displayName: "Example",
-            setupCompletedAt: null,
-            grantedAt: "2026-08-20T00:00:00.000Z",
-          },
-        ],
+        setupCompletedAt: null,
       },
     }),
   };
@@ -162,6 +154,7 @@ function services() {
     },
     workspaceSetupService: {
       complete: vi.fn().mockResolvedValue({ setupCompletedAt: "2026-08-19T00:00:00.000Z" }),
+      completeForAccount: vi.fn().mockResolvedValue({ setupCompletedAt: "2026-08-19T00:00:00.000Z" }),
     },
   };
 }
@@ -324,6 +317,7 @@ describe("Account-native management collections", () => {
     expect(service.machineAuthService.issueForAccount).not.toHaveBeenCalled();
     expect(service.machineAuthService.issueForWorkspaceAdmin).not.toHaveBeenCalled();
     expect(service.workspaceSetupService.complete).not.toHaveBeenCalled();
+    expect(service.workspaceSetupService.completeForAccount).not.toHaveBeenCalled();
     expect(service.accountScope.resolveCompatibilityWorkspaceId).not.toHaveBeenCalled();
   });
 
@@ -358,9 +352,18 @@ describe("Account-native management collections", () => {
       const response = await app.inject({ method: "GET", url, headers: authorization });
       expect(response.statusCode).toBe(200);
     }
+    const setup = await app.inject({
+      method: "POST",
+      url: HTTP_PATHS.accountSetupComplete,
+      headers: authorization,
+      payload: { agentId },
+    });
+    expect(setup.statusCode).toBe(200);
     expect(service.agentService.listForAccount).toHaveBeenCalledWith(userId);
     expect(service.workspaceService.listAccountComputers).toHaveBeenCalledWith(userId, false);
     expect(service.taskService.list).toHaveBeenCalledWith(userId, { limit: 50 });
+    expect(service.workspaceSetupService.completeForAccount).toHaveBeenCalledWith(userId, agentId);
+    expect(service.workspaceSetupService.complete).not.toHaveBeenCalled();
     expect(service.accountScope.resolveCompatibilityWorkspaceId).not.toHaveBeenCalled();
     expect(service.agentService.listForWorkspace).not.toHaveBeenCalled();
     expect(service.workspaceService.listComputers).not.toHaveBeenCalled();
@@ -395,13 +398,16 @@ describe("Account-native management collections", () => {
     expect(service.accountScope.resolveCompatibilityWorkspaceId).not.toHaveBeenCalled();
   });
 
-  it("registers no Account-native collection without the compatibility resolver", async () => {
+  it("registers Account-native collections without the compatibility resolver", async () => {
+    const service = services();
     const app = createApp({
       authService: authService(),
-      agentService: services().agentService as unknown as AgentService,
+      agentService: service.agentService as unknown as AgentService,
     });
     apps.push(app);
     const response = await app.inject({ method: "GET", url: HTTP_PATHS.accountAgents, headers: authorization });
-    expect(response.statusCode).toBe(404);
+    expect(response.statusCode).toBe(200);
+    expect(service.agentService.listForAccount).toHaveBeenCalledWith(userId);
+    expect(service.accountScope.resolveCompatibilityWorkspaceId).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/__tests__/agent-api.test.ts
+++ b/packages/server/src/__tests__/agent-api.test.ts
@@ -98,15 +98,7 @@ function authService(): UserAuthService {
       tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
       me: {
         user: { id: userId, email: "admin@example.com", displayName: "Admin" },
-        workspaces: [
-          {
-            id: workspaceId,
-            name: "example",
-            displayName: "Example",
-            setupCompletedAt: null,
-            grantedAt: "2026-08-20T00:00:00.000Z",
-          },
-        ],
+        setupCompletedAt: null,
       },
     }),
   };

--- a/packages/server/src/__tests__/auth-api.test.ts
+++ b/packages/server/src/__tests__/auth-api.test.ts
@@ -5,7 +5,6 @@ import type { ConnectCodeIssuer, UserAuthService } from "../services/auth/index.
 import { signedInBrowser } from "./signed-in-browser.js";
 
 const apps: ReturnType<typeof createApp>[] = [];
-const workspaceId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
 
 afterEach(async () => {
   await Promise.all(apps.splice(0).map((app) => app.close()));
@@ -33,20 +32,12 @@ function createAuthService(): UserAuthService {
           email: "admin@example.com",
           displayName: "Admin",
         },
-        workspaces: [
-          {
-            id: workspaceId,
-            name: "example",
-            displayName: "Example",
-            setupCompletedAt: null,
-            grantedAt: "2026-08-20T00:00:00.000Z",
-          },
-        ],
+        setupCompletedAt: null,
       },
     }),
     getActiveUserById: vi.fn().mockResolvedValue({
       user: { id: "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e", email: "admin@example.com", displayName: "Admin" },
-      workspaces: [],
+      setupCompletedAt: null,
     }),
     updateSelfProfile: vi.fn().mockResolvedValue({
       id: "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e",
@@ -118,7 +109,7 @@ describe("auth HTTP API", () => {
     expect(response.json()).toMatchObject({ error: { code: "INTERNAL_ERROR", category: "transient" } });
   });
 
-  it("authenticates /api/v1/me and returns ordered Workspace data", async () => {
+  it("authenticates /api/v1/me without a management Workspace projection", async () => {
     const authService = createAuthService();
     const app = createApp({ authService });
     apps.push(app);
@@ -132,7 +123,15 @@ describe("auth HTTP API", () => {
       headers: { authorization: "Bearer access" },
     });
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toMatchObject({ workspaces: [{ name: "example", displayName: "Example" }] });
+    expect(response.json()).toEqual({
+      user: {
+        id: "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e",
+        email: "admin@example.com",
+        displayName: "Admin",
+      },
+      setupCompletedAt: null,
+    });
+    expect(response.json()).not.toHaveProperty("workspaces");
     expect(authService.getAuthenticatedUser).toHaveBeenCalledWith("access");
   });
 

--- a/packages/server/src/__tests__/better-auth-surface.test.ts
+++ b/packages/server/src/__tests__/better-auth-surface.test.ts
@@ -175,7 +175,7 @@ describe("published Better Auth surface", () => {
         ...authService(),
         getActiveUserById: vi.fn().mockResolvedValue({
           user: { id: "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e", email: "admin@example.com", displayName: "Admin" },
-          workspaces: [],
+          setupCompletedAt: null,
         }),
       },
       betterAuth,

--- a/packages/server/src/__tests__/im-binding-api.test.ts
+++ b/packages/server/src/__tests__/im-binding-api.test.ts
@@ -15,7 +15,6 @@ import { FeishuOperationError, type FeishuSetupService } from "../services/im-bi
 import type { ImBindingService } from "../services/im-bindings/index.js";
 
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
-const workspaceId = "d3fda800-7ce2-4338-aae8-3d2120401ed6";
 const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const imBindingId = "6d93de68-ec32-4ac9-a41e-e96ed2d7dac0";
 const attemptId = "f645f26d-9184-4f2f-98a1-4ee83ae6a603";
@@ -79,15 +78,7 @@ function authService(): UserAuthService {
       tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
       me: {
         user: { id: userId, email: "admin@example.com", displayName: "Admin" },
-        workspaces: [
-          {
-            id: workspaceId,
-            name: "example",
-            displayName: "Example",
-            setupCompletedAt: null,
-            grantedAt: "2030-01-01T00:00:00.000Z",
-          },
-        ],
+        setupCompletedAt: null,
       },
     }),
   };

--- a/packages/server/src/__tests__/im-resource-api.test.ts
+++ b/packages/server/src/__tests__/im-resource-api.test.ts
@@ -26,7 +26,7 @@ function authService(): UserAuthService {
       tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
       me: {
         user: { id: workspaceId, email: "admin@example.com", displayName: "Admin" },
-        workspaces: [],
+        setupCompletedAt: null,
       },
     }),
   };

--- a/packages/server/src/__tests__/integration/account-ownership-expansion.test.ts
+++ b/packages/server/src/__tests__/integration/account-ownership-expansion.test.ts
@@ -102,10 +102,11 @@ const HAZARD_CONSTRAINTS = [
   "computer_connect_codes_workspace_enrollment_fk",
   "agents_workspace_enrollment_fk",
 ] as const;
-const HAZARD_INDEXES = [
+const LEGACY_HAZARD_INDEXES = [
   "slack_installations_workspace_current_unique",
   "session_placements_workspace_computer_id_idx",
 ] as const;
+const CURRENT_HAZARD_INDEXES = ["session_placements_workspace_computer_id_idx"] as const;
 
 async function expansionSchema(sql: postgres.Sql) {
   const [row] = await sql<
@@ -344,7 +345,7 @@ describe("account-owned computer expansion migrations", () => {
     ]);
   });
 
-  it("migrates an empty database to 0026 and reruns idempotently", async () => {
+  it("migrates an empty database through the current journal and reruns idempotently", async () => {
     const journal = await readJournal();
     await migrateDatabase(databaseUrl, migrationsFolder);
     await migrateDatabase(databaseUrl, migrationsFolder);
@@ -363,7 +364,7 @@ describe("account-owned computer expansion migrations", () => {
         slack_agent_id: true,
         connect_mode: true,
         hazards: [...HAZARD_CONSTRAINTS].sort(),
-        hazard_indexes: [...HAZARD_INDEXES].sort(),
+        hazard_indexes: [...CURRENT_HAZARD_INDEXES].sort(),
       });
       const [counts] = await sql<{ account_computers: number; computer_credentials: number }[]>`
         select
@@ -525,7 +526,7 @@ describe("account-owned computer expansion migrations", () => {
         });
         const schema = await expansionSchema(sql);
         expect(schema?.hazards).toEqual([...HAZARD_CONSTRAINTS].sort());
-        expect(schema?.hazard_indexes).toEqual([...HAZARD_INDEXES].sort());
+        expect(schema?.hazard_indexes).toEqual([...LEGACY_HAZARD_INDEXES].sort());
         const [stable] = await sql<{ enrollment_id: string; credential_hash: string; agent_creator: string }[]>`
           select
             ${ACTIVE_ENROLLMENT_ID}::text as enrollment_id,
@@ -686,13 +687,8 @@ describe("account-owned computer expansion migrations", () => {
     }
   });
 
-  it("preserves legacy enrollment hazards and fail-closes new projection constraints", async () => {
-    const through0026 = await truncatedMigrations(26);
-    try {
-      await migrateDatabase(databaseUrl, through0026);
-    } finally {
-      await rm(through0026, { force: true, recursive: true });
-    }
+  it("preserves enrollment hazards and fail-closes current projection constraints", async () => {
+    await migrateDatabase(databaseUrl, migrationsFolder);
     const client = createDatabaseClient(databaseUrl);
     try {
       const bootstrap = await bootstrapInitialAdmin(client.database, {
@@ -720,7 +716,7 @@ describe("account-owned computer expansion migrations", () => {
       `;
       expect(hazards).toEqual({
         constraints: [...HAZARD_CONSTRAINTS].sort(),
-        indexes: [...HAZARD_INDEXES].sort(),
+        indexes: [...CURRENT_HAZARD_INDEXES].sort(),
       });
 
       const computerId = crypto.randomUUID();
@@ -748,8 +744,8 @@ describe("account-owned computer expansion migrations", () => {
         )
       `.catch((error: unknown) => error);
       expect(postgresError(orphan)).toMatchObject({
-        code: "23503",
-        constraint_name: "agents_computer_id_account_computers_id_fk",
+        code: "23514",
+        constraint_name: "agents_computer_matches_enrollment",
       });
 
       await sql`
@@ -778,11 +774,12 @@ describe("account-owned computer expansion migrations", () => {
       await sql`insert into workspaces (id, name, display_name) values (${otherWorkspace}, 'other', 'Other')`;
       const crossCode = await sql`
         insert into computer_connect_codes (
-          workspace_id, token_hash, issued_by_user_id, expires_at, consumed_workspace_computer_id, consumed_at
+          workspace_id, token_hash, issued_by_user_id, issued_by_account_id, mode, expires_at,
+          consumed_workspace_computer_id, consumed_computer_id, consumed_at
         )
         values (
-          ${otherWorkspace}, ${"2".repeat(64)}, ${bootstrap.userId}, now() + interval '15 minutes',
-          ${enrollment.id}, now()
+          ${otherWorkspace}, ${"2".repeat(64)}, ${bootstrap.userId}, ${bootstrap.userId}, 'create',
+          now() + interval '15 minutes', ${enrollment.id}, ${enrollment.id}, now()
         )
       `.catch((error: unknown) => error);
       expect(postgresError(crossCode)).toMatchObject({
@@ -790,41 +787,100 @@ describe("account-owned computer expansion migrations", () => {
         constraint_name: "computer_connect_codes_workspace_enrollment_fk",
       });
 
+      const slackAgents = await sql<{ id: string }[]>`
+        insert into agents (
+          workspace_id, created_by_user_id, workspace_computer_id, computer_id,
+          name, display_name, runtime_provider
+        )
+        values
+          (
+            ${bootstrap.workspaceId}, ${bootstrap.userId}, ${enrollment.id}, ${enrollment.id},
+            'slack-one', 'Slack One', 'codex'
+          ),
+          (
+            ${bootstrap.workspaceId}, ${bootstrap.userId}, ${enrollment.id}, ${enrollment.id},
+            'slack-two', 'Slack Two', 'codex'
+          )
+        returning id::text
+      `;
+      const [firstSlackAgent, secondSlackAgent] = slackAgents;
+      if (!firstSlackAgent || !secondSlackAgent) throw new Error("Slack Agent fixtures were not created");
+
       await sql`
         insert into slack_installations (
-          workspace_id, status, external_app_id, external_team_id, external_bot_id,
+          workspace_id, agent_id, status, external_app_id, external_team_id, external_bot_id,
           credential_schema_version, credential_generation, encrypted_credential, activated_at
         )
         values (
-          ${bootstrap.workspaceId}, 'active', 'A1', 'T1', 'U1', 1, 1, 'secret', now()
+          ${bootstrap.workspaceId}, ${firstSlackAgent.id}, 'active', 'A1', 'T1', 'U1',
+          1, 1, 'secret', now()
         )
       `;
-      const duplicateSlack = await sql`
+      await sql`
         insert into slack_installations (
-          workspace_id, status, external_app_id, external_team_id, external_bot_id,
+          workspace_id, agent_id, status, external_app_id, external_team_id, external_bot_id,
           credential_schema_version, credential_generation, encrypted_credential, activated_at
         )
         values (
-          ${bootstrap.workspaceId}, 'active', 'A2', 'T2', 'U2', 1, 1, 'secret-2', now()
+          ${bootstrap.workspaceId}, ${secondSlackAgent.id}, 'active', 'A2', 'T2', 'U2',
+          1, 1, 'secret-2', now()
+        )
+      `;
+      const [currentSlack] = await sql<{ count: number }[]>`
+        select count(*)::int as count
+        from slack_installations
+        where workspace_id = ${bootstrap.workspaceId}
+          and status in ('active', 'reauthorization_required')
+      `;
+      expect(currentSlack?.count).toBe(2);
+
+      const duplicateSlack = await sql`
+        insert into slack_installations (
+          workspace_id, agent_id, status, external_app_id, external_team_id, external_bot_id,
+          credential_schema_version, credential_generation, encrypted_credential, activated_at
+        )
+        values (
+          ${bootstrap.workspaceId}, ${secondSlackAgent.id}, 'active', 'A1', 'T1', 'U3',
+          1, 1, 'secret-3', now()
         )
       `.catch((error: unknown) => error);
       expect(postgresError(duplicateSlack)).toMatchObject({
         code: "23505",
-        constraint_name: "slack_installations_workspace_current_unique",
+        constraint_name: "slack_installations_app_team_current_unique",
       });
 
-      const [otherEnrollment] = await sql<{ id: string }[]>`
+      const [otherComputer] = await sql<{ id: string }[]>`
+        insert into computers (id) values (${crypto.randomUUID()})
+        returning id::text
+      `;
+      if (!otherComputer) throw new Error("Cross-workspace Computer fixture was not created");
+      const [crossWorkspaceEnrollment] = await sql<{ id: string }[]>`
         insert into workspace_computers (
           workspace_id, computer_id, display_name, platform, arch, client_version, enrolled_by_user_id
         )
-        values (${otherWorkspace}, ${computerId}, 'other-box', 'linux', 'x64', '0.0.1', ${bootstrap.userId})
+        values (
+          ${otherWorkspace}, ${otherComputer.id}, 'other-box', 'linux', 'x64', '0.0.1', ${bootstrap.userId}
+        )
         returning id::text
       `;
-      if (!otherEnrollment) throw new Error("Cross-workspace enrollment fixture was not created");
-      const crossAgent = await sql`
-        insert into agents (workspace_id, created_by_user_id, workspace_computer_id, name, display_name, runtime_provider)
+      if (!crossWorkspaceEnrollment) throw new Error("Cross-workspace enrollment fixture was not created");
+      await sql`
+        insert into account_computers (
+          id, owner_account_id, current_installation_id, display_name, platform, arch, client_version
+        )
         values (
-          ${bootstrap.workspaceId}, ${bootstrap.userId}, ${otherEnrollment.id},
+          ${crossWorkspaceEnrollment.id}, ${bootstrap.userId}, ${otherComputer.id},
+          'other-box', 'linux', 'x64', '0.0.1'
+        )
+      `;
+      const crossAgent = await sql`
+        insert into agents (
+          workspace_id, created_by_user_id, workspace_computer_id, computer_id,
+          name, display_name, runtime_provider
+        )
+        values (
+          ${bootstrap.workspaceId}, ${bootstrap.userId},
+          ${crossWorkspaceEnrollment.id}, ${crossWorkspaceEnrollment.id},
           'cross', 'Cross', 'codex'
         )
       `.catch((error: unknown) => error);

--- a/packages/server/src/__tests__/integration/auth-migrations.test.ts
+++ b/packages/server/src/__tests__/integration/auth-migrations.test.ts
@@ -1489,8 +1489,9 @@ describe("authentication persistence", () => {
     try {
       const tokens = await fixture.auth.exchangeConnectCode(fixture.bootstrap.connectCode);
       await expect(fixture.auth.getAuthenticatedUser(tokens.accessToken)).resolves.toMatchObject({
-        me: { workspaces: [{ id: fixture.bootstrap.workspaceId }] },
+        me: { user: { id: fixture.bootstrap.userId }, setupCompletedAt: null },
       });
+      expect((await fixture.auth.getAuthenticatedUser(tokens.accessToken)).me).not.toHaveProperty("workspaces");
 
       await fixture.database
         .update(workspaceAdminGrants)
@@ -1499,9 +1500,9 @@ describe("authentication persistence", () => {
           revokedByUserId: fixture.bootstrap.userId,
         })
         .where(eq(workspaceAdminGrants.userId, fixture.bootstrap.userId));
-      // Losing every Admin grant drops Workspace authority but keeps the Account session.
+      // Losing every Admin grant does not change Account identity or invalidate the session.
       await expect(fixture.auth.getAuthenticatedUser(tokens.accessToken)).resolves.toMatchObject({
-        me: { user: { id: fixture.bootstrap.userId }, workspaces: [] },
+        me: { user: { id: fixture.bootstrap.userId }, setupCompletedAt: null },
       });
       // Refreshing withdraws what it replaces, so the renewed credential is the one that carries on from here.
       const renewed = await fixture.auth.refresh(tokens.refreshToken);

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -601,6 +601,12 @@ describe("IM binding persistence", () => {
       await expect(
         value.database.select({ setupCompletedAt: workspaces.setupCompletedAt }).from(workspaces).limit(1),
       ).resolves.toEqual([{ setupCompletedAt: null }]);
+      await expect(
+        value.database
+          .select({ setupCompletedAt: users.setupCompletedAt })
+          .from(users)
+          .where(eq(users.id, value.bootstrap.userId)),
+      ).resolves.toEqual([{ setupCompletedAt: null }]);
 
       const setup = new WorkspaceSetupService(value.database, value.imBindingService, {
         now: () => completedAt,
@@ -610,6 +616,12 @@ describe("IM binding persistence", () => {
       ).resolves.toEqual({
         setupCompletedAt: completedAt.toISOString(),
       });
+      await expect(
+        value.database
+          .select({ setupCompletedAt: users.setupCompletedAt })
+          .from(users)
+          .where(eq(users.id, value.bootstrap.userId)),
+      ).resolves.toEqual([{ setupCompletedAt: completedAt }]);
 
       await value.database.update(agents).set({ status: "suspended" }).where(eq(agents.id, value.agent.id));
       await expect(
@@ -622,7 +634,7 @@ describe("IM binding persistence", () => {
         .returning();
       if (!member) throw new Error("Setup member fixture was not created");
       await expect(setup.complete(member.id, value.bootstrap.workspaceId, value.agent.id)).rejects.toMatchObject({
-        code: "RESOURCE_NOT_FOUND",
+        code: "WORKSPACE_SETUP_AGENT_NOT_FOUND",
         statusCode: 404,
       });
     } finally {
@@ -1393,54 +1405,25 @@ describe("IM binding persistence", () => {
     }
   });
 
-  it("waits for an in-flight admin downgrade and rejects the IM mutation after revocation commits", async () => {
+  it("keeps IM mutations authorized by the Agent creator after Workspace grant revocation", async () => {
     const value = await fixture();
-    const revoker = createDatabaseClient(databaseUrl);
-    const workspaceLocked = deferred<void>();
-    const releaseRevocation = deferred<void>();
     try {
-      const revocation = revoker.database.transaction(async (transaction) => {
-        await transaction
-          .select({ id: workspaces.id })
-          .from(workspaces)
-          .where(eq(workspaces.id, value.bootstrap.workspaceId))
-          .limit(1)
-          .for("update");
-        await transaction
-          .update(workspaceAdminGrants)
-          .set({ revokedByUserId: value.bootstrap.userId, revokedAt: new Date() })
-          .where(
-            and(
-              eq(workspaceAdminGrants.workspaceId, value.bootstrap.workspaceId),
-              eq(workspaceAdminGrants.userId, value.bootstrap.userId),
-              isNull(workspaceAdminGrants.revokedAt),
-            ),
-          );
-        workspaceLocked.resolve();
-        await releaseRevocation.promise;
-      });
-      await workspaceLocked.promise;
-      const mutation = value.imBindingService.disable(value.bootstrap.userId, value.imBindingId);
-      let settled = false;
-      void mutation.then(
-        () => {
-          settled = true;
-        },
-        () => {
-          settled = true;
-        },
-      );
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(settled).toBe(false);
-      releaseRevocation.resolve();
-      await revocation;
-      await expect(mutation).rejects.toMatchObject({ code: "IM_BINDING_NOT_FOUND", statusCode: 404 });
+      await value.database
+        .update(workspaceAdminGrants)
+        .set({ revokedByUserId: value.bootstrap.userId, revokedAt: new Date() })
+        .where(
+          and(
+            eq(workspaceAdminGrants.workspaceId, value.bootstrap.workspaceId),
+            eq(workspaceAdminGrants.userId, value.bootstrap.userId),
+            isNull(workspaceAdminGrants.revokedAt),
+          ),
+        );
+      await expect(value.imBindingService.disable(value.bootstrap.userId, value.imBindingId)).resolves.toBeUndefined();
       expect(
         (await value.database.select().from(imBindings).where(eq(imBindings.id, value.imBindingId)))[0]?.status,
-      ).toBe("active");
+      ).toBe("disabled");
     } finally {
-      releaseRevocation.resolve();
-      await Promise.all([revoker.sql.end(), value.sql.end()]);
+      await value.sql.end();
     }
   });
 
@@ -6881,8 +6864,13 @@ describe("IM binding persistence", () => {
     }
   });
 
-  it("rechecks Admin authority after Slack token inspection before committing configuration", async () => {
+  it("rechecks Agent creator authority after Slack token inspection before committing configuration", async () => {
     const value = await unboundFixture();
+    const [outsider] = await value.database
+      .insert(users)
+      .values({ email: "authority-outsider@example.com", displayName: "Authority Outsider" })
+      .returning();
+    if (!outsider) throw new Error("Authority outsider fixture was not created");
     const service = new SlackConfigurationService({
       api: {
         inspectInstallation: vi.fn().mockResolvedValue({
@@ -6897,15 +6885,7 @@ describe("IM binding persistence", () => {
       database: value.database,
       imBindings: value.imBindingService,
       beforeConfigurationTransaction: async () => {
-        await value.database
-          .update(workspaceAdminGrants)
-          .set({ revokedByUserId: value.bootstrap.userId, revokedAt: new Date() })
-          .where(
-            and(
-              eq(workspaceAdminGrants.workspaceId, value.bootstrap.workspaceId),
-              eq(workspaceAdminGrants.userId, value.bootstrap.userId),
-            ),
-          );
+        await value.database.update(agents).set({ createdByUserId: outsider.id }).where(eq(agents.id, value.agent.id));
       },
     });
     try {

--- a/packages/server/src/__tests__/integration/onboarding-lab-reset.test.ts
+++ b/packages/server/src/__tests__/integration/onboarding-lab-reset.test.ts
@@ -151,6 +151,7 @@ async function seedAccount(
     generation: 1,
   });
   await database.update(workspaces).set({ setupCompletedAt: now }).where(eq(workspaces.id, input.workspaceId));
+  await database.update(users).set({ setupCompletedAt: now }).where(eq(users.id, input.accountId));
   return {
     accountId: input.accountId,
     agentId: agent.id,
@@ -246,6 +247,10 @@ async function facts(database: DatabaseClient, scope: SeededAccount) {
       .from(imBindings)
       .where(eq(imBindings.id, scope.imBindingId)),
   ]);
+  const [accountRow] = await database
+    .select({ setupCompletedAt: users.setupCompletedAt })
+    .from(users)
+    .where(eq(users.id, scope.accountId));
   return {
     activeAgents: activeAgents.length,
     activeBindings: activeBindings.length,
@@ -254,6 +259,7 @@ async function facts(database: DatabaseClient, scope: SeededAccount) {
     activeCredentials: activeCredentials.length,
     usableCodes: usableCodes.length,
     setupCompletedAt: workspaceRow[0]?.setupCompletedAt ?? null,
+    accountSetupCompletedAt: accountRow?.setupCompletedAt ?? null,
     binding: bindingRow[0],
   };
 }
@@ -264,6 +270,7 @@ describe("staging Onboarding Lab reset", () => {
     const before = await facts(value.database, value.lab);
     expect(before).toMatchObject({ activeAgents: 1, activeBindings: 1, openSessions: 1, activeEnrollments: 1 });
     expect(before.setupCompletedAt).not.toBeNull();
+    expect(before.accountSetupCompletedAt).not.toBeNull();
 
     await value.reset.resetOnboarding(value.lab.accountId);
 
@@ -276,6 +283,7 @@ describe("staging Onboarding Lab reset", () => {
       activeCredentials: 0,
       usableCodes: 0,
       setupCompletedAt: null,
+      accountSetupCompletedAt: null,
     });
     expect(after.binding).toMatchObject({
       status: "disabled",
@@ -586,5 +594,34 @@ describe("staging Onboarding Lab reset", () => {
 
     expect(socket.close).toHaveBeenCalledWith(4002, "Machine credential rotated or revoked");
     expect(value.registry.currentInstanceId(value.lab.enrollmentId)).toBeUndefined();
+  });
+
+  it("fails closed when clearing setup would rewrite another Account's Workspace evidence", async () => {
+    const value = await fixture();
+    const [foreign] = await value.database
+      .insert(users)
+      .values({ displayName: "Foreign", email: "foreign@example.com" })
+      .returning({ id: users.id });
+    if (!foreign) throw new Error("Foreign Account fixture was not created");
+    await value.database.insert(agents).values({
+      workspaceId: value.lab.workspaceId,
+      createdByUserId: foreign.id,
+      workspaceComputerId: value.lab.enrollmentId,
+      computerId: value.lab.enrollmentId,
+      name: "foreign-agent",
+      displayName: "Foreign Agent",
+      runtimeProvider: "codex",
+      status: "deleted",
+    });
+
+    await expect(value.reset.resetOnboarding(value.lab.accountId)).rejects.toMatchObject({
+      code: "ONBOARDING_RESET_OWNERSHIP_INCONSISTENT",
+      statusCode: 409,
+    });
+    expect(await facts(value.database, value.lab)).toMatchObject({
+      activeAgents: 1,
+      accountSetupCompletedAt: expect.any(Date),
+      setupCompletedAt: expect.any(Date),
+    });
   });
 });

--- a/packages/server/src/__tests__/integration/setup-completion-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/setup-completion-backfill.test.ts
@@ -1,0 +1,379 @@
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createDatabaseClient } from "../../db/client.js";
+import { migrateDatabase, verifyDatabaseMigrations } from "../../db/migrate.js";
+import { AuthService } from "../../services/auth/index.js";
+import { WorkspaceSetupService } from "../../services/workspaces/index.js";
+
+const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.url));
+
+const ACCOUNT_A = "00000000-0000-4000-8000-0000000000a1";
+const ACCOUNT_B = "00000000-0000-4000-8000-0000000000a2";
+const ACCOUNT_GRANT_ONLY = "00000000-0000-4000-8000-0000000000a3";
+const ACCOUNT_EMPTY = "00000000-0000-4000-8000-0000000000a4";
+const WORKSPACE_EARLY = "00000000-0000-4000-8000-0000000000b1";
+const WORKSPACE_LATE = "00000000-0000-4000-8000-0000000000b2";
+const WORKSPACE_GRANT = "00000000-0000-4000-8000-0000000000b3";
+const ENROLLMENT_A = "00000000-0000-4000-8000-0000000000c1";
+const ENROLLMENT_B = "00000000-0000-4000-8000-0000000000c2";
+const INSTALLATION_A = "00000000-0000-4000-8000-0000000000d1";
+const INSTALLATION_B = "00000000-0000-4000-8000-0000000000d2";
+const AGENT_DELETED = "00000000-0000-4000-8000-0000000000e1";
+const AGENT_ACTIVE = "00000000-0000-4000-8000-0000000000e2";
+const AGENT_LATE = "00000000-0000-4000-8000-0000000000e3";
+
+const EARLY = new Date("2026-08-01T00:00:00.000Z");
+const LATE = new Date("2026-08-20T00:00:00.000Z");
+
+const THROUGH_0028_IDX = 28;
+const THROUGH_0028_COUNT = 29;
+const THROUGH_0030_COUNT = 31;
+
+type Journal = {
+  version: string;
+  dialect: string;
+  entries: Array<{ idx: number; version: string; when: number; tag: string; breakpoints: boolean }>;
+};
+
+let container: StartedPostgreSqlContainer;
+let databaseUrl: string;
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("postgres:17-alpine").start();
+  databaseUrl = container.getConnectionUri();
+}, 120_000);
+
+afterAll(async () => {
+  await container.stop();
+});
+
+beforeEach(async () => {
+  const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+  try {
+    await sql.unsafe("drop schema if exists public cascade");
+    await sql.unsafe("drop schema if exists drizzle cascade");
+    await sql.unsafe("create schema public");
+  } finally {
+    await sql.end();
+  }
+});
+
+async function readJournal(): Promise<Journal> {
+  return JSON.parse(await readFile(join(migrationsFolder, "meta/_journal.json"), "utf8")) as Journal;
+}
+
+async function truncatedMigrations(lastIndex: number): Promise<string> {
+  const journal = await readJournal();
+  const folder = await mkdtemp(join(tmpdir(), `opentag-${lastIndex}-migrations-`));
+  await mkdir(join(folder, "meta"));
+  const entries = journal.entries.filter(({ idx }) => idx <= lastIndex);
+  for (const entry of entries) {
+    await copyFile(join(migrationsFolder, `${entry.tag}.sql`), join(folder, `${entry.tag}.sql`));
+  }
+  await writeFile(join(folder, "meta/_journal.json"), JSON.stringify({ ...journal, entries }, null, 2));
+  return folder;
+}
+
+async function journalCount(sql: postgres.Sql): Promise<number> {
+  const [row] = await sql<{ count: string }[]>`select count(*)::text as count from drizzle.__drizzle_migrations`;
+  return Number(row?.count ?? 0);
+}
+
+async function insertEnrollment(
+  sql: postgres.Sql,
+  input: { enrollmentId: string; installationId: string; workspaceId: string; ownerId: string },
+): Promise<void> {
+  const now = EARLY;
+  await sql`insert into computers (id, created_at) values (${input.installationId}, ${now})`;
+  await sql`
+    insert into workspace_computers (
+      id, workspace_id, computer_id, display_name, platform, arch, client_version,
+      enrolled_by_user_id, enrolled_at, updated_at
+    )
+    values (
+      ${input.enrollmentId}, ${input.workspaceId}, ${input.installationId}, 'box', 'linux', 'x64', '0.0.1',
+      ${input.ownerId}, ${now}, ${now}
+    )
+  `;
+  await sql`
+    insert into account_computers (
+      id, owner_account_id, current_installation_id, display_name, platform, arch, client_version,
+      created_at, updated_at
+    )
+    values (
+      ${input.enrollmentId}, ${input.ownerId}, ${input.installationId}, 'box', 'linux', 'x64', '0.0.1',
+      ${now}, ${now}
+    )
+  `;
+}
+
+async function populateHistoricalEvidence(sql: postgres.Sql): Promise<void> {
+  await sql`
+    insert into users (id, email, display_name)
+    values
+      (${ACCOUNT_A}, 'a@example.com', 'A'),
+      (${ACCOUNT_B}, 'b@example.com', 'B'),
+      (${ACCOUNT_GRANT_ONLY}, 'grant@example.com', 'Grant Only'),
+      (${ACCOUNT_EMPTY}, 'empty@example.com', 'Empty')
+  `;
+  await sql`
+    insert into workspaces (id, name, display_name, setup_completed_at)
+    values
+      (${WORKSPACE_EARLY}, 'early', 'Early', ${EARLY}),
+      (${WORKSPACE_LATE}, 'late', 'Late', ${LATE}),
+      (${WORKSPACE_GRANT}, 'grant-only', 'Grant Only', ${LATE})
+  `;
+  await sql`
+    insert into workspace_admin_grants (workspace_id, user_id, granted_by_user_id, granted_at)
+    values
+      (${WORKSPACE_GRANT}, ${ACCOUNT_GRANT_ONLY}, ${ACCOUNT_GRANT_ONLY}, ${LATE}),
+      (${WORKSPACE_EARLY}, ${ACCOUNT_GRANT_ONLY}, ${ACCOUNT_A}, ${LATE})
+  `;
+  await insertEnrollment(sql, {
+    enrollmentId: ENROLLMENT_A,
+    installationId: INSTALLATION_A,
+    workspaceId: WORKSPACE_EARLY,
+    ownerId: ACCOUNT_A,
+  });
+  await insertEnrollment(sql, {
+    enrollmentId: ENROLLMENT_B,
+    installationId: INSTALLATION_B,
+    workspaceId: WORKSPACE_LATE,
+    ownerId: ACCOUNT_A,
+  });
+  await sql`
+    insert into agents (
+      id, workspace_id, created_by_user_id, workspace_computer_id, computer_id,
+      name, display_name, runtime_provider, status
+    )
+    values
+      (
+        ${AGENT_DELETED}, ${WORKSPACE_EARLY}, ${ACCOUNT_A}, ${ENROLLMENT_A}, ${ENROLLMENT_A},
+        'deleted-assistant', 'Deleted', 'codex', 'deleted'
+      ),
+      (
+        ${AGENT_ACTIVE}, ${WORKSPACE_LATE}, ${ACCOUNT_A}, ${ENROLLMENT_B}, ${ENROLLMENT_B},
+        'active-assistant', 'Active', 'codex', 'active'
+      ),
+      (
+        ${AGENT_LATE}, ${WORKSPACE_LATE}, ${ACCOUNT_B}, ${ENROLLMENT_B}, ${ENROLLMENT_B},
+        'b-assistant', 'B', 'codex', 'active'
+      )
+  `;
+}
+
+async function accountSetup(sql: postgres.Sql): Promise<Record<string, string | null>> {
+  const rows = await sql<{ id: string; setup_completed_at: Date | null }[]>`
+    select id::text, setup_completed_at
+    from users
+    order by id
+  `;
+  return Object.fromEntries(rows.map((row) => [row.id, row.setup_completed_at?.toISOString() ?? null]));
+}
+
+function errorChain(error: unknown): string {
+  const messages: string[] = [];
+  const visited = new Set<unknown>();
+  let current = error;
+  while (typeof current === "object" && current !== null && !visited.has(current)) {
+    visited.add(current);
+    if ("message" in current && typeof current.message === "string") messages.push(current.message);
+    current = "cause" in current ? current.cause : undefined;
+  }
+  return messages.join("\n");
+}
+
+describe("Account setup completion backfill", () => {
+  it("journals 0029 and 0030 after 0028 and migrates an empty database", async () => {
+    const journal = await readJournal();
+    expect(journal.entries).toHaveLength(THROUGH_0030_COUNT);
+    expect(journal.entries.at(-3)?.tag).toBe("0028_overjoyed_speedball");
+    expect(journal.entries.at(-2)?.tag).toBe("0029_tiresome_bedlam");
+    expect(journal.entries.at(-1)?.tag).toBe("0030_low_ulik");
+
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+    try {
+      expect(await journalCount(sql)).toBe(THROUGH_0030_COUNT);
+      const [column] = await sql<{ data_type: string; is_nullable: string }[]>`
+        select data_type, is_nullable
+        from information_schema.columns
+        where table_schema = 'public' and table_name = 'users' and column_name = 'setup_completed_at'
+      `;
+      expect(column).toEqual({ data_type: "timestamp with time zone", is_nullable: "YES" });
+      await verifyDatabaseMigrations(databaseUrl, migrationsFolder);
+    } finally {
+      await sql.end();
+    }
+  });
+
+  it("backfills from the earliest creator-Agent Workspace timestamp and ignores grants", async () => {
+    const through0028 = await truncatedMigrations(THROUGH_0028_IDX);
+    try {
+      await migrateDatabase(databaseUrl, through0028);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        expect(await journalCount(sql)).toBe(THROUGH_0028_COUNT);
+        await populateHistoricalEvidence(sql);
+        const [missing] = await sql<{ present: number }[]>`
+          select count(*)::int as present
+          from information_schema.columns
+          where table_schema = 'public' and table_name = 'users' and column_name = 'setup_completed_at'
+        `;
+        expect(missing?.present).toBe(0);
+      } finally {
+        await sql.end();
+      }
+
+      await migrateDatabase(databaseUrl, migrationsFolder);
+      const after = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        expect(await journalCount(after)).toBe(THROUGH_0030_COUNT);
+        expect(await accountSetup(after)).toEqual({
+          [ACCOUNT_A]: EARLY.toISOString(),
+          [ACCOUNT_B]: LATE.toISOString(),
+          [ACCOUNT_GRANT_ONLY]: null,
+          [ACCOUNT_EMPTY]: null,
+        });
+        await verifyDatabaseMigrations(databaseUrl, migrationsFolder);
+      } finally {
+        await after.end();
+      }
+    } finally {
+      await rm(through0028, { recursive: true, force: true });
+    }
+  });
+
+  it("is retry-safe and leaves already-populated Account rows unchanged", async () => {
+    const through0028 = await truncatedMigrations(THROUGH_0028_IDX);
+    try {
+      await migrateDatabase(databaseUrl, through0028);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateHistoricalEvidence(sql);
+      } finally {
+        await sql.end();
+      }
+      await migrateDatabase(databaseUrl, migrationsFolder);
+      await migrateDatabase(databaseUrl, migrationsFolder);
+      const after = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        expect(await journalCount(after)).toBe(THROUGH_0030_COUNT);
+        expect(await accountSetup(after)).toEqual({
+          [ACCOUNT_A]: EARLY.toISOString(),
+          [ACCOUNT_B]: LATE.toISOString(),
+          [ACCOUNT_GRANT_ONLY]: null,
+          [ACCOUNT_EMPTY]: null,
+        });
+      } finally {
+        await after.end();
+      }
+    } finally {
+      await rm(through0028, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls a failed 0029 back completely and succeeds on retry after the obstruction is removed", async () => {
+    const through0028 = await truncatedMigrations(THROUGH_0028_IDX);
+    try {
+      await migrateDatabase(databaseUrl, through0028);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateHistoricalEvidence(sql);
+        await sql.unsafe(`
+          create function reject_setup_backfill() returns trigger language plpgsql as $$
+          begin
+            raise exception 'fixture rejects setup backfill';
+          end
+          $$
+        `);
+        await sql.unsafe(`
+          create trigger reject_setup_backfill before update on users
+          for each row execute function reject_setup_backfill()
+        `);
+      } finally {
+        await sql.end();
+      }
+
+      const failure = await migrateDatabase(databaseUrl, migrationsFolder).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect(errorChain(failure)).toContain("fixture rejects setup backfill");
+      const failed = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        expect(await journalCount(failed)).toBe(THROUGH_0028_COUNT);
+        const [column] = await failed<{ present: number }[]>`
+          select count(*)::int as present
+          from information_schema.columns
+          where table_schema = 'public' and table_name = 'users' and column_name = 'setup_completed_at'
+        `;
+        expect(column?.present).toBe(0);
+        await failed.unsafe("drop trigger reject_setup_backfill on users");
+        await failed.unsafe("drop function reject_setup_backfill()");
+      } finally {
+        await failed.end();
+      }
+
+      await migrateDatabase(databaseUrl, migrationsFolder);
+      const retried = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        expect(await journalCount(retried)).toBe(THROUGH_0030_COUNT);
+        expect(await accountSetup(retried)).toMatchObject({
+          [ACCOUNT_A]: EARLY.toISOString(),
+          [ACCOUNT_B]: LATE.toISOString(),
+        });
+        await verifyDatabaseMigrations(databaseUrl, migrationsFolder);
+      } finally {
+        await retried.end();
+      }
+    } finally {
+      await rm(through0028, { recursive: true, force: true });
+    }
+  });
+
+  it("reads and writes Account setup through the application after the production runner", async () => {
+    await migrateDatabase(databaseUrl, migrationsFolder);
+    const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+    try {
+      await populateHistoricalEvidence(sql);
+      await sql`
+        update users set setup_completed_at = ${EARLY} where id = ${ACCOUNT_A}
+      `;
+    } finally {
+      await sql.end();
+    }
+
+    const client = createDatabaseClient(databaseUrl);
+    try {
+      const auth = new AuthService(client.database, {
+        issuePairForUser: async () => ({ accessToken: "a", refreshToken: "r", expiresIn: 1 }),
+        rotate: async () => ({ accessToken: "a", refreshToken: "r", expiresIn: 1 }),
+        verifyAccess: async () => ({ userId: ACCOUNT_A, expiresAt: new Date() }),
+        verifyRefresh: async () => ({ userId: ACCOUNT_A }),
+      } as never);
+      await expect(auth.getActiveUserById(ACCOUNT_A)).resolves.toMatchObject({
+        setupCompletedAt: EARLY.toISOString(),
+      });
+      await expect(auth.getActiveUserById(ACCOUNT_GRANT_ONLY)).resolves.toMatchObject({ setupCompletedAt: null });
+      await expect(auth.getActiveUserById(ACCOUNT_EMPTY)).resolves.toMatchObject({ setupCompletedAt: null });
+
+      const setup = new WorkspaceSetupService(client.database, {
+        getHandoffForAgent: async () => ({ bindingState: "active", handoffReady: true }),
+      } as never);
+      await expect(setup.completeForAccount(ACCOUNT_B, AGENT_LATE)).resolves.toEqual({
+        setupCompletedAt: LATE.toISOString(),
+      });
+      await expect(auth.getActiveUserById(ACCOUNT_B)).resolves.toMatchObject({
+        setupCompletedAt: LATE.toISOString(),
+      });
+    } finally {
+      await client.sql.end();
+    }
+  });
+});

--- a/packages/server/src/__tests__/integration/slack-workspace-routing.test.ts
+++ b/packages/server/src/__tests__/integration/slack-workspace-routing.test.ts
@@ -113,6 +113,47 @@ async function activate(
 }
 
 describe("Slack workspace installation routing", () => {
+  it("allows different Agents in one legacy Workspace to own different current Slack installations", async () => {
+    const value = await fixture();
+    try {
+      const first = await activate(value.imBindingsService, value.first.id, "create");
+      const second = await activate(value.imBindingsService, value.second.id, "create", {
+        appId: "A_SECOND",
+        teamId: "T_SECOND",
+        botUserId: "U_SECOND",
+        botId: "B_SECOND",
+        token: "xoxb-second",
+      });
+
+      expect(await value.database.select().from(slackInstallations)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            agentId: value.first.id,
+            externalAppId: "A_OPENTAG",
+            externalTeamId: "T_TEAM",
+            status: "active",
+            workspaceId: value.bootstrap.workspaceId,
+          }),
+          expect.objectContaining({
+            agentId: value.second.id,
+            externalAppId: "A_SECOND",
+            externalTeamId: "T_SECOND",
+            status: "active",
+            workspaceId: value.bootstrap.workspaceId,
+          }),
+        ]),
+      );
+      expect(await value.database.select().from(imBindings)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: first.imBindingId, agentId: value.first.id, status: "active" }),
+          expect.objectContaining({ id: second.imBindingId, agentId: value.second.id, status: "active" }),
+        ]),
+      );
+    } finally {
+      await value.sql.end();
+    }
+  });
+
   it("rejects cross-Agent create on a current installation without side effects", async () => {
     const value = await fixture();
     try {
@@ -178,7 +219,7 @@ describe("Slack workspace installation routing", () => {
     }
   });
 
-  it("fails closed for unconfigured, cross-workspace, and deleted default Agents", async () => {
+  it("fails closed for unconfigured, cross-Agent, and deleted default Agents", async () => {
     const value = await fixture();
     try {
       await expect(
@@ -501,7 +542,7 @@ describe("Slack workspace installation routing", () => {
     }
   });
 
-  it("projects outbound Bot tokens from the workspace installation without the signing secret", async () => {
+  it("projects outbound Bot tokens from the Agent installation without the signing secret", async () => {
     const value = await fixture();
     try {
       const created = await activate(value.imBindingsService, value.first.id, "create");

--- a/packages/server/src/__tests__/onboarding-lab-routes.test.ts
+++ b/packages/server/src/__tests__/onboarding-lab-routes.test.ts
@@ -25,7 +25,7 @@ function fixture(options: { environment?: "dev" | "staging" | "prod"; registered
   const betterAuth = signedInBrowser(accountId, { publicUrl: PUBLIC_ORIGIN });
   const app = createApp({
     authService: {
-      getActiveUserById: vi.fn().mockResolvedValue({ user: { id: accountId }, workspaces: [] }),
+      getActiveUserById: vi.fn().mockResolvedValue({ user: { id: accountId }, setupCompletedAt: null }),
     } as never,
     betterAuth,
     browserAuth: { publicOrigin: PUBLIC_ORIGIN, secureCookies: true, sessionTtlSeconds: 3600 } as never,

--- a/packages/server/src/__tests__/request-logging.test.ts
+++ b/packages/server/src/__tests__/request-logging.test.ts
@@ -27,7 +27,7 @@ describe("request logging", () => {
     const app = createApp({
       authService: {
         getAuthenticatedUser: vi.fn().mockResolvedValue({
-          me: { user: { id: crypto.randomUUID() }, workspaces: [] },
+          me: { user: { id: crypto.randomUUID() }, setupCompletedAt: null },
           tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
         }),
       } as never,

--- a/packages/server/src/__tests__/runtime.test.ts
+++ b/packages/server/src/__tests__/runtime.test.ts
@@ -26,15 +26,7 @@ afterEach(async () => Promise.all(apps.splice(0).map((app) => app.close())));
 const workspaceId = randomUUID();
 const me = {
   user: { id: randomUUID(), email: "admin@example.com", displayName: "Admin" },
-  workspaces: [
-    {
-      id: workspaceId,
-      name: "example",
-      displayName: "Example",
-      setupCompletedAt: null,
-      grantedAt: "2030-01-01T00:00:00.000Z",
-    },
-  ],
+  setupCompletedAt: null,
 };
 
 const machineContext = {

--- a/packages/server/src/__tests__/slack-oauth.test.ts
+++ b/packages/server/src/__tests__/slack-oauth.test.ts
@@ -22,14 +22,14 @@ function authService(): UserAuthService {
     refresh: vi.fn(),
     getActiveUserById: vi.fn().mockResolvedValue({
       user: { id: userId, email: "admin@example.com", displayName: "Admin" },
-      workspaces: [],
+      setupCompletedAt: null,
     }),
     updateSelfProfile: vi.fn(),
     getAuthenticatedUser: vi.fn().mockResolvedValue({
       tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
       me: {
         user: { id: userId, email: "admin@example.com", displayName: "Admin" },
-        workspaces: [],
+        setupCompletedAt: null,
       },
     }),
   };

--- a/packages/server/src/__tests__/topology-freeze-routes.test.ts
+++ b/packages/server/src/__tests__/topology-freeze-routes.test.ts
@@ -23,7 +23,7 @@ function fixture() {
   const app = createApp({
     authService: {
       getAuthenticatedUser: vi.fn().mockResolvedValue({
-        me: { user: { id: accountId }, workspaces: [] },
+        me: { user: { id: accountId }, setupCompletedAt: null },
         tokenExpiresAt: new Date("2030-01-01T00:00:00.000Z"),
       }),
     } as never,

--- a/packages/server/src/api/account.ts
+++ b/packages/server/src/api/account.ts
@@ -41,16 +41,15 @@ const TaskDetailQuerySchema = z
 const TaskParamsSchema = z.object({ sessionId: z.string().uuid() }).strict();
 
 /**
- * Resolves the authenticated Account to the compatibility Workspace that still backs management storage.
- * `WorkspaceAdminAccess` is the only implementation; the seam exists so that removing it is a single
- * deletion once Agents and enrollments carry a direct Account owner.
+ * Resolves the authenticated Account to the compatibility Workspace that still backs hidden dual-write
+ * persistence. Canonical Account resource authority uses `created_by_user_id` and `owner_account_id`.
  */
 export interface AccountScopeResolver {
   resolveCompatibilityWorkspaceId(accountId: string): Promise<string>;
 }
 
 export interface AccountRoutesOptions {
-  accountScope: AccountScopeResolver;
+  accountScope?: AccountScopeResolver;
   agentService?: AgentService;
   computerConnectCode?: { environment: ChannelName; publicUrl: string };
   machineAuthService?: MachineAuthService;
@@ -78,11 +77,6 @@ export function registerAccountRoutes(
 ): void {
   const preHandler = createUserAuthPreHandler(authService, options.authOptions ?? {});
   const { accountScope } = options;
-
-  async function scopeOf(request: FastifyRequest): Promise<{ accountId: string; workspaceId: string }> {
-    const account = accountId(request);
-    return { accountId: account, workspaceId: await accountScope.resolveCompatibilityWorkspaceId(account) };
-  }
 
   if (options.agentService) {
     const agentService = options.agentService;
@@ -144,7 +138,7 @@ export function registerAccountRoutes(
           : await machineAuthService.issueForAccount(
               account,
               input,
-              await accountScope.resolveCompatibilityWorkspaceId(account),
+              await accountScope?.resolveCompatibilityWorkspaceId(account),
             );
       return reply
         .header("Cache-Control", "no-store")
@@ -165,12 +159,11 @@ export function registerAccountRoutes(
 
     app.post(HTTP_PATHS.accountSetupComplete, { preHandler }, async (request, reply) => {
       const { agentId } = parseRequest(CompleteWorkspaceSetupRequestSchema, request.body);
-      const scope = await scopeOf(request);
       return reply
         .code(200)
         .send(
           WorkspaceSetupCompletionSchema.parse(
-            await workspaceSetupService.complete(scope.accountId, scope.workspaceId, agentId),
+            await workspaceSetupService.completeForAccount(accountId(request), agentId),
           ),
         );
     });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -235,9 +235,16 @@ export function createApp(options: CreateAppOptions = {}) {
     if (options.workspaceService) {
       registerWorkspaceRoutes(app, authService, options.workspaceService, authOptions, options.workspaceSetupService);
     }
-    if (options.accountScope) {
+    if (
+      options.accountScope ||
+      options.agentService ||
+      options.taskService ||
+      options.workspaceService ||
+      options.workspaceSetupService ||
+      (options.machineAuthService && options.computerConnectCode)
+    ) {
       registerAccountRoutes(app, authService, {
-        accountScope: options.accountScope,
+        ...(options.accountScope ? { accountScope: options.accountScope } : {}),
         ...(options.agentService ? { agentService: options.agentService } : {}),
         ...(options.computerConnectCode ? { computerConnectCode: options.computerConnectCode } : {}),
         ...(options.machineAuthService ? { machineAuthService: options.machineAuthService } : {}),

--- a/packages/server/src/db/schema/auth.ts
+++ b/packages/server/src/db/schema/auth.ts
@@ -26,6 +26,7 @@ export const users = pgTable(
     displayName: text("display_name").notNull(),
     image: text("image"),
     suspendedAt: timestamp("suspended_at", { withTimezone: true }),
+    setupCompletedAt: timestamp("setup_completed_at", { withTimezone: true }),
     ...timestamps,
   },
   (table) => [uniqueIndex("users_email_unique").on(sql`lower(${table.email})`)],

--- a/packages/server/src/db/schema/slack-installations.ts
+++ b/packages/server/src/db/schema/slack-installations.ts
@@ -65,9 +65,6 @@ export const slackInstallations = pgTable(
     uniqueIndex("slack_installations_app_team_current_unique")
       .on(table.externalAppId, table.externalTeamId)
       .where(sql`${table.status} <> 'disabled'`),
-    uniqueIndex("slack_installations_workspace_current_unique")
-      .on(table.workspaceId)
-      .where(sql`${table.status} <> 'disabled'`),
     index("slack_installations_workspace_id_idx").on(table.workspaceId),
     index("slack_installations_agent_id_idx").on(table.agentId),
     index("slack_installations_app_team_idx").on(table.externalAppId, table.externalTeamId),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -183,7 +183,6 @@ export async function startServer(): Promise<void> {
           observations.find(({ observation }) => observation.provider === provider)?.observation.status ?? "checking"
         );
       },
-      workspaceAdmins,
     });
     const workspaceSetupService = new WorkspaceSetupService(database, imBindingService, { workspaceAdmins });
     const imMessageInbox = new ImMessageInbox(database);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -135,9 +135,7 @@ export async function startServer(): Promise<void> {
       ...(config.emailPasswordAuth ? { emailPassword: true } : {}),
       ...(config.google ? { google: config.google } : {}),
     });
-    const authService = new AuthService(database, new BetterAuthSessionTokens(betterAuth, database), {
-      workspaceAdmins,
-    });
+    const authService = new AuthService(database, new BetterAuthSessionTokens(betterAuth, database));
     const connectCodeService = new ConnectCodeService(database);
     const registry = new ConnectionRegistry();
     const machineAuthService = new MachineAuthService(database, {
@@ -184,7 +182,7 @@ export async function startServer(): Promise<void> {
         );
       },
     });
-    const workspaceSetupService = new WorkspaceSetupService(database, imBindingService, { workspaceAdmins });
+    const workspaceSetupService = new WorkspaceSetupService(database, imBindingService);
     const imMessageInbox = new ImMessageInbox(database);
     const sessionService = new SessionService(database);
     const taskService = new TaskService(database);

--- a/packages/server/src/observability/__tests__/observability.test.ts
+++ b/packages/server/src/observability/__tests__/observability.test.ts
@@ -998,7 +998,7 @@ function runtimeAuthService() {
     getAuthenticatedUser: vi.fn().mockResolvedValue({
       me: {
         user: { id: randomUUID(), email: "admin@example.com", displayName: "Admin" },
-        workspaces: [],
+        setupCompletedAt: null,
       },
       tokenExpiresAt: new Date(Date.now() + 60_000),
     }),

--- a/packages/server/src/services/auth/auth-service.ts
+++ b/packages/server/src/services/auth/auth-service.ts
@@ -9,7 +9,6 @@ import {
 import { and, eq, isNull } from "drizzle-orm";
 import type { DatabaseClient } from "../../db/client.js";
 import { accountCliLoginCodes, users } from "../../db/schema/index.js";
-import { WorkspaceAdminAccess } from "../workspace-admin-access/index.js";
 import { AuthServiceError, invalidCredential } from "./errors.js";
 import { hashSecret } from "./security.js";
 import type { AuthTokenProvider } from "./token-provider.js";
@@ -43,17 +42,11 @@ export class AuthService implements ResolvedUserTokenIssuer, UserAuthService {
   readonly #authTokens: AuthTokenProvider;
   readonly #database: DatabaseClient;
   readonly #now: () => Date;
-  readonly #workspaceAdmins: WorkspaceAdminAccess;
 
-  constructor(
-    database: DatabaseClient,
-    authTokens: AuthTokenProvider,
-    options: AuthServiceOptions & { workspaceAdmins?: WorkspaceAdminAccess } = {},
-  ) {
+  constructor(database: DatabaseClient, authTokens: AuthTokenProvider, options: AuthServiceOptions = {}) {
     this.#database = database;
     this.#authTokens = authTokens;
     this.#now = options.now ?? (() => new Date());
-    this.#workspaceAdmins = options.workspaceAdmins ?? new WorkspaceAdminAccess(database, { now: options.now });
   }
 
   /**
@@ -161,21 +154,9 @@ export class AuthService implements ResolvedUserTokenIssuer, UserAuthService {
       throw new AuthServiceError("AUTH_USER_SUSPENDED", "deterministic", "The user account is suspended", 403);
     }
 
-    /**
-     * Authentication proves the Account identity, not ownership of every stored resource. A legacy or revoked
-     * Account may have no active Workspace grant, and resource-scoped authority is always checked separately.
-     */
-    const activeWorkspaces = await this.#workspaceAdmins.listActiveAdminWorkspaces(userId);
-
     return {
       user: { id: user.id, email: user.email, displayName: user.displayName },
-      workspaces: activeWorkspaces.map((workspace) => ({
-        id: workspace.workspaceId,
-        name: workspace.workspaceName,
-        displayName: workspace.workspaceDisplayName,
-        setupCompletedAt: workspace.setupCompletedAt?.toISOString() ?? null,
-        grantedAt: workspace.grantedAt.toISOString(),
-      })),
+      setupCompletedAt: user.setupCompletedAt?.toISOString() ?? null,
     };
   }
 }

--- a/packages/server/src/services/im-bindings/im-binding-service.ts
+++ b/packages/server/src/services/im-bindings/im-binding-service.ts
@@ -31,9 +31,7 @@ import {
   slackInstallations,
   workspaceComputers,
 } from "../../db/schema/index.js";
-import { AuthServiceError } from "../auth/index.js";
 import type { ApplicationCipher } from "../crypto.js";
-import { WorkspaceAdminAccess } from "../workspace-admin-access/index.js";
 
 type QueryExecutor = Pick<DatabaseClient, "select">;
 
@@ -67,6 +65,7 @@ export interface VerifiedFeishuBinding {
 export interface SlackInstallationIngress {
   installationId: string;
   generation: number;
+  agentId: string;
   workspaceId: string;
   appId: string;
   teamId: string;
@@ -307,7 +306,6 @@ export class ImBindingService {
   readonly #now: () => Date;
   readonly #agentRuntimeReadiness: (agentId: string) => Promise<ProviderReadinessStatus>;
   readonly #imCliReadiness: (agentId: string, provider: "feishu" | "slack") => Promise<ImCliReadinessStatus>;
-  readonly #workspaceAdmins: WorkspaceAdminAccess;
 
   constructor(
     database: DatabaseClient,
@@ -320,7 +318,6 @@ export class ImBindingService {
         agentId: string,
         provider: "feishu" | "slack",
       ) => Promise<ImCliReadinessStatus> | ImCliReadinessStatus;
-      workspaceAdmins?: WorkspaceAdminAccess;
     } = {},
   ) {
     this.#database = database;
@@ -329,7 +326,6 @@ export class ImBindingService {
     this.#now = options.now ?? (() => new Date());
     this.#agentRuntimeReadiness = async (agentId) => (await options.agentRuntimeReadiness?.(agentId)) ?? "ready";
     this.#imCliReadiness = async (agentId, provider) => (await options.imCliReadiness?.(agentId, provider)) ?? "ready";
-    this.#workspaceAdmins = options.workspaceAdmins ?? new WorkspaceAdminAccess(database, { now: options.now });
   }
 
   async getAgentWorkspaceComputerId(agentId: string): Promise<string | undefined> {
@@ -455,7 +451,7 @@ export class ImBindingService {
     if (!installation) return rejected("binding_inactive");
     if (
       installation.status !== "active" ||
-      installation.workspaceId !== row.workspaceId ||
+      installation.agentId !== row.boundAgentId ||
       !installation.observedConnectedAt
     ) {
       return rejected("binding_inactive");
@@ -512,14 +508,7 @@ export class ImBindingService {
         throw new ImBindingServiceError(
           "SLACK_APP_TEAM_ALREADY_BOUND",
           409,
-          "This Slack App installation is already bound to another OpenTag workspace",
-        );
-      }
-      if (isImBindingUniqueViolation(error, "slack_installations_workspace_current_unique")) {
-        throw new ImBindingServiceError(
-          "SLACK_CONFIGURATION_CONFLICT",
-          409,
-          "This OpenTag workspace already has a Slack installation",
+          "This Slack App installation is already bound to another OpenTag Agent",
         );
       }
       throw error;
@@ -589,7 +578,7 @@ export class ImBindingService {
           eq(imBindings.provider, "slack"),
           eq(imBindings.status, "active"),
           eq(slackInstallations.status, "active"),
-          eq(slackInstallations.workspaceId, agents.workspaceId),
+          eq(slackInstallations.agentId, agentId),
           ne(agents.status, "deleted"),
         ),
       )
@@ -623,7 +612,7 @@ export class ImBindingService {
 
   async getSlackConnectionMaterial(imBindingId: string): Promise<SlackConnectionMaterial | undefined> {
     const [row] = await this.#database
-      .select({ imBinding: imBindings, installation: slackInstallations, workspaceId: agents.workspaceId })
+      .select({ imBinding: imBindings, installation: slackInstallations })
       .from(imBindings)
       .innerJoin(agents, eq(agents.id, imBindings.agentId))
       .innerJoin(slackInstallations, eq(slackInstallations.id, imBindings.slackInstallationId))
@@ -633,11 +622,12 @@ export class ImBindingService {
           eq(imBindings.provider, "slack"),
           eq(imBindings.status, "active"),
           eq(slackInstallations.status, "active"),
+          eq(slackInstallations.agentId, imBindings.agentId),
           ne(agents.status, "deleted"),
         ),
       )
       .limit(1);
-    if (!row || row.installation.workspaceId !== row.workspaceId || !row.installation.observedConnectedAt) {
+    if (!row?.installation.observedConnectedAt) {
       return undefined;
     }
     const ingress = this.#slackInstallationIngressFromRow(row.installation);
@@ -1113,14 +1103,12 @@ export class ImBindingService {
     agentId: string,
     executor: QueryExecutor = this.#database,
   ): Promise<void> {
-    try {
-      await this.#workspaceAdmins.requireAdminForAgent(callerUserId, agentId, executor);
-    } catch (error) {
-      if (error instanceof AuthServiceError && error.statusCode === 404) {
-        throw new ImBindingServiceError("IM_BINDING_NOT_FOUND", 404, "The Agent was not found");
-      }
-      throw error;
-    }
+    const [agent] = await executor
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.id, agentId), eq(agents.createdByUserId, callerUserId), ne(agents.status, "deleted")))
+      .limit(1);
+    if (!agent) throw new ImBindingServiceError("IM_BINDING_NOT_FOUND", 404, "The Agent was not found");
   }
 
   async assertCanManageForMutation(
@@ -1128,18 +1116,10 @@ export class ImBindingService {
     agentId: string,
     transaction: DatabaseTransaction,
   ): Promise<void> {
-    try {
-      await this.#workspaceAdmins.requireAdminForAgentMutation(transaction, callerUserId, agentId);
-    } catch (error) {
-      if (error instanceof AuthServiceError && error.statusCode === 404) {
-        throw new ImBindingServiceError("IM_BINDING_NOT_FOUND", 404, "The Agent was not found");
-      }
-      throw error;
-    }
     const [agent] = await transaction
       .select({ id: agents.id })
       .from(agents)
-      .where(and(eq(agents.id, agentId), ne(agents.status, "deleted")))
+      .where(and(eq(agents.id, agentId), eq(agents.createdByUserId, callerUserId), ne(agents.status, "deleted")))
       .limit(1)
       .for("update");
     if (!agent) throw new ImBindingServiceError("IM_BINDING_NOT_FOUND", 404, "The Agent was not found");
@@ -1334,6 +1314,7 @@ export class ImBindingService {
     return {
       installationId: installation.id,
       generation: installation.credentialGeneration,
+      agentId: installation.agentId,
       workspaceId: installation.workspaceId,
       appId: installation.externalAppId,
       teamId: installation.externalTeamId,
@@ -1348,7 +1329,6 @@ export class ImBindingService {
     const rows = await this.#database
       .select({
         imBinding: imBindings,
-        agentWorkspaceId: agents.workspaceId,
         agentStatus: agents.status,
         installation: slackInstallations,
       })
@@ -1363,13 +1343,14 @@ export class ImBindingService {
           eq(imBindings.slackRouteKind, "default"),
           eq(slackInstallations.id, installationId),
           eq(slackInstallations.status, "active"),
+          eq(slackInstallations.agentId, imBindings.agentId),
           ...(agentId ? [eq(imBindings.agentId, agentId)] : []),
         ),
       )
       .limit(2);
     if (rows.length !== 1) return undefined;
     const row = rows[0];
-    if (!row || row.agentStatus === "deleted" || row.agentWorkspaceId !== row.installation.workspaceId) {
+    if (!row || row.agentStatus === "deleted") {
       return undefined;
     }
     if (row.imBinding.slackRouteKind !== "default") return undefined;
@@ -1446,17 +1427,17 @@ export class ImBindingService {
         )
         .limit(1)
         .for("update");
-      if (appTeamInstallation && appTeamInstallation.workspaceId !== agent.workspaceId) {
+      if (appTeamInstallation && appTeamInstallation.agentId !== input.agentId) {
         throw new ImBindingServiceError(
           "SLACK_APP_TEAM_ALREADY_BOUND",
           409,
-          "This Slack App installation is already bound to another OpenTag workspace",
+          "This Slack App installation is already bound to another OpenTag Agent",
         );
       }
-      const [workspaceInstallation] = await transaction
+      const [sameAgentInstallation] = await transaction
         .select()
         .from(slackInstallations)
-        .where(and(eq(slackInstallations.workspaceId, agent.workspaceId), ne(slackInstallations.status, "disabled")))
+        .where(and(eq(slackInstallations.agentId, input.agentId), ne(slackInstallations.status, "disabled")))
         .limit(1)
         .for("update");
       const configuredRoute = currentRoute?.status === "provisioning" ? undefined : currentRoute;
@@ -1475,57 +1456,50 @@ export class ImBindingService {
         );
       }
       const now = this.#now();
-      let currentWorkspaceInstallation = workspaceInstallation;
       let currentAppTeamInstallation = appTeamInstallation;
-      let releasedWorkspaceInstallationId: string | undefined;
-      if (currentWorkspaceInstallation) {
+      let currentSameAgentInstallation = sameAgentInstallation;
+      let releasedInstallationId: string | undefined;
+      if (currentSameAgentInstallation) {
         const [installationRoute] = await transaction
           .select({ id: imBindings.id })
           .from(imBindings)
           .where(
             and(
-              eq(imBindings.slackInstallationId, currentWorkspaceInstallation.id),
+              eq(imBindings.slackInstallationId, currentSameAgentInstallation.id),
               eq(imBindings.provider, "slack"),
               ne(imBindings.status, "disabled"),
             ),
           )
           .limit(1);
         if (!installationRoute) {
-          await this.#disableSlackInstallation(transaction, currentWorkspaceInstallation.id, now);
-          releasedWorkspaceInstallationId = currentWorkspaceInstallation.id;
-          if (currentAppTeamInstallation?.id === currentWorkspaceInstallation.id) {
+          await this.#disableSlackInstallation(transaction, currentSameAgentInstallation.id, now);
+          releasedInstallationId = currentSameAgentInstallation.id;
+          if (currentAppTeamInstallation?.id === currentSameAgentInstallation.id) {
             currentAppTeamInstallation = undefined;
           }
-          currentWorkspaceInstallation = undefined;
+          currentSameAgentInstallation = undefined;
         }
       }
       if (
-        currentWorkspaceInstallation &&
+        currentSameAgentInstallation &&
         currentAppTeamInstallation &&
-        currentWorkspaceInstallation.id !== currentAppTeamInstallation.id
+        currentSameAgentInstallation.id !== currentAppTeamInstallation.id
       ) {
         throw new ImBindingServiceError(
           "SLACK_CONFIGURATION_CONFLICT",
           409,
-          "This OpenTag workspace already has a different Slack installation",
+          "This Agent already has a different Slack installation",
         );
       }
-      if (input.intent === "create" && currentWorkspaceInstallation && !currentAppTeamInstallation) {
+      if (input.intent === "create" && currentSameAgentInstallation && !currentAppTeamInstallation) {
         throw new ImBindingServiceError(
           "SLACK_CONFIGURATION_CONFLICT",
           409,
-          "This OpenTag workspace already has a Slack installation",
+          "This Agent already has a Slack installation",
         );
       }
-      const existingInstallation = currentAppTeamInstallation ?? currentWorkspaceInstallation;
+      const existingInstallation = currentAppTeamInstallation ?? currentSameAgentInstallation;
       if (existingInstallation) {
-        if (existingInstallation.agentId !== input.agentId) {
-          throw new ImBindingServiceError(
-            "SLACK_APP_TEAM_ALREADY_BOUND",
-            409,
-            "This Slack App installation is already bound to another OpenTag Agent",
-          );
-        }
         const currentCredential = this.#decodeSlackCredential(existingInstallation.encryptedCredential);
         const sameIdentity =
           existingInstallation.externalAppId === input.appId &&
@@ -1537,7 +1511,7 @@ export class ImBindingService {
             throw new ImBindingServiceError(
               "SLACK_CONFIGURATION_CONFLICT",
               409,
-              "The configured Slack route does not belong to the current workspace installation",
+              "The configured Slack route does not belong to the current Agent installation",
             );
           }
           await this.#disableSlackInstallation(transaction, existingInstallation.id, now);
@@ -1570,7 +1544,6 @@ export class ImBindingService {
           .update(slackInstallations)
           .set({
             status: "active",
-            agentId: input.agentId,
             externalAppId: input.appId,
             externalTeamId: input.teamId,
             externalEnterpriseId: input.enterpriseId ?? null,
@@ -1586,7 +1559,7 @@ export class ImBindingService {
             lastErrorCode: null,
             updatedAt: now,
           })
-          .where(eq(slackInstallations.id, existingInstallation.id))
+          .where(and(eq(slackInstallations.id, existingInstallation.id), eq(slackInstallations.agentId, input.agentId)))
           .returning();
         if (!updatedInstallation) throw new Error("Slack installation update did not return a row");
         await this.#syncSlackRoutesFromInstallation(transaction, updatedInstallation, now);
@@ -1622,11 +1595,11 @@ export class ImBindingService {
         },
         now,
       );
-      if (releasedWorkspaceInstallationId) {
+      if (releasedInstallationId) {
         await transaction
           .update(slackInstallations)
           .set({ replacementSlackInstallationId: created.installationId, updatedAt: now })
-          .where(eq(slackInstallations.id, releasedWorkspaceInstallationId));
+          .where(eq(slackInstallations.id, releasedInstallationId));
       }
       return created;
     };

--- a/packages/server/src/services/onboarding-lab/onboarding-reset-service.ts
+++ b/packages/server/src/services/onboarding-lab/onboarding-reset-service.ts
@@ -7,6 +7,7 @@ import {
   computerConnectCodes,
   computerCredentials,
   imBindings,
+  users,
   workspaceAdminGrants,
   workspaceComputerCredentials,
   workspaceComputers,
@@ -108,6 +109,7 @@ export class OnboardingResetService {
     // Re-confirm the environment before any mutation rather than trusting route registration.
     if (!this.enabled) throw resourceNotFound();
     const scope = await this.#resolveOwnedScope(accountId);
+    await this.#assertWorkspaceNotShared(accountId, scope.workspaceId);
 
     await this.#deleteOwnedAgents(accountId, scope);
     const enrollmentIds = await this.#revokeComputerAccess(accountId, scope);
@@ -248,13 +250,35 @@ export class OnboardingResetService {
     const now = this.#now();
     await this.#database.transaction(async (transaction) => {
       await this.#workspaceAdmins.requireAdminForMutation(transaction, accountId, scope.workspaceId);
+      await this.#assertWorkspaceNotShared(accountId, scope.workspaceId, transaction);
       await this.#verifyCleanedUp(transaction, scope, now);
       await this.#afterVerified?.();
+      await transaction.update(users).set({ setupCompletedAt: null, updatedAt: now }).where(eq(users.id, accountId));
       await transaction
         .update(workspaces)
         .set({ setupCompletedAt: null, updatedAt: now })
         .where(eq(workspaces.id, scope.workspaceId));
     });
+  }
+
+  /**
+   * Clearing a shared Workspace setup marker would destructively rewrite another Account's rollback
+   * evidence. Refuse rather than broaden the reset onto that Account.
+   */
+  async #assertWorkspaceNotShared(
+    accountId: string,
+    workspaceId: string,
+    executor: QueryExecutor = this.#database,
+  ): Promise<void> {
+    const [{ foreignAgents } = { foreignAgents: 0 }] = await executor
+      .select({ foreignAgents: count() })
+      .from(agents)
+      .where(and(eq(agents.workspaceId, workspaceId), ne(agents.createdByUserId, accountId)));
+    if (foreignAgents > 0) {
+      throw ownershipInconsistent(
+        "The Lab Account Workspace is shared with another Account; reset refused to protect that Account",
+      );
+    }
   }
 
   /**

--- a/packages/server/src/services/workspaces/workspace-setup-service.ts
+++ b/packages/server/src/services/workspaces/workspace-setup-service.ts
@@ -1,9 +1,8 @@
 import type { WorkspaceSetupCompletion } from "@opentag/shared";
 import { and, eq } from "drizzle-orm";
 import type { DatabaseClient } from "../../db/client.js";
-import { agents, workspaces } from "../../db/schema/index.js";
+import { agents, users, workspaces } from "../../db/schema/index.js";
 import type { ImBindingService } from "../im-bindings/index.js";
-import { WorkspaceAdminAccess } from "../workspace-admin-access/index.js";
 
 export class WorkspaceSetupServiceError extends Error {
   readonly category = "deterministic" as const;
@@ -23,82 +22,134 @@ export class WorkspaceSetupService {
   readonly #database: DatabaseClient;
   readonly #imBindings: ImBindingService;
   readonly #now: () => Date;
-  readonly #workspaceAdmins: WorkspaceAdminAccess;
 
-  constructor(
-    database: DatabaseClient,
-    imBindings: ImBindingService,
-    options: { now?: () => Date; workspaceAdmins?: WorkspaceAdminAccess } = {},
-  ) {
+  constructor(database: DatabaseClient, imBindings: ImBindingService, options: { now?: () => Date } = {}) {
     this.#database = database;
     this.#imBindings = imBindings;
     this.#now = options.now ?? (() => new Date());
-    this.#workspaceAdmins = options.workspaceAdmins ?? new WorkspaceAdminAccess(database, { now: options.now });
+  }
+
+  async completeForAccount(callerUserId: string, agentId: string): Promise<WorkspaceSetupCompletion> {
+    return this.#complete(callerUserId, agentId);
   }
 
   async complete(callerUserId: string, workspaceId: string, agentId: string): Promise<WorkspaceSetupCompletion> {
-    await this.#workspaceAdmins.requireAdmin(callerUserId, workspaceId);
-    const [current] = await this.#database
-      .select({ setupCompletedAt: workspaces.setupCompletedAt })
-      .from(workspaces)
-      .where(eq(workspaces.id, workspaceId))
-      .limit(1);
-    if (current?.setupCompletedAt) return this.#projection(current.setupCompletedAt);
+    return this.#complete(callerUserId, agentId, workspaceId);
+  }
 
-    const [agent] = await this.#database
-      .select({ id: agents.id })
-      .from(agents)
-      .where(and(eq(agents.id, agentId), eq(agents.workspaceId, workspaceId), eq(agents.status, "active")))
-      .limit(1);
-    if (!agent) {
-      throw new WorkspaceSetupServiceError(
-        "WORKSPACE_SETUP_AGENT_NOT_FOUND",
-        404,
-        "The active setup Agent was not found in this Workspace",
-      );
-    }
+  /**
+   * Completes Account onboarding from an Agent this Account created. Canonical state is
+   * `users.setup_completed_at`. The selected creator-Agent's Workspace is dual-written for rollback.
+   * Workspace administrator grants never contribute.
+   */
+  async #complete(callerUserId: string, agentId: string, workspaceId?: string): Promise<WorkspaceSetupCompletion> {
+    const current = await this.#existingCompletion(callerUserId);
+    if (current) return current;
+    await this.#ownedActiveAgent(callerUserId, agentId, workspaceId);
 
     const handoff = await this.#imBindings.getHandoffForAgent(callerUserId, agentId);
     if (!handoff?.handoffReady) {
       throw new WorkspaceSetupServiceError(
         "WORKSPACE_SETUP_NOT_READY",
         409,
-        "The Agent handoff is not ready to complete Workspace setup",
+        "The Agent handoff is not ready to complete Account setup",
       );
     }
 
     return this.#database.transaction(async (transaction) => {
-      await this.#workspaceAdmins.requireAdminForMutation(transaction, callerUserId, workspaceId);
-      const [lockedWorkspace] = await transaction
-        .select({ setupCompletedAt: workspaces.setupCompletedAt })
-        .from(workspaces)
-        .where(eq(workspaces.id, workspaceId))
-        .limit(1);
-      if (lockedWorkspace?.setupCompletedAt) return this.#projection(lockedWorkspace.setupCompletedAt);
+      const [lockedUser] = await transaction
+        .select({ setupCompletedAt: users.setupCompletedAt })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1)
+        .for("update");
+      if (!lockedUser) {
+        throw new WorkspaceSetupServiceError(
+          "WORKSPACE_SETUP_AGENT_NOT_FOUND",
+          404,
+          "The active setup Agent was not found",
+        );
+      }
+      if (lockedUser.setupCompletedAt) return this.#projection(lockedUser.setupCompletedAt);
 
       const [lockedAgent] = await transaction
-        .select({ id: agents.id })
+        .select({ id: agents.id, workspaceId: agents.workspaceId })
         .from(agents)
-        .where(and(eq(agents.id, agentId), eq(agents.workspaceId, workspaceId), eq(agents.status, "active")))
+        .where(
+          and(
+            eq(agents.id, agentId),
+            eq(agents.createdByUserId, callerUserId),
+            eq(agents.status, "active"),
+            ...(workspaceId === undefined ? [] : [eq(agents.workspaceId, workspaceId)]),
+          ),
+        )
         .limit(1)
         .for("update");
       if (!lockedAgent) {
         throw new WorkspaceSetupServiceError(
           "WORKSPACE_SETUP_AGENT_NOT_FOUND",
           404,
-          "The active setup Agent was not found in this Workspace",
+          "The active setup Agent was not found",
         );
       }
 
-      const completedAt = this.#now();
+      const [lockedWorkspace] = await transaction
+        .select({ setupCompletedAt: workspaces.setupCompletedAt })
+        .from(workspaces)
+        .where(eq(workspaces.id, lockedAgent.workspaceId))
+        .limit(1)
+        .for("update");
+      const completedAt = lockedWorkspace?.setupCompletedAt ?? this.#now();
       const [completed] = await transaction
-        .update(workspaces)
+        .update(users)
         .set({ setupCompletedAt: completedAt, updatedAt: completedAt })
-        .where(eq(workspaces.id, workspaceId))
-        .returning({ setupCompletedAt: workspaces.setupCompletedAt });
-      if (!completed?.setupCompletedAt) throw new Error("Workspace setup completion did not return a timestamp");
+        .where(eq(users.id, callerUserId))
+        .returning({ setupCompletedAt: users.setupCompletedAt });
+      if (!completed?.setupCompletedAt) throw new Error("Account setup completion did not return a timestamp");
+      if (!lockedWorkspace?.setupCompletedAt) {
+        await transaction
+          .update(workspaces)
+          .set({ setupCompletedAt: completedAt, updatedAt: completedAt })
+          .where(eq(workspaces.id, lockedAgent.workspaceId));
+      }
       return this.#projection(completed.setupCompletedAt);
     });
+  }
+
+  async #existingCompletion(callerUserId: string): Promise<WorkspaceSetupCompletion | undefined> {
+    const [row] = await this.#database
+      .select({ setupCompletedAt: users.setupCompletedAt })
+      .from(users)
+      .where(eq(users.id, callerUserId))
+      .limit(1);
+    return row?.setupCompletedAt ? this.#projection(row.setupCompletedAt) : undefined;
+  }
+
+  async #ownedActiveAgent(
+    callerUserId: string,
+    agentId: string,
+    workspaceId?: string,
+  ): Promise<{ id: string; workspaceId: string }> {
+    const [agent] = await this.#database
+      .select({ id: agents.id, workspaceId: agents.workspaceId })
+      .from(agents)
+      .where(
+        and(
+          eq(agents.id, agentId),
+          eq(agents.createdByUserId, callerUserId),
+          eq(agents.status, "active"),
+          ...(workspaceId === undefined ? [] : [eq(agents.workspaceId, workspaceId)]),
+        ),
+      )
+      .limit(1);
+    if (!agent) {
+      throw new WorkspaceSetupServiceError(
+        "WORKSPACE_SETUP_AGENT_NOT_FOUND",
+        404,
+        "The active setup Agent was not found",
+      );
+    }
+    return agent;
   }
 
   #projection(setupCompletedAt: Date): WorkspaceSetupCompletion {

--- a/packages/shared/src/__tests__/auth.test.ts
+++ b/packages/shared/src/__tests__/auth.test.ts
@@ -57,25 +57,22 @@ describe("auth contracts", () => {
     }
   });
 
-  it("validates the current Account and ordered Workspace response", () => {
+  it("validates the current Account without a management Workspace projection", () => {
     const response = {
       user: {
         id: "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e",
         email: "admin@example.com",
         displayName: "Admin",
       },
-      workspaces: [
-        {
-          id: "d3fda800-7ce2-4338-aae8-3d2120401ed6",
-          name: "example",
-          displayName: "Example",
-          setupCompletedAt: null,
-          grantedAt: "2026-08-20T00:00:00.000Z",
-        },
-      ],
+      setupCompletedAt: null,
     };
 
     expect(MeResponseSchema.parse(response)).toEqual(response);
+    expect(MeResponseSchema.parse({ ...response, setupCompletedAt: "2026-08-20T00:00:00.000Z" })).toEqual({
+      ...response,
+      setupCompletedAt: "2026-08-20T00:00:00.000Z",
+    });
+    expect(() => MeResponseSchema.parse({ ...response, workspaces: [] })).toThrow();
     expect(() => MeResponseSchema.parse({ ...response, state: "active" })).toThrow();
   });
 

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -55,11 +55,14 @@ export const UserProfileSchema = z
 
 export const UpdateUserProfileRequestSchema = z.object({ displayName: UserDisplayNameSchema }).strict();
 
-/** Workspaces are ordered by setup-complete, earliest grant, then UUID. */
+/**
+ * Authentication proves Account identity only. `setupCompletedAt` is durable Account state from
+ * `users.setup_completed_at`; it is never derived from Agents, Workspaces, or grants.
+ */
 export const MeResponseSchema = z
   .object({
     user: UserProfileSchema,
-    workspaces: z.array(MeWorkspaceSchema),
+    setupCompletedAt: z.string().datetime().nullable(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

This is Stages G-H of the workspace-removal rollout. It moves the remaining management surfaces to Account/Agent ownership while retaining legacy database projections and routes for the rollback window.

- adds canonical nullable `users.setup_completed_at` with deterministic historical backfill
- routes Slack installation authority, ingress, diagnostics, and current uniqueness through the owning Agent
- exposes canonical Account-native Agent, Computer, Session, Task, connect-code, and setup APIs
- removes Workspace authority, selection, context, and gates from Web
- removes Workspace-scoped management calls from CLI
- adds Account-only migration, API, Slack, Web, CLI, reset, and rolling-compatibility coverage

This implementation task must not merge this PR.

## Exact state

- base: `4f4ff6983d3d77507dbd296410eef5268407858a`
- head: `914105d3b843e4c625dd8273e46cc1fddb4c4714`
- migration start: `0028_overjoyed_speedball` (29 journal entries)
- migration target: `0030_low_ulik` (31 journal entries, `1788077592745`)

The six planned Conventional Commit boundaries are preserved:

1. `feat(server): migrate setup completion to accounts`
2. `feat(server): route Slack installations through owning agents`
3. `refactor(server): expose account-native resource APIs`
4. `refactor(web): remove workspace authority and selection surfaces`
5. `refactor(cli): remove workspace-scoped management commands`
6. `test: cover account-only management surfaces`

The branch was rebased after inspecting each live-main advance. The final intervening commit moved Web Agent modules only; it had no file-level overlap. All acceptance below was rerun after the final rebase.

## Gate 0

- Node `v24.7.0`; repository package manager `pnpm@10.12.1`; Git `2.50.1`; GitHub CLI `2.91.0`
- `pnpm install --frozen-lockfile --config.engine-strict=true` passed
- Docker client/server `29.4.1`, Compose `5.1.3`, Docker Desktop `overlayfs`
- host `psql` is intentionally absent; PostgreSQL 17, Testcontainers, and the checked-in production migration runner were exercised successfully
- GitHub authentication is active for `yuezengwu`; repository permissions report admin/push/pull/maintain/triage
- CI, Deploy Staging, Docker, npm Publish, and Unit Coverage workflow visibility is available
- staging observation and bounded database reads remain with the coordinating task; no staging write was performed here
- deferred CapRover token rotation and dedicated database observer-role creation were not changed

## Gate 1 commands

| Command | Result |
| --- | --- |
| `pnpm check` | passed; 557 files and third-party notices |
| `pnpm build` | passed; 5/5 packages |
| `pnpm typecheck` | passed; 7/7 tasks |
| `pnpm test` | passed; scripts 77, Shared 84, Server 292, Web 374, Client 561, CLI 152 |
| `pnpm --filter @opentag/server test:integration` | passed; 16 files / 284 tests |
| focused production migration matrix | passed; 4 files / 66 tests |
| focused Account/Slack/reset/API matrix | passed; 5 files / 135 tests |
| `pnpm --filter @opentag/client test:agent-runtime:coverage` | passed; 22 files / 315 tests; statements, branches, functions, and lines all 100% |
| source CLI pack and Node compatibility smoke | passed for `open-tag@0.0.1` through `opentag-dev` |
| full local Container Smoke equivalent | passed against PostgreSQL 17 and the production image |
| `pnpm --filter @opentag/server db:generate` | no schema drift |
| `git diff --exit-code`, `git diff --check` | clean |

The container path proved SPA/API separation, migration, bootstrap, Account login, legacy connect-code compatibility, normal Computer connect, daemon registration, Account Computer listing, installation/logical Computer identity separation, installation-ID Agent rejection without side effects, logical-ID Agent CRUD, daemon single ownership and restart, non-root image execution, license presence, and absence of the CLI artifact from the server image. Its journal evidence was `31:1788077592745`.

## Migration and behavior matrix

| Scenario | Evidence / expected result |
| --- | --- |
| empty database | production runner reaches 31 entries; nullable `timestamptz` Account setup column exists; removed Workspace-current Slack index is absent |
| immediately previous migration | 0028 fixture upgrades through 0029/0030 with no hand-applied SQL |
| representative historical | 0024/0025/0026 fixtures, current/replaced Slack rows, active/revoked credentials, consumed/unconsumed codes, active/ended Sessions, pending delivery, accepted custody, stale placement/connection evidence all pass the checked-in path |
| deterministic setup backfill | earliest creator-Agent Workspace timestamp wins; soft-deleted Agents count as evidence; grant-only and no-evidence Accounts stay null |
| idempotency | repeated production-runner execution stays at 31 entries and preserves already-populated Account values |
| failure and retry | an injected trigger aborts 0029 transactionally, leaves the journal/schema at 0028, and a retry succeeds after only the external obstruction is removed |
| abnormal ownership/data | orphan Computers, owner mismatches, credential conflicts, connect-code conflicts, ambiguous Slack binding, divergent Agent/placement/proof projections, and constraint violations fail closed; fixtures do not repair migration inputs |
| Slack current ownership | same Agent reauthorization updates the same installation; a live cross-Agent attempt returns stable 409 without mutation |
| Slack manual transfer | explicit remove disables the old row and route; fresh install creates a different row for the new Agent; old owner stays historical; app/team has exactly one current row |
| legacy Workspace cardinality | two Agents in one legacy Workspace may own distinct current Slack installations; duplicate App/Team remains rejected by `slack_installations_app_team_current_unique` |
| onboarding reset | Account and selected creator-Agent legacy Workspace are cleared together; a Workspace shared with another Account fails closed with 409 before destructive work |
| post-migration application | `/me` reads Account setup only; Account-native reads/writes and retained legacy routes both pass |

Backfill row evidence uses four Accounts: the two with creator-Agent history receive the expected earliest timestamps, while the grant-only Account and Account without evidence remain null. No `workspace_admin_grants` row participates.

## Known migration risks and invariants

- consumed connect-code Workspace/enrollment composite FK is retained and covered by conflict fixtures
- Slack installation keeps the legacy `workspace_id` shadow, but canonical ownership and route checks use immutable `agent_id`; App/Team remains globally current-unique
- Session placement/custody and Workspace-qualified compatibility projections remain intact; PR3 execution/rebind blockers are unchanged
- Agent/enrollment composite FK remains non-deferrable; no cascade or in-place Slack owner rewrite was introduced

## Rolling deploy and rollback boundary

- legacy columns, `workspace_id` Slack shadows, compatibility API routes, and setup dual writes remain through the rollback window
- Account setup completion writes the Account row and selected creator-Agent legacy Workspace row in one transaction
- runtime Slack ingress and delivery remain keyed by explicit installation/binding IDs, so existing routes are readable by the previous server during a mixed deployment
- after a legacy Workspace contains multiple current Slack installations, a previous-version Slack configuration writer can reject a management mutation because it still assumes one current installation per Workspace; it fails closed rather than rewriting ownership. Drain previous-version writers before enabling that new cardinality, and quiesce Slack configuration writes if rollback is required after it appears
- the `/me` and Web authority contract is an intentional same-PR cutover; already-loaded previous Web bundles should be reloaded during deployment. Database rollback does not require destructive repair

## Browser QA

A real loopback Server plus PostgreSQL 17 was exercised through development sign-in. `/onboarding` showed only Account setup state; `/agents` used Account-native requests; the Account menu contained only Account and Sign out; no Workspace selector/gate was visible; browser console error/warn count was zero.

Screenshot artifacts are retained on the acceptance host outside the Git worktree:

- `account-onboarding.png` — SHA-256 `13ec2a875324a41803bdca60101ba10026782ca4041750564f51ee9a0b07d137`
- `account-agents.png` — SHA-256 `f2052e59e5f010464308a025bd07b1137df770f672bbe7636ba683cd590459b5`
- `account-menu.png` — SHA-256 `29bbf7a34299189dbe616035fbcece1e5b145883f5cd457abb36b6f34b72d7db`

## Limits

- no staging write, merge, later-stage work, Context Tree change, infrastructure credential rotation, or database-role creation was performed
- exact-head required CI remains a merge gate for the coordinating task; any branch-head change invalidates this acceptance and requires a fresh run
