### PR TITLE
feat(workspace): enforce the workspace dependency contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "turbo run build && pnpm --silent bundle:report",
     "bundle:report": "node scripts/report-bundle-sizes.mjs",
     "dev": "turbo run dev",
-    "check": "biome check . && node scripts/third-party-notices.mjs --check",
+    "check": "biome check . && node scripts/third-party-notices.mjs --check && node scripts/check-workspace-contract.mjs",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "typecheck": "turbo run typecheck",

--- a/scripts/__tests__/check-workspace-contract.test.mjs
+++ b/scripts/__tests__/check-workspace-contract.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { verifyWorkspaceContract } from "../check-workspace-contract.mjs";
+
+const manifests = {
+  "apps/cli": {
+    name: "@opentag/cli",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    exports: { ".": "./dist/index.mjs" },
+    files: ["dist"],
+    dependencies: { "@opentag/client": "workspace:*", "@opentag/shared": "workspace:*" },
+  },
+  "apps/web": {
+    name: "@opentag/web",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    dependencies: { "@opentag/shared": "workspace:*" },
+  },
+  "packages/client": {
+    name: "@opentag/client",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    exports: { ".": "./dist/index.mjs" },
+    files: ["dist"],
+    dependencies: { "@opentag/shared": "workspace:*" },
+  },
+  "packages/server": {
+    name: "@opentag/server",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    exports: { ".": "./dist/index.mjs" },
+    files: ["dist"],
+    dependencies: { "@opentag/shared": "workspace:*" },
+  },
+  "packages/shared": {
+    name: "@opentag/shared",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    exports: { ".": "./dist/index.mjs", "./browser": "./dist/browser.mjs" },
+    files: ["dist"],
+  },
+  e2e: {
+    name: "@opentag/e2e",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+  },
+};
+
+const contract = {
+  schemaVersion: 1,
+  workspaces: {
+    "apps/cli": {
+      name: "@opentag/cli",
+      requiresRootExport: true,
+      requiresFiles: true,
+      allowedWorkspaceDependencies: ["@opentag/client", "@opentag/shared"],
+    },
+    "apps/web": {
+      name: "@opentag/web",
+      requiresRootExport: false,
+      requiresFiles: false,
+      allowedWorkspaceDependencies: ["@opentag/shared"],
+    },
+    "packages/client": {
+      name: "@opentag/client",
+      requiresRootExport: true,
+      requiresFiles: true,
+      allowedWorkspaceDependencies: ["@opentag/shared"],
+    },
+    "packages/server": {
+      name: "@opentag/server",
+      requiresRootExport: true,
+      requiresFiles: true,
+      allowedWorkspaceDependencies: ["@opentag/shared"],
+    },
+    "packages/shared": {
+      name: "@opentag/shared",
+      requiresRootExport: true,
+      requiresFiles: true,
+      allowedWorkspaceDependencies: [],
+    },
+    e2e: { name: "@opentag/e2e", requiresRootExport: false, requiresFiles: false, allowedWorkspaceDependencies: [] },
+  },
+};
+
+async function writeJson(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), "opentag-workspace-contract-"));
+  await writeFile(join(root, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n  - packages/*\n  - e2e\n", "utf8");
+  await writeJson(join(root, "workspace-contracts.json"), contract);
+  for (const [workspacePath, manifest] of Object.entries(manifests)) {
+    await writeJson(join(root, workspacePath, "package.json"), manifest);
+    await mkdir(join(root, workspacePath, "src"), { recursive: true });
+    await writeFile(join(root, workspacePath, "src/index.ts"), "export {};\n", "utf8");
+  }
+  await writeFile(
+    join(root, "apps/cli/src/index.ts"),
+    'import "@opentag/client";\nimport "@opentag/shared";\n',
+    "utf8",
+  );
+  await writeFile(join(root, "apps/web/src/index.ts"), 'import "@opentag/shared/browser";\n', "utf8");
+  await writeFile(join(root, "packages/client/src/index.ts"), 'import "@opentag/shared";\n', "utf8");
+  await writeFile(join(root, "packages/server/src/index.ts"), 'import "@opentag/shared";\n', "utf8");
+  return root;
+}
+
+async function withFixture(run) {
+  const root = await createFixture();
+  try {
+    return await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function updateManifest(root, workspacePath, update) {
+  const path = join(root, workspacePath, "package.json");
+  const manifest = JSON.parse(await readFile(path, "utf8"));
+  await writeJson(path, update(manifest));
+}
+
+test("accepts a clean graph, including the intentional e2e workspace", async () => {
+  await withFixture(async (root) => {
+    assert.deepEqual(await verifyWorkspaceContract({ rootDirectory: root }), {
+      workspaceCount: 6,
+      allowedDependencyCount: 5,
+    });
+  });
+});
+
+test("rejects a forbidden dependency edge with source and target", async () => {
+  await withFixture(async (root) => {
+    await updateManifest(root, "packages/client", (manifest) => ({
+      ...manifest,
+      dependencies: { ...manifest.dependencies, "@opentag/server": "workspace:*" },
+    }));
+    await assert.rejects(
+      verifyWorkspaceContract({ rootDirectory: root }),
+      /packages\/client\/package\.json.*@opentag\/server/,
+    );
+  });
+});
+
+test("rejects an unregistered workspace", async () => {
+  await withFixture(async (root) => {
+    await writeJson(join(root, "packages/rogue/package.json"), { name: "@opentag/rogue", version: "0.0.0" });
+    await assert.rejects(
+      verifyWorkspaceContract({ rootDirectory: root }),
+      /packages\/rogue\/package\.json.*not registered/,
+    );
+  });
+});
+
+test("rejects non-workspace ranges for internal dependencies", async () => {
+  await withFixture(async (root) => {
+    await updateManifest(root, "packages/client", (manifest) => ({
+      ...manifest,
+      dependencies: { ...manifest.dependencies, "@opentag/shared": "^0.0.0" },
+    }));
+    await assert.rejects(
+      verifyWorkspaceContract({ rootDirectory: root }),
+      /packages\/client\/package\.json.*@opentag\/shared.*workspace:\*/,
+    );
+  });
+});
+
+test("rejects deep imports while naming the imported target", async () => {
+  await withFixture(async (root) => {
+    await writeFile(join(root, "apps/cli/src/index.ts"), 'import "@opentag/client/src/private.js";\n', "utf8");
+    await assert.rejects(
+      verifyWorkspaceContract({ rootDirectory: root }),
+      /apps\/cli\/src\/index\.ts.*@opentag\/client\/src\/private\.js/,
+    );
+    await writeFile(join(root, "apps/cli/src/index.ts"), 'import "@opentag/client/dist/private.mjs";\n', "utf8");
+    await assert.rejects(verifyWorkspaceContract({ rootDirectory: root }), /@opentag\/client\/dist\/private\.mjs/);
+  });
+});
+
+test("rejects relative cross-workspace imports", async () => {
+  await withFixture(async (root) => {
+    await writeFile(join(root, "apps/cli/src/index.ts"), 'import "../../../packages/shared/src/private.js";\n', "utf8");
+    await assert.rejects(
+      verifyWorkspaceContract({ rootDirectory: root }),
+      /apps\/cli\/src\/index\.ts.*relative import.*@opentag\/shared/,
+    );
+  });
+});
+
+test("rejects a missing public export surface", async () => {
+  await withFixture(async (root) => {
+    await updateManifest(root, "packages/client", (manifest) => {
+      const { exports: _exports, ...withoutExports } = manifest;
+      return withoutExports;
+    });
+    await assert.rejects(
+      verifyWorkspaceContract({ rootDirectory: root }),
+      /packages\/client\/package\.json.*public.*\./,
+    );
+  });
+});

