### PR TITLE
feat(web): expand control panel i18n coverage

### DIFF
--- a/apps/web/messages/onboarding/en.json
+++ b/apps/web/messages/onboarding/en.json
@@ -1,3 +1,24 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "onboarding_done_description": "Tag @{name} in {provider} to put it to work.",
+  "onboarding_done_title": "{name} is ready.",
+  "onboarding_error_feishu_attempt": "That code is no longer usable. Pick Feishu again to get a new one.",
+  "onboarding_messaging_cli_missing": "{provider} messages are sent through its CLI, which isn't installed on your computer yet. Run opentag doctor to add it.",
+  "onboarding_messaging_computer_offline": "Your computer is offline. Reconnect it and this will finish on its own.",
+  "onboarding_messaging_confirming": "Connected. Checking your agent can be reached…",
+  "onboarding_messaging_description": "Pick the app your team already works in.",
+  "onboarding_messaging_failed": "That didn't work. Try again to get a new code.",
+  "onboarding_messaging_feishu_description": "Your Feishu workspace",
+  "onboarding_messaging_feishu_intro": "Scan this with Lark. You'll finish the last step inside Lark itself.",
+  "onboarding_messaging_feishu_title": "Lark",
+  "onboarding_messaging_provider_label": "Messaging app",
+  "onboarding_messaging_qr_alt": "Scan this QR code in Lark",
+  "onboarding_messaging_retry": "Try again",
+  "onboarding_messaging_slack_action": "Add to Slack",
+  "onboarding_messaging_slack_description": "Your Slack workspace",
+  "onboarding_messaging_slack_intro": "Install OpenTag in your Slack workspace. We'll take you to Slack and bring you back.",
+  "onboarding_messaging_slack_title": "Slack",
+  "onboarding_messaging_slack_waiting": "Waiting for you to finish in Slack…",
+  "onboarding_messaging_title": "Connect your messaging app",
+  "onboarding_messaging_waiting": "Waiting for you to scan…"
 }

--- a/apps/web/messages/onboarding/zh.json
+++ b/apps/web/messages/onboarding/zh.json
@@ -1,3 +1,24 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "onboarding_done_description": "在{provider}中标记 @{name}，让它开始工作。",
+  "onboarding_done_title": "{name}已准备就绪。",
+  "onboarding_error_feishu_attempt": "该二维码已失效。请重新选择飞书获取新的二维码。",
+  "onboarding_messaging_cli_missing": "{provider}消息需要通过其 CLI 发送，但你的计算机尚未安装。运行 opentag doctor 进行安装。",
+  "onboarding_messaging_computer_offline": "你的计算机处于离线状态。重新连接后，这里会自动完成。",
+  "onboarding_messaging_confirming": "已连接，正在检查智能体是否可达…",
+  "onboarding_messaging_description": "选择团队已经在使用的应用。",
+  "onboarding_messaging_failed": "操作未成功。请重试以获取新的二维码。",
+  "onboarding_messaging_feishu_description": "你的飞书工作区",
+  "onboarding_messaging_feishu_intro": "使用飞书扫描此二维码。最后一步将在飞书中完成。",
+  "onboarding_messaging_feishu_title": "飞书",
+  "onboarding_messaging_provider_label": "消息应用",
+  "onboarding_messaging_qr_alt": "使用飞书扫描此二维码",
+  "onboarding_messaging_retry": "重试",
+  "onboarding_messaging_slack_action": "添加到 Slack",
+  "onboarding_messaging_slack_description": "你的 Slack 工作区",
+  "onboarding_messaging_slack_intro": "在你的 Slack 工作区中安装 OpenTag。我们会带你前往 Slack，再带你回来。",
+  "onboarding_messaging_slack_title": "Slack",
+  "onboarding_messaging_slack_waiting": "等待你在 Slack 中完成操作…",
+  "onboarding_messaging_title": "连接消息应用",
+  "onboarding_messaging_waiting": "等待你扫描…"
 }

--- a/apps/web/messages/shell/en.json
+++ b/apps/web/messages/shell/en.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "shell_language_label": "Language"
 }

