### PR TITLE
fix(coverage): emit concatenated coverage-final.json for the patch gate

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -73,6 +73,12 @@ root `scripts/`, Server PostgreSQL integration tests, and Provider end-to-end te
 prioritizing gaps, not a required pull request check, and does not yet enforce repository-wide or per-workspace coverage
 thresholds. Add regression thresholds only after the measurement is stable across repeated runs.
 
+`pnpm test:coverage` measures one Vitest project at a time and concatenates the per-workspace summaries into
+`coverage/unit/coverage-summary.json` and the detailed Istanbul maps into `coverage/unit/coverage-final.json`. A single
+merged Vitest pass under-reports, so those aggregates must not be produced by the coverage provider's merge. Pull
+requests run a separate `Patch Coverage` check that reads the detailed map and fails when fewer than 80% of the
+executable TypeScript lines the pull request added or changed were hit.
+
 Required pull request CI still runs all offline unit tests. Agent Runtime keeps its separate 100% gate in
 `packages/client/vitest.agent-runtime.config.ts`, enforced by
 `pnpm --filter @opentag/client test:agent-runtime:coverage`.

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -1,7 +1,7 @@
 # OpenTag 开发指南
 
 > Canonical source: [DEVELOPMENT.md](./DEVELOPMENT.md)
-> Last synced with: 2026-08-30
+> Last synced with: 2026-08-31
 
 ## 前置要求
 
@@ -69,6 +69,11 @@ pnpm --filter @opentag/server test:integration
 但排除根目录 `scripts/`、Server PostgreSQL integration tests 和 Provider E2E。该统计是用于定位缺口和安排
 优先级的测量基线，不属于 Pull Request 必过检查，暂不设置全仓或分 workspace 覆盖率阈值。只有在重复运行的
 统计结果稳定后，才应增加回退阈值。
+
+`pnpm test:coverage` 会逐个测量 Vitest project，再把各 workspace 的 summary 拼到
+`coverage/unit/coverage-summary.json`，把 detailed Istanbul map 拼到 `coverage/unit/coverage-final.json`。一次合并
+的 Vitest 运行会低估覆盖率，因此这两份聚合不能交给 coverage provider 去做 merge。Pull Request 会另跑
+`Patch Coverage`：它读取这份 detailed map，并在本次新增或改动的可执行 TypeScript 行命中率低于 80% 时失败。
 
 Pull Request 必过 CI 仍会运行全部离线单测。Agent Runtime 继续使用
 `packages/client/vitest.agent-runtime.config.ts` 中独立的 100% 门槛，并由

--- a/scripts/__tests__/unit-coverage.test.mjs
+++ b/scripts/__tests__/unit-coverage.test.mjs
@@ -37,12 +37,14 @@ test("the patch-coverage gate still reads the concatenated detailed map", async 
   assert.match(workflow, /coverage\/unit\/coverage-final\.json/);
 });
 
