### PR TITLE
feat(web): give the Agent its dependencies as a card, not a banner

### DIFF
--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1422,9 +1422,20 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("heading", { name: "Tasks" })).toBeTruthy();
     expect(await screen.findByRole("link", { name: "Investigate the failed deployment" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "View Details" }).getAttribute("href")).toBe(`/agents/${agentId}/usage`);
-    expect(screen.getByRole("link", { name: "Feishu · @reviewer" }).getAttribute("href")).toBe(
-      `/agents/${agentId}/settings/messaging`,
-    );
+    /*
+     * Connection sits beside Usage and names the channel, so the header carries no messaging
+     * control of its own -- Settings is its only trailing link.
+     */
+    expect(screen.getByRole("heading", { name: "Connection" })).toBeTruthy();
+    const connection = screen.getByRole("region", { name: "Connection" });
+    expect(within(connection).getByText("Feishu · @reviewer")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Feishu · @reviewer" })).toBeNull();
+    const header = screen.getByRole("heading", { name: "Reviewer" }).closest("header");
+    expect(
+      within(header as HTMLElement)
+        .getAllByRole("link")
+        .map((item) => item.textContent?.trim()),
+    ).toEqual(["Agents", "Settings"]);
     expect(screen.getByRole("link", { name: "Settings" }).getAttribute("href")).toBe(`/agents/${agentId}/settings`);
     expect(screen.queryByRole("heading", { name: "Current work" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Messaging" })).toBeNull();
@@ -1541,7 +1552,8 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", `/agents/${agentId}`);
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("link", { name: "Feishu · @reviewer" }));
+    const connection = await screen.findByRole("region", { name: "Connection" });
+    fireEvent.click(within(connection).getByRole("link", { name: "View messaging" }));
     expect(await screen.findByRole("heading", { name: "Messaging" })).toBeTruthy();
     const backLink = screen.getByRole("link", { name: "Back to Reviewer" });
     expect(backLink.getAttribute("href")).toBe(`/agents/${agentId}`);
@@ -1825,7 +1837,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByText("Offline")).toBeTruthy();
     expect(screen.getByText(/Last seen/)).toBeTruthy();
     expect(
-      screen.getByText("OpenTag is not running on Ada's Mac. Start it there to bring this Computer back online."),
+      screen.getByText("OpenTag is not running on Ada's Mac. Start it there to bring it back online."),
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Check again" })).toBeNull();
   });
@@ -1871,7 +1883,7 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByText("Offline")).toBeTruthy();
     expect(
-      screen.getByText("OpenTag is not running on Ada's Mac. Start it there to bring this Computer back online."),
+      screen.getByText("OpenTag is not running on Ada's Mac. Start it there to bring it back online."),
     ).toBeTruthy();
 
     computerStatus = "online";
@@ -1907,8 +1919,13 @@ describe("OpenTag Web App Shell", () => {
 
     computerStatus = "offline";
     fireEvent(window, new Event("focus"));
-    expect(await screen.findByText("This agent's computer is offline. Retrying automatically.")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "View Computer" })).toBeTruthy();
+    const offlineReason = await screen.findByText(
+      "OpenTag is not running on this Computer. Start it there to bring it back online.",
+    );
+    const computerRow = offlineReason.closest('[data-ui="connection-computer"]') as HTMLElement;
+    expect(computerRow).toBeTruthy();
+    expect(within(computerRow).getByText("Offline")).toBeTruthy();
+    expect(within(computerRow).getByRole("link", { name: "View Computer" })).toBeTruthy();
   });
 
   it("keeps Agent cards useful when Computer status cannot be confirmed", async () => {
@@ -1957,8 +1974,11 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByText("Messaging disconnected")).toBeNull();
     expect(screen.queryByText("Needs attention")).toBeNull();
     expect(screen.queryByText("Action required")).toBeNull();
-    expect(screen.getByText("Messages cannot be sent to this Agent.")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "View messaging" })).toBeTruthy();
+    const messagingRow = screen
+      .getByRole("region", { name: "Connection" })
+      .querySelector('[data-ui="connection-messaging"]') as HTMLElement;
+    expect(within(messagingRow).getByText("Messages cannot be delivered to this Agent right now.")).toBeTruthy();
+    expect(within(messagingRow).getByRole("link", { name: "View messaging" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Usage" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Tasks" })).toBeTruthy();
     expect(screen.queryByText("Handoff")).toBeNull();
@@ -1972,56 +1992,62 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Messaging status unavailable" }).getAttribute("href")).toBe(
+    const messagingRow = screen
+      .getByRole("region", { name: "Connection" })
+      .querySelector('[data-ui="connection-messaging"]') as HTMLElement;
+    // Unreadable evidence says so; it must not be reported as "no channel connected".
+    expect(within(messagingRow).getByText("Unknown")).toBeTruthy();
+    expect(within(messagingRow).getByText("OpenTag could not read this Agent's messaging connection.")).toBeTruthy();
+    expect(within(messagingRow).getByRole("link", { name: "View messaging" }).getAttribute("href")).toBe(
       `/agents/${agentId}/settings/messaging`,
     );