--- a/apps/web/messages/shell/zh.json
+++ b/apps/web/messages/shell/zh.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "shell_language_label": "语言"
 }

--- a/apps/web/src/features/agents/agent-presentation.ts
+++ b/apps/web/src/features/agents/agent-presentation.ts
@@ -1,4 +1,5 @@
 import type { AgentSummary, ImBindingSummary } from "@opentag/shared/browser";
+import { messagingProviderChoices, messagingProviderLabel } from "../../im/provider-label.js";
 import type { StatusTone } from "../../ui/design-system.js";
 import type { AgentAvailability, AgentDetailView, AgentListItem, AgentStatusSource } from "./agent-model.js";
 import { type AgentSettingsSectionLink, agentSettingsSectionLink } from "./agent-routes.js";
@@ -183,8 +184,9 @@ export function sharedConversationLabel(provider: ImBindingSummary["provider"]):
 }
 
 export function sharedConversationDestination(provider: ImBindingSummary["provider"], plural = false): string {
-  if (provider === "feishu") return plural ? "connected Feishu group chats" : "a Feishu group chat";
-  return plural ? "connected Slack channels" : "a Slack channel";
+  const brand = messagingProviderLabel(provider);
+  const noun = provider === "feishu" ? "group chat" : "channel";
+  return plural ? `connected ${brand} ${noun}s` : `a ${brand} ${noun}`;
 }
 
 /**
@@ -192,7 +194,7 @@ export function sharedConversationDestination(provider: ImBindingSummary["provid
  * so the verified Bot name is used and no per-Agent handle is synthesized.
  */
 export function messagingChannelLabel(agent: AgentDetailView, binding: ImBindingSummary): string {
-  const provider = titleCase(binding.provider);
+  const provider = messagingProviderLabel(binding.provider);
   if (binding.provider === "feishu") return `${provider} · @${agent.name}`;
   return binding.bot.displayName ? `${provider} · ${binding.bot.displayName}` : provider;
 }
