### PR TITLE
feat(web): raise the Agents surface's primary controls

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1995,22 +1995,35 @@ describe("OpenTag Web App Shell", () => {
     expect(link.getAttribute("data-ui")).toBe("agent-messaging-link");
     expect(link.textContent).toContain("Slack");
     expect(link.getAttribute("href")).toBe(`/agents/${agentId}/settings/messaging`);
-    // The gear is what says this control manages the channel rather than only naming it.
-    expect(link.querySelectorAll("svg")).toHaveLength(1);
+    /*
+     * The gear is what says this control manages the channel rather than only naming it, and it
+     * trails the label. Asserted by its own hook rather than by counting glyphs: a glyph count
+     * happens to equal one today only because the provider mark is an `img`, so it would stop
+     * guarding the gear the day `ProviderIcon` renders an svg.
+     */
+    const manage = link.querySelector('[data-ui="agent-messaging-manage"]');
+    expect(manage).toBeTruthy();
+    expect(link.lastElementChild).toBe(manage);
     const connectedClassName = link.className;
     expect(connectedClassName).toMatch(/\bh-\d/);
     connected.unmount();
 
-    installApi({ bound: false });
-    window.history.replaceState({}, "", `/agents/${agentId}`);
-    render(<App />);
-
-    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    const unconnected = screen.getByRole("link", { name: "Connect messaging" });
-    expect(unconnected.getAttribute("data-ui")).toBe("agent-messaging-link");
-    expect(unconnected.textContent).toContain("Connect messaging");
     // Same control, same size: the header must not resize as the messaging state changes.
-    expect(unconnected.className).toBe(connectedClassName);
+    for (const state of [{ bound: false }, { bound: true, bindingEvidenceFails: true }]) {
+      installApi(state);
+      window.history.replaceState({}, "", `/agents/${agentId}`);
+      const rendered = render(<App />);
+
+      expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+      const control = screen.getByRole("link", {
+        name: state.bound ? "Messaging status unavailable" : "Connect messaging",
+      });
+      expect(control.getAttribute("data-ui")).toBe("agent-messaging-link");
+      expect(control.textContent).toContain(state.bound ? "Messaging status unavailable" : "Connect messaging");
+      expect(control.querySelector('[data-ui="agent-messaging-manage"]')).toBe(control.lastElementChild);
+      expect(control.className).toBe(connectedClassName);
+      rendered.unmount();
+    }
   });
 
   it("offers messaging setup only when the missing binding is confirmed", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -544,7 +544,8 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByText("Example")).toBeNull();
     const agentLink = await screen.findByRole("link", { name: "Open Reviewer" });
     const createAgent = screen.getByRole("button", { name: "New Agent" });
-    expect(createAgent.closest('[data-ui="page-header"]')).toBeTruthy();
+    expect(createAgent.closest('[data-ui="page-header"]')).toBeNull();
+    expect(createAgent.closest('[data-ui="agents-page-action"]')).toBeTruthy();
     const agentCard = agentLink.closest('[data-ui="agent-card"]');
     expect(agentCard).toBeTruthy();
     expect(screen.queryByText(/Monitor availability/)).toBeNull();
@@ -554,12 +555,20 @@ describe("OpenTag Web App Shell", () => {
     expect(within(agentCard as HTMLElement).getByText("Tasks")).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("Tokens")).toBeTruthy();
     expect(within(agentCard as HTMLElement).getByText("428K")).toBeTruthy();
-    expect(within(agentCard as HTMLElement).getByText("Messaging disconnected")).toBeTruthy();
+    const cardState = (agentCard as HTMLElement).querySelector('[data-ui="agent-card-state"]');
+    expect(cardState).toBeTruthy();
+    expect(within(cardState as HTMLElement).getByText("Messaging disconnected")).toBeTruthy();
+    expect(within(cardState as HTMLElement).getByText("Cannot receive new work")).toBeTruthy();
+    // The card reports the failure and nothing else; opening the Agent is its only follow-up.
+    expect(within(agentCard as HTMLElement).queryByRole("link", { name: "Connect messaging" })).toBeNull();
     expect(
       within(agentCard as HTMLElement)
-        .getByRole("link", { name: "Connect messaging" })
-        .getAttribute("href"),
-    ).toBe(`/agents/${agentId}/settings/messaging`);
+        .getAllByRole("link")
+        .map((item) => item.getAttribute("href")),
+    ).toEqual([`/agents/${agentId}`]);
+    expect(
+      (agentCard as HTMLElement).querySelector('[data-ui="agent-card-identity-copy"] [data-ui="agent-card-state"]'),
+    ).toBe(cardState);
     expect(screen.queryByText("Ada's Mac · macOS")).toBeNull();
     expect(screen.queryByText("Mentions only")).toBeNull();
     const workspaceNavigation = screen.getByRole("navigation", { name: "Product" });
