### PR TITLE
ci(docker): repair checkout ordering and add a PR build-only job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - "v*"
+  pull_request:
 
 permissions:
   contents: read
@@ -29,7 +30,7 @@ jobs:
     # would put two writers on one supposedly immutable coordinate whenever a tag is pushed while
     # the branch build for the same commit is still running: both would find it absent, and both
     # would publish a differently attested digest under it.
-    if: github.repository == 'first-tree-ai/opentag' && github.ref_type == 'branch'
+    if: github.repository == 'first-tree-ai/opentag' && github.event_name == 'push' && github.ref_type == 'branch'
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.commit.outputs.present == 'true' && steps.commit.outputs.digest || steps.build.outputs.digest }}
@@ -108,7 +109,7 @@ jobs:
     name: Publish Release Coordinate
     # Deliberately not on a shared concurrency group. A release coordinate is immutable and must
     # never be dropped, and GitHub cancels a pending run when another queues into its group.
-    if: github.repository == 'first-tree-ai/opentag' && github.ref_type == 'tag'
+    if: github.repository == 'first-tree-ai/opentag' && github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - name: Check out pushed revision
@@ -175,6 +176,7 @@ jobs:
   reconcile-edge:
     name: Reconcile Edge
     needs: build
+    if: github.repository == 'first-tree-ai/opentag' && github.event_name == 'push' && github.ref_type == 'branch'
     runs-on: ubuntu-latest
     # `edge` has its own writer. Sharing a group with the release pointer would let a branch run
     # cancel a pending release-pointer run, which would then never move its own pointer.
@@ -182,13 +184,13 @@ jobs:
       group: ${{ github.workflow }}-edge
       cancel-in-progress: false
     steps:
+      - name: Check out pushed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
-
-      - name: Check out pushed revision
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve the newest published main commit
         id: target
@@ -221,9 +223,34 @@ jobs:
           printf -- "- Moved \`%s:edge\` to \`%s\` (%s)\n" \
             "$IMAGE" "$DIGEST" "$COMMIT" >> "$GITHUB_STEP_SUMMARY"
 
+  pull-request-build:
+    name: Build Pull Request Image
+    if: github.repository == 'first-tree-ai/opentag' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out pull request revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build pull request image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          push: false
+          tags: ${{ env.IMAGE }}:pr-${{ github.event.pull_request.number }}
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=server-image-pr
+          cache-to: type=gha,mode=max,scope=server-image-pr
+
   reconcile-latest:
     name: Reconcile Latest
     needs: release
+    if: github.repository == 'first-tree-ai/opentag' && github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-latest

--- a/scripts/__tests__/docker-workflow.test.mjs
+++ b/scripts/__tests__/docker-workflow.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const workflowPath = join(repoRoot, ".github", "workflows", "docker.yml");
+
+function readJobs(workflow) {
+  const lines = workflow.split(/\r?\n/);
+  const jobsStart = lines.findIndex((line) => line === "jobs:");
+  assert.notEqual(jobsStart, -1, "docker workflow must define jobs");
+
+  const jobs = new Map();
+  let currentJob = null;
+  for (const line of lines.slice(jobsStart + 1)) {
+    const match = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (match) {
+      currentJob = { name: match[1], lines: [line] };
+      jobs.set(match[1], currentJob);
+      continue;
+    }
+    if (currentJob) currentJob.lines.push(line);
+  }
+  return jobs;
+}
+
+function jobText(job) {
+  return job.lines.join("\n");
+}
+
+test("every setup-node version-file job checks out the repository first", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const jobs = readJobs(workflow);
+
+  for (const job of jobs.values()) {
+    const lines = job.lines;
+    const setupIndex = lines.findIndex(
+      (line) =>
+        line.includes("uses: actions/setup-node@") &&
+        lines.some((candidate) => candidate.includes("node-version-file: .node-version")),
+    );
+    const versionFileIndex = lines.findIndex((line) => line.includes("node-version-file: .node-version"));
+    if (setupIndex === -1 || versionFileIndex === -1) continue;
+
+    const checkoutIndex = lines.findIndex((line) => line.includes("uses: actions/checkout@"));
+    assert.ok(checkoutIndex >= 0, `${job.name} uses a version file but has no checkout step`);
+    assert.ok(checkoutIndex < setupIndex, `${job.name} must check out before setup-node reads .node-version`);
+  }
+});
+
+test("pull-request builds are isolated from registry publication", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const jobs = readJobs(workflow);
+  assert.match(workflow, /^ {2}pull_request:\s*$/m, "docker workflow must run on pull requests");
+
+  const pullRequestJob = jobs.get("pull-request-build");
+  assert.ok(pullRequestJob, "docker workflow must define a pull-request build job");
+  const pullRequestText = jobText(pullRequestJob);
+  assert.match(pullRequestText, /if: .*github\.event_name == 'pull_request'/);
+  assert.match(pullRequestText, /permissions:\n {6}contents: read\n {4}steps:/);
+  assert.match(pullRequestText, /uses: docker\/build-push-action@/);
+  assert.match(pullRequestText, /\n {10}push: false\n/);
+  assert.doesNotMatch(pullRequestText, /uses: docker\/login-action@/);
+
+  for (const job of jobs.values()) {
+    const text = jobText(job);
+    const ifLine = text.match(/^ {4}if: (.+)$/m)?.[1] ?? "";
+    const isPushOnly = ifLine.includes("github.event_name == 'push'");
+    if (isPushOnly) continue;
+
+    assert.doesNotMatch(text, /uses: docker\/login-action@/, `${job.name} must not log in during pull requests`);
+    assert.doesNotMatch(text, /\n\s+push: true\s*$/, `${job.name} must not push during pull requests`);
+    assert.doesNotMatch(text, /docker buildx imagetools create/, `${job.name} must not publish during pull requests`);
+  }
+});


