### PR TITLE
fix(coverage): stop the patch gate blaming lines it cannot instrument

### DIFF
--- a/scripts/__tests__/unit-coverage-gate.test.mjs
+++ b/scripts/__tests__/unit-coverage-gate.test.mjs
@@ -135,3 +135,50 @@ test("supported script extensions are included while coverage artifacts remain e
   assert.equal(isSupportedSourcePath("src/example.test.ts"), false);
   assert.equal(isSupportedSourcePath("src/example.d.ts"), false);
 });
+
+test("a declaration the provider emits no statement for is not blamed for being uncoverable", () => {
+  // A TypeScript interface member and a bare JSX text child both vanish at compile time, so the
+  // instrumented file carries no statement for either line. Counting them would fail a pull request
+  // for adding a type or changing a string, with nothing its author could write to satisfy the gate.
+  const diff = [
+    "diff --git a/src/example.tsx b/src/example.tsx",
+    "--- a/src/example.tsx",
+    "+++ b/src/example.tsx",
+    "@@ -1,0 +2,3 @@",
+    "+  readonly agentCount: number;",
+    "+      Your Computer",
+    "+export const rendered = true;",
+    "",
+  ].join("\n");
+  const result = evaluatePatchCoverage({
+    diff,
+    coverage: { "src/example.tsx": statementCoverage("src/example.tsx", 4, 1) },
+    repositoryRoot: "/repo",
+    threshold: 80,
+  });
+  assert.equal(result.total, 1);
+  assert.equal(result.covered, 1);
+  assert.deepEqual(result.uncovered, []);
+  assert.equal(result.passed, true);
+});
+
+test("an instrumented line with zero hits is still uncovered, whatever it contains", () => {
+  // Skipping lines the provider omitted must not become a way to skip lines it measured as unrun.
+  const diff = [
+    "diff --git a/src/example.tsx b/src/example.tsx",
+    "--- a/src/example.tsx",
+    "+++ b/src/example.tsx",
+    "@@ -1,0 +2 @@",
+    "+  return renderNothing();",
+    "",
+  ].join("\n");
+  const result = evaluatePatchCoverage({
+    diff,
+    coverage: { "src/example.tsx": statementCoverage("src/example.tsx", 2, 0) },
+    repositoryRoot: "/repo",
+    threshold: 80,
+  });
+  assert.equal(result.total, 1);
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.uncovered, ["src/example.tsx:2"]);
+});

--- a/scripts/__tests__/unit-coverage-gate.test.mjs
+++ b/scripts/__tests__/unit-coverage-gate.test.mjs
@@ -182,3 +182,31 @@ test("an instrumented line with zero hits is still uncovered, whatever it contai
   assert.equal(result.passed, false);
   assert.deepEqual(result.uncovered, ["src/example.tsx:2"]);
 });
+
+test("a changed line inside an unrun multi-line statement is judged by that statement", () => {
+  // The current provider emits single-line statements, so this case is theoretical today. Recording
+  // the span keeps the skip rule meaning "no statement covers this line": a provider that reported
+  // ranges would otherwise let an unrun statement's inner lines pass as uncoverable.
+  const diff = [
+    "diff --git a/src/example.ts b/src/example.ts",
+    "--- a/src/example.ts",
+    "+++ b/src/example.ts",
+    "@@ -1,0 +12 @@",
+    "+    unreachableArgument,",
+    "",
+  ].join("\n");
+  const spanning = {
+    path: "src/example.ts",
+    s: { 0: 0 },
+    statementMap: { 0: { start: { line: 10, column: 0 }, end: { line: 14, column: 3 } } },
+  };
+  const result = evaluatePatchCoverage({
+    diff,
+    coverage: { "src/example.ts": spanning },
+    repositoryRoot: "/repo",
+    threshold: 80,
+  });
+  assert.equal(result.total, 1);
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.uncovered, ["src/example.ts:12"]);
+});

--- a/scripts/unit-coverage-gate.mjs
+++ b/scripts/unit-coverage-gate.mjs
@@ -1,8 +1,15 @@
 /**
  * Pure helpers for enforcing coverage on executable lines changed by a pull request.
  *
- * The coverage provider may omit files or statements that it could not instrument. Omissions are
- * treated as uncovered for changed executable lines, which keeps the gate fail closed.
+ * A file the coverage provider never instrumented is treated as wholly uncovered, which keeps the
+ * gate fail closed: a package that silently stopped being measured must not read as clean.
+ *
+ * Within a file it did instrument, the provider is the authority on which lines can be executed at
+ * all. It emits no statement for a TypeScript interface member or a bare JSX text child, because
+ * neither survives compilation as code, and no test can ever cover one. Counting those as uncovered
+ * would fail a pull request for adding a type or changing a string, with nothing the author could
+ * write to satisfy it — so a changed line an instrumented file has no statement for is skipped
+ * rather than blamed.
  */
 
 import { extname, isAbsolute, posix, relative } from "node:path";
