### PR TITLE
test(web): settle the render before reading a missing warning

### DIFF
--- a/apps/web/src/onboarding-v2/messaging-cli-routing.test.tsx
+++ b/apps/web/src/onboarding-v2/messaging-cli-routing.test.tsx
@@ -5,6 +5,10 @@
  * happens at this call site rather than inside the check. Nothing else asserts that: a hard-coded
  * provider would warn a Slack user about a CLI they do not need, or stay silent about one they do,
  * and every other test feeds the two providers the same status.
+ *
+ * Both cases wait for something the step must render before reading. The silence one needs it: an
+ * absent warning and a warning that has not arrived yet look identical to a synchronous query, so
+ * without a settled render the assertion would pass on a slow machine for the wrong reason.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -34,13 +38,15 @@ function renderStep(provider: MessagingProvider) {
 }
 
 describe("the messaging step's CLI check", () => {
-  it("warns about the chosen provider's missing CLI", () => {
+  it("warns about the chosen provider's missing CLI", async () => {
     renderStep("feishu");
-    expect(screen.getByText(warningFor("feishu"))).toBeTruthy();
+    expect(await screen.findByText(warningFor("feishu"))).toBeTruthy();
   });
 
-  it("stays silent for a provider whose CLI is present, on the same facts", () => {
+  it("stays silent for a provider whose CLI is present, on the same facts", async () => {
     renderStep("slack");
+    // The Slack panel's own lead, so what is waited for is this step rather than the page around it.
+    await screen.findByText(SETUP_COPY.messaging.slackIntro);
     // Neither its own warning nor the other provider's: reading position 0 would show one here.
     expect(screen.queryByText(warningFor("slack"))).toBeNull();
     expect(screen.queryByText(warningFor("feishu"))).toBeNull();

--- a/apps/web/src/onboarding-v2/messaging-cli-routing.test.tsx
+++ b/apps/web/src/onboarding-v2/messaging-cli-routing.test.tsx
@@ -6,9 +6,12 @@
  * provider would warn a Slack user about a CLI they do not need, or stay silent about one they do,
  * and every other test feeds the two providers the same status.
  *
- * Both cases wait for something the step must render before reading. The silence one needs it: an
- * absent warning and a warning that has not arrived yet look identical to a synchronous query, so
- * without a settled render the assertion would pass on a slow machine for the wrong reason.
+ * Both cases wait for something the step must render before reading. Nothing on this path is
+ * asynchronous today — the panel and its warning are decided in one pass and settle inside
+ * `render` — so the silence case is not currently at risk. It waits anyway because "no warning"
+ * and "no warning yet" are the same reading to a synchronous query, and an anchor is what keeps
+ * those apart the day something async lands ahead of the warning. The anchor is the Slack panel's
+ * own lead rather than a page-level element, so what is waited for is the step under test.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -45,7 +48,6 @@ describe("the messaging step's CLI check", () => {
 
   it("stays silent for a provider whose CLI is present, on the same facts", async () => {
     renderStep("slack");
-    // The Slack panel's own lead, so what is waited for is this step rather than the page around it.
     await screen.findByText(SETUP_COPY.messaging.slackIntro);
     // Neither its own warning nor the other provider's: reading position 0 would show one here.
     expect(screen.queryByText(warningFor("slack"))).toBeNull();


### PR DESCRIPTION
## Summary

Follow-up to #310, agreed with the reviewer rather than deferred silently: `messaging-cli-routing.test.tsx` asserted that neither provider's CLI warning is on screen, using a synchronous `queryByText`. An absent warning and a warning that has not rendered yet are indistinguishable to that query, so on a loaded machine the case could pass without the step having drawn anything at all — a green with no content behind it.

Both cases now settle the render first. The silence case waits on the Slack panel's own lead (`SETUP_COPY.messaging.slackIntro`) rather than a page-level element, so what it waits for is the step under test and not the shell around it.

**Corrected after review.** The original comment claimed the case would false-green on a slow machine. It would not: nothing on this path is asynchronous — `MessagingStep`'s only effect calls the injected `onStart`, and the one async component, `QrCode`, renders only at `messaging.kind === "waiting"` while the test passes `idle` — so the panel and its warning settle inside `render`. The anchor still earns its place, because "no warning" and "no warning yet" read identically and the anchor is what separates them once anything async lands ahead of the warning; but the reason written in the file now says that instead of describing a failure this component cannot reach. A comment is read as documentation.

Test-only. No product code changes.

## Testing

- `pnpm check` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm build` — exit 0
- `pnpm --filter @opentag/web exec vitest run src/onboarding-v2 src/setup` — exit 0, **17 files / 140 tests** green
- `pnpm --filter @opentag/web exec vitest run src/onboarding-v2/page.test.tsx` — exit 0, 42 tests green

**Mutation-verified in both directions, with a cold Vite cache before each run** (`rm -rf apps/web/node_modules/.vite`). Running a control pass and a mutated pass in the same hot worktree can reuse the cached transform of the unmutated file, which makes a mutant pass and look like a toothless assertion:

| `steps.tsx:335` | Result |
|---|---|
| unmutated | 2 passed |
| hard-coded `.feishu` | case 2 red — `expected <span></span> to be null` |
| hard-coded `.slack` | case 1 red — `Unable to find an element with the text: Lark messages are sent through its CLI…` |

**Evidence boundary.** The full local `@opentag/web` suite is not included: this machine is running several agents' test suites concurrently (load average 46–56 during this work), which starves vitest into 5s timeouts on files unrelated to any change. The run above is the affected surface — every test file under `src/onboarding-v2` and `src/setup` — and CI covers the whole suite on a clean machine.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (Full suite via CI; see the evidence boundary above for why the local full run is not cited.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
