### PR TITLE
refactor(web): extract the shared setup pieces from onboarding

### DIFF
--- a/apps/web/src/onboarding-v2/copy.ts
+++ b/apps/web/src/onboarding-v2/copy.ts
@@ -6,7 +6,7 @@
  * setup copy, so the same work says the same thing on both surfaces.
  */
 
-import { SETUP_COPY } from "../setup/index.js";
+import { SETUP_COPY } from "../setup/copy.js";
 import type { CloudRuntime, Destination, Runtime, StepId, TokenSource } from "./flow.js";
 
 export const STEP_LABELS: Record<StepId, string> = {

--- a/apps/web/src/onboarding-v2/copy.ts
+++ b/apps/web/src/onboarding-v2/copy.ts
@@ -1,9 +1,13 @@
 /**
  * Every user-visible string in the onboarding flow, in one place. Copy is reviewed far more often
  * than layout during this phase, so it stays out of the components and can be read end to end.
+ *
+ * The two steps that are also reachable from an Agent's settings read their words from the shared
+ * setup copy, so the same work says the same thing on both surfaces.
  */
 
-import type { CheckRow, CheckState, CloudRuntime, Destination, Runtime, StepId, TokenSource } from "./flow.js";
+import { SETUP_COPY } from "../setup/index.js";
+import type { CloudRuntime, Destination, Runtime, StepId, TokenSource } from "./flow.js";
 
 export const STEP_LABELS: Record<StepId, string> = {
   agent: "Create agent",
@@ -38,44 +42,6 @@ export const CLOUD_RUNTIME_COPY: Record<CloudRuntime, { readonly title: string; 
 export const TOKEN_COPY: Record<TokenSource, { readonly title: string; readonly description: string }> = {
   opentag: { title: "OpenTag Tokens", description: "Select from all open source models." },
   "own-plan": { title: "Your own coding plan", description: "Use the subscription you already pay for" },
-};
-
-/**
- * Every check carries a line of detail in every state, not only when it fails. The list is the
- * page's spine while the user works in their terminal, so its rows must not change height as
- * results land — a list that reflows under someone is worse than one that says "checking".
- */
-export const CHECK_COPY: Record<
-  CheckRow["id"],
-  { readonly title: (runtime: string) => string; readonly detail: Record<CheckState, (runtime: string) => string> }
-> = {
-  "runtime-cli": {
-    title: (runtime) => `${runtime} CLI is installed`,
-    detail: {
-      pending: (runtime) => `Looking for the ${runtime} command.`,
-      passed: () => "Found on this computer.",
-      failed: (runtime) => `We can't find the ${runtime} command on this computer.`,
-      blocked: () => "",
-    },
-  },
-  "runtime-auth": {
-    title: (runtime) => `${runtime} is signed in`,
-    detail: {
-      pending: (runtime) => `Checking your ${runtime} sign-in.`,
-      passed: () => "Signed in and ready.",
-      failed: (runtime) => `${runtime} is installed but not signed in.`,
-      blocked: () => "We'll know once the CLI is installed.",
-    },
-  },
-  "messaging-cli": {
-    title: () => "Lark CLI is installed",
-    detail: {
-      pending: () => "Looking for lark-cli.",
-      passed: () => "Found on this computer.",
-      failed: () => "We need lark-cli to send Lark messages.",
-      blocked: () => "",
-    },
-  },
 };
 
 export const COPY = {
@@ -126,23 +92,11 @@ export const COPY = {
     nameFixed: "Your agent's name is set once it's created.",
   },
 
-  connect: {
-    title: "Connect your computer",
-    /** What the step is about, and what it means for your data: both belong with the title. */
-    lead: "Your AI worker runs on your own computer. Connect that computer to OpenTag.",
-    privacy: "Your code and data never leave your machine.",
-    /** How to run it, which belongs with the command itself. */
-    commandIntro: "Run this in your terminal, or paste it to your agent.",
-    commandComment: "# Install the OpenTag CLI and connect this computer to OpenTag.",
-    copy: "Copy",
-    copied: "Copied",
-    copyFallback: "Copying is unavailable here. The command is selected — press Ctrl or Cmd + C.",
-    expiresIn: (remaining: string) => `Expires in ${remaining}`,
-    expired: "This command has expired.",
-    refresh: "Get a new command",
-    waiting: "Waiting for your computer…",
-    connected: "Your computer is connected.",
-  },
+  /**
+   * Connecting a computer, and connecting a messaging app, are the same work here as they are when
+   * an Agent's settings reopens them later. Their words live with the pieces that show them.
+   */
+  connect: SETUP_COPY.connect,
 
   check: {
     title: "Computer check",
@@ -164,30 +118,7 @@ export const COPY = {
     creating: "Creating…",
   },
 
-  messaging: {
-    title: "Connect your messaging app",
-    description: "Pick the app your team already works in.",
-    providerLabel: "Messaging app",
-    /**
-     * Lark is the name this product goes by in English; Feishu is the same app under its
-     * mainland China name. The provider's id stays `feishu`, because that is the Server's own
-     * vocabulary — only what the reader sees changes here.
-     */
-    feishu: { title: "Lark", description: "Also called Feishu" },
-    slack: { title: "Slack", description: "Your Slack workspace" },
-    feishuIntro: "Scan this with Lark. You'll finish the last step inside Lark itself.",
-    qrAlt: "Scan this QR code in Lark",
-    waiting: "Waiting for you to scan…",
-    cliMissing: (provider: string) =>
-      `${provider} messages are sent through its CLI, which isn't installed on your computer yet. Run opentag doctor to add it.`,
-    slackIntro: "Install OpenTag in your Slack workspace. We'll take you to Slack and bring you back.",
-    slackAction: "Add to Slack",
-    slackWaiting: "Waiting for you to finish in Slack…",
-    confirming: "Connected. Checking your agent can be reached…",
-    computerOffline: "Your computer is offline. Reconnect it and this will finish on its own.",
-    retry: "Try again",
-    failed: "That didn't work. Try again to get a new code.",
-  },
+  messaging: SETUP_COPY.messaging,
 
   done: {
     title: (name: string) => `${name} is ready.`,

--- a/apps/web/src/onboarding-v2/flow.test.ts
+++ b/apps/web/src/onboarding-v2/flow.test.ts
@@ -2,12 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   type AgentDraft,
   type ConnectState,
-  deriveChecks,
   deriveFlowState,
   type FlowFacts,
-  formatRemaining,
   initialFacts,
-  messagingCliCheck,
   type ReadinessFacts,
   readinessPassed,
   validateAgentName,
@@ -100,49 +97,9 @@ describe("deriveFlowState", () => {
   });
 });
 
-describe("deriveChecks", () => {
-  it("reports every row as pending before the first probe resolves", () => {
-    expect(deriveChecks(undefined).map((check) => check.state)).toEqual(["pending", "pending"]);
-  });
-
-  it("passes both runtime rows when the runtime is ready", () => {
-    expect(deriveChecks(ready).map((check) => check.state)).toEqual(["passed", "passed"]);
-  });
-
-  it("leaves the messaging CLI out: its provider is not chosen yet", () => {
+describe("readinessPassed", () => {
+  it("does not wait on the messaging CLI: its provider is not chosen yet", () => {
     // A missing lark-cli used to block a user who was going to pick Slack.
-    expect(deriveChecks(ready).map((check) => check.id)).toEqual(["runtime-cli", "runtime-auth"]);
     expect(readinessPassed({ runtime: "ready", messagingCli: { feishu: "install", slack: "install" } })).toBe(true);
-  });
-
-  it("treats a sign-in failure as proof the CLI runs", () => {
-    const checks = deriveChecks({ runtime: "sign-in", messagingCli: { feishu: "ready", slack: "ready" } });
-    expect(checks[0]).toEqual({ id: "runtime-cli", state: "passed" });
-    expect(checks[1]).toEqual({ id: "runtime-auth", state: "failed" });
-  });
-
-  it("blocks the sign-in row when the CLI is missing, rather than guessing", () => {
-    const checks = deriveChecks({ runtime: "install", messagingCli: { feishu: "ready", slack: "ready" } });
-    expect(checks[0]).toEqual({ id: "runtime-cli", state: "failed" });
-    expect(checks[1]).toEqual({ id: "runtime-auth", state: "blocked" });
-  });
-
-  it("reports the chosen provider's CLI separately, at handoff", () => {
-    const facts = { runtime: "ready", messagingCli: { feishu: "install", slack: "ready" } } as const;
-    expect(messagingCliCheck(facts, "feishu")).toBe("failed");
-    expect(messagingCliCheck(facts, "slack")).toBe("passed");
-    // A CLI the Server has not reported on is still being checked, not failing.
-    expect(messagingCliCheck({ runtime: "ready", messagingCli: {} }, "slack")).toBe("pending");
-  });
-});
-
-describe("formatRemaining", () => {
-  it("renders minutes and zero-padded seconds", () => {
-    expect(formatRemaining(15 * 60 * 1_000)).toBe("15:00");
-    expect(formatRemaining(65_000)).toBe("1:05");
-  });
-
-  it("never renders a negative duration", () => {
-    expect(formatRemaining(-1_000)).toBe("0:00");
   });
 });

--- a/apps/web/src/onboarding-v2/flow.ts
+++ b/apps/web/src/onboarding-v2/flow.ts
@@ -4,6 +4,8 @@
  * data. The page derives what to render from `deriveFlowState`; it never keeps a step cursor.
  */
 
+import type { MessagingCliStatus, RuntimeStatus } from "../setup/checks.js";
+
 export const RUNTIMES = ["codex", "claude-code"] as const;
 export type Runtime = (typeof RUNTIMES)[number];
 
@@ -31,11 +33,6 @@ export type Destination = "local" | "cloud";
 /** Display order only. The Server's own order is unrelated and stays as it is. */
 export const MESSAGING_PROVIDERS = ["slack", "feishu"] as const;
 export type MessagingProvider = (typeof MESSAGING_PROVIDERS)[number];
-
-/** Mirrors the Server's provider readiness vocabulary so the mock stays swappable for the real API. */
-export type RuntimeStatus = "checking" | "ready" | "install" | "sign-in" | "unavailable";
-/** The messaging CLI has no sign-in of its own: it is installed or it is not. */
-export type MessagingCliStatus = "checking" | "ready" | "install" | "unavailable";
 
 export const AGENT_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 export const AGENT_NAME_MAX_LENGTH = 64;
@@ -203,69 +200,11 @@ export function computerIsConnected(connect: ConnectState): boolean {
 }
 
 /**
- * The three rows Step 4 renders. `install` and `sign-in` are mutually exclusive outcomes of one
- * Server-side probe, so the two runtime rows are derived from a single status rather than being
- * two independent facts. A runtime that is not installed leaves sign-in genuinely unknown, which
- * the `blocked` state says out loud instead of guessing.
- */
-export type CheckState = "pending" | "passed" | "failed" | "blocked";
-
-export interface CheckRow {
-  readonly id: "runtime-cli" | "runtime-auth" | "messaging-cli";
-  readonly state: CheckState;
-}
-
-/**
  * A cloud Agent runs on a Computer too — OpenTag allocates one instead of the user connecting
  * theirs. The Server requires a `computerId` either way, so the cloud route allocates before it
  * creates rather than modelling an Agent with no Computer at all.
  */
 export type CloudComputerState = "idle" | "allocating" | "allocated";
-
-/**
- * The computer step answers one question: can this Agent run. The messaging CLI is not part of that
- * — which one is even needed depends on a provider the user has not chosen yet, so a missing
- * `lark-cli` used to block someone who was going to pick Slack. That check moved to the messaging
- * step, where the requirement becomes real and the provider is known.
- */
-export function deriveChecks(readiness: ReadinessFacts | undefined): readonly CheckRow[] {
-  if (!readiness) {
-    return [
-      { id: "runtime-cli", state: "pending" },
-      { id: "runtime-auth", state: "pending" },
-    ];
-  }
-  return [
-    { id: "runtime-cli", state: runtimeCliState(readiness.runtime) },
-    { id: "runtime-auth", state: runtimeAuthState(readiness.runtime) },
-  ];
-}
-
-/** The chosen provider's CLI, probed on the messaging step once there is a provider to probe. */
-export function messagingCliCheck(readiness: ReadinessFacts | undefined, provider: MessagingProvider): CheckState {
-  return messagingCliState(readiness?.messagingCli[provider] ?? "checking");
-}
-
-function runtimeCliState(status: RuntimeStatus): CheckState {
-  if (status === "checking") return "pending";
-  // A runtime that reports `sign-in` proved its CLI runs; only the credential is missing.
-  if (status === "ready" || status === "sign-in") return "passed";
-  return "failed";
-}
-
-function runtimeAuthState(status: RuntimeStatus): CheckState {
-  if (status === "checking") return "pending";
-  if (status === "ready") return "passed";
-  if (status === "sign-in") return "failed";
-  // Without a working CLI there is no credential answer to report.
-  return "blocked";
-}
-
-function messagingCliState(status: MessagingCliStatus): CheckState {
-  if (status === "checking") return "pending";
-  if (status === "ready") return "passed";
-  return "failed";
-}
 
 /**
  * Creating an Agent waits on its runtime only. IM handoff readiness is provider-specific and is
@@ -331,10 +270,4 @@ function stepStatus(isDone: boolean, index: number, currentIndex: number): StepS
   if (isDone) return "complete";
   if (currentIndex === index) return "current";
   return "upcoming";
-}
-
-/** Formats a remaining duration as `m:ss`, never rounding a live second up. */
-export function formatRemaining(remainingMs: number): string {
-  const seconds = Math.max(0, Math.ceil(remainingMs / 1_000));
-  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
 }

--- a/apps/web/src/onboarding-v2/layout.test.ts
+++ b/apps/web/src/onboarding-v2/layout.test.ts
@@ -39,17 +39,6 @@ describe("onboarding flow layout", () => {
     });
   });
 
-  it("keeps the command block wrapping rather than forcing a horizontal scroll", () => {
-    expect(declarationValue(".otv2-command__code", "white-space")).toBe("pre-wrap");
-    expect(declarationValue(".otv2-command__code", "overflow-wrap")).toBe("break-word");
-    // `break-all` splits short tokens like `sh`, which reads as a typo in a runnable command.
-    expect(() => declarationValue(".otv2-command__code", "word-break")).toThrow();
-    // The code alone breaks strictly by character, so a reissued one cannot change the block's
-    // height. `overflow-wrap: anywhere` is not enough: it still prefers an existing break
-    // opportunity, so codes ending in `-` or `_` took an extra line at some widths.
-    expect(declarationValue(".otv2-command__token", "word-break")).toBe("break-all");
-  });
-
   /*
    * The reserved heights are declarations again: this app compiles no utilities of its own, so a
    * bracketed class would be inert. They are still measurements the flow depends on — each is the
@@ -57,12 +46,8 @@ describe("onboarding flow layout", () => {
    * resolves — so they are guarded here rather than left to be deleted as decoration.
    */
   it("holds a reserved height for every slot whose contents change length", () => {
-    // The connect status: waiting on one line, connected on another.
-    expect(declarationValue(".otv2-slot--status", "min-height")).toBe("28px");
     // The check outcome: waiting, a two-line repair summary, or a pass.
     expect(declarationValue(".otv2-slot--outcome", "min-height")).toBe("50px");
-    // A check row, whose failure detail takes a second line on a narrow screen.
-    expect(declarationValue(".otv2-check", "min-height")).toBe("73px");
     // The name field's error line, which exists whether or not it says anything.
     expect(declarationValue(".otv2-field-error", "min-height")).toBe("20px");
     // The sign-in slot, which holds a button, a waiting line, or a result.
@@ -85,7 +70,6 @@ describe("onboarding flow layout", () => {
     };
     expect(atWidth("640px", ".otv2-slot--outcome", "min-height")).toBe("71px");
     expect(atWidth("640px", ".otv2-field-error", "min-height")).toBe("34px");
-    expect(atWidth("399px", ".otv2-check", "min-height")).toBe("90px");
     expect(atWidth("359px", ".otv2-slot--outcome", "min-height")).toBe("114px");
   });
 });

--- a/apps/web/src/onboarding-v2/messaging-cli-routing.test.tsx
+++ b/apps/web/src/onboarding-v2/messaging-cli-routing.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * The messaging step asks about the CLI of the provider that was actually chosen.
+ *
+ * `messagingCliCheck` takes a bare status, so picking the right entry out of `ReadinessFacts`
+ * happens at this call site rather than inside the check. Nothing else asserts that: a hard-coded
+ * provider would warn a Slack user about a CLI they do not need, or stay silent about one they do,
+ * and every other test feeds the two providers the same status.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SETUP_COPY } from "../setup/copy.js";
+import type { MessagingProvider, ReadinessFacts } from "./flow.js";
+import { MessagingStep } from "./steps.js";
+
+/** One set of facts that answers differently per provider: Lark's CLI is missing, Slack's is not. */
+const readiness: ReadinessFacts = { runtime: "ready", messagingCli: { feishu: "install", slack: "ready" } };
+
+const warningFor = (provider: MessagingProvider): string =>
+  SETUP_COPY.messaging.cliMissing(SETUP_COPY.messaging[provider].title);
+
+function renderStep(provider: MessagingProvider) {
+  render(
+    <MessagingStep
+      computerOnline
+      messaging={{ kind: "idle" }}
+      onChoose={() => undefined}
+      onSlackInstall={() => undefined}
+      onStart={() => undefined}
+      provider={provider}
+      readiness={readiness}
+    />,
+  );
+}
+
+describe("the messaging step's CLI check", () => {
+  it("warns about the chosen provider's missing CLI", () => {
+    renderStep("feishu");
+    expect(screen.getByText(warningFor("feishu"))).toBeTruthy();
+  });
+
+  it("stays silent for a provider whose CLI is present, on the same facts", () => {
+    renderStep("slack");
+    // Neither its own warning nor the other provider's: reading position 0 would show one here.
+    expect(screen.queryByText(warningFor("slack"))).toBeNull();
+    expect(screen.queryByText(warningFor("feishu"))).toBeNull();
+  });
+});

--- a/apps/web/src/onboarding-v2/mock-backend.ts
+++ b/apps/web/src/onboarding-v2/mock-backend.ts
@@ -10,16 +10,9 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MessagingCliStatus, RuntimeStatus } from "../setup/checks.js";
 import type { CreatedAgent, OnboardingBackend, PlanSignIn } from "./backend.js";
-import type {
-  AgentDraft,
-  ConnectState,
-  CreationState,
-  MessagingCliStatus,
-  MessagingState,
-  ReadinessFacts,
-  RuntimeStatus,
-} from "./flow.js";
+import type { AgentDraft, ConnectState, CreationState, MessagingState, ReadinessFacts } from "./flow.js";
 
 export interface MockScenario {
   readonly id: string;

--- a/apps/web/src/onboarding-v2/onboarding-v2.css
+++ b/apps/web/src/onboarding-v2/onboarding-v2.css
@@ -3,10 +3,13 @@
  *
  * Everything expressible as a class — layout, colour, radius, type, and every reserved height the
  * flow depends on — now sits on the element itself. What stayed is the styling that is driven by
- * an attribute the page already publishes for assistive technology (`aria-pressed`, `data-state`,
- * `data-status`), and the command block, which is a terminal quotation with its own palette and its
- * own wrapping rules. Stating those as variants would spread one decision across a dozen class
- * lists; stating them here keeps each in one place.
+ * an attribute the page already publishes for assistive technology (`aria-pressed`, `data-status`).
+ * Stating those as variants would spread one decision across a dozen class lists; stating them here
+ * keeps each in one place.
+ *
+ * Only what belongs to this flow alone lives here. The styling of the setup pieces it shares with
+ * Agent settings — the command block, the check rows, the QR frame, the waiting dot — travels with
+ * those pieces in `../setup/setup.css`.
  */
 
 /* Brand mark ------------------------------------------------------------- */
@@ -78,154 +81,6 @@
   color: var(--text-color-kumo-inverse);
 }
 
-/* Check markers ---------------------------------------------------------- */
-
-/*
- * These two need to read as green and amber at 22px. The operational status palette is tuned for
- * large surfaces and goes indistinct at this size, so the pair is stated locally.
- */
-.otv2-check__marker {
-  width: 22px;
-  height: 22px;
-  border: 1px solid var(--color-kumo-hairline);
-  line-height: 1;
-}
-
-.otv2-check[data-state="passed"] .otv2-check__marker {
-  border-color: #17a04a;
-  background: #e6f7ec;
-  color: #17a04a;
-}
-
-.otv2-check[data-state="failed"] .otv2-check__marker {
-  border-color: #d98207;
-  background: #fdf1de;
-  color: #d98207;
-}
-
-.otv2-check[data-state="pending"] .otv2-check__marker {
-  border-style: dashed;
-  animation: otv2-fade 1.4s ease-in-out infinite;
-}
-
-@keyframes otv2-fade {
-  0%,
-  100% {
-    opacity: 0.4;
-  }
-
-  50% {
-    opacity: 1;
-  }
-}
-
-/* Command block ---------------------------------------------------------- */
-
-/*
- * The block carries its own near-black surface in both modes: it is a terminal quotation, and it
- * reads as one only if it does not follow the page.
- */
-.otv2-command__body {
-  position: relative;
-  background: #0b101d;
-  border-color: var(--color-kumo-hairline);
-  transition: opacity 160ms ease;
-}
-
-.otv2-command__code {
-  margin: 0;
-  color: #e6e9e0;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, "PingFang SC", monospace;
-  font-size: 13px;
-  line-height: 1.55;
-
-  /* Wraps rather than scrolling sideways: a command that runs off the edge cannot be read, and
-     `break-word` keeps short tokens like `sh` whole. */
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
-}
-
-.otv2-command__comment {
-  color: #9fb27f;
-}
-
-/*
- * The trailing token is an opaque secret and breaks strictly by character. Left to break at its own
- * hyphens and underscores, two codes of the same length wrap to a different number of lines and the
- * block changes height when one is reissued.
- *
- * `overflow-wrap: anywhere` is not enough on its own: it still prefers an existing break opportunity
- * when there is one, so a code ending in `-` or `_` took an extra line at some widths — 19 of 200
- * random codes at 320px. `word-break: break-all` ignores those opportunities entirely. It is scoped
- * to this span and no wider: on the whole command it would split short words like `sh`, which reads
- * as a typo in something the reader is about to run.
- */
-.otv2-command__token {
-  word-break: break-all;
-}
-
-/*
- * Sized as a real target rather than around the icon: a Kumo icon is 16px, which on a compact
- * button reads as an afterthought next to the command it belongs to.
- */
-.otv2-command__copy {
-  width: 48px;
-  min-width: 48px;
-  height: 48px;
-  min-height: 48px;
-  padding: 0;
-  background: transparent;
-
-  /* The same value the command itself is set in, so the control is as legible as what it copies. */
-  color: #e6e9e0;
-}
-
-.otv2-command__copy svg {
-  width: 24px;
-  height: 24px;
-}
-
-.otv2-command__copy:hover:not(:disabled) {
-  background: rgb(230 233 224 / 14%);
-  color: #fff;
-}
-
-.otv2-command__copy:active:not(:disabled) {
-  background: rgb(230 233 224 / 22%);
-}
-
-/* The block's shape while its command is still being issued: same box, nothing legible in it. */
-.otv2-command-pending {
-  opacity: 0.35;
-  filter: blur(3px);
-  pointer-events: none;
-}
-
-/*
- * An expired command says so on the block itself, over a heavy scrim: the block is the thing that
- * expired, and a line underneath is easy to miss when the command above it still looks runnable.
- * The scrim sits over the content rather than fading the whole block, so the notice stays legible.
- */
-.otv2-command[data-expired="true"] .otv2-command__code,
-.otv2-command[data-expired="true"] .otv2-command__copy {
-  opacity: 0.18;
-}
-
-.otv2-command__expired {
-  position: absolute;
-  inset: 0;
-  background: rgb(11 16 29 / 78%);
-  color: #e6e9e0;
-}
-
-.otv2-command__expired button {
-  color: #cfe3a6;
-}
-
-.otv2-command__expired button:hover {
-  color: #e8f5cd;
-}
-
 /* Measurements ----------------------------------------------------------- */
 
 /*
@@ -252,10 +107,6 @@
  * Anything that changes length while someone is reading is given the height of its tallest state,
  * so the step's footer keeps one position. These are measured, not chosen.
  */
-.otv2-slot--status {
-  min-height: 28px;
-}
-
 .otv2-slot--outcome {
   min-height: 50px;
 }
@@ -266,11 +117,6 @@
 
 .otv2-field-error {
   min-height: 20px;
-}
-
-/* A check row's second line is a status, and a failure reads longer than what it replaces. */
-.otv2-check {
-  min-height: 73px;
 }
 
 @media (width <= 640px) {
@@ -289,38 +135,11 @@
   }
 }
 
-/* Below this width a failing check's status takes a second line. */
-@media (width <= 399px) {
-  .otv2-check {
-    min-height: 90px;
-  }
-}
-
 /* And below this one the repair summary takes a second pair of lines. */
 @media (width <= 359px) {
   .otv2-slot--outcome {
     min-height: 114px;
   }
-}
-
-/* The waiting dot carries its own animation. */
-.otv2-pulse {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--color-kumo-brand);
-  animation: otv2-fade 1.4s ease-in-out infinite;
-}
-
-/* The QR keeps its box whether or not a code has arrived, so the panel never changes height. */
-.otv2-qr {
-  width: 208px;
-  height: 208px;
-}
-
-.otv2-qr__image {
-  width: 100%;
-  height: 100%;
 }
 
 /* Slack's published button, at the size Slack publishes it. */

--- a/apps/web/src/onboarding-v2/page.test.tsx
+++ b/apps/web/src/onboarding-v2/page.test.tsx
@@ -242,7 +242,7 @@ describe("OnboardingV2Page", () => {
     await reachCheckStep();
 
     // Mid-probe: every row already has its detail line.
-    const rowsWhileChecking = document.querySelectorAll(".otv2-check");
+    const rowsWhileChecking = document.querySelectorAll(".ots-check");
     expect(rowsWhileChecking).toHaveLength(2);
     for (const row of rowsWhileChecking) {
       // One title and one detail line, always both, so a resolving row never changes height.
@@ -251,8 +251,8 @@ describe("OnboardingV2Page", () => {
     }
 
     await settleCheck();
-    expect(document.querySelectorAll(".otv2-check")).toHaveLength(2);
-    for (const row of document.querySelectorAll(".otv2-check")) {
+    expect(document.querySelectorAll(".ots-check")).toHaveLength(2);
+    for (const row of document.querySelectorAll(".ots-check")) {
       expect((row.textContent ?? "").trim().length).toBeGreaterThan(0);
     }
   });
@@ -279,7 +279,7 @@ describe("OnboardingV2Page", () => {
     // Still probing: the slot already holds its waiting line, in the same shape step 3 uses.
     const slot = () => document.querySelector('[data-ui="onboarding-v2-check-outcome"]');
     expect(slot()?.textContent ?? "").toContain("Waiting for the computer check…");
-    expect(slot()?.querySelector(".otv2-pulse")).toBeTruthy();
+    expect(slot()?.querySelector(".ots-pulse")).toBeTruthy();
 
     await settleCheck();
     expect(slot()).toBeTruthy();

--- a/apps/web/src/onboarding-v2/server-backend.regressions.test.tsx
+++ b/apps/web/src/onboarding-v2/server-backend.regressions.test.tsx
@@ -12,7 +12,8 @@ import type { AgentAdminConfig, FeishuSetupAttempt, WorkspaceComputerSummary } f
 import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { browserApi } from "../api.js";
-import { type AgentDraft, messagingCliCheck, type Runtime } from "./flow.js";
+import { messagingCliCheck } from "../setup/index.js";
+import type { AgentDraft, Runtime } from "./flow.js";
 import { OnboardingV2Page } from "./page.js";
 import { useServerBackend } from "./server-backend.js";
 import { ComputerStep } from "./steps.js";
@@ -239,7 +240,7 @@ describe("Server-backed onboarding: the defects it had", () => {
     // Slack's result answers for Slack and for nothing else; Lark has simply not been probed.
     expect(view.result.current.readiness?.messagingCli.slack).toBe("ready");
     expect(view.result.current.readiness?.messagingCli.feishu).toBeUndefined();
-    expect(messagingCliCheck(view.result.current.readiness, "feishu")).toBe("pending");
+    expect(messagingCliCheck(view.result.current.readiness?.messagingCli.feishu)).toBe("pending");
   });
 
   it("stops polling a Lark attempt that Start over abandoned", async () => {

--- a/apps/web/src/onboarding-v2/server-backend.ts
+++ b/apps/web/src/onboarding-v2/server-backend.ts
@@ -10,17 +10,16 @@
 import type { AgentRuntimeProvider, ImBindingHandoffStatus, WorkspaceComputerSummary } from "@opentag/shared/browser";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { browserApi } from "../api.js";
+import type { MessagingCliStatus, RuntimeStatus } from "../setup/checks.js";
 import type { CreatedAgent, OnboardingBackend, PlanSignIn } from "./backend.js";
 import { COPY } from "./copy.js";
 import type {
   AgentDraft,
   ConnectState,
   CreationState,
-  MessagingCliStatus,
   MessagingProvider,
   MessagingState,
   ReadinessFacts,
-  RuntimeStatus,
 } from "./flow.js";
 
 /** The existing onboarding polls Computers at this rate while it waits for one. */

--- a/apps/web/src/onboarding-v2/steps.tsx
+++ b/apps/web/src/onboarding-v2/steps.tsx
@@ -1,11 +1,18 @@
-import { toString as qrToString } from "qrcode";
 import { type FormEvent, useEffect, useId, useState } from "react";
+import {
+  CheckLine,
+  CommandBlock,
+  ConnectStatus,
+  Countdown,
+  deriveChecks,
+  messagingCliCheck,
+  QrCode,
+  WAITING_LINE,
+} from "../setup/index.js";
 import { Button, Icon, KumoInputControl, StatusIndicator, Text } from "../ui/design-system.js";
 import type { PlanSignIn } from "./backend.js";
 import { ADD_TO_SLACK_URL, BrandMark } from "./brand-mark.js";
-import { CommandBlock } from "./command-block.js";
 import {
-  CHECK_COPY,
   CLOUD_RUNTIME_COPY,
   COMING_SOON,
   COPY,
@@ -16,21 +23,17 @@ import {
 } from "./copy.js";
 import {
   type AgentDraft,
-  type CheckRow,
   CLOUD_RUNTIMES,
   type CloudComputerState,
   type ConnectState,
   type CreationState,
   DEFAULT_AGENT_NAME,
   type Destination,
-  deriveChecks,
   draftIsSubmittable,
   type FlowState,
-  formatRemaining,
   MESSAGING_PROVIDERS,
   type MessagingProvider,
   type MessagingState,
-  messagingCliCheck,
   needsPlanSignIn,
   type ReadinessFacts,
   RUNTIMES,
@@ -52,7 +55,6 @@ const CHOICES = "flex flex-col gap-3 m-0 p-0 list-none";
 const CHOICE_GRID = "otv2-choices--grid grid gap-3 m-0 p-0 list-none";
 const CARD =
   "otv2-choice flex w-full items-center gap-4 rounded-xl bg-kumo-base p-4 ring ring-kumo-line cursor-pointer";
-const WAITING = "flex items-center gap-2 text-sm text-kumo-subtle m-0";
 const PANEL = "flex flex-col items-center gap-3 text-sm text-center";
 
 export function StepRail({ steps }: { steps: FlowState["steps"] }) {
@@ -330,7 +332,7 @@ function MessagingConnection({
    * depends on the provider, and until this point there was no provider. A missing one used to
    * block creating the Agent at all, which stopped a Slack user over a Lark dependency.
    */
-  const cliState = provider ? messagingCliCheck(readiness, provider) : "pending";
+  const cliState = provider ? messagingCliCheck(readiness?.messagingCli[provider]) : "pending";
   /*
    * Reachability needs more than the binding, and the Server's handoff status carries no reason —
    * so a wait on one of its other conditions would otherwise be an unexplained spinner.
@@ -361,7 +363,7 @@ function MessagingConnection({
       {provider === "feishu" ? (
         <div className={PANEL}>
           <p className="text-kumo-subtle m-0">{COPY.messaging.feishuIntro}</p>
-          <div className="otv2-qr flex items-center justify-center rounded-xl bg-kumo-base ring ring-kumo-line">
+          <div className="ots-qr flex items-center justify-center rounded-xl bg-kumo-base ring ring-kumo-line">
             {messaging.kind === "waiting" ? <QrCode value={messaging.qrValue} /> : null}
           </div>
           {/*
@@ -375,8 +377,8 @@ function MessagingConnection({
                 <span>{waitingReason}</span>
               </p>
             ) : (
-              <p className={WAITING} role="status">
-                <span aria-hidden="true" className="otv2-pulse shrink-0" />
+              <p className={WAITING_LINE} role="status">
+                <span aria-hidden="true" className="ots-pulse shrink-0" />
                 {COPY.messaging.confirming}
               </p>
             )
@@ -388,8 +390,8 @@ function MessagingConnection({
               </Button>
             </div>
           ) : (
-            <p className={WAITING} role="status">
-              <span aria-hidden="true" className="otv2-pulse shrink-0" />
+            <p className={WAITING_LINE} role="status">
+              <span aria-hidden="true" className="ots-pulse shrink-0" />
               {COPY.messaging.waiting}
             </p>
           )}
@@ -409,14 +411,14 @@ function MessagingConnection({
                   <span>{waitingReason}</span>
                 </p>
               ) : (
-                <p className={WAITING} role="status">
-                  <span aria-hidden="true" className="otv2-pulse shrink-0" />
+                <p className={WAITING_LINE} role="status">
+                  <span aria-hidden="true" className="ots-pulse shrink-0" />
                   {COPY.messaging.confirming}
                 </p>
               )
             ) : messaging.kind === "away" ? (
-              <p className={WAITING} role="status">
-                <span aria-hidden="true" className="otv2-pulse shrink-0" />
+              <p className={WAITING_LINE} role="status">
+                <span aria-hidden="true" className="ots-pulse shrink-0" />
                 {COPY.messaging.slackWaiting}
               </p>
             ) : (
@@ -637,8 +639,8 @@ function PlanSignInPanel({
         {signIn === "signed-in" ? (
           <StatusIndicator label={COPY.cloud.signInDone(runtimeLabel)} tone="success" />
         ) : signIn === "pending" ? (
-          <p className={WAITING} role="status">
-            <span aria-hidden="true" className="otv2-pulse shrink-0" />
+          <p className={WAITING_LINE} role="status">
+            <span aria-hidden="true" className="ots-pulse shrink-0" />
             {COPY.cloud.signInPending}
           </p>
         ) : (
@@ -672,7 +674,7 @@ export function ComputerStep({
   readiness: ReadinessFacts | undefined;
 }) {
   const connected = connect.kind === "connected";
-  const checks = deriveChecks(readiness);
+  const checks = deriveChecks(readiness?.runtime);
   const runtimeLabel = draft.runtime ? RUNTIME_COPY[draft.runtime].title : "";
   const resolving = readinessIsResolving(readiness);
   // Asked about the runtime this draft chose, so a verdict left over from a different one
@@ -712,7 +714,7 @@ export function ComputerStep({
         </div>
       )}
 
-      <ConnectStatus connect={connect} />
+      <ConnectStatus connected={connected} dataUi="onboarding-v2-connect-status" />
 
       {connected ? (
         <>
@@ -723,8 +725,8 @@ export function ComputerStep({
           </ol>
           <div className="otv2-slot--outcome flex flex-col justify-start" data-ui="onboarding-v2-check-outcome">
             {resolving ? (
-              <p className={WAITING} role="status">
-                <span aria-hidden="true" className="otv2-pulse shrink-0" />
+              <p className={WAITING_LINE} role="status">
+                <span aria-hidden="true" className="ots-pulse shrink-0" />
                 {COPY.check.waiting}
               </p>
             ) : failures.length > 0 ? (
@@ -756,7 +758,7 @@ function ConnectCommand({ connect, onRefreshCommand }: { connect: ConnectState; 
   // moves when the real one lands. It is inert: nothing to copy and nothing to announce.
   if (connect.kind === "idle" || connect.kind === "issuing") {
     return (
-      <div aria-hidden="true" className="otv2-command-pending">
+      <div aria-hidden="true" className="ots-command-pending">
         <CommandBlock
           command={PLACEHOLDER_CONNECT_COMMAND}
           comment={COPY.connect.commandComment}
@@ -787,64 +789,6 @@ function ConnectCommand({ connect, onRefreshCommand }: { connect: ConnectState; 
       fallbackHint={COPY.connect.copyFallback}
       key={connect.command}
     />
-  );
-}
-
-function ConnectStatus({ connect }: { connect: ConnectState }) {
-  return (
-    <div className="otv2-slot--status flex flex-col justify-center" data-ui="onboarding-v2-connect-status">
-      {connect.kind === "connected" ? (
-        <StatusIndicator label={COPY.connect.connected} tone="success" />
-      ) : (
-        <p className={WAITING} role="status">
-          <span aria-hidden="true" className="otv2-pulse shrink-0" />
-          {COPY.connect.waiting}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function Countdown({ expiresAt }: { expiresAt: number }) {
-  return <span>{COPY.connect.expiresIn(formatRemaining(useRemaining(expiresAt)))}</span>;
-}
-
-/** Ticks once a second and settles at zero, so an expired code never shows a negative duration. */
-function useRemaining(expiresAt: number): number {
-  const [remaining, setRemaining] = useState(() => Math.max(0, expiresAt - Date.now()));
-  useEffect(() => {
-    setRemaining(Math.max(0, expiresAt - Date.now()));
-    const id = window.setInterval(() => {
-      const next = Math.max(0, expiresAt - Date.now());
-      setRemaining(next);
-      if (next === 0) window.clearInterval(id);
-    }, 1_000);
-    return () => window.clearInterval(id);
-  }, [expiresAt]);
-  return remaining;
-}
-
-function CheckLine({ check, position, runtimeLabel }: { check: CheckRow; position: number; runtimeLabel: string }) {
-  const copy = CHECK_COPY[check.id];
-  // Always rendered, even when empty, so a resolving check never changes the row's height.
-  const detail = copy.detail[check.state](runtimeLabel);
-  const dim = check.state === "blocked" || check.state === "pending";
-  return (
-    <li
-      className="otv2-check flex items-center gap-3 p-4 border-t border-kumo-line first:border-t-0 "
-      data-state={check.state}
-    >
-      <span
-        aria-hidden="true"
-        className="otv2-check__marker inline-flex shrink-0 items-center justify-center rounded-full text-xs text-kumo-subtle"
-      >
-        {position}
-      </span>
-      <span className="flex flex-col gap-1 min-w-0">
-        <span className={dim ? "text-kumo-subtle" : "font-medium text-kumo-strong"}>{copy.title(runtimeLabel)}</span>
-        <span className="text-xs text-kumo-subtle">{detail || " "}</span>
-      </span>
-    </li>
   );
 }
 
@@ -895,23 +839,6 @@ export function MessagingStep({
       */}
     </section>
   );
-}
-
-function QrCode({ value }: { value: string }) {
-  const [source, setSource] = useState<string>();
-  useEffect(() => {
-    let active = true;
-    void qrToString(value, { margin: 1, type: "svg", width: 208 }).then(
-      (svg) => {
-        if (active) setSource(`data:image/svg+xml;utf8,${encodeURIComponent(svg)}`);
-      },
-      () => undefined,
-    );
-    return () => {
-      active = false;
-    };
-  }, [value]);
-  return source ? <img alt={COPY.messaging.qrAlt} className="otv2-qr__image" src={source} /> : null;
 }
 
 export function DoneStep({ name }: { name: string }) {

--- a/apps/web/src/setup/checks.test.ts
+++ b/apps/web/src/setup/checks.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { deriveChecks, formatRemaining, messagingCliCheck } from "./checks.js";
+
+describe("deriveChecks", () => {
+  it("reports every row as pending before the first probe resolves", () => {
+    expect(deriveChecks(undefined).map((check) => check.state)).toEqual(["pending", "pending"]);
+    expect(deriveChecks("checking").map((check) => check.state)).toEqual(["pending", "pending"]);
+  });
+
+  it("passes both runtime rows when the runtime is ready", () => {
+    expect(deriveChecks("ready").map((check) => check.state)).toEqual(["passed", "passed"]);
+  });
+
+  it("leaves the messaging CLI out: it is asked about separately, once there is a provider", () => {
+    expect(deriveChecks("ready").map((check) => check.id)).toEqual(["runtime-cli", "runtime-auth"]);
+  });
+
+  it("treats a sign-in failure as proof the CLI runs", () => {
+    const checks = deriveChecks("sign-in");
+    expect(checks[0]).toEqual({ id: "runtime-cli", state: "passed" });
+    expect(checks[1]).toEqual({ id: "runtime-auth", state: "failed" });
+  });
+
+  it("blocks the sign-in row when the CLI is missing, rather than guessing", () => {
+    const checks = deriveChecks("install");
+    expect(checks[0]).toEqual({ id: "runtime-cli", state: "failed" });
+    expect(checks[1]).toEqual({ id: "runtime-auth", state: "blocked" });
+  });
+});
+
+describe("messagingCliCheck", () => {
+  it("reports the CLI it is given, whichever provider it belongs to", () => {
+    expect(messagingCliCheck("install")).toBe("failed");
+    expect(messagingCliCheck("ready")).toBe("passed");
+  });
+
+  it("treats a CLI the Server has not reported on as still being checked, not failing", () => {
+    expect(messagingCliCheck(undefined)).toBe("pending");
+    expect(messagingCliCheck("checking")).toBe("pending");
+  });
+});
+
+describe("formatRemaining", () => {
+  it("renders minutes and zero-padded seconds", () => {
+    expect(formatRemaining(15 * 60 * 1_000)).toBe("15:00");
+    expect(formatRemaining(65_000)).toBe("1:05");
+  });
+
+  it("never renders a negative duration", () => {
+    expect(formatRemaining(-1_000)).toBe("0:00");
+  });
+});

--- a/apps/web/src/setup/checks.ts
+++ b/apps/web/src/setup/checks.ts
@@ -1,0 +1,74 @@
+/**
+ * What a computer has to have before an Agent can run on it, as data.
+ *
+ * These are the checks themselves, not the flow that collects them: they take the two statuses the
+ * Server reports and say what a reader should see. Onboarding gathers those statuses while walking
+ * someone through setup; Agent settings reads them back off an Agent that already exists. Both feed
+ * the same functions, so both describe a computer the same way.
+ */
+
+/** Mirrors the Server's provider readiness vocabulary so a mock stays swappable for the real API. */
+export type RuntimeStatus = "checking" | "ready" | "install" | "sign-in" | "unavailable";
+/** The messaging CLI has no sign-in of its own: it is installed or it is not. */
+export type MessagingCliStatus = "checking" | "ready" | "install" | "unavailable";
+
+/**
+ * `install` and `sign-in` are mutually exclusive outcomes of one Server-side probe, so the two
+ * runtime rows are derived from a single status rather than being two independent facts. A runtime
+ * that is not installed leaves sign-in genuinely unknown, which the `blocked` state says out loud
+ * instead of guessing.
+ */
+export type CheckState = "pending" | "passed" | "failed" | "blocked";
+
+export interface CheckRow {
+  readonly id: "runtime-cli" | "runtime-auth" | "messaging-cli";
+  readonly state: CheckState;
+}
+
+/**
+ * The runtime rows, from the one status they are both derived from. An absent status is a probe
+ * that has not answered yet, which reads the same as `checking`.
+ *
+ * The messaging CLI is deliberately not here: which one is even needed depends on a provider that
+ * is chosen separately, so a missing `lark-cli` used to block someone who was going to pick Slack.
+ * That check is asked for on its own, where the requirement becomes real.
+ */
+export function deriveChecks(runtime: RuntimeStatus | undefined): readonly CheckRow[] {
+  const status = runtime ?? "checking";
+  return [
+    { id: "runtime-cli", state: runtimeCliState(status) },
+    { id: "runtime-auth", state: runtimeAuthState(status) },
+  ];
+}
+
+/** The chosen provider's CLI, asked about once there is a provider to ask about. */
+export function messagingCliCheck(status: MessagingCliStatus | undefined): CheckState {
+  return messagingCliState(status ?? "checking");
+}
+
+function runtimeCliState(status: RuntimeStatus): CheckState {
+  if (status === "checking") return "pending";
+  // A runtime that reports `sign-in` proved its CLI runs; only the credential is missing.
+  if (status === "ready" || status === "sign-in") return "passed";
+  return "failed";
+}
+
+function runtimeAuthState(status: RuntimeStatus): CheckState {
+  if (status === "checking") return "pending";
+  if (status === "ready") return "passed";
+  if (status === "sign-in") return "failed";
+  // Without a working CLI there is no credential answer to report.
+  return "blocked";
+}
+
+function messagingCliState(status: MessagingCliStatus): CheckState {
+  if (status === "checking") return "pending";
+  if (status === "ready") return "passed";
+  return "failed";
+}
+
+/** Formats a remaining duration as `m:ss`, never rounding a live second up. */
+export function formatRemaining(remainingMs: number): string {
+  const seconds = Math.max(0, Math.ceil(remainingMs / 1_000));
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}

--- a/apps/web/src/setup/command-block.tsx
+++ b/apps/web/src/setup/command-block.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Button, Icon } from "../ui/design-system.js";
+import "./setup.css";
 
 const COPY_FEEDBACK_MS = 1_600;
 
@@ -73,11 +74,11 @@ export function CommandBlock({
   }
 
   return (
-    <div className="otv2-command flex flex-col gap-1" data-expired={expiredNotice ? "true" : undefined}>
-      <div className="otv2-command__body flex items-start gap-3 rounded-lg border py-3 pr-3 pl-4">
-        <pre className="otv2-command__code flex-1 min-w-0">
+    <div className="ots-command flex flex-col gap-1" data-expired={expiredNotice ? "true" : undefined}>
+      <div className="ots-command__body flex items-start gap-3 rounded-lg border py-3 pr-3 pl-4">
+        <pre className="ots-command__code flex-1 min-w-0">
           <code ref={codeRef}>
-            <span className="otv2-command__comment">{comment}</span>
+            <span className="ots-command__comment">{comment}</span>
             {"\n"}
             {lead}
             {/*
@@ -87,7 +88,7 @@ export function CommandBlock({
               one is reissued; measured, that was 19px of movement below 640px. The rest of the
               command still breaks between words, so short tokens like `sh` stay whole.
             */}
-            <span className="otv2-command__token">{token}</span>
+            <span className="ots-command__token">{token}</span>
           </code>
         </pre>
         {/*
@@ -97,7 +98,7 @@ export function CommandBlock({
         */}
         <Button
           aria-label={copied ? copiedLabel : copyLabel}
-          className="otv2-command__copy shrink-0"
+          className="ots-command__copy shrink-0"
           data-copied={copied ? "true" : undefined}
           disabled={inert || expiredNotice !== undefined}
           onClick={() => void copy()}
@@ -108,7 +109,7 @@ export function CommandBlock({
           <Icon name={copied ? "check" : "copy"} />
         </Button>
         {expiredNotice ? (
-          <div className="otv2-command__expired flex flex-wrap items-center justify-center gap-2 rounded-lg p-4 text-sm text-center">
+          <div className="ots-command__expired flex flex-wrap items-center justify-center gap-2 rounded-lg p-4 text-sm text-center">
             {expiredNotice}
           </div>
         ) : null}

--- a/apps/web/src/setup/components.tsx
+++ b/apps/web/src/setup/components.tsx
@@ -1,0 +1,103 @@
+import { toString as qrToString } from "qrcode";
+import { useEffect, useState } from "react";
+import { StatusIndicator } from "../ui/design-system.js";
+import "./setup.css";
+import { type CheckRow, formatRemaining } from "./checks.js";
+import { CHECK_COPY, SETUP_COPY } from "./copy.js";
+
+/**
+ * A line that says something is still being waited on. Shared because every wait on these surfaces
+ * has to read as the same kind of thing — one dot, one sentence, one height.
+ */
+export const WAITING_LINE = "flex items-center gap-2 text-sm text-kumo-subtle m-0";
+
+/**
+ * Whether the computer has arrived, on a line that reserves its own height so nothing below it
+ * moves when the answer lands.
+ *
+ * `dataUi` is the surface's own hook for its tests. The status itself is a boolean rather than a
+ * connect state: onboarding is watching a connection being made, settings is reporting one that
+ * already exists, and the row says the same thing either way.
+ */
+export function ConnectStatus({ connected, dataUi }: { connected: boolean; dataUi?: string }) {
+  return (
+    <div className="ots-slot--status flex flex-col justify-center" data-ui={dataUi}>
+      {connected ? (
+        <StatusIndicator label={SETUP_COPY.connect.connected} tone="success" />
+      ) : (
+        <p className={WAITING_LINE} role="status">
+          <span aria-hidden="true" className="ots-pulse shrink-0" />
+          {SETUP_COPY.connect.waiting}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function Countdown({ expiresAt }: { expiresAt: number }) {
+  return <span>{SETUP_COPY.connect.expiresIn(formatRemaining(useRemaining(expiresAt)))}</span>;
+}
+
+/** Ticks once a second and settles at zero, so an expired code never shows a negative duration. */
+export function useRemaining(expiresAt: number): number {
+  const [remaining, setRemaining] = useState(() => Math.max(0, expiresAt - Date.now()));
+  useEffect(() => {
+    setRemaining(Math.max(0, expiresAt - Date.now()));
+    const id = window.setInterval(() => {
+      const next = Math.max(0, expiresAt - Date.now());
+      setRemaining(next);
+      if (next === 0) window.clearInterval(id);
+    }, 1_000);
+    return () => window.clearInterval(id);
+  }, [expiresAt]);
+  return remaining;
+}
+
+export function CheckLine({
+  check,
+  position,
+  runtimeLabel,
+}: {
+  check: CheckRow;
+  position: number;
+  runtimeLabel: string;
+}) {
+  const copy = CHECK_COPY[check.id];
+  // Always rendered, even when empty, so a resolving check never changes the row's height.
+  const detail = copy.detail[check.state](runtimeLabel);
+  const dim = check.state === "blocked" || check.state === "pending";
+  return (
+    <li
+      className="ots-check flex items-center gap-3 p-4 border-t border-kumo-line first:border-t-0 "
+      data-state={check.state}
+    >
+      <span
+        aria-hidden="true"
+        className="ots-check__marker inline-flex shrink-0 items-center justify-center rounded-full text-xs text-kumo-subtle"
+      >
+        {position}
+      </span>
+      <span className="flex flex-col gap-1 min-w-0">
+        <span className={dim ? "text-kumo-subtle" : "font-medium text-kumo-strong"}>{copy.title(runtimeLabel)}</span>
+        <span className="text-xs text-kumo-subtle">{detail || " "}</span>
+      </span>
+    </li>
+  );
+}
+
+export function QrCode({ value }: { value: string }) {
+  const [source, setSource] = useState<string>();
+  useEffect(() => {
+    let active = true;
+    void qrToString(value, { margin: 1, type: "svg", width: 208 }).then(
+      (svg) => {
+        if (active) setSource(`data:image/svg+xml;utf8,${encodeURIComponent(svg)}`);
+      },
+      () => undefined,
+    );
+    return () => {
+      active = false;
+    };
+  }, [value]);
+  return source ? <img alt={SETUP_COPY.messaging.qrAlt} className="ots-qr__image" src={source} /> : null;
+}

--- a/apps/web/src/setup/copy.ts
+++ b/apps/web/src/setup/copy.ts
@@ -1,0 +1,93 @@
+/**
+ * The strings the setup pieces show, in one place. Copy is reviewed far more often than layout, so
+ * it stays out of the components and can be read end to end.
+ *
+ * Everything here belongs to connecting a computer and connecting a messaging app — the two pieces
+ * of work that are the same whether they are met during onboarding or reopened later from an
+ * Agent's settings. Copy that only one of those surfaces says stays with that surface.
+ */
+
+import type { CheckRow, CheckState } from "./checks.js";
+
+/**
+ * Every check carries a line of detail in every state, not only when it fails. The list is the
+ * page's spine while the user works in their terminal, so its rows must not change height as
+ * results land — a list that reflows under someone is worse than one that says "checking".
+ */
+export const CHECK_COPY: Record<
+  CheckRow["id"],
+  { readonly title: (runtime: string) => string; readonly detail: Record<CheckState, (runtime: string) => string> }
+> = {
+  "runtime-cli": {
+    title: (runtime) => `${runtime} CLI is installed`,
+    detail: {
+      pending: (runtime) => `Looking for the ${runtime} command.`,
+      passed: () => "Found on this computer.",
+      failed: (runtime) => `We can't find the ${runtime} command on this computer.`,
+      blocked: () => "",
+    },
+  },
+  "runtime-auth": {
+    title: (runtime) => `${runtime} is signed in`,
+    detail: {
+      pending: (runtime) => `Checking your ${runtime} sign-in.`,
+      passed: () => "Signed in and ready.",
+      failed: (runtime) => `${runtime} is installed but not signed in.`,
+      blocked: () => "We'll know once the CLI is installed.",
+    },
+  },
+  "messaging-cli": {
+    title: () => "Lark CLI is installed",
+    detail: {
+      pending: () => "Looking for lark-cli.",
+      passed: () => "Found on this computer.",
+      failed: () => "We need lark-cli to send Lark messages.",
+      blocked: () => "",
+    },
+  },
+};
+
+export const SETUP_COPY = {
+  connect: {
+    title: "Connect your computer",
+    /** What the step is about, and what it means for your data: both belong with the title. */
+    lead: "Your AI worker runs on your own computer. Connect that computer to OpenTag.",
+    privacy: "Your code and data never leave your machine.",
+    /** How to run it, which belongs with the command itself. */
+    commandIntro: "Run this in your terminal, or paste it to your agent.",
+    commandComment: "# Install the OpenTag CLI and connect this computer to OpenTag.",
+    copy: "Copy",
+    copied: "Copied",
+    copyFallback: "Copying is unavailable here. The command is selected — press Ctrl or Cmd + C.",
+    expiresIn: (remaining: string) => `Expires in ${remaining}`,
+    expired: "This command has expired.",
+    refresh: "Get a new command",
+    waiting: "Waiting for your computer…",
+    connected: "Your computer is connected.",
+  },
+
+  messaging: {
+    title: "Connect your messaging app",
+    description: "Pick the app your team already works in.",
+    providerLabel: "Messaging app",
+    /**
+     * Lark is the name this product goes by in English; Feishu is the same app under its
+     * mainland China name. The provider's id stays `feishu`, because that is the Server's own
+     * vocabulary — only what the reader sees changes here.
+     */
+    feishu: { title: "Lark", description: "Also called Feishu" },
+    slack: { title: "Slack", description: "Your Slack workspace" },
+    feishuIntro: "Scan this with Lark. You'll finish the last step inside Lark itself.",
+    qrAlt: "Scan this QR code in Lark",
+    waiting: "Waiting for you to scan…",
+    cliMissing: (provider: string) =>
+      `${provider} messages are sent through its CLI, which isn't installed on your computer yet. Run opentag doctor to add it.`,
+    slackIntro: "Install OpenTag in your Slack workspace. We'll take you to Slack and bring you back.",
+    slackAction: "Add to Slack",
+    slackWaiting: "Waiting for you to finish in Slack…",
+    confirming: "Connected. Checking your agent can be reached…",
+    computerOffline: "Your computer is offline. Reconnect it and this will finish on its own.",
+    retry: "Try again",
+    failed: "That didn't work. Try again to get a new code.",
+  },
+} as const;

--- a/apps/web/src/setup/index.ts
+++ b/apps/web/src/setup/index.ts
@@ -1,0 +1,24 @@
+/**
+ * The setup pieces onboarding and Agent settings both use.
+ *
+ * Connecting a computer and connecting a messaging app are the same work whether they are met while
+ * setting an Agent up for the first time or reopened later from its settings. What differs is the
+ * frame around them — a numbered flow with a Continue button, or a dialog over a settings page — so
+ * what lives here is the inside of that frame and nothing of either frame itself.
+ *
+ * Each visual piece imports its own stylesheet, so nothing that uses one has to know which sheet it
+ * came from.
+ */
+
+export {
+  type CheckRow,
+  type CheckState,
+  deriveChecks,
+  formatRemaining,
+  type MessagingCliStatus,
+  messagingCliCheck,
+  type RuntimeStatus,
+} from "./checks.js";
+export { CommandBlock } from "./command-block.js";
+export { CheckLine, ConnectStatus, Countdown, QrCode, useRemaining, WAITING_LINE } from "./components.js";
+export { CHECK_COPY, SETUP_COPY } from "./copy.js";

--- a/apps/web/src/setup/layout.test.ts
+++ b/apps/web/src/setup/layout.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import postcss, { type Root } from "postcss";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const stylesheet: Root = postcss.parse(readFileSync(resolve(here, "setup.css"), "utf8"));
+
+/** Reads a declaration from the top-level rule only, ignoring media-query overrides. */
+function declarationValue(selector: string, property: string): string {
+  let value: string | undefined;
+  stylesheet.walkRules((rule) => {
+    if (rule.parent?.type !== "root" || !rule.selectors.includes(selector)) return;
+    rule.walkDecls(property, (declaration) => {
+      value = declaration.value;
+    });
+  });
+  if (!value) throw new Error(`Missing ${property} declaration for ${selector}`);
+  return value;
+}
+
+describe("setup piece layout", () => {
+  it("keeps the command block wrapping rather than forcing a horizontal scroll", () => {
+    expect(declarationValue(".ots-command__code", "white-space")).toBe("pre-wrap");
+    expect(declarationValue(".ots-command__code", "overflow-wrap")).toBe("break-word");
+    // `break-all` splits short tokens like `sh`, which reads as a typo in a runnable command.
+    expect(() => declarationValue(".ots-command__code", "word-break")).toThrow();
+    // The code alone breaks strictly by character, so a reissued one cannot change the block's
+    // height. `overflow-wrap: anywhere` is not enough: it still prefers an existing break
+    // opportunity, so codes ending in `-` or `_` took an extra line at some widths.
+    expect(declarationValue(".ots-command__token", "word-break")).toBe("break-all");
+  });
+
+  it("answers a press with colour rather than shrinking the control", () => {
+    // Nothing on these surfaces may shrink under a click.
+    stylesheet.walkRules((rule) => {
+      if (!rule.selectors.some((selector) => selector.includes(":active"))) return;
+      rule.walkDecls("transform", (declaration) => {
+        expect(declaration.value).not.toContain("scale");
+      });
+    });
+  });
+
+  /*
+   * The reserved heights are declarations rather than utilities: this app compiles none of its own,
+   * so a bracketed class would be inert. They are still measurements the surfaces depend on — each
+   * is the tallest state its slot holds, and losing one lets whatever sits below move while a check
+   * resolves — so they are guarded here rather than left to be deleted as decoration.
+   */
+  it("holds a reserved height for every piece whose contents change length", () => {
+    // The connect status: waiting on one line, connected on another.
+    expect(declarationValue(".ots-slot--status", "min-height")).toBe("28px");
+    // A check row, whose failure detail takes a second line on a narrow screen.
+    expect(declarationValue(".ots-check", "min-height")).toBe("73px");
+    // The QR frame, which holds its box whether or not a code has arrived.
+    expect(declarationValue(".ots-qr", "height")).toBe("208px");
+  });
+
+  it("holds the taller reserve a check row needs once its status wraps", () => {
+    let value: string | undefined;
+    stylesheet.walkAtRules("media", (atRule) => {
+      if (!atRule.params.includes("399px")) return;
+      atRule.walkRules((rule) => {
+        if (!rule.selectors.includes(".ots-check")) return;
+        rule.walkDecls("min-height", (declaration) => {
+          value = declaration.value;
+        });
+      });
+    });
+    expect(value).toBe("90px");
+  });
+});

--- a/apps/web/src/setup/setup.css
+++ b/apps/web/src/setup/setup.css
@@ -1,0 +1,208 @@
+/*
+ * The styling the setup pieces carry with them.
+ *
+ * These rules belong to the components in this directory rather than to any one page, so they
+ * travel with them: a surface that renders a check row or a command block gets the row's markers
+ * and the block's terminal palette without having to know where they came from. Everything here is
+ * either driven by an attribute the markup already publishes for assistive technology
+ * (`data-state`, `data-expired`) or is a measured height the layout depends on, neither of which a
+ * utility class can express.
+ *
+ * The `ots-` prefix is this module's, and only this module's. Onboarding keeps `otv2-` for the
+ * styling that stays its own.
+ */
+
+/* Check rows ------------------------------------------------------------- */
+
+/*
+ * These two need to read as green and amber at 22px. The operational status palette is tuned for
+ * large surfaces and goes indistinct at this size, so the pair is stated locally.
+ */
+.ots-check__marker {
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--color-kumo-hairline);
+  line-height: 1;
+}
+
+.ots-check[data-state="passed"] .ots-check__marker {
+  border-color: #17a04a;
+  background: #e6f7ec;
+  color: #17a04a;
+}
+
+.ots-check[data-state="failed"] .ots-check__marker {
+  border-color: #d98207;
+  background: #fdf1de;
+  color: #d98207;
+}
+
+.ots-check[data-state="pending"] .ots-check__marker {
+  border-style: dashed;
+  animation: ots-fade 1.4s ease-in-out infinite;
+}
+
+@keyframes ots-fade {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Command block ---------------------------------------------------------- */
+
+/*
+ * The block carries its own near-black surface in both modes: it is a terminal quotation, and it
+ * reads as one only if it does not follow the page.
+ */
+.ots-command__body {
+  position: relative;
+  background: #0b101d;
+  border-color: var(--color-kumo-hairline);
+  transition: opacity 160ms ease;
+}
+
+.ots-command__code {
+  margin: 0;
+  color: #e6e9e0;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, "PingFang SC", monospace;
+  font-size: 13px;
+  line-height: 1.55;
+
+  /* Wraps rather than scrolling sideways: a command that runs off the edge cannot be read, and
+     `break-word` keeps short tokens like `sh` whole. */
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.ots-command__comment {
+  color: #9fb27f;
+}
+
+/*
+ * The trailing token is an opaque secret and breaks strictly by character. Left to break at its own
+ * hyphens and underscores, two codes of the same length wrap to a different number of lines and the
+ * block changes height when one is reissued.
+ *
+ * `overflow-wrap: anywhere` is not enough on its own: it still prefers an existing break opportunity
+ * when there is one, so a code ending in `-` or `_` took an extra line at some widths — 19 of 200
+ * random codes at 320px. `word-break: break-all` ignores those opportunities entirely. It is scoped
+ * to this span and no wider: on the whole command it would split short words like `sh`, which reads
+ * as a typo in something the reader is about to run.
+ */
+.ots-command__token {
+  word-break: break-all;
+}
+
+/*
+ * Sized as a real target rather than around the icon: a Kumo icon is 16px, which on a compact
+ * button reads as an afterthought next to the command it belongs to.
+ */
+.ots-command__copy {
+  width: 48px;
+  min-width: 48px;
+  height: 48px;
+  min-height: 48px;
+  padding: 0;
+  background: transparent;
+
+  /* The same value the command itself is set in, so the control is as legible as what it copies. */
+  color: #e6e9e0;
+}
+
+.ots-command__copy svg {
+  width: 24px;
+  height: 24px;
+}
+
+.ots-command__copy:hover:not(:disabled) {
+  background: rgb(230 233 224 / 14%);
+  color: #fff;
+}
+
+.ots-command__copy:active:not(:disabled) {
+  background: rgb(230 233 224 / 22%);
+}
+
+/* The block's shape while its command is still being issued: same box, nothing legible in it. */
+.ots-command-pending {
+  opacity: 0.35;
+  filter: blur(3px);
+  pointer-events: none;
+}
+
+/*
+ * An expired command says so on the block itself, over a heavy scrim: the block is the thing that
+ * expired, and a line underneath is easy to miss when the command above it still looks runnable.
+ * The scrim sits over the content rather than fading the whole block, so the notice stays legible.
+ */
+.ots-command[data-expired="true"] .ots-command__code,
+.ots-command[data-expired="true"] .ots-command__copy {
+  opacity: 0.18;
+}
+
+.ots-command__expired {
+  position: absolute;
+  inset: 0;
+  background: rgb(11 16 29 / 78%);
+  color: #e6e9e0;
+}
+
+.ots-command__expired button {
+  color: #cfe3a6;
+}
+
+.ots-command__expired button:hover {
+  color: #e8f5cd;
+}
+
+/* Measurements ----------------------------------------------------------- */
+
+/*
+ * The numbers these pieces depend on. They live here because this app compiles no utilities of its
+ * own: it ships Kumo's prebuilt sheet, so a bracketed class would be inert.
+ *
+ * Anything that changes length while someone is reading is given the height of its tallest state,
+ * so what sits under it keeps one position. These are measured, not chosen.
+ */
+
+/* The connect status: waiting on one line, connected on another. */
+.ots-slot--status {
+  min-height: 28px;
+}
+
+/* A check row's second line is a status, and a failure reads longer than what it replaces. */
+.ots-check {
+  min-height: 73px;
+}
+
+/* Below this width a failing check's status takes a second line. */
+@media (width <= 399px) {
+  .ots-check {
+    min-height: 90px;
+  }
+}
+
+/* The waiting dot carries its own animation. */
+.ots-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-kumo-brand);
+  animation: ots-fade 1.4s ease-in-out infinite;
+}
+
+/* The QR keeps its box whether or not a code has arrived, so the panel never changes height. */
+.ots-qr {
+  width: 208px;
+  height: 208px;
+}
+
+.ots-qr__image {
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## Summary

Reconnecting a computer and rebinding a messaging app are the same work whether they are met while setting an Agent up for the first time or reopened later from its settings. Only the frame around them differs — a numbered flow with a Continue button, or a dialog over a settings page — so the inside of that frame now lives in `apps/web/src/setup/`, and onboarding holds those pieces rather than owning them.

**Moved out of `onboarding-v2/`:**

| Piece | From |
|---|---|
| `CommandBlock` (whole file) | `command-block.tsx` |
| `QrCode`, `Countdown` + `useRemaining`, `CheckLine`, `ConnectStatus` | `steps.tsx` |
| `deriveChecks`, `messagingCliCheck`, `CheckRow`, `CheckState`, `RuntimeStatus`, `MessagingCliStatus`, `formatRemaining` | `flow.ts` |
| `CHECK_COPY`, and the `connect` / `messaging` copy subtrees | `copy.ts` |
| The styling those pieces carry | `onboarding-v2.css` |

Onboarding's step components stay where they are and are now thin shells over the shared pieces. Copy is moved verbatim — no wording changes anywhere.

**The one design judgement.** `ReadinessFacts` deliberately did **not** move: it is the shape of an onboarding flow in progress, and settings has an Agent that already exists. So the shared functions take the statuses they actually read instead:

```ts
deriveChecks(runtime: RuntimeStatus | undefined): readonly CheckRow[]
messagingCliCheck(status: MessagingCliStatus | undefined): CheckState
```

Onboarding passes `readiness?.runtime` and `readiness?.messagingCli[provider]`; settings can pass the equivalent facts off `AgentDetailView.availability.dependencies`. Both narrowings are behaviour-preserving: `deriveChecks(undefined)` and `deriveChecks("checking")` already produced the same two pending rows, and an unreported messaging CLI still reads as `pending` rather than `failed`.

**CSS prefix.** The moved rules take an `ots-` prefix, because `otv2-` names a flow they no longer belong to and settings would otherwise render onboarding-named classes. Onboarding keeps `otv2-` for what stays its own (`otv2-choice`, `otv2-rail__*`, `otv2-frame`, `otv2-slot--outcome`, `otv2-slot--signin`, `otv2-field-error`, `otv2-command-lead`, `otv2-slack-install`). The rename is complete: every `ots-` class used in TSX is defined in `setup.css` and vice versa. Each visual piece imports `./setup.css` itself, so nothing that uses one has to know which sheet it came from.

**Follow-ups from review** (in `46a8b26`). `onboarding-v2/copy.ts` imports `../setup/copy.js` rather than the barrel: it wants strings, and the barrel evaluates the components beside them — React, `qrcode`, and a stylesheet side effect no tree shake removes — which `server-backend.ts` was inheriting for the sake of one copy object. `flow.ts` already reached the pure check layer directly; this makes `copy.ts` consistent with it. And `messaging-cli-routing.test.tsx` pins the messaging step to the provider actually chosen: narrowing `messagingCliCheck` to a bare status moved that indexing out to the call site, and every other test gives both providers the same status, so a hard-coded provider stayed green. Mutation-checked — hard-coding `.feishu` at `steps.tsx:335` turns it red.

**Non-goals.** No new behaviour, no API changes, no copy edits, nothing outside `apps/web/src/onboarding-v2/` and the new `apps/web/src/setup/`. `packages/shared` is untouched. The duplicate `formatRemaining` in `features/agents/computer-setup.tsx` was left alone: that file belongs to a parallel track.

## Testing

- `pnpm check` — pass (the one warning is a pre-existing unsafe-fix suggestion in `packages/server`, untouched here)
- `pnpm build` — pass
- `pnpm typecheck` — pass
- `pnpm test` — `@opentag/web` **41 files / 543 tests, all green**, including every onboarding gatekeeper (`page.test.tsx`, `server-flow.test.tsx`, `flow.test.ts`, `layout.test.ts`, and the whole `pr262-*-findings` series)

`packages/client`'s `client-runtime-composition.test.ts` fails under `pnpm test`, with a different subset of ~5–10 timing-sensitive cases each run. It is **pre-existing and unrelated**: the same file fails the same way on an untouched `origin/main` worktree at `683f646` (7 failures on one run, 10 on the next), and this branch changes nothing outside `apps/web`.

Test coverage moved with the code rather than shrinking: `deriveChecks` / `messagingCliCheck` / `formatRemaining` cases now live in `setup/checks.test.ts` against the narrowed signatures, and the CSS assertions for the moved rules live in `setup/layout.test.ts`. `onboarding-v2/layout.test.ts` keeps the assertions for the rules that stayed. Reviewed at `5c2ef7d` as HEALTHY with independent QA; `46a8b26` adds the two follow-ups above.

## Breaking changes

None. This is a pure refactor; onboarding renders exactly what it rendered before.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (See the note above on the pre-existing `packages/client` flake.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