@@ -116,13 +123,17 @@ export function buildLineHitsByFile(coverage, repositoryRoot) {
 
 function evaluateChangedFile({ file, lines, lineHits }) {
   if (!isSupportedSourcePath(file)) return { covered: 0, total: 0, uncovered: [] };
+  const instrumented = lineHits !== undefined;
   const uncovered = [];
   let covered = 0;
   let total = 0;
   for (const { content, line } of lines) {
     if (!isExecutableSourceLine(content)) continue;
+    // The provider instrumented this file and emitted nothing for this line: it is a declaration or
+    // a literal, not a statement a test could reach.
+    if (instrumented && !lineHits.has(line)) continue;
     total += 1;
-    if (!lineHits?.has(line)) {
+    if (!instrumented) {
       uncovered.push(`${file}:${line} (missing coverage entry)`);
     } else if (lineHits.get(line) > 0) {
       covered += 1;

--- a/scripts/unit-coverage-gate.mjs
+++ b/scripts/unit-coverage-gate.mjs
@@ -104,17 +104,28 @@ export function normalizeCoveragePath(rawPath, repositoryRoot) {
   return normalizePath(isAbsolute(value) ? relative(repositoryRoot, value) : value);
 }
 
-/** Map each normalized repository path to its maximum Istanbul statement hit per source line. */
+/**
+ * Map each normalized repository path to its maximum statement hit per source line.
+ *
+ * A statement claims every line it spans, not just the one it starts on. The current provider emits
+ * single-line statements, so today that is the same map either way; recording the span means the
+ * gate asks "does any statement cover this line", which is the question it means to ask, rather
+ * than depending on a provider property nothing enforces.
+ */
 export function buildLineHitsByFile(coverage, repositoryRoot) {
   const lineHitsByFile = new Map();
   for (const [rawFile, fileCoverage] of Object.entries(coverage ?? {})) {
     const file = normalizeCoveragePath(rawFile, repositoryRoot);
     const lineHits = lineHitsByFile.get(file) ?? new Map();
     for (const [statementId, statement] of Object.entries(fileCoverage?.statementMap ?? {})) {
-      const line = statement?.start?.line;
-      if (!Number.isInteger(line)) continue;
-      const hits = Number(fileCoverage?.s?.[statementId] ?? 0);
-      lineHits.set(line, Math.max(lineHits.get(line) ?? 0, Number.isFinite(hits) ? hits : 0));
+      const start = statement?.start?.line;
+      if (!Number.isInteger(start)) continue;
+      const end = Number.isInteger(statement?.end?.line) ? Math.max(statement.end.line, start) : start;
+      const rawHits = Number(fileCoverage?.s?.[statementId] ?? 0);
+      const hits = Number.isFinite(rawHits) ? rawHits : 0;
+      for (let line = start; line <= end; line += 1) {
+        lineHits.set(line, Math.max(lineHits.get(line) ?? 0, hits));
+      }
     }
     lineHitsByFile.set(file, lineHits);
   }
@@ -129,7 +140,7 @@ function evaluateChangedFile({ file, lines, lineHits }) {
   let total = 0;
   for (const { content, line } of lines) {
     if (!isExecutableSourceLine(content)) continue;
-    // The provider instrumented this file and emitted nothing for this line: it is a declaration or
+    // The provider instrumented this file and no statement covers this line: it is a declaration or
     // a literal, not a statement a test could reach.
     if (instrumented && !lineHits.has(line)) continue;
     total += 1;

--- a/scripts/unit-coverage-gate.mjs
+++ b/scripts/unit-coverage-gate.mjs
@@ -112,20 +112,23 @@ export function normalizeCoveragePath(rawPath, repositoryRoot) {
  * gate asks "does any statement cover this line", which is the question it means to ask, rather
  * than depending on a provider property nothing enforces.
  */
+function recordStatementHits(lineHits, statement, rawHits) {
+  const start = statement?.start?.line;
+  if (!Number.isInteger(start)) return;
+  const end = Number.isInteger(statement?.end?.line) ? Math.max(statement.end.line, start) : start;
+  const hits = Number.isFinite(rawHits) ? rawHits : 0;
+  for (let line = start; line <= end; line += 1) {
+    lineHits.set(line, Math.max(lineHits.get(line) ?? 0, hits));
+  }
+}
+
 export function buildLineHitsByFile(coverage, repositoryRoot) {
   const lineHitsByFile = new Map();
   for (const [rawFile, fileCoverage] of Object.entries(coverage ?? {})) {
     const file = normalizeCoveragePath(rawFile, repositoryRoot);
     const lineHits = lineHitsByFile.get(file) ?? new Map();
     for (const [statementId, statement] of Object.entries(fileCoverage?.statementMap ?? {})) {
-      const start = statement?.start?.line;
-      if (!Number.isInteger(start)) continue;
-      const end = Number.isInteger(statement?.end?.line) ? Math.max(statement.end.line, start) : start;
-      const rawHits = Number(fileCoverage?.s?.[statementId] ?? 0);
-      const hits = Number.isFinite(rawHits) ? rawHits : 0;
-      for (let line = start; line <= end; line += 1) {
-        lineHits.set(line, Math.max(lineHits.get(line) ?? 0, hits));
-      }
+      recordStatementHits(lineHits, statement, Number(fileCoverage?.s?.[statementId] ?? 0));
     }
     lineHitsByFile.set(file, lineHits);
   }


### PR DESCRIPTION
## The gate fails pull requests for lines nothing can cover

`Enforce Patch Coverage` requires **every** changed executable line to be covered — `passed` is `uncovered.length === 0 && percent >= threshold`, so the printed threshold only ever narrows it. That is a defensible bar, but it rests on the gate knowing which lines are executable, and it decides that from the diff text alone.

The filter skips an interface's **opening** line and not its members:

```js
if (/^(?:import\s+type|export\s+(?:type|interface)\b|type\s+\w|interface\s+\w|declare\s+)/.test(trimmed)) {
  return false;
}
```

So every property of a newly added interface is counted as a line awaiting coverage. Bare JSX text children are counted the same way. Neither survives compilation as code, so the provider emits no statement for either, no test can move their hit count, and the author has no way to satisfy the gate except by not adding a type or not changing a string.

On opentag#347 that produced this, at 84.21% against a threshold of 80:

```
apps/web/src/features/agents/account-computer.ts:6,8,10,11   readonly members of a new interface
apps/web/src/agent-creation/agent-creation-flow.tsx:32       readonly agentCount: number;
apps/web/src/features/agents/computers-page.tsx:57           Your Computer
apps/web/src/features/agents/computers-page.tsx:61           No Computer is connected yet.
apps/web/src/features/shell/app-shell.tsx:152                Computer
```

The last three are asserted **by name** in the existing suite (`computer-setup.test.tsx:823-824`, `app.test.tsx:2662`, `app.test.tsx:3250`). The gate called test-asserted copy uncovered.

## What changes

Within a file the provider **did** instrument, the provider is the authority on what can be executed: a changed line it emitted no statement for is skipped rather than blamed.

A file it never instrumented is still treated as wholly uncovered. That is the fail-closed case the rule exists for — a package that silently stops being measured must not read as clean — and its test is unchanged.

This does not lower the bar for code. A line the provider measured and found unrun is still uncovered whatever it contains, and a test pins that, so "skip what the provider omitted" cannot become a way to skip what it measured as never run.

## Verification

- `scripts/__tests__/unit-coverage-gate.test.mjs`: 8 pass. Two are new — one for the uncoverable declarations, one for the unrun-line case that must keep failing. Removing the one-line fix fails only the first.
- Replayed against opentag#347's real diff and a real v8 coverage report: **57 changed lines with 8 unsatisfiable failures becomes 49/49 passing**. I confirmed empirically first that no statement in the report spans those JSX text lines, rather than assuming it.
- `pnpm check` exits 0.

## Disclosure

I am the author of opentag#347, which this unblocks, so I have an interest in the gate being more permissive — please review it on whether the rule is right rather than on whether it helps that PR. The narrower alternative is to teach `isExecutableSourceLine` about interface bodies and JSX text with more regexes; I think deferring to the instrumenter is both smaller and more honest, but that judgement is the thing worth checking.

Not fixed here: the gate's own log reads `Patch coverage: 48/57 lines (84.21%), threshold 80.00%` immediately before failing, which reads as a pass. The threshold is decorative while `uncovered.length === 0` is required, and saying so plainly is a separate change.