@@ -593,7 +602,7 @@ describe("OpenTag Web App Shell", () => {
     expect(within(status as HTMLElement).getByText("Started 8m ago")).toBeTruthy();
   });
 
-  it("keeps an offline reason and its Computer exit together in the Agent status", async () => {
+  it("states an offline reason under the Agent name and carries no exit of its own", async () => {
     installApi({
       bound: true,
       computerStatus: () => "offline",
@@ -601,23 +610,22 @@ describe("OpenTag Web App Shell", () => {
     });
     render(<App />);
 
-    const agentCard = (await screen.findByRole("link", { name: "Open Reviewer" })).closest('[data-ui="agent-card"]');
+    const open = await screen.findByRole("link", { name: "Open Reviewer" });
+    const agentCard = open.closest('[data-ui="agent-card"]');
     expect(agentCard).toBeTruthy();
     const status = within(agentCard as HTMLElement)
       .getByText("Computer offline")
       .closest("[data-state]");
     expect(status).toBeTruthy();
     expect(within(status as HTMLElement).getByText("Cannot receive new work")).toBeTruthy();
-    const exit = within(status as HTMLElement).getByRole("link", { name: "View Computer" });
-    expect(exit.getAttribute("href")).toBe(`/agents/${agentId}/settings/computer`);
+    // The status reads directly under the name it belongs to, inside the card's identity block.
+    expect((status as HTMLElement).closest('[data-ui="agent-card-identity-copy"]')).toBeTruthy();
     /*
-     * The exit is inline text, not a button. It sits inside the status sentence, so a control with
-     * its own height and padding breaks the line and leaves the separator dangling. Two rebuilds of
-     * this card have now reached for the button class, so the property is asserted here rather than
-     * left to be noticed on screen.
+     * No recovery exit beside the reason. Which page repairs an offline Computer is the Agent's
+     * business, so the card states the problem and the row link is the single way to follow it.
      */
-    expect(exit.className).toContain("text-kumo-link");
-    expect(exit.className).not.toMatch(/\bh-\d/);
+    expect(within(status as HTMLElement).queryByRole("link")).toBeNull();
+    expect(within(agentCard as HTMLElement).getAllByRole("link")).toEqual([open]);
   });
 
   it("opens the Agent from the row itself rather than from a trailing affordance", async () => {
@@ -633,14 +641,10 @@ describe("OpenTag Web App Shell", () => {
     expect(card).toBeTruthy();
     expect((card as HTMLElement).querySelector('[data-ui="agent-card-action"]')).toBeNull();
     /*
-     * The failure exit is a second link inside the same row. It has to stay a sibling of the row
-     * link rather than a child of it: nesting would be invalid, and wrapping the row in one anchor
-     * is the shortcut that would produce it.
+     * Even a card reporting a broken dependency carries no second link. Where the repair lives
+     * depends on which dependency failed, so the row link is the whole answer: open the Agent.
      */
-    const exit = within(card as HTMLElement).getByRole("link", { name: "Connect messaging" });
-    expect(open.contains(exit)).toBe(false);
-    expect(exit.getAttribute("href")).toBe(`/agents/${agentId}/settings/messaging`);
-    expect(new Set(within(card as HTMLElement).getAllByRole("link"))).toEqual(new Set([open, exit]));
+    expect(within(card as HTMLElement).getAllByRole("link")).toEqual([open]);
   });
 
   it.each(["/", "/agents"])("redirects unauthenticated protected path %s to login", async (path) => {
@@ -824,13 +828,15 @@ describe("OpenTag Web App Shell", () => {
     expect(heading.closest("main")?.getAttribute("data-ui")).toBe("not-found");
   });
 
-  it("uses the page header as the Account owner's sole empty-state action", async () => {
+  it("keeps New Agent under the page title as the Account owner's sole empty-state action", async () => {
     installApi({ emptyAgents: true });
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "No Agents yet" })).toBeTruthy();
     expect(screen.getByText("Create your first shared AI teammate with New Agent.")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "New Agent" }).closest('[data-ui="page-header"]')).toBeTruthy();
+    const createAgent = screen.getByRole("button", { name: "New Agent" });
+    expect(createAgent.closest('[data-ui="page-header"]')).toBeNull();
+    expect(createAgent.closest('[data-ui="agents-page-action"]')).toBeTruthy();
     expect(screen.queryByRole("region", { name: "Agents" })).toBeNull();
   });
 
@@ -1901,7 +1907,7 @@ describe("OpenTag Web App Shell", () => {
 
     computerStatus = "offline";
     fireEvent(window, new Event("focus"));
-    expect(await screen.findByText("This Agent's Computer is offline. Retrying automatically.")).toBeTruthy();
+    expect(await screen.findByText("This agent's computer is offline. Retrying automatically.")).toBeTruthy();
     expect(screen.getByRole("link", { name: "View Computer" })).toBeTruthy();
   });
 
@@ -1935,9 +1941,7 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByText("Claude Code sign-in required")).toBeTruthy();
     expect(screen.getByText("Cannot receive new work")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "View Computer" }).getAttribute("href")).toBe(
-      `/agents/${agentId}/settings/computer`,
-    );
+    expect(screen.queryByRole("link", { name: "View Computer" })).toBeNull();
     expect(screen.queryByText("Available")).toBeNull();
   });
 
