### PR TITLE
test: fix unit coverage measurement and harness result semantics

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck": "turbo run typecheck",
     "test": "node --test --test-concurrency=1 scripts/__tests__/*.test.mjs && turbo run test --concurrency=2",
     "test:e2e:doctor-docker": "node scripts/e2e/doctor-docker.mjs",
-    "test:coverage": "pnpm build && vitest run --config vitest.coverage.config.ts --maxWorkers=1",
+    "test:coverage": "pnpm build && node scripts/unit-coverage.mjs",
     "check:node-compat": "pnpm build && pnpm test && node scripts/node-compat-smoke.mjs",
     "notices:write": "node scripts/third-party-notices.mjs --write"
   },

--- a/packages/server/src/__tests__/support/unit-database.ts
+++ b/packages/server/src/__tests__/support/unit-database.ts
@@ -26,11 +26,12 @@ const migrationsFolder = fileURLToPath(new URL("../../../drizzle", import.meta.u
 
 export interface UnitDatabase {
   /**
-   * A Drizzle client over the embedded engine, typed as the `postgres-js` client the services accept.
+   * A Drizzle client over the embedded engine, presented as the `postgres-js` client services accept.
    *
-   * The two drivers expose the same query-builder surface; they differ only in the connection they
-   * carry, which no service touches. The cast keeps every service callable from a test without
-   * widening its production signature to accommodate a test driver.
+   * The query builders match, but the two drivers disagree on one thing: `postgres-js` resolves
+   * `execute()` to the rows themselves, while PGlite resolves it to a `{ rows, fields, command, ... }`
+   * envelope. A service that reads the result directly would therefore need a shape check that is dead
+   * code in production, so the difference is absorbed here instead - see `asPostgresJsClient`.
    */
   readonly database: DatabaseClient;
   /** The raw engine, for the rare assertion that needs SQL the query builder cannot express. */
@@ -53,10 +54,53 @@ export async function createUnitDatabase(): Promise<UnitDatabase> {
 
   return {
     close: () => engine.close(),
-    database: database as unknown as DatabaseClient,
+    database: asPostgresJsClient(database),
     engine,
     reset: () => truncateApplicationTables(engine),
   };
+}
+
+/**
+ * Presents a PGlite Drizzle client with `postgres-js` result semantics.
+ *
+ * `postgres-js` resolves `execute()` to an array of rows; PGlite resolves it to an envelope holding
+ * those rows under `rows`. Production code is written against the former, and the driver difference is
+ * an artifact of the test harness, so it is unwrapped here. The alternative - a shape check inside each
+ * service - adds a production branch that only ever runs under test, and silently returning `[]` from
+ * such a check would turn an unexpected driver result into an empty page instead of a failure.
+ *
+ * Transactions get the same treatment: the object handed to a `transaction()` callback is a session in
+ * its own right and carries its own `execute()`.
+ */
+function asPostgresJsClient<T extends object>(client: T): DatabaseClient {
+  return new Proxy(client, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+
+      if (property === "execute" && typeof value === "function") {
+        return async (...args: unknown[]) => unwrapRows(await value.apply(target, args));
+      }
+
+      if (property === "transaction" && typeof value === "function") {
+        return (callback: (transaction: unknown) => unknown, ...rest: unknown[]) =>
+          value.call(target, (transaction: object) => callback(asPostgresJsClient(transaction)), ...rest);
+      }
+
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as unknown as DatabaseClient;
+}
+
+function unwrapRows(result: unknown): unknown {
+  if (
+    result &&
+    !Array.isArray(result) &&
+    typeof result === "object" &&
+    Array.isArray((result as { rows?: unknown }).rows)
+  ) {
+    return (result as { rows: unknown[] }).rows;
+  }
+  return result;
 }
 
 /**

--- a/packages/server/src/__tests__/unit-database.test.ts
+++ b/packages/server/src/__tests__/unit-database.test.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { users } from "../db/schema/index.js";
 import { createUnitDatabase, type UnitDatabase } from "./support/unit-database.js";
@@ -47,6 +47,25 @@ describe("unit database harness", () => {
     ).rejects.toThrow("forced rollback");
 
     expect(await unitDatabase.database.select().from(users)).toHaveLength(0);
+  });
+
+  it("resolves execute() to rows, the way postgres-js does", async () => {
+    // PGlite's own driver resolves to a { rows, fields, command, ... } envelope. Services are written
+    // against postgres-js, so the harness unwraps it; without this a service would need a shape check
+    // that never runs in production.
+    const rows = await unitDatabase.database.execute(sql`select 1 as one, 2 as two`);
+
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows[0]).toEqual({ one: 1, two: 2 });
+  });
+
+  it("resolves execute() to rows inside a transaction too", async () => {
+    await unitDatabase.database.transaction(async (transaction) => {
+      const rows = await transaction.execute(sql`select 3 as three`);
+
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows[0]).toEqual({ three: 3 });
+    });
   });
 
   it("clears application data between tests without losing the schema", async () => {

--- a/scripts/unit-coverage.mjs
+++ b/scripts/unit-coverage.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+/**
+ * Measures unit-test line coverage one workspace at a time.
+ *
+ * Running every Vitest project in a single pass and letting the coverage provider merge the results
+ * under-reports: the `include` list spans all five workspaces, so each project's `all: true` sweep
+ * emits a zero-coverage entry for every *other* workspace's files, and the merge does not reliably
+ * keep the covered lines a different project already recorded. Files that are fully executed the
+ * moment they are imported showed the damage most clearly -- the Drizzle table declarations in
+ * `packages/server/src/db/schema` reported between 49% and 83% merged, and 100% on their own.
+ *
+ * So each project runs alone here, with `include` narrowed to the workspace that project actually
+ * tests. Every file is then measured exactly once, by the only suite that can execute it, and the
+ * per-workspace summaries are concatenated rather than merged.
+ *
+ * Usage:
+ *   node scripts/unit-coverage.mjs                 # every workspace, then the aggregate table
+ *   node scripts/unit-coverage.mjs --project server  # one workspace, for a fast inner loop
+ *   node scripts/unit-coverage.mjs --scope 'packages/server/src/services/im-bindings/**'
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Each Vitest project alongside the workspace whose sources it is the only suite able to execute. */
+const PROJECTS = [
+  { name: "cli", sources: "apps/cli/src" },
+  { name: "web", sources: "apps/web/src" },
+  { name: "shared", sources: "packages/shared/src" },
+  { name: "client", sources: "packages/client/src" },
+  { name: "server", sources: "packages/server/src" },
+];
+
+const COVERAGE_ROOT = resolve(repositoryRoot, "coverage/unit");
+
+function parseArguments(argv) {
+  const options = { project: null, scope: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--project") {
+      options.project = argv[index + 1];
+      index += 1;
+    } else if (argv[index] === "--scope") {
+      options.scope = argv[index + 1];
+      index += 1;
+    }
+  }
+  return options;
+}
+
+function runProject(project, scope) {
+  const reportsDirectory = resolve(COVERAGE_ROOT, project.name);
+  mkdirSync(reportsDirectory, { recursive: true });
+
+  const include = scope ?? `${project.sources}/**/*.{ts,tsx}`;
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "vitest",
+      "run",
+      "--config",
+      "vitest.coverage.config.ts",
+      "--project",
+      project.name,
+      `--coverage.include=${include}`,
+      "--coverage.reporter=json-summary",
+      "--coverage.reporter=text-summary",
+      `--coverage.reportsDirectory=${reportsDirectory}`,
+    ],
+    { cwd: repositoryRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  const summaryPath = resolve(reportsDirectory, "coverage-summary.json");
+  if (!existsSync(summaryPath)) {
+    process.stderr.write(result.stdout ?? "");
+    process.stderr.write(result.stderr ?? "");
+    throw new Error(`Coverage run for project "${project.name}" produced no summary`);
+  }
+
+  return {
+    failed: result.status !== 0,
+    summary: JSON.parse(readFileSync(summaryPath, "utf8")),
+  };
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const selected = options.project ? PROJECTS.filter((entry) => entry.name === options.project) : PROJECTS;
+
+  if (selected.length === 0) {
+    throw new Error(`Unknown project "${options.project}". Known: ${PROJECTS.map((p) => p.name).join(", ")}`);
+  }
+
+  const aggregate = {};
+  const perProject = [];
+  let anyFailed = false;
+
+  for (const project of selected) {
+    process.stdout.write(`\n── ${project.name} ──\n`);
+    const { failed, summary } = runProject(project, options.scope);
+    anyFailed ||= failed;
+
+    for (const [file, metrics] of Object.entries(summary)) {
+      if (file !== "total") {
+        aggregate[file] = metrics;
+      }
+    }
+    perProject.push({ lines: summary.total.lines, name: project.name });
+    const { covered, total, pct } = summary.total.lines;
+    process.stdout.write(`   lines ${pct}% (${covered}/${total})${failed ? "  [tests failed]" : ""}\n`);
+  }
+
+  const totals = Object.values(aggregate).reduce(
+    (accumulator, metrics) => ({
+      branchesCovered: accumulator.branchesCovered + metrics.branches.covered,
+      branchesTotal: accumulator.branchesTotal + metrics.branches.total,
+      functionsCovered: accumulator.functionsCovered + metrics.functions.covered,
+      functionsTotal: accumulator.functionsTotal + metrics.functions.total,
+      linesCovered: accumulator.linesCovered + metrics.lines.covered,
+      linesTotal: accumulator.linesTotal + metrics.lines.total,
+    }),
+    {
+      branchesCovered: 0,
+      branchesTotal: 0,
+      functionsCovered: 0,
+      functionsTotal: 0,
+      linesCovered: 0,
+      linesTotal: 0,
+    },
+  );
+
+  const percentage = (covered, total) => (total === 0 ? 100 : Number(((100 * covered) / total).toFixed(2)));
+  aggregate.total = {
+    branches: {
+      covered: totals.branchesCovered,
+      pct: percentage(totals.branchesCovered, totals.branchesTotal),
+      total: totals.branchesTotal,
+    },
+    functions: {
+      covered: totals.functionsCovered,
+      pct: percentage(totals.functionsCovered, totals.functionsTotal),
+      total: totals.functionsTotal,
+    },
+    lines: {
+      covered: totals.linesCovered,
+      pct: percentage(totals.linesCovered, totals.linesTotal),
+      total: totals.linesTotal,
+    },
+    statements: {
+      covered: totals.linesCovered,
+      pct: percentage(totals.linesCovered, totals.linesTotal),
+      total: totals.linesTotal,
+    },
+  };
+
+  if (!options.project && !options.scope) {
+    mkdirSync(COVERAGE_ROOT, { recursive: true });
+    writeFileSync(resolve(COVERAGE_ROOT, "coverage-summary.json"), `${JSON.stringify(aggregate, null, 2)}\n`);
+  }
+
+  process.stdout.write("\n=== unit line coverage ===\n");
+  for (const entry of perProject) {
+    process.stdout.write(
+      `${entry.name.padEnd(8)} ${String(entry.lines.pct).padStart(6)}%  ${entry.lines.covered}/${entry.lines.total}\n`,
+    );
+  }
+  process.stdout.write(
+    `${"TOTAL".padEnd(8)} ${String(aggregate.total.lines.pct).padStart(6)}%  ` +
+      `${aggregate.total.lines.covered}/${aggregate.total.lines.total}\n`,
+  );
+
+  if (anyFailed) {
+    process.stderr.write("\nAt least one project reported failing tests.\n");
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
Two changes that unit-test coverage work depends on, kept separate from the tests themselves because both touch shared tooling and one of them changes a number the team reads.

## 1. Unit coverage was being measured wrong

`vitest.coverage.config.ts` ran all five projects in a single pass and let the coverage provider merge the results. The `include` list spans every workspace, so each project's `all: true` sweep emitted a zero-coverage entry for every *other* workspace's files, and the merge did not reliably keep covered lines that a different project had already recorded.

The Drizzle table declarations showed it plainly. Those files execute fully the moment they are imported, so they can only be 100%:

| file | merged run | measured alone |
| --- | --- | --- |
| `db/schema/im-bindings.ts` | 49.32% | 100% |
| `db/schema/sessions.ts` | 52.03% | 100% |
| `db/schema/agents.ts` | 52.94% | 100% |
| `db/schema/computers.ts` | 60.69% | 100% |

`scripts/unit-coverage.mjs` now runs each project by itself with `include` narrowed to the workspace that project tests, so every file is measured once by the only suite that can execute it, and the per-workspace summaries are concatenated rather than merged. `pnpm test:coverage` calls it; the output shape (`coverage/unit/coverage-summary.json`) is unchanged, and the scheduled `Unit Coverage` workflow needs no edit.

It also takes `--project <name>` and `--scope <glob>` for a fast inner loop while writing tests.

**The reported baseline moves from 74.01% to 74.93%.** Nothing was tested differently; the old number was simply too low.

## 2. The unit database harness now matches postgres-js result semantics

`packages/server/src/__tests__/support/unit-database.ts` (already on `main`) gives server unit tests a real PostgreSQL via PGlite, in-process — no Docker, no port, no external service.

One driver difference leaked: `postgres-js` resolves `execute()` to the rows themselves, while PGlite resolves it to a `{ rows, fields, command, ... }` envelope. Left alone, that pushes a shape check into every service that calls `execute()` — a branch that is dead code in production. Two agents writing tests against this harness did exactly that, and one of them wrote a fallback returning `[]`, which would turn an unexpected driver result into an empty page instead of a failure.

The difference belongs to the harness, so the harness absorbs it, transactions included. Services keep one query path. Two regression tests pin the contract.

## Verification

- `pnpm check` — pass
- `pnpm typecheck` — pass
- `pnpm test` — pass
- `pnpm test:coverage` — pass, 74.93% baseline

---

*Dispatched as run `0af99c`. Written by Claude as orchestrator, not by a lane agent — the ten coverage lanes in that run build on this.*
