### PR TITLE
fix: correlate connect codes with redeemed computers

### DIFF
--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -251,6 +251,7 @@ describe("BrowserApi", () => {
       expect(init?.body).toBeUndefined();
       return new Response(
         JSON.stringify({
+          connectCodeId: "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f",
           bootstrapCommand: `opentag computer connect --server http://127.0.0.1:8000 -- code`,
           expiresIn: 900,
           issuedAt: "2030-01-01T00:00:00.000Z",
@@ -327,5 +328,44 @@ describe("BrowserApi", () => {
     });
     await expect(new BrowserApi(malformedCookieFetch).logout()).resolves.toBeUndefined();
     setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
+  });
+
+  it("reads the connect code's redemption verdict from its Account-native path", async () => {
+    const status = {
+      connectCodeId: "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f",
+      state: "redeemed",
+      computerId: "85fe9af3-d1c6-472b-b78c-8a7ccf512750",
+      redeemedAt: "2030-01-01T00:00:05.000Z",
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      expect(String(input)).toBe(`/api/v1/computer-connect-codes/${status.connectCodeId}`);
+      expect(init?.method).toBeUndefined();
+      return new Response(JSON.stringify(status), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const api = new BrowserApi(fetchImpl);
+
+    await expect(api.computerConnectCodeStatus(status.connectCodeId)).resolves.toEqual(status);
+  });
+
+  it("fails the connect code status read closed when the Server will not name it", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "RESOURCE_NOT_FOUND",
+              category: "deterministic",
+              message: "The requested resource was not found",
+              requestId: "req_1",
+            },
+          }),
+          { status: 404, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const api = new BrowserApi(fetchImpl);
+
+    const failure = await api.computerConnectCodeStatus("7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f").catch((cause) => cause);
+    expect(failure).toBeInstanceOf(ApiError);
+    expect(failure.status).toBe(404);
   });
 });

