### PR TITLE
fix(web): restore Computers management page

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -659,7 +659,7 @@ describe("OpenTag Web App Shell", () => {
     expect(signIn.getAttribute("data-ui")).toBe("login-provider-google");
     expect(signIn.querySelector('img[alt="Sign in with Google"]')).toBeTruthy();
     expect(new URL(signIn.getAttribute("href") ?? "", window.location.origin).searchParams.get("next")).toBe("/agents");
-    expect(screen.getByText("Sign in to manage your Agents.")).toBeTruthy();
+    expect(screen.getByText("Sign in to manage your Agents and Computers.")).toBeTruthy();
   });
 
   it("offers the password form only where the server enabled it", async () => {
@@ -2282,7 +2282,7 @@ describe("OpenTag Web App Shell", () => {
     expect(within(menu).queryByRole("group", { name: "Workspaces" })).toBeNull();
     expect(within(menu).queryByRole("menuitem", { name: "Workspace" })).toBeNull();
     expect(within(menu).queryByText("Secondary")).toBeNull();
-    expect(within(menu).queryByRole("menuitem", { name: "Computers" })).toBeNull();
+    expect(within(menu).getByRole("menuitem", { name: "Computers" })).toBeTruthy();
     expect(within(menu).queryByRole("menuitem", { name: "Admins" })).toBeNull();
   });
 
@@ -2749,12 +2749,19 @@ describe("OpenTag Web App Shell", () => {
     );
   });
 
-  it("sends a retired Computers bookmark to Agents", async () => {
+  it("opens the Computers page from the account menu", async () => {
     installApi();
-    window.history.replaceState({}, "", "/agents/computers");
     render(<App />);
-    expect(await screen.findByRole("heading", { name: "Agents" })).toBeTruthy();
-    expect(window.location.pathname).toBe("/agents");
+    fireEvent.click(await screen.findByRole("button", { name: "Account menu" }));
+    const computers = screen.getByRole("menuitem", { name: "Computers" });
+    expect(computers.getAttribute("href")).toBe("/agents/computers");
+    fireEvent.click(computers);
+    expect(await screen.findByRole("heading", { level: 1, name: "Computers" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Enrolled Computers" })).toBeTruthy();
+    expect(screen.getByText("Ada's Mac")).toBeTruthy();
+    expect(screen.getByText("Online")).toBeTruthy();
+    expect(window.location.pathname).toBe("/agents/computers");
+    expect(screen.queryByRole("menu", { name: "Account" })).toBeNull();
   });
 
   it("moves focus into account actions and returns it to the trigger on Escape", async () => {

--- a/apps/web/src/features/agents/computers-page.tsx
+++ b/apps/web/src/features/agents/computers-page.tsx
@@ -1,0 +1,74 @@
+import type { WorkspaceComputerSummary } from "@opentag/shared/browser";
+import { browserApi } from "../../api.js";
+import { StatusIndicator, Text } from "../../ui/design-system.js";
+import { Page } from "../layout/page.js";
+import { AsyncState, useResource } from "../resource/use-resource.js";
+import { useAccount } from "../session/session-context.js";
+import { ComputerSetup } from "./computer-setup.js";
+
+/**
+ * Lists the Account's enrolled Computers and keeps the connection flow available as its own
+ * management surface. A Computer can be enrolled before an Agent exists, so this page cannot be
+ * folded into the Agent list without making that first-run path unnecessarily indirect.
+ */
+export function ComputersPage() {
+  const { me } = useAccount();
+  const state = useResource(() => browserApi.computers(), me.user.id, {
+    revalidateMs: 30_000,
+    refreshOnFocus: true,
+  });
+
+  return (
+    <Page title="Computers" description="Enroll and recover the Computers used by your Agents.">
+      <AsyncState state={state}>
+        {(value) => (
+          <div className="grid gap-6">
+            <ComputerList computers={value.computers} />
+            <ComputerSetup />
+          </div>
+        )}
+      </AsyncState>
+    </Page>
+  );
+}
+
+export function ComputerList({ computers }: { computers: readonly WorkspaceComputerSummary[] }) {
+  return (
+    <section
+      aria-labelledby="enrolled-computers-heading"
+      className="grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
+    >
+      <Text as="h2" id="enrolled-computers-heading" variant="heading">
+        Enrolled Computers
+      </Text>
+      {computers.length === 0 ? (
+        <Text as="p" variant="secondary">
+          No Computers are enrolled yet.
+        </Text>
+      ) : (
+        <ul className="grid divide-y divide-kumo-line">
+          {computers.map((computer) => (
+            <ComputerListItem computer={computer} key={computer.computerId} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ComputerListItem({ computer }: { computer: WorkspaceComputerSummary }) {
+  const online = computer.connectionStatus === "online";
+  const platform = computer.platform === "darwin" ? "macOS" : computer.platform === "win32" ? "Windows" : "Linux";
+  const agentCount = computer.agentIds.length;
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+      <div className="grid min-w-0 gap-1">
+        <strong className="truncate text-sm font-medium text-kumo-strong">{computer.displayName}</strong>
+        <span className="text-sm text-kumo-subtle">
+          {platform} · {agentCount} {agentCount === 1 ? "Agent" : "Agents"}
+        </span>
+      </div>
+      <StatusIndicator label={online ? "Online" : "Offline"} tone={online ? "success" : "warning"} />
+    </li>
+  );
+}

--- a/apps/web/src/features/auth/login-page.tsx
+++ b/apps/web/src/features/auth/login-page.tsx
@@ -68,7 +68,7 @@ export function LoginPage({ next: requested }: { next?: string }) {
           }}
         </AsyncState>
         <p className="text-sm text-kumo-subtle" data-ui="login-access-note">
-          Sign in to manage your Agents.
+          Sign in to manage your Agents and Computers.
         </p>
       </section>
     </main>

--- a/apps/web/src/features/shell/app-shell.tsx
+++ b/apps/web/src/features/shell/app-shell.tsx
@@ -130,6 +130,9 @@ export function AppShellContent() {
                     }
                   />
                   <DropdownMenu.Content aria-label="Account" ref={accountMenuRef}>
+                    <DropdownMenu.Item href="/agents/computers" onClickCapture={() => setOpenMobile(false)}>
+                      Computers
+                    </DropdownMenu.Item>
                     <DropdownMenu.Item
                       onClick={() => {
                         setOpenMobile(false);

--- a/apps/web/src/routes/_authenticated/_workspace/_shell/agents.computers.tsx
+++ b/apps/web/src/routes/_authenticated/_workspace/_shell/agents.computers.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Redirect } from "../../../../features/navigation/redirect.js";
+import { ComputersPage } from "../../../../features/agents/computers-page.js";
 
 export const Route = createFileRoute("/_authenticated/_workspace/_shell/agents/computers")({
-  component: () => <Redirect replace to="/agents" />,
+  component: ComputersPage,
 });


### PR DESCRIPTION
## Summary

- Restore the Computers entry in the Account menu.
- Restore the /agents/computers management page with enrolled Computer state and connection setup.
- Restore the login copy and add route/menu regression coverage.

## Root cause

Commit 1902c70 intentionally removed the standalone Computers page and changed /agents/computers to redirect to /agents; the Computer API and connection flow remained available.

## Verification

- pnpm check
- pnpm typecheck
- pnpm test
- pnpm --filter @opentag/web build
- Pre-push format and lint hooks