### PR TITLE
chore(ts): stage TypeScript strictness

### DIFF
--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -14,6 +14,10 @@ type AppErrorBoundaryState = {
   error?: BoundaryError;
 };
 
+abstract class ErrorBoundaryComponent extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  declare static getDerivedStateFromError: (error: unknown) => AppErrorBoundaryState;
+}
+
 /**
  * Keeps an unexpected render failure from leaving the application root blank.
  *
@@ -21,14 +25,14 @@ type AppErrorBoundaryState = {
  * around the router itself because providers, the router boot process, and non-route UI can fail
  * before a route match has a chance to install its own boundary.
  */
-export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
-  state: AppErrorBoundaryState = {};
+export class AppErrorBoundary extends ErrorBoundaryComponent {
+  override state: AppErrorBoundaryState = {};
 
-  static getDerivedStateFromError(error: unknown): AppErrorBoundaryState {
+  static override getDerivedStateFromError(error: unknown): AppErrorBoundaryState {
     return { error: normalizeError(error) };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     reportBoundaryError("app", error, errorInfo);
   }
 
@@ -36,7 +40,7 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
     window.location.reload();
   };
 
-  render() {
+  override render() {
     if (this.state.error) {
       return <StandaloneErrorPage actionLabel="Try again" onAction={this.reload} />;
     }

--- a/packages/client/src/providers/claude-code/agent-runtime.ts
+++ b/packages/client/src/providers/claude-code/agent-runtime.ts
@@ -224,7 +224,7 @@ export class ClaudeCodeAgentRuntime extends BaseAgentRuntime {
     }
   }
 
-  protected async abortProvider(_request: AgentAbortRequest): Promise<void> {
+  protected override async abortProvider(_request: AgentAbortRequest): Promise<void> {
     if (this.#terminalClaimed) return;
     await this.#process?.interrupt();
   }

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -276,7 +276,7 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
     }
   }
 
-  protected async steerProvider(request: AgentSteerRequest): Promise<void> {
+  protected override async steerProvider(request: AgentSteerRequest): Promise<void> {
     const turnId = await this.#activeTurnId();
     const response = requireRecord(
       await this.#client.request("turn/steer", {
@@ -291,7 +291,7 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
     }
   }
 
-  protected async respondProvider(response: AgentInteractionResponse): Promise<void> {
+  protected override async respondProvider(response: AgentInteractionResponse): Promise<void> {
     const request = this.#wireInteractions.get(response.requestId);
     /* v8 ignore next -- Base and the serial Codex envelope queue fence this map with the public interaction. */
     if (!request) throw new AgentRuntimeError("interaction_not_found", "Codex interaction is no longer pending");
@@ -300,7 +300,7 @@ export class CodexAgentRuntime extends BaseAgentRuntime {
     this.#wireInteractions.delete(response.requestId);
   }
 
-  protected async abortProvider(request: AgentAbortRequest): Promise<void> {
+  protected override async abortProvider(request: AgentAbortRequest): Promise<void> {
     const turnId = await this.#activeTurnId();
     /* v8 ignore next 3 -- Base validates expectedRunId before entering the Provider hook. */
     if (request.expectedRunId !== this.#context?.runId) {

--- a/packages/client/src/providers/pi/agent-runtime.ts
+++ b/packages/client/src/providers/pi/agent-runtime.ts
@@ -240,7 +240,7 @@ export class PiAgentRuntime extends BaseAgentRuntime {
     }
   }
 
-  protected async steerProvider(request: AgentSteerRequest): Promise<void> {
+  protected override async steerProvider(request: AgentSteerRequest): Promise<void> {
     /* v8 ignore next -- BaseAgentRuntime admits steer only while executeRun owns an active prompt. */
     if (!this.#promptAccepted) throw new AgentRuntimeError("run_mismatch", "there is no active Pi prompt");
     await this.#promptAccepted.promise;
@@ -250,7 +250,7 @@ export class PiAgentRuntime extends BaseAgentRuntime {
     await client.request({ type: "steer", message: piItems(request.input.items) });
   }
 
-  protected async abortProvider(_request: AgentAbortRequest): Promise<void> {
+  protected override async abortProvider(_request: AgentAbortRequest): Promise<void> {
     if (this.#terminalClaimed) return;
     await this.#client?.request({ type: "abort" }, AbortSignal.timeout(2_000));
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2023"],
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "noUncheckedIndexedAccess": true,
     "verbatimModuleSyntax": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ES2023"],
     "strict": true,
     "forceConsistentCasingInFileNames": true,
+    "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,
     "verbatimModuleSyntax": true,
     "declaration": true,


### PR DESCRIPTION
## Summary

- Enabled `forceConsistentCasingInFileNames` and `noImplicitOverride` in the root `tsconfig.json`.
- Fixed all ten override sites: one Claude Code hook, three Codex hooks, two Pi hooks, and four React error-boundary members (`state`, `getDerivedStateFromError`, `componentDidCatch`, and `render`). None was a real bug; every site was a genuine override. React's static lifecycle contract is exposed through `ComponentClass`, so the Web boundary now uses a local declaration-only base member to make that contract source-visible to TypeScript.
- Item 1 and item 2 remain separately revertable commits: `b651a67` (`chore(ts): enable force consistent casing`) and `1cd477e` (`chore(ts): require explicit overrides`). The deferred-option measurements and the lane-boundary record are reproduced in this description rather than in a committed file.
- The deferred options remain disabled. Throwaway measurements on this checkout are:

  | Workspace | `exactOptionalPropertyTypes` | `noPropertyAccessFromIndexSignature` |
  | --- | ---: | ---: |
  | `packages/shared` | 4 | 0 |
  | `packages/client` | 113 | 756 |
  | `packages/server` | 65 | 152 |
  | `apps/cli` | 10 | 53 |
  | `apps/web` | 25 | 28 |
  | **Total** | **217** | **989** |

- The dominant `exactOptionalPropertyTypes` shape is explicit `undefined` passed or assigned to an optional property that means “absent” (TS2322: 99, TS2379: 50, TS2375: 29, TS2412: 12). The dominant `noPropertyAccessFromIndexSignature` shape is TS4111 on dynamic `Record<string, unknown>` provider/JSON envelopes and `process.env`; client has 756, server 152, CLI 53, Web 28, and shared 0. Test fixtures account for 369 of the 989 TS4111 diagnostics.
- Staged follow-up plan: migrate `packages/shared` first for schema/protocol semantics; then `packages/client` for provider/runtime option builders and dynamic envelopes; then `packages/server` for API/config/runtime boundaries; finish with CLI daemon/env records and Web route/Kumo/TanStack adapters. Use conditional spreads to omit undefined optional keys, add `| undefined` only for intentional lifecycle state, use bracket access only for truly open records or environment maps, and use Zod/schema-derived types for known envelopes. Run affected tests and the full gates at each stage.

## Testing

- `pnpm install --frozen-lockfile` — passed; lockfile was up to date. Commands used Node `v24.18.0`.
- `pnpm exec tsc -p <workspace>/tsconfig.json --noEmit --forceConsistentCasingInFileNames --pretty false` — passed with 0 errors in all five workspaces, including `apps/web`.
- Throwaway `noImplicitOverride` measurement — initially 9 direct diagnostics (6 client, 3 Web); after the ten source-visible override fixes, all workspace typechecks pass.
- Throwaway `exactOptionalPropertyTypes` and `noPropertyAccessFromIndexSignature` measurements — completed for all five workspaces; counts are recorded above and neither option was enabled.
- `pnpm typecheck` — passed; all 7 Turbo tasks succeeded.
- `pnpm check` — passed; Biome checked 561 files and third-party notices passed.
- `pnpm test` — passed with exit code 0; root Node tests and all workspace Vitest suites passed. Expected jsdom navigation and clipboard warnings were emitted by existing tests but did not fail the run.
- `pnpm build` — passed; all 5 workspace builds succeeded.
- `pnpm --filter @opentag/server test:integration` — intentionally skipped because it requires a running PostgreSQL instance and is not expected to pass on this machine.

## Breaking changes

No runtime or wire/API behavior changes. The compiler now requires explicit `override` modifiers for genuine overrides, so future TypeScript changes that omit one will fail typecheck until corrected.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

---

*Produced by codex under `/dispatch-codex` run `ea55b2`, lane `dx-ea55b2-4`, running with approvals and sandbox bypassed inside an isolated git worktree. Verified by the orchestrator before publishing: worktree clean, commits present, and `pnpm check` / `pnpm typecheck` / `pnpm test` / `pnpm build` all pass on Node v24.18.0.*