### PR DESCRIPTION
Implements backlog item **QG-02 — Repair Docker checkout ordering and add a PR container build**
from the OpenTag architecture backlog (Phase 0: restore trustworthy gates).

## Revalidated evidence

Run [33356162207](https://github.com/first-tree-ai/opentag/actions/runs/33356162207) was
re-checked at 2026-08-31T12:47:05+08:00: created 2026-08-31T04:10:26Z for commit `a648112` on
`main`, concluded `failure`. Failing job/step: `Reconcile Edge` / `Set up Node.js` —
`actions/setup-node` could not find `.node-version` because it ran before checkout.

## What this changes

- `reconcile-edge` now checks out the repository before `setup-node`, matching the other
  version-file jobs (`build`, `release`, `reconcile-latest` were audited and already correct).
- New `pull-request-build` job: on `pull_request`, checks out the revision, sets up Buildx, and runs
  `docker/build-push-action` with `push: false`; explicit job-level `contents: read` permissions and
  no registry login step.
- Publication and reconciliation jobs gained explicit `github.event_name == 'push'` guards, so
  adding the PR trigger cannot reach GHCR login or publication paths. Branch publication remains
  `main`-only and release/latest remain tag-gated.
- `scripts/__tests__/docker-workflow.test.mjs` (Node built-ins only) — structural regression test:
  checkout must precede version-file `setup-node` in every matching job; the PR build must keep
  read-only permissions and `push: false`; jobs that are not explicitly push-only must not log in to
  or publish to a registry.
- `actionlint` (already installed on the host) passes with no diagnostics for `docker.yml`.

## Checklist (final state)

- [x] Revalidate the failed run and record fresh evidence
- [x] Audit `docker.yml` ordering and permissions
- [x] Fix checkout-before-setup-node ordering
- [x] Add least-privilege PR build-only job; preserve publication gates
- [x] Structural workflow regression test
- [x] actionlint (already installed) — clean
- [x] Local verification

## Verification

Run by the lane and re-run independently by the orchestrator in the lane's checkout (Node 24.19.0,
pnpm 10.12.1):

- `pnpm check` — pass
- `pnpm typecheck` — pass
- `pnpm test` — pass. One host-environment caveat: the pre-existing
  `scripts/__tests__/lefthook-stage-fixed.test.mjs` fails on this machine when the host's global
  `commit.gpgsign` config invokes the 1Password signer inside the test's temporary repository
  (`git` exit 128, unrelated to this change); the full suite passes with
  `GIT_CONFIG_GLOBAL=/dev/null` (86 Node tests, 8/8 Turbo tasks). CI runners have no such global
  config.
- No Docker build was run locally (out of the lane's boundary).

## Post-merge maintainer actions

- Verify the repaired ordering on a real fresh runner (the next `main` push exercises `reconcile-edge`).
- Review branch protection and effective workflow permissions (workflow-level `packages: write` is
  still inherited by non-publishing jobs other than the new PR build job).

## Provenance

Written by a Codex agent (dispatch run `950417`, lane `docker-workflow-fix-4`) running with
approvals and sandbox bypassed inside an isolated git worktree; verified and published by the
orchestrating Claude session. Review accordingly.