+    expect(screen.queryByText("Not connected")).toBeNull();
     expect(screen.queryByRole("link", { name: "Connect messaging" })).toBeNull();
     expect(screen.queryByText("Handoff")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
-  it("names the messaging channel on one manage control that keeps its shape in every state", async () => {
+  it("names the channel and keeps a repair exit in every messaging state", async () => {
     /*
-     * Messaging is what makes an Agent reachable, so this control is read before it is clicked. A
-     * bare provider glyph made a viewer guess at both the channel and what clicking it would do,
-     * and it collapsed to nothing readable when no channel was connected at all.
+     * Messaging is what makes an Agent reachable, and this card replaced the header control that
+     * used to carry it. Every state has to name what is true and still offer the way to change it:
+     * dropping the exit on a healthy channel would leave rebinding reachable only by hunting.
      */
-    installApi({ bound: true, provider: "slack" });
-    window.history.replaceState({}, "", `/agents/${agentId}`);
-    const connected = render(<App />);
-
-    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    const link = screen.getByRole("link", { name: /^Slack/ });
-    expect(link.getAttribute("data-ui")).toBe("agent-messaging-link");
-    expect(link.textContent).toContain("Slack");
-    expect(link.getAttribute("href")).toBe(`/agents/${agentId}/settings/messaging`);
-    /*
-     * The gear is what says this control manages the channel rather than only naming it, and it
-     * trails the label. Asserted by its own hook rather than by counting glyphs: a glyph count
-     * happens to equal one today only because the provider mark is an `img`, so it would stop
-     * guarding the gear the day `ProviderIcon` renders an svg.
-     */
-    const manage = link.querySelector('[data-ui="agent-messaging-manage"]');
-    expect(manage).toBeTruthy();
-    expect(link.lastElementChild).toBe(manage);
-    const connectedClassName = link.className;
-    expect(connectedClassName).toMatch(/\bh-\d/);
-    connected.unmount();
-
-    // Same control, same size: the header must not resize as the messaging state changes.
-    for (const state of [{ bound: false }, { bound: true, bindingEvidenceFails: true }]) {
-      installApi(state);
+    const states = [
+      {
+        detail: "Slack · Reviewer",
+        label: "Connected",
+        exit: "View messaging",
+        options: { bound: true, provider: "slack" as const },
+      },
+      {
+        detail: "Connect a chat app so teammates can send this Agent work.",
+        label: "Not connected",
+        exit: "Connect messaging",
+        options: { bound: false },
+      },
+      {
+        detail: "OpenTag could not read this Agent's messaging connection.",
+        label: "Unknown",
+        exit: "View messaging",
+        options: { bound: true, bindingEvidenceFails: true },
+      },
+    ];
+    for (const state of states) {
+      installApi(state.options);
       window.history.replaceState({}, "", `/agents/${agentId}`);
       const rendered = render(<App />);
 
       expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-      const control = screen.getByRole("link", {
-        name: state.bound ? "Messaging status unavailable" : "Connect messaging",
-      });
-      expect(control.getAttribute("data-ui")).toBe("agent-messaging-link");
-      expect(control.textContent).toContain(state.bound ? "Messaging status unavailable" : "Connect messaging");
-      expect(control.querySelector('[data-ui="agent-messaging-manage"]')).toBe(control.lastElementChild);
-      expect(control.className).toBe(connectedClassName);
+      const row = screen
+        .getByRole("region", { name: "Connection" })
+        .querySelector('[data-ui="connection-messaging"]') as HTMLElement;
+      expect(row).toBeTruthy();
+      expect(within(row).getByText(state.label)).toBeTruthy();
+      expect(within(row).getByText(state.detail)).toBeTruthy();
+      expect(within(row).getByRole("link", { name: state.exit }).getAttribute("href")).toBe(
+        `/agents/${agentId}/settings/messaging`,
+      );
       rendered.unmount();
     }
   });
@@ -2077,8 +2103,9 @@ describe("OpenTag Web App Shell", () => {
 
     window.history.replaceState({}, "", `/agents/${agentId}`);
     render(<App />);
-    expect(await screen.findByRole("link", { name: "Slack · Reviewer" })).toBeTruthy();
-    expect(screen.queryByRole("link", { name: /Slack · @reviewer/ })).toBeNull();
+    const connection = await screen.findByRole("region", { name: "Connection" });
+    expect(within(connection).getByText("Slack · Reviewer")).toBeTruthy();
+    expect(within(connection).queryByText(/Slack · @reviewer/)).toBeNull();
   });
 
   it("keeps the loaded Tasks when loading the next page fails", async () => {
@@ -2179,7 +2206,9 @@ describe("OpenTag Web App Shell", () => {
     expect(agentReads).toBe(2);
 
     releaseAgentRead();
-    expect(await screen.findByText("This agent's computer is offline. Retrying automatically.")).toBeTruthy();
+    expect(
+      await screen.findByText("OpenTag is not running on this Computer. Start it there to bring it back online."),
+    ).toBeTruthy();
   });
 
   it("invalidates a stale Agent detail after a background not-found response", async () => {

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -1421,7 +1421,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("heading", { name: "Usage" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Tasks" })).toBeTruthy();
     expect(await screen.findByRole("link", { name: "Investigate the failed deployment" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "View details" }).getAttribute("href")).toBe(`/agents/${agentId}/usage`);
+    expect(screen.getByRole("link", { name: "View Details" }).getAttribute("href")).toBe(`/agents/${agentId}/usage`);
     expect(screen.getByRole("link", { name: "Feishu · @reviewer" }).getAttribute("href")).toBe(
       `/agents/${agentId}/settings/messaging`,
     );
@@ -1443,7 +1443,7 @@ describe("OpenTag Web App Shell", () => {
   });
 
   it.each([
-    ["View details", "Usage"],
+    ["View Details", "Usage"],
     ["Settings", "Agent settings"],
   ])("keeps Agent context visible while opening %s", async (linkName, destinationHeading) => {
     let agentReads = 0;
@@ -1486,7 +1486,7 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("link", { name: "View details" }));
+    fireEvent.click(screen.getByRole("link", { name: "View Details" }));
     expect(await screen.findByRole("heading", { name: "Usage" })).toBeTruthy();
     await waitFor(() => expect(agentReads).toBe(2));
     expect((await screen.findByRole("alert")).textContent).toContain("Agent unavailable");

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -2061,6 +2061,94 @@ describe("OpenTag Web App Shell", () => {
     expect(within(messagingRow).getByText("OpenTag could not confirm whether messages reach this Agent.")).toBeTruthy();
   });
 
+  it("keeps a repair exit in every Computer state", async () => {
+    /*
+     * The mirror of the messaging case below, and the assertion whose absence let `Checking` ship
+     * without an exit. This card is the only Computer recovery surface on the Agent home, so a
+     * state that drops the link leaves no route to the Computer from this page at all.
+     *
+     * Each row's sentence is asserted with its label because the two are derived from different
+     * places: the label from the per-dependency `runtime.status`, the sentence previously from the
+     * Agent-wide reason, which let a paused Agent label a Provider "Checking" while claiming the
+     * connection was unconfirmed about a Computer that was online.
+     */
+    const readiness = (status: "checking" | "install" | "sign-in" | "unavailable" | "ready") =>
+      [{ observedAt: "2026-08-20T00:00:00.000Z", provider: "codex" as const, status }] as const;
+    const states = [
+      {
+        detail: "OpenTag could not confirm this Computer's current connection.",
+        label: "Unknown",
+        options: { computerEvidenceFails: true },
+      },
+      {
+        detail: "OpenTag is not running on this Computer. Start it there to bring it back online.",
+        label: "Offline",
+        options: { computerStatus: () => "offline" as const },
+      },
+      {
+        detail: "OpenTag is still checking Codex on this Computer.",
+        label: "Checking Codex",
+        options: { computerProviderReadiness: readiness("checking") },
+      },
+      {
+        detail: "Codex is not installed on this Computer.",
+        label: "Codex not installed",
+        options: { computerProviderReadiness: readiness("install") },
+      },
+      {
+        detail: "Codex is not signed in on this Computer.",
+        label: "Codex sign-in required",
+        options: { computerProviderReadiness: readiness("sign-in") },
+      },
+      {
+        detail: "Codex is unavailable on this Computer.",
+        label: "Codex unavailable",
+        options: { computerProviderReadiness: readiness("unavailable") },
+      },
+      { detail: undefined, label: "Online", options: { computerProviderReadiness: readiness("ready") } },
+    ];
+    for (const state of states) {
+      installApi({ bound: true, ...state.options });
+      window.history.replaceState({}, "", `/agents/${agentId}`);
+      const rendered = render(<App />);
+
+      expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+      const row = screen
+        .getByRole("region", { name: "Connection" })
+        .querySelector('[data-ui="connection-computer"]') as HTMLElement;
+      expect(row).toBeTruthy();
+      expect(within(row).getByText(state.label)).toBeTruthy();
+      if (state.detail) expect(within(row).getByText(state.detail)).toBeTruthy();
+      expect(within(row).getByRole("link", { name: "View Computer" }).getAttribute("href")).toBe(
+        `/agents/${agentId}/settings/computer`,
+      );
+      rendered.unmount();
+    }
+  });
+
+  it("does not let a paused Agent make the Computer row contradict itself", async () => {
+    /*
+     * `agent_suspended` outranks every dependency reason, so a row deriving its sentence from the
+     * Agent-wide reason described a masked state: "Checking Codex" beside "could not confirm this
+     * Computer's current connection", about a Computer that was online and confirmed.
+     */
+    installApi({
+      bound: true,
+      initialStatus: "suspended",
+      computerProviderReadiness: [{ observedAt: "2026-08-20T00:00:00.000Z", provider: "codex", status: "checking" }],
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    const row = screen
+      .getByRole("region", { name: "Connection" })
+      .querySelector('[data-ui="connection-computer"]') as HTMLElement;
+    expect(within(row).getByText("Checking Codex")).toBeTruthy();
+    expect(within(row).getByText("OpenTag is still checking Codex on this Computer.")).toBeTruthy();
+    expect(within(row).queryByText(/could not confirm this Computer's current connection/)).toBeNull();
+  });
+
   it("names the channel and keeps a repair exit in every messaging state", async () => {
     /*
      * Messaging is what makes an Agent reachable, and this card replaced the header control that

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -77,6 +77,8 @@ function installApi(
     computerStatus?: () => "online" | "offline";
     computerReadStatus?: (connected: boolean) => number | undefined;
     handoffReady?: boolean;
+    /** Fails only the handoff read, so the binding stays readable and `handoff_unconfirmed` is reachable. */
+    handoffEvidenceFails?: boolean;
     initialStatus?: "active" | "suspended";
     provider?: "feishu" | "slack";
     runtimeProvider?: "codex" | "claude-code";
@@ -409,7 +411,7 @@ function installApi(
       return json(adminConfig());
     }
     if (path === `/api/v1/agents/${agentId}/im-binding/handoff`) {
-      if (options.bindingEvidenceFails) {
+      if (options.bindingEvidenceFails || options.handoffEvidenceFails) {
         return json(
           {
             error: {
@@ -2005,6 +2007,58 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("link", { name: "Connect messaging" })).toBeNull();
     expect(screen.queryByText("Handoff")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("still names a paused Agent and its resume exit on the Agent home", async () => {
+    /*
+     * A pause is not a dependency failure, so no Connection row speaks for it: a suspended Agent
+     * can have a healthy Computer and a live channel, and `projectAgentAvailability` ranks the
+     * pause first while still filling both dependencies. Without an Agent-level notice the home
+     * reads Online / Connected and never says the Agent is off.
+     */
+    installApi({ bound: true, initialStatus: "suspended" });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    const notice = screen.getByRole("region", { name: "Agent status: Suspended" });
+    expect(within(notice).getByText("Suspended")).toBeTruthy();
+    expect(within(notice).getByText("This Agent is paused. Resume it to start receiving messages again.")).toBeTruthy();
+    expect(within(notice).getByRole("link", { name: "Manage Agent" }).getAttribute("href")).toBe(
+      `/agents/${agentId}/settings/manage`,
+    );
+  });
+
+  it("keeps unreadable Computer and Messaging evidence out of the success states", async () => {
+    /*
+     * Both rows used to fall through to Online / Connected when the evidence behind them could not
+     * be read -- a reachable Computer with no Provider readiness, and an active binding whose
+     * delivery could not be confirmed. Missing evidence is not a working Agent.
+     */
+    installApi({ bound: true, computerProviderReadiness: [] });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    const unconfirmedRuntime = render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    const computerRow = screen
+      .getByRole("region", { name: "Connection" })
+      .querySelector('[data-ui="connection-computer"]') as HTMLElement;
+    expect(within(computerRow).queryByText("Online")).toBeNull();
+    expect(within(computerRow).getByText("Unknown")).toBeTruthy();
+    expect(within(computerRow).getByText("OpenTag could not confirm Codex on this Computer.")).toBeTruthy();
+    unconfirmedRuntime.unmount();
+
+    installApi({ bound: true, handoffEvidenceFails: true });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    const messagingRow = screen
+      .getByRole("region", { name: "Connection" })
+      .querySelector('[data-ui="connection-messaging"]') as HTMLElement;
+    expect(within(messagingRow).queryByText("Connected")).toBeNull();
+    expect(within(messagingRow).getByText("Unknown")).toBeTruthy();
+    expect(within(messagingRow).getByText("OpenTag could not confirm whether messages reach this Agent.")).toBeTruthy();
   });
 
   it("names the channel and keeps a repair exit in every messaging state", async () => {

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -57,7 +57,7 @@ export function AgentUsageOverview({
         <div className="flex flex-wrap items-center gap-4">
           <UsageWindowSelect options={AGENT_HOME_USAGE_WINDOW_OPTIONS} value={windowDays} onChange={setWindowDays} />
           <Link className="text-sm text-kumo-link" params={{ agentId }} state={{ agent }} to="/agents/$agentId/usage">
-            View details
+            View Details
           </Link>
         </div>
       </div>

--- a/apps/web/src/features/agents/agent-detail-page.tsx
+++ b/apps/web/src/features/agents/agent-detail-page.tsx
@@ -7,8 +7,10 @@ import { AgentTasksSection } from "../tasks-page.js";
 import type { AgentDetailView } from "./agent-model.js";
 import {
   type AgentDependencyStatus,
+  agentAvailabilityRecovery,
   agentComputerStatus,
   agentMessagingStatus,
+  agentRecoveryMessage,
   agentStatusPresentation,
   initials,
   messagingChannelLabel,
@@ -25,6 +27,7 @@ export function AgentDetailPage({ agentId }: { agentId: string }) {
         <section className="grid gap-6">
           <AgentObjectHeader agent={agent} />
           <div className="grid gap-6">
+            <AgentLifecycleNotice agent={agent} />
             {/*
              * Usage and Connection share a row: neither fills the width on its own, and a failed
              * dependency belongs beside the work it is stopping rather than in a banner above it.
@@ -164,8 +167,9 @@ function ConnectionRow({
 
 export function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
   /*
-   * Only while the Agent is healthy. Every other state is already named, with its recovery exit, by
-   * the banner directly beneath this header, and saying it twice reads as two problems.
+   * Only while the Agent is healthy. A failed dependency is already named, with its own exit, by
+   * the Connection card below, and saying it twice reads as two problems. A paused Agent is not a
+   * dependency failure and no card speaks for it, so it gets the notice beneath this header.
    */
   if (agent.availability.state !== "ready") return null;
   const status = agentStatusPresentation(agent);
@@ -173,5 +177,38 @@ export function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
     <div className="inline-flex">
       <StatusIndicator label={status.label} tone={status.tone} />
     </div>
+  );
+}
+
+/**
+ * The Agent's own lifecycle, which no dependency row can carry. Computer and Messaging state their
+ * own failures in the Connection card, but a paused Agent has nothing wrong with either -- it was
+ * turned off -- so without this the home reports a healthy Computer and channel and never mentions
+ * that the Agent is not running.
+ */
+export function AgentLifecycleNotice({ agent }: { agent: AgentDetailView }) {
+  if (agent.availability.state !== "suspended") return null;
+  const status = agentStatusPresentation(agent);
+  const recovery = agentAvailabilityRecovery(agent);
+  return (
+    <section
+      className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-kumo-tint p-4"
+      aria-label={`Agent status: ${status.label}`}
+      data-ui="agent-lifecycle-notice"
+    >
+      <div className="grid gap-1">
+        <StatusIndicator label={status.label} tone={status.tone} />
+        <p className="text-sm text-kumo-subtle">{agentRecoveryMessage(agent)}</p>
+      </div>
+      {recovery ? (
+        <Link
+          className={buttonClassName({ size: "compact", variant: "secondary" })}
+          state={{ agent }}
+          {...recovery.link}
+        >
+          {recovery.label}
+        </Link>
+      ) : null}
+    </section>
   );
 }

--- a/apps/web/src/features/agents/agent-detail-page.tsx
+++ b/apps/web/src/features/agents/agent-detail-page.tsx
@@ -1,17 +1,18 @@
 import { Link } from "@tanstack/react-router";
 import { buttonClassName, Icon, StatusIndicator, Text } from "../../ui/design-system.js";
-import { ProviderIcon } from "../../ui/provider-icon.js";
 import { AgentUsageOverview } from "../agent-usage.js";
 import { AsyncState } from "../resource/resource-state.js";
 import { useAccount } from "../session/session-context.js";
 import { AgentTasksSection } from "../tasks-page.js";
 import type { AgentDetailView } from "./agent-model.js";
 import {
-  agentAvailabilityRecovery,
-  agentRecoveryMessage,
+  type AgentDependencyStatus,
+  agentComputerStatus,
+  agentMessagingStatus,
   agentStatusPresentation,
   initials,
   messagingChannelLabel,
+  platformLabel,
 } from "./agent-presentation.js";
 import { useAgentDetailView } from "./agent-queries.js";
 import { agentDetailLink, agentSettingsLink, agentSettingsSectionLink } from "./agent-routes.js";
@@ -24,8 +25,14 @@ export function AgentDetailPage({ agentId }: { agentId: string }) {
         <section className="grid gap-6">
           <AgentObjectHeader agent={agent} />
           <div className="grid gap-6">
-            {agent.availability.state !== "ready" ? <AgentRecoveryBanner agent={agent} /> : null}
-            <AgentUsageOverview agent={agent} agentId={agent.id} />
+            {/*
+             * Usage and Connection share a row: neither fills the width on its own, and a failed
+             * dependency belongs beside the work it is stopping rather than in a banner above it.
+             */}
+            <div className="grid gap-6 @min-[48rem]/workspace:grid-cols-2">
+              <AgentUsageOverview agent={agent} agentId={agent.id} />
+              <AgentConnectionCard agent={agent} />
+            </div>
             <AgentTasksSection agentId={agent.id} />
           </div>
         </section>
@@ -74,7 +81,6 @@ export function AgentObjectHeader({ agent, backToSettings }: { agent: AgentDetai
           </div>
         </div>
         <div className="flex flex-wrap items-center justify-end gap-3">
-          {!backToSettings ? <AgentMessagingLink agent={agent} /> : null}
           {!backToSettings ? (
             <Link
               className={buttonClassName({ variant: "secondary" })}
@@ -90,28 +96,69 @@ export function AgentObjectHeader({ agent, backToSettings }: { agent: AgentDetai
   );
 }
 
-export function AgentRecoveryBanner({ agent }: { agent: AgentDetailView }) {
-  const recovery = agentAvailabilityRecovery(agent);
-  const status = agentStatusPresentation(agent);
+/**
+ * Computer and Messaging, side by side, each carrying its own status and its own repair exit. One
+ * card rather than two: they are the pair an Agent needs before it can do anything, and reading
+ * them together is how a viewer answers "can this Agent work" without holding two cards in mind.
+ */
+export function AgentConnectionCard({ agent }: { agent: AgentDetailView }) {
+  const computer = agentComputerStatus(agent);
+  const messaging = agentMessagingStatus(agent);
+  const binding = agent.messaging.kind === "ready" ? agent.messaging.value : undefined;
   return (
     <section
-      className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-kumo-danger-tint p-4"
-      aria-label={`Agent status: ${status.label}`}
+      className="grid content-start gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
+      aria-labelledby="agent-connection-heading"
+      data-ui="connection-overview"
     >
-      <div>
-        <strong>{status.label}</strong>
-        <p>{agentRecoveryMessage(agent)}</p>
+      <Text as="h2" id="agent-connection-heading" variant="heading">
+        Connection
+      </Text>
+      <ConnectionRow
+        agent={agent}
+        identity={`${agent.computer.displayName} · ${platformLabel(agent.computer.platform)}`}
+        name="Computer"
+        status={computer}
+      />
+      <ConnectionRow
+        agent={agent}
+        identity={binding ? messagingChannelLabel(agent, binding) : undefined}
+        name="Messaging"
+        status={messaging}
+      />
+    </section>
+  );
+}
+
+function ConnectionRow({
+  agent,
+  identity,
+  name,
+  status,
+}: {
+  agent: AgentDetailView;
+  identity?: string;
+  name: string;
+  status: AgentDependencyStatus;
+}) {
+  return (
+    <div className="grid gap-1 border-t border-kumo-line pt-3" data-ui={`connection-${name.toLowerCase()}`}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <strong className="text-sm">{name}</strong>
+        <StatusIndicator label={status.label} tone={status.tone} />
       </div>
-      {recovery ? (
+      {identity ? <p className="truncate text-sm text-kumo-subtle">{identity}</p> : null}
+      {status.detail ? <p className="text-sm text-kumo-subtle">{status.detail}</p> : null}
+      {status.action ? (
         <Link
-          className={buttonClassName({ size: "compact", variant: "secondary" })}
-          state={{ agent }}
-          {...recovery.link}
+          className="w-fit text-sm text-kumo-link"
+          state={{ agent, returnAgentId: agent.id, returnLabel: agent.displayName }}
+          {...agentSettingsSectionLink(agent.id, status.action.section)}
         >
-          {recovery.label}
+          {status.action.label}
         </Link>
       ) : null}
-    </section>
+    </div>
   );
 }
 
@@ -126,35 +173,5 @@ export function AgentAvailabilityAction({ agent }: { agent: AgentDetailView }) {
     <div className="inline-flex">
       <StatusIndicator label={status.label} tone={status.tone} />
     </div>
-  );
-}
-
-/**
- * One affordance for messaging, beside Settings. Messaging is what makes an Agent reachable, so this
- * states the channel rather than hinting at it with a bare provider glyph, and the gear says the
- * same control manages it. Every state — a live channel, unreadable evidence, nothing connected —
- * renders the same three-part shape at the same height, so the header does not resize as the state
- * changes and a missing binding keeps its entry point rather than disappearing.
- */
-function AgentMessagingLink({ agent }: { agent: AgentDetailView }) {
-  const binding = agent.messaging.kind === "ready" ? agent.messaging.value : undefined;
-  const label = binding
-    ? messagingChannelLabel(agent, binding)
-    : agent.messaging.kind === "unconfirmed"
-      ? "Messaging status unavailable"
-      : "Connect messaging";
-  return (
-    <Link
-      aria-label={label}
-      className={buttonClassName({ className: "max-w-64", variant: "secondary" })}
-      data-ui="agent-messaging-link"
-      state={{ agent, returnAgentId: agent.id, returnLabel: agent.displayName }}
-      title={label}
-      {...agentSettingsSectionLink(agent.id, "messaging")}
-    >
-      {binding ? <ProviderIcon className="size-4 shrink-0" provider={binding.provider} /> : <Icon name="message" />}
-      <span className="truncate">{label}</span>
-      <Icon className="text-kumo-subtle" data-ui="agent-messaging-manage" name="settings" />
-    </Link>
   );
 }

--- a/apps/web/src/features/agents/agent-presentation.ts
+++ b/apps/web/src/features/agents/agent-presentation.ts
@@ -254,7 +254,7 @@ export function messagingAgentStatusDescription(
 export function agentAvailabilityRecovery(
   agent: AgentDetailView,
 ): { label: string; link: AgentSettingsSectionLink } | undefined {
-  if (!true || agent.availability.state === "ready") return undefined;
+  if (agent.availability.state === "ready") return undefined;
   if (agent.availability.reason === "agent_suspended") {
     return { label: "Manage Agent", link: agentSettingsSectionLink(agent.id, "manage") };
   }
@@ -353,7 +353,19 @@ export function agentComputerStatus(agent: AgentDetailView): AgentDependencyStat
   if (computer.state === "unconfirmed") return { action, detail: recovery, label: "Unknown", tone: "neutral" };
   if (computer.state === "action_required") return { action, detail: recovery, label: "Offline", tone: "warning" };
   const providerName = runtimeProviderName(runtime.provider);
-  if (runtime.status && runtime.status !== "ready") {
+  /*
+   * A reachable Computer whose Provider readiness could not be read is `runtime_unconfirmed`, not
+   * ready. Falling through to Online here would paint missing evidence as a working Agent.
+   */
+  if (!runtime.status) {
+    return {
+      action,
+      detail: `OpenTag could not confirm ${providerName} on this Computer.`,
+      label: "Unknown",
+      tone: "neutral",
+    };
+  }
+  if (runtime.status !== "ready") {
     // Named per Provider status, and worded by the same helper the Computer settings page uses.
     const detail = recovery;
     if (runtime.status === "checking") return { detail, label: `Checking ${providerName}`, tone: "info" };
@@ -396,9 +408,33 @@ export function agentMessagingStatus(agent: AgentDetailView): AgentDependencySta
     };
   }
   /*
+   * An active binding whose delivery evidence could not be read is `handoff_unconfirmed`. The
+   * channel may well be fine, but this row states what is known, and "Connected" is not known.
+   */
+  if (binding.bindingState === "active" && handoff.state === "unconfirmed") {
+    return {
+      action,
+      detail: "OpenTag could not confirm whether messages reach this Agent.",
+      label: "Unknown",
+      tone: "neutral",
+    };
+  }
+  const detail: Record<ImBindingSummary["bindingState"], string | undefined> = {
+    active: undefined,
+    provisioning: "The messaging connection is still being set up.",
+    reauthorization_required: "The messaging connection needs to be re-authorized before it can receive messages.",
+    error: "The messaging connection failed. Reconnect it to receive messages.",
+    disabled: "Messaging is turned off for this Agent. Reconnect it to receive messages.",
+  };
+  /*
    * The exit stays even when the channel is healthy. This card replaced the header's messaging
    * control, so dropping it on success would leave changing the bound bot reachable only by
    * hunting through Settings.
    */
-  return { action, label: messagingConnectionLabel(binding), tone: messagingConnectionTone(binding) };
+  return {
+    action,
+    detail: detail[binding.bindingState],
+    label: messagingConnectionLabel(binding),
+    tone: messagingConnectionTone(binding),
+  };
 }

--- a/apps/web/src/features/agents/agent-presentation.ts
+++ b/apps/web/src/features/agents/agent-presentation.ts
@@ -344,19 +344,35 @@ export type AgentDependencyStatus = {
 
 export function agentComputerStatus(agent: AgentDetailView): AgentDependencyStatus {
   const { computer, runtime } = agent.availability.dependencies;
-  const action = { label: "View Computer", section: "computer" as const };
-  /*
-   * "this Computer" rather than the machine name: the identity line directly above this sentence
-   * already carries the name, and repeating it made one row read as though it named two machines.
-   */
-  const recovery = computerRecoveryMessage(agent, "this Computer");
-  if (computer.state === "unconfirmed") return { action, detail: recovery, label: "Unknown", tone: "neutral" };
-  if (computer.state === "action_required") return { action, detail: recovery, label: "Offline", tone: "warning" };
   const providerName = runtimeProviderName(runtime.provider);
   /*
-   * A reachable Computer whose Provider readiness could not be read is `runtime_unconfirmed`, not
-   * ready. Falling through to Online here would paint missing evidence as a working Agent.
+   * Every branch carries the exit, including the healthy one. This card is the only Computer
+   * recovery surface on the Agent home now that the banner is gone, so a state without an exit
+   * leaves the Computer reachable only by hunting through Settings.
+   *
+   * The wording is derived from these two dependency fields rather than from
+   * `computerRecoveryMessage`, which answers a different question: it branches on the Agent-wide
+   * `availability.reason`, and a higher-ranked reason such as `agent_suspended` masks the runtime
+   * one -- which made this row label a Provider as "Checking" while its sentence claimed the
+   * connection was unconfirmed, about a Computer that was online.
    */
+  const action = { label: "View Computer", section: "computer" as const };
+  if (computer.state === "unconfirmed") {
+    return {
+      action,
+      detail: "OpenTag could not confirm this Computer's current connection.",
+      label: "Unknown",
+      tone: "neutral",
+    };
+  }
+  if (computer.state === "action_required") {
+    return {
+      action,
+      detail: "OpenTag is not running on this Computer. Start it there to bring it back online.",
+      label: "Offline",
+      tone: "warning",
+    };
+  }
   if (!runtime.status) {
     return {
       action,
@@ -365,16 +381,37 @@ export function agentComputerStatus(agent: AgentDetailView): AgentDependencyStat
       tone: "neutral",
     };
   }
+  if (runtime.status === "checking") {
+    return {
+      action,
+      detail: `OpenTag is still checking ${providerName} on this Computer.`,
+      label: `Checking ${providerName}`,
+      tone: "info",
+    };
+  }
+  if (runtime.status === "install") {
+    return {
+      action,
+      detail: `${providerName} is not installed on this Computer.`,
+      label: `${providerName} not installed`,
+      tone: "warning",
+    };
+  }
+  if (runtime.status === "sign-in") {
+    return {
+      action,
+      detail: `${providerName} is not signed in on this Computer.`,
+      label: `${providerName} sign-in required`,
+      tone: "warning",
+    };
+  }
   if (runtime.status !== "ready") {
-    // Named per Provider status, and worded by the same helper the Computer settings page uses.
-    const detail = recovery;
-    if (runtime.status === "checking") return { detail, label: `Checking ${providerName}`, tone: "info" };
-    if (runtime.status === "install")
-      return { action, detail, label: `${providerName} not installed`, tone: "warning" };
-    if (runtime.status === "sign-in") {
-      return { action, detail, label: `${providerName} sign-in required`, tone: "warning" };
-    }
-    return { action, detail, label: `${providerName} unavailable`, tone: "warning" };
+    return {
+      action,
+      detail: `${providerName} is unavailable on this Computer.`,
+      label: `${providerName} unavailable`,
+      tone: "warning",
+    };
   }
   return { action, label: "Online", tone: "success" };
 }

--- a/apps/web/src/features/agents/agent-presentation.ts
+++ b/apps/web/src/features/agents/agent-presentation.ts
@@ -2,6 +2,7 @@ import type { AgentSummary, ImBindingSummary } from "@opentag/shared/browser";
 import type { StatusTone } from "../../ui/design-system.js";
 import type { AgentAvailability, AgentDetailView, AgentListItem, AgentStatusSource } from "./agent-model.js";
 import { type AgentSettingsSectionLink, agentSettingsSectionLink } from "./agent-routes.js";
+import type { AgentSettingsSection } from "./agent-settings/sections.js";
 
 export const agentAvatarTones = ["brand", "amber", "blue", "neutral"] as const;
 
@@ -75,8 +76,7 @@ export function formatUsageNumber(value: number): string {
  * rather than a person: the Workspace has no authoritative operator field, and issue #125 makes the
  * Agent creator audit-only while stating that enrollment implies no control of the physical host.
  */
-export function computerRecoveryMessage(agent: AgentDetailView): string {
-  const computerName = agent.computer.displayName;
+export function computerRecoveryMessage(agent: AgentDetailView, computerName = agent.computer.displayName): string {
   if (agent.availability.reason === "runtime_unavailable") {
     const { provider, status } = agent.availability.dependencies.runtime;
     const providerName = provider === "codex" ? "Codex" : "Claude Code";
@@ -88,7 +88,7 @@ export function computerRecoveryMessage(agent: AgentDetailView): string {
   if (agent.availability.dependencies.computer.state !== "action_required") {
     return "OpenTag could not confirm this Computer's current connection.";
   }
-  return `OpenTag is not running on ${computerName}. Start it there to bring this Computer back online.`;
+  return `OpenTag is not running on ${computerName}. Start it there to bring it back online.`;
 }
 
 export function imBindingStateLabel(binding: ImBindingSummary): string {
@@ -328,4 +328,77 @@ export function formatRelativeTime(value: string): string {
   if (elapsedHours < 24) return `${elapsedHours} ${elapsedHours === 1 ? "hour" : "hours"} ago`;
   const elapsedDays = Math.floor(elapsedHours / 24);
   return `${elapsedDays} ${elapsedDays === 1 ? "day" : "days"} ago`;
+}
+
+/**
+ * The two dependencies an Agent needs to do any work, each presented on its own terms. They are
+ * deliberately not collapsed into one verdict: a connected channel can coexist with an offline
+ * Computer, and a viewer repairing one needs to see the other's state unchanged while they do it.
+ */
+export type AgentDependencyStatus = {
+  action?: { label: string; section: AgentSettingsSection };
+  detail?: string;
+  label: string;
+  tone: StatusTone;
+};
+
+export function agentComputerStatus(agent: AgentDetailView): AgentDependencyStatus {
+  const { computer, runtime } = agent.availability.dependencies;
+  const action = { label: "View Computer", section: "computer" as const };
+  /*
+   * "this Computer" rather than the machine name: the identity line directly above this sentence
+   * already carries the name, and repeating it made one row read as though it named two machines.
+   */
+  const recovery = computerRecoveryMessage(agent, "this Computer");
+  if (computer.state === "unconfirmed") return { action, detail: recovery, label: "Unknown", tone: "neutral" };
+  if (computer.state === "action_required") return { action, detail: recovery, label: "Offline", tone: "warning" };
+  const providerName = runtimeProviderName(runtime.provider);
+  if (runtime.status && runtime.status !== "ready") {
+    // Named per Provider status, and worded by the same helper the Computer settings page uses.
+    const detail = recovery;
+    if (runtime.status === "checking") return { detail, label: `Checking ${providerName}`, tone: "info" };
+    if (runtime.status === "install")
+      return { action, detail, label: `${providerName} not installed`, tone: "warning" };
+    if (runtime.status === "sign-in") {
+      return { action, detail, label: `${providerName} sign-in required`, tone: "warning" };
+    }
+    return { action, detail, label: `${providerName} unavailable`, tone: "warning" };
+  }
+  return { action, label: "Online", tone: "success" };
+}
+
+export function agentMessagingStatus(agent: AgentDetailView): AgentDependencyStatus {
+  const action = { label: "View messaging", section: "messaging" as const };
+  if (agent.messaging.kind === "unconfirmed") {
+    return {
+      action,
+      detail: "OpenTag could not read this Agent's messaging connection.",
+      label: "Unknown",
+      tone: "neutral",
+    };
+  }
+  const binding = agent.messaging.value;
+  if (!binding) {
+    return {
+      action: { label: "Connect messaging", section: "messaging" },
+      detail: "Connect a chat app so teammates can send this Agent work.",
+      label: "Not connected",
+      tone: "neutral",
+    };
+  }
+  const handoff = agent.availability.dependencies.handoff;
+  if (binding.bindingState === "active" && handoff.state === "action_required") {
+    return {
+      action,
+      detail: "Messages cannot be delivered to this Agent right now.",
+      label: "Cannot receive messages",
+      tone: "warning",
+    };
+  }
+  /*
+   * The exit stays even when the channel is healthy. This card replaced the header's messaging
+   * control, so dropping it on success would leave changing the bound bot reachable only by
+   * hunting through Settings.
+   */
+  return { action, label: messagingConnectionLabel(binding), tone: messagingConnectionTone(binding) };
 }

--- a/apps/web/src/features/agents/agents-page.tsx
+++ b/apps/web/src/features/agents/agents-page.tsx
@@ -32,8 +32,12 @@ export function AgentsPage() {
          * one primary action, and the reading edge is where a viewer looks for it first.
          */}
         <div data-ui="agents-page-action">
-          <Button ref={createTriggerRef} onClick={() => setCreateOpen(true)}>
-            New Agent <Icon name="plus" />
+          {/*
+           * The plus leads the label: it marks what the action does, and reading the mark before
+           * the words is the order every other control on this page already uses.
+           */}
+          <Button ref={createTriggerRef} variant="secondary" onClick={() => setCreateOpen(true)}>
+            <Icon name="plus" weight="bold" /> New Agent
           </Button>
         </div>
         <AsyncState state={state}>{(value) => <AgentsContent agents={value.agents} />}</AsyncState>

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -273,7 +273,7 @@ export function AgentTasksSection({ agentId }: { agentId: string }) {
       ) : null}
       {!unavailable && tasksQuery.data && tasks.length === 0 ? (
         <p className="text-sm text-kumo-subtle" role="status">
-          No Tasks yet. Work this Agent handles in Feishu or Slack appears here.
+          No Tasks yet. Message this Agent in your chat app to put it to work.
         </p>
       ) : null}
       {!unavailable && tasks.length > 0 ? (

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -49,6 +49,7 @@ import {
   Cpu,
   DotsThreeVertical,
   Gear,
+  type IconWeight,
   Info,
   Laptop,
   List,
@@ -361,7 +362,11 @@ const icons: Record<IconName, PhosphorIcon> = {
   user: User,
 };
 
-export function Icon({ className, name, ...props }: SVGAttributes<SVGSVGElement> & { name: IconName }) {
+export function Icon({
+  className,
+  name,
+  ...props
+}: SVGAttributes<SVGSVGElement> & { name: IconName; weight?: IconWeight }) {
   const Glyph = icons[name];
   return (
     <Glyph


### PR DESCRIPTION
## Summary

Second round of feedback on the Agents surface, stacked on #303 (base is that PR's branch, so this diff is only the new work).

**Computer and Messaging become a Connection card beside Usage.** They are what an Agent needs before it can do anything, and neither could be read without acting: Computer state appeared only as a red banner when it broke, Messaging was a bare glyph in the header, and a healthy Agent showed neither. They now sit in one card, each row naming what is true, why, and the way to change it. Usage takes the other half of the row instead of the full width, so the pair reads as one answer to "can this Agent work right now".

**The recovery banner is removed.** One offline Computer was stating itself three times — on the list card, in the banner, and in the header. The Connection card carries both the reason and the repair, per dependency.

**The header messaging control is removed**, since the card names the channel and carries its exit.

**New Agent steps down to `secondary`.** Kumo has no CTA variant beyond `primary`, so the weight had to come off the variant rather than the component: the filled brand green was the only heavy element on a page built from hairline rules. Its plus now leads the label and takes `bold` — that is what makes it read as an icon rather than a typed character. `Icon` did not accept a `weight` prop before this.

Also: `View details` → `View Details` to match `All Tasks`; the empty Tasks line says what to do rather than describing what the region will contain; and the Computer row stops naming the machine twice.

## Interaction with #313 — please read before merging either

#313 makes `agent.computer` **nullable** and adds a `computer_not_bound` reason. Two consequences for this PR:

1. The Connection card reads `agent.computer.displayName` and `agent.computer.platform` for its identity line. After #313 that dereference is unsound and needs a not-bound branch.
2. bestony asked on #303 that `computer_not_bound` keep its exit "in the detail banner, not back on the card". That is the right principle, but **this PR deletes the banner** — so on current `main` + this PR the correct home for that exit is the Connection card's Computer row, which is the detail-page, per-dependency exit the banner used to be. The card's own list-page exit stays removed.

I did not resolve this here because #313 is not merged and I did not want to guess at its final shape. Whichever lands second should take the not-bound state into the Connection card.

## Testing

- `pnpm check` — exit 0
- `pnpm typecheck` — exit 0
- Verified in a real browser against a local server and database at this head: the Agents list, the Agent detail page with an offline Computer and a Slack channel needing re-authorization, and the button at rest.

**`pnpm test` is not a clean signal from my machine right now and I am not claiming it as one.** Another session is running ~16 concurrent vitest workers here; load average went from 22 to 70 during verification, and the identical tree produced 0, 1, 4, and then 130 failures on successive full runs, each time a different set, including files this PR never touches (login, onboarding). Individual files pass in isolation. Even at a 60s timeout the suite starved. CI on a clean runner is the signal to trust here; please treat a green CI run as the verdict rather than my local numbers.

## Breaking changes

None.