@@ -207,7 +209,7 @@ export function agentUseInstruction(agent: AgentDetailView, provider: ImBindingS
 export function agentAvailabilitySummary(agent: AgentDetailView): string {
   if (agent.availability.state === "ready") {
     const provider = agent.availability.dependencies.channel.provider;
-    return provider ? `Available in ${titleCase(provider)}` : "Ready for new work";
+    return provider ? `Available in ${messagingProviderLabel(provider)}` : "Ready for new work";
   }
   return {
     action_required: "Cannot receive new work",
@@ -225,13 +227,13 @@ export function messagingAgentStatusDescription(
   if (agent.availability.state === "ready") {
     return agent.activity.state === "working"
       ? "This Agent is handling a request and remains connected for new messages."
-      : `Ready to receive new messages from ${titleCase(provider)}.`;
+      : `Ready to receive new messages from ${messagingProviderLabel(provider)}.`;
   }
   if (agent.availability.reason === "computer_offline" || agent.availability.reason === "runtime_unavailable") {
     return computerRecoveryMessage(agent);
   }
   if (agent.availability.reason === "handoff_unavailable") {
-    return `${titleCase(provider)} is connected, but messages cannot currently be handed off to this Agent.`;
+    return `${messagingProviderLabel(provider)} is connected, but messages cannot currently be handed off to this Agent.`;
   }
   return agentRecoveryMessage(agent);
 }
@@ -268,11 +270,11 @@ export function agentRecoveryMessage(agent: AgentDetailView): string {
     runtime_unconfirmed: "Could not confirm the assigned Computer. Retrying automatically.",
     computer_offline: "This agent's computer is offline. Retrying automatically.",
     runtime_unavailable: runtimeRecoveryMessage(agent),
-    im_not_connected: "Connect Feishu or Slack so teammates can send this Agent work.",
+    im_not_connected: `Connect ${messagingProviderChoices()} so teammates can send this Agent work.`,
     im_provisioning: "The messaging connection is still being set up.",
     im_reauthorization_required: "The messaging connection needs to be re-authorized before it can receive messages.",
-    im_error: "The messaging connection failed. Reconnect Feishu or Slack to receive messages.",
-    im_disabled: "Messaging is turned off for this Agent. Reconnect Feishu or Slack to receive messages.",
+    im_error: `The messaging connection failed. Reconnect ${messagingProviderChoices()} to receive messages.`,
+    im_disabled: `Messaging is turned off for this Agent. Reconnect ${messagingProviderChoices()} to receive messages.`,
     handoff_unavailable: "Messages cannot be sent to this Agent.",
   };
   return agent.availability.reason ? messages[agent.availability.reason] : agentAvailabilitySummary(agent);

--- a/apps/web/src/features/agents/agent-settings/im-tab.tsx
+++ b/apps/web/src/features/agents/agent-settings/im-tab.tsx
@@ -5,18 +5,14 @@ import { type Ref, useEffect, useRef, useState } from "react";
 import { browserApi } from "../../../api.js";
 import { formatDateTime } from "../../../i18n/format.js";
 import { FeishuSetup } from "../../../im/feishu-setup.js";
+import { messagingProviderLabel } from "../../../im/provider-label.js";
 import { SlackConfiguration } from "../../../im/slack-configuration.js";
 import { queryKeys } from "../../../query/keys.js";
 import { Banner, Button, Dialog, StatusIndicator, Text } from "../../../ui/design-system.js";
 import { ProviderIcon } from "../../../ui/provider-icon.js";
 import { AsyncState, toResourceState } from "../../resource/resource-state.js";
 import type { AgentDetailView } from "../agent-model.js";
-import {
-  messagingConnectionLabel,
-  messagingConnectionTone,
-  runtimeProviderName,
-  titleCase,
-} from "../agent-presentation.js";
+import { messagingConnectionLabel, messagingConnectionTone, runtimeProviderName } from "../agent-presentation.js";
 import { agentSettingsSectionLink } from "../agent-routes.js";
 
 export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChanged: () => void }) {
@@ -135,7 +131,7 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
                             <div className="flex flex-wrap items-center gap-3">
                               <ProviderIcon className="size-6" provider={binding.provider} />
                               <span className="grid min-w-0 gap-1">
-                                <strong>{binding.bot.displayName ?? titleCase(binding.provider)}</strong>
+                                <strong>{binding.bot.displayName ?? messagingProviderLabel(binding.provider)}</strong>
                                 <small className="text-kumo-subtle">{messagingChannelDetail(agent, binding)}</small>
                               </span>
                               <StatusIndicator
@@ -174,7 +170,7 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
                                   variant="outline"
                                   onClick={() => void connectFeishu("replace")}
                                 >
-                                  Change Feishu Bot
+                                  Change bot
                                 </Button>
                               ) : null}
                               <Button
@@ -186,7 +182,7 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
                                   setConfirmation({ bindingId: binding.id, kind: "disable_binding" });
                                 }}
                               >
-                                Disconnect {titleCase(binding.provider)}
+                                Disconnect {messagingProviderLabel(binding.provider)}
                               </Button>
                             </div>
                           </section>
