### PR TITLE
fix(web): drop unused messaging-cli check-row copy

### DIFF
--- a/apps/web/src/onboarding-v2/messaging-cli-warning.test.tsx
+++ b/apps/web/src/onboarding-v2/messaging-cli-warning.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * A missing messaging CLI is named as a sentence on this step, not as a numbered check row.
+ *
+ * `messagingCliCheck` picks the chosen provider's status out of `ReadinessFacts`. A hard-coded
+ * provider would warn a Slack user about a CLI they do not need, or stay silent about one they do.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { COPY } from "./copy.js";
+import type { MessagingProvider, ReadinessFacts } from "./flow.js";
+import { MessagingStep } from "./steps.js";
+
+/** Lark's CLI is missing; Slack's is not. */
+const readiness: ReadinessFacts = { runtime: "ready", messagingCli: { feishu: "install", slack: "ready" } };
+
+const warningFor = (provider: MessagingProvider): string => COPY.messaging.cliMissing(COPY.messaging[provider].title);
+
+function renderStep(provider: MessagingProvider) {
+  render(
+    <MessagingStep
+      computerOnline
+      messaging={{ kind: "idle" }}
+      onChoose={() => undefined}
+      onSlackInstall={() => undefined}
+      onStart={() => undefined}
+      provider={provider}
+      readiness={readiness}
+    />,
+  );
+}
+
+describe("the messaging step's CLI warning", () => {
+  it("names the chosen provider's missing CLI as a sentence, not a check row", () => {
+    renderStep("feishu");
+    expect(screen.getByText(warningFor("feishu"))).toBeTruthy();
+    expect(document.querySelectorAll(".ots-check")).toHaveLength(0);
+  });
+
+  it("stays silent for a provider whose CLI is present, on the same facts", () => {
+    renderStep("slack");
+    expect(screen.queryByText(warningFor("slack"))).toBeNull();
+    expect(screen.queryByText(warningFor("feishu"))).toBeNull();
+    expect(document.querySelectorAll(".ots-check")).toHaveLength(0);
+  });
+});

--- a/apps/web/src/onboarding-v2/page.test.tsx
+++ b/apps/web/src/onboarding-v2/page.test.tsx
@@ -215,8 +215,9 @@ describe("OnboardingV2Page", () => {
     await settleCheck();
 
     expect(screen.getByText("Codex CLI is installed")).toBeTruthy();
-    // The messaging CLI is not checked here: no provider has been chosen yet.
-    expect(screen.queryByText("Lark CLI is installed")).toBeNull();
+    // The messaging CLI is not a computer-step row: no provider has been chosen yet, and a
+    // missing one is named later as a sentence on the messaging step, not a third check line.
+    expect(screen.queryByText(/lark-cli/i)).toBeNull();
     expect(screen.getByText("Everything your agent needs is ready.")).toBeTruthy();
   });
 

--- a/apps/web/src/setup/checks.ts
+++ b/apps/web/src/setup/checks.ts
@@ -17,11 +17,16 @@ export type MessagingCliStatus = "checking" | "ready" | "install" | "unavailable
  * runtime rows are derived from a single status rather than being two independent facts. A runtime
  * that is not installed leaves sign-in genuinely unknown, which the `blocked` state says out loud
  * instead of guessing.
+ *
+ * The messaging CLI is not a row: which binary is needed depends on a provider chosen later, and
+ * both onboarding and Agent settings name a missing one with a sentence
+ * (`SETUP_COPY.messaging.cliMissing`) rather than a third check line. `messagingCliCheck` returns
+ * that sentence's `CheckState`.
  */
 export type CheckState = "pending" | "passed" | "failed" | "blocked";
 
 export interface CheckRow {
-  readonly id: "runtime-cli" | "runtime-auth" | "messaging-cli";
+  readonly id: "runtime-cli" | "runtime-auth";
   readonly state: CheckState;
 }
 
@@ -41,7 +46,7 @@ export function deriveChecks(runtime: RuntimeStatus | undefined): readonly Check
   ];
 }
 
-/** The chosen provider's CLI, asked about once there is a provider to ask about. */
+/** The chosen provider's CLI, as the `CheckState` behind the missing-CLI sentence. */
 export function messagingCliCheck(status: MessagingCliStatus | undefined): CheckState {
   return messagingCliState(status ?? "checking");
 }

--- a/apps/web/src/setup/copy.ts
+++ b/apps/web/src/setup/copy.ts
@@ -10,9 +10,9 @@
 import type { CheckRow, CheckState } from "./checks.js";
 
 /**
- * Every check carries a line of detail in every state, not only when it fails. The list is the
- * page's spine while the user works in their terminal, so its rows must not change height as
- * results land — a list that reflows under someone is worse than one that says "checking".
+ * Copy for the numbered computer-check rows. Every row carries a line of detail in every state,
+ * not only when it fails, so the list does not reflow as results land. A missing messaging CLI is
+ * named later, as a sentence (`SETUP_COPY.messaging.cliMissing`) rather than a third check line.
  */
 export const CHECK_COPY: Record<
   CheckRow["id"],
@@ -34,15 +34,6 @@ export const CHECK_COPY: Record<
       passed: () => "Signed in and ready.",
       failed: (runtime) => `${runtime} is installed but not signed in.`,
       blocked: () => "We'll know once the CLI is installed.",
-    },
-  },
-  "messaging-cli": {
-    title: () => "Lark CLI is installed",
-    detail: {
-      pending: () => "Looking for lark-cli.",
-      passed: () => "Found on this computer.",
-      failed: () => "We need lark-cli to send Lark messages.",
-      blocked: () => "",
     },
   },
 };


### PR DESCRIPTION
## Summary

#315 offered two ways out of a typed union member that never became a row: render `CHECK_COPY["messaging-cli"]` on the messaging step, or delete it.

The messaging step already names a missing provider CLI. `messagingCliCheck` drives `COPY.messaging.cliMissing` — a sentence that works for Feishu and Slack. `CHECK_COPY["messaging-cli"]` was CheckLine copy that nothing rendered, and it is hardcoded to Lark/`lark-cli`. Putting that row on screen would tell a Slack user about a binary they do not need.

This PR takes the remove side, with one correction: **`messagingCliCheck` stays.** It is not dead. What goes is the unused CheckRow id and its copy. A focused test pins the live contract: the chosen provider's missing CLI is a sentence, not a numbered check row.

Related in-flight work:

- #310 extracts this module into `apps/web/src/setup/`. This change is on current `main`; that branch will need a rebase (the same files move).
- #311 rewrote the unused CheckLine copy to name `lark-cli`. That wording is still a good fit for the Feishu *sentence* later; it should not come back as a third computer-style row.

Closes #315

## Testing

- `pnpm check` — pass (the one warning is a pre-existing unsafe-fix suggestion in `server-backend.ts`, untouched)
- `pnpm --filter @opentag/web typecheck` — pass
- `pnpm --filter @opentag/web test` — **35 files / 446 tests**, including `messaging-cli-warning.test.tsx`, `flow.test.ts`, and `page.test.tsx`

## Breaking changes

None. The onboarding messaging step still shows the same missing-CLI sentence. Only unused CheckLine copy is gone.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (`pnpm check` and `@opentag/web` typecheck + test as above; this change is web-only.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