--- a/scripts/check-workspace-contract.mjs
+++ b/scripts/check-workspace-contract.mjs
@@ -1,0 +1,409 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CONTRACT_FILENAME = "workspace-contracts.json";
+const DEPENDENCY_FIELDS = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"];
+const SOURCE_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"]);
+const SKIPPED_DIRECTORIES = new Set([".git", ".turbo", "dist", "node_modules", "coverage"]);
+
+export class WorkspaceContractError extends Error {
+  constructor(violations) {
+    super(`Workspace contract violations:\n${violations.join("\n")}`);
+    this.name = "WorkspaceContractError";
+    this.violations = violations;
+  }
+}
+
+async function readJson(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`${filePath}: cannot read JSON (${reason})`);
+  }
+}
+
+function toPosix(value) {
+  return value.split("\\").join("/");
+}
+
+function parseWorkspacePatterns(yaml) {
+  const patterns = [];
+  let inPackages = false;
+  for (const line of yaml.split(/\r?\n/)) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages && line.length > 0 && !/^\s/.test(line) && !/^\s*#/.test(line)) {
+      inPackages = false;
+    }
+    if (!inPackages) continue;
+    const match = line.match(/^\s+-\s*(?:['"])?([^'"#]+?)(?:['"])?\s*(?:#.*)?$/);
+    if (match?.[1].trim() && !match[1].includes(":")) {
+      patterns.push(toPosix(match[1].trim()));
+    }
+  }
+  return patterns;
+}
+
+function globToRegExp(pattern) {
+  let source = "^";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (character === "*" && pattern[index + 1] === "*") {
+      if (pattern[index + 2] === "/") {
+        source += "(?:[^/]+/)*";
+        index += 2;
+      } else {
+        source += ".*";
+        index += 1;
+      }
+    } else if (character === "*") {
+      source += "[^/]*";
+    } else if (character === "?") {
+      source += "[^/]";
+    } else {
+      source += character.replace(/[\\^$.*+()[\]{}|]/g, "\\$&");
+    }
+  }
+  return new RegExp(`${source}$`);
+}
+
+async function collectPackageJsonFiles(directory, rootDirectory, result = []) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+        await collectPackageJsonFiles(join(directory, entry.name), rootDirectory, result);
+      }
+    } else if (entry.isFile() && entry.name === "package.json") {
+      result.push({
+        directory: dirname(join(directory, entry.name)),
+        workspacePath: toPosix(relative(rootDirectory, directory)),
+      });
+    }
+  }
+  return result;
+}
+
+async function discoverWorkspaces(rootDirectory, patterns) {
+  const packageFiles = await collectPackageJsonFiles(rootDirectory, rootDirectory);
+  const selected = new Map();
+  const unmatchedPatterns = [];
+  for (const pattern of patterns) {
+    const matcher = globToRegExp(pattern.replace(/\/$/, ""));
+    const matches = packageFiles.filter(({ workspacePath }) => matcher.test(workspacePath));
+    if (matches.length === 0) unmatchedPatterns.push(pattern);
+    for (const match of matches) selected.set(match.workspacePath, match);
+  }
+  return {
+    unmatchedPatterns,
+    workspaces: [...selected.values()].sort((left, right) => left.workspacePath.localeCompare(right.workspacePath)),
+  };
+}
+
+function packageTargetIsInside(workspaceDirectory, candidatePath) {
+  const path = resolve(candidatePath);
+  const root = resolve(workspaceDirectory);
+  return path === root || path.startsWith(`${root}/`);
+}
+
+async function collectSourceFiles(directory, result = []) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+  for (const entry of entries) {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name)) await collectSourceFiles(entryPath, result);
+    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(extname(entry.name))) {
+      result.push(entryPath);
+    }
+  }
+  return result;
+}
+
+function collectModuleSpecifiers(source) {
+  const specifiers = [];
+  const patterns = [/\b(?:from|import)\s*["']([^"']+)["']/g, /\b(?:import|require)\s*\(\s*["']([^"']+)["']\s*\)/g];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+function exportKeys(exportsField) {
+  if (typeof exportsField === "string" || Array.isArray(exportsField) || exportsField === null) return new Set(["."]);
+  if (!exportsField || typeof exportsField !== "object") return new Set();
+  return new Set(Object.keys(exportsField).filter((key) => key === "." || key.startsWith("./")));
+}
+
+function collectExportTargets(value, targets = []) {
+  if (typeof value === "string") targets.push(value);
+  else if (Array.isArray(value)) for (const item of value) collectExportTargets(item, targets);
+  else if (value && typeof value === "object")
+    for (const item of Object.values(value)) collectExportTargets(item, targets);
+  return targets;
+}
+
+function rootExportValue(exportsField) {
+  if (typeof exportsField === "string" || Array.isArray(exportsField) || exportsField === null) return exportsField;
+  if (exportsField && typeof exportsField === "object" && Object.hasOwn(exportsField, ".")) return exportsField["."];
+  return undefined;
+}
+
+function filesCoverTarget(files, target) {
+  const normalizedTarget = target.replace(/^\.\//, "");
+  return files.some((entry) => {
+    if (typeof entry !== "string" || entry.startsWith("!")) return false;
+    const normalizedEntry = entry.replace(/^\.\//, "").replace(/\/$/, "");
+    if (normalizedEntry.includes("*")) return globToRegExp(normalizedEntry).test(normalizedTarget);
+    return normalizedTarget === normalizedEntry || normalizedTarget.startsWith(`${normalizedEntry}/`);
+  });
+}
+
+function isGeneratedPath(rootDirectory, filePath) {
+  return toPosix(relative(rootDirectory, filePath))
+    .split("/")
+    .some((segment) => segment === "paraglide" || /(?:\.gen|\.generated)(?:\.|$)/.test(segment));
+}
+
+function contractAllowed(workspaceContract) {
+  return new Set(workspaceContract.allowedWorkspaceDependencies ?? []);
+}
+
+function validateContractWorkspaceEntry(workspacePath, workspaceContract, names, violations) {
+  if (isAbsolute(workspacePath) || workspacePath.split("/").some((segment) => segment === "." || segment === "..")) {
+    violations.push(`${CONTRACT_FILENAME}: invalid workspace path "${workspacePath}"`);
+  }
+  if (!workspaceContract || typeof workspaceContract !== "object") {
+    violations.push(`${CONTRACT_FILENAME}: contract for "${workspacePath}" must be an object`);
+    return;
+  }
+  if (typeof workspaceContract.name !== "string" || workspaceContract.name.length === 0) {
+    violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" must declare a package name`);
+  } else if (names.has(workspaceContract.name)) {
+    violations.push(`${CONTRACT_FILENAME}: duplicate package name "${workspaceContract.name}"`);
+  } else names.add(workspaceContract.name);
+  if (!Array.isArray(workspaceContract.allowedWorkspaceDependencies)) {
+    violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" must declare allowedWorkspaceDependencies`);
+  }
+  for (const dependencyName of workspaceContract.allowedWorkspaceDependencies ?? []) {
+    if (typeof dependencyName !== "string")
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" has a non-string dependency`);
+    if (dependencyName === workspaceContract.name)
+      violations.push(`${CONTRACT_FILENAME}: "${workspacePath}" cannot depend on itself`);
+  }
+}
+
+function validateContractConfiguration(contract, violations) {
+  if (contract?.schemaVersion !== 1 || !contract.workspaces || typeof contract.workspaces !== "object") {
+    violations.push(`${CONTRACT_FILENAME}: schemaVersion must be 1 and workspaces must be an object`);
+    return;
+  }
+  const names = new Set();
+  for (const [workspacePath, workspaceContract] of Object.entries(contract.workspaces)) {
+    validateContractWorkspaceEntry(workspacePath, workspaceContract, names, violations);
+  }
+}
+
+function validateExportSurface({ contract, manifest, workspacePath }, violations) {
+  const manifestPath = `${workspacePath}/package.json`;
+  const rootExport = rootExportValue(manifest.exports);
+  if (!contract.requiresRootExport) return;
+  if (rootExport === undefined) {
+    violations.push(`${manifestPath}: public export "." is missing for workspace package "${manifest.name}"`);
+    return;
+  }
+  const targets = collectExportTargets(rootExport);
+  if (targets.length === 0)
+    violations.push(`${manifestPath}: public export "." has no target for workspace package "${manifest.name}"`);
+  for (const target of targets) {
+    const invalid =
+      typeof target !== "string" ||
+      !target.startsWith("./") ||
+      target.includes("\\") ||
+      target
+        .slice(2)
+        .split("/")
+        .some((part) => part === "." || part === ".." || part === "node_modules");
+    if (invalid) {
+      violations.push(
+        `${manifestPath}: public export "." target "${target}" is invalid for workspace package "${manifest.name}"`,
+      );
+    } else if (contract.requiresFiles && Array.isArray(manifest.files) && !filesCoverTarget(manifest.files, target)) {
+      violations.push(
+        `${manifestPath}: public export "." target "${target}" is outside files boundary for workspace package "${manifest.name}"`,
+      );
+    }
+  }
+}
+
+function validateManifestDependencies({ contract, manifest, workspacePath }, workspaceNames, violations) {
+  const manifestPath = `${workspacePath}/package.json`;
+  const allowed = contractAllowed(contract);
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const [dependencyName, range] of Object.entries(manifest[field] ?? {})) {
+      if (!workspaceNames.has(dependencyName)) continue;
+      if (!allowed.has(dependencyName))
+        violations.push(`${manifestPath}: forbidden dependency edge to workspace package "${dependencyName}"`);
+      if (range !== "workspace:*")
+        violations.push(
+          `${manifestPath}: internal dependency "${dependencyName}" must use range "workspace:*" (found "${range}")`,
+        );
+    }
+  }
+}
+
+function declaredDependencyNames(manifest) {
+  const declared = new Set();
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const name of Object.keys(manifest[field] ?? {})) declared.add(name);
+  }
+  return declared;
+}
+
+function validateRelativeImport(
+  { rootDirectory, sourceFile, displayPath, specifier, workspace, workspaces },
+  violations,
+) {
+  const resolvedImport = resolve(dirname(sourceFile), specifier);
+  const target = workspaces.find(
+    (candidate) => candidate !== workspace && packageTargetIsInside(candidate.directory, resolvedImport),
+  );
+  if (!target) return;
+  const generated = isGeneratedPath(rootDirectory, resolvedImport) ? " (generated file)" : "";
+  violations.push(
+    `${displayPath}: relative import "${specifier}" crosses into workspace package "${target.manifest.name}"${generated}`,
+  );
+}
+
+function validatePackageImport({ displayPath, specifier, target, allowed, declared }, violations) {
+  const subpath = specifier.slice(target.manifest.name.length);
+  if (subpath) {
+    const key = `.${subpath}`;
+    const keys = exportKeys(target.manifest.exports);
+    if (specifier.includes("/src/") || specifier.includes("/dist/") || !keys.has(key)) {
+      violations.push(
+        `${displayPath}: import "${specifier}" bypasses the public export surface of workspace package "${target.manifest.name}"`,
+      );
+    }
+  }
+  if (!allowed.has(target.manifest.name))
+    violations.push(`${displayPath}: imports forbidden workspace package "${target.manifest.name}"`);
+  if (!declared.has(target.manifest.name))
+    violations.push(`${displayPath}: imports undeclared workspace package "${target.manifest.name}"`);
+}
+
+async function validateWorkspaceImports(rootDirectory, workspace, workspaces, byName, names, violations) {
+  const declared = declaredDependencyNames(workspace.manifest);
+  const allowed = contractAllowed(workspace.contract);
+  for (const sourceFile of await collectSourceFiles(workspace.directory)) {
+    const displayPath = toPosix(relative(rootDirectory, sourceFile));
+    const source = await readFile(sourceFile, "utf8");
+    for (const specifier of collectModuleSpecifiers(source)) {
+      if (specifier.startsWith(".")) {
+        validateRelativeImport(
+          { rootDirectory, sourceFile, displayPath, specifier, workspace, workspaces },
+          violations,
+        );
+        continue;
+      }
+      const targetName = names.find((name) => specifier === name || specifier.startsWith(`${name}/`));
+      if (!targetName || targetName === workspace.manifest.name) continue;
+      validatePackageImport({ displayPath, specifier, target: byName.get(targetName), allowed, declared }, violations);
+    }
+  }
+}
+
+async function validateImports(rootDirectory, workspaces, violations) {
+  const byName = new Map(workspaces.map((workspace) => [workspace.manifest.name, workspace]));
+  const names = [...byName.keys()].sort((left, right) => right.length - left.length);
+  for (const workspace of workspaces) {
+    await validateWorkspaceImports(rootDirectory, workspace, workspaces, byName, names, violations);
+  }
+}
+
+function validateManifest(workspace, workspaceNames, violations) {
+  const { contract, manifest, workspacePath } = workspace;
+  const manifestPath = `${workspacePath}/package.json`;
+  if (manifest.name !== contract.name)
+    violations.push(`${manifestPath}: name does not match contract (target "${contract.name}")`);
+  if (manifest.private !== true)
+    violations.push(`${manifestPath}: workspace must be private (target "${manifest.name ?? "missing"}")`);
+  if (manifest.type !== "module")
+    violations.push(`${manifestPath}: type must be "module" (target "${manifest.name ?? "missing"}")`);
+  validateExportSurface(workspace, violations);
+  if (contract.requiresFiles && (!Array.isArray(manifest.files) || manifest.files.length === 0))
+    violations.push(`${manifestPath}: files boundary is missing for workspace package "${manifest.name}"`);
+  validateManifestDependencies(workspace, workspaceNames, violations);
+}
+
+export async function verifyWorkspaceContract({
+  rootDirectory = process.cwd(),
+  contractPath = join(rootDirectory, CONTRACT_FILENAME),
+} = {}) {
+  const root = resolve(rootDirectory);
+  const violations = [];
+  const contract = await readJson(contractPath);
+  validateContractConfiguration(contract, violations);
+  const workspaceYaml = await readFile(join(root, "pnpm-workspace.yaml"), "utf8");
+  const discovery = await discoverWorkspaces(root, parseWorkspacePatterns(workspaceYaml));
+  for (const pattern of discovery.unmatchedPatterns)
+    violations.push(`pnpm-workspace.yaml: pattern "${pattern}" matches no workspace package (target "${pattern}")`);
+  const contractPaths = new Set(Object.keys(contract.workspaces ?? {}));
+  const discoveredPaths = new Set(discovery.workspaces.map(({ workspacePath }) => workspacePath));
+  for (const { workspacePath } of discovery.workspaces)
+    if (!contractPaths.has(workspacePath))
+      violations.push(
+        `${workspacePath}/package.json: workspace is not registered in ${CONTRACT_FILENAME} (target "${workspacePath}")`,
+      );
+  for (const workspacePath of contractPaths)
+    if (!discoveredPaths.has(workspacePath))
+      violations.push(
+        `${CONTRACT_FILENAME}: registered workspace "${workspacePath}" is not selected by pnpm-workspace.yaml (target "${workspacePath}")`,
+      );
+  const workspaces = [];
+  for (const { directory, workspacePath } of discovery.workspaces) {
+    const workspaceContract = contract.workspaces?.[workspacePath];
+    if (!workspaceContract) continue;
+    const manifest = await readJson(join(directory, "package.json"));
+    workspaces.push({ contract: workspaceContract, directory, manifest, workspacePath });
+  }
+  const names = new Set(workspaces.map((workspace) => workspace.manifest.name));
+  if (names.size !== workspaces.length)
+    violations.push("workspace package names must be unique (target workspace package name)");
+  for (const workspace of workspaces) validateManifest(workspace, names, violations);
+  await validateImports(root, workspaces, violations);
+  if (violations.length > 0) throw new WorkspaceContractError([...new Set(violations)].sort());
+  return {
+    workspaceCount: workspaces.length,
+    allowedDependencyCount: workspaces.reduce(
+      (count, workspace) => count + (workspace.contract.allowedWorkspaceDependencies?.length ?? 0),
+      0,
+    ),
+  };
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    const result = await verifyWorkspaceContract();
+    console.log(
+      `Workspace contract verified (${result.workspaceCount} workspaces, ${result.allowedDependencyCount} allowed dependency edges).`,
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/workspace-contracts.json
+++ b/workspace-contracts.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "workspaces": {
+    "apps/cli": {
+      "name": "open-tag",
+      "requiresRootExport": true,
+      "requiresFiles": true,
+      "allowedWorkspaceDependencies": ["@opentag/client", "@opentag/shared"]
+    },
+    "apps/web": {
+      "name": "@opentag/web",
+      "requiresRootExport": false,
+      "requiresFiles": false,
+      "allowedWorkspaceDependencies": ["@opentag/shared"]
+    },
+    "packages/client": {
+      "name": "@opentag/client",
+      "requiresRootExport": true,
+      "requiresFiles": true,
+      "allowedWorkspaceDependencies": ["@opentag/shared"]
+    },
+    "packages/server": {
+      "name": "@opentag/server",
+      "requiresRootExport": true,
+      "requiresFiles": true,
+      "allowedWorkspaceDependencies": ["@opentag/shared"]
+    },
+    "packages/shared": {
+      "name": "@opentag/shared",
+      "requiresRootExport": true,
+      "requiresFiles": true,
+      "allowedWorkspaceDependencies": []
+    },
+    "e2e": {
+      "name": "@opentag/e2e",
+      "requiresRootExport": false,
+      "requiresFiles": false,
+      "allowedWorkspaceDependencies": []
+    }
+  }
+}


### PR DESCRIPTION
Implements backlog item **ARCH-01 — Enforce the workspace dependency contract** from the OpenTag
architecture backlog (Phase 0: restore trustworthy gates).

## What this adds

- `scripts/check-workspace-contract.mjs` — a verifier (Node built-ins only) run from `pnpm check`
  that enforces the declared workspace graph: workspace registration, allowed manifest and import
  edges, exact `workspace:*` internal ranges, public export/file boundaries, deep-import and
  relative cross-workspace-import bans, and generated-file crossings. Every diagnostic names the
  offending source and target.
- `scripts/workspace-contracts.json` — the declarative contract covering all six current workspaces:
  `apps/cli` may use client/shared; `apps/web` may use shared (including the exported `browser`
  subpath); client and server may use shared only; shared and e2e have no internal edges.
- `scripts/__tests__/check-workspace-contract.test.mjs` — fixture-based `node --test` coverage for a
  clean graph, forbidden edge, unregistered workspace, non-`workspace:*` range, deep imports,
  relative cross-workspace imports, and a missing public export surface (tests were written first
  and failed until the verifier landed).
- Root `check` script gains exactly one appended command: `&& node scripts/check-workspace-contract.mjs`.

The design adapts the workspace-contract idea from historical PR #9 to the current
`apps/*` / `packages/*` / `e2e` layout; nothing was copied from it verbatim.

## Checklist (final state)

- [x] Survey the current graph and PR #9 design
- [x] Failing fixture tests first (`node --test` pattern)
- [x] Implement the verifier with named diagnostics
- [x] Wire into `pnpm check` (single appended command)
- [x] Clean repo passes; every violation class fails with a named diagnostic
- [x] Full local verification

## Verification

Run by the lane and re-run independently by the orchestrator in the lane's checkout (Node 24.19.0,
pnpm 10.12.1):

- `pnpm check` — pass (Biome's pre-existing complexity warnings remain warnings; the new verifier passes)
- `pnpm typecheck` — pass (8/8 Turbo tasks)
- `pnpm test` — pass. One host-environment caveat: the pre-existing
  `scripts/__tests__/lefthook-stage-fixed.test.mjs` fails on this machine when the host's global
  `commit.gpgsign` config invokes the 1Password signer inside the test's temporary repository
  (`git` exit 128, unrelated to this change); the full suite passes with
  `GIT_CONFIG_GLOBAL=/dev/null` (91/91 script tests, 8/8 Turbo tasks). CI runners have no such
  global config.

## Provenance

Written by a Codex agent (dispatch run `950417`, lane `workspace-contract-1`) running with
approvals and sandbox bypassed inside an isolated git worktree; verified and published by the
orchestrating Claude session. Review accordingly.