-test("coverage reporter flags restate json so the CLI override still writes coverage-final.json", () => {
+test("coverage reporter flags restate json so the CLI override still writes coverage-final.json", async () => {
   assert.deepEqual(COVERAGE_REPORTER_FLAGS, [
     "--coverage.reporter=json",
     "--coverage.reporter=json-summary",
     "--coverage.reporter=text-summary",
   ]);
+  const source = await readFile(join(repoRoot, "scripts/unit-coverage.mjs"), "utf8");
+  assert.match(source, /\.\.\.COVERAGE_REPORTER_FLAGS/);
 });
 
 test("concatenateCoverageMaps unions disjoint Istanbul maps and keeps statement hits", () => {

--- a/scripts/__tests__/unit-coverage.test.mjs
+++ b/scripts/__tests__/unit-coverage.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assertCoverageArtifacts,
+  COVERAGE_REPORTER_FLAGS,
+  concatenateCoverageMaps,
+  writeAggregateReports,
+} from "../unit-coverage.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function fileCoverage(path, line, hits) {
+  return {
+    path,
+    s: { 0: hits },
+    statementMap: {
+      0: { start: { column: 0, line }, end: { column: 10, line } },
+    },
+  };
+}
+
+async function withTemporaryDirectory(run) {
+  const directory = await mkdtemp(join(tmpdir(), "opentag-unit-coverage-"));
+  try {
+    return await run(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("the patch-coverage gate still reads the concatenated detailed map", async () => {
+  const workflow = await readFile(join(repoRoot, ".github/workflows/coverage.yml"), "utf8");
+  assert.match(workflow, /coverage\/unit\/coverage-final\.json/);
+});
+
+test("coverage reporter flags restate json so the CLI override still writes coverage-final.json", () => {
+  assert.deepEqual(COVERAGE_REPORTER_FLAGS, [
+    "--coverage.reporter=json",
+    "--coverage.reporter=json-summary",
+    "--coverage.reporter=text-summary",
+  ]);
+});
+
+test("concatenateCoverageMaps unions disjoint Istanbul maps and keeps statement hits", () => {
+  const serverFile = "/repo/packages/server/src/db/schema/agents.ts";
+  const webFile = "/repo/apps/web/src/routes/index.tsx";
+  const concatenated = concatenateCoverageMaps([
+    { [serverFile]: fileCoverage(serverFile, 4, 3) },
+    { [webFile]: fileCoverage(webFile, 12, 0) },
+  ]);
+
+  assert.equal(concatenated[serverFile].s["0"], 3);
+  assert.equal(concatenated[serverFile].statementMap["0"].start.line, 4);
+  assert.equal(concatenated[webFile].s["0"], 0);
+  assert.equal(Object.keys(concatenated).length, 2);
+});
+
+test("concatenateCoverageMaps refuses a second copy of the same file instead of merging hits", () => {
+  const file = "/repo/packages/server/src/db/schema/agents.ts";
+  assert.throws(
+    () => concatenateCoverageMaps([{ [file]: fileCoverage(file, 4, 3) }, { [file]: fileCoverage(file, 4, 0) }]),
+    /collision/,
+  );
+});
+
+test("assertCoverageArtifacts requires both the summary and the detailed Istanbul report", async () => {
+  await withTemporaryDirectory(async (directory) => {
+    await mkdir(join(directory, "server"), { recursive: true });
+    const reportsDirectory = join(directory, "server");
+
+    assert.throws(() => assertCoverageArtifacts(reportsDirectory, "server"), /no summary/);
+
+    await writeFile(join(reportsDirectory, "coverage-summary.json"), "{}\n");
+    assert.throws(() => assertCoverageArtifacts(reportsDirectory, "server"), /no detailed report/);
+
+    await writeFile(join(reportsDirectory, "coverage-final.json"), "{}\n");
+    const paths = assertCoverageArtifacts(reportsDirectory, "server");
+    assert.equal(paths.summaryPath, join(reportsDirectory, "coverage-summary.json"));
+    assert.equal(paths.detailedPath, join(reportsDirectory, "coverage-final.json"));
+  });
+});
+
+test("writeAggregateReports emits the concatenated detailed map the patch-coverage gate reads", async () => {
+  await withTemporaryDirectory(async (directory) => {
+    const serverFile = "/repo/packages/server/src/db/schema/agents.ts";
+    const webFile = "/repo/apps/web/src/routes/index.tsx";
+    const summary = {
+      total: { lines: { covered: 1, pct: 50, total: 2 } },
+    };
+
+    const detailed = writeAggregateReports({
+      coverageRoot: directory,
+      detailedMaps: [{ [serverFile]: fileCoverage(serverFile, 4, 3) }, { [webFile]: fileCoverage(webFile, 12, 0) }],
+      summary,
+    });
+
+    const written = JSON.parse(await readFile(join(directory, "coverage-final.json"), "utf8"));
+    const writtenSummary = JSON.parse(await readFile(join(directory, "coverage-summary.json"), "utf8"));
+
+    assert.deepEqual(written, detailed);
+    assert.equal(written[serverFile].statementMap["0"].start.line, 4);
+    assert.equal(written[webFile].s["0"], 0);
+    assert.equal(writtenSummary.total.lines.pct, 50);
+  });
+});

--- a/scripts/unit-coverage.mjs
+++ b/scripts/unit-coverage.mjs
@@ -12,7 +12,9 @@
  *
  * So each project runs alone here, with `include` narrowed to the workspace that project actually
  * tests. Every file is then measured exactly once, by the only suite that can execute it, and the
- * per-workspace summaries are concatenated rather than merged.
+ * per-workspace summaries and detailed Istanbul maps are concatenated rather than merged. The
+ * detailed map at `coverage/unit/coverage-final.json` is what the pull-request patch-coverage gate
+ * walks for per-line hits; a provider-merged pass must not be used to produce it.
  *
  * Usage:
  *   node scripts/unit-coverage.mjs                 # every workspace, then the aggregate table
@@ -23,7 +25,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -38,7 +40,14 @@ const PROJECTS = [
 
 const COVERAGE_ROOT = resolve(repositoryRoot, "coverage/unit");
 
-function parseArguments(argv) {
+/** CLI reporter flags. Passing any `--coverage.reporter` replaces the config list, so json must be restated. */
+export const COVERAGE_REPORTER_FLAGS = [
+  "--coverage.reporter=json",
+  "--coverage.reporter=json-summary",
+  "--coverage.reporter=text-summary",
+];
+
+export function parseArguments(argv) {
   const options = { project: null, scope: null };
   for (let index = 0; index < argv.length; index += 1) {
     if (argv[index] === "--project") {
@@ -50,6 +59,52 @@ function parseArguments(argv) {
     }
   }
   return options;
+}
+
+export function assertCoverageArtifacts(reportsDirectory, projectName) {
+  const summaryPath = resolve(reportsDirectory, "coverage-summary.json");
+  const detailedPath = resolve(reportsDirectory, "coverage-final.json");
+  if (!existsSync(summaryPath)) {
+    throw new Error(`Coverage run for project "${projectName}" produced no summary`);
+  }
+  if (!existsSync(detailedPath)) {
+    throw new Error(`Coverage run for project "${projectName}" produced no detailed report`);
+  }
+  return { detailedPath, summaryPath };
+}
+
+/**
+ * Concatenate per-workspace Istanbul maps. Each file must appear in exactly one map: a second copy
+ * is the merged-pass collision this script exists to avoid, not a number to max() or last-write.
+ */
+export function concatenateCoverageMaps(maps) {
+  const aggregate = {};
+  const owners = new Map();
+  for (const [index, map] of maps.entries()) {
+    if (map === null || typeof map !== "object" || Array.isArray(map)) {
+      throw new Error(`Coverage map ${index} is not an Istanbul file map`);
+    }
+    for (const [file, coverage] of Object.entries(map)) {
+      const owner = owners.get(file);
+      if (owner !== undefined) {
+        throw new Error(
+          `Coverage map collision for ${file} (already recorded from map ${owner}, also in map ${index}). ` +
+            "Per-workspace measurement must record each file once.",
+        );
+      }
+      aggregate[file] = coverage;
+      owners.set(file, index);
+    }
+  }
+  return aggregate;
+}
+
+export function writeAggregateReports({ coverageRoot, detailedMaps, summary }) {
+  mkdirSync(coverageRoot, { recursive: true });
+  const detailed = concatenateCoverageMaps(detailedMaps);
+  writeFileSync(resolve(coverageRoot, "coverage-summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+  writeFileSync(resolve(coverageRoot, "coverage-final.json"), `${JSON.stringify(detailed)}\n`);
+  return detailed;
 }
 
 function runProject(project, scope) {
@@ -68,24 +123,24 @@ function runProject(project, scope) {
       "--project",
       project.name,
       `--coverage.include=${include}`,
-      "--coverage.reporter=json-summary",
-      "--coverage.reporter=text-summary",
+      ...COVERAGE_REPORTER_FLAGS,
       `--coverage.reportsDirectory=${reportsDirectory}`,
     ],
     { cwd: repositoryRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
   );
 
-  const summaryPath = resolve(reportsDirectory, "coverage-summary.json");
-  if (!existsSync(summaryPath)) {
+  try {
+    const { detailedPath, summaryPath } = assertCoverageArtifacts(reportsDirectory, project.name);
+    return {
+      detailed: JSON.parse(readFileSync(detailedPath, "utf8")),
+      failed: result.status !== 0,
+      summary: JSON.parse(readFileSync(summaryPath, "utf8")),
+    };
+  } catch (error) {
     process.stderr.write(result.stdout ?? "");
     process.stderr.write(result.stderr ?? "");
-    throw new Error(`Coverage run for project "${project.name}" produced no summary`);
+    throw error;
   }
-
-  return {
-    failed: result.status !== 0,
-    summary: JSON.parse(readFileSync(summaryPath, "utf8")),
-  };
 }
 
 function main() {
@@ -97,13 +152,15 @@ function main() {
   }
 
   const aggregate = {};
+  const detailedMaps = [];
   const perProject = [];
   let anyFailed = false;
 
   for (const project of selected) {
     process.stdout.write(`\n── ${project.name} ──\n`);
-    const { failed, summary } = runProject(project, options.scope);
+    const { detailed, failed, summary } = runProject(project, options.scope);
     anyFailed ||= failed;
+    detailedMaps.push(detailed);
 
     for (const [file, metrics] of Object.entries(summary)) {
       if (file !== "total") {
@@ -159,8 +216,12 @@ function main() {
   };
 
   if (!options.project && !options.scope) {
-    mkdirSync(COVERAGE_ROOT, { recursive: true });
-    writeFileSync(resolve(COVERAGE_ROOT, "coverage-summary.json"), `${JSON.stringify(aggregate, null, 2)}\n`);
+    const detailed = writeAggregateReports({
+      coverageRoot: COVERAGE_ROOT,
+      detailedMaps,
+      summary: aggregate,
+    });
+    process.stdout.write(`   detailed ${Object.keys(detailed).length} files -> coverage/unit/coverage-final.json\n`);
   }
 
   process.stdout.write("\n=== unit line coverage ===\n");
@@ -180,4 +241,8 @@ function main() {
   }
 }
 
-main();
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  main();
+}

--- a/scripts/unit-coverage.mjs
+++ b/scripts/unit-coverage.mjs
@@ -47,7 +47,7 @@ export const COVERAGE_REPORTER_FLAGS = [
   "--coverage.reporter=text-summary",
 ];
 
-export function parseArguments(argv) {
+function parseArguments(argv) {
   const options = { project: null, scope: null };
   for (let index = 0; index < argv.length; index += 1) {
     if (argv[index] === "--project") {


### PR DESCRIPTION
## Summary

`Enforce Patch Coverage` crashes on every pull request with `ENOENT` for `coverage/unit/coverage-final.json`. That is not a coverage shortfall: after #293, `pnpm test:coverage` measures one Vitest project at a time and only concatenates `coverage-summary.json`. The CLI reporter override also dropped the Istanbul `json` reporter, so the detailed map the gate walks (`statementMap` / `s`) is never written.

This restores that map without reintroducing the merged-pass under-count #293 fixed:

- Restate `--coverage.reporter=json` so each workspace writes `coverage/unit/<project>/coverage-final.json`.
- Concatenate those maps into `coverage/unit/coverage-final.json` the same way summaries are concatenated.
- Fail closed if the same file appears in two workspace maps, instead of last-write or `max()`-merging hits.

The workflow still reads the same path. A single merged Vitest pass is still not used.

Fixes #320

## Testing

- `node --test scripts/__tests__/unit-coverage.test.mjs` — 6 passed (reporter flags including spawn-site pin, concatenate, collision, missing artifacts, gate path contract)
- `pnpm check` — pass (pre-existing `useOptionalChain` warning in `onboarding-v2/server-backend.ts`, untouched)
- `pnpm typecheck` — pass (server `tsc` needed `NODE_OPTIONS=--max-old-space-size=8192` and turbo `--concurrency=2` on this machine; CI has more headroom)
- `pnpm test` — pass, including the new script tests
- `pnpm build` — pass with the same extra heap / `--concurrency=2` (default parallel `pnpm build` OOM'd web vite on this machine)
- `node scripts/unit-coverage.mjs --project shared` — wrote `coverage/unit/shared/coverage-final.json` with `statementMap` and `s` (21 files). `--project` still skips the root aggregate, as before.
- Full `pnpm test:coverage` (all five workspaces) not run locally; CI Patch Coverage will exercise the aggregate write.

## Breaking changes

None. Weekly `Unit Coverage` still consumes `coverage/unit/coverage-summary.json`. The detailed map is an additional concatenated artifact.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
