### PR TITLE
test(web): realign the empty-Tasks assertion with the shipped copy

### DIFF
--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -543,7 +543,7 @@ describe("Tasks debug view", () => {
     expect(screen.getByText("Loading Tasks…")).toBeTruthy();
     release({ tasks: [], nextCursor: null });
     expect(
-      await screen.findByText("No Tasks yet. Work this Agent handles in Feishu or Slack appears here."),
+      await screen.findByText("No Tasks yet. Message this Agent in your chat app to put it to work."),
     ).toBeTruthy();
 
     vi.mocked(browserApi.tasks)


### PR DESCRIPTION
Closes #331.

## `main` is red, and it broke on landing rather than in review

`apps/web/src/features/tasks-page.test.tsx` asserts an empty-state sentence that the product stopped
saying:

| | |
|---|---|
| Test expects | `No Tasks yet. Work this Agent handles in Feishu or Slack appears here.` |
| Product renders | `No Tasks yet. Message this Agent in your chat app to put it to work.` |

### How two green PRs produced a red `main`

- **#317** (`0e36908`) rewrote the empty state in `tasks-page.tsx` — deliberately, to stop naming
  providers in that sentence.
- **#294** (`e858cca`) added a test asserting the sentence as it read *before* #317.

Neither touched the other's lines, so there was no textual conflict and both merged clean. The break
only exists in the combination — a semantic conflict git cannot see, which is why no PR gate caught
it.

### Which side is wrong

The **test**. #317 changed the copy on purpose, so the shipped string is the intended one and the
assertion is what went stale.

### Verified rather than inferred

I reproduced the failure on a **pristine worktree at `e858cca`** with nothing else applied, to rule
out any in-flight branch as the cause:

```
FAIL src/features/tasks-page.test.tsx > renders Agent Tasks loading, empty, append success, and append failure states
TestingLibraryElementError: Unable to find an element with the text:
  No Tasks yet. Work this Agent handles in Feishu or Slack appears here.
Tests  1 failed | 479 passed (480)
```

Still present on current `main` (`2dbc5df`) — #316 landing did not touch it.

With this one-line change, on `2dbc5df`:

| Command | Result |
|---|---|
| `pnpm --filter @opentag/web test` | **40 files / 482 tests passed** (exit 0) |

Found while rebasing #311, which edits this file and inherited the red. Sent as its own PR rather
than folded into a naming change, so it can land immediately and unblock every branch — the fix
belongs to `main`, not to #311.

