### PR TITLE
feat(server): let an Account re-board without taking anything down

### DIFF
--- a/packages/server/src/__tests__/account-api.test.ts
+++ b/packages/server/src/__tests__/account-api.test.ts
@@ -139,9 +139,13 @@ function services() {
   };
 }
 
-function appWith(overrides: Partial<ReturnType<typeof services>> = {}) {
+function appWith(
+  overrides: Partial<ReturnType<typeof services>> = {},
+  setupReset?: { reboard: ReturnType<typeof vi.fn>; resetOnboarding: ReturnType<typeof vi.fn> },
+) {
   const service = { ...services(), ...overrides };
   const app = createApp({
+    ...(setupReset ? { stagingOnboardingLab: { reset: setupReset as never } } : {}),
     authService: authService(),
     agentService: service.agentService as unknown as AgentService,
     machineAuthService: service.machineAuthService as unknown as MachineAuthService,
@@ -153,6 +157,81 @@ function appWith(overrides: Partial<ReturnType<typeof services>> = {}) {
   apps.push(app);
   return { app, service };
 }
+
+describe("undoing setup on the authenticated Account", () => {
+  function resetService() {
+    return { reboard: vi.fn().mockResolvedValue(undefined), resetOnboarding: vi.fn().mockResolvedValue(undefined) };
+  }
+
+  it("routes each mode to the operation it names", async () => {
+    const setupReset = resetService();
+    const { app } = appWith({}, setupReset);
+
+    const all = await app.inject({
+      method: "POST",
+      url: HTTP_PATHS.accountSetupReset,
+      headers: authorization,
+      payload: { mode: "all" },
+    });
+    expect(all.statusCode).toBe(204);
+    expect(setupReset.resetOnboarding).toHaveBeenCalledWith(userId);
+    expect(setupReset.reboard).not.toHaveBeenCalled();
+
+    const reboard = await app.inject({
+      method: "POST",
+      url: HTTP_PATHS.accountSetupReset,
+      headers: authorization,
+      payload: { mode: "reboard" },
+    });
+    expect(reboard.statusCode).toBe(204);
+    expect(setupReset.reboard).toHaveBeenCalledWith(userId);
+    expect(setupReset.resetOnboarding).toHaveBeenCalledTimes(1);
+  });
+
+  it("takes the Account from the token, so no body can name another one", async () => {
+    const setupReset = resetService();
+    const { app } = appWith({}, setupReset);
+
+    const response = await app.inject({
+      method: "POST",
+      url: HTTP_PATHS.accountSetupReset,
+      headers: authorization,
+      payload: { mode: "reboard", accountId: "11111111-1111-4111-8111-111111111111" },
+    });
+
+    // Rejected outright rather than ignored: a caller who thought they were choosing an Account
+    // should be told they were not.
+    expect(response.statusCode).toBe(400);
+    expect(setupReset.reboard).not.toHaveBeenCalled();
+  });
+
+  it("requires authentication", async () => {
+    const setupReset = resetService();
+    const { app } = appWith({}, setupReset);
+
+    const response = await app.inject({
+      method: "POST",
+      url: HTTP_PATHS.accountSetupReset,
+      payload: { mode: "reboard" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(setupReset.reboard).not.toHaveBeenCalled();
+  });
+
+  it("is not registered when the deployment does not offer it", async () => {
+    const { app } = appWith();
+
+    const response = await app.inject({
+      method: "POST",
+      url: HTTP_PATHS.accountSetupReset,
+      headers: authorization,
+      payload: { mode: "reboard" },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+});
 
 describe("Account-native management collections", () => {
   it("lists and reads read-only Tasks in the authenticated Account scope", async () => {

--- a/packages/server/src/__tests__/integration/onboarding-lab-reset.test.ts
+++ b/packages/server/src/__tests__/integration/onboarding-lab-reset.test.ts
@@ -488,6 +488,9 @@ describe("staging Onboarding Lab reset", () => {
 
       await expect(guarded.resetOnboarding(value.lab.accountId)).rejects.toMatchObject({ statusCode: 404 });
       await expect(guarded.resetOnboarding(other.accountId)).rejects.toMatchObject({ statusCode: 404 });
+      // Re-boarding is the lighter operation, not the less guarded one.
+      await expect(guarded.reboard(value.lab.accountId)).rejects.toMatchObject({ statusCode: 404 });
+      await expect(guarded.reboard(other.accountId)).rejects.toMatchObject({ statusCode: 404 });
     }
 
     expect((await facts(value.database, value.lab)).activeAgents).toBe(1);
@@ -628,5 +631,32 @@ describe("staging Onboarding Lab reset", () => {
 
     const [row] = await value.database.select().from(users).where(eq(users.id, empty.id));
     expect(row?.setupCompletedAt).toBeNull();
+  });
+});
+
+describe("re-boarding an Account without taking anything down", () => {
+  it("clears setup completion and keeps every resource the Account has", async () => {
+    const value = await fixture();
+    const before = await facts(value.database, value.lab);
+    expect(before).toMatchObject({ activeAgents: 1, activeBindings: 1, openSessions: 1, ownedComputers: 1 });
+    expect(before.accountSetupCompletedAt).not.toBeNull();
+    expect(before.activeCredentials).toBeGreaterThan(0);
+
+    await value.reset.reboard(value.lab.accountId);
+
+    const after = await facts(value.database, value.lab);
+    // The whole point: onboarding is reachable again, and nothing had to be rebuilt to get there.
+    expect(after.accountSetupCompletedAt).toBeNull();
+    expect(after).toMatchObject({
+      activeAgents: before.activeAgents,
+      activeBindings: before.activeBindings,
+      openSessions: before.openSessions,
+      ownedComputers: before.ownedComputers,
+      // Still enrolled: the machine token survives, so the Computer is not connected again.
+      activeCredentials: before.activeCredentials,
+    });
+    expect(after.binding).toMatchObject({ status: before.binding?.status });
+    // A reset closes the live enrollment; re-boarding has no reason to.
+    expect(value.closeEnrollment).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/api/account.ts
+++ b/packages/server/src/api/account.ts
@@ -1,5 +1,6 @@
 import {
   AccountComputerConnectCodeIssueRequestSchema,
+  AccountSetupResetRequestSchema,
   AgentAdminConfigSchema,
   type ChannelName,
   CompleteWorkspaceSetupRequestSchema,
@@ -50,8 +51,19 @@ export interface AccountRoutesOptions {
   computerService?: ComputerService;
   machineAuthService?: MachineAuthService;
   authOptions?: UserAuthPreHandlerOptions;
+  /**
+   * Undoing setup so onboarding can be walked again. Staging decides whether it exists at all, and
+   * the service answers a request outside staging exactly like a path that was never registered.
+   */
+  setupResetService?: AccountSetupResetService;
   taskService?: TaskService;
   workspaceSetupService?: WorkspaceSetupService;
+}
+
+/** The two ways to undo setup. Both act on the authenticated Account and never a chosen one. */
+export interface AccountSetupResetService {
+  reboard(accountId: string): Promise<void>;
+  resetOnboarding(accountId: string): Promise<void>;
 }
 
 function accountId(request: FastifyRequest): string {
@@ -151,6 +163,23 @@ export function registerAccountRoutes(
             await workspaceSetupService.completeForAccount(accountId(request), agentId),
           ),
         );
+    });
+  }
+
+  if (options.setupResetService) {
+    const setupResetService = options.setupResetService;
+
+    /*
+     * Reflexive by construction: the Account comes from the access token, and the body carries only
+     * how much to undo. There is no field here that could name somebody else's Account, which is
+     * what makes this safe to offer to every signed-in tester rather than to administrators.
+     */
+    app.post(HTTP_PATHS.accountSetupReset, { preHandler }, async (request, reply) => {
+      const { mode } = parseRequest(AccountSetupResetRequestSchema, request.body);
+      const account = accountId(request);
+      if (mode === "all") await setupResetService.resetOnboarding(account);
+      else await setupResetService.reboard(account);
+      return reply.code(204).send();
     });
   }
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -239,6 +239,8 @@ export function createApp(options: CreateAppOptions = {}) {
         ...(options.machineAuthService ? { machineAuthService: options.machineAuthService } : {}),
         ...(options.workspaceSetupService ? { workspaceSetupService: options.workspaceSetupService } : {}),
         ...(options.taskService ? { taskService: options.taskService } : {}),
+        // Same service the Lab exposes, on a path that does not depend on the Lab existing.
+        ...(options.stagingOnboardingLab ? { setupResetService: options.stagingOnboardingLab.reset } : {}),
         authOptions,
       });
     }

--- a/packages/server/src/services/onboarding-lab/onboarding-reset-service.ts
+++ b/packages/server/src/services/onboarding-lab/onboarding-reset-service.ts
@@ -85,6 +85,23 @@ export class OnboardingResetService {
     return this.#environment === "staging";
   }
 
+  /**
+   * Clear the setup marker and nothing else, so onboarding can be walked again.
+   *
+   * There is no cleanup to verify here, which is the whole difference: the Agents, Computers and
+   * messaging connections the Account already has are exactly what it keeps. That makes the next
+   * run a resume rather than a first run — anyone who needs first-run behaviour wants
+   * `resetOnboarding` instead.
+   */
+  async reboard(accountId: string): Promise<void> {
+    if (!this.enabled) throw resourceNotFound();
+    const now = this.#now();
+    await this.#database.transaction(async (transaction) => {
+      await lockActiveAccount(transaction, accountId);
+      await transaction.update(users).set({ setupCompletedAt: null, updatedAt: now }).where(eq(users.id, accountId));
+    });
+  }
+
   async resetOnboarding(accountId: string): Promise<void> {
     if (!this.enabled) throw resourceNotFound();
     await this.#deleteOwnedAgents(accountId);

--- a/packages/shared/src/http-paths.ts
+++ b/packages/shared/src/http-paths.ts
@@ -36,6 +36,7 @@ export const ACCOUNT_AGENTS_PATH = `${API_V1_PREFIX}/agents`;
 export const ACCOUNT_COMPUTERS_PATH = `${API_V1_PREFIX}/computers`;
 export const ACCOUNT_COMPUTER_CONNECT_CODES_PATH = `${API_V1_PREFIX}/computer-connect-codes`;
 export const ACCOUNT_SETUP_COMPLETE_PATH = `${API_V1_PREFIX}/me/setup/complete`;
+export const ACCOUNT_SETUP_RESET_PATH = `${API_V1_PREFIX}/me/setup/reset`;
 export const ACCOUNT_TASKS_PATH = `${API_V1_PREFIX}/sessions`;
 export const TASK_BY_ID_TEMPLATE = `${ACCOUNT_TASKS_PATH}/:sessionId`;
 
@@ -44,6 +45,7 @@ export const HTTP_PATHS = {
   accountComputerConnectCodes: ACCOUNT_COMPUTER_CONNECT_CODES_PATH,
   accountComputers: ACCOUNT_COMPUTERS_PATH,
   accountSetupComplete: ACCOUNT_SETUP_COMPLETE_PATH,
+  accountSetupReset: ACCOUNT_SETUP_RESET_PATH,
   accountTasks: ACCOUNT_TASKS_PATH,
   agentById: AGENT_BY_ID_TEMPLATE,
   slackEvents: SLACK_EVENTS_PATH,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -380,6 +380,10 @@ export * from "./session-cli.js";
 export * from "./sign-in-destination.js";
 export * from "./task.js";
 export {
+  type AccountSetupResetMode,
+  AccountSetupResetModeSchema,
+  type AccountSetupResetRequest,
+  AccountSetupResetRequestSchema,
   type CompleteWorkspaceSetupRequest,
   CompleteWorkspaceSetupRequestSchema,
   type ListWorkspaceComputersResponse,

--- a/packages/shared/src/workspace.ts
+++ b/packages/shared/src/workspace.ts
@@ -7,6 +7,22 @@ import {
 } from "./computer.js";
 
 export const CompleteWorkspaceSetupRequestSchema = z.object({ agentId: z.string().uuid() }).strict();
+
+/**
+ * How much of an Account to undo so onboarding can be walked again.
+ *
+ * `all` returns the Account to a genuine first run: the Agents it created, its Computer
+ * enrollments and its messaging connections are all taken down before setup is cleared, so the
+ * next run has nothing to resume from.
+ *
+ * `reboard` clears only the setup marker. Everything the Account owns stays, which is the point —
+ * it makes onboarding repeatable without making the tester rebuild an Agent and re-enroll a
+ * machine first. Because those resources survive, the next run resumes into them rather than
+ * exercising first-run creation.
+ */
+export const AccountSetupResetModeSchema = z.enum(["all", "reboard"]);
+
+export const AccountSetupResetRequestSchema = z.object({ mode: AccountSetupResetModeSchema }).strict();
 export const WorkspaceSetupCompletionSchema = z.object({ setupCompletedAt: z.string().datetime() }).strict();
 
 export const WorkspaceComputerSummarySchema = z
@@ -30,6 +46,8 @@ export const ListWorkspaceComputersResponseSchema = z
   .strict();
 
 export type CompleteWorkspaceSetupRequest = z.infer<typeof CompleteWorkspaceSetupRequestSchema>;
+export type AccountSetupResetMode = z.infer<typeof AccountSetupResetModeSchema>;
+export type AccountSetupResetRequest = z.infer<typeof AccountSetupResetRequestSchema>;
 export type WorkspaceSetupCompletion = z.infer<typeof WorkspaceSetupCompletionSchema>;
 export type WorkspaceComputerSummary = z.infer<typeof WorkspaceComputerSummarySchema>;
 export type ListWorkspaceComputersResponse = z.infer<typeof ListWorkspaceComputersResponseSchema>;


### PR DESCRIPTION
## What

Getting back into onboarding cost an Account everything it had.

The only operation that cleared the setup marker also deleted every Agent the Account created, revoked its Computers' credentials and disabled its messaging bindings. Looking at onboarding a second time therefore meant rebuilding an Agent and re-enrolling a machine first.

That operation is still right for a genuine first run and is unchanged. Beside it there is now a lighter one:

| | reset all | re-board |
|---|---|---|
| Agents | deleted | **kept** |
| Computer enrollments | revoked | **kept** |
| Messaging bindings | disabled | **kept** |
| Setup marker | cleared | cleared |

## Where it lives

`POST /api/v1/me/setup/reset` with `{ "mode": "all" | "reboard" }` — a sibling of the `me/setup/complete` path that was already there.

Deliberately **not** behind the staging Onboarding Lab. @liuchao-001 has said the Lab is on its way out; a capability meant to outlive that page should not be reached through it. The Lab's own endpoint is untouched by this change and can be retired with the rest of it.

## Safety properties, kept from the existing reset

- **Reflexive.** The Account comes from the access token; the body carries only how much to undo. There is no field a caller could use to name another Account — and a body that tries is **rejected**, not ignored, because a caller who believed they were choosing an Account should be told they were not.
- **Staging only.** Outside staging both modes answer exactly like a path that was never registered, and the route is not registered at all where the deployment does not offer it.

## Worth knowing before using it

Re-boarding leaves the Account's resources in place, so the next run **resumes into them** rather than exercising first-run creation. Anyone testing first-run behaviour specifically still wants `mode: "all"`. The tests state that difference directly rather than leaving it implied.

## How to invoke it while there is no UI

Signed in on staging, from the browser console:

```js
await fetch("/api/v1/me/setup/reset", {
  method: "POST",
  headers: { "content-type": "application/json" },
  body: JSON.stringify({ mode: "reboard" }),
});
```

Then open `/onboarding`.

## Verification

`pnpm check`, `pnpm build` clean. Shared 88, server 300, web 536 — all passing.

Each new test was checked against its own mutation rather than trusted for being green:

- make `reboard` not clear the marker → the keep-everything test fails
- swap the two modes in the route → the mode-routing test fails

⚠️ Two things a reviewer should know:

1. **`@opentag/client` has failing tests on my machine**, in packages this change does not touch (shared and server only). The failures differ between runs — a different set of six, then ten, one taking 227s — so they read as local resource contention, not a regression. CI is the arbiter.
2. **`onboarding-lab-reset.test.ts` is at a connection ceiling.** Every `fixture()` opens a database client and none are closed, so adding a second fixture to that file fails with `sorry, too many clients already`. I worked within it by folding the staging-guard assertion into the existing guard test rather than adding a fixture, but the next person to add a test there will hit the same wall.
