### PR TITLE
fix(web): align the empty Tasks assertion with the shipped copy

### DIFF
--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -543,7 +543,7 @@ describe("Tasks debug view", () => {
     expect(screen.getByText("Loading Tasks…")).toBeTruthy();
     release({ tasks: [], nextCursor: null });
     expect(
-      await screen.findByText("No Tasks yet. Work this Agent handles in Feishu or Slack appears here."),
+      await screen.findByText("No Tasks yet. Message this Agent in your chat app to put it to work."),
     ).toBeTruthy();
 
     vi.mocked(browserApi.tasks)


### PR DESCRIPTION
## What is broken

`main` is red. `Checks`, `Node 22.13.0 Compatibility` and `Node 26 Compatibility` all fail on the same assertion, and `Deploy Staging` is skipped as a result ([run 33351770516](https://github.com/first-tree-ai/opentag/actions/runs/33351770516)):

```
FAIL web src/features/tasks-page.test.tsx > Tasks debug view > renders Agent Tasks loading, empty, append success, and append failure states
TestingLibraryElementError: Unable to find an element with the text:
No Tasks yet. Work this Agent handles in Feishu or Slack appears here.
```

## Why

Two merged PRs disagree about one string, and neither was wrong on its own branch.

- #317 (`0e36908`) changed the Tasks empty state to **"No Tasks yet. Message this Agent in your chat app to put it to work."**
- #294 (`e858cca`) landed afterwards carrying an assertion that still expects the pre-#317 copy.

Nothing in the source renders the old sentence any more — `git grep` finds it only in this assertion.

## The fix

Point the assertion at the copy the component actually renders. The component text is the intentional one: #317 deliberately replaced the provider-naming sentence, and the stale copy also names a channel we have since stopped naming in that surface.

## Verification

- `apps/web/src/features/tasks-page.test.tsx` — **32/32 pass** with this change
- positive control: with the change stashed, the same run fails 1/32 with exactly the CI error above, so the fix is what closes it

Repository-wide test noise on my host is documented elsewhere and is not touched by this one-line change; exact-head CI is the full-suite signal.
