### PR TITLE
ci(coverage): enforce pull request patch coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,135 @@
+name: Patch Coverage
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  patch:
+    name: Enforce Patch Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.12.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --config.engine-strict=true
+
+      - name: Measure unit coverage
+        run: pnpm test:coverage
+
+      - name: Enforce changed-line coverage
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PATCH_COVERAGE_THRESHOLD: "80"
+        run: |
+          node --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+          import path from "node:path";
+          import { spawnSync } from "node:child_process";
+
+          const repositoryRoot = process.cwd();
+          const baseSha = process.env.BASE_SHA;
+          const threshold = Number(process.env.PATCH_COVERAGE_THRESHOLD);
+          if (!baseSha || !Number.isFinite(threshold)) {
+            throw new Error("BASE_SHA and PATCH_COVERAGE_THRESHOLD are required");
+          }
+
+          const diff = spawnSync(
+            "git",
+            ["diff", "--unified=0", "--no-color", `${baseSha}...HEAD`, "--", "*.ts", "*.tsx"],
+            { encoding: "utf8" },
+          );
+          if (diff.status !== 0) {
+            throw new Error(diff.stderr || "Unable to read the pull-request diff");
+          }
+
+          const changedLines = new Map();
+          let currentFile;
+          let nextLine;
+          for (const line of diff.stdout.split("\n")) {
+            if (line.startsWith("+++ b/")) {
+              currentFile = line.slice(6);
+              continue;
+            }
+            if (line.startsWith("@@")) {
+              const match = line.match(/\+([0-9]+)(?:,([0-9]+))?/);
+              if (!match) throw new Error(`Unable to parse diff hunk: ${line}`);
+              nextLine = Number(match[1]);
+              continue;
+            }
+            if (!currentFile || nextLine === undefined || line.startsWith("\\")) continue;
+            if (line.startsWith("+")) {
+              if (!line.startsWith("+++")) {
+                const lines = changedLines.get(currentFile) ?? [];
+                lines.push(nextLine);
+                changedLines.set(currentFile, lines);
+                nextLine += 1;
+              }
+              continue;
+            }
+            if (line.startsWith("-")) continue;
+            nextLine += 1;
+          }
+
+          const coveragePath = path.join(repositoryRoot, "coverage/unit/coverage-final.json");
+          const coverage = JSON.parse(readFileSync(coveragePath, "utf8"));
+          const lineHitsByFile = new Map();
+          for (const [rawFile, fileCoverage] of Object.entries(coverage)) {
+            const file = path.posix.normalize(
+              (path.isAbsolute(rawFile) ? path.relative(repositoryRoot, rawFile) : rawFile).replaceAll("\\", "/"),
+            );
+            const lineHits = new Map();
+            for (const [statementId, statement] of Object.entries(fileCoverage.statementMap ?? {})) {
+              const line = statement.start?.line;
+              if (!Number.isInteger(line)) continue;
+              const hits = fileCoverage.s?.[statementId] ?? 0;
+              lineHits.set(line, Math.max(lineHits.get(line) ?? 0, hits));
+            }
+            lineHitsByFile.set(file, lineHits);
+          }
+
+          let covered = 0;
+          let total = 0;
+          const uncovered = [];
+          for (const [file, lines] of changedLines) {
+            const lineHits = lineHitsByFile.get(path.posix.normalize(file));
+            if (!lineHits) continue;
+            for (const line of lines) {
+              if (!lineHits.has(line)) continue;
+              total += 1;
+              if (lineHits.get(line) > 0) covered += 1;
+              else uncovered.push(`${file}:${line}`);
+            }
+          }
+
+          if (total === 0) {
+            console.log("Patch coverage: no executable changed lines were found.");
+            process.exit(0);
+          }
+          const percent = (covered / total) * 100;
+          console.log(`Patch coverage: ${covered}/${total} lines (${percent.toFixed(2)}%), threshold ${threshold.toFixed(2)}%.`);
+          if (uncovered.length > 0) console.log(`Uncovered changed lines:\n${uncovered.join("\n")}`);
+          if (percent < threshold) process.exit(1);
+          NODE

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -24,6 +24,7 @@ import {
   createClientRuntime,
   createClientRuntimeHandlers,
   createClientRuntimePreflight,
+  createLoginShellDiscovery,
   refreshImCliReadiness,
   resolveCodexHome,
   resolvedClaudeCodeFactory,
@@ -43,6 +44,16 @@ afterEach(async () => {
 });
 
 describe("createClientRuntime production composition", () => {
+  it("allows the login-shell readiness callback to be invoked directly", () => {
+    const loginShellDiscovery = createLoginShellDiscovery();
+    const includeLoginShell = loginShellDiscovery.options.includeLoginShell;
+
+    if (typeof includeLoginShell !== "function") throw new Error("login-shell discovery callback is missing");
+    expect(includeLoginShell()).toBe(false);
+    loginShellDiscovery.enable();
+    expect(includeLoginShell()).toBe(true);
+  });
+
   it("probes Feishu and Slack CLI readiness independently from Agent Runtime providers", async () => {
     const home = await temporaryDirectory("opentag-im-cli-readiness-");
     const lark = resolve(home, "lark-cli");

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -76,6 +76,24 @@ interface SharedProviderRefresh {
   waiters: number;
 }
 
+export interface LoginShellDiscovery {
+  readonly options: ResolveAgentRuntimeExecutableOptions;
+  enable(): void;
+}
+
+export function createLoginShellDiscovery(): LoginShellDiscovery {
+  let enabled = false;
+  function includeLoginShell(): boolean {
+    return enabled;
+  }
+  return {
+    options: { includeLoginShell },
+    enable() {
+      enabled = true;
+    },
+  };
+}
+
 async function waitForSharedRefresh(refresh: Promise<boolean>, signal?: AbortSignal): Promise<boolean> {
   if (!signal) return refresh;
   signal.throwIfAborted();
@@ -254,10 +272,8 @@ export async function createClientRuntime(
     codex: createHash("sha256").update(codexHome, "utf8").digest("hex"),
     "claude-code": createHash("sha256").update(claudeCodeHome, "utf8").digest("hex"),
   };
-  let includeLoginShell = false;
-  const discovery: ResolveAgentRuntimeExecutableOptions = {
-    includeLoginShell: () => includeLoginShell,
-  };
+  const loginShellDiscovery = createLoginShellDiscovery();
+  const discovery = loginShellDiscovery.options;
   const factories =
     options.factories ??
     (options.factory
@@ -420,7 +436,7 @@ export async function createClientRuntime(
     capabilityAbort.abort(error);
     throw error;
   }
-  includeLoginShell = true;
+  loginShellDiscovery.enable();
 
   const bindingStore = new SessionBindingStore({
     home: options.home,

--- a/packages/client/vitest.agent-runtime.config.ts
+++ b/packages/client/vitest.agent-runtime.config.ts
@@ -1,5 +1,18 @@
 import { defineConfig } from "vitest/config";
 
+/**
+ * The Agent Runtime 100% gate is authoritative on ubuntu-latest (the platform
+ * used by CI). Runtime discovery and process ownership intentionally retain
+ * host-specific paths that are not meaningful to execute on every host:
+ * `agent-runtime-installation.ts` handles Windows `PATHEXT`, macOS desktop
+ * locations, and the Windows login-shell skip; `login-shell-path.ts` selects
+ * zsh versus bash, skips Windows, and applies macOS protected-root handling;
+ * provider process adapters and the watchdog choose platform-specific process
+ * groups; and `client-runtime-composition.ts` has a Windows-only executable
+ * suffix probe. Tests inject a platform for discovery/login-shell logic where
+ * possible, while the remaining process branches are covered by the Ubuntu
+ * CI authority boundary.
+ */
 export default defineConfig({
   test: {
     include: [

--- a/vitest.coverage.config.ts
+++ b/vitest.coverage.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
         "packages/server/src/**/*.{ts,tsx}",
       ],
       provider: "v8",
-      reporter: ["text", "json-summary", "html"],
+      reporter: ["text", "json", "json-summary", "html"],
       reportOnFailure: true,
       reportsDirectory: "coverage/unit",
     },


### PR DESCRIPTION
## Summary

Add a standalone `coverage.yml` pull-request check that measures the existing unit coverage once and
fails only when executable lines added or changed by the pull request are below the 80% patch threshold.
The workflow reads V8 JSON coverage, pins every action by commit SHA with a version comment, and leaves
the weekly `Unit Coverage` schedule/manual workflow and `ci.yml` unchanged.

The Agent Runtime 100% gate remains unchanged and its Ubuntu authority boundary is documented. The
platform-independent login-shell callback test raises the focused Agent Runtime result to 100% for
statements, branches, functions, and lines.

The measured checkout baseline is 141 test files and 1,482 tests: 74.01% statements, 87.06% branches,
77.98% functions, and 74.01% lines. The proposed staged ratchet is deliberately below that measurement:

| Stage | Stable observations | Statements | Branches | Functions | Lines |
| --- | ---: | ---: | ---: | ---: | ---: |
| 0 | 3 | 73.00% | 86.00% | 76.00% | 73.00% |
| 1 | 5 | 73.50% | 86.50% | 77.00% | 73.50% |
| 2 | 8 | 74.00% | 87.00% | 77.50% | 74.00% |
| 3 | 12 | 75.00% | 88.00% | 78.00% | 75.00% |

Because `coverage.yml` is a separate workflow, `Enforce Patch Coverage` cannot join `ci.yml`'s
`needs:` fan-in. The repository owner must add this job as a required branch-protection check by hand
after the pull request is opened.

## Testing

- `pnpm --filter @opentag/client test:agent-runtime:coverage` passed: 22 files, 316 tests, and 100% for
  statements, branches, functions, and lines.
- `pnpm test:coverage` passed: 141 files, 1,482 tests, 74.01% statements, 87.06% branches, 77.98%
  functions, and 74.01% lines.
- The workflow's extracted changed-line script passed against `origin/main...HEAD`: 15/15 executable
  changed lines covered (100.00%), threshold 80.00%.
- `actionlint .github/workflows/coverage.yml` passed.
- `pnpm check` passed.
- `pnpm build` passed all 5 Turbo build tasks.
- `pnpm typecheck` passed all 7 Turbo tasks.
- `pnpm test` passed all 7 Turbo tasks and the 77 script tests.
- Skipped `pnpm --filter @opentag/server test:integration` because it requires a running PostgreSQL
  instance, which is unavailable on this machine.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

> **Cross-PR note.** This branch and `chore/static-analysis-hardening` both modify `packages/client/src/runtime/client-runtime-composition.ts` and its test file: each lane independently extracted and covered the `includeLoginShell` gate that was holding the Agent Runtime coverage below its 100% function threshold. The two branches will conflict there. The other branch additionally refactors that file for cognitive complexity, so prefer merging it first and rebasing this one onto the result.

---

*Produced by codex under `/dispatch-codex` run `ea55b2`, lane `dx-ea55b2-2`, running with approvals and sandbox bypassed inside an isolated git worktree. Verified by the orchestrator before publishing: worktree clean, commits present, and `pnpm check` / `pnpm typecheck` / `pnpm test` / `pnpm build` all pass on Node v24.18.0.*