@@ -1974,6 +1978,39 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("link", { name: "Connect messaging" })).toBeNull();
     expect(screen.queryByText("Handoff")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("names the messaging channel on one manage control that keeps its shape in every state", async () => {
+    /*
+     * Messaging is what makes an Agent reachable, so this control is read before it is clicked. A
+     * bare provider glyph made a viewer guess at both the channel and what clicking it would do,
+     * and it collapsed to nothing readable when no channel was connected at all.
+     */
+    installApi({ bound: true, provider: "slack" });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    const connected = render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    const link = screen.getByRole("link", { name: /^Slack/ });
+    expect(link.getAttribute("data-ui")).toBe("agent-messaging-link");
+    expect(link.textContent).toContain("Slack");
+    expect(link.getAttribute("href")).toBe(`/agents/${agentId}/settings/messaging`);
+    // The gear is what says this control manages the channel rather than only naming it.
+    expect(link.querySelectorAll("svg")).toHaveLength(1);
+    const connectedClassName = link.className;
+    expect(connectedClassName).toMatch(/\bh-\d/);
+    connected.unmount();
+
+    installApi({ bound: false });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    const unconnected = screen.getByRole("link", { name: "Connect messaging" });
+    expect(unconnected.getAttribute("data-ui")).toBe("agent-messaging-link");
+    expect(unconnected.textContent).toContain("Connect messaging");
+    // Same control, same size: the header must not resize as the messaging state changes.
+    expect(unconnected.className).toBe(connectedClassName);
   });
 
   it("offers messaging setup only when the missing binding is confirmed", async () => {
@@ -2067,8 +2104,8 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Connected channel" })).toBeTruthy();
-    expect(screen.getByText(/Messages wait until Codex is ready on this Agent's Computer\./)).toBeTruthy();
-    expect(screen.queryByText(/until this Agent's Computer is online/)).toBeNull();
+    expect(screen.getByText(/Messages wait until Codex is ready on this agent's computer\./)).toBeTruthy();
+    expect(screen.queryByText(/until this agent's computer is online/)).toBeNull();
   });
 
   it("keeps the delivery explanation neutral when no blocker is observable", async () => {
@@ -2091,7 +2128,7 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Connected channel" })).toBeTruthy();
-    expect(screen.getByText(/Messages wait until this Agent's Computer is online\./)).toBeTruthy();
+    expect(screen.getByText(/Messages wait until this agent's computer is online\./)).toBeTruthy();
   });
 
   it("shows a Messaging error instead of inferring an empty channel", async () => {
@@ -2129,7 +2166,7 @@ describe("OpenTag Web App Shell", () => {
     expect(agentReads).toBe(2);
 
     releaseAgentRead();
-    expect(await screen.findByText("This Agent's Computer is offline. Retrying automatically.")).toBeTruthy();
+    expect(await screen.findByText("This agent's computer is offline. Retrying automatically.")).toBeTruthy();
   });
 
   it("invalidates a stale Agent detail after a background not-found response", async () => {
@@ -2418,7 +2455,7 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByText("Slack")).toBeTruthy();
-    expect(screen.getByText(/Messages wait until Codex is ready on this Agent's Computer\./)).toBeTruthy();
+    expect(screen.getByText(/Messages wait until Codex is ready on this agent's computer\./)).toBeTruthy();
     expect(screen.getByRole("link", { name: "View Computer" }).getAttribute("href")).toBe(
       `/agents/${agentId}/settings/computer`,
     );

--- a/apps/web/src/features/agents/agent-detail-page.tsx
+++ b/apps/web/src/features/agents/agent-detail-page.tsx
@@ -154,7 +154,7 @@ function AgentMessagingLink({ agent }: { agent: AgentDetailView }) {
     >
       {binding ? <ProviderIcon className="size-4 shrink-0" provider={binding.provider} /> : <Icon name="message" />}
       <span className="truncate">{label}</span>
-      <Icon className="text-kumo-subtle" name="settings" />
+      <Icon className="text-kumo-subtle" data-ui="agent-messaging-manage" name="settings" />
     </Link>
   );
 }

--- a/apps/web/src/features/agents/agent-detail-page.tsx
+++ b/apps/web/src/features/agents/agent-detail-page.tsx
@@ -130,8 +130,11 @@ export function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
 }
 
 /**
- * One affordance for messaging, beside Settings. It always opens messaging settings, so a missing
- * binding and unreadable evidence keep their entry point rather than disappearing.
+ * One affordance for messaging, beside Settings. Messaging is what makes an Agent reachable, so this
+ * states the channel rather than hinting at it with a bare provider glyph, and the gear says the
+ * same control manages it. Every state — a live channel, unreadable evidence, nothing connected —
+ * renders the same three-part shape at the same height, so the header does not resize as the state
+ * changes and a missing binding keeps its entry point rather than disappearing.
  */
 function AgentMessagingLink({ agent }: { agent: AgentDetailView }) {
   const binding = agent.messaging.kind === "ready" ? agent.messaging.value : undefined;
@@ -143,12 +146,15 @@ function AgentMessagingLink({ agent }: { agent: AgentDetailView }) {
   return (
     <Link
       aria-label={label}
-      className="grid size-9 place-items-center rounded-md text-kumo-subtle ring ring-kumo-line"
+      className={buttonClassName({ className: "max-w-64", variant: "secondary" })}
+      data-ui="agent-messaging-link"
       state={{ agent, returnAgentId: agent.id, returnLabel: agent.displayName }}
       title={label}
       {...agentSettingsSectionLink(agent.id, "messaging")}
     >
-      {binding ? <ProviderIcon className="size-5" provider={binding.provider} /> : <Icon name="message" />}
+      {binding ? <ProviderIcon className="size-4 shrink-0" provider={binding.provider} /> : <Icon name="message" />}
+      <span className="truncate">{label}</span>
+      <Icon className="text-kumo-subtle" name="settings" />
     </Link>
   );
 }

--- a/apps/web/src/features/agents/agent-presentation.ts
+++ b/apps/web/src/features/agents/agent-presentation.ts
@@ -2,7 +2,6 @@ import type { AgentSummary, ImBindingSummary } from "@opentag/shared/browser";
 import type { StatusTone } from "../../ui/design-system.js";
 import type { AgentAvailability, AgentDetailView, AgentListItem, AgentStatusSource } from "./agent-model.js";
 import { type AgentSettingsSectionLink, agentSettingsSectionLink } from "./agent-routes.js";
-import type { AgentSettingsSection } from "./agent-settings/sections.js";
 
 export const agentAvatarTones = ["brand", "amber", "blue", "neutral"] as const;
 
@@ -15,11 +14,10 @@ export function agentAvatarTone(agentId: string): (typeof agentAvatarTones)[numb
 }
 
 /**
- * Every state a viewer can act on carries the Settings section that explains it. A state without an
- * exit reads as a dead end: the card reports a failure the viewer cannot follow anywhere.
+ * The card states what is true and how urgent it is; it carries no exit of its own. Opening the
+ * Agent is the single follow-up, and the Agent page is where each failed dependency is explained.
  */
 export function agentCardStatus(agent: AgentListItem): {
-  action?: { label: string; section: AgentSettingsSection };
   detail?: string;
   label: string;
   priority: number;
@@ -34,32 +32,18 @@ export function agentCardStatus(agent: AgentListItem): {
     return { detail: "Unable to confirm readiness", label: status.label, priority: 1, tone: status.tone };
   }
   if (agent.availability.state === "action_required") {
-    const action =
-      agent.availability.reason === "computer_offline"
-        ? { label: "View Computer", section: "computer" as const }
-        : agent.availability.reason === "runtime_unavailable"
-          ? // Provider readiness is observed per Computer, so the Computer page is where it is explained.
-            { label: "View Computer", section: "computer" as const }
-          : { label: "View messaging", section: "messaging" as const };
-    return {
-      action,
-      detail: "Cannot receive new work",
-      label: status.label,
-      priority: 0,
-      tone: status.tone,
-    };
+    /*
+     * No recovery exit on the card. What to do about a stuck Agent depends on which dependency
+     * failed, and that explanation lives on the Agent itself; the card states the problem and
+     * lets its own open-the-Agent target carry the viewer to where it can be fixed.
+     */
+    return { detail: "Cannot receive new work", label: status.label, priority: 0, tone: status.tone };
   }
   if (agent.availability.state === "setting_up") {
     return { detail: "Messaging setup in progress", label: status.label, priority: 2, tone: status.tone };
   }
   if (agent.availability.state === "not_connected") {
-    return {
-      action: { label: "Connect messaging", section: "messaging" },
-      detail: "Cannot receive new work",
-      label: status.label,
-      priority: 2,
-      tone: status.tone,
-    };
+    return { detail: "Cannot receive new work", label: status.label, priority: 2, tone: status.tone };
   }
   if (agent.activity.state === "working") {
     return {
@@ -297,7 +281,7 @@ export function agentRecoveryMessage(agent: AgentDetailView): string {
     handoff_unconfirmed: "Could not refresh this Agent's status. Retrying automatically.",
     computer_unconfirmed: "Could not confirm the assigned Computer. Retrying automatically.",
     runtime_unconfirmed: "Could not confirm the assigned Computer. Retrying automatically.",
-    computer_offline: "This Agent's Computer is offline. Retrying automatically.",
+    computer_offline: "This agent's computer is offline. Retrying automatically.",
     runtime_unavailable: runtimeRecoveryMessage(agent),
     im_not_connected: "Connect Feishu or Slack so teammates can send this Agent work.",
     im_provisioning: "The messaging connection is still being set up.",
@@ -316,10 +300,10 @@ export function agentRecoveryMessage(agent: AgentDetailView): string {
 function runtimeRecoveryMessage(agent: AgentDetailView): string {
   const { provider, status } = agent.availability.dependencies.runtime;
   const providerName = runtimeProviderName(provider);
-  if (status === "checking") return `Still checking ${providerName} on this Agent's Computer.`;
-  if (status === "install") return `Install ${providerName} on this Agent's Computer.`;
-  if (status === "sign-in") return `Sign in to ${providerName} on this Agent's Computer.`;
-  return `${providerName} is not available on this Agent's Computer.`;
+  if (status === "checking") return `Still checking ${providerName} on this agent's computer.`;
+  if (status === "install") return `Install ${providerName} on this agent's computer.`;
+  if (status === "sign-in") return `Sign in to ${providerName} on this agent's computer.`;
+  return `${providerName} is not available on this agent's computer.`;
 }
 
 export function initials(value: string): string {

--- a/apps/web/src/features/agents/agent-settings/im-tab.tsx
+++ b/apps/web/src/features/agents/agent-settings/im-tab.tsx
@@ -385,7 +385,7 @@ function MessagingChannelNote({ agent, binding }: { agent: AgentDetailView; bind
   if (computerState === "action_required") {
     return (
       <p className="text-sm text-kumo-subtle">
-        The channel itself is connected. Messages wait until this Agent's Computer is online.{" "}
+        The channel itself is connected. Messages wait until this agent's computer is online.{" "}
         <Link className="text-kumo-link" {...agentSettingsSectionLink(agent.id, "computer")}>
           View Computer
         </Link>
@@ -396,7 +396,7 @@ function MessagingChannelNote({ agent, binding }: { agent: AgentDetailView; bind
     return (
       <p className="text-sm text-kumo-subtle">
         The channel itself is connected. Messages wait until {runtimeProviderName(agent.runtimeProvider)} is ready on
-        this Agent's Computer.{" "}
+        this agent's computer.{" "}
         <Link className="text-kumo-link" {...agentSettingsSectionLink(agent.id, "computer")}>
           View Computer
         </Link>

--- a/apps/web/src/features/agents/agents-page.tsx
+++ b/apps/web/src/features/agents/agents-page.tsx
@@ -16,7 +16,7 @@ import {
   titleCase,
 } from "./agent-presentation.js";
 import { useAgentListView } from "./agent-queries.js";
-import { agentDetailLink, agentSettingsSectionLink } from "./agent-routes.js";
+import { agentDetailLink } from "./agent-routes.js";
 import { NewAgentDialog } from "./new-agent-page.js";
 
 export function AgentsPage() {
@@ -26,14 +26,16 @@ export function AgentsPage() {
   const state = useAgentListView(me.user.id);
   return (
     <>
-      <Page
-        title="Agents"
-        action={
-          <Button ref={createTriggerRef} size="compact" variant="outline" onClick={() => setCreateOpen(true)}>
+      <Page title="Agents">
+        {/*
+         * Below the title rather than in the header's right-hand action slot: this is the page's
+         * one primary action, and the reading edge is where a viewer looks for it first.
+         */}
+        <div data-ui="agents-page-action">
+          <Button ref={createTriggerRef} onClick={() => setCreateOpen(true)}>
             New Agent <Icon name="plus" />
           </Button>
-        }
-      >
+        </div>
         <AsyncState state={state}>{(value) => <AgentsContent agents={value.agents} />}</AsyncState>
       </Page>
       <NewAgentDialog open={createOpen} returnFocusRef={createTriggerRef} onClose={() => setCreateOpen(false)} />
@@ -77,31 +79,13 @@ export function AgentList({ agents }: { agents: AgentListItem[] }) {
 
 export function AgentCard({ agent }: { agent: AgentListItem }) {
   const status = agentCardStatus(agent);
-  const action = status.action;
   const channel = agent.availability.dependencies.channel.provider;
   const statusDetail: ReactNode =
     agent.activity.state === "working" && status.label === "Working" ? (
       <>Started {formatElapsedCompact(agent.activity.startedAt)} ago</>
-    ) : status.detail ? (
-      action ? (
-        <>
-          <span className="text-kumo-subtle">{status.detail}</span>
-          <span className="text-kumo-subtle" aria-hidden="true">
-            {" · "}
-          </span>
-          <Link
-            // Inline text, not a button: this exit sits inside the status sentence, and a control
-            // with its own height and padding breaks the line and strands the separator before it.
-            className="relative z-10 whitespace-nowrap text-kumo-link"
-            {...agentSettingsSectionLink(agent.id, action.section)}
-          >
-            {action.label}
-          </Link>
-        </>
-      ) : (
-        status.detail
-      )
-    ) : undefined;
+    ) : (
+      status.detail
+    );
   return (
     <article
       className="relative grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line hover:bg-kumo-tint"
@@ -126,6 +110,9 @@ export function AgentCard({ agent }: { agent: AgentListItem }) {
               </span>
             ) : null}
           </strong>
+          <div className="min-w-0" data-ui="agent-card-state">
+            <StatusIndicator className="flex-wrap" detail={statusDetail} label={status.label} tone={status.tone} />
+          </div>
         </div>
       </div>
       <dl className="grid grid-cols-2 gap-4 border-t border-kumo-line pt-3" data-ui="agent-card-usage">
@@ -138,13 +125,10 @@ export function AgentCard({ agent }: { agent: AgentListItem }) {
           <dd>{formatUsageNumber(agent.usage.tokens)}</dd>
         </div>
       </dl>
-      <div data-ui="agent-card-state">
-        <StatusIndicator detail={statusDetail} label={status.label} tone={status.tone} />
-      </div>
       {/*
-       * Last, and covering the row: the whole card opens the Agent, while the recovery exit above it
-       * keeps its own target. Kumo ships no `after:inset-0`, so this is an overlay rather than a
-       * stretched pseudo-element.
+       * Last, and covering the row: the whole card is the single target, so a card reporting a
+       * broken dependency opens the Agent where that dependency is explained and repaired. Kumo
+       * ships no `after:inset-0`, so this is an overlay rather than a stretched pseudo-element.
        */}
       <Link
         aria-label={`Open ${agent.displayName}`}


### PR DESCRIPTION
## Summary

Four presentation changes across the Agents list and the Agent detail header, from feedback on `dev.opentag.build/agents`.

**New Agent moves under the title, at brand weight.** It sat in the page header's trailing action slot as a compact `outline` button — the page's one primary action, placed where a viewer scans last and styled like a secondary one. It now sits below the title on the reading edge as a full-size `primary` button, which resolves to the OpenTag brand green through `--kumo-button-emphasis-bg`. Both the populated and empty states use the same control.

**Each card's status moves under the Agent name.** It was the last row of the card, below the usage figures, detached from the name it describes. It now reads directly beneath the name inside the card's identity block.

**A failing card no longer carries its own recovery exit.** Which page repairs a stuck Agent depends on which dependency failed, and that explanation already lives on the Agent. The card now states the problem only, and the row link that already covers the whole card is the single way to follow it. `agentCardStatus` loses its `action` field; the Agent detail recovery banner keeps its exit.

**The messaging control on an Agent names its channel.** It was a bare provider glyph, which made a viewer guess at both the channel and what clicking it would do, and collapsed to nothing readable when no channel was connected. It is now a `secondary` button carrying the provider mark, the channel name, and a gear for the settings it opens — the same three-part shape and the same height across a live channel, unreadable evidence, and nothing connected, so the header does not resize as the messaging state changes.

The offline recovery sentence also drops its title case: "This agent's computer is offline." reads as prose rather than as two product nouns. The same possessive is lowercased in the four runtime recovery sentences and the two messaging-tab delivery notes, so one banner does not mix both forms.

## Testing

- `pnpm check` — pass (one pre-existing `useOptionalChain` warning in `onboarding-v2/server-backend.ts`, untouched here)
- `pnpm build` — pass
- `pnpm typecheck` — pass
- `pnpm test` — `@opentag/web` 537 passed, `@opentag/shared` 88, `@opentag/server` 296, `open-tag` 153. `@opentag/client`'s `client-runtime-composition.test.ts` fails on this machine, and it fails identically on an unmodified `origin/main` worktree here (timeouts and temp-dir `ENOTEMPTY`); it is untouched by this change, which is confined to `apps/web`.

Test coverage follows the moved behavior: the New Agent placement assertions now anchor on `agents-page-action` instead of `page-header`; the card status assertions anchor inside `agent-card-identity-copy` and assert the card exposes exactly one link; and a new case covers the messaging control naming its channel, carrying the gear, and keeping identical button classes with and without a binding.

Live visual verification is not included — it needs the server, database, and a connected Computer, so it is left to independent QA.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