@@ -353,13 +349,13 @@ function TriggerModeOption({
 /** The row already shows the Bot name above, so the line beneath it does not repeat it. */
 function messagingChannelDetail(agent: AgentDetailView, binding: ImBindingSummary): string {
   return binding.provider === "feishu"
-    ? `${titleCase(binding.provider)} · @${agent.name}`
-    : titleCase(binding.provider);
+    ? `${messagingProviderLabel(binding.provider)} · @${agent.name}`
+    : messagingProviderLabel(binding.provider);
 }
 
 /** The one repair a channel state offers, or nothing when the state cannot be repaired from here. */
 function messagingRecoveryLabel(binding: ImBindingSummary): string | undefined {
-  const provider = titleCase(binding.provider);
+  const provider = messagingProviderLabel(binding.provider);
   if (binding.bindingState === "reauthorization_required") return `Reauthorize ${provider}`;
   if (binding.bindingState === "error" || binding.bindingState === "disabled") return `Reconnect ${provider}`;
   return undefined;

--- a/apps/web/src/features/agents/agents-page.tsx
+++ b/apps/web/src/features/agents/agents-page.tsx
@@ -2,13 +2,14 @@ import { Link } from "@tanstack/react-router";
 import { type ReactNode, useRef, useState } from "react";
 import { orderAgentIds } from "../../features/agent-list-order.js";
 import { formatCompactNumber, formatElapsedCompact, initials } from "../../i18n/format.js";
+import { messagingProviderLabel } from "../../im/provider-label.js";
 import { Button, Icon, StatusIndicator } from "../../ui/design-system.js";
 import { ProviderIcon } from "../../ui/provider-icon.js";
 import { EmptyState, Page } from "../layout/page.js";
 import { AsyncState } from "../resource/resource-state.js";
 import { useAccount } from "../session/session-context.js";
 import type { AgentListItem } from "./agent-model.js";
-import { agentAvatarTone, agentCardStatus, titleCase } from "./agent-presentation.js";
+import { agentAvatarTone, agentCardStatus } from "./agent-presentation.js";
 import { useAgentListView } from "./agent-queries.js";
 import { agentDetailLink } from "./agent-routes.js";
 import { NewAgentDialog } from "./new-agent-page.js";
@@ -104,7 +105,7 @@ export function AgentCard({ agent }: { agent: AgentListItem }) {
             {channel ? (
               <span className="inline-flex shrink-0 items-center" data-ui="agent-card-channel">
                 <ProviderIcon className="size-4" provider={channel} />
-                <span className="sr-only">{titleCase(channel)}</span>
+                <span className="sr-only">{messagingProviderLabel(channel)}</span>
               </span>
             ) : null}
           </strong>

--- a/apps/web/src/features/auth/login-page.tsx
+++ b/apps/web/src/features/auth/login-page.tsx
@@ -2,6 +2,7 @@ import { type AuthProvidersResponse, DEFAULT_SIGN_IN_DESTINATION } from "@openta
 import { useQuery } from "@tanstack/react-query";
 import { browserApi } from "../../api.js";
 import googleSignInButton from "../../assets/google-sign-in-light@2x.png";
+import { LanguageSwitcher } from "../../i18n/language-switcher.js";
 import { queryKeys } from "../../query/keys.js";
 import { Icon, Text } from "../../ui/design-system.js";
 import { AsyncState, toResourceState } from "../resource/resource-state.js";
@@ -15,7 +16,10 @@ export function LoginPage({ next: requested }: { next?: string }) {
   );
   const next = requested ?? DEFAULT_SIGN_IN_DESTINATION;
   return (
-    <main className="grid min-h-screen place-items-center bg-kumo-canvas p-6" data-ui="login-page">
+    <main className="relative grid min-h-screen place-items-center bg-kumo-canvas p-6" data-ui="login-page">
+      <div className="absolute right-6 top-6">
+        <LanguageSwitcher />
+      </div>
       <section
         aria-labelledby="login-title"
         className="grid w-full max-w-md gap-6 rounded-lg bg-kumo-base p-6 ring ring-kumo-line"

--- a/apps/web/src/features/shell/app-shell.tsx
+++ b/apps/web/src/features/shell/app-shell.tsx
@@ -3,6 +3,7 @@ import { Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-route
 import { useEffect, useRef, useState } from "react";
 import { browserApi } from "../../api.js";
 import { initials } from "../../i18n/format.js";
+import { LanguageSwitcher } from "../../i18n/language-switcher.js";
 import { queryKeys } from "../../query/keys.js";
 import {
   DropdownMenu,
@@ -118,6 +119,9 @@ export function AppShellContent() {
         </Sidebar.Content>
         <Sidebar.Footer>
           <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="px-2 group-data-[state=collapsed]/sidebar:hidden">
+              <LanguageSwitcher />
+            </div>
             <Sidebar.Menu className="min-w-0 flex-1 group-data-[state=collapsed]/sidebar:hidden">
               <Sidebar.MenuItem>
                 <DropdownMenu

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -5,6 +5,7 @@ import { type ReactNode, useMemo, useState } from "react";
 import { ApiError, browserApi } from "../api.js";
 import { PageHeader } from "../components/kumo/page-header/page-header.js";
 import { compareText, foldCase, formatDateTime, formatNumber, formatRelativeTime, initials } from "../i18n/format.js";
+import { messagingProviderLabel } from "../im/provider-label.js";
 import * as m from "../paraglide/messages.js";
 import { queryKeys } from "../query/keys.js";
 import {
@@ -609,7 +610,7 @@ function TaskRow({ showAgent = true, task }: { showAgent?: boolean; task: TaskSu
             </>
           ) : null}
           <TaskProviderIcon provider={task.source.provider} compact />
-          <span>{task.source.provider}</span>
+          <span>{messagingProviderLabel(task.source.provider)}</span>
           <span aria-hidden="true"> · </span>
           <span>{task.sessionKind}</span>
           <span aria-hidden="true"> · </span>
@@ -635,7 +636,8 @@ function SourceIdentity({ task }: { task: TaskSummary }) {
       <span>
         <strong>{task.agent.displayName}</strong>
         <small>
-          {task.source.provider} · {task.sessionKind} · {shortId(task.source.threadKey ?? task.source.channelId)}
+          {messagingProviderLabel(task.source.provider)} · {task.sessionKind} ·{" "}
+          {shortId(task.source.threadKey ?? task.source.channelId)}
         </small>
       </span>
     </span>

--- a/apps/web/src/i18n/language-switcher.test.tsx
+++ b/apps/web/src/i18n/language-switcher.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { overwriteGetLocale, overwriteSetLocale } from "../paraglide/runtime.js";
+import { LanguageSwitcher } from "./language-switcher.js";
+
+describe("LanguageSwitcher", () => {
+  afterEach(() => {
+    overwriteGetLocale(() => "en");
+    overwriteSetLocale(() => undefined);
+  });
+
+  it("renders the negotiated locale and persists an explicit selection", async () => {
+    overwriteGetLocale(() => "en");
+    const setLocale = vi.fn();
+    overwriteSetLocale(setLocale);
+    render(<LanguageSwitcher />);
+
+    const selector = screen.getByRole("combobox", { name: "Language" });
+    expect(selector.textContent).toContain("English");
+    fireEvent.click(selector);
+    const chinese = screen.getByRole("option", { name: "中文" });
+    fireEvent.keyDown(chinese, { key: "Enter" });
+
+    await waitFor(() => expect(setLocale).toHaveBeenCalledWith("zh"));
+  });
+});

--- a/apps/web/src/i18n/language-switcher.tsx
+++ b/apps/web/src/i18n/language-switcher.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import * as m from "../paraglide/messages.js";
+import { KumoSelectControl } from "../ui/design-system.js";
+import { getLocale, LOCALE_LABELS, type Locale, locales, setLocale } from "./locale.js";
+
+/** A compact, keyboard-accessible locale selector shared by authenticated and public surfaces. */
+export function LanguageSwitcher() {
+  const [locale, setCurrentLocale] = useState<Locale>(() => getLocale());
+  const label = m.shell_language_label();
+
+  async function changeLocale(next: Locale) {
+    setCurrentLocale(next);
+    await setLocale(next);
+  }
+
+  return (
+    <label className="inline-flex items-center gap-2 text-sm text-kumo-subtle" htmlFor="language-switcher">
+      <span>{label}</span>
+      <KumoSelectControl
+        aria-label={label}
+        id="language-switcher"
+        size="sm"
+        value={locale}
+        onValueChange={(value) => void changeLocale(value as Locale)}
+      >
+        {locales.map((availableLocale) => (
+          <option key={availableLocale} value={availableLocale}>
+            {LOCALE_LABELS[availableLocale]}
+          </option>
+        ))}
+      </KumoSelectControl>
+    </label>
+  );
+}

--- a/apps/web/src/im/provider-label.test.ts
+++ b/apps/web/src/im/provider-label.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { messagingProviderChoices, messagingProviderLabel } from "./provider-label.js";
+
+describe("messaging provider labels", () => {
+  it("uses stable product names for provider ids", () => {
+    expect(messagingProviderLabel("feishu")).toBe("Feishu");
+    expect(messagingProviderLabel("slack")).toBe("Slack");
+  });
+
+  it("formats the complete provider choice list", () => {
+    expect(messagingProviderChoices()).toBe("Feishu or Slack");
+  });
+});

--- a/apps/web/src/im/provider-label.ts
+++ b/apps/web/src/im/provider-label.ts
@@ -1,0 +1,26 @@
+import type { ImBindingSummary } from "@opentag/shared/browser";
+
+type MessagingProvider = ImBindingSummary["provider"];
+
+/** Maps provider ids to the product names users should see. */
+export function messagingProviderLabel(provider: MessagingProvider): string {
+  switch (provider) {
+    case "feishu":
+      return "Feishu";
+    case "slack":
+      return "Slack";
+    default:
+      return assertNeverProvider(provider);
+  }
+}
+
+function assertNeverProvider(provider: never): never {
+  throw new Error(`Unlabelled messaging provider: ${String(provider)}`);
+}
+
+/** Formats the complete provider set for user-facing alternatives. */
+export function messagingProviderChoices(): string {
+  const labels = (["feishu", "slack"] as const).map(messagingProviderLabel);
+  const last = labels.at(-1) ?? "";
+  return labels.length > 1 ? `${labels.slice(0, -1).join(", ")} or ${last}` : last;
+}

--- a/apps/web/src/onboarding-v2/copy.ts
+++ b/apps/web/src/onboarding-v2/copy.ts
@@ -6,6 +6,7 @@
  * setup copy, so the same work says the same thing on both surfaces.
  */
 
+import * as m from "../paraglide/messages.js";
 import { SETUP_COPY } from "../setup/copy.js";
 import type { CloudRuntime, Destination, Runtime, StepId, TokenSource } from "./flow.js";
 
@@ -121,8 +122,8 @@ export const COPY = {
   messaging: SETUP_COPY.messaging,
 
   done: {
-    title: (name: string) => `${name} is ready.`,
-    description: (name: string) => `Tag @${name} in Lark to put it to work.`,
+    title: (name: string) => m.onboarding_done_title({ name }),
+    description: (name: string, provider = "Lark") => m.onboarding_done_description({ name, provider }),
   },
 
   /**
@@ -134,7 +135,7 @@ export const COPY = {
     computers: "We lost contact while waiting for your computer.",
     createAgent: "We couldn't create your agent.",
     messaging: "We couldn't start connecting your messaging app.",
-    feishuAttempt: "That code is no longer usable. Pick Lark again to get a new one.",
+    feishuAttempt: m.onboarding_error_feishu_attempt(),
     resume: "We couldn't check what your account already has.",
     completeSetup: "Your agent is ready, but we couldn't finish setting up your account. Reload to try again.",
   },

--- a/apps/web/src/onboarding-v2/page.tsx
+++ b/apps/web/src/onboarding-v2/page.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { messagingProviderLabel } from "../im/provider-label.js";
 import { Button, Loader } from "../ui/design-system.js";
 import type { OnboardingBackend } from "./backend.js";
 import { COPY } from "./copy.js";
@@ -305,7 +306,10 @@ function OnboardingV2Flow({
             </div>
           ) : null}
           {flow.complete ? (
-            <DoneStep name={backend.agent?.name ?? draft.name} />
+            <DoneStep
+              name={backend.agent?.name ?? draft.name}
+              provider={backend.messagingProvider ? messagingProviderLabel(backend.messagingProvider) : undefined}
+            />
           ) : flow.page === "destination" ? (
             <DestinationStep
               cloudAvailable={cloudAvailable}

--- a/apps/web/src/onboarding-v2/steps.tsx
+++ b/apps/web/src/onboarding-v2/steps.tsx
@@ -880,7 +880,7 @@ export function MessagingStep({
   );
 }
 
-export function DoneStep({ name }: { name: string }) {
+export function DoneStep({ name, provider }: { name: string; provider?: string }) {
   return (
     <section className="flex flex-col items-center gap-6 text-center" data-ui="onboarding-v2-step-done">
       <span
@@ -893,7 +893,7 @@ export function DoneStep({ name }: { name: string }) {
         <Text as="h1" size="lg" variant="heading">
           {COPY.done.title(name)}
         </Text>
-        <p className="text-kumo-subtle m-0">{COPY.done.description(name)}</p>
+        <p className="text-kumo-subtle m-0">{COPY.done.description(name, provider)}</p>
       </header>
     </section>
   );

--- a/apps/web/src/setup/copy.ts
+++ b/apps/web/src/setup/copy.ts
@@ -7,6 +7,7 @@
  * Agent's settings. Copy that only one of those surfaces says stays with that surface.
  */
 
+import * as m from "../paraglide/messages.js";
 import type { CheckRow, CheckState } from "./checks.js";
 
 /**
@@ -72,27 +73,26 @@ export const SETUP_COPY = {
   },
 
   messaging: {
-    title: "Connect your messaging app",
-    description: "Pick the app your team already works in.",
-    providerLabel: "Messaging app",
+    title: m.onboarding_messaging_title(),
+    description: m.onboarding_messaging_description(),
+    providerLabel: m.onboarding_messaging_provider_label(),
     /**
      * Lark is the name this product goes by in English; Feishu is the same app under its
      * mainland China name. The provider's id stays `feishu`, because that is the Server's own
      * vocabulary — only what the reader sees changes here.
      */
-    feishu: { title: "Lark", description: "Also called Feishu" },
-    slack: { title: "Slack", description: "Your Slack workspace" },
-    feishuIntro: "Scan this with Lark. You'll finish the last step inside Lark itself.",
-    qrAlt: "Scan this QR code in Lark",
-    waiting: "Waiting for you to scan…",
-    cliMissing: (provider: string) =>
-      `${provider} messages are sent through its CLI, which isn't installed on your computer yet. Run opentag doctor to add it.`,
-    slackIntro: "Install OpenTag in your Slack workspace. We'll take you to Slack and bring you back.",
-    slackAction: "Add to Slack",
-    slackWaiting: "Waiting for you to finish in Slack…",
-    confirming: "Connected. Checking your agent can be reached…",
-    computerOffline: "Your computer is offline. Reconnect it and this will finish on its own.",
-    retry: "Try again",
-    failed: "That didn't work. Try again to get a new code.",
+    feishu: { title: m.onboarding_messaging_feishu_title(), description: m.onboarding_messaging_feishu_description() },
+    slack: { title: m.onboarding_messaging_slack_title(), description: m.onboarding_messaging_slack_description() },
+    feishuIntro: m.onboarding_messaging_feishu_intro(),
+    qrAlt: m.onboarding_messaging_qr_alt(),
+    waiting: m.onboarding_messaging_waiting(),
+    cliMissing: (provider: string) => m.onboarding_messaging_cli_missing({ provider }),
+    slackIntro: m.onboarding_messaging_slack_intro(),
+    slackAction: m.onboarding_messaging_slack_action(),
+    slackWaiting: m.onboarding_messaging_slack_waiting(),
+    confirming: m.onboarding_messaging_confirming(),
+    computerOffline: m.onboarding_messaging_computer_offline(),
+    retry: m.onboarding_messaging_retry(),
+    failed: m.onboarding_messaging_failed(),
   },
 } as const;


### PR DESCRIPTION
## Summary
- add an accessible language switcher to login and authenticated shell surfaces
- route onboarding messaging copy through English and Simplified Chinese Paraglide catalogues
- centralize messaging provider labels and use them in Agent and Task presentation
- add provider-label and locale-switching tests

## Validation
- `pnpm --filter @opentag/web exec paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --output-structure message-modules --strategy localStorage preferredLanguage baseLocale`
- focused Vitest suites for i18n, provider labels, setup, and onboarding messaging
- repository pre-push format, lint, check, and typecheck hooks

Closes #241
