### PR TITLE
build(web): govern install scripts and bundle size

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,41 @@
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin, type Rollup } from "vite";
+
+const ENTRY_CHUNK_BUDGET_BYTES = 600 * 1024;
+const ECHARTS_CHUNK_BUDGET_BYTES = 600 * 1024;
+
+/**
+ * Keep the entry budget close to the measured baseline while making growth fail loudly.
+ * The ECharts chunk has its own budget so chart changes do not hide in the application entry.
+ */
+const bundleBudgetPlugin: Plugin = {
+  name: "opentag-bundle-budget",
+  apply: "build",
+  generateBundle(_options: Rollup.OutputOptions, bundle: Rollup.OutputBundle) {
+    const breaches = Object.values(bundle)
+      .filter((output): output is Rollup.OutputChunk => output.type === "chunk")
+      .flatMap((chunk) => {
+        const budget =
+          chunk.name === "echarts" ? ECHARTS_CHUNK_BUDGET_BYTES : chunk.isEntry ? ENTRY_CHUNK_BUDGET_BYTES : undefined;
+        if (budget === undefined) return [];
+
+        const size = Buffer.byteLength(chunk.code);
+        return size > budget ? [{ budget, chunk, size }] : [];
+      });
+
+    if (breaches.length > 0) {
+      const details = breaches
+        .map(
+          ({ budget, chunk, size }) =>
+            `${chunk.fileName} is ${(size / 1024).toFixed(2)} KiB (budget ${(budget / 1024).toFixed(2)} KiB)`,
+        )
+        .join("; ");
+      this.error(`[bundle-budget] FAIL: ${details}`);
+    }
+  },
+};
 
 /**
  * Regenerating the route tree, and splitting each route's component out of the entry, is only useful
@@ -17,6 +51,7 @@ export default defineConfig({
     ...(generateRoutes ? [tanstackRouter({ autoCodeSplitting: true, target: "react" })] : []),
     tailwindcss(),
     react(),
+    bundleBudgetPlugin,
   ],
   server: {
     proxy: {
@@ -30,5 +65,19 @@ export default defineConfig({
     name: "web",
     sequence: { groupOrder: 2 },
     setupFiles: ["./src/__tests__/setup.ts"],
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        // Keep ECharts and its renderer attributable to one independently budgeted chunk.
+        manualChunks(id) {
+          const normalizedId = id.replaceAll("\\\\", "/");
+          if (normalizedId.includes("/node_modules/echarts/") || normalizedId.includes("/node_modules/zrender/")) {
+            return "echarts";
+          }
+          return undefined;
+        },
+      },
+    },
   },
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "prepare": "node scripts/install-git-hooks.mjs",
     "worktree:setup": "node scripts/worktree-bootstrap.mjs --force",
-    "build": "turbo run build",
+    "build": "turbo run build && pnpm --silent bundle:report",
+    "bundle:report": "node scripts/report-bundle-sizes.mjs",
     "dev": "turbo run dev",
     "check": "biome check . && node scripts/third-party-notices.mjs --check",
     "lint": "biome lint .",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
 packages:
   - apps/*
   - packages/*
+
+# Build scripts are opt-in. Keep optional native addons on their JavaScript fallbacks.
+onlyBuiltDependencies:
+  # esbuild's postinstall installs the platform binary used by Vite and related tooling.
+  - esbuild
+  # lefthook's postinstall links its platform binary and installs the repository hooks.
+  - lefthook
+  # protobufjs 7's postinstall checks the dependency version scheme for API compatibility.
+  - protobufjs

--- a/scripts/report-bundle-sizes.mjs
+++ b/scripts/report-bundle-sizes.mjs
@@ -1,0 +1,30 @@
+import { readdir, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+const assetsDirectory = process.argv[2] ?? "apps/web/dist/assets";
+const entries = await readdir(assetsDirectory, { withFileTypes: true });
+const chunks = [];
+
+for (const entry of entries) {
+  if (!entry.isFile() || !entry.name.endsWith(".js")) continue;
+
+  const file = join(assetsDirectory, entry.name);
+  const bytes = (await stat(file)).size;
+  chunks.push({
+    bytes,
+    file: relative(process.cwd(), file),
+    kibibytes: Number((bytes / 1024).toFixed(2)),
+    name: entry.name.replace(/-[A-Za-z0-9_-]{8}\.js$/, ""),
+  });
+}
+
+chunks.sort((left, right) => left.file.localeCompare(right.file));
+
+const report = {
+  version: 1,
+  directory: relative(process.cwd(), assetsDirectory),
+  chunks,
+  totalBytes: chunks.reduce((total, chunk) => total + chunk.bytes, 0),
+};
+
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);


### PR DESCRIPTION
## Summary

- Added a pnpm 10 `onlyBuiltDependencies` allowlist in `pnpm-workspace.yaml`.
  - `esbuild` is allowed because its postinstall installs the platform binary used by Vite and related tooling.
  - `lefthook` is allowed because its postinstall links the platform binary and installs the repository hooks.
  - `protobufjs` is allowed because the 7.x package used by `dockerode` runs a postinstall version-scheme compatibility check.
  - `cpu-features` remains excluded because it is an optional native addon and `ssh2` has a JavaScript fallback.
  - `ssh2` remains excluded because its install script builds only an optional native crypto binding and the package continues with its JavaScript implementation when that build is unavailable.
- Split `echarts` and `zrender` into a named `echarts` Vite chunk. The critical entry and ECharts budgets are both `600 KiB` (`614,400` bytes); the Vite warning limit was not raised. A Rollup plugin emits `[bundle-budget] FAIL` and fails the build on a breach.
- Before/after JavaScript sizes:
  - Main entry: `575,957 B` (`575.96 kB`) before and after (`0 B` delta).
  - ECharts weight: `562,866 B` (`562.87 kB`) in `agent-usage-echarts-*` before; `562,892 B` (`562.89 kB`) in `echarts-*` after (`+26 B`). The after-build output also has a 130-byte lazy loader wrapper.
- Added `scripts/report-bundle-sizes.mjs` and the root `bundle:report` script. The root `build` command emits a versioned, sorted JSON report with per-chunk file names, stable labels, byte sizes, KiB sizes, and a total.
- Exact CI step to add to `.github/workflows/ci.yml` as a follow-up (workflow ownership remains with lane 3; no workflow file is changed here):

```yaml
- name: Report frontend bundle sizes
  if: ${{ success() }}
  run: |
    pnpm --silent bundle:report > bundle-sizes.json
    {
      echo '### Frontend bundle sizes'
      echo
      echo '```json'
      cat bundle-sizes.json
      echo '```'
    } >> "$GITHUB_STEP_SUMMARY"
```

## Testing

- `pnpm install --frozen-lockfile --force` — passed on Node 24.18.0; all allowlisted scripts ran for `esbuild`, `lefthook`, and `protobufjs`.
- `pnpm install --frozen-lockfile` — passed; the only remaining ignored-script warning names the intentionally excluded `cpu-features` and `ssh2` packages.
- `esbuild --version`, `pnpm exec lefthook version`, and direct module-load checks for `protobufjs`, `ssh2`, and `dockerode` — passed; optional native bindings remained absent and JavaScript fallbacks loaded.
- `pnpm build` — passed; the named ECharts chunk and JSON report were emitted, the budget plugin found no breach, and the existing over-500-kB Vite warning remained visible.
- `pnpm check` — passed.
- `pnpm typecheck` — passed (all 7 Turbo tasks).
- `pnpm test` — passed (77 script tests plus all workspace tests: Web 24 files/393 tests, Server 42/292, Client 45/555, Shared 15/88, CLI 15/153).
- `pnpm --filter @opentag/server test:integration` — skipped as directed because it requires a running PostgreSQL instance.

## Breaking changes

`pnpm install` now runs the `esbuild`, `lefthook`, and `protobufjs` lifecycle scripts that were previously ignored. These scripts can fetch or link platform binaries and perform the protobufjs compatibility check. The optional native `cpu-features` and `ssh2` scripts remain disabled, so their JavaScript fallback behavior is unchanged.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [ ] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no canonical documentation files changed).

---

*Produced by codex under `/dispatch-codex` run `ea55b2`, lane `dx-ea55b2-5`, running with approvals and sandbox bypassed inside an isolated git worktree. Verified by the orchestrator before publishing: worktree clean, commits present, and `pnpm check` / `pnpm typecheck` / `pnpm test` / `pnpm build` all pass on Node v24.18.0.*