--- a/apps/web/src/__tests__/app.test.tsx
+++ b/apps/web/src/__tests__/app.test.tsx
@@ -123,6 +123,7 @@ function installApi(
   let loggedOut = false;
   let meFailuresRemaining = options.meFailuresAfterProfileUpdate ?? 0;
   let computerConnectCodeIssued = false;
+  const connectCodeId = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
   vi.mocked(fetch).mockImplementation(async (input, init) => {
     const path = String(input);
     if (path === "/api/v1/auth/providers") {
@@ -285,28 +286,23 @@ function installApi(
             ],
       });
     }
-    if (path === "/api/v1/computers") {
-      const failureStatus = options.computerReadStatus?.(computerConnectCodeIssued);
-      if (failureStatus) return json({ error: { message: "Computer readiness unavailable" } }, failureStatus);
-      if (options.computerEvidenceFails) return json({ error: { message: "Computer evidence unavailable" } }, 503);
+    const normalizeComputer = (computer: Record<string, unknown>) => ({
+      computerId: computer.computerId ?? computer.id,
+      displayName: computer.displayName,
+      platform: computer.platform,
+      connectionStatus: computer.connectionStatus,
+      providerReadiness: computer.providerReadiness,
+      connectedAt: computer.connectedAt ?? null,
+      lastSeenAt: computer.lastSeenAt ?? null,
+      observedAt: computer.observedAt ?? computer.lastSeenAt ?? computer.connectedAt ?? "2026-08-20T00:00:00.000Z",
+      enrolledAt: computer.enrolledAt ?? "2026-08-20T00:00:00.000Z",
+      agentIds: computer.agentIds ?? [agentId],
+    });
+    const listComputers = async (connected: boolean) => {
       const configured =
-        typeof options.computers === "function"
-          ? await options.computers(computerConnectCodeIssued)
-          : options.computers;
-      const normalizeComputer = (computer: Record<string, unknown>) => ({
-        computerId: computer.computerId ?? computer.id,
-        displayName: computer.displayName,
-        platform: computer.platform,
-        connectionStatus: computer.connectionStatus,
-        providerReadiness: computer.providerReadiness,
-        connectedAt: computer.connectedAt ?? null,
-        lastSeenAt: computer.lastSeenAt ?? null,
-        observedAt: computer.observedAt ?? computer.lastSeenAt ?? computer.connectedAt ?? "2026-08-20T00:00:00.000Z",
-        enrolledAt: computer.enrolledAt ?? "2026-08-20T00:00:00.000Z",
-        agentIds: computer.agentIds ?? [agentId],
-      });
-      return json({
-        computers: configured?.map(normalizeComputer) ?? [
+        typeof options.computers === "function" ? await options.computers(connected) : options.computers;
+      return (
+        configured?.map(normalizeComputer) ?? [
           normalizeComputer({
             id: computerId,
             displayName: "Ada's Mac",
@@ -318,19 +314,52 @@ function installApi(
             connectedAt: "2026-08-20T00:00:00.000Z",
             lastSeenAt: "2026-08-20T00:00:00.000Z",
           }),
-        ],
-      });
+        ]
+      );
+    };
+    if (path === "/api/v1/computers") {
+      const failureStatus = options.computerReadStatus?.(computerConnectCodeIssued);
+      if (failureStatus) return json({ error: { message: "Computer readiness unavailable" } }, failureStatus);
+      if (options.computerEvidenceFails) return json({ error: { message: "Computer evidence unavailable" } }, 503);
+      return json({ computers: await listComputers(computerConnectCodeIssued) });
     }
     if (path === "/api/v1/computer-connect-codes" && init?.method === "POST") {
       computerConnectCodeIssued = true;
       return json(
         {
+          connectCodeId,
           bootstrapCommand: "opentag computer connect --server https://opentag.example.com -- example",
           expiresIn: 900,
           issuedAt: "2026-08-20T00:00:00.000Z",
         },
         201,
       );
+    }
+    if (path === `/api/v1/computer-connect-codes/${connectCodeId}`) {
+      // The mock Server's own verdict: pending until the issued code is redeemed, then the exact
+      // Computer — the one the post-issuance Computers list gained or saw reconnect. Never the raw
+      // code, and never a machine that was simply already there.
+      if (!computerConnectCodeIssued) {
+        return json({ connectCodeId, state: "pending", computerId: null, redeemedAt: null });
+      }
+      const before = await listComputers(false);
+      const after = await listComputers(true);
+      const baseline = new Map(before.map((computer) => [computer.computerId, computer.connectedAt]));
+      const arrived = after.find(
+        (computer) =>
+          computer.connectionStatus === "online" &&
+          typeof computer.computerId === "string" &&
+          (!baseline.has(computer.computerId) || baseline.get(computer.computerId) !== computer.connectedAt),
+      );
+      if (!arrived || typeof arrived.computerId !== "string") {
+        return json({ connectCodeId, state: "pending", computerId: null, redeemedAt: null });
+      }
+      return json({
+        connectCodeId,
+        state: "redeemed",
+        computerId: arrived.computerId,
+        redeemedAt: typeof arrived.connectedAt === "string" ? arrived.connectedAt : "2026-08-20T00:00:00.000Z",
+      });
     }
     if (path.startsWith(`/api/v1/agents/${agentId}/usage?`)) {
       const days = Number(new URL(path, "https://opentag.test").searchParams.get("days"));

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -10,6 +10,7 @@ import {
   type AgentUsageWindowDays,
   type AuthProvidersResponse,
   AuthProvidersResponseSchema,
+  accountComputerConnectCodePath,
   agentByIdPath,
   agentConfigPath,
   agentFeishuSetupAttemptsPath,
@@ -22,6 +23,8 @@ import {
   agentUsagePath,
   type ComputerConnectCodeIssueResponse,
   ComputerConnectCodeIssueResponseSchema,
+  type ComputerConnectCodeStatus,
+  ComputerConnectCodeStatusSchema,
   type CreateAgentRequest,
   type EmailSignInRequest,
   type EmailSignUpRequest,
@@ -262,6 +265,15 @@ export class BrowserApi {
       body: JSON.stringify({ mode }),
       headers: { "content-type": "application/json", ...this.csrfHeaders() },
     });
+  }
+
+  /**
+   * The Server's own verdict on a code this Account issued: pending until a machine redeems it,
+   * then the exact Computer that did. This — never a Computers-list heuristic — is how a waiting
+   * page learns which Computer its command enrolled.
+   */
+  computerConnectCodeStatus(connectCodeId: string): Promise<ComputerConnectCodeStatus> {
+    return this.request(accountComputerConnectCodePath(connectCodeId), ComputerConnectCodeStatusSchema);
   }
 
   async health(path: "/healthz" | "/readyz"): Promise<{ latencyMs: number; observedAt: string; status: string }> {

--- a/apps/web/src/features/agents/computer-setup.test.tsx
+++ b/apps/web/src/features/agents/computer-setup.test.tsx
@@ -82,16 +82,17 @@ describe("ComputerSetup", () => {
     Reflect.deleteProperty(navigator, "clipboard");
   });
 
-  it("captures the owned-Computer baseline before issuing a targeted recovery code", async () => {
+  it("issues a repair code against the target Computer, without a Computers read", async () => {
     const calls: string[] = [];
     vi.spyOn(browserApi, "computers").mockImplementation(async () => {
-      calls.push("baseline");
+      calls.push("computers");
       return { computers: [existingComputer] };
     });
-    vi.spyOn(browserApi, "issueComputerConnectCode").mockImplementation(async () => {
+    const issue = vi.spyOn(browserApi, "issueComputerConnectCode").mockImplementation(async () => {
       calls.push("issue");
       return { connectCodeId: CONNECT_CODE_ID, bootstrapCommand, expiresIn: 900, issuedAt: connectedAt };
     });
+    verdictsReturning();
 
     render(
       <ComputerSetup target={{ computerId: existingComputer.computerId, displayName: existingComputer.displayName }} />,
@@ -99,8 +100,9 @@ describe("ComputerSetup", () => {
     expect(screen.getByRole("button", { name: "Generate connection command" })).toBeTruthy();
     await clickGenerate();
 
-    // The targeted wait reads the list against this baseline, so the baseline must precede the code.
-    expect(calls).toEqual(["baseline", "issue"]);
+    // The recovery is a repair of that exact Computer, and no list read precedes or informs it.
+    expect(calls).toEqual(["issue"]);
+    expect(issue).toHaveBeenCalledWith({ mode: "repair", targetComputerId: existingComputer.computerId });
     expect(screen.getByText(bootstrapCommand)).toBeTruthy();
     expect(screen.getByRole("status").textContent).toBe("Waiting for Ada's Mac to connect…");
   });
@@ -554,13 +556,36 @@ describe("ComputerSetup", () => {
       expiresIn: 900,
       issuedAt: connectedAt,
     });
-    // The status read is the open wait's only poll; a transient failure is reported and retired.
+    // The status read is the wait's only poll; a transient failure is reported and retired.
     let statusCall = 0;
     vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(async () => {
       statusCall += 1;
       if (statusCall === 1) return Promise.reject("offline");
       return verdict();
     });
+
+    render(<ComputerSetup />);
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+
+    expect(screen.getByRole("alert").textContent).toBe("Unable to refresh the connection command status");
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(vi.getTimerCount()).toBe(2);
+  });
+
+  it("reports a failed Computers read after redemption with its own wording, and keeps waiting", async () => {
+    // The Computers read only happens once a verdict names a Computer, so its failure wording is
+    // about the list, not the command status.
+    vi.spyOn(browserApi, "computers").mockRejectedValue("offline");
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+    verdictsReturning(redeemedVerdict(newComputer.computerId));
 
     render(<ComputerSetup />);
     await clickGenerate();
@@ -591,17 +616,18 @@ describe("ComputerSetup", () => {
     expect(screen.getByRole("status").textContent).toBe("Waiting for Ada's Mac to connect…");
   });
 
-  it("confirms the target Computer by name once it reconnects", async () => {
+  it("adopts the target Computer once the Server reports the repair code redeemed", async () => {
     const onConnected = vi.fn();
-    vi.spyOn(browserApi, "computers")
-      .mockResolvedValueOnce({ computers: [existingComputer] })
-      .mockResolvedValue({ computers: [{ ...existingComputer, connectedAt: "2026-08-20T00:00:02.000Z" }] });
+    vi.spyOn(browserApi, "computers").mockResolvedValue({
+      computers: [{ ...existingComputer, connectedAt: "2026-08-20T00:00:02.000Z" }],
+    });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
       connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
     });
+    verdictsReturning(redeemedVerdict(existingComputer.computerId));
 
     render(
       <ComputerSetup
@@ -616,19 +642,19 @@ describe("ComputerSetup", () => {
 
     expect(screen.getByRole("status").textContent).toBe("Ada's Mac is connected.");
     expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(onConnected.mock.calls[0]?.[0].computerId).toBe(existingComputer.computerId);
   });
 
-  it("keeps waiting for the target when an unrelated Computer reconnects", async () => {
+  it("keeps waiting for the target while the repair code is pending, whatever else reconnects", async () => {
     const onConnected = vi.fn();
-    vi.spyOn(browserApi, "computers")
-      .mockResolvedValueOnce({ computers: [existingComputer] })
-      .mockResolvedValue({ computers: [existingComputer, newComputer] });
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer, newComputer] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
       connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
     });
+    verdictsReturning();
 
     render(
       <ComputerSetup
@@ -646,6 +672,101 @@ describe("ComputerSetup", () => {
     expect(onConnected).not.toHaveBeenCalled();
     expect(vi.getTimerCount()).toBe(2);
   });
+
+  it("refuses a redemption verdict that names a different Computer than the target", async () => {
+    // A repair verdict can only ever name the target; anything else is not this command's answer,
+    // and adopting it would drift the recovery onto a Computer it was never meant for.
+    const onConnected = vi.fn();
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer, newComputer] });
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+    verdictsReturning(redeemedVerdict(newComputer.computerId));
+
+    render(
+      <ComputerSetup
+        onConnected={onConnected}
+        target={{ computerId: existingComputer.computerId, displayName: existingComputer.displayName }}
+      />,
+    );
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Waiting for Ada's Mac to connect…");
+    expect(onConnected).not.toHaveBeenCalled();
+    expect(browserApi.computers).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(2);
+  });
+
+  it.each([
+    ["offline", { ...existingComputer, connectionStatus: "offline" as const, connectedAt: null }],
+    ["on a connection predating redemption", { ...existingComputer, connectedAt: "2026-08-19T23:59:58.000Z" }],
+  ])("keeps waiting for the repaired target while it is %s", async (_state, targetComputer) => {
+    const onConnected = vi.fn();
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [targetComputer] });
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+    verdictsReturning(redeemedVerdict(existingComputer.computerId));
+
+    render(
+      <ComputerSetup
+        onConnected={onConnected}
+        target={{ computerId: existingComputer.computerId, displayName: existingComputer.displayName }}
+      />,
+    );
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Waiting for Ada's Mac to connect…");
+    expect(onConnected).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(2);
+  });
+
+  it.each(["expired", "revoked"] as const)(
+    "ends a targeted wait on the Server's %s verdict without adopting anything",
+    async (state) => {
+      const onConnected = vi.fn();
+      vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer, newComputer] });
+      vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+        connectCodeId: CONNECT_CODE_ID,
+        bootstrapCommand,
+        expiresIn: 900,
+        issuedAt: connectedAt,
+      });
+      verdictsReturning(verdict({ state }));
+
+      render(
+        <ComputerSetup
+          onConnected={onConnected}
+          target={{ computerId: existingComputer.computerId, displayName: existingComputer.displayName }}
+        />,
+      );
+      await clickGenerate();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_500);
+      });
+
+      expect(screen.getByRole("alert").textContent).toBe(
+        "This Computer connection command expired. Generate a new one to continue.",
+      );
+      expect(screen.queryByRole("status")).toBeNull();
+      expect(onConnected).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
 
   it("answers the primary action in preview without issuing a code or polling", async () => {
     const issue = vi.spyOn(browserApi, "issueComputerConnectCode");

--- a/apps/web/src/features/agents/computer-setup.test.tsx
+++ b/apps/web/src/features/agents/computer-setup.test.tsx
@@ -1,4 +1,4 @@
-import type { WorkspaceComputerSummary as Computer } from "@opentag/shared/browser";
+import type { WorkspaceComputerSummary as Computer, ComputerConnectCodeStatus } from "@opentag/shared/browser";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { browserApi } from "../../api.js";
@@ -8,6 +8,10 @@ import { ComputerList } from "./computers-page.js";
 
 const bootstrapCommand = "opentag computer connect --server https://opentag.example.com -- connect-code";
 const connectedAt = "2026-08-20T00:00:00.000Z";
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+const REPLACEMENT_CODE_ID = "8b2d0f63-0b9c-4d8e-9f2a-3b4c5d6e7f8a";
+/** The Server's redemption time for a verdict; every connected fixture connects at or after it. */
+const REDEEMED_AT = "2026-08-19T23:59:59.000Z";
 const existingComputer: Computer = {
   computerId: "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e",
   displayName: "Ada's Mac",
@@ -34,6 +38,32 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+/** The Server's verdict on the issued code; pending until a test says otherwise. */
+function verdict(
+  overrides: { connectCodeId?: string; state?: "pending" | "expired" | "revoked" } = {},
+): ComputerConnectCodeStatus {
+  return {
+    connectCodeId: overrides.connectCodeId ?? CONNECT_CODE_ID,
+    state: overrides.state ?? "pending",
+    computerId: null,
+    redeemedAt: null,
+  };
+}
+
+function redeemedVerdict(computerId: string): ComputerConnectCodeStatus {
+  return { connectCodeId: CONNECT_CODE_ID, state: "redeemed", computerId, redeemedAt: REDEEMED_AT };
+}
+
+/** An open wait polls the issued code's status; a code the test says nothing about stays pending. */
+function verdictsReturning(...pages: readonly ComputerConnectCodeStatus[]) {
+  let call = 0;
+  return vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(async () => {
+    const page = pages[Math.min(call, pages.length - 1)] ?? verdict();
+    call += 1;
+    return page;
+  });
+}
+
 async function clickGenerate(): Promise<void> {
   await act(async () => {
     fireEvent.click(screen.getByRole("button", { name: "Generate connection command" }));
@@ -52,7 +82,7 @@ describe("ComputerSetup", () => {
     Reflect.deleteProperty(navigator, "clipboard");
   });
 
-  it("captures the owned-Computer baseline before issuing a connect code", async () => {
+  it("captures the owned-Computer baseline before issuing a targeted recovery code", async () => {
     const calls: string[] = [];
     vi.spyOn(browserApi, "computers").mockImplementation(async () => {
       calls.push("baseline");
@@ -60,31 +90,59 @@ describe("ComputerSetup", () => {
     });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockImplementation(async () => {
       calls.push("issue");
-      return { bootstrapCommand, expiresIn: 900, issuedAt: connectedAt };
+      return { connectCodeId: CONNECT_CODE_ID, bootstrapCommand, expiresIn: 900, issuedAt: connectedAt };
     });
 
-    render(<ComputerSetup />);
+    render(
+      <ComputerSetup target={{ computerId: existingComputer.computerId, displayName: existingComputer.displayName }} />,
+    );
     expect(screen.getByRole("button", { name: "Generate connection command" })).toBeTruthy();
     await clickGenerate();
 
+    // The targeted wait reads the list against this baseline, so the baseline must precede the code.
     expect(calls).toEqual(["baseline", "issue"]);
     expect(screen.getByText(bootstrapCommand)).toBeTruthy();
-    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(screen.getByRole("status").textContent).toBe("Waiting for Ada's Mac to connect…");
   });
 
-  it.each([
-    ["new", [existingComputer, newComputer]],
-    ["refreshed", [{ ...existingComputer, connectedAt: "2026-08-20T00:00:02.000Z" }]],
-  ])("detects a %s Computer and cleans up polling on completion", async (_kind, polledComputers) => {
+  it("takes no baseline for an open wait: the Server's verdict names the Computer", async () => {
+    const calls: string[] = [];
+    vi.spyOn(browserApi, "computers").mockImplementation(async () => {
+      calls.push("computers");
+      return { computers: [existingComputer] };
+    });
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockImplementation(async () => {
+      calls.push("issue");
+      return { connectCodeId: CONNECT_CODE_ID, bootstrapCommand, expiresIn: 900, issuedAt: connectedAt };
+    });
+    const verdicts = verdictsReturning();
+
+    render(<ComputerSetup />);
+    await clickGenerate();
+
+    expect(calls).toEqual(["issue"]);
+    expect(screen.getByText(bootstrapCommand)).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+
+    // The wait polls the code's status, and a pending verdict never consults the Computers list.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+    expect(verdicts).toHaveBeenCalledWith(CONNECT_CODE_ID);
+    expect(calls).toEqual(["issue"]);
+  });
+
+  it("adopts exactly the Computer the Server says redeemed the code, and cleans up polling", async () => {
     const onConnected = vi.fn();
-    vi.spyOn(browserApi, "computers")
-      .mockResolvedValueOnce({ computers: [existingComputer] })
-      .mockResolvedValue({ computers: polledComputers });
+    // An unrelated machine is online throughout; only the verdict's machine can settle the wait.
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer, newComputer] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
     });
+    verdictsReturning(redeemedVerdict(newComputer.computerId));
 
     render(<ComputerSetup onConnected={onConnected} />);
     await clickGenerate();
@@ -96,21 +154,24 @@ describe("ComputerSetup", () => {
 
     expect(screen.getByRole("status").textContent).toBe("Computer connected.");
     expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(onConnected.mock.calls[0]?.[0].computerId).toBe(newComputer.computerId);
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("does not report an existing Computer heartbeat as connected", async () => {
+  it("keeps waiting while the verdict is pending, whatever the Computers list shows", async () => {
     const onConnected = vi.fn();
-    vi.spyOn(browserApi, "computers")
-      .mockResolvedValueOnce({ computers: [existingComputer] })
-      .mockResolvedValue({
-        computers: [{ ...existingComputer, lastSeenAt: "2026-08-20T00:00:10.000Z" }],
-      });
+    // A new Computer enrolling and an existing one reconnecting are both just list movement: no
+    // verdict, no arrival.
+    vi.spyOn(browserApi, "computers").mockResolvedValue({
+      computers: [newComputer, { ...existingComputer, connectedAt: "2026-08-20T00:00:02.000Z" }],
+    });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
     });
+    verdictsReturning();
 
     render(<ComputerSetup onConnected={onConnected} />);
     await clickGenerate();
@@ -123,13 +184,71 @@ describe("ComputerSetup", () => {
     expect(vi.getTimerCount()).toBe(2);
   });
 
-  it("cleans up polling when unmounted", async () => {
-    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer] });
+  it("keeps waiting when the redeemed Computer has not connected yet", async () => {
+    const onConnected = vi.fn();
+    // The verdict names the machine the moment the code is spent; the panel waits for that exact
+    // machine to actually come online rather than reporting the redemption itself as a connection.
+    vi.spyOn(browserApi, "computers").mockResolvedValue({
+      computers: [{ ...newComputer, connectionStatus: "offline" as const, connectedAt: null }],
+    });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
     });
+    verdictsReturning(redeemedVerdict(newComputer.computerId));
+
+    render(<ComputerSetup onConnected={onConnected} />);
+    await clickGenerate();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
+    expect(onConnected).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(2);
+  });
+
+  it.each(["expired", "revoked"] as const)(
+    "ends the wait on the Server's %s verdict, ahead of the local clock",
+    async (state) => {
+      const onConnected = vi.fn();
+      vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [newComputer] });
+      vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+        connectCodeId: CONNECT_CODE_ID,
+        bootstrapCommand,
+        expiresIn: 900,
+        issuedAt: connectedAt,
+      });
+      verdictsReturning(verdict({ state }));
+
+      render(<ComputerSetup onConnected={onConnected} />);
+      await clickGenerate();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_500);
+      });
+
+      // Fail closed: the wait ends with the same terminal the local expiry uses, and the machine
+      // that happens to be enrolled nearby is not adopted.
+      expect(screen.getByRole("alert").textContent).toBe(
+        "This Computer connection command expired. Generate a new one to continue.",
+      );
+      expect(screen.queryByRole("status")).toBeNull();
+      expect(onConnected).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("cleans up polling when unmounted", async () => {
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer] });
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      bootstrapCommand,
+      expiresIn: 900,
+      issuedAt: connectedAt,
+    });
+    verdictsReturning();
 
     const view = render(<ComputerSetup />);
     await clickGenerate();
@@ -144,10 +263,12 @@ describe("ComputerSetup", () => {
     const onConnected = vi.fn();
     vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 2,
       issuedAt: connectedAt,
     });
+    verdictsReturning();
 
     render(<ComputerSetup onConnected={onConnected} />);
     await clickGenerate();
@@ -169,15 +290,18 @@ describe("ComputerSetup", () => {
     vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [] });
     vi.spyOn(browserApi, "issueComputerConnectCode")
       .mockResolvedValueOnce({
+        connectCodeId: CONNECT_CODE_ID,
         bootstrapCommand: "first command",
         expiresIn: 2,
         issuedAt: connectedAt,
       })
       .mockResolvedValueOnce({
+        connectCodeId: REPLACEMENT_CODE_ID,
         bootstrapCommand: "replacement command",
         expiresIn: 5,
         issuedAt: "2026-08-20T00:00:01.000Z",
       });
+    const verdicts = verdictsReturning();
 
     render(<ComputerSetup />);
     await clickGenerate();
@@ -190,20 +314,33 @@ describe("ComputerSetup", () => {
     expect(vi.getTimerCount()).toBe(2);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1_001);
+      await vi.advanceTimersByTimeAsync(1_500);
     });
 
     expect(screen.getByRole("status").textContent).toBe("Waiting for the Computer to connect…");
     expect(screen.queryByRole("alert")).toBeNull();
     expect(vi.getTimerCount()).toBe(2);
+    // The replacement cycle polls its own code, never the expired one.
+    expect(verdicts).toHaveBeenLastCalledWith(REPLACEMENT_CODE_ID);
   });
 
   it("clears an old-cycle error when replacement issuance succeeds", async () => {
-    const replacementIssue = deferred<{ bootstrapCommand: string; expiresIn: number; issuedAt: string }>();
+    const replacementIssue = deferred<{
+      connectCodeId: string;
+      bootstrapCommand: string;
+      expiresIn: number;
+      issuedAt: string;
+    }>();
     vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [] });
     vi.spyOn(browserApi, "issueComputerConnectCode")
-      .mockResolvedValueOnce({ bootstrapCommand: "first command", expiresIn: 2, issuedAt: connectedAt })
+      .mockResolvedValueOnce({
+        connectCodeId: CONNECT_CODE_ID,
+        bootstrapCommand: "first command",
+        expiresIn: 2,
+        issuedAt: connectedAt,
+      })
       .mockImplementationOnce(() => replacementIssue.promise);
+    verdictsReturning();
 
     render(<ComputerSetup />);
     await clickGenerate();
@@ -218,6 +355,7 @@ describe("ComputerSetup", () => {
 
     await act(async () => {
       replacementIssue.resolve({
+        connectCodeId: REPLACEMENT_CODE_ID,
         bootstrapCommand: "replacement command",
         expiresIn: 5,
         issuedAt: "2026-08-20T00:00:02.000Z",
@@ -232,16 +370,27 @@ describe("ComputerSetup", () => {
   });
 
   it("ignores an old in-flight poll after replacement issuance succeeds", async () => {
-    const oldPoll = deferred<{ computers: Computer[] }>();
-    const replacementIssue = deferred<{ bootstrapCommand: string; expiresIn: number; issuedAt: string }>();
+    const oldPoll = deferred<ComputerConnectCodeStatus>();
+    const replacementIssue = deferred<{
+      connectCodeId: string;
+      bootstrapCommand: string;
+      expiresIn: number;
+      issuedAt: string;
+    }>();
     const onConnected = vi.fn();
-    let ownComputersCall = 0;
-    vi.spyOn(browserApi, "computers").mockImplementation(() => {
-      ownComputersCall += 1;
-      return ownComputersCall === 2 ? oldPoll.promise : Promise.resolve({ computers: [] });
+    let statusCall = 0;
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(() => {
+      statusCall += 1;
+      // 1 = the poll left in flight across the replacement, 2+ = the replacement code's own polls.
+      return statusCall === 1 ? oldPoll.promise : Promise.resolve(verdict({ connectCodeId: REPLACEMENT_CODE_ID }));
     });
     vi.spyOn(browserApi, "issueComputerConnectCode")
-      .mockResolvedValueOnce({ bootstrapCommand: "first command", expiresIn: 900, issuedAt: connectedAt })
+      .mockResolvedValueOnce({
+        connectCodeId: CONNECT_CODE_ID,
+        bootstrapCommand: "first command",
+        expiresIn: 900,
+        issuedAt: connectedAt,
+      })
       .mockImplementationOnce(() => replacementIssue.promise);
 
     render(<ComputerSetup onConnected={onConnected} />);
@@ -253,12 +402,14 @@ describe("ComputerSetup", () => {
 
     await act(async () => {
       replacementIssue.resolve({
+        connectCodeId: REPLACEMENT_CODE_ID,
         bootstrapCommand: "replacement command",
         expiresIn: 900,
         issuedAt: "2026-08-20T00:00:01.500Z",
       });
       await Promise.resolve();
-      oldPoll.resolve({ computers: [newComputer] });
+      // The stale verdict lands redeemed — for the superseded code, so it must not be adopted.
+      oldPoll.resolve(redeemedVerdict(newComputer.computerId));
       await Promise.resolve();
     });
 
@@ -270,13 +421,16 @@ describe("ComputerSetup", () => {
 
   it("keeps the current polling cycle when replacement issuance fails", async () => {
     const onConnected = vi.fn();
-    vi.spyOn(browserApi, "computers")
-      .mockResolvedValueOnce({ computers: [] })
-      .mockResolvedValueOnce({ computers: [] })
-      .mockResolvedValue({ computers: [newComputer] });
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer, newComputer] });
     vi.spyOn(browserApi, "issueComputerConnectCode")
-      .mockResolvedValueOnce({ bootstrapCommand: "first command", expiresIn: 900, issuedAt: connectedAt })
+      .mockResolvedValueOnce({
+        connectCodeId: CONNECT_CODE_ID,
+        bootstrapCommand: "first command",
+        expiresIn: 900,
+        issuedAt: connectedAt,
+      })
       .mockRejectedValueOnce(new Error("Replacement command failed"));
+    verdictsReturning(redeemedVerdict(newComputer.computerId));
 
     render(<ComputerSetup onConnected={onConnected} />);
     await clickGenerate();
@@ -300,10 +454,12 @@ describe("ComputerSetup", () => {
     Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
     vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
     });
+    verdictsReturning();
 
     render(<ComputerSetup />);
     await clickGenerate();
@@ -337,10 +493,12 @@ describe("ComputerSetup", () => {
     });
     vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
     });
+    verdictsReturning();
 
     render(<ComputerSetup />);
     await clickGenerate();
@@ -355,14 +513,14 @@ describe("ComputerSetup", () => {
   });
 
   it("stops showing the countdown once the Computer connects", async () => {
-    vi.spyOn(browserApi, "computers")
-      .mockResolvedValueOnce({ computers: [existingComputer] })
-      .mockResolvedValue({ computers: [existingComputer, newComputer] });
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer, newComputer] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
     });
+    verdictsReturning(redeemedVerdict(newComputer.computerId));
 
     render(<ComputerSetup />);
     await clickGenerate();
@@ -389,14 +547,19 @@ describe("ComputerSetup", () => {
   });
 
   it("normalizes polling errors and keeps waiting", async () => {
-    vi.spyOn(browserApi, "computers")
-      .mockResolvedValueOnce({ computers: [] })
-      .mockRejectedValueOnce("offline")
-      .mockResolvedValue({ computers: [] });
+    vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
+    });
+    // The status read is the open wait's only poll; a transient failure is reported and retired.
+    let statusCall = 0;
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(async () => {
+      statusCall += 1;
+      if (statusCall === 1) return Promise.reject("offline");
+      return verdict();
     });
 
     render(<ComputerSetup />);
@@ -412,6 +575,7 @@ describe("ComputerSetup", () => {
   it("names the target Computer in its prompt and waiting status", async () => {
     vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [existingComputer] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
@@ -433,6 +597,7 @@ describe("ComputerSetup", () => {
       .mockResolvedValueOnce({ computers: [existingComputer] })
       .mockResolvedValue({ computers: [{ ...existingComputer, connectedAt: "2026-08-20T00:00:02.000Z" }] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,
@@ -459,6 +624,7 @@ describe("ComputerSetup", () => {
       .mockResolvedValueOnce({ computers: [existingComputer] })
       .mockResolvedValue({ computers: [existingComputer, newComputer] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand,
       expiresIn: 900,
       issuedAt: connectedAt,

--- a/apps/web/src/features/agents/computer-setup.tsx
+++ b/apps/web/src/features/agents/computer-setup.tsx
@@ -1,14 +1,16 @@
-import type { WorkspaceComputerSummary } from "@opentag/shared/browser";
+import type { ComputerConnectCodeStatus, WorkspaceComputerSummary } from "@opentag/shared/browser";
 import { useEffect, useRef, useState } from "react";
 import { browserApi } from "../../api.js";
 import { Banner, Button, ClipboardText, Loader, Text } from "../../ui/design-system.js";
 
 /*
  * This stays outside the query cache on purpose. It is not a resource the page subscribes to but a
- * wait on a mutation's side effect: a connect code is issued, and the Computer list is compared
- * against a baseline captured at that moment, bounded by the code's own expiry. The baseline has to
- * be genuinely fresh at click time, which a shared cache entry cannot promise, and the countdown
- * beside it is a clock rather than Server state.
+ * wait on a mutation's side effect: a connect code is issued, and the panel waits for the Computer
+ * that redeems it, bounded by the code's own expiry. Which Computer that is comes from the Server's
+ * own verdict on the issued code — never from comparing the Computers list against a baseline — so
+ * an unrelated machine enrolling or reconnecting during the wait cannot be read as this command's
+ * arrival. The targeted recovery is the exception: it still watches for its own named Computer to
+ * reconnect, and lets the code expire rather than read a foreign reconnection as proof.
  */
 const COMPUTER_POLL_INTERVAL_MS = 1_500;
 const CONNECT_CODE_EXPIRED_MESSAGE = "This Computer connection command expired. Generate a new one to continue.";
@@ -43,6 +45,31 @@ function formatRemaining(remainingMs: number): string {
   return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
 }
 
+/** The redeemed Computer counts once it is online on a connection the redemption bought. */
+function isFreshlyConnected(computer: WorkspaceComputerSummary, redeemedAt: string): boolean {
+  return (
+    computer.connectionStatus === "online" &&
+    computer.connectedAt !== null &&
+    Date.parse(computer.connectedAt) >= Date.parse(redeemedAt)
+  );
+}
+
+type VerdictRead =
+  | { readonly kind: "wait" }
+  | { readonly kind: "expire" }
+  | { readonly kind: "adopt"; readonly computerId: string; readonly redeemedAt: string };
+
+/**
+ * The verdict's reading. Pending keeps the wait; redeemed names the machine to adopt. Expired and
+ * revoked fail closed through the same terminal the local expiry uses — neither ever names a
+ * Computer — and a malformed redemption is refused rather than believed.
+ */
+function readVerdict(status: ComputerConnectCodeStatus): VerdictRead {
+  if (status.state === "pending") return { kind: "wait" };
+  if (status.state !== "redeemed" || !status.computerId || !status.redeemedAt) return { kind: "expire" };
+  return { kind: "adopt", computerId: status.computerId, redeemedAt: status.redeemedAt };
+}
+
 export function ComputerSetup({ onConnected, preview, target }: ComputerSetupProps) {
   return (
     <ComputerSetupLifecycle
@@ -65,6 +92,7 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
   const [pollCycle, setPollCycle] = useState(0);
   const [remainingMs, setRemainingMs] = useState<number>();
   const baselineConnections = useRef<Map<string, string | null>>(new Map());
+  const connectCodeId = useRef<string | undefined>(undefined);
   const connectCodeExpiresAt = useRef(0);
   const connectAttempt = useRef(0);
   const activePollCycle = useRef(0);
@@ -99,15 +127,17 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
     setGenerating(true);
     setError(undefined);
     try {
-      const baseline = new Map(
-        (await browserApi.computers()).computers.map((computer) => [computer.computerId, computer.connectedAt]),
-      );
+      // A targeted recovery waits on its own Computer, so it still captures the list as it stands
+      // before the code exists. An open wait needs no baseline: the Server's verdict on the issued
+      // code names the Computer, and nothing is inferred from the list.
+      const baseline = await captureBaseline();
       if (!mounted.current || connectAttempt.current !== attempt) return;
       const issued = await browserApi.issueComputerConnectCode();
       if (!mounted.current || connectAttempt.current !== attempt) return;
       const cycle = activePollCycle.current + 1;
       activePollCycle.current = cycle;
       baselineConnections.current = baseline;
+      connectCodeId.current = issued.connectCodeId;
       connectCodeExpiresAt.current = Date.parse(issued.issuedAt) + issued.expiresIn * 1_000;
       setError(undefined);
       setBootstrapCommand(issued.bootstrapCommand);
@@ -123,61 +153,100 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
     }
   }
 
+  /** The targeted wait's pre-issue snapshot of the Computers list; an open wait takes none. */
+  async function captureBaseline(): Promise<Map<string, string | null>> {
+    if (!targetComputerId) return new Map();
+    const { computers } = await browserApi.computers();
+    return new Map(computers.map((computer) => [computer.computerId, computer.connectedAt]));
+  }
+
   useEffect(() => {
     if (!waitingForComputer || pollCycle === 0) return;
     const baseline = baselineConnections.current;
+    const codeId = connectCodeId.current;
     const expiresAt = connectCodeExpiresAt.current;
     let active = true;
     let completed = false;
     let pollTimer = 0;
-    const expiryTimer = window.setTimeout(
-      () => {
+    let expiryTimer = 0;
+    const expire = () => {
+      if (!active || completed || activePollCycle.current !== pollCycle) return;
+      completed = true;
+      window.clearInterval(pollTimer);
+      setWaitingForComputer(false);
+      setComputerConnected(false);
+      setRemainingMs(undefined);
+      setError(CONNECT_CODE_EXPIRED_MESSAGE);
+    };
+    const complete = (connected: WorkspaceComputerSummary) => {
+      if (!active || completed || activePollCycle.current !== pollCycle) return;
+      completed = true;
+      window.clearInterval(pollTimer);
+      window.clearTimeout(expiryTimer);
+      setWaitingForComputer(false);
+      setComputerConnected(true);
+      setRemainingMs(undefined);
+      onConnectedRef.current?.(connected);
+    };
+    const reportPollFailure = (cause: unknown) => {
+      if (active && !completed && activePollCycle.current === pollCycle) {
+        setError(errorMessage(cause, "Unable to refresh Computers"));
+      }
+    };
+    // A targeted recovery waits for its own Computer and lets the code expire rather than
+    // reading a foreign reconnection as proof.
+    const isReconnection = (computer: WorkspaceComputerSummary) =>
+      computer.connectionStatus === "online" &&
+      ((!baseline.has(computer.computerId) && computer.connectedAt !== null) ||
+        (baseline.has(computer.computerId) &&
+          computer.connectedAt !== null &&
+          baseline.get(computer.computerId) !== computer.connectedAt));
+    const pollTarget = () =>
+      browserApi.computers().then((value) => {
         if (!active || completed || activePollCycle.current !== pollCycle) return;
-        completed = true;
-        window.clearInterval(pollTimer);
-        setWaitingForComputer(false);
-        setComputerConnected(false);
-        setRemainingMs(undefined);
-        setError(CONNECT_CODE_EXPIRED_MESSAGE);
-      },
-      Math.max(0, expiresAt - Date.now()),
-    );
-    pollTimer = window.setInterval(() => {
+        const connected = targetComputerId
+          ? value.computers.filter(isReconnection).find((computer) => computer.computerId === targetComputerId)
+          : undefined;
+        if (connected) complete(connected);
+      }, reportPollFailure);
+    /*
+     * The Server's verdict on this exact code decides the arrival. Pending keeps waiting; expired
+     * or revoked fails closed through the same terminal as the local expiry; redeemed names the one
+     * Computer that can satisfy the wait — adopted once the Computers list shows it online on a
+     * connection that postdates the redemption, so a machine that redeemed but has not connected
+     * yet is still waited on rather than reported.
+     */
+    const adoptVerdict = async (redeemedComputerId: string, redeemedAt: string) => {
+      const { computers } = await browserApi.computers();
+      const connected = computers.find(
+        (computer) => computer.computerId === redeemedComputerId && isFreshlyConnected(computer, redeemedAt),
+      );
+      if (connected) complete(connected);
+    };
+    const pollVerdict = async () => {
+      if (!codeId) return;
+      try {
+        const status = await browserApi.computerConnectCodeStatus(codeId);
+        if (!active || completed || activePollCycle.current !== pollCycle) return;
+        const verdict = readVerdict(status);
+        if (verdict.kind === "wait") return;
+        if (verdict.kind === "expire") {
+          expire();
+          return;
+        }
+        await adoptVerdict(verdict.computerId, verdict.redeemedAt);
+      } catch (cause) {
+        reportPollFailure(cause);
+      }
+    };
+    expiryTimer = window.setTimeout(expire, Math.max(0, expiresAt - Date.now()));
+    const tick = () => {
       // The existing poll cycle also drives the countdown, so the command needs no timer of its own.
       setRemainingMs(Math.max(0, expiresAt - Date.now()));
-      void browserApi.computers().then(
-        (value) => {
-          if (!active || completed || activePollCycle.current !== pollCycle) return;
-          const reconnected = value.computers.filter(
-            (computer) =>
-              computer.connectionStatus === "online" &&
-              ((!baseline.has(computer.computerId) && computer.connectedAt !== null) ||
-                (baseline.has(computer.computerId) &&
-                  computer.connectedAt !== null &&
-                  baseline.get(computer.computerId) !== computer.connectedAt)),
-          );
-          // The Computers response carries no link back to the issued code, so another Computer
-          // registering says nothing about this command. A targeted recovery waits for its own
-          // Computer and lets the code expire rather than reading a foreign reconnection as proof.
-          const connected = targetComputerId
-            ? reconnected.find((computer) => computer.computerId === targetComputerId)
-            : reconnected[0];
-          if (!connected) return;
-          completed = true;
-          window.clearInterval(pollTimer);
-          window.clearTimeout(expiryTimer);
-          setWaitingForComputer(false);
-          setComputerConnected(true);
-          setRemainingMs(undefined);
-          onConnectedRef.current?.(connected);
-        },
-        (cause: unknown) => {
-          if (active && !completed && activePollCycle.current === pollCycle) {
-            setError(errorMessage(cause, "Unable to refresh Computers"));
-          }
-        },
-      );
-    }, COMPUTER_POLL_INTERVAL_MS);
+      if (targetComputerId) void pollTarget();
+      else void pollVerdict();
+    };
+    pollTimer = window.setInterval(tick, COMPUTER_POLL_INTERVAL_MS);
     return () => {
       active = false;
       window.clearInterval(pollTimer);

--- a/apps/web/src/features/agents/computer-setup.tsx
+++ b/apps/web/src/features/agents/computer-setup.tsx
@@ -1,6 +1,7 @@
-import type { ComputerConnectCodeStatus, WorkspaceComputerSummary } from "@opentag/shared/browser";
+import type { WorkspaceComputerSummary } from "@opentag/shared/browser";
 import { useEffect, useRef, useState } from "react";
 import { browserApi } from "../../api.js";
+import { readConnectCodeVerdict } from "../../setup/connect-code-verdict.js";
 import { Banner, Button, ClipboardText, Loader, Text } from "../../ui/design-system.js";
 
 /*
@@ -9,11 +10,13 @@ import { Banner, Button, ClipboardText, Loader, Text } from "../../ui/design-sys
  * that redeems it, bounded by the code's own expiry. Which Computer that is comes from the Server's
  * own verdict on the issued code — never from comparing the Computers list against a baseline — so
  * an unrelated machine enrolling or reconnecting during the wait cannot be read as this command's
- * arrival. The targeted recovery is the exception: it still watches for its own named Computer to
- * reconnect, and lets the code expire rather than read a foreign reconnection as proof.
+ * arrival. A targeted recovery repairs that exact Computer: the code is issued against it, and the
+ * verdict is refused if it names any other.
  */
 const COMPUTER_POLL_INTERVAL_MS = 1_500;
 const CONNECT_CODE_EXPIRED_MESSAGE = "This Computer connection command expired. Generate a new one to continue.";
+const CONNECT_CODE_STATUS_FAILURE_MESSAGE = "Unable to refresh the connection command status";
+const COMPUTER_REFRESH_FAILURE_MESSAGE = "Unable to refresh Computers";
 /**
  * The command and validity Preview shows in place of an issued one. Review needs the shape of this
  * step — a long install-and-connect line, its copy affordance and a running validity — and none of
@@ -54,22 +57,6 @@ function isFreshlyConnected(computer: WorkspaceComputerSummary, redeemedAt: stri
   );
 }
 
-type VerdictRead =
-  | { readonly kind: "wait" }
-  | { readonly kind: "expire" }
-  | { readonly kind: "adopt"; readonly computerId: string; readonly redeemedAt: string };
-
-/**
- * The verdict's reading. Pending keeps the wait; redeemed names the machine to adopt. Expired and
- * revoked fail closed through the same terminal the local expiry uses — neither ever names a
- * Computer — and a malformed redemption is refused rather than believed.
- */
-function readVerdict(status: ComputerConnectCodeStatus): VerdictRead {
-  if (status.state === "pending") return { kind: "wait" };
-  if (status.state !== "redeemed" || !status.computerId || !status.redeemedAt) return { kind: "expire" };
-  return { kind: "adopt", computerId: status.computerId, redeemedAt: status.redeemedAt };
-}
-
 export function ComputerSetup({ onConnected, preview, target }: ComputerSetupProps) {
   return (
     <ComputerSetupLifecycle
@@ -91,7 +78,6 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
   const [generating, setGenerating] = useState(false);
   const [pollCycle, setPollCycle] = useState(0);
   const [remainingMs, setRemainingMs] = useState<number>();
-  const baselineConnections = useRef<Map<string, string | null>>(new Map());
   const connectCodeId = useRef<string | undefined>(undefined);
   const connectCodeExpiresAt = useRef(0);
   const connectAttempt = useRef(0);
@@ -127,16 +113,18 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
     setGenerating(true);
     setError(undefined);
     try {
-      // A targeted recovery waits on its own Computer, so it still captures the list as it stands
-      // before the code exists. An open wait needs no baseline: the Server's verdict on the issued
-      // code names the Computer, and nothing is inferred from the list.
-      const baseline = await captureBaseline();
-      if (!mounted.current || connectAttempt.current !== attempt) return;
-      const issued = await browserApi.issueComputerConnectCode();
+      /*
+       * A targeted recovery repairs its own Computer rather than enrolling a second one beside it:
+       * the code is issued against that exact Computer, and the Server's verdict on the code names
+       * the machine that answered. No Computers-list comparison ever speaks for the recovery, so a
+       * duplicate Computer or a foreign machine is never inferred from an arrival.
+       */
+      const issued = await browserApi.issueComputerConnectCode(
+        targetComputerId ? { mode: "repair", targetComputerId } : undefined,
+      );
       if (!mounted.current || connectAttempt.current !== attempt) return;
       const cycle = activePollCycle.current + 1;
       activePollCycle.current = cycle;
-      baselineConnections.current = baseline;
       connectCodeId.current = issued.connectCodeId;
       connectCodeExpiresAt.current = Date.parse(issued.issuedAt) + issued.expiresIn * 1_000;
       setError(undefined);
@@ -153,16 +141,8 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
     }
   }
 
-  /** The targeted wait's pre-issue snapshot of the Computers list; an open wait takes none. */
-  async function captureBaseline(): Promise<Map<string, string | null>> {
-    if (!targetComputerId) return new Map();
-    const { computers } = await browserApi.computers();
-    return new Map(computers.map((computer) => [computer.computerId, computer.connectedAt]));
-  }
-
   useEffect(() => {
     if (!waitingForComputer || pollCycle === 0) return;
-    const baseline = baselineConnections.current;
     const codeId = connectCodeId.current;
     const expiresAt = connectCodeExpiresAt.current;
     let active = true;
@@ -188,36 +168,29 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
       setRemainingMs(undefined);
       onConnectedRef.current?.(connected);
     };
-    const reportPollFailure = (cause: unknown) => {
+    const reportPollFailure = (cause: unknown, fallback: string) => {
       if (active && !completed && activePollCycle.current === pollCycle) {
-        setError(errorMessage(cause, "Unable to refresh Computers"));
+        setError(errorMessage(cause, fallback));
       }
     };
-    // A targeted recovery waits for its own Computer and lets the code expire rather than
-    // reading a foreign reconnection as proof.
-    const isReconnection = (computer: WorkspaceComputerSummary) =>
-      computer.connectionStatus === "online" &&
-      ((!baseline.has(computer.computerId) && computer.connectedAt !== null) ||
-        (baseline.has(computer.computerId) &&
-          computer.connectedAt !== null &&
-          baseline.get(computer.computerId) !== computer.connectedAt));
-    const pollTarget = () =>
-      browserApi.computers().then((value) => {
-        if (!active || completed || activePollCycle.current !== pollCycle) return;
-        const connected = targetComputerId
-          ? value.computers.filter(isReconnection).find((computer) => computer.computerId === targetComputerId)
-          : undefined;
-        if (connected) complete(connected);
-      }, reportPollFailure);
     /*
      * The Server's verdict on this exact code decides the arrival. Pending keeps waiting; expired
      * or revoked fails closed through the same terminal as the local expiry; redeemed names the one
      * Computer that can satisfy the wait — adopted once the Computers list shows it online on a
      * connection that postdates the redemption, so a machine that redeemed but has not connected
-     * yet is still waited on rather than reported.
+     * yet is still waited on rather than reported. A targeted recovery refuses a verdict naming
+     * any other Computer: the repair code was issued against the target, so a different id can
+     * never be this command's answer.
      */
     const adoptVerdict = async (redeemedComputerId: string, redeemedAt: string) => {
-      const { computers } = await browserApi.computers();
+      if (targetComputerId && redeemedComputerId !== targetComputerId) return;
+      let computers: WorkspaceComputerSummary[];
+      try {
+        ({ computers } = await browserApi.computers());
+      } catch (cause) {
+        reportPollFailure(cause, COMPUTER_REFRESH_FAILURE_MESSAGE);
+        return;
+      }
       const connected = computers.find(
         (computer) => computer.computerId === redeemedComputerId && isFreshlyConnected(computer, redeemedAt),
       );
@@ -225,26 +198,27 @@ function ComputerSetupLifecycle({ onConnected, preview = false, target }: Comput
     };
     const pollVerdict = async () => {
       if (!codeId) return;
+      let status: Awaited<ReturnType<typeof browserApi.computerConnectCodeStatus>>;
       try {
-        const status = await browserApi.computerConnectCodeStatus(codeId);
-        if (!active || completed || activePollCycle.current !== pollCycle) return;
-        const verdict = readVerdict(status);
-        if (verdict.kind === "wait") return;
-        if (verdict.kind === "expire") {
-          expire();
-          return;
-        }
-        await adoptVerdict(verdict.computerId, verdict.redeemedAt);
+        status = await browserApi.computerConnectCodeStatus(codeId);
       } catch (cause) {
-        reportPollFailure(cause);
+        reportPollFailure(cause, CONNECT_CODE_STATUS_FAILURE_MESSAGE);
+        return;
       }
+      if (!active || completed || activePollCycle.current !== pollCycle) return;
+      const verdict = readConnectCodeVerdict(status);
+      if (verdict.kind === "wait") return;
+      if (verdict.kind === "expire") {
+        expire();
+        return;
+      }
+      await adoptVerdict(verdict.computerId, verdict.redeemedAt);
     };
     expiryTimer = window.setTimeout(expire, Math.max(0, expiresAt - Date.now()));
     const tick = () => {
       // The existing poll cycle also drives the countdown, so the command needs no timer of its own.
       setRemainingMs(Math.max(0, expiresAt - Date.now()));
-      if (targetComputerId) void pollTarget();
-      else void pollVerdict();
+      void pollVerdict();
     };
     pollTimer = window.setInterval(tick, COMPUTER_POLL_INTERVAL_MS);
     return () => {

--- a/apps/web/src/onboarding-v2/pr262-findings.test.tsx
+++ b/apps/web/src/onboarding-v2/pr262-findings.test.tsx
@@ -25,6 +25,8 @@ const BINDING_ID = "3c83a21e-f6c7-4474-91ea-4dabf0566a24";
 const AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const USER_ID = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const ATTEMPT_ID = "2b73a21e-f6c7-4474-91ea-4dabf0566a24";
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+const REDEEMED_AT = "2026-08-29T00:00:05.000Z";
 const POLL_MS = 1_500;
 const FEISHU_POLL_MS = 2_000;
 const HANDOFF_POLL_MS = 2_000;
@@ -124,6 +126,7 @@ function computersReturning(...pages: readonly (readonly WorkspaceComputerSummar
 
 function issuing() {
   return vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+    connectCodeId: CONNECT_CODE_ID,
     bootstrapCommand: "sh -c 'curl -fsSL https://example.test/install.sh | sh' -- connect ABC",
     expiresIn: 900,
     issuedAt: NOW,
@@ -167,6 +170,14 @@ describe("onboarding-v2 as the real onboarding: findings at 9a64ce6", () => {
     vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [] });
     vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
     vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
+    // Every walk here connects its Computer: the Server's verdict is that the issued code was
+    // redeemed by exactly it.
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      state: "redeemed",
+      computerId: COMPUTER_ID,
+      redeemedAt: REDEEMED_AT,
+    });
   });
 
   afterEach(() => {
@@ -177,7 +188,7 @@ describe("onboarding-v2 as the real onboarding: findings at 9a64ce6", () => {
   it("keeps a failed creation's explanation on screen while the reader reads it", async () => {
     // The readiness poll now clears `error` on every success, and it keeps running through the
     // rest of the flow — so it retires messages it never set, within one poll interval.
-    computersReturning([], [computer()]);
+    computersReturning([computer()]);
     issuing();
     vi.spyOn(browserApi, "createAgent").mockRejectedValue(new Error("An active Agent with this name already exists"));
 
@@ -196,7 +207,7 @@ describe("onboarding-v2 as the real onboarding: findings at 9a64ce6", () => {
   it("offers a way back after Lark refuses the attempt", async () => {
     // `failed` no longer retries on sight, which is right — but nothing restarts it either, and
     // the messaging step has no footer, so the panel is inert.
-    computersReturning([], [computer()]);
+    computersReturning([computer()]);
     issuing();
     vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockRejectedValue(new Error("Lark is unavailable"));
@@ -229,7 +240,7 @@ describe("onboarding-v2 as the real onboarding: findings at 9a64ce6", () => {
   });
 
   it("reports completion once the messaging app is connected", async () => {
-    computersReturning([], [computer()]);
+    computersReturning([computer()]);
     issuing();
     vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(attempt());
@@ -257,7 +268,7 @@ describe("onboarding-v2 as the real onboarding: findings at 9a64ce6", () => {
   it("reports completion for a Slack install too", async () => {
     // Slack's callback redirects to a gated Agent route, the setup gate sends it back here, and a
     // fresh page has no Agent — so `onComplete` is never reached and setup is never marked done.
-    computersReturning([], [computer()]);
+    computersReturning([computer()]);
     issuing();
     vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     vi.spyOn(browserApi, "startSlackOAuth").mockResolvedValue({
@@ -298,7 +309,7 @@ describe("onboarding-v2 as the real onboarding: findings at 9a64ce6", () => {
     // `onComplete` is latched by agent id before it is called and its result is never inspected, so
     // a single failure is permanent: the reader sits on the finished screen with setup incomplete,
     // and every route they try bounces them back to a flow that starts from nothing.
-    computersReturning([], [computer()]);
+    computersReturning([computer()]);
     issuing();
     vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(attempt());
@@ -330,7 +341,7 @@ describe("onboarding-v2 as the real onboarding: findings at 9a64ce6", () => {
    * doing it.
    */
   it("does not complete setup on an installed app the Server cannot yet reach", async () => {
-    computersReturning([], [computer()]);
+    computersReturning([computer()]);
     issuing();
     vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(attempt());
@@ -367,10 +378,7 @@ describe("onboarding-v2 as the real onboarding: findings at 9a64ce6", () => {
    * readiness, so an unexplained spinner is a choice rather than a limitation.
    */
   it("says what a wait for reachability is waiting on, when it knows", async () => {
-    computersReturning(
-      [],
-      [computer({ imCliReadiness: [{ provider: "feishu", status: "install", observedAt: NOW }] })],
-    );
+    computersReturning([computer({ imCliReadiness: [{ provider: "feishu", status: "install", observedAt: NOW }] })]);
     issuing();
     vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(attempt());

--- a/apps/web/src/onboarding-v2/pr262-r12-findings.test.tsx
+++ b/apps/web/src/onboarding-v2/pr262-r12-findings.test.tsx
@@ -18,6 +18,8 @@ const OTHER_COMPUTER = "95fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const USER_ID = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const POLL_MS = 1_500;
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+const REDEEMED_AT = "2026-08-29T00:05:00.000Z";
 
 function agentOn(computerId: string, displayName: string): AgentListItem {
   return {
@@ -68,10 +70,18 @@ describe("repair and handoff at cabaf79", () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"] });
     vi.setSystemTime(new Date(NOW));
     vi.spyOn(browserApi, "issueComputerConnectCode").mockImplementation(async () => ({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand: "sh install",
       expiresIn: 900,
       issuedAt: new Date(Date.now()).toISOString(),
     }));
+    // A code the test says nothing about stays pending: the wait never concludes without a verdict.
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      state: "pending",
+      computerId: null,
+      redeemedAt: null,
+    });
   });
 
   afterEach(() => {
@@ -103,16 +113,17 @@ describe("repair and handoff at cabaf79", () => {
   });
 
   it("does not accept another machine against a repair code", async () => {
-    // Lock-in for the new `findRepaired`: the code names its target, so a different Computer
-    // enrolling during the wait cannot satisfy it — which is what removed the heuristic from the
-    // path that mutates ownership.
+    // Lock-in for the repair correlation: the code names its target, and the Server's verdict is
+    // the only thing that can settle the wait — a different Computer enrolling during the wait
+    // cannot satisfy it, here or on any path that mutates ownership.
     vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [agentOn(AGENT_COMPUTER, "Ada's old Mac")] });
     vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
     let call = 0;
     vi.spyOn(browserApi, "computers").mockImplementation(async () => {
       call += 1;
+      // 1 = the resume read; the verdict stays pending, so nothing later is even consulted.
       const departed = machine(AGENT_COMPUTER, "Ada's old Mac", false);
-      if (call <= 2) return { computers: [departed] };
+      if (call <= 1) return { computers: [departed] };
       return { computers: [departed, machine(OTHER_COMPUTER, "Someone else's Mac", true)] };
     });
 
@@ -125,13 +136,21 @@ describe("repair and handoff at cabaf79", () => {
   });
 
   it("accepts the named machine coming back", async () => {
-    // The other half of the same lock-in: the repair target returning does settle it.
+    // The other half of the same lock-in: the Server reports the repair code redeemed by its
+    // target, and the target back online on a fresh connection settles it.
     vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [agentOn(AGENT_COMPUTER, "Ada's Mac")] });
     vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
+    vi.mocked(browserApi.computerConnectCodeStatus).mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      state: "redeemed",
+      computerId: AGENT_COMPUTER,
+      redeemedAt: REDEEMED_AT,
+    });
     let call = 0;
     vi.spyOn(browserApi, "computers").mockImplementation(async () => {
       call += 1;
-      if (call <= 2) return { computers: [machine(AGENT_COMPUTER, "Ada's Mac", false)] };
+      // 1 = the resume read; the verdict's redemption read finds the machine back.
+      if (call <= 1) return { computers: [machine(AGENT_COMPUTER, "Ada's Mac", false)] };
       return { computers: [machine(AGENT_COMPUTER, "Ada's Mac", true, "2026-08-29T00:09:00.000Z")] };
     });
 

--- a/apps/web/src/onboarding-v2/pr262-r3-findings.test.tsx
+++ b/apps/web/src/onboarding-v2/pr262-r3-findings.test.tsx
@@ -16,6 +16,7 @@ const NOW = "2026-08-29T00:00:00.000Z";
 const COMPUTER_ID = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const USER_ID = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
 
 function existingAgent(): AgentListItem {
   return {
@@ -68,9 +69,17 @@ function resumeOntoDepartedComputer() {
   vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
   vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [departedComputer()] });
   vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+    connectCodeId: CONNECT_CODE_ID,
     bootstrapCommand: "sh -c 'curl -fsSL https://example.test/install.sh | sh' -- connect ABC",
     expiresIn: 900,
     issuedAt: NOW,
+  });
+  // The repair code is never redeemed in these tests: the wait never concludes without a verdict.
+  vi.spyOn(browserApi, "computerConnectCodeStatus").mockResolvedValue({
+    connectCodeId: CONNECT_CODE_ID,
+    state: "pending",
+    computerId: null,
+    redeemedAt: null,
   });
 }
 

--- a/apps/web/src/onboarding-v2/pr262-r4-findings.test.tsx
+++ b/apps/web/src/onboarding-v2/pr262-r4-findings.test.tsx
@@ -18,6 +18,7 @@ const OTHER_COMPUTER = "95fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const ATTEMPT_ID = "2b73a21e-f6c7-4474-91ea-4dabf0566a24";
 const USER_ID = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
 
 function agentOn(computerId: string, displayName: string, extra: Partial<AgentListItem> = {}): AgentListItem {
   return {
@@ -83,9 +84,18 @@ describe("resume at a4e2662", () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"] });
     vi.setSystemTime(new Date(NOW));
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand: "sh -c 'curl -fsSL https://example.test/install.sh | sh' -- connect ABC",
       expiresIn: 900,
       issuedAt: NOW,
+    });
+    // Nobody redeems the issued repair code in these tests: the wait never concludes without the
+    // Server's verdict, whichever machines the Computers list happens to show.
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      state: "pending",
+      computerId: null,
+      redeemedAt: null,
     });
     vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
     vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
@@ -97,17 +107,17 @@ describe("resume at a4e2662", () => {
   });
 
   it("does not finish setup on a Computer the Agent is not bound to", async () => {
-    // Resume correctly refuses to claim the offline Computer, so the step issues a fresh code. But
-    // the arrival it then accepts is any machine at all: this one is a different Computer, the
-    // Agent is never rebound to it — `UpdateAgentRequest` cannot carry a `computerId`, so it
-    // cannot be — and the checks that go green belong to a machine the Agent will never run on.
+    // Resume correctly refuses to claim the offline Computer, so the step issues a repair code for
+    // it. A different machine enrolling during the wait is not the machine the code names, and the
+    // Server's verdict is the only thing that can settle the wait — so the checks that would go
+    // green on the wrong machine never run.
     vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [agentOn(AGENT_COMPUTER, "Ada's old Mac")] });
     let call = 0;
     vi.spyOn(browserApi, "computers").mockImplementation(async () => {
       call += 1;
-      // 1 = the resume read, 2 = the baseline for the fresh code, 3+ = a different machine arrives.
+      // 1 = the resume read; the verdict stays pending, so nothing later is even consulted.
       const departed = machine(AGENT_COMPUTER, "Ada's old Mac", false);
-      if (call <= 2) return { computers: [departed] };
+      if (call <= 1) return { computers: [departed] };
       return { computers: [departed, machine(OTHER_COMPUTER, "Ada's new Mac", true)] };
     });
     const create = vi.spyOn(browserApi, "createAgent");

--- a/apps/web/src/onboarding-v2/pr262-r5-findings.test.tsx
+++ b/apps/web/src/onboarding-v2/pr262-r5-findings.test.tsx
@@ -17,6 +17,8 @@ const AGENT_COMPUTER = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const USER_ID = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const POLL_MS = 1_500;
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+const REDEEMED_AT = "2026-08-29T00:00:05.000Z";
 
 function agentOn(computerId: string, displayName: string): AgentListItem {
   return {
@@ -67,9 +69,17 @@ describe("rebind at ff218a7", () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"] });
     vi.setSystemTime(new Date(NOW));
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand: "sh -c 'curl -fsSL https://example.test/install.sh | sh' -- connect ABC",
       expiresIn: 900,
       issuedAt: NOW,
+    });
+    // A code the test says nothing about stays pending: the wait never concludes without a verdict.
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      state: "pending",
+      computerId: null,
+      redeemedAt: null,
     });
     vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
     vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
@@ -106,13 +116,18 @@ describe("rebind at ff218a7", () => {
     // Same effect, reached the ordinary way: nothing demotes `connected`, so this is not specific
     // to resume — a daemon that stops while the check is still running does it as well.
     vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [] });
+    // The issued code is redeemed by this exact Computer: that is what settles the wait.
+    vi.mocked(browserApi.computerConnectCodeStatus).mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      state: "redeemed",
+      computerId: AGENT_COMPUTER,
+      redeemedAt: REDEEMED_AT,
+    });
     let call = 0;
     vi.spyOn(browserApi, "computers").mockImplementation(async () => {
       call += 1;
-      // An empty Account returns before reading Computers, so 1 = baseline, 2 = the arrival,
-      // 3+ = the daemon stops.
-      if (call === 1) return { computers: [] };
-      if (call === 2) return { computers: [machine(AGENT_COMPUTER, "Ada's Mac", true, false)] };
+      // 1 = the read the redemption verdict unlocks, 2+ = the daemon stops.
+      if (call === 1) return { computers: [machine(AGENT_COMPUTER, "Ada's Mac", true, false)] };
       return { computers: [machine(AGENT_COMPUTER, "Ada's Mac", false, false)] };
     });
 

--- a/apps/web/src/onboarding-v2/pr262-r6-findings.test.tsx
+++ b/apps/web/src/onboarding-v2/pr262-r6-findings.test.tsx
@@ -83,6 +83,7 @@ describe("demotion and the rebind gate at 7967e49", () => {
     // them back to a connect step they had already finished.
     vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [agentOn(AGENT_COMPUTER, "Ada's Mac")] });
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f",
       bootstrapCommand: "sh install",
       expiresIn: 900,
       issuedAt: NOW,

--- a/apps/web/src/onboarding-v2/server-backend.regressions.test.tsx
+++ b/apps/web/src/onboarding-v2/server-backend.regressions.test.tsx
@@ -8,7 +8,12 @@
  * are guarded here rather than left to a live run to catch.
  */
 
-import type { AgentAdminConfig, FeishuSetupAttempt, WorkspaceComputerSummary } from "@opentag/shared/browser";
+import type {
+  AgentAdminConfig,
+  ComputerConnectCodeStatus,
+  FeishuSetupAttempt,
+  WorkspaceComputerSummary,
+} from "@opentag/shared/browser";
 import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { browserApi } from "../api.js";
@@ -23,6 +28,8 @@ const COMPUTER_ID = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const USER_ID = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const ATTEMPT_ID = "2b73a21e-f6c7-4474-91ea-4dabf0566a24";
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+const REDEEMED_AT = "2026-08-29T00:00:05.000Z";
 const POLL_MS = 1_500;
 const FEISHU_POLL_MS = 2_000;
 
@@ -86,13 +93,25 @@ function computersReturning(...pages: readonly (readonly WorkspaceComputerSummar
   });
 }
 
-function issuing(overrides: Partial<{ bootstrapCommand: string; expiresIn: number; issuedAt: string }> = {}) {
+function issuing(
+  overrides: Partial<{ connectCodeId: string; bootstrapCommand: string; expiresIn: number; issuedAt: string }> = {},
+) {
   return vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+    connectCodeId: CONNECT_CODE_ID,
     bootstrapCommand: "sh -c 'curl -fsSL https://example.test/install.sh | sh' -- connect ABC",
     expiresIn: 900,
     issuedAt: NOW,
     ...overrides,
   });
+}
+
+/** The Server's verdict on the issued code: the exact Computer redeemed it. */
+function redeemedVerdict(): ComputerConnectCodeStatus {
+  return { connectCodeId: CONNECT_CODE_ID, state: "redeemed", computerId: COMPUTER_ID, redeemedAt: REDEEMED_AT };
+}
+
+function pendingVerdict(): ComputerConnectCodeStatus {
+  return { connectCodeId: CONNECT_CODE_ID, state: "pending", computerId: null, redeemedAt: null };
 }
 
 function deferred<T>() {
@@ -134,6 +153,8 @@ describe("Server-backed onboarding: the defects it had", () => {
     vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [] });
     vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
     vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
+    // A code the test says nothing about stays pending: the wait never concludes without a verdict.
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(async () => pendingVerdict());
   });
 
   afterEach(() => {
@@ -142,30 +163,27 @@ describe("Server-backed onboarding: the defects it had", () => {
   });
 
   it("does not adopt a Computer from a poll that returns after the code expired", async () => {
-    // The expiry check runs at the top of the interval, but a request already in flight when the
-    // code expires still lands. Its handler adopts the Computer and publishes readiness before it
-    // looks at whether the connection is still the one being waited on.
-    const late = deferred<{ computers: WorkspaceComputerSummary[] }>();
+    // The expiry check runs at the top of the interval, but a status read already in flight when
+    // the code expires still lands — and a redemption verdict for a dead code must not be adopted.
+    const late = deferred<ComputerConnectCodeStatus>();
     let call = 0;
-    vi.spyOn(browserApi, "computers").mockImplementation(async () => {
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(() => {
       call += 1;
-      if (call === 2) return late.promise;
-      return { computers: [] };
+      return call === 1 ? late.promise : Promise.resolve(pendingVerdict());
     });
+    computersReturning([computer({ providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }] })]);
     issuing({ expiresIn: 2 });
     const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
 
     const view = mount();
     act(() => view.result.current.issueConnectCode());
     await settle();
-    await tick(POLL_MS); // the poll leaves; the code has 500ms left
+    await tick(POLL_MS); // the status read leaves; the code has 500ms left
     await tick(POLL_MS); // the next tick finds it expired
     expect(view.result.current.connect.kind).toBe("expired");
 
     await act(async () => {
-      late.resolve({
-        computers: [computer({ providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }] })],
-      });
+      late.resolve(redeemedVerdict());
       await Promise.resolve();
     });
 
@@ -197,18 +215,16 @@ describe("Server-backed onboarding: the defects it had", () => {
     // Readiness is stored as one flat fact with no record of which runtime produced it, so
     // changing the runtime leaves the previous runtime's verdict on screen — and the footer
     // enabled — until the next poll lands, up to a full interval later.
-    computersReturning(
-      [],
-      [
-        computer({
-          providerReadiness: [
-            { provider: "codex", status: "ready", observedAt: NOW },
-            { provider: "claude-code", status: "install", observedAt: NOW },
-          ],
-        }),
-      ],
-    );
+    computersReturning([
+      computer({
+        providerReadiness: [
+          { provider: "codex", status: "ready", observedAt: NOW },
+          { provider: "claude-code", status: "install", observedAt: NOW },
+        ],
+      }),
+    ]);
     issuing();
+    vi.mocked(browserApi.computerConnectCodeStatus).mockResolvedValue(redeemedVerdict());
 
     const view = mount(draft("codex"));
     await connected(view);
@@ -223,16 +239,14 @@ describe("Server-backed onboarding: the defects it had", () => {
     // `imCliReadiness[0]` is whichever CLI the Server happened to observe first, in its own
     // canonical order. Here only Slack has been probed, so a reader who picks Lark is told
     // Lark's CLI is present on the strength of Slack's result.
-    computersReturning(
-      [],
-      [
-        computer({
-          providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }],
-          imCliReadiness: [{ provider: "slack", status: "ready", observedAt: NOW }],
-        }),
-      ],
-    );
+    computersReturning([
+      computer({
+        providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }],
+        imCliReadiness: [{ provider: "slack", status: "ready", observedAt: NOW }],
+      }),
+    ]);
     issuing();
+    vi.mocked(browserApi.computerConnectCodeStatus).mockResolvedValue(redeemedVerdict());
 
     const view = mount();
     await connected(view);
@@ -244,11 +258,9 @@ describe("Server-backed onboarding: the defects it had", () => {
   });
 
   it("stops polling a Lark attempt that Start over abandoned", async () => {
-    computersReturning(
-      [],
-      [computer({ providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }] })],
-    );
+    computersReturning([computer({ providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }] })]);
     issuing();
+    vi.mocked(browserApi.computerConnectCodeStatus).mockResolvedValue(redeemedVerdict());
     vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(attempt());
     const poll = vi.spyOn(browserApi, "feishuSetupAttempt").mockResolvedValue(attempt());
@@ -274,11 +286,9 @@ describe("Server-backed onboarding: the defects it had", () => {
     // The messaging step starts an attempt whenever the state is idle, and a refused attempt is
     // returned to idle, so the effect starts another one immediately. Nothing paces the two, and
     // nothing bounds them: the mock below has to stop refusing in order for the test to end.
-    computersReturning(
-      [],
-      [computer({ providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }] })],
-    );
+    computersReturning([computer({ providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }] })]);
     issuing();
+    vi.mocked(browserApi.computerConnectCodeStatus).mockResolvedValue(redeemedVerdict());
     vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     let calls = 0;
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockImplementation(async () => {
@@ -306,19 +316,15 @@ describe("Server-backed onboarding: the defects it had", () => {
   });
 
   it("clears a transient polling error once the Computer it was waiting for arrives", async () => {
-    // `error` is only cleared by issuing a code or creating an Agent, so a poll that failed once
-    // leaves its line above a step that has since succeeded.
+    // A poll that failed once leaves its line on screen; the verdict that lands after it retires
+    // the error as the connection settles.
     let call = 0;
-    vi.spyOn(browserApi, "computers").mockImplementation(async () => {
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(async () => {
       call += 1;
-      if (call === 2) throw new Error("We lost contact");
-      if (call >= 3) {
-        return {
-          computers: [computer({ providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }] })],
-        };
-      }
-      return { computers: [] };
+      if (call === 1) throw new Error("We lost contact");
+      return redeemedVerdict();
     });
+    computersReturning([computer({ providerReadiness: [{ provider: "codex", status: "ready", observedAt: NOW }] })]);
     issuing();
 
     const view = mount();

--- a/apps/web/src/onboarding-v2/server-backend.test.ts
+++ b/apps/web/src/onboarding-v2/server-backend.test.ts
@@ -250,9 +250,9 @@ describe("useServerBackend", () => {
       expect(view.result.current.error).toBe("network down");
     });
 
-    it("issues one code per visit even where React double-invokes state updaters", async () => {
-      // The request is started from inside a `setConnect` updater, and updaters must be pure.
-      // StrictMode is the cheapest place a second invocation would show up as a second POST.
+    it("issues one code per visit even where React double-invokes the step effect", async () => {
+      // The issue request starts from a plain call that marks the connection ref synchronously.
+      // StrictMode is the cheapest place a second run would show up as a second POST.
       computersReturning([]);
       const issue = issuing();
 
@@ -395,18 +395,44 @@ describe("useServerBackend", () => {
       expect(view.result.current.connect.kind).toBe("expired");
     });
 
-    it("stops waiting on a code the Server no longer knows", async () => {
-      computersReturning([]);
-      issuing();
+    it("expires recoverably, command and Refresh intact, when the Server disowns the code", async () => {
+      computersReturning([computer(ready())]);
+      const issue = issuing();
       vi.spyOn(browserApi, "computerConnectCodeStatus").mockRejectedValue(
         new ApiError(404, "The requested resource was not found", "RESOURCE_NOT_FOUND", "deterministic"),
       );
 
       const view = mount();
-      await connected(view);
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS);
 
-      expect(view.result.current.connect.kind).toBe("idle");
-      expect(view.result.current.error).toBe("The requested resource was not found");
+      // The raw 404 is never shown, no Computer is adopted, and the dead command keeps its Refresh.
+      expect(view.result.current.connect).toEqual({
+        kind: "expired",
+        command: "sh -c 'curl -fsSL https://example.test/install.sh' -- connect ABC",
+      });
+      expect(view.result.current.error).toBeUndefined();
+      expect(view.result.current.readiness).toBeUndefined();
+
+      const second = deferred<ComputerConnectCodeStatus>();
+      vi.mocked(browserApi.computerConnectCodeStatus).mockImplementation(() => second.promise);
+      issue.mockResolvedValue({
+        connectCodeId: REPLACEMENT_CODE_ID,
+        bootstrapCommand: "sh install-2",
+        expiresIn: EXPIRES_IN_S,
+        issuedAt: new Date(Date.now()).toISOString(),
+      });
+      act(() => view.result.current.refreshConnectCode());
+      await settle();
+
+      // Refresh reissues and waits on the new code; nothing from the disowned one carries over.
+      expect(issue).toHaveBeenCalledTimes(2);
+      expect(view.result.current.connect).toMatchObject({ kind: "issued", command: "sh install-2" });
+      await tick(POLL_MS);
+      expect(browserApi.computerConnectCodeStatus).toHaveBeenCalledWith(REPLACEMENT_CODE_ID);
+      expect(view.result.current.connect.kind).toBe("issued");
+      expect(view.result.current.readiness).toBeUndefined();
     });
 
     it("keeps waiting when the status read fails, and says so", async () => {

--- a/apps/web/src/onboarding-v2/server-backend.test.ts
+++ b/apps/web/src/onboarding-v2/server-backend.test.ts
@@ -1,17 +1,23 @@
 /**
  * The Server-backed half of the onboarding seam, driven through stubbed `browserApi` calls.
  *
- * Everything this hook decides is a reading of a Computers list that carries no link back to the
- * code that was issued, so the interesting behaviour is all in what it refuses to conclude: which
- * Computer is this run's, when a reply belongs to a superseded attempt, and when a machine has
- * simply not answered yet. Those are the cases here.
+ * Which Computer a run adopts is the Server's own verdict — the issued code's status read, which
+ * says pending until a machine redeems it and then names the exact Computer that did. The
+ * interesting behaviour is all in what the hook refuses to conclude from anything else: a Computers
+ * list full of arrivals, a verdict meant for a superseded code, or a redeemed machine that has not
+ * actually connected yet. Those are the cases here.
  */
 
-import type { AgentAdminConfig, WorkspaceComputerSummary } from "@opentag/shared/browser";
+import type {
+  AgentAdminConfig,
+  AgentListItem,
+  ComputerConnectCodeStatus,
+  WorkspaceComputerSummary,
+} from "@opentag/shared/browser";
 import { act, renderHook } from "@testing-library/react";
 import { createElement, StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { browserApi } from "../api.js";
+import { ApiError, browserApi } from "../api.js";
 import type { AgentDraft, Runtime } from "./flow.js";
 import { useServerBackend } from "./server-backend.js";
 
@@ -20,6 +26,10 @@ const COMPUTER_ID = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const OTHER_COMPUTER_ID = "95fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const USER_ID = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+const REPLACEMENT_CODE_ID = "8b2d0f63-0b9c-4d8e-9f2a-3b4c5d6e7f8a";
+/** The Server's redemption time; every connected fixture connects after it. */
+const REDEEMED_AT = "2026-08-29T00:00:05.000Z";
 
 /** The poll cadence the hook waits on, and one full expiry window. */
 const POLL_MS = 1_500;
@@ -65,9 +75,28 @@ function adminConfig(): AgentAdminConfig {
   };
 }
 
+/** The Agent a resumed run finds, bound to a Computer that has since gone silent. */
+function existingAgent(): AgentListItem {
+  return {
+    id: AGENT_ID,
+    name: "opentag",
+    displayName: "opentag",
+    createdBy: { userId: USER_ID, displayName: "Ada" },
+    computer: { computerId: COMPUTER_ID, displayName: "Ada's Mac", platform: "darwin" },
+    runtimeProvider: "codex",
+    receiveMode: "mention_only",
+    status: "active",
+    activity: { state: "idle" },
+    usage: { windowDays: 30, tasks: 0, failed: 0, tokens: 0 },
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
 /**
  * Each entry answers one `computers()` call, in order; the last entry answers every call after it.
- * The first call is always the baseline read, so a fixture reads as "before the code, then after".
+ * The first call is the redemption-confirmed read — the hook no longer takes a baseline, because it
+ * never infers an arrival from this list.
  */
 function computersReturning(...pages: readonly (readonly WorkspaceComputerSummary[])[]) {
   let call = 0;
@@ -78,12 +107,44 @@ function computersReturning(...pages: readonly (readonly WorkspaceComputerSummar
   });
 }
 
-function issuing(overrides: Partial<{ bootstrapCommand: string; expiresIn: number; issuedAt: string }> = {}) {
+function issuing(
+  overrides: Partial<{ connectCodeId: string; bootstrapCommand: string; expiresIn: number; issuedAt: string }> = {},
+) {
   return vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
-    bootstrapCommand: "sh -c 'curl -fsSL https://example.test/install.sh | sh' -- connect ABC",
+    connectCodeId: CONNECT_CODE_ID,
+    bootstrapCommand: "sh -c 'curl -fsSL https://example.test/install.sh' -- connect ABC",
     expiresIn: EXPIRES_IN_S,
     issuedAt: NOW,
     ...overrides,
+  });
+}
+
+/** The Server's verdict on the issued code. Pending until a test says otherwise. */
+function verdict(
+  overrides: { connectCodeId?: string; state?: "pending" | "expired" | "revoked" } = {},
+): ComputerConnectCodeStatus {
+  return {
+    connectCodeId: overrides.connectCodeId ?? CONNECT_CODE_ID,
+    state: overrides.state ?? "pending",
+    computerId: null,
+    redeemedAt: null,
+  };
+}
+
+function redeemed(computerId: string = COMPUTER_ID, redeemedAt: string = REDEEMED_AT): ComputerConnectCodeStatus {
+  return { connectCodeId: CONNECT_CODE_ID, state: "redeemed", computerId, redeemedAt };
+}
+
+/**
+ * Each entry answers one `computerConnectCodeStatus()` call, in order; the last entry answers every
+ * call after it. With no entries the code stays pending forever.
+ */
+function verdictsReturning(...pages: readonly ComputerConnectCodeStatus[]) {
+  let call = 0;
+  return vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(async () => {
+    const page = pages[Math.min(call, pages.length - 1)] ?? verdict();
+    call += 1;
+    return page;
   });
 }
 
@@ -128,6 +189,8 @@ describe("useServerBackend", () => {
     vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [] });
     vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
     vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
+    // A code the test says nothing about stays pending: the wait never concludes without a verdict.
+    verdictsReturning();
   });
 
   afterEach(() => {
@@ -136,7 +199,7 @@ describe("useServerBackend", () => {
   });
 
   describe("issuing the code", () => {
-    it("reads the Computers baseline before the code exists, never after", async () => {
+    it("issues the code without consulting the Computers list", async () => {
       const order: string[] = [];
       vi.spyOn(browserApi, "computers").mockImplementation(async () => {
         order.push("computers");
@@ -144,14 +207,20 @@ describe("useServerBackend", () => {
       });
       vi.spyOn(browserApi, "issueComputerConnectCode").mockImplementation(async () => {
         order.push("issue");
-        return { bootstrapCommand: "sh install", expiresIn: EXPIRES_IN_S, issuedAt: NOW };
+        return {
+          connectCodeId: CONNECT_CODE_ID,
+          bootstrapCommand: "sh install",
+          expiresIn: EXPIRES_IN_S,
+          issuedAt: NOW,
+        };
       });
 
       const view = mount();
       act(() => view.result.current.issueConnectCode());
       await settle();
 
-      expect(order).toEqual(["computers", "issue"]);
+      // No baseline, in either order: the Computers list is not evidence of which machine answered.
+      expect(order).toEqual(["issue"]);
       expect(view.result.current.connect).toMatchObject({ kind: "issued", command: "sh install" });
     });
 
@@ -210,22 +279,27 @@ describe("useServerBackend", () => {
     });
   });
 
-  describe("deciding which Computer arrived", () => {
-    it("does not accept a Computer that was already enrolled before the code was issued", async () => {
-      const existing = computer(ready());
-      computersReturning([existing], [existing]);
+  describe("the Server's redemption verdict", () => {
+    it("keeps waiting while the code is pending, whatever the Computers list shows", async () => {
+      // A Computer already enrolled, one enrolling mid-wait, one reconnecting: none of them is
+      // evidence about this code, and none of them is read as this run's arrival.
+      const foreign = computer({ computerId: OTHER_COMPUTER_ID, displayName: "Bob's Mac", ...ready() });
+      computersReturning([foreign]);
       issuing();
 
       const view = mount();
-      await connected(view);
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS * 3);
 
       expect(view.result.current.connect.kind).toBe("issued");
       expect(view.result.current.readiness).toBeUndefined();
     });
 
-    it("accepts a Computer that is absent from the baseline", async () => {
-      computersReturning([], [computer(ready())]);
+    it("adopts the exact Computer the verdict names, once it connects", async () => {
+      computersReturning([computer(ready())]);
       issuing();
+      verdictsReturning(redeemed());
 
       const view = mount();
       await connected(view);
@@ -238,79 +312,107 @@ describe("useServerBackend", () => {
       });
     });
 
-    it("accepts a known Computer whose connectedAt has moved since the baseline", async () => {
-      const before = computer({ connectedAt: "2026-08-28T00:00:00.000Z" });
-      computersReturning([before], [computer({ ...ready(), connectedAt: "2026-08-29T00:00:10.000Z" })]);
+    it("never selects an unrelated Computer that enrolls or reconnects during the wait", async () => {
+      // The colleague case the list heuristic could not answer: Bob's machine shows up online while
+      // this run's code is pending, and is still there when the verdict names Ada's.
+      const bobs = computer({ computerId: OTHER_COMPUTER_ID, displayName: "Bob's Mac", ...ready() });
+      computersReturning([bobs, computer(ready())]);
       issuing();
+      verdictsReturning(verdict(), redeemed());
 
       const view = mount();
-      await connected(view);
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS);
+      expect(view.result.current.connect.kind).toBe("issued");
 
+      await tick(POLL_MS);
+      expect(view.result.current.connect).toMatchObject({ kind: "connected", computerName: "Ada's Mac" });
+    });
+
+    it("keeps waiting when the redeemed Computer has not connected yet", async () => {
+      // Redemption is durable and immediate; reachability is neither. The verdict names the machine
+      // the moment the code is spent, and the step waits for that exact machine — and no other —
+      // to come online.
+      const offline = computer({ ...ready(), connectionStatus: "offline", connectedAt: null, lastSeenAt: null });
+      computersReturning([offline], [computer(ready())]);
+      issuing();
+      verdictsReturning(redeemed());
+
+      const view = mount();
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS);
+      expect(view.result.current.connect.kind).toBe("issued");
+
+      await tick(POLL_MS);
+      expect(view.result.current.connect).toMatchObject({ kind: "connected", computerName: "Ada's Mac" });
+    });
+
+    it("does not adopt the redeemed Computer on a connection that predates the redemption", async () => {
+      // A repaired machine can still be showing its old connection while the exchange lands. The
+      // connection that counts is the one the redemption bought.
+      const stale = computer({ ...ready(), connectedAt: "2026-08-28T00:00:00.000Z" });
+      computersReturning([stale], [computer(ready())]);
+      issuing();
+      verdictsReturning(redeemed());
+
+      const view = mount();
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS);
+      expect(view.result.current.connect.kind).toBe("issued");
+
+      await tick(POLL_MS);
       expect(view.result.current.connect.kind).toBe("connected");
     });
 
-    it("does not accept a Computer that is listed but offline", async () => {
-      computersReturning([], [computer({ ...ready(), connectionStatus: "offline" })]);
+    it("ends the wait when the Server reports the code expired, ahead of the local clock", async () => {
+      computersReturning([]);
       issuing();
+      verdictsReturning(verdict(), verdict({ state: "expired" }));
 
       const view = mount();
-      await connected(view);
-
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS);
       expect(view.result.current.connect.kind).toBe("issued");
+
+      await tick(POLL_MS);
+      expect(view.result.current.connect).toMatchObject({ kind: "expired" });
     });
 
-    it("does not accept a Computer that has never connected", async () => {
-      computersReturning([], [computer({ ...ready(), connectedAt: null })]);
+    it("ends the wait when the Server reports the code revoked, and never names a Computer", async () => {
+      computersReturning([computer(ready())]);
       issuing();
+      verdictsReturning(verdict({ state: "revoked" }));
 
       const view = mount();
       await connected(view);
 
-      expect(view.result.current.connect.kind).toBe("issued");
+      // Fail closed: a revoked code reads exactly like an expired one, and the machine that happens
+      // to be online nearby is not adopted.
+      expect(view.result.current.connect.kind).toBe("expired");
     });
 
-    /**
-     * Documented limitation, not a guarantee. The baseline rules out machines that were already
-     * enrolled, and nothing more: the Computers list is Workspace-wide and carries no link back to
-     * the issued code, so a colleague enrolling — or reconnecting — during the wait is read as this
-     * reader's arrival. Closing it needs a discriminator from the Server (the issue response
-     * naming the code, and the Computer summary echoing the code it enrolled with). The existing
-     * onboarding's Computer step has the same gap, so this is inherited rather than introduced.
-     */
-    it("cannot tell a colleague's enrollment during the wait from this reader's own", async () => {
-      const otherAccountsMachine = computer({ computerId: OTHER_COMPUTER_ID, displayName: "Bob's Mac", ...ready() });
-      computersReturning([], [otherAccountsMachine]);
+    it("stops waiting on a code the Server no longer knows", async () => {
+      computersReturning([]);
       issuing();
+      vi.spyOn(browserApi, "computerConnectCodeStatus").mockRejectedValue(
+        new ApiError(404, "The requested resource was not found", "RESOURCE_NOT_FOUND", "deterministic"),
+      );
 
       const view = mount();
       await connected(view);
 
-      expect(view.result.current.connect).toMatchObject({ kind: "connected", computerName: "Bob's Mac" });
+      expect(view.result.current.connect.kind).toBe("idle");
+      expect(view.result.current.error).toBe("The requested resource was not found");
     });
 
-    it("cannot tell a colleague's reconnection during the wait from this reader's own", async () => {
-      const before = computer({
-        computerId: OTHER_COMPUTER_ID,
-        displayName: "Bob's Mac",
-        connectedAt: "2026-08-28T00:00:00.000Z",
-      });
-      computersReturning([before], [{ ...before, ...ready(), connectedAt: "2026-08-29T00:00:10.000Z" }]);
+    it("keeps waiting when the status read fails, and says so", async () => {
+      computersReturning([]);
       issuing();
-
-      const view = mount();
-      await connected(view);
-
-      expect(view.result.current.connect).toMatchObject({ kind: "connected", computerName: "Bob's Mac" });
-    });
-
-    it("keeps waiting when the Computers call fails, and says so", async () => {
-      let call = 0;
-      vi.spyOn(browserApi, "computers").mockImplementation(async () => {
-        call += 1;
-        if (call === 1) return { computers: [] };
-        throw new Error("gateway timeout");
-      });
-      issuing();
+      vi.spyOn(browserApi, "computerConnectCodeStatus").mockRejectedValue(new Error("gateway timeout"));
 
       const view = mount();
       await connected(view);
@@ -318,12 +420,35 @@ describe("useServerBackend", () => {
       expect(view.result.current.connect.kind).toBe("issued");
       expect(view.result.current.error).toBe("gateway timeout");
     });
+
+    it("keeps waiting when the Computers read fails after redemption, and recovers", async () => {
+      let call = 0;
+      vi.spyOn(browserApi, "computers").mockImplementation(async () => {
+        call += 1;
+        if (call === 1) throw new Error("gateway timeout");
+        return { computers: [computer(ready())] };
+      });
+      issuing();
+      verdictsReturning(redeemed());
+
+      const view = mount();
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS);
+      expect(view.result.current.connect.kind).toBe("issued");
+      expect(view.result.current.error).toBe("gateway timeout");
+
+      await tick(POLL_MS);
+      expect(view.result.current.connect.kind).toBe("connected");
+      expect(view.result.current.error).toBeUndefined();
+    });
   });
 
   describe("reading readiness", () => {
     it("reports checking, not a failure, while the Computer has reported nothing", async () => {
-      computersReturning([], [computer()]);
+      computersReturning([computer()]);
       issuing();
+      verdictsReturning(redeemed());
 
       const view = mount();
       await connected(view);
@@ -336,8 +461,9 @@ describe("useServerBackend", () => {
     });
 
     it("reports checking when the chosen runtime has no observation of its own", async () => {
-      computersReturning([], [computer(ready("codex"))]);
+      computersReturning([computer(ready("codex"))]);
       issuing();
+      verdictsReturning(redeemed());
 
       const view = mount(draft("claude-code"));
       await connected(view);
@@ -346,18 +472,16 @@ describe("useServerBackend", () => {
     });
 
     it("reads the runtime the draft chose rather than the first one reported", async () => {
-      computersReturning(
-        [],
-        [
-          computer({
-            providerReadiness: [
-              { provider: "codex", status: "ready", observedAt: NOW },
-              { provider: "claude-code", status: "install", observedAt: NOW },
-            ],
-          }),
-        ],
-      );
+      computersReturning([
+        computer({
+          providerReadiness: [
+            { provider: "codex", status: "ready", observedAt: NOW },
+            { provider: "claude-code", status: "install", observedAt: NOW },
+          ],
+        }),
+      ]);
       issuing();
+      verdictsReturning(redeemed());
 
       const view = mount(draft("claude-code"));
       await connected(view);
@@ -367,11 +491,11 @@ describe("useServerBackend", () => {
 
     it("keeps re-reading readiness after the Computer is connected, so a repair turns green", async () => {
       computersReturning(
-        [],
         [computer({ providerReadiness: [{ provider: "codex", status: "sign-in", observedAt: NOW }] })],
         [computer(ready())],
       );
       issuing();
+      verdictsReturning(redeemed());
 
       const view = mount();
       await connected(view);
@@ -382,9 +506,52 @@ describe("useServerBackend", () => {
     });
   });
 
+  describe("repairing the Agent's own Computer", () => {
+    /** A resumed run whose Agent's Computer has gone silent: the step repairs that exact machine. */
+    function resumingOntoDepartedComputer() {
+      vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [existingAgent()] });
+    }
+
+    it("issues a repair code for the departed Computer and adopts it on the Server's verdict", async () => {
+      resumingOntoDepartedComputer();
+      verdictsReturning(redeemed());
+      const departed = computer({ connectionStatus: "offline", connectedAt: null, lastSeenAt: null });
+      computersReturning([departed], [computer(ready())]);
+      const issue = issuing();
+
+      const view = mount();
+      await settle();
+      expect(view.result.current.connect.kind).toBe("idle");
+
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      expect(issue).toHaveBeenCalledWith({ mode: "repair", targetComputerId: COMPUTER_ID });
+
+      await tick(POLL_MS);
+      expect(view.result.current.connect).toMatchObject({ kind: "connected", computerName: "Ada's Mac" });
+    });
+
+    it("keeps waiting while the repair code is pending and another machine reconnects", async () => {
+      resumingOntoDepartedComputer();
+      const departed = computer({ connectionStatus: "offline", connectedAt: null, lastSeenAt: null });
+      const foreign = computer({ computerId: OTHER_COMPUTER_ID, displayName: "Bob's Mac", ...ready() });
+      computersReturning([departed], [departed, foreign]);
+      issuing();
+      verdictsReturning();
+
+      const view = mount();
+      await settle();
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS * 2);
+
+      expect(view.result.current.connect.kind).toBe("issued");
+    });
+  });
+
   describe("expiry", () => {
     it("expires the code on the Server's clock and keeps the command on screen", async () => {
-      computersReturning([], []);
+      computersReturning([]);
       issuing({ expiresIn: 3 });
 
       const view = mount();
@@ -395,24 +562,25 @@ describe("useServerBackend", () => {
       expect(view.result.current.connect).toMatchObject({ kind: "expired" });
     });
 
-    it("stops polling once the code has expired, so a later arrival cannot satisfy it", async () => {
-      const computers = computersReturning([], [], [computer(ready())]);
+    it("stops polling once the code has expired, so a later redemption cannot satisfy it", async () => {
+      const verdicts = verdictsReturning();
       issuing({ expiresIn: 3 });
 
       const view = mount();
       act(() => view.result.current.issueConnectCode());
       await settle();
       await tick(POLL_MS * 3);
-      const afterExpiry = computers.mock.calls.length;
+      const afterExpiry = verdicts.mock.calls.length;
       await tick(POLL_MS * 4);
 
       expect(view.result.current.connect.kind).toBe("expired");
-      expect(computers).toHaveBeenCalledTimes(afterExpiry);
+      expect(verdicts).toHaveBeenCalledTimes(afterExpiry);
     });
 
     it("replaces an expired code with a fresh one and starts waiting again", async () => {
-      computersReturning([], [], [], [computer(ready())]);
+      computersReturning([computer(ready())]);
       const issue = issuing({ expiresIn: 3 });
+      const verdicts = verdictsReturning();
 
       const view = mount();
       act(() => view.result.current.issueConnectCode());
@@ -421,6 +589,7 @@ describe("useServerBackend", () => {
       expect(view.result.current.connect.kind).toBe("expired");
 
       issue.mockResolvedValue({
+        connectCodeId: REPLACEMENT_CODE_ID,
         bootstrapCommand: "sh install-2",
         expiresIn: EXPIRES_IN_S,
         issuedAt: new Date(Date.now()).toISOString(),
@@ -429,21 +598,25 @@ describe("useServerBackend", () => {
       await settle();
       expect(view.result.current.connect).toMatchObject({ kind: "issued", command: "sh install-2" });
 
+      // The wait tracks the replacement code, not the expired one.
+      verdicts.mockImplementation(async (connectCodeId: string) =>
+        connectCodeId === REPLACEMENT_CODE_ID ? { ...redeemed(), connectCodeId } : verdict(),
+      );
       await tick(POLL_MS);
       expect(view.result.current.connect.kind).toBe("connected");
     });
   });
 
   describe("superseded attempts", () => {
-    it("discards a Computers reply issued before the command was refreshed", async () => {
-      const pending = deferred<{ computers: WorkspaceComputerSummary[] }>();
+    it("discards a redemption verdict that was in flight for a superseded code", async () => {
+      const stale = deferred<ComputerConnectCodeStatus>();
       let call = 0;
-      vi.spyOn(browserApi, "computers").mockImplementation(async () => {
+      vi.spyOn(browserApi, "computerConnectCodeStatus").mockImplementation(() => {
         call += 1;
-        // 1 = first baseline, 2 = the poll left in flight, 3 = the refreshed baseline.
-        if (call === 2) return pending.promise;
-        return { computers: [] };
+        // 1 = the poll left in flight across the refresh, 2+ = the fresh code's polls.
+        return call === 1 ? stale.promise : Promise.resolve(verdict());
       });
+      computersReturning([computer(ready())]);
       issuing();
 
       const view = mount();
@@ -454,7 +627,7 @@ describe("useServerBackend", () => {
       act(() => view.result.current.refreshConnectCode());
       await settle();
       await act(async () => {
-        pending.resolve({ computers: [computer(ready())] });
+        stale.resolve(redeemed());
         await Promise.resolve();
       });
 
@@ -462,44 +635,43 @@ describe("useServerBackend", () => {
       expect(view.result.current.readiness).toBeUndefined();
     });
 
-    it("discards a baseline reply from an attempt that was already replaced", async () => {
+    it("discards a Computers reply that was in flight for a superseded code", async () => {
       const stale = deferred<{ computers: WorkspaceComputerSummary[] }>();
-      let call = 0;
-      vi.spyOn(browserApi, "computers").mockImplementation(async () => {
-        call += 1;
-        if (call === 1) return stale.promise;
-        return { computers: [] };
+      vi.spyOn(browserApi, "computers").mockImplementation(() => stale.promise);
+      issuing();
+      verdictsReturning(redeemed());
+
+      const view = mount();
+      act(() => view.result.current.issueConnectCode());
+      await settle();
+      await tick(POLL_MS);
+
+      act(() => view.result.current.refreshConnectCode());
+      await settle();
+      await act(async () => {
+        stale.resolve({ computers: [computer(ready())] });
+        await Promise.resolve();
       });
+
+      // The in-flight read belonged to the old code's wait; the fresh code is still pending, so
+      // nothing is adopted from it.
+      expect(view.result.current.connect.kind).toBe("issued");
+      expect(view.result.current.readiness).toBeUndefined();
+    });
+
+    it("stops polling once the hook is unmounted", async () => {
+      const verdicts = verdictsReturning();
       issuing();
 
       const view = mount();
       act(() => view.result.current.issueConnectCode());
-      act(() => view.result.current.refreshConnectCode());
       await settle();
-
-      const alreadyEnrolled = computer(ready());
-      await act(async () => {
-        stale.resolve({ computers: [alreadyEnrolled] });
-        await Promise.resolve();
-      });
       await tick(POLL_MS);
-
-      // The stale baseline never lands, so the machine it listed is still read against the fresh
-      // (empty) one. What matters is that the superseded reply did not become the baseline.
-      expect(view.result.current.connect.kind).not.toBe("issuing");
-    });
-
-    it("stops polling once the hook is unmounted", async () => {
-      const computers = computersReturning([], []);
-      issuing();
-
-      const view = mount();
-      await connected(view);
-      const before = computers.mock.calls.length;
+      const before = verdicts.mock.calls.length;
       view.unmount();
       await tick(POLL_MS * 3);
 
-      expect(computers).toHaveBeenCalledTimes(before);
+      expect(verdicts).toHaveBeenCalledTimes(before);
     });
   });
 
@@ -518,8 +690,9 @@ describe("useServerBackend", () => {
     });
 
     it("creates on the Computer this run enrolled, with the drafted name and runtime", async () => {
-      computersReturning([], [computer(ready("claude-code"))]);
+      computersReturning([computer(ready("claude-code"))]);
       issuing();
+      verdictsReturning(redeemed());
       const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
 
       const view = mount(draft("claude-code"));
@@ -538,8 +711,9 @@ describe("useServerBackend", () => {
     });
 
     it("returns to a pressable state after a failed creation, and the retry succeeds", async () => {
-      computersReturning([], [computer(ready())]);
+      computersReturning([computer(ready())]);
       issuing();
+      verdictsReturning(redeemed());
       const create = vi
         .spyOn(browserApi, "createAgent")
         .mockRejectedValueOnce(new Error("name already taken"))
@@ -562,8 +736,9 @@ describe("useServerBackend", () => {
     });
 
     it("does not create twice while a creation is in flight", async () => {
-      computersReturning([], [computer(ready())]);
+      computersReturning([computer(ready())]);
       issuing();
+      verdictsReturning(redeemed());
       const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
 
       const view = mount();
@@ -580,8 +755,9 @@ describe("useServerBackend", () => {
 
   describe("starting over", () => {
     it("forgets the run's Computer, its readiness and its Agent", async () => {
-      computersReturning([], [computer(ready())]);
+      computersReturning([computer(ready())]);
       issuing();
+      verdictsReturning(redeemed());
       vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
 
       const view = mount();
@@ -598,8 +774,9 @@ describe("useServerBackend", () => {
     });
 
     it("does not let a creation started before the restart land afterwards", async () => {
-      computersReturning([], [computer(ready())]);
+      computersReturning([computer(ready())]);
       issuing();
+      verdictsReturning(redeemed());
       const pending = deferred<AgentAdminConfig>();
       vi.spyOn(browserApi, "createAgent").mockReturnValue(pending.promise);
 

--- a/apps/web/src/onboarding-v2/server-backend.ts
+++ b/apps/web/src/onboarding-v2/server-backend.ts
@@ -16,6 +16,7 @@ import type {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ApiError, browserApi } from "../api.js";
 import type { MessagingCliStatus, RuntimeStatus } from "../setup/checks.js";
+import { readConnectCodeVerdict } from "../setup/connect-code-verdict.js";
 import type { CreatedAgent, OnboardingBackend, PlanSignIn } from "./backend.js";
 import { COPY } from "./copy.js";
 import type {
@@ -54,22 +55,6 @@ async function findRedeemedComputer(
   const computer = computers.find((candidate) => candidate.computerId === computerId);
   if (computer?.connectionStatus !== "online" || computer.connectedAt === null) return undefined;
   return Date.parse(computer.connectedAt) >= Date.parse(redeemedAt) ? computer : undefined;
-}
-
-type ConnectCodeVerdict =
-  | { readonly action: "wait" }
-  | { readonly action: "expire" }
-  | { readonly action: "adopt"; readonly computerId: string; readonly redeemedAt: string };
-
-/**
- * The verdict's reading. Pending keeps the wait; redeemed names the machine to adopt. Expired and
- * revoked fail closed through the same terminal the local expiry uses — neither ever names a
- * Computer — and a malformed redemption is refused rather than believed.
- */
-function readConnectCodeVerdict(status: ComputerConnectCodeStatus): ConnectCodeVerdict {
-  if (status.state === "pending") return { action: "wait" };
-  if (status.state !== "redeemed" || !status.computerId || !status.redeemedAt) return { action: "expire" };
-  return { action: "adopt", computerId: status.computerId, redeemedAt: status.redeemedAt };
 }
 
 /** The connection being waited on, unless the wait has moved on since the poll left. */
@@ -153,12 +138,6 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
   const connectCodeId = useRef<string | undefined>(undefined);
   const redeemed = useRef<{ computerId: string; redeemedAt: string } | undefined>(undefined);
   const expiresAt = useRef(0);
-  /**
-   * True while the issue request is in flight. A StrictMode double-invocation of the updater
-   * schedules `issue` twice in the same flush, and the second run is the same request — not a
-   * reason to mint a second code.
-   */
-  const issuingFlight = useRef(false);
   /** Bumped by every reissue and by unmount, so a reply from a superseded attempt is discarded. */
   const attempt = useRef(0);
   const creationRef = useRef<CreationState>("idle");
@@ -294,8 +273,6 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
   }, [readAccount]);
 
   const issue = useCallback(async () => {
-    if (issuingFlight.current) return;
-    issuingFlight.current = true;
     const mine = attempt.current + 1;
     attempt.current = mine;
     // Everything keyed to the run just superseded is released with it — what the reader can see as
@@ -326,30 +303,40 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
       if (!mounted.current || attempt.current !== mine) return;
       setConnect({ kind: "idle" });
       setConnectionError(errorMessage(cause, COPY.errors.connectCode));
-    } finally {
-      // A reset may allow a successor issue while this request is still in flight. The older
-      // request must not clear the successor's guard when it eventually settles.
-      if (attempt.current === mine) issuingFlight.current = false;
     }
   }, []);
 
   const issueConnectCode = useCallback(() => {
-    setConnect((current) => {
-      if (current.kind !== "idle") return current;
-      queueMicrotask(() => void issue());
-      return { kind: "issuing" };
-    });
+    // Decide outside a state updater and update the ref before starting work. A same-flush repeat,
+    // including StrictMode's second effect run, sees `issuing` and cannot mint another code.
+    if (connectRef.current.kind !== "idle") return;
+    connectRef.current = { kind: "issuing" };
+    void issue();
   }, [issue]);
 
-  const refreshConnectCode = useCallback(() => void issue(), [issue]);
+  const refreshConnectCode = useCallback(() => {
+    if (connectRef.current.kind === "issuing") return;
+    connectRef.current = { kind: "issuing" };
+    void issue();
+  }, [issue]);
 
-  /** A failed read of the verdict: report it, and close the wait on a code the Server disowns. */
+  /** A failed read of the verdict: reported unless the Server has disowned the code entirely. */
   const failIssuedCodePoll = useCallback((cause: unknown) => {
-    const gone = cause instanceof ApiError && cause.status === 404;
-    // A code the Server no longer acknowledges can never be redeemed: stop waiting on it rather
-    // than poll a dead handle until the local clock runs out.
-    if (gone) setConnect({ kind: "idle" });
-    setConnectionError(errorMessage(cause, gone ? COPY.errors.connectCode : COPY.errors.computers));
+    if (!(cause instanceof ApiError && cause.status === 404)) {
+      setConnectionError(errorMessage(cause, COPY.errors.computers));
+      return;
+    }
+    /*
+     * A code the Server no longer acknowledges can never be redeemed, and a raw 404 is no answer
+     * to give a reader holding a command. The code fails closed through the same recoverable
+     * terminal as an expiry: the dead command stays on screen, Refresh reissues, and no Computer
+     * is adopted.
+     */
+    const waiting = issuedConnection(connectRef.current);
+    if (waiting) {
+      setConnectionError(undefined);
+      setConnect({ kind: "expired", command: waiting.command });
+    }
   }, []);
 
   /** Adopts the redeemed Computer once it is verifiably online; otherwise the wait continues. */
@@ -388,12 +375,12 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
       const waiting = issuedConnection(connectRef.current);
       if (!waiting) return;
       const verdict = readConnectCodeVerdict(status);
-      if (verdict.action === "wait") {
+      if (verdict.kind === "wait") {
         // A poll that succeeds retires whatever the last failed one put on screen.
         setConnectionError(undefined);
         return;
       }
-      if (verdict.action === "expire") {
+      if (verdict.kind === "expire") {
         // The Server has closed the code and nothing can redeem it now, so the wait ends the way
         // a local expiry ends it — the dead command stays on screen with its refresh offered.
         setConnect({ kind: "expired", command: waiting.command });
@@ -617,13 +604,13 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
 
   const reset = useCallback(() => {
     attempt.current += 1;
-    issuingFlight.current = false;
     window.clearInterval(feishuTimer.current);
     computerId.current = undefined;
     connectCodeId.current = undefined;
     redeemed.current = undefined;
     expiresAt.current = 0;
     creationRef.current = "idle";
+    connectRef.current = { kind: "idle" };
     setConnect({ kind: "idle" });
     setComputer(undefined);
     setMessaging({ kind: "idle" });

--- a/apps/web/src/onboarding-v2/server-backend.ts
+++ b/apps/web/src/onboarding-v2/server-backend.ts
@@ -7,9 +7,14 @@
  * never has two clocks disagreeing about the same moment.
  */
 
-import type { AgentRuntimeProvider, ImBindingHandoffStatus, WorkspaceComputerSummary } from "@opentag/shared/browser";
+import type {
+  AgentRuntimeProvider,
+  ComputerConnectCodeStatus,
+  ImBindingHandoffStatus,
+  WorkspaceComputerSummary,
+} from "@opentag/shared/browser";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { browserApi } from "../api.js";
+import { ApiError, browserApi } from "../api.js";
 import type { MessagingCliStatus, RuntimeStatus } from "../setup/checks.js";
 import type { CreatedAgent, OnboardingBackend, PlanSignIn } from "./backend.js";
 import { COPY } from "./copy.js";
@@ -22,7 +27,7 @@ import type {
   ReadinessFacts,
 } from "./flow.js";
 
-/** The existing onboarding polls Computers at this rate while it waits for one. */
+/** The connect step polls the issued code's status at this rate while it waits for a Computer. */
 const COMPUTER_POLL_MS = 1_500;
 /** The Feishu attempt is a QR the user scans on a phone; there is nothing to see faster than this. */
 const FEISHU_POLL_MS = 2_000;
@@ -34,24 +39,42 @@ export function errorMessage(cause: unknown, fallback: string): string {
 }
 
 /**
- * Which Computer this run is waiting for.
- *
- * The Computers response carries no link back to the code that was issued, so "a Computer appeared"
- * is not the same claim as "my Computer appeared". Every enrollment visible before the code was
- * issued is recorded, and only a Computer that is absent from that baseline — or one whose
- * `connectedAt` has moved since — counts as this run's arrival. Without that, someone else's
- * machine registering would satisfy this reader's step.
+ * Which Computer this run is waiting for is the Server's call, never an inference from the
+ * Computers list. The status read for the issued code says pending until a machine redeems it and
+ * then names the exact Computer that did, so another machine enrolling — or coming back — during
+ * the wait cannot be mistaken for this reader's. Reachability is a separate question: redemption is
+ * durable, and the exact Computer is adopted only once the Computers list shows it online on a
+ * connection that postdates the redemption.
  */
-function findArrival(
-  computers: readonly WorkspaceComputerSummary[],
-  baseline: ReadonlyMap<string, string | null>,
-): WorkspaceComputerSummary | undefined {
-  return computers.find(
-    (computer) =>
-      computer.connectionStatus === "online" &&
-      computer.connectedAt !== null &&
-      (!baseline.has(computer.computerId) || baseline.get(computer.computerId) !== computer.connectedAt),
-  );
+async function findRedeemedComputer(
+  computerId: string,
+  redeemedAt: string,
+): Promise<WorkspaceComputerSummary | undefined> {
+  const { computers } = await browserApi.computers();
+  const computer = computers.find((candidate) => candidate.computerId === computerId);
+  if (computer?.connectionStatus !== "online" || computer.connectedAt === null) return undefined;
+  return Date.parse(computer.connectedAt) >= Date.parse(redeemedAt) ? computer : undefined;
+}
+
+type ConnectCodeVerdict =
+  | { readonly action: "wait" }
+  | { readonly action: "expire" }
+  | { readonly action: "adopt"; readonly computerId: string; readonly redeemedAt: string };
+
+/**
+ * The verdict's reading. Pending keeps the wait; redeemed names the machine to adopt. Expired and
+ * revoked fail closed through the same terminal the local expiry uses — neither ever names a
+ * Computer — and a malformed redemption is refused rather than believed.
+ */
+function readConnectCodeVerdict(status: ComputerConnectCodeStatus): ConnectCodeVerdict {
+  if (status.state === "pending") return { action: "wait" };
+  if (status.state !== "redeemed" || !status.computerId || !status.redeemedAt) return { action: "expire" };
+  return { action: "adopt", computerId: status.computerId, redeemedAt: status.redeemedAt };
+}
+
+/** The connection being waited on, unless the wait has moved on since the poll left. */
+function issuedConnection(connect: ConnectState) {
+  return connect.kind === "issued" ? connect : undefined;
 }
 
 /**
@@ -66,23 +89,6 @@ function readMessaging(handoff: ImBindingHandoffStatus | undefined): MessagingSt
   if (handoff?.handoffReady) return { kind: "connected" };
   if (handoff?.bindingState === "active") return { kind: "waiting-handoff" };
   return { kind: "idle" };
-}
-
-/**
- * The Computer a repair code was issued for, once it has answered.
- *
- * Nothing is inferred here. The code named this machine, so the only question is whether it has
- * come back — which is a fresh `connectedAt` on that exact Computer, and cannot be satisfied by
- * any other machine enrolling during the wait.
- */
-function findRepaired(
-  computers: readonly WorkspaceComputerSummary[],
-  targetComputerId: string,
-  baseline: ReadonlyMap<string, string | null>,
-): WorkspaceComputerSummary | undefined {
-  const target = computers.find((computer) => computer.computerId === targetComputerId);
-  if (!target || target.connectionStatus !== "online" || target.connectedAt === null) return undefined;
-  return baseline.get(targetComputerId) === target.connectedAt ? undefined : target;
 }
 
 /**
@@ -143,8 +149,16 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
 
   /** The Computer this run enrolled. Messaging and creation both need it after the step is left. */
   const computerId = useRef<string | undefined>(undefined);
-  const baseline = useRef<Map<string, string | null>>(new Map());
+  /** The code this run is waiting on, and the Server's redemption verdict once it lands. */
+  const connectCodeId = useRef<string | undefined>(undefined);
+  const redeemed = useRef<{ computerId: string; redeemedAt: string } | undefined>(undefined);
   const expiresAt = useRef(0);
+  /**
+   * True while the issue request is in flight. A StrictMode double-invocation of the updater
+   * schedules `issue` twice in the same flush, and the second run is the same request — not a
+   * reason to mint a second code.
+   */
+  const issuingFlight = useRef(false);
   /** Bumped by every reissue and by unmount, so a reply from a superseded attempt is discarded. */
   const attempt = useRef(0);
   const creationRef = useRef<CreationState>("idle");
@@ -228,7 +242,7 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
           setConnect({ kind: "connected", command: "", computerName: enrolled.displayName });
         }
         // An offline or missing Computer leaves the connection idle, which is what makes the step
-        // issue a fresh code — and whatever machine answers it gets bound to this Agent.
+        // issue a fresh code — and the machine that redeems it is the one this run continues with.
 
         /*
          * Handoff readiness, not binding state. The Server refuses to complete setup unless the
@@ -280,6 +294,8 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
   }, [readAccount]);
 
   const issue = useCallback(async () => {
+    if (issuingFlight.current) return;
+    issuingFlight.current = true;
     const mine = attempt.current + 1;
     attempt.current = mine;
     // Everything keyed to the run just superseded is released with it — what the reader can see as
@@ -289,11 +305,6 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
     setConnect({ kind: "issuing" });
     setConnectionError(undefined);
     try {
-      // Baselined before the code is issued, never after: a Computer that enrolls between the two
-      // calls would otherwise be read as this run's arrival.
-      const before = await browserApi.computers();
-      if (!mounted.current || attempt.current !== mine) return;
-      baseline.current = new Map(before.computers.map((computer) => [computer.computerId, computer.connectedAt]));
       /*
        * A Computer this Account already has is repaired, not replaced. The Agent is bound to that
        * exact machine, so a code that named no target would enrol a second Computer beside it and
@@ -307,12 +318,18 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
         repairing ? { mode: "repair", targetComputerId: repairing } : undefined,
       );
       if (!mounted.current || attempt.current !== mine) return;
+      connectCodeId.current = issued.connectCodeId;
+      redeemed.current = undefined;
       expiresAt.current = Date.parse(issued.issuedAt) + issued.expiresIn * 1_000;
       setConnect({ kind: "issued", command: issued.bootstrapCommand, expiresAt: expiresAt.current });
     } catch (cause) {
       if (!mounted.current || attempt.current !== mine) return;
       setConnect({ kind: "idle" });
       setConnectionError(errorMessage(cause, COPY.errors.connectCode));
+    } finally {
+      // A reset may allow a successor issue while this request is still in flight. The older
+      // request must not clear the successor's guard when it eventually settles.
+      if (attempt.current === mine) issuingFlight.current = false;
     }
   }, []);
 
@@ -326,8 +343,78 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
 
   const refreshConnectCode = useCallback(() => void issue(), [issue]);
 
+  /** A failed read of the verdict: report it, and close the wait on a code the Server disowns. */
+  const failIssuedCodePoll = useCallback((cause: unknown) => {
+    const gone = cause instanceof ApiError && cause.status === 404;
+    // A code the Server no longer acknowledges can never be redeemed: stop waiting on it rather
+    // than poll a dead handle until the local clock runs out.
+    if (gone) setConnect({ kind: "idle" });
+    setConnectionError(errorMessage(cause, gone ? COPY.errors.connectCode : COPY.errors.computers));
+  }, []);
+
+  /** Adopts the redeemed Computer once it is verifiably online; otherwise the wait continues. */
+  const adoptRedeemedComputer = useCallback(async (mine: number) => {
+    const verdict = redeemed.current;
+    if (!verdict) return;
+    let arrived: WorkspaceComputerSummary | undefined;
+    try {
+      arrived = await findRedeemedComputer(verdict.computerId, verdict.redeemedAt);
+    } catch (cause) {
+      if (mounted.current && attempt.current === mine) {
+        setConnectionError(errorMessage(cause, COPY.errors.computers));
+      }
+      return;
+    }
+    const stillWaiting = issuedConnection(connectRef.current);
+    if (!(mounted.current && attempt.current === mine) || !stillWaiting || !arrived) return;
+    computerId.current = arrived.computerId;
+    setComputer(arrived);
+    setConnectionError(undefined);
+    setConnect({ kind: "connected", command: stillWaiting.command, computerName: arrived.displayName });
+  }, []);
+
+  /** One read of the issued code's verdict; the interval effect only paces it. */
+  const pollIssuedCode = useCallback(
+    async (codeId: string, mine: number) => {
+      const alive = () => mounted.current && attempt.current === mine;
+      let status: ComputerConnectCodeStatus;
+      try {
+        status = await browserApi.computerConnectCodeStatus(codeId);
+      } catch (cause) {
+        if (alive()) failIssuedCodePoll(cause);
+        return;
+      }
+      if (!alive()) return;
+      const waiting = issuedConnection(connectRef.current);
+      if (!waiting) return;
+      const verdict = readConnectCodeVerdict(status);
+      if (verdict.action === "wait") {
+        // A poll that succeeds retires whatever the last failed one put on screen.
+        setConnectionError(undefined);
+        return;
+      }
+      if (verdict.action === "expire") {
+        // The Server has closed the code and nothing can redeem it now, so the wait ends the way
+        // a local expiry ends it — the dead command stays on screen with its refresh offered.
+        setConnect({ kind: "expired", command: waiting.command });
+        return;
+      }
+      /*
+       * Redeemed. The verdict is latched: which machine answered never changes, and no other
+       * machine enrolling or returning during the wait can satisfy it. The Computer is adopted
+       * once the Computers list shows that exact machine online on a connection that postdates
+       * the redemption — a machine that redeemed but has not connected yet keeps the wait
+       * open, which is the only honest reading of "your computer is connected".
+       */
+      redeemed.current ??= { computerId: verdict.computerId, redeemedAt: verdict.redeemedAt };
+      await adoptRedeemedComputer(mine);
+    },
+    [adoptRedeemedComputer, failIssuedCodePoll],
+  );
+
   // One interval for the whole wait. It expires the code on the Server's own clock rather than a
-  // local countdown, and hands over to the readiness poll below the moment a Computer arrives.
+  // local countdown, and the Server's redemption verdict — never a reading of the Computers list —
+  // decides which Computer this run's command enrolled.
   useEffect(() => {
     if (connect.kind !== "issued") return;
     const mine = attempt.current;
@@ -337,37 +424,12 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
         setConnect((current) => (current.kind === "issued" ? { kind: "expired", command: current.command } : current));
         return;
       }
-      void browserApi.computers().then(
-        (value) => {
-          if (!mounted.current || attempt.current !== mine) return;
-          const arrived = repairTarget.current
-            ? findRepaired(value.computers, repairTarget.current, baseline.current)
-            : findArrival(value.computers, baseline.current);
-          // A reply can land after its code expired. Adopting outside this guard let an expired
-          // attempt claim a machine, enable Continue, and create an Agent the page could then never
-          // move past — so nothing is adopted unless the connection is still the one waiting.
-          const waiting = connectRef.current;
-          if (!arrived || waiting.kind !== "issued") return;
-          /*
-           * A machine that is not the one the Agent is bound to has to become it. An Agent's
-           * Computer can be changed after creation even though its runtime cannot, so the honest
-           * answer to "my laptop was replaced" is to move the Agent — not to insist the old machine
-           * comes back, and not to quietly finish setup with the Agent still pointing at a machine
-           * nobody checked. Until the move lands, this is not a connection worth reporting.
-           */
-          computerId.current = arrived.computerId;
-          setComputer(arrived);
-          setConnectionError(undefined);
-          setConnect({ kind: "connected", command: waiting.command, computerName: arrived.displayName });
-        },
-        (cause: unknown) => {
-          if (mounted.current && attempt.current === mine)
-            setConnectionError(errorMessage(cause, COPY.errors.computers));
-        },
-      );
+      const codeId = connectCodeId.current;
+      if (!codeId) return;
+      void pollIssuedCode(codeId, mine);
     }, COMPUTER_POLL_MS);
     return () => window.clearInterval(timer);
-  }, [connect.kind]);
+  }, [connect.kind, pollIssuedCode]);
 
   // Once the Computer is here, the same cadence keeps reading its readiness. The daemon re-probes on
   // its own schedule, so a failure that gets repaired in a terminal turns green here with no page
@@ -555,9 +617,11 @@ export function useServerBackend(draft: AgentDraft): OnboardingBackend {
 
   const reset = useCallback(() => {
     attempt.current += 1;
+    issuingFlight.current = false;
     window.clearInterval(feishuTimer.current);
     computerId.current = undefined;
-    baseline.current = new Map();
+    connectCodeId.current = undefined;
+    redeemed.current = undefined;
     expiresAt.current = 0;
     creationRef.current = "idle";
     setConnect({ kind: "idle" });

--- a/apps/web/src/onboarding-v2/server-flow.test.tsx
+++ b/apps/web/src/onboarding-v2/server-flow.test.tsx
@@ -17,6 +17,8 @@ const COMPUTER_ID = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
 const AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
 const USER_ID = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const ATTEMPT_ID = "2b73a21e-f6c7-4474-91ea-4dabf0566a24";
+const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+const REDEEMED_AT = "2026-08-29T00:00:05.000Z";
 const POLL_MS = 1_500;
 const FEISHU_POLL_MS = 2_000;
 const HANDOFF_POLL_MS = 2_000;
@@ -79,6 +81,16 @@ function computersReturning(...pages: readonly (readonly WorkspaceComputerSummar
   });
 }
 
+/** The Server's verdict on the issued code: the exact Computer redeemed it. */
+function redeemedVerdict() {
+  return vi.spyOn(browserApi, "computerConnectCodeStatus").mockResolvedValue({
+    connectCodeId: CONNECT_CODE_ID,
+    state: "redeemed",
+    computerId: COMPUTER_ID,
+    redeemedAt: REDEEMED_AT,
+  });
+}
+
 async function settle() {
   await act(async () => {
     for (let index = 0; index < 12; index += 1) await Promise.resolve();
@@ -114,9 +126,17 @@ describe("the onboarding flow against the Server", () => {
     vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
     vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
     vi.spyOn(browserApi, "issueComputerConnectCode").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
       bootstrapCommand: COMMAND,
       expiresIn: 900,
       issuedAt: NOW,
+    });
+    // A code the test says nothing about stays pending: the wait never concludes without a verdict.
+    vi.spyOn(browserApi, "computerConnectCodeStatus").mockResolvedValue({
+      connectCodeId: CONNECT_CODE_ID,
+      state: "pending",
+      computerId: null,
+      redeemedAt: null,
     });
   });
 
@@ -126,7 +146,8 @@ describe("the onboarding flow against the Server", () => {
   });
 
   it("walks from the connect command to a created Agent and a scanned Lark code", async () => {
-    computersReturning([], [computer()]);
+    computersReturning([computer()]);
+    redeemedVerdict();
     const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
     vi.spyOn(browserApi, "createFeishuSetupAttempt").mockResolvedValue(attempt());
     vi.spyOn(browserApi, "feishuSetupAttempt")
@@ -181,7 +202,8 @@ describe("the onboarding flow against the Server", () => {
   });
 
   it("keeps the reader on the check while the runtime is still being probed", async () => {
-    computersReturning([], [computer({ providerReadiness: undefined })]);
+    computersReturning([computer({ providerReadiness: undefined })]);
+    redeemedVerdict();
 
     render(<OnboardingV2Page />);
 
@@ -195,10 +217,8 @@ describe("the onboarding flow against the Server", () => {
   });
 
   it("names the failing check and refuses to create the Agent", async () => {
-    computersReturning(
-      [],
-      [computer({ providerReadiness: [{ provider: "codex", status: "install", observedAt: NOW }] })],
-    );
+    computersReturning([computer({ providerReadiness: [{ provider: "codex", status: "install", observedAt: NOW }] })]);
+    redeemedVerdict();
     const create = vi.spyOn(browserApi, "createAgent").mockResolvedValue(adminConfig());
 
     render(<OnboardingV2Page />);

--- a/apps/web/src/setup/connect-code-verdict.test.ts
+++ b/apps/web/src/setup/connect-code-verdict.test.ts
@@ -1,0 +1,30 @@
+import type { ComputerConnectCodeStatus } from "@opentag/shared/browser";
+import { describe, expect, it } from "vitest";
+import { readConnectCodeVerdict } from "./connect-code-verdict.js";
+
+const CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+const COMPUTER_ID = "85fe9af3-d1c6-472b-b78c-8a7ccf512750";
+const REDEEMED_AT = "2026-08-29T00:00:05.000Z";
+
+function terminal(state: "pending" | "expired" | "revoked"): ComputerConnectCodeStatus {
+  return { connectCodeId: CODE_ID, state, computerId: null, redeemedAt: null };
+}
+
+describe("readConnectCodeVerdict", () => {
+  it("waits on a pending code and adopts the exact redeemed Computer", () => {
+    expect(readConnectCodeVerdict(terminal("pending"))).toEqual({ kind: "wait" });
+    expect(
+      readConnectCodeVerdict({
+        connectCodeId: CODE_ID,
+        state: "redeemed",
+        computerId: COMPUTER_ID,
+        redeemedAt: REDEEMED_AT,
+      }),
+    ).toEqual({ kind: "adopt", computerId: COMPUTER_ID, redeemedAt: REDEEMED_AT });
+  });
+
+  it("fails closed on expired and revoked codes, which never name a Computer", () => {
+    expect(readConnectCodeVerdict(terminal("expired"))).toEqual({ kind: "expire" });
+    expect(readConnectCodeVerdict(terminal("revoked"))).toEqual({ kind: "expire" });
+  });
+});

--- a/apps/web/src/setup/connect-code-verdict.ts
+++ b/apps/web/src/setup/connect-code-verdict.ts
@@ -1,0 +1,24 @@
+/**
+ * The reading of the Server's verdict on an issued connect code, shared so the onboarding wait and
+ * the Agent-settings recovery panel can never disagree about what a verdict means.
+ */
+
+import type { ComputerConnectCodeStatus } from "@opentag/shared/browser";
+
+export type ConnectCodeVerdict =
+  | { readonly kind: "wait" }
+  | { readonly kind: "expire" }
+  | { readonly kind: "adopt"; readonly computerId: string; readonly redeemedAt: string };
+
+/**
+ * Pending keeps the wait; redeemed names the machine to adopt. Expired and revoked fail closed
+ * through the same terminal the local expiry uses — neither ever names a Computer. The schema
+ * itself guarantees a redemption carries its evidence, so nothing malformed reaches here.
+ */
+export function readConnectCodeVerdict(status: ComputerConnectCodeStatus): ConnectCodeVerdict {
+  if (status.state === "pending") return { kind: "wait" };
+  if (status.state === "redeemed") {
+    return { kind: "adopt", computerId: status.computerId, redeemedAt: status.redeemedAt };
+  }
+  return { kind: "expire" };
+}

--- a/apps/web/src/setup/index.ts
+++ b/apps/web/src/setup/index.ts
@@ -21,4 +21,5 @@ export {
 } from "./checks.js";
 export { CommandBlock } from "./command-block.js";
 export { CheckLine, ConnectStatus, Countdown, QrCode, useRemaining, WAITING_LINE } from "./components.js";
+export { type ConnectCodeVerdict, readConnectCodeVerdict } from "./connect-code-verdict.js";
 export { CHECK_COPY, SETUP_COPY } from "./copy.js";

--- a/packages/client/src/__tests__/workspace-api.test.ts
+++ b/packages/client/src/__tests__/workspace-api.test.ts
@@ -35,6 +35,7 @@ describe("OpenTagApi Workspace surface", () => {
 
   it("issues a machine connect code without exposing enrollment revocation", async () => {
     const code = {
+      connectCodeId: "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f",
       bootstrapCommand: "opentag computer connect --code secret",
       expiresIn: 900,
       issuedAt: grantedAt,
@@ -44,5 +45,21 @@ describe("OpenTagApi Workspace surface", () => {
 
     await expect(api.issueComputerConnectCode("access")).resolves.toEqual(code);
     expect("revokeWorkspaceComputer" in api).toBe(false);
+  });
+
+  it("reads a connect code's redemption status under the issuing Account", async () => {
+    const status = {
+      connectCodeId: "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f",
+      state: "redeemed" as const,
+      computerId: "85fe9af3-d1c6-472b-b78c-8a7ccf512750",
+      redeemedAt: grantedAt,
+    };
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(json(status));
+    const api = new OpenTagApi("https://opentag.example.com", fetchImpl);
+
+    await expect(api.getComputerConnectCodeStatus("access", status.connectCodeId)).resolves.toEqual(status);
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(String(url)).toBe(`https://opentag.example.com/api/v1/computer-connect-codes/${status.connectCodeId}`);
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer access");
   });
 });

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -6,6 +6,7 @@ import {
   type AgentUsageDetail,
   AgentUsageDetailSchema,
   type AgentUsageWindowDays,
+  accountComputerConnectCodePath,
   agentByIdPath,
   agentConfigPath,
   agentFeishuSetupAttemptsPath,
@@ -20,6 +21,8 @@ import {
   ComputerConnectCodeExchangeResponseSchema,
   type ComputerConnectCodeIssueResponse,
   ComputerConnectCodeIssueResponseSchema,
+  type ComputerConnectCodeStatus,
+  ComputerConnectCodeStatusSchema,
   type ConnectCodeExchangeResponse,
   ConnectCodeExchangeResponseSchema,
   type CreateAgentRequest,
@@ -122,6 +125,12 @@ export class OpenTagApi {
   issueComputerConnectCode(accessToken: string): Promise<ComputerConnectCodeIssueResponse> {
     return this.#request(HTTP_PATHS.accountComputerConnectCodes, ComputerConnectCodeIssueResponseSchema, {
       method: "POST",
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+  }
+
+  getComputerConnectCodeStatus(accessToken: string, connectCodeId: string): Promise<ComputerConnectCodeStatus> {
+    return this.#request(accountComputerConnectCodePath(connectCodeId), ComputerConnectCodeStatusSchema, {
       headers: { authorization: `Bearer ${accessToken}` },
     });
   }

--- a/packages/server/src/__tests__/account-api.test.ts
+++ b/packages/server/src/__tests__/account-api.test.ts
@@ -1,8 +1,14 @@
-import { HTTP_PATHS, PROVIDER_READINESS_V1_HEADER, workspaceComputersPath } from "@opentag/shared";
+import {
+  accountComputerConnectCodePath,
+  HTTP_PATHS,
+  PROVIDER_READINESS_V1_HEADER,
+  workspaceComputersPath,
+} from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import type { AgentService } from "../services/agents/index.js";
 import type { UserAuthService } from "../services/auth/index.js";
+import { AuthServiceError } from "../services/auth/index.js";
 import type { ComputerService, MachineAuthService } from "../services/computers/index.js";
 import { OnboardingResetError } from "../services/onboarding-reset/index.js";
 import type { TaskService } from "../services/tasks/index.js";
@@ -114,6 +120,7 @@ function services() {
     },
     machineAuthService: {
       issueForAccount: vi.fn().mockResolvedValue({
+        connectCodeId: "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f",
         code: "connect-code-value",
         expiresIn: 900,
         issuedAt: new Date("2026-08-19T00:00:00.000Z"),
@@ -125,6 +132,12 @@ function services() {
         machineToken: "machine-token",
         workspaceComputerId: computerId,
         workspaceId,
+      }),
+      getConnectCodeStatusForAccount: vi.fn().mockResolvedValue({
+        connectCodeId: "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f",
+        state: "pending",
+        computerId: null,
+        redeemedAt: null,
       }),
     },
     taskService: {
@@ -491,5 +504,89 @@ describe("Account-native management collections", () => {
     const response = await app.inject({ method: "GET", url: HTTP_PATHS.accountAgents, headers: authorization });
     expect(response.statusCode).toBe(200);
     expect(service.agentService.listForAccount).toHaveBeenCalledWith(userId);
+  });
+
+  it("names the issued code's non-secret id in the issue response", async () => {
+    const { app } = appWith();
+
+    const response = await app.inject({
+      method: "POST",
+      url: HTTP_PATHS.accountComputerConnectCodes,
+      headers: authorization,
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json().connectCodeId).toBe("7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f");
+  });
+});
+
+describe("the connect-code redemption status read", () => {
+  const connectCodeId = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
+
+  it("answers pending before redemption under the issuing Account's authority", async () => {
+    const { app, service } = appWith();
+
+    const response = await app.inject({
+      method: "GET",
+      url: accountComputerConnectCodePath(connectCodeId),
+      headers: authorization,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["cache-control"]).toBe("no-store");
+    expect(response.json()).toEqual({ connectCodeId, state: "pending", computerId: null, redeemedAt: null });
+    expect(service.machineAuthService.getConnectCodeStatusForAccount).toHaveBeenCalledWith(userId, connectCodeId);
+  });
+
+  it("answers the exact Computer after redemption, and nothing secret", async () => {
+    const { app, service } = appWith();
+    service.machineAuthService.getConnectCodeStatusForAccount.mockResolvedValueOnce({
+      connectCodeId,
+      state: "redeemed",
+      computerId,
+      redeemedAt: "2026-08-19T00:01:00.000Z",
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: accountComputerConnectCodePath(connectCodeId),
+      headers: authorization,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toEqual({ connectCodeId, state: "redeemed", computerId, redeemedAt: "2026-08-19T00:01:00.000Z" });
+    expect(Object.keys(body).sort()).toEqual(["computerId", "connectCodeId", "redeemedAt", "state"]);
+  });
+
+  it("fails closed when the code is not the caller's own", async () => {
+    const { app, service } = appWith();
+    service.machineAuthService.getConnectCodeStatusForAccount.mockRejectedValueOnce(
+      new AuthServiceError("RESOURCE_NOT_FOUND", "deterministic", "The requested resource was not found", 404),
+    );
+
+    const response = await app.inject({
+      method: "GET",
+      url: accountComputerConnectCodePath(connectCodeId),
+      headers: authorization,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().error.code).toBe("RESOURCE_NOT_FOUND");
+  });
+
+  it("rejects a malformed code id and an unauthenticated caller", async () => {
+    const { app, service } = appWith();
+
+    const malformed = await app.inject({
+      method: "GET",
+      url: `${HTTP_PATHS.accountComputerConnectCodes}/not-a-uuid`,
+      headers: authorization,
+    });
+    expect(malformed.statusCode).toBe(400);
+
+    const anonymous = await app.inject({ method: "GET", url: accountComputerConnectCodePath(connectCodeId) });
+    expect(anonymous.statusCode).toBe(401);
+    expect(service.machineAuthService.getConnectCodeStatusForAccount).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/__tests__/integration/computers.test.ts
+++ b/packages/server/src/__tests__/integration/computers.test.ts
@@ -1,4 +1,5 @@
 import {
+  accountComputerConnectCodePath,
   HTTP_PATHS,
   PROVIDER_READINESS_V1_HEADER,
   RUNTIME_PROTOCOL_V2,
@@ -22,7 +23,7 @@ import {
   workspaceComputers,
 } from "../../db/schema/index.js";
 import { ConnectionRegistry } from "../../runtime/connection-registry.js";
-import { AuthService } from "../../services/auth/index.js";
+import { AuthService, ConnectCodeService } from "../../services/auth/index.js";
 import { ComputerService, MachineAuthService } from "../../services/computers/index.js";
 import { bootstrapTestAccount as bootstrapInitialAdmin } from "../test-account.js";
 import { type MigratedTestDatabase, startMigratedTestDatabase } from "./migrated-test-database.js";
@@ -619,6 +620,228 @@ describe("Computer enrollment persistence", () => {
             { provider: "claude-code", status: "checking", observedAt: null },
           ],
         });
+      } finally {
+        await app.close();
+      }
+    } finally {
+      await value.sql.end();
+    }
+  });
+});
+
+describe("Connect code redemption status", () => {
+  it("reports pending before redemption and the exact Computer after it", async () => {
+    const value = await fixture();
+    try {
+      const issued = await value.machineAuth.issueForAccount(value.bootstrap.userId, {});
+      const pending = await value.machineAuth.getConnectCodeStatusForAccount(
+        value.bootstrap.userId,
+        issued.connectCodeId,
+      );
+      expect(pending).toEqual({
+        connectCodeId: issued.connectCodeId,
+        state: "pending",
+        computerId: null,
+        redeemedAt: null,
+      });
+
+      const enrollment = await value.machineAuth.exchangeConnectCode(exchangeInput(issued.code, crypto.randomUUID()));
+      const redeemed = await value.machineAuth.getConnectCodeStatusForAccount(
+        value.bootstrap.userId,
+        issued.connectCodeId,
+      );
+      expect(redeemed.state).toBe("redeemed");
+      expect(redeemed.computerId).toBe(enrollment.workspaceComputerId);
+      expect(redeemed.redeemedAt).not.toBeNull();
+
+      // Durable evidence, not a reachability report: the machine that redeemed the code has not
+      // connected yet, and the verdict still names it.
+      const { computers: listed } = await value.service.listAccountComputers(value.bootstrap.userId);
+      const enrolled = listed.find((one) => one.computerId === enrollment.workspaceComputerId);
+      expect(enrolled?.connectionStatus).toBe("offline");
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("correlates each code with its own redeemer when machines answer out of order", async () => {
+    const value = await fixture();
+    try {
+      const first = await value.machineAuth.issueForAccount(value.bootstrap.userId, {});
+      const second = await value.machineAuth.issueForAccount(value.bootstrap.userId, {});
+      // The second code is spent first: correlation follows the code, never the order of arrival.
+      const secondEnrollment = await value.machineAuth.exchangeConnectCode(
+        exchangeInput(second.code, crypto.randomUUID()),
+      );
+      const firstEnrollment = await value.machineAuth.exchangeConnectCode(
+        exchangeInput(first.code, crypto.randomUUID()),
+      );
+
+      const firstStatus = await value.machineAuth.getConnectCodeStatusForAccount(
+        value.bootstrap.userId,
+        first.connectCodeId,
+      );
+      const secondStatus = await value.machineAuth.getConnectCodeStatusForAccount(
+        value.bootstrap.userId,
+        second.connectCodeId,
+      );
+      expect(firstStatus).toMatchObject({ state: "redeemed", computerId: firstEnrollment.workspaceComputerId });
+      expect(secondStatus).toMatchObject({ state: "redeemed", computerId: secondEnrollment.workspaceComputerId });
+      expect(firstStatus.computerId).not.toBe(secondStatus.computerId);
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("fails closed for an expired code and for a revoked code, never naming a Computer", async () => {
+    const value = await fixture();
+    try {
+      const expiring = await value.machineAuth.issueForAccount(value.bootstrap.userId, {});
+      await value.database
+        .update(computerConnectCodes)
+        .set({ expiresAt: new Date() })
+        .where(eq(computerConnectCodes.id, expiring.connectCodeId));
+      await expect(
+        value.machineAuth.getConnectCodeStatusForAccount(value.bootstrap.userId, expiring.connectCodeId),
+      ).resolves.toEqual({
+        connectCodeId: expiring.connectCodeId,
+        state: "expired",
+        computerId: null,
+        redeemedAt: null,
+      });
+
+      const revoking = await value.machineAuth.issueForAccount(value.bootstrap.userId, {});
+      await value.database
+        .update(computerConnectCodes)
+        .set({ revokedByUserId: value.bootstrap.userId, revokedAt: new Date() })
+        .where(eq(computerConnectCodes.id, revoking.connectCodeId));
+      await expect(
+        value.machineAuth.getConnectCodeStatusForAccount(value.bootstrap.userId, revoking.connectCodeId),
+      ).resolves.toEqual({
+        connectCodeId: revoking.connectCodeId,
+        state: "revoked",
+        computerId: null,
+        redeemedAt: null,
+      });
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("answers a foreign Account and an unknown id with the same not-found", async () => {
+    const value = await fixture();
+    try {
+      const otherAccountId = crypto.randomUUID();
+      await value.database.insert(users).values({
+        id: otherAccountId,
+        email: "other@example.com",
+        displayName: "Other",
+      });
+      const issued = await value.machineAuth.issueForAccount(value.bootstrap.userId, {});
+
+      await expect(
+        value.machineAuth.getConnectCodeStatusForAccount(otherAccountId, issued.connectCodeId),
+      ).rejects.toMatchObject({ code: "RESOURCE_NOT_FOUND", statusCode: 404 });
+      await expect(
+        value.machineAuth.getConnectCodeStatusForAccount(value.bootstrap.userId, crypto.randomUUID()),
+      ).rejects.toMatchObject({ code: "RESOURCE_NOT_FOUND", statusCode: 404 });
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("answers repeated and concurrent reads identically across the redemption boundary", async () => {
+    const value = await fixture();
+    try {
+      const issued = await value.machineAuth.issueForAccount(value.bootstrap.userId, {});
+      const read = () => value.machineAuth.getConnectCodeStatusForAccount(value.bootstrap.userId, issued.connectCodeId);
+
+      const before = await Promise.all([read(), read(), read()]);
+      for (const verdict of before) expect(verdict).toEqual(before[0]);
+
+      const enrollment = await value.machineAuth.exchangeConnectCode(exchangeInput(issued.code, crypto.randomUUID()));
+      const after = await Promise.all([read(), read(), read()]);
+      for (const verdict of after) {
+        expect(verdict).toEqual(after[0]);
+        expect(verdict).toMatchObject({ state: "redeemed", computerId: enrollment.workspaceComputerId });
+      }
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("serves the poll over HTTP to the issuing Account only, and never leaks the code", async () => {
+    const value = await fixture();
+    try {
+      const account = await value.auth.exchangeConnectCode(value.bootstrap.connectCode);
+      const otherAccountId = crypto.randomUUID();
+      await value.database.insert(users).values({
+        id: otherAccountId,
+        email: "other@example.com",
+        displayName: "Other",
+      });
+      const otherLogin = await new ConnectCodeService(value.database).issueForUser(otherAccountId);
+      const otherAccount = await value.auth.exchangeConnectCode(otherLogin.code);
+      const app = createApp({
+        authService: value.auth,
+        computerConnectCode: { environment: "staging", publicUrl: "https://dev.example.com" },
+        computerService: value.service,
+        machineAuthService: value.machineAuth,
+      });
+      try {
+        const issued = await app.inject({
+          method: "POST",
+          url: HTTP_PATHS.accountComputerConnectCodes,
+          headers: { authorization: `Bearer ${account.accessToken}` },
+        });
+        expect(issued.statusCode).toBe(201);
+        const { connectCodeId } = issued.json() as { connectCodeId: string };
+
+        const pending = await app.inject({
+          method: "GET",
+          url: accountComputerConnectCodePath(connectCodeId),
+          headers: { authorization: `Bearer ${account.accessToken}` },
+        });
+        expect(pending.statusCode).toBe(200);
+        expect(pending.headers["cache-control"]).toBe("no-store");
+        expect(pending.json()).toEqual({ connectCodeId, state: "pending", computerId: null, redeemedAt: null });
+
+        // The code redeems; the Account reads back the exact Computer, and the answer carries no
+        // code, hash, or machine token.
+        const command = issued.json().bootstrapCommand as string;
+        const code = command.split(" -- ").at(-1);
+        if (!code) throw new Error("Computer connect command did not contain a code");
+        const enrollment = await value.machineAuth.exchangeConnectCode(exchangeInput(code, crypto.randomUUID()));
+        const redeemed = await app.inject({
+          method: "GET",
+          url: accountComputerConnectCodePath(connectCodeId),
+          headers: { authorization: `Bearer ${account.accessToken}` },
+        });
+        expect(redeemed.statusCode).toBe(200);
+        expect(redeemed.json()).toEqual({
+          connectCodeId,
+          state: "redeemed",
+          computerId: enrollment.workspaceComputerId,
+          redeemedAt: expect.any(String),
+        });
+        expect(redeemed.body).not.toContain(code);
+        expect(redeemed.body).not.toContain(enrollment.machineToken);
+
+        // Another Account's token and the machine's own credential both fail closed.
+        const foreign = await app.inject({
+          method: "GET",
+          url: accountComputerConnectCodePath(connectCodeId),
+          headers: { authorization: `Bearer ${otherAccount.accessToken}` },
+        });
+        expect(foreign.statusCode).toBe(404);
+        const machine = await app.inject({
+          method: "GET",
+          url: accountComputerConnectCodePath(connectCodeId),
+          headers: { authorization: `Bearer ${enrollment.machineToken}` },
+        });
+        expect(machine.statusCode).toBe(401);
+        const anonymous = await app.inject({ method: "GET", url: accountComputerConnectCodePath(connectCodeId) });
+        expect(anonymous.statusCode).toBe(401);
       } finally {
         await app.close();
       }

--- a/packages/server/src/api/account.ts
+++ b/packages/server/src/api/account.ts
@@ -1,10 +1,12 @@
 import {
+  ACCOUNT_COMPUTER_CONNECT_CODE_TEMPLATE,
   AccountComputerConnectCodeIssueRequestSchema,
   AccountSetupResetRequestSchema,
   AgentAdminConfigSchema,
   type ChannelName,
   CompleteWorkspaceSetupRequestSchema,
   ComputerConnectCodeIssueResponseSchema,
+  ComputerConnectCodeStatusSchema,
   CreateAgentRequestSchema,
   HTTP_PATHS,
   ListAgentsResponseSchema,
@@ -44,6 +46,7 @@ const TaskDetailQuerySchema = z
   })
   .strict();
 const TaskParamsSchema = z.object({ sessionId: z.string().uuid() }).strict();
+const ConnectCodeParamsSchema = z.object({ connectCodeId: z.string().uuid() }).strict();
 
 export interface AccountRoutesOptions {
   agentService?: AgentService;
@@ -146,12 +149,24 @@ export function registerAccountRoutes(
         .code(201)
         .send(
           ComputerConnectCodeIssueResponseSchema.parse({
+            connectCodeId: issued.connectCodeId,
             bootstrapCommand: buildComputerConnectCommand({ code: issued.code, environment, publicUrl }),
             expiresIn: issued.expiresIn,
             issuedAt: issued.issuedAt.toISOString(),
             mode: issued.mode,
           }),
         );
+    });
+
+    /*
+     * The pollable correlation for a code this Account issued: pending until redemption, the exact
+     * Computer after it. The id in the path is the only thing named, and ownership is checked
+     * against the token's Account — a foreign id is indistinguishable from one that never existed.
+     */
+    app.get(ACCOUNT_COMPUTER_CONNECT_CODE_TEMPLATE, { preHandler }, async (request, reply) => {
+      const { connectCodeId } = parseRequest(ConnectCodeParamsSchema, request.params);
+      const status = await machineAuthService.getConnectCodeStatusForAccount(accountId(request), connectCodeId);
+      return reply.header("Cache-Control", "no-store").code(200).send(ComputerConnectCodeStatusSchema.parse(status));
     });
   }
 

--- a/packages/server/src/services/computers/machine-auth-service.ts
+++ b/packages/server/src/services/computers/machine-auth-service.ts
@@ -3,6 +3,7 @@ import {
   type AccountComputerConnectCodeIssueRequest,
   type ChannelName,
   type ComputerConnectCodeMode,
+  type ComputerConnectCodeStatus,
   getChannelConfig,
   isSupportedClientVersion,
   unsupportedClientVersionMessage,
@@ -41,6 +42,11 @@ export interface ComputerAuthContext {
 }
 
 export interface IssuedComputerConnectCode {
+  /**
+   * The code row's own id. Opaque and non-secret: the issuing Account polls it for the redemption
+   * verdict, and it is worthless at the exchange, which still requires the code itself.
+   */
+  connectCodeId: string;
   code: string;
   expiresAt: Date;
   expiresIn: number;
@@ -109,6 +115,47 @@ export class MachineAuthService implements ComputerAuthVerifier, MachineConnectC
         workspaceId: await ensureSchemaWorkspaceId(transaction, accountId, now),
       });
     });
+  }
+
+  /**
+   * The redemption verdict for one code, readable only by the Account that issued it. Any other
+   * Account — and any Workspace the caller does not hold — gets the same 404 as a code that never
+   * existed, so the read cannot be used to probe somebody else's enrollments. Expired and revoked
+   * codes still answer, but never name a Computer: redemption is the only state that carries one.
+   */
+  async getConnectCodeStatusForAccount(accountId: string, connectCodeId: string): Promise<ComputerConnectCodeStatus> {
+    const [connectCode] = await this.#database
+      .select({
+        id: computerConnectCodes.id,
+        issuedByAccountId: computerConnectCodes.issuedByAccountId,
+        consumedComputerId: computerConnectCodes.consumedComputerId,
+        consumedAt: computerConnectCodes.consumedAt,
+        revokedAt: computerConnectCodes.revokedAt,
+        expiresAt: computerConnectCodes.expiresAt,
+      })
+      .from(computerConnectCodes)
+      .where(eq(computerConnectCodes.id, connectCodeId))
+      .limit(1);
+    if (!connectCode || connectCode.issuedByAccountId !== accountId) {
+      throw new AuthServiceError("RESOURCE_NOT_FOUND", "deterministic", "The requested resource was not found", 404);
+    }
+    // Redemption is durable evidence: it answers with the exact Computer whether or not that
+    // machine is connected right now, because reachability moves and this fact does not.
+    if (connectCode.consumedAt && connectCode.consumedComputerId) {
+      return {
+        connectCodeId: connectCode.id,
+        state: "redeemed",
+        computerId: connectCode.consumedComputerId,
+        redeemedAt: connectCode.consumedAt.toISOString(),
+      };
+    }
+    if (connectCode.revokedAt) {
+      return { connectCodeId: connectCode.id, state: "revoked", computerId: null, redeemedAt: null };
+    }
+    if (connectCode.expiresAt <= this.#now()) {
+      return { connectCodeId: connectCode.id, state: "expired", computerId: null, redeemedAt: null };
+    }
+    return { connectCodeId: connectCode.id, state: "pending", computerId: null, redeemedAt: null };
   }
 
   async exchangeConnectCode(input: MachineEnrollmentInput): Promise<MachineEnrollmentResult> {
@@ -224,17 +271,21 @@ export class MachineAuthService implements ComputerAuthVerifier, MachineConnectC
     const code = `${COMPUTER_CONNECT_CODE_PREFIX}${generateSecret(24)}`;
     const expiresIn = COMPUTER_CONNECT_CODE_TTL_SECONDS;
     const expiresAt = new Date(input.now.getTime() + expiresIn * 1000);
-    await transaction.insert(computerConnectCodes).values({
-      ...schemaRequiredConnectCodeProjection(workspaceId),
-      tokenHash: hashSecret(code),
-      issuedByUserId: input.accountId,
-      issuedByAccountId: input.accountId,
-      mode: input.mode,
-      targetComputerId: input.mode === "repair" ? input.targetComputerId : null,
-      createdAt: input.now,
-      expiresAt,
-    });
-    return { code, expiresAt, expiresIn, issuedAt: input.now, mode: input.mode };
+    const [inserted] = await transaction
+      .insert(computerConnectCodes)
+      .values({
+        ...schemaRequiredConnectCodeProjection(workspaceId),
+        tokenHash: hashSecret(code),
+        issuedByUserId: input.accountId,
+        issuedByAccountId: input.accountId,
+        mode: input.mode,
+        targetComputerId: input.mode === "repair" ? input.targetComputerId : null,
+        createdAt: input.now,
+        expiresAt,
+      })
+      .returning({ id: computerConnectCodes.id });
+    if (!inserted) throw new Error("The Computer connect code was not created");
+    return { connectCodeId: inserted.id, code, expiresAt, expiresIn, issuedAt: input.now, mode: input.mode };
   }
 
   async #createComputer(

--- a/packages/shared/src/__tests__/computer.test.ts
+++ b/packages/shared/src/__tests__/computer.test.ts
@@ -4,6 +4,7 @@ import {
   ComputerConnectCodeExchangeRequestSchema,
   ComputerConnectCodeExchangeResponseSchema,
   ComputerConnectCodeIssueResponseSchema,
+  ComputerConnectCodeStatusSchema,
   ComputerImCliReadinessCollectionSchema,
   ComputerProviderReadinessCollectionSchema,
 } from "../computer.js";
@@ -54,6 +55,7 @@ describe("computer contracts", () => {
 
   it("accepts optional create and repair mode on the issue response", () => {
     const response = {
+      connectCodeId: crypto.randomUUID(),
       bootstrapCommand: "opentag computer connect --server https://opentag.example -- otcc_code",
       expiresIn: 900,
       issuedAt: "2026-08-29T00:00:00.000Z",
@@ -64,6 +66,48 @@ describe("computer contracts", () => {
       mode: "repair",
     });
     expect(() => ComputerConnectCodeIssueResponseSchema.parse({ ...response, mode: "merge" })).toThrow();
+  });
+
+  it("requires the non-secret connectCodeId on the issue response", () => {
+    const response = {
+      bootstrapCommand: "opentag computer connect --server https://opentag.example -- otcc_code",
+      expiresIn: 900,
+      issuedAt: "2026-08-29T00:00:00.000Z",
+    };
+    expect(() => ComputerConnectCodeIssueResponseSchema.parse(response)).toThrow();
+    expect(() => ComputerConnectCodeIssueResponseSchema.parse({ ...response, connectCodeId: "not-a-uuid" })).toThrow();
+  });
+
+  it("correlates a redeemed code with exactly the Computer that redeemed it, and nothing else", () => {
+    const connectCodeId = crypto.randomUUID();
+    const computerId = crypto.randomUUID();
+    const redeemed = {
+      connectCodeId,
+      state: "redeemed",
+      computerId,
+      redeemedAt: "2026-08-29T00:00:10.000Z",
+    };
+    expect(ComputerConnectCodeStatusSchema.parse(redeemed)).toEqual(redeemed);
+
+    for (const state of ["pending", "expired", "revoked"] as const) {
+      const quiet = { connectCodeId, state, computerId: null, redeemedAt: null };
+      expect(ComputerConnectCodeStatusSchema.parse(quiet)).toEqual(quiet);
+    }
+
+    // The correlation read must never become a channel for the code, its hash, or a machine token.
+    expect(() => ComputerConnectCodeStatusSchema.parse({ ...redeemed, code: "otcc_raw" })).toThrow();
+    expect(() => ComputerConnectCodeStatusSchema.parse({ ...redeemed, tokenHash: "abc123" })).toThrow();
+    expect(() => ComputerConnectCodeStatusSchema.parse({ ...redeemed, machineToken: "otmc_secret" })).toThrow();
+    expect(() => ComputerConnectCodeStatusSchema.parse({ ...redeemed, state: "consumed" })).toThrow();
+    expect(() => ComputerConnectCodeStatusSchema.parse({ ...redeemed, computerId: null })).toThrow();
+    expect(() =>
+      ComputerConnectCodeStatusSchema.parse({
+        connectCodeId,
+        state: "pending",
+        computerId,
+        redeemedAt: "2026-08-29T00:00:10.000Z",
+      }),
+    ).toThrow();
   });
 
   it("keeps provider readiness canonical", () => {

--- a/packages/shared/src/computer.ts
+++ b/packages/shared/src/computer.ts
@@ -64,12 +64,49 @@ export const AccountComputerConnectCodeIssueRequestSchema = z.union([
 
 export const ComputerConnectCodeIssueResponseSchema = z
   .object({
+    /**
+     * The Server's own handle on the issued code row. Opaque and non-secret: it names the code for the
+     * pollable status read and is worthless at the exchange, which still requires the code itself.
+     */
+    connectCodeId: z.string().uuid(),
     bootstrapCommand: z.string().min(1),
     expiresIn: z.number().int().positive(),
     issuedAt: z.string().datetime(),
     mode: ComputerConnectCodeModeSchema.optional(),
   })
   .strict();
+
+/**
+ * The lifecycle of one issued connect code as the issuing Account may observe it. `pending` means
+ * nobody has redeemed it yet; `redeemed` names the exact Computer that did. `expired` and `revoked`
+ * fail closed: the read keeps answering, but it never names a Computer for them.
+ */
+export const ComputerConnectCodeStateSchema = z.enum(["pending", "redeemed", "expired", "revoked"]);
+
+/**
+ * The Server-authoritative correlation between a connect code and the Computer that redeemed it.
+ * Carries identity and timing evidence only — never the raw code, its hash, or any machine token.
+ * `computerId` and `redeemedAt` are present exactly in the `redeemed` state.
+ */
+const ComputerConnectCodeTerminalStatusFields = {
+  connectCodeId: z.string().uuid(),
+  computerId: z.null(),
+  redeemedAt: z.null(),
+};
+
+export const ComputerConnectCodeStatusSchema = z.discriminatedUnion("state", [
+  z.object({ ...ComputerConnectCodeTerminalStatusFields, state: z.literal("pending") }).strict(),
+  z.object({ ...ComputerConnectCodeTerminalStatusFields, state: z.literal("expired") }).strict(),
+  z.object({ ...ComputerConnectCodeTerminalStatusFields, state: z.literal("revoked") }).strict(),
+  z
+    .object({
+      connectCodeId: z.string().uuid(),
+      state: z.literal("redeemed"),
+      computerId: z.string().uuid(),
+      redeemedAt: z.string().datetime(),
+    })
+    .strict(),
+]);
 
 export const ComputerProviderReadinessSchema = z
   .object({
@@ -141,6 +178,8 @@ export type ComputerConnectCodeExchangeRequest = z.infer<typeof ComputerConnectC
 export type ComputerConnectCodeExchangeResponse = z.infer<typeof ComputerConnectCodeExchangeResponseSchema>;
 export type ComputerConnectCodeIssueRequest = z.infer<typeof ComputerConnectCodeIssueRequestSchema>;
 export type ComputerConnectCodeIssueResponse = z.infer<typeof ComputerConnectCodeIssueResponseSchema>;
+export type ComputerConnectCodeState = z.infer<typeof ComputerConnectCodeStateSchema>;
+export type ComputerConnectCodeStatus = z.infer<typeof ComputerConnectCodeStatusSchema>;
 export type AccountComputerConnectCodeCreateRequest = z.infer<typeof AccountComputerConnectCodeCreateRequestSchema>;
 export type AccountComputerConnectCodeRepairRequest = z.infer<typeof AccountComputerConnectCodeRepairRequestSchema>;
 export type AccountComputerConnectCodeIssueRequest = z.infer<typeof AccountComputerConnectCodeIssueRequestSchema>;

--- a/packages/shared/src/http-paths.ts
+++ b/packages/shared/src/http-paths.ts
@@ -32,6 +32,7 @@ export const WORKSPACE_COMPUTER_CONNECT_CODES_TEMPLATE = `${WORKSPACE_BY_ID_TEMP
 export const ACCOUNT_AGENTS_PATH = `${API_V1_PREFIX}/agents`;
 export const ACCOUNT_COMPUTERS_PATH = `${API_V1_PREFIX}/computers`;
 export const ACCOUNT_COMPUTER_CONNECT_CODES_PATH = `${API_V1_PREFIX}/computer-connect-codes`;
+export const ACCOUNT_COMPUTER_CONNECT_CODE_TEMPLATE = `${ACCOUNT_COMPUTER_CONNECT_CODES_PATH}/:connectCodeId`;
 export const ACCOUNT_SETUP_COMPLETE_PATH = `${API_V1_PREFIX}/me/setup/complete`;
 export const ACCOUNT_SETUP_RESET_PATH = `${API_V1_PREFIX}/me/setup/reset`;
 export const ACCOUNT_TASKS_PATH = `${API_V1_PREFIX}/sessions`;
@@ -83,6 +84,10 @@ export function workspaceComputersPath(workspaceId: string): string {
 
 export function workspaceComputerConnectCodesPath(workspaceId: string): string {
   return `${API_V1_PREFIX}/workspaces/${encodeURIComponent(workspaceId)}/computer-connect-codes`;
+}
+
+export function accountComputerConnectCodePath(connectCodeId: string): string {
+  return `${ACCOUNT_COMPUTER_CONNECT_CODES_PATH}/${encodeURIComponent(connectCodeId)}`;
 }
 
 export function workspaceAgentsPath(workspaceId: string): string {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -112,6 +112,10 @@ export {
   ComputerConnectCodeIssueResponseSchema,
   type ComputerConnectCodeMode,
   ComputerConnectCodeModeSchema,
+  type ComputerConnectCodeState,
+  ComputerConnectCodeStateSchema,
+  type ComputerConnectCodeStatus,
+  ComputerConnectCodeStatusSchema,
   type ComputerConnectionStatus,
   ComputerConnectionStatusSchema,
   type ComputerImCliReadiness,
@@ -148,6 +152,7 @@ export {
 export { type ServerHealth, ServerHealthSchema } from "./health.js";
 export {
   ACCOUNT_AGENTS_PATH,
+  ACCOUNT_COMPUTER_CONNECT_CODE_TEMPLATE,
   ACCOUNT_COMPUTER_CONNECT_CODES_PATH,
   ACCOUNT_COMPUTERS_PATH,
   ACCOUNT_SETUP_COMPLETE_PATH,
@@ -165,6 +170,7 @@ export {
   AGENT_SUSPEND_TEMPLATE,
   AGENT_USAGE_TEMPLATE,
   API_V1_PREFIX,
+  accountComputerConnectCodePath,
   agentByIdPath,
   agentComputerRebindPath,
   agentConfigPath,


### PR DESCRIPTION
## Summary

Relates to #295.

Implementation head: `f0acd47bebefa35b5052ff24aaacddb6bd53b01e`.

The browser can now correlate a Computer connect command with the exact Computer that redeemed it, using Server-owned evidence instead of Computer arrival or reconnect timing.

- The issue response includes an opaque, non-secret `connectCodeId`.
- `GET /api/v1/computer-connect-codes/:connectCodeId` returns `pending`, `redeemed`, `expired`, or `revoked`; only `redeemed` carries the exact `computerId` and `redeemedAt`.
- The read is authenticated to the Account that issued the code. Foreign and unknown ids are indistinguishable `404`s; machine credentials and anonymous callers are rejected.
- The response schema is strict and cannot carry the raw code, token hash, machine token, or a Computer in a non-redeemed state.
- New onboarding and `ComputerSetup` poll this exact verdict. Unrelated Computer enrollment or reconnects cannot satisfy the wait.
- After redemption, the UI waits until that exact Computer has an online connection at or after `redeemedAt`. A redeemed-but-offline Computer remains pending in the UI rather than being treated as connected.
- Every targeted recovery, including Agent Settings, issues `{ mode: "repair", targetComputerId }`. `ComputerSetup` accepts only a verdict for that exact target, so recovery neither creates a duplicate Computer nor drifts the Agent binding.
- A status-read `404` now ends in the existing recoverable expired state, preserves the command and Refresh action, and does not expose the raw Fastify error or adopt a nearby Computer.
- Both Web flows share one connect-code verdict parser. Connect-code issuance no longer performs work inside a React state updater.

No confirmation step, fallback heuristic, Agent placement change, or optional-Computer behavior is added.

## Security and migration

No database migration is required. The implementation reuses the existing `computer_connect_codes.id`, `issued_by_account_id`, `consumed_computer_id`, `consumed_at`, `expires_at`, and `revoked_at` fields.

`connectCodeId` is a UUID row identifier, not an exchange credential. Redemption still requires the one-time connect code itself. Status responses use `Cache-Control: no-store` and expose only correlation state.

Repair target ownership is enforced by the existing Server issue-time Account authorization and database checks; this follow-up does not add a second client-side authority model.

## Testing

- `pnpm check` — passed; 153 existing complexity diagnostics remain warnings
- `pnpm build` — passed
- `pnpm typecheck` — 8/8 tasks passed
- `pnpm test` — 84 repository script tests and 1,907 package tests passed:
  - shared 94
  - client 582
  - server 486
  - CLI 206
  - Web 539
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — 22 files / 317 tests passed; 100% statements, branches, functions, and lines
- `pnpm --filter @opentag/server test:integration` — 16 files / 293 tests passed
- Focused Web correlation coverage — 3 files / 65 tests passed
- Focused cases include 404-to-Refresh recovery, replacement-code isolation, repair request arguments, target-id refusal, online and `connectedAt >= redeemedAt` gating, pending, expired, revoked, unrelated Computer activity, superseded polls, and redeemed-but-offline behavior.

## Breaking changes

The connect-code issue response now requires `connectCodeId`, so the updated Web/client and Server must be deployed together. A new Web bundle against an older Server recovers from the missing status route through the Refresh-capable expired state rather than becoming stuck. The machine exchange endpoint and its secret-bearing response are unchanged. There is no persisted-data migration.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
