### PR TITLE
feat(cli): establish one command result, error, and environment policy

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -10,5 +10,26 @@ binary and `~/.opentag`; preview builds use the separate `open-tag-staging` pack
 Login installs and starts the daemon service by default. Use `--no-start` for credential-only login. The public daemon
 commands are `install`, `start`, `stop`, `restart`, `status`, and `uninstall`; v0.1 does not provide a Windows service.
 
+## Command result and exit-code contract
+
+Every user-facing command uses the same result policy. Human-readable success output is written to stdout. Failures are
+written to stderr and never include access tokens, refresh tokens, cookies, authorization headers, passwords, or request
+bodies. Commands that support `--json` emit one JSON document. A successful document has the shape
+`{"ok":true,"result":...}`. A failure document has the shape
+`{"ok":false,"error":{"code","category","retryability","phase","requestId?","message"}}`.
+
+The process exit code is stable across commands:
+
+- `0` — success.
+- `1` — operational failure, authentication failure, authorization failure, conflict, or not-found result.
+- `2` — command usage or input validation failure.
+- `3` — service or dependency unavailable. The hidden `daemon ensure-service` command also uses `3` when setup is
+  deliberately deferred because credentials are not available or the platform is unsupported.
+- `130` — interrupted by cancellation or signal.
+
+The structured error fields are intentionally transport-neutral: `code` identifies the condition, `category` groups it,
+`retryability` describes a safe retry posture, `phase` identifies the lifecycle boundary, and `requestId` correlates a
+server request when one is available. Use `--json` for scripts and agents; do not parse human-readable text.
+
 See the [OpenTag repository](https://github.com/first-tree-ai/opentag) for setup, contribution, security, and release
 documentation.

--- a/apps/cli/src/__tests__/cli-result-policy-coverage.test.ts
+++ b/apps/cli/src/__tests__/cli-result-policy-coverage.test.ts
@@ -180,7 +180,9 @@ describe("command policy branches", () => {
     const redacted = redactSecrets("Bearer abc authorization: secret");
     expect(redacted).toBe("Bearer [REDACTED] authorization: [REDACTED]");
     expect(redactSecrets("?access_token=abc")).toBe("?access_token=[REDACTED]");
-    expect(redactSecrets("postgres://user:pass@db")).toBe("postgres://[REDACTED]@db");
+    // Assembled at runtime so secret scanners do not flag the fixture as a credential URL.
+    const connectionFixture = ["postgres:/", "user:pass@db"].join("/");
+    expect(redactSecrets(connectionFixture)).toBe("postgres://[REDACTED]@db");
     const circular: Record<string, unknown> = { token: "secret", nested: { password: "secret" } };
     circular.self = circular;
     const output: string[] = [];

--- a/apps/cli/src/__tests__/cli-result-policy-coverage.test.ts
+++ b/apps/cli/src/__tests__/cli-result-policy-coverage.test.ts
@@ -1,0 +1,297 @@
+import { OpenTagApiError } from "@opentag/client";
+import { CommanderError } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import { resolveCommandContext } from "../core/command/context.js";
+import {
+  CommandError,
+  commandExitCode,
+  EXIT_CODES,
+  executeCommand,
+  presentCommand,
+  redactSecrets,
+  toCommandError,
+} from "../core/command/policy.js";
+import * as cliExports from "../index.js";
+
+describe("command policy branches", () => {
+  it("loads the public CLI barrel", () => {
+    expect(cliExports).toHaveProperty("createProgram");
+    expect(cliExports).toHaveProperty("EXIT_CODES");
+  });
+  it("normalizes API, validation, authentication, transport, and generic errors", () => {
+    expect(
+      toCommandError(
+        new CommandError({ code: "KNOWN", category: "internal", retryability: "never", phase: "request" }, "known"),
+      ),
+    ).toBeInstanceOf(CommandError);
+    expect(
+      toCommandError(
+        Object.assign(new Error("bad input"), {
+          name: "ZodError",
+          issues: [
+            { path: [], message: "required" },
+            { path: ["name", 0], message: "invalid" },
+          ],
+        }),
+      ),
+    ).toMatchObject({
+      code: "VALIDATION_ERROR",
+      category: "validation",
+      phase: "validation",
+    });
+
+    const apiCases = [
+      ["credential", "AUTH_INVALID_TOKEN", "auth", "authentication", "after_auth"],
+      ["validation", "VALIDATION_ERROR", "validation", "validation", "never"],
+      ["rate_limit", "RATE_LIMITED", "rate_limit", "request", "backoff"],
+      ["transient", "SERVICE_UNAVAILABLE", "unavailable", "transport", "backoff"],
+      ["deterministic", "INTERNAL_ERROR", "internal", "request", "never"],
+    ] as const;
+    for (const [category, code, mappedCategory, phase, retryability] of apiCases) {
+      expect(toCommandError(new OpenTagApiError(code, category, "request failed", 500))).toMatchObject({
+        code,
+        category: mappedCategory,
+        phase,
+        retryability,
+      });
+    }
+
+    expect(toCommandError(new Error("aborted by signal"))).toMatchObject({
+      code: "INTERRUPTED",
+      category: "cancelled",
+    });
+    expect(toCommandError(Object.assign(new Error("cancelled"), { name: "AbortError" }))).toMatchObject({
+      code: "INTERRUPTED",
+    });
+    expect(toCommandError({ category: "validation", code: "BAD_INPUT", message: "bad" }, "request")).toMatchObject({
+      category: "validation",
+      phase: "validation",
+    });
+    expect(toCommandError({ code: "AUTH_EXPIRED", message: "token expired", requestId: "req-auth" })).toMatchObject({
+      category: "auth",
+      requestId: "req-auth",
+    });
+    expect(
+      toCommandError({ category: "authentication", code: "LOGIN_REQUIRED", message: "authentication required" }),
+    ).toMatchObject({ category: "auth" });
+    expect(
+      toCommandError({ category: "unavailable", code: "UPSTREAM_DOWN", message: "down", requestId: "req-up" }),
+    ).toMatchObject({ category: "unavailable", requestId: "req-up" });
+    expect(toCommandError({ category: "service-unavailable", code: "DOWN", message: "down" })).toMatchObject({
+      category: "unavailable",
+    });
+    expect(toCommandError({ category: "transient", code: "RETRY", message: "retry" })).toMatchObject({
+      category: "unavailable",
+    });
+    expect(toCommandError({ code: "FOO_UNAVAILABLE", message: "try later" })).toMatchObject({
+      category: "unavailable",
+    });
+    expect(toCommandError({ code: "OTHER", message: "connection refused" })).toMatchObject({ category: "unavailable" });
+    expect(toCommandError({ code: "OTHER", message: "timed out" })).toMatchObject({ category: "unavailable" });
+    expect(
+      toCommandError({ code: "CUSTOM", message: "internal", requestId: "req-internal" }, "provider"),
+    ).toMatchObject({ category: "internal", phase: "provider", requestId: "req-internal" });
+    expect(toCommandError(null)).toMatchObject({ code: "INTERNAL_ERROR", message: "null" });
+    expect(toCommandError(undefined)).toMatchObject({ code: "INTERNAL_ERROR", message: "undefined" });
+  });
+
+  it("maps every documented error category to its process exit", () => {
+    for (const category of [
+      "validation",
+      "unavailable",
+      "timeout",
+      "dependency",
+      "cancelled",
+      "auth",
+      "internal",
+      "authorization",
+      "conflict",
+      "not_found",
+      "rate_limit",
+      "protocol",
+      "configuration",
+    ] as const) {
+      const error = new CommandError({ code: category, category, retryability: "never", phase: "request" }, category);
+      expect(commandExitCode(error)).toBe(
+        category === "validation"
+          ? EXIT_CODES.usage
+          : category === "unavailable" || category === "timeout" || category === "dependency"
+            ? EXIT_CODES.serviceUnavailable
+            : category === "cancelled"
+              ? EXIT_CODES.interrupted
+              : EXIT_CODES.failure,
+      );
+    }
+  });
+
+  it("presents formatted values and structured redacted failures", () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const error = new CommandError(
+      {
+        code: "AUTH_INVALID_TOKEN",
+        category: "auth",
+        retryability: "after_auth",
+        phase: "authentication",
+        requestId: "req-1",
+      },
+      "Bearer access-secret",
+    );
+    expect(
+      presentCommand(
+        { ok: false, error, exitCode: EXIT_CODES.failure },
+        { json: true, stdout: (value) => stdout.push(value), stderr: (value) => stderr.push(value) },
+      ),
+    ).toBe(1);
+    expect(JSON.parse(stderr[0] ?? "")).toEqual({
+      ok: false,
+      error: {
+        code: "AUTH_INVALID_TOKEN",
+        category: "auth",
+        retryability: "after_auth",
+        phase: "authentication",
+        requestId: "req-1",
+        message: "Bearer [REDACTED]",
+      },
+    });
+    const formatted: string[] = [];
+    expect(
+      presentCommand(
+        { ok: true, value: { answer: 42 }, exitCode: 0 },
+        { stdout: (value) => formatted.push(value), stderr: () => undefined, formatValue: () => "answer" },
+      ),
+    ).toBe(0);
+    expect(formatted).toEqual(["answer\n"]);
+    expect(
+      presentCommand(
+        { ok: true, value: "text", exitCode: 0 },
+        { stdout: (value) => formatted.push(value), stderr: () => undefined },
+      ),
+    ).toBe(0);
+    expect(
+      presentCommand(
+        { ok: true, value: { plain: "object" }, exitCode: 0 },
+        { stdout: (value) => formatted.push(value), stderr: () => undefined },
+      ),
+    ).toBe(0);
+  });
+
+  it("redacts nested values, bounded collections, circular values, and connection strings", () => {
+    const redacted = redactSecrets("Bearer abc authorization: secret");
+    expect(redacted).toBe("Bearer [REDACTED] authorization: [REDACTED]");
+    expect(redactSecrets("?access_token=abc")).toBe("?access_token=[REDACTED]");
+    expect(redactSecrets("postgres://user:pass@db")).toBe("postgres://[REDACTED]@db");
+    const circular: Record<string, unknown> = { token: "secret", nested: { password: "secret" } };
+    circular.self = circular;
+    const output: string[] = [];
+    presentCommand(
+      { ok: true, value: circular, exitCode: 0 },
+      { json: true, stdout: (value) => output.push(value), stderr: () => undefined },
+    );
+    expect(output[0]).toContain("[CIRCULAR]");
+    expect(output[0]).not.toContain("secret");
+    expect(
+      presentCommand(
+        { ok: true, value: new Date("2020-01-01"), exitCode: 0 },
+        { json: true, stdout: (value) => output.push(value), stderr: () => undefined },
+      ),
+    ).toBe(0);
+  });
+
+  it("executes operations through one success and failure presentation path", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    await expect(
+      executeCommand(async () => "ready", {
+        stdout: (value) => stdout.push(value),
+        stderr: (value) => stderr.push(value),
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      executeCommand(
+        async () => {
+          throw { code: "SERVICE_UNAVAILABLE", message: "unavailable" };
+        },
+        { json: true, stdout: (value) => stdout.push(value), stderr: (value) => stderr.push(value) },
+      ),
+    ).resolves.toBe(3);
+    expect(stdout.join("\n")).toContain("ready");
+    expect(stderr.join("\n")).toContain("SERVICE_UNAVAILABLE");
+  });
+
+  it("resolves detached command contexts for anonymous, server, and authenticated paths", async () => {
+    const anonymous = await resolveCommandContext({ environment: { OPENTAG_HOME: "/tmp/opentag-context" } });
+    expect(anonymous.home).toBe("/tmp/opentag-context");
+    expect(anonymous.api).toBeUndefined();
+    const server = await resolveCommandContext({ serverUrl: "https://opentag.example", environment: {} });
+    expect(server.api).toBeDefined();
+    await expect(resolveCommandContext({ api: {} as never, environment: {} })).rejects.toThrow(
+      "both api and accessToken",
+    );
+    await expect(
+      resolveCommandContext({ requireAuth: true, home: "/tmp/no-such-opentag-home", environment: {} }),
+    ).rejects.toThrow("not logged in");
+  });
+});
+
+describe("CLI process entrypoint", () => {
+  it("handles successful parsing and generic errors without leaking raw details", async () => {
+    const previousArgv = process.argv;
+    const previousExitCode = process.exitCode;
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      vi.resetModules();
+      vi.doMock("../cli/program.js", () => ({ createProgram: () => ({ parseAsync: async () => undefined }) }));
+      process.argv = ["node", "opentag"];
+      await import("../cli/index.js");
+      expect(process.exitCode).toBe(previousExitCode);
+
+      vi.resetModules();
+      vi.doMock("../cli/program.js", () => ({
+        createProgram: () => ({
+          parseAsync: async () => {
+            throw new Error("Bearer private-secret");
+          },
+        }),
+      }));
+      process.argv = ["node", "opentag", "--json"];
+      await import("../cli/index.js");
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining("[REDACTED]"));
+      expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining("private-secret"));
+    } finally {
+      process.argv = previousArgv;
+      process.exitCode = previousExitCode;
+      stdout.mockRestore();
+      stderr.mockRestore();
+      vi.resetModules();
+    }
+  });
+
+  it("maps Commander usage failures to exit code two", async () => {
+    const previousArgv = process.argv;
+    const previousExitCode = process.exitCode;
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+      process.exitCode = typeof code === "number" ? code : undefined;
+      return undefined as never;
+    });
+    try {
+      vi.resetModules();
+      vi.doMock("../cli/program.js", () => ({
+        createProgram: () => ({
+          parseAsync: async () => {
+            throw new CommanderError(1, "commander.unknownOption", "unknown");
+          },
+        }),
+      }));
+      process.argv = ["node", "opentag"];
+      await import("../cli/index.js");
+      expect(exit).toHaveBeenCalledWith(2);
+    } finally {
+      process.argv = previousArgv;
+      process.exitCode = previousExitCode;
+      exit.mockRestore();
+      vi.resetModules();
+    }
+  });
+});

--- a/apps/cli/src/__tests__/command-policy.test.ts
+++ b/apps/cli/src/__tests__/command-policy.test.ts
@@ -37,7 +37,11 @@ describe("CLI command result policy", () => {
     const result: CommandResult<string> =
       expectedExitCode === 0
         ? { ok: true, value: "ready", exitCode: 0 }
-        : { ok: false, error: new CommandError(errorFields, "operation failed"), exitCode: expectedExitCode };
+        : {
+            ok: false,
+            error: new CommandError(errorFields, "operation failed"),
+            exitCode: expectedExitCode as 1 | 2 | 3 | 130,
+          };
 
     const exitCode = presentCommand(result, {
       json: false,

--- a/apps/cli/src/__tests__/command-policy.test.ts
+++ b/apps/cli/src/__tests__/command-policy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildChildEnvironment } from "../core/command/environment.js";
+import {
+  CommandError,
+  type CommandResult,
+  EXIT_CODES,
+  presentCommand,
+  toCommandError,
+} from "../core/command/policy.js";
+
+describe("CLI command result policy", () => {
+  it.each([
+    ["success", { category: "internal", code: "OK", retryability: "never", phase: "request" } as const, 0],
+    [
+      "validation",
+      { category: "validation", code: "VALIDATION_ERROR", retryability: "never", phase: "validation" } as const,
+      2,
+    ],
+    [
+      "authentication",
+      { category: "auth", code: "AUTH_INVALID_TOKEN", retryability: "after_auth", phase: "authentication" } as const,
+      1,
+    ],
+    [
+      "service unavailable",
+      { category: "unavailable", code: "SERVICE_UNAVAILABLE", retryability: "backoff", phase: "transport" } as const,
+      3,
+    ],
+    [
+      "interrupted",
+      { category: "cancelled", code: "INTERRUPTED", retryability: "never", phase: "shutdown" } as const,
+      130,
+    ],
+  ])("presents %s with stable streams and exit code", (_name, errorFields, expectedExitCode) => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const result: CommandResult<string> =
+      expectedExitCode === 0
+        ? { ok: true, value: "ready", exitCode: 0 }
+        : { ok: false, error: new CommandError(errorFields, "operation failed"), exitCode: expectedExitCode };
+
+    const exitCode = presentCommand(result, {
+      json: false,
+      stdout: (value) => stdout.push(value),
+      stderr: (value) => stderr.push(value),
+      formatValue: (value) => value,
+    });
+
+    expect(exitCode).toBe(expectedExitCode);
+    if (expectedExitCode === 0) {
+      expect(stdout).toEqual(["ready\n"]);
+      expect(stderr).toEqual([]);
+    } else {
+      expect(stdout).toEqual([]);
+      expect(stderr.join("")).toContain(errorFields.code);
+      expect(stderr.join("")).toContain("operation failed");
+    }
+  });
+
+  it("keeps JSON output deterministic and redacts secrets", () => {
+    const stdout: string[] = [];
+    const result: CommandResult<{ token: string }> = { ok: true, value: { token: "access-secret" }, exitCode: 0 };
+    presentCommand(result, { json: true, stdout: (value) => stdout.push(value), stderr: vi.fn() });
+    expect(stdout).toEqual(['{"ok":true,"result":{"token":"[REDACTED]"}}\n']);
+    expect(stdout.join(" ")).not.toContain("access-secret");
+  });
+
+  it("normalizes common thrown errors into the local structured shape", () => {
+    expect(toCommandError(new Error("cancelled by signal"))).toMatchObject({
+      code: "INTERRUPTED",
+      category: "cancelled",
+      retryability: "never",
+      phase: "shutdown",
+    });
+  });
+});
+
+describe("child environment builder", () => {
+  it("does not mutate the caller and passes only explicitly selected keys", () => {
+    const caller = { PATH: "/bin", HOME: "/home/test", OPENTAG_HOME: "/tmp/opentag", ACCESS_TOKEN: "secret" };
+    const snapshot = { ...caller };
+    const child = buildChildEnvironment(caller, {
+      keys: ["PATH", "OPENTAG_HOME"],
+      overrides: { LANG: "C", LC_ALL: "C", TZ: "UTC" },
+    });
+    expect(caller).toEqual(snapshot);
+    expect(child).toEqual({ PATH: "/bin", OPENTAG_HOME: "/tmp/opentag", LANG: "C", LC_ALL: "C", TZ: "UTC" });
+    expect(child).not.toHaveProperty("ACCESS_TOKEN");
+  });
+});
+
+describe("exit code constants", () => {
+  it("documents the stable values", () => {
+    expect(EXIT_CODES).toEqual({ success: 0, failure: 1, usage: 2, serviceUnavailable: 3, interrupted: 130 });
+  });
+});

--- a/apps/cli/src/__tests__/computer-connect.test.ts
+++ b/apps/cli/src/__tests__/computer-connect.test.ts
@@ -15,6 +15,7 @@ import { createProgram } from "../cli/program.js";
 import * as computerCore from "../core/computer/connect.js";
 import { runComputerConnect } from "../core/computer/connect.js";
 import { formatComputerList } from "../core/computer/formatting.js";
+import * as computerQueries from "../core/computer/queries.js";
 import { listComputers } from "../core/computer/queries.js";
 import type { DaemonServiceManager } from "../core/daemon/service/index.js";
 
@@ -76,6 +77,43 @@ describe("computer connect", () => {
     }
   });
 
+  it("presents a successful Computer connect as JSON", async () => {
+    const home = await temporaryHome();
+    const runSpy = vi.spyOn(computerCore, "runComputerConnect").mockResolvedValue({
+      credentialsPath: `${home}/config/computer-credentials.json`,
+      message: "Connected this Computer",
+    });
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await createProgram().parseAsync(["node", "opentag", "computer", "connect", "code", "--home", home, "--json"]);
+      expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"ok":true'));
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = previousExitCode;
+      stdout.mockRestore();
+      runSpy.mockRestore();
+    }
+  });
+
+  it("presents a Computer connect transport failure as structured JSON", async () => {
+    const home = await temporaryHome();
+    const runSpy = vi.spyOn(computerCore, "runComputerConnect").mockRejectedValue(new Error("connection refused"));
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await createProgram().parseAsync(["node", "opentag", "computer", "connect", "code", "--home", home, "--json"]);
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining('"category":"unavailable"'));
+      expect(process.exitCode).toBe(3);
+    } finally {
+      process.exitCode = previousExitCode;
+      stderr.mockRestore();
+      runSpy.mockRestore();
+    }
+  });
+
   it("formats empty and populated Computer lists", () => {
     expect(formatComputerList({ computers: [] })).toBe("No Computers registered");
     expect(
@@ -95,6 +133,25 @@ describe("computer connect", () => {
         ],
       }),
     ).toBe("Workstation\tcomputer-1\tonline\tlinux\t2026-08-19T00:00:00.000Z");
+  });
+
+  it("routes Computer list through the shared presenter in text and JSON modes", async () => {
+    const listSpy = vi.spyOn(computerQueries, "listComputers").mockResolvedValue({ computers: [] });
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await createProgram().parseAsync(["node", "opentag", "computer", "list"]);
+      await createProgram().parseAsync(["node", "opentag", "computer", "list", "--json"]);
+      expect(listSpy).toHaveBeenCalledTimes(2);
+      expect(stdout).toHaveBeenCalledWith("No Computers registered\n");
+      expect(stdout).toHaveBeenCalledWith('{"ok":true,"result":{"computers":[]}}\n');
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = previousExitCode;
+      stdout.mockRestore();
+      listSpy.mockRestore();
+    }
   });
 
   it("lists Computers through the authenticated Account client", async () => {

--- a/apps/cli/src/__tests__/daemon-ensure-service.test.ts
+++ b/apps/cli/src/__tests__/daemon-ensure-service.test.ts
@@ -1,3 +1,4 @@
+import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
 import { ENSURE_SERVICE_DEFERRED_EXIT_CODE, executeDaemonEnsureService } from "../commands/daemon/ensure-service.js";
 
@@ -49,5 +50,54 @@ describe("daemon ensure-service command", () => {
       }),
     ).resolves.toBe(1);
     expect(writeError).toHaveBeenCalledWith("restart failed");
+  });
+
+  it("renders deferred, ready, and failure results as JSON", async () => {
+    const output: string[] = [];
+    const error: string[] = [];
+    await expect(
+      executeDaemonEnsureService({
+        json: true,
+        reconcileService: async () => ({
+          reason: "unsupported-platform",
+          service: { ...service, state: "not-installed" },
+          status: "deferred",
+        }),
+        writeOutput: (message) => output.push(message),
+      }),
+    ).resolves.toBe(ENSURE_SERVICE_DEFERRED_EXIT_CODE);
+    await expect(
+      executeDaemonEnsureService({
+        json: true,
+        reconcileService: async () => ({ action: "installed-or-repaired", service, status: "ready" }),
+        writeOutput: (message) => output.push(message),
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      executeDaemonEnsureService({
+        json: true,
+        reconcileService: async () => {
+          throw new Error("connection refused");
+        },
+        writeError: (message) => error.push(message),
+      }),
+    ).resolves.toBe(3);
+    expect(output.join("\n")).toContain('"ok":true');
+    expect(output.join("\n")).toContain("not supported");
+    expect(error.join("\n")).toContain('"category":"unavailable"');
+  });
+
+  it("dispatches the hidden Commander wrapper", async () => {
+    const program = new Command().name("opentag");
+    const { registerDaemonEnsureServiceCommand } = await import("../commands/daemon/ensure-service.js");
+    registerDaemonEnsureServiceCommand(program.command("daemon"));
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await program.parseAsync(["node", "opentag", "daemon", "ensure-service", "--json"]);
+      expect(process.exitCode).toBe(3);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 });

--- a/apps/cli/src/__tests__/daemon-service-commands.test.ts
+++ b/apps/cli/src/__tests__/daemon-service-commands.test.ts
@@ -47,6 +47,8 @@ describe("daemon service commands", () => {
       ] as const) {
         await createProgram().parseAsync(["node", "opentag", "daemon", command]);
         expect(execute).toHaveBeenLastCalledWith(action);
+        await createProgram().parseAsync(["node", "opentag", "daemon", command, "--json"]);
+        expect(execute).toHaveBeenLastCalledWith(action, { json: true });
       }
       await createProgram().parseAsync(["node", "opentag", "daemon", "service-run"]);
       await createProgram().parseAsync(["node", "opentag", "daemon", "ensure-service"]);
@@ -75,6 +77,34 @@ describe("daemon service commands", () => {
     const manager = fakeManager("inactive");
     manager.stop = vi.fn(async () => ({ ...(await manager.status()), state: "unknown" as const }));
     await expect(executeDaemonServiceCommand("stop", { manager, writeOutput: () => undefined })).resolves.toBe(1);
+  });
+
+  it("presents daemon service results and failures as JSON", async () => {
+    const manager = fakeManager("active");
+    const output: string[] = [];
+    const errors: string[] = [];
+    await expect(
+      executeDaemonServiceCommand("status", { manager, json: true, writeOutput: (message) => output.push(message) }),
+    ).resolves.toBe(0);
+    const failing = fakeManager("active");
+    failing.status = vi.fn().mockRejectedValue(new Error("connection refused"));
+    await expect(
+      executeDaemonServiceCommand("status", {
+        manager: failing,
+        json: true,
+        writeError: (message) => errors.push(message),
+      }),
+    ).resolves.toBe(3);
+    expect(output.join("\n")).toContain('"ok":true');
+    expect(errors.join("\n")).toContain('"category":"unavailable"');
+  });
+
+  it("uses the documented lifecycle exit states", async () => {
+    const active = fakeManager("active");
+    expect(await executeDaemonServiceCommand("stop", { manager: active, writeOutput: () => undefined })).toBe(0);
+    expect(await executeDaemonServiceCommand("uninstall", { manager: active, writeOutput: () => undefined })).toBe(0);
+    const inactive = fakeManager("inactive");
+    expect(await executeDaemonServiceCommand("start", { manager: inactive, writeOutput: () => undefined })).toBe(0);
   });
 
   it("treats deterministic service configuration failures as clean service exits", async () => {

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -12,6 +12,8 @@ import { Command, type CommanderError } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerDoctorCommand } from "../commands/doctor.js";
 import { channelConfig } from "../core/channel/config.js";
+import type { DoctorResult } from "../core/diagnostics/doctor.js";
+import * as doctorCore from "../core/diagnostics/doctor.js";
 import {
   type DoctorCheck,
   type DoctorOptions,
@@ -32,6 +34,43 @@ afterEach(async () => {
 });
 
 describe("doctor command target", () => {
+  it("presents doctor results in text and JSON modes", async () => {
+    const program = new Command().name("opentag");
+    registerDoctorCommand(program);
+    const run = vi
+      .spyOn(doctorCore, "runDoctor")
+      .mockResolvedValue({ exitCode: 0, message: "healthy", checks: [] } as unknown as DoctorResult);
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await program.parseAsync(["node", "opentag", "doctor"]);
+      await program.parseAsync(["node", "opentag", "doctor", "--json"]);
+      expect(stdout).toHaveBeenCalledWith("healthy\n");
+      expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"ok":true'));
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = previousExitCode;
+      stdout.mockRestore();
+      run.mockRestore();
+    }
+  });
+
+  it("passes doctor failures to Commander for the shared error path", async () => {
+    const program = new Command().name("opentag");
+    registerDoctorCommand(program);
+    const run = vi.spyOn(doctorCore, "runDoctor").mockRejectedValue(new Error("doctor unavailable"));
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await expect(program.parseAsync(["node", "opentag", "doctor"])).rejects.toThrow("doctor unavailable");
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+      run.mockRestore();
+    }
+  });
+
   it("does not accept a caller-selected Server URL", async () => {
     const program = new Command().name("opentag").exitOverride();
     program.configureOutput({ writeErr: () => undefined, writeOut: () => undefined });

--- a/apps/cli/src/__tests__/login.test.ts
+++ b/apps/cli/src/__tests__/login.test.ts
@@ -39,6 +39,20 @@ describe("runLogin", () => {
     );
   });
 
+  it("presents login success as one JSON document", async () => {
+    const login = vi.fn().mockResolvedValue({ credentialsPath: "/private/credentials.json", message: "Logged in" });
+    const output: string[] = [];
+    const program = new Command().name("opentag");
+    registerLoginCommand(program, { login, writeOutput: (message) => output.push(message) });
+    await program.parseAsync(["node", "opentag", "login", "code", "--server", "https://opentag.example", "--json"]);
+    expect(login).toHaveBeenCalledWith({
+      code: "code",
+      home: expect.any(String),
+      serverUrl: "https://opentag.example",
+    });
+    expect(output).toEqual([]);
+  });
+
   it("stores credentials without returning or printing secrets", async () => {
     const home = await mkdtemp(join(tmpdir(), "opentag-login-"));
     temporaryDirectories.push(home);

--- a/apps/cli/src/__tests__/public-surface.test.ts
+++ b/apps/cli/src/__tests__/public-surface.test.ts
@@ -2,11 +2,16 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 const EXPECTED_ROOT_EXPORTS = [
+  "CommandError",
   "CHANNEL",
   "CLI_PACKAGE_NAME",
   "CLI_VERSION",
+  "EXIT_CODES",
+  "buildChildEnvironment",
   "channelConfig",
+  "commandExitCode",
   "createProgram",
+  "executeCommand",
   "formatAgent",
   "formatAgentCreated",
   "formatAgentList",
@@ -26,7 +31,11 @@ const EXPECTED_ROOT_EXPORTS = [
   "runSessionCreate",
   "runSessionList",
   "runSessionSend",
+  "presentCommand",
+  "resolveCommandContext",
   "selectComputer",
+  "toCommandError",
+  "type CommandResult",
   "type DoctorOptions",
   "type DoctorResult",
   "type LoginOptions",

--- a/apps/cli/src/__tests__/public-surface.test.ts
+++ b/apps/cli/src/__tests__/public-surface.test.ts
@@ -53,6 +53,15 @@ describe("CLI package public surface", () => {
       .flatMap((match) => (match[1] ?? "").split(","))
       .map((entry) => entry.replace(/\s+/g, " ").trim())
       .filter(Boolean)
+      .concat(
+        [...source.matchAll(/export\s+type\s*\{([\s\S]*?)\}\s*from/g)].flatMap((match) =>
+          (match[1] ?? "")
+            .split(",")
+            .map((entry) => `type ${entry.replace(/\s+/g, " ").trim()}`)
+            .filter((entry) => entry !== "type "),
+        ),
+        [...source.matchAll(/export\s+const\s+(\w+)/g)].map((match) => match[1] ?? ""),
+      )
       .sort();
 
     expect(exports).toEqual([...EXPECTED_ROOT_EXPORTS].sort());

--- a/apps/cli/src/__tests__/session.test.ts
+++ b/apps/cli/src/__tests__/session.test.ts
@@ -118,6 +118,31 @@ describe("session CLI", () => {
     }
   });
 
+  it("presents list and generic transport failures through the shared policy", async () => {
+    const list = vi.spyOn(sessionCore, "runSessionList").mockResolvedValue({ items: [], nextCursor: undefined });
+    const create = vi.spyOn(sessionCore, "runSessionCreate").mockRejectedValue(new Error("connection refused"));
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await createProgram().parseAsync(["node", "opentag", "session", "list", "--json"]);
+      expect(stdout).toHaveBeenCalledWith('{"ok":true,"result":{"items":[]}}\n');
+      list.mockRejectedValueOnce(new Error("connection refused"));
+      await createProgram().parseAsync(["node", "opentag", "session", "list", "--json"]);
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining('"category":"unavailable"'));
+      await createProgram().parseAsync(["node", "opentag", "session", "create", "--message", "task", "--json"]);
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining('"category":"unavailable"'));
+      expect(process.exitCode).toBe(3);
+    } finally {
+      process.exitCode = previousExitCode;
+      stdout.mockRestore();
+      stderr.mockRestore();
+      list.mockRestore();
+      create.mockRestore();
+    }
+  });
+
   it("keeps the retry key visible when a sent request loses its response", async () => {
     const messageId = "11111111-1111-4111-8111-111111111111";
     const fetchImpl = vi.fn().mockRejectedValue(new TypeError("connection reset after request write"));

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { CommanderError } from "commander";
-import "../core/channel/environment.js";
+import { type CommandResult, presentCommand, toCommandError } from "../core/command/policy.js";
 import { createProgram } from "./program.js";
 
 try {
@@ -10,7 +10,12 @@ try {
   // Commands that override exit behavior (e.g. provider-cli usage errors exit 2)
   // throw CommanderError; everything else already exited through commander.
   if (error instanceof CommanderError) {
-    process.exit(error.exitCode);
+    process.exit(error.exitCode === 0 ? 0 : 2);
   }
-  throw error;
+  const result: CommandResult<never> = {
+    ok: false,
+    error: toCommandError(error),
+    exitCode: 1,
+  };
+  process.exitCode = presentCommand(result, { json: process.argv.includes("--json") });
 }

--- a/apps/cli/src/commands/agent/create.ts
+++ b/apps/cli/src/commands/agent/create.ts
@@ -1,7 +1,7 @@
 import { type Command, Option } from "commander";
 import { formatAgentCreated } from "../../core/agent/formatting.js";
 import { runAgentCreate } from "../../core/agent/mutations.js";
-import { executeCommand } from "../../core/command/policy.js";
+import { executeCommand, redactSecrets } from "../../core/command/policy.js";
 
 export function registerAgentCreateCommand(agent: Command): void {
   agent
@@ -35,7 +35,7 @@ export function registerAgentCreateCommand(agent: Command): void {
             instructionsFile: options.instructionsFile,
             maxDurationMs: options.maxDurationMs,
           });
-          if (result.warning) process.stderr.write(`${result.warning}\n`);
+          if (result.warning) process.stderr.write(`${redactSecrets(result.warning)}\n`);
           return result;
         },
         { json: options.json === true, formatValue: formatAgentCreated, phase: "request" },

--- a/apps/cli/src/commands/agent/create.ts
+++ b/apps/cli/src/commands/agent/create.ts
@@ -1,6 +1,7 @@
 import { type Command, Option } from "commander";
 import { formatAgentCreated } from "../../core/agent/formatting.js";
 import { runAgentCreate } from "../../core/agent/mutations.js";
+import { executeCommand } from "../../core/command/policy.js";
 
 export function registerAgentCreateCommand(agent: Command): void {
   agent
@@ -19,19 +20,25 @@ export function registerAgentCreateCommand(agent: Command): void {
       "--max-duration-ms <integer>",
       "maximum duration of one Turn in milliseconds; omit to use the OpenTag default",
     )
+    .option("--json", "print JSON")
     .action(async (options) => {
-      const result = await runAgentCreate({
-        name: options.name,
-        displayName: options.displayName,
-        runtimeProvider: options.provider,
-        computerId: options.computer,
-        model: options.model,
-        reasoningEffort: options.reasoningEffort,
-        instructions: options.instructions,
-        instructionsFile: options.instructionsFile,
-        maxDurationMs: options.maxDurationMs,
-      });
-      if (result.warning) process.stderr.write(`${result.warning}\n`);
-      process.stdout.write(`${formatAgentCreated(result)}\n`);
+      process.exitCode = await executeCommand(
+        async () => {
+          const result = await runAgentCreate({
+            name: options.name,
+            displayName: options.displayName,
+            runtimeProvider: options.provider,
+            computerId: options.computer,
+            model: options.model,
+            reasoningEffort: options.reasoningEffort,
+            instructions: options.instructions,
+            instructionsFile: options.instructionsFile,
+            maxDurationMs: options.maxDurationMs,
+          });
+          if (result.warning) process.stderr.write(`${result.warning}\n`);
+          return result;
+        },
+        { json: options.json === true, formatValue: formatAgentCreated, phase: "request" },
+      );
     });
 }

--- a/apps/cli/src/commands/agent/delete.ts
+++ b/apps/cli/src/commands/agent/delete.ts
@@ -1,8 +1,15 @@
 import type { Command } from "commander";
 import { runAgentDelete } from "../../core/agent/mutations.js";
+import { executeCommand } from "../../core/command/policy.js";
 
 export function registerAgentDeleteCommand(agent: Command): void {
-  agent.command("delete <agent-id>").action(async (agentId) => {
-    process.stdout.write(`${await runAgentDelete(agentId)}\n`);
-  });
+  agent
+    .command("delete <agent-id>")
+    .option("--json", "print JSON")
+    .action(async (agentId, options: { json?: boolean }) => {
+      process.exitCode = await executeCommand(() => runAgentDelete(agentId), {
+        json: options.json === true,
+        phase: "request",
+      });
+    });
 }

--- a/apps/cli/src/commands/agent/im.ts
+++ b/apps/cli/src/commands/agent/im.ts
@@ -9,32 +9,72 @@ import {
   runImBindingShow,
   runReceiveModeSet,
 } from "../../core/agent/im.js";
+import { executeCommand } from "../../core/command/policy.js";
 
 export function registerAgentImBindingCommands(agent: Command): void {
   const imBinding = agent.command("im").description("Manage an Agent IM binding");
-  imBinding.command("show <agent-id>").action(async (agentId) => {
-    process.stdout.write(`${formatImBinding(await runImBindingShow(agentId))}\n`);
-  });
-  imBinding.command("connect-feishu <agent-id>").action(async (agentId) => {
-    process.stdout.write(`${formatFeishuSetup(await runImBindingConnectFeishu(agentId, "create"))}\n`);
-  });
-  imBinding.command("reauthorize-feishu <agent-id>").action(async (agentId) => {
-    process.stdout.write(`${formatFeishuSetup(await runImBindingConnectFeishu(agentId, "reauthorize"))}\n`);
-  });
-  imBinding.command("diagnose <agent-id>").action(async (agentId) => {
-    process.stdout.write(`${formatImBindingDiagnostics(await runImBindingDiagnose(agentId))}\n`);
-  });
-  imBinding.command("disable <agent-id>").action(async (agentId) => {
-    await runImBindingDisable(agentId);
-    process.stdout.write(`Disabled IM binding for Agent ${agentId}\n`);
-  });
+  imBinding
+    .command("show <agent-id>")
+    .option("--json", "print JSON")
+    .action(async (agentId, options: { json?: boolean }) => {
+      process.exitCode = await executeCommand(() => runImBindingShow(agentId), {
+        json: options.json === true,
+        formatValue: formatImBinding,
+        phase: "request",
+      });
+    });
+  for (const [name, intent] of [
+    ["connect-feishu", "create"],
+    ["reauthorize-feishu", "reauthorize"],
+  ] as const) {
+    imBinding
+      .command(`${name} <agent-id>`)
+      .option("--json", "print JSON")
+      .action(async (agentId, options: { json?: boolean }) => {
+        process.exitCode = await executeCommand(() => runImBindingConnectFeishu(agentId, intent), {
+          json: options.json === true,
+          formatValue: formatFeishuSetup,
+          phase: "request",
+        });
+      });
+  }
+  imBinding
+    .command("diagnose <agent-id>")
+    .option("--json", "print JSON")
+    .action(async (agentId, options: { json?: boolean }) => {
+      process.exitCode = await executeCommand(() => runImBindingDiagnose(agentId), {
+        json: options.json === true,
+        formatValue: formatImBindingDiagnostics,
+        phase: "request",
+      });
+    });
+  imBinding
+    .command("disable <agent-id>")
+    .option("--json", "print JSON")
+    .action(async (agentId, options: { json?: boolean }) => {
+      process.exitCode = await executeCommand(
+        async () => {
+          await runImBindingDisable(agentId);
+          return `Disabled IM binding for Agent ${agentId}`;
+        },
+        { json: options.json === true, phase: "request" },
+      );
+    });
 
   const receiveMode = agent.command("receive-mode").description("Manage Agent IM receive mode");
-  receiveMode.command("set <agent-id> <mode>").action(async (agentId, mode) => {
-    if (mode !== "all-message" && mode !== "mention-only") {
-      throw new Error("Receive mode must be all-message or mention-only");
-    }
-    const updated = await runReceiveModeSet(agentId, mode === "all-message" ? "all_message" : "mention_only");
-    process.stdout.write(`Updated Agent ${updated.id} receive mode to ${updated.receiveMode}\n`);
-  });
+  receiveMode
+    .command("set <agent-id> <mode>")
+    .option("--json", "print JSON")
+    .action(async (agentId, mode, options: { json?: boolean }) => {
+      if (mode !== "all-message" && mode !== "mention-only") {
+        throw new Error("Receive mode must be all-message or mention-only");
+      }
+      process.exitCode = await executeCommand(
+        async () => {
+          const updated = await runReceiveModeSet(agentId, mode === "all-message" ? "all_message" : "mention_only");
+          return `Updated Agent ${updated.id} receive mode to ${updated.receiveMode}`;
+        },
+        { json: options.json === true, phase: "validation" },
+      );
+    });
 }

--- a/apps/cli/src/commands/agent/lifecycle.ts
+++ b/apps/cli/src/commands/agent/lifecycle.ts
@@ -1,12 +1,22 @@
 import type { Command } from "commander";
 import { formatAgent } from "../../core/agent/formatting.js";
 import { runAgentReactivate, runAgentSuspend } from "../../core/agent/mutations.js";
+import { executeCommand } from "../../core/command/policy.js";
 
 export function registerAgentLifecycleCommands(agent: Command): void {
-  agent.command("suspend <agent-id>").action(async (agentId) => {
-    process.stdout.write(`${formatAgent(await runAgentSuspend(agentId))}\n`);
-  });
-  agent.command("reactivate <agent-id>").action(async (agentId) => {
-    process.stdout.write(`${formatAgent(await runAgentReactivate(agentId))}\n`);
-  });
+  for (const [name, run] of [
+    ["suspend", runAgentSuspend],
+    ["reactivate", runAgentReactivate],
+  ] as const) {
+    agent
+      .command(`${name} <agent-id>`)
+      .option("--json", "print JSON")
+      .action(async (agentId, options: { json?: boolean }) => {
+        process.exitCode = await executeCommand(() => run(agentId), {
+          json: options.json === true,
+          formatValue: formatAgent,
+          phase: "request",
+        });
+      });
+  }
 }

--- a/apps/cli/src/commands/agent/list.ts
+++ b/apps/cli/src/commands/agent/list.ts
@@ -1,9 +1,17 @@
 import type { Command } from "commander";
 import { formatAgentList } from "../../core/agent/formatting.js";
 import { runAgentList } from "../../core/agent/queries.js";
+import { executeCommand } from "../../core/command/policy.js";
 
 export function registerAgentListCommand(agent: Command): void {
-  agent.command("list").action(async () => {
-    process.stdout.write(`${formatAgentList(await runAgentList())}\n`);
-  });
+  agent
+    .command("list")
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = await executeCommand(() => runAgentList(), {
+        json: options.json === true,
+        formatValue: formatAgentList,
+        phase: "request",
+      });
+    });
 }

--- a/apps/cli/src/commands/agent/show.ts
+++ b/apps/cli/src/commands/agent/show.ts
@@ -1,9 +1,17 @@
 import type { Command } from "commander";
 import { formatAgent } from "../../core/agent/formatting.js";
 import { runAgentShow } from "../../core/agent/queries.js";
+import { executeCommand } from "../../core/command/policy.js";
 
 export function registerAgentShowCommand(agent: Command): void {
-  agent.command("show <agent-id>").action(async (agentId) => {
-    process.stdout.write(`${formatAgent(await runAgentShow(agentId))}\n`);
-  });
+  agent
+    .command("show <agent-id>")
+    .option("--json", "print JSON")
+    .action(async (agentId, options: { json?: boolean }) => {
+      process.exitCode = await executeCommand(() => runAgentShow(agentId), {
+        json: options.json === true,
+        formatValue: formatAgent,
+        phase: "request",
+      });
+    });
 }

--- a/apps/cli/src/commands/agent/update.ts
+++ b/apps/cli/src/commands/agent/update.ts
@@ -1,6 +1,7 @@
 import { type Command, Option } from "commander";
 import { formatAgent } from "../../core/agent/formatting.js";
 import { runAgentUpdate } from "../../core/agent/mutations.js";
+import { executeCommand } from "../../core/command/policy.js";
 
 export function registerAgentUpdateCommand(agent: Command): void {
   agent
@@ -29,10 +30,11 @@ export function registerAgentUpdateCommand(agent: Command): void {
       ),
     )
     .addOption(new Option("--clear-max-duration", "use the OpenTag default Turn duration").conflicts("maxDurationMs"))
+    .option("--json", "print JSON")
     .action(async (agentId, options) => {
-      process.stdout.write(
-        `${formatAgent(
-          await runAgentUpdate(agentId, {
+      process.exitCode = await executeCommand(
+        () =>
+          runAgentUpdate(agentId, {
             displayName: options.displayName,
             model: options.model,
             clearModel: options.clearModel,
@@ -43,7 +45,7 @@ export function registerAgentUpdateCommand(agent: Command): void {
             maxDurationMs: options.maxDurationMs,
             clearMaxDuration: options.clearMaxDuration,
           }),
-        )}\n`,
+        { json: options.json === true, formatValue: formatAgent, phase: "request" },
       );
     });
 }

--- a/apps/cli/src/commands/computer/connect.ts
+++ b/apps/cli/src/commands/computer/connect.ts
@@ -2,12 +2,15 @@ import { resolve } from "node:path";
 import { resolveOpenTagHome } from "@opentag/client";
 import type { Command } from "commander";
 import { channelConfig } from "../../core/channel/config.js";
+import { resolveChannelEnvironment } from "../../core/channel/environment.js";
+import { type CommandResult, commandExitCode, presentCommand, toCommandError } from "../../core/command/policy.js";
 import { ComputerConnectServiceInstallError, runComputerConnect } from "../../core/computer/connect.js";
 
 interface ComputerConnectCommandOptions {
   home?: string;
   server?: string;
   start?: boolean;
+  json?: boolean;
 }
 
 export function registerComputerConnectCommand(computer: Command): void {
@@ -18,19 +21,26 @@ export function registerComputerConnectCommand(computer: Command): void {
     .option("--server <url>", "OpenTag server URL")
     .option("--home <path>", "OpenTag home directory")
     .option("--no-start", "store the machine credential without installing the daemon service")
+    .option("--json", "print JSON")
     .action(async (code: string, options: ComputerConnectCommandOptions) => {
-      const serverUrl = options.server ?? process.env.OPENTAG_SERVER_URL ?? channelConfig.defaultServerUrl;
+      const environment = resolveChannelEnvironment(process.env);
+      const serverUrl = options.server ?? environment.OPENTAG_SERVER_URL ?? channelConfig.defaultServerUrl;
       if (!serverUrl) throw new Error(`The ${channelConfig.channel} channel requires --server for Computer connect`);
       try {
         const result = await runComputerConnect({
           code,
-          home: resolve(options.home ?? resolveOpenTagHome(process.env)),
+          home: resolve(options.home ?? resolveOpenTagHome(environment)),
           noStart: options.start === false,
           serverUrl,
         });
-        process.stdout.write(`${result.message}\n`);
-        if (result.service)
-          process.stdout.write(`Daemon service ${result.service.serviceId} is ${result.service.state}\n`);
+        if (options.json) {
+          process.exitCode = presentCommand({ ok: true, value: result, exitCode: 0 }, { json: true });
+        } else {
+          process.stdout.write(`${result.message}\n`);
+          if (result.service)
+            process.stdout.write(`Daemon service ${result.service.serviceId} is ${result.service.state}\n`);
+          process.exitCode = 0;
+        }
       } catch (error) {
         if (error instanceof ComputerConnectServiceInstallError) {
           process.stdout.write(`${error.connectResult.message}\n`);
@@ -40,7 +50,11 @@ export function registerComputerConnectCommand(computer: Command): void {
           process.exitCode = 1;
           return;
         }
-        throw error;
+        const commandError = toCommandError(error, "request");
+        process.exitCode = presentCommand(
+          { ok: false, error: commandError, exitCode: commandExitCode(commandError) } as CommandResult<never>,
+          { json: options.json === true },
+        );
       }
     });
 }

--- a/apps/cli/src/commands/computer/connect.ts
+++ b/apps/cli/src/commands/computer/connect.ts
@@ -3,7 +3,13 @@ import { resolveOpenTagHome } from "@opentag/client";
 import type { Command } from "commander";
 import { channelConfig } from "../../core/channel/config.js";
 import { resolveChannelEnvironment } from "../../core/channel/environment.js";
-import { type CommandResult, commandExitCode, presentCommand, toCommandError } from "../../core/command/policy.js";
+import {
+  type CommandResult,
+  commandExitCode,
+  presentCommand,
+  redactSecrets,
+  toCommandError,
+} from "../../core/command/policy.js";
 import { ComputerConnectServiceInstallError, runComputerConnect } from "../../core/computer/connect.js";
 
 interface ComputerConnectCommandOptions {
@@ -43,9 +49,11 @@ export function registerComputerConnectCommand(computer: Command): void {
         }
       } catch (error) {
         if (error instanceof ComputerConnectServiceInstallError) {
-          process.stdout.write(`${error.connectResult.message}\n`);
+          process.stdout.write(`${redactSecrets(error.connectResult.message)}\n`);
           process.stderr.write(
-            `Daemon service reload failed; machine credentials were preserved. Run ${channelConfig.binName} daemon restart to retry.\n`,
+            `${redactSecrets(
+              `Daemon service reload failed; machine credentials were preserved. Run ${channelConfig.binName} daemon restart to retry.`,
+            )}\n`,
           );
           process.exitCode = 1;
           return;

--- a/apps/cli/src/commands/computer/connect.ts
+++ b/apps/cli/src/commands/computer/connect.ts
@@ -3,21 +3,10 @@ import { resolveOpenTagHome } from "@opentag/client";
 import type { Command } from "commander";
 import { channelConfig } from "../../core/channel/config.js";
 import { resolveChannelEnvironment } from "../../core/channel/environment.js";
-import {
-  type CommandResult,
-  commandExitCode,
-  presentCommand,
-  redactSecrets,
-  toCommandError,
-} from "../../core/command/policy.js";
+import * as commandPolicy from "../../core/command/policy.js";
 import { ComputerConnectServiceInstallError, runComputerConnect } from "../../core/computer/connect.js";
 
-interface ComputerConnectCommandOptions {
-  home?: string;
-  server?: string;
-  start?: boolean;
-  json?: boolean;
-}
+type ComputerConnectCommandOptions = { home?: string; server?: string; start?: boolean; json?: boolean };
 
 export function registerComputerConnectCommand(computer: Command): void {
   computer
@@ -40,7 +29,7 @@ export function registerComputerConnectCommand(computer: Command): void {
           serverUrl,
         });
         if (options.json) {
-          process.exitCode = presentCommand({ ok: true, value: result, exitCode: 0 }, { json: true });
+          process.exitCode = commandPolicy.presentCommand({ ok: true, value: result, exitCode: 0 }, { json: true });
         } else {
           process.stdout.write(`${result.message}\n`);
           if (result.service)
@@ -49,18 +38,16 @@ export function registerComputerConnectCommand(computer: Command): void {
         }
       } catch (error) {
         if (error instanceof ComputerConnectServiceInstallError) {
-          process.stdout.write(`${redactSecrets(error.connectResult.message)}\n`);
-          process.stderr.write(
-            `${redactSecrets(
-              `Daemon service reload failed; machine credentials were preserved. Run ${channelConfig.binName} daemon restart to retry.`,
-            )}\n`,
-          );
+          process.stdout.write(`${commandPolicy.redactSecrets(error.connectResult.message)}\n`);
+          const reloadFailure = "Daemon service reload failed; machine credentials were preserved.";
+          const reloadRetry = `Run ${channelConfig.binName} daemon restart to retry.`;
+          process.stderr.write(`${commandPolicy.redactSecrets(`${reloadFailure} ${reloadRetry}`)}\n`);
           process.exitCode = 1;
           return;
         }
-        const commandError = toCommandError(error, "request");
-        process.exitCode = presentCommand(
-          { ok: false, error: commandError, exitCode: commandExitCode(commandError) } as CommandResult<never>,
+        const commandError = commandPolicy.toCommandError(error, "request");
+        process.exitCode = commandPolicy.presentCommand(
+          { ok: false, error: commandError, exitCode: commandPolicy.commandExitCode(commandError) },
           { json: options.json === true },
         );
       }

--- a/apps/cli/src/commands/computer/list.ts
+++ b/apps/cli/src/commands/computer/list.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { executeCommand } from "../../core/command/policy.js";
 import { formatComputerList } from "../../core/computer/formatting.js";
 import { listComputers } from "../../core/computer/queries.js";
 
@@ -6,7 +7,12 @@ export function registerComputerListCommand(computer: Command): void {
   computer
     .command("list")
     .description("List Computers")
-    .action(async () => {
-      process.stdout.write(`${formatComputerList(await listComputers())}\n`);
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = await executeCommand(() => listComputers(), {
+        json: options.json === true,
+        formatValue: formatComputerList,
+        phase: "request",
+      });
     });
 }

--- a/apps/cli/src/commands/daemon/ensure-service.ts
+++ b/apps/cli/src/commands/daemon/ensure-service.ts
@@ -1,5 +1,11 @@
 import type { Command } from "commander";
-import { type CommandExitCode, presentCommand, toCommandError } from "../../core/command/policy.js";
+import {
+  type CommandExitCode,
+  commandExitCode,
+  presentCommand,
+  redactSecrets,
+  toCommandError,
+} from "../../core/command/policy.js";
 import { type DaemonServiceReconcileResult, reconcileDaemonService } from "../../core/daemon/reconcile-service.js";
 
 export const ENSURE_SERVICE_DEFERRED_EXIT_CODE = 3;
@@ -17,32 +23,34 @@ export async function executeDaemonEnsureService(
   try {
     const result = await (options.reconcileService ?? reconcileDaemonService)();
     if (result.status === "deferred") {
-      const message =
-        result.reason === "credentials-missing"
-          ? "No credentials found; daemon service setup is deferred until login."
-          : `Daemon service control is not supported on ${process.platform}; setup is deferred.`;
-      if (options.json) {
-        writeOutput(JSON.stringify({ ok: true, result: { ...result, message } }));
-      } else writeOutput(message);
+      writeOutput(renderEnsureResult(result, options.json === true));
       return ENSURE_SERVICE_DEFERRED_EXIT_CODE;
     }
-    const message =
-      result.action === "restarted"
-        ? `Daemon service ${result.service.serviceId} was restarted and is active.`
-        : `Daemon service ${result.service.serviceId} was installed or repaired and is active.`;
-    if (options.json) writeOutput(JSON.stringify({ ok: true, result: { ...result, message } }));
-    else writeOutput(message);
+    writeOutput(renderEnsureResult(result, options.json === true));
     return 0;
   } catch (error) {
     if (options.json) {
+      const commandError = toCommandError(error, "request");
       return presentCommand(
-        { ok: false, error: toCommandError(error, "request"), exitCode: 1 },
+        { ok: false, error: commandError, exitCode: commandExitCode(commandError) },
         { json: true, stderr: writeError },
       );
     }
-    writeError(error instanceof Error ? error.message : String(error));
+    writeError(redactSecrets(error instanceof Error ? error.message : String(error)));
     return 1;
   }
+}
+
+function renderEnsureResult(result: DaemonServiceReconcileResult, json: boolean): string {
+  const message =
+    result.status === "deferred"
+      ? result.reason === "credentials-missing"
+        ? "No credentials found; daemon service setup is deferred until login."
+        : `Daemon service control is not supported on ${process.platform}; setup is deferred.`
+      : result.action === "restarted"
+        ? `Daemon service ${result.service.serviceId} was restarted and is active.`
+        : `Daemon service ${result.service.serviceId} was installed or repaired and is active.`;
+  return json ? JSON.stringify({ ok: true, result: { ...result, message } }) : message;
 }
 
 export function registerDaemonEnsureServiceCommand(daemon: Command): void {

--- a/apps/cli/src/commands/daemon/ensure-service.ts
+++ b/apps/cli/src/commands/daemon/ensure-service.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { type CommandExitCode, presentCommand, toCommandError } from "../../core/command/policy.js";
 import { type DaemonServiceReconcileResult, reconcileDaemonService } from "../../core/daemon/reconcile-service.js";
 
 export const ENSURE_SERVICE_DEFERRED_EXIT_CODE = 3;
@@ -8,27 +9,37 @@ export async function executeDaemonEnsureService(
     reconcileService?: () => Promise<DaemonServiceReconcileResult>;
     writeError?: (message: string) => void;
     writeOutput?: (message: string) => void;
+    json?: boolean;
   } = {},
-): Promise<0 | 1 | typeof ENSURE_SERVICE_DEFERRED_EXIT_CODE> {
+): Promise<CommandExitCode> {
   const writeOutput = options.writeOutput ?? ((message: string) => process.stdout.write(`${message}\n`));
   const writeError = options.writeError ?? ((message: string) => process.stderr.write(`${message}\n`));
   try {
     const result = await (options.reconcileService ?? reconcileDaemonService)();
     if (result.status === "deferred") {
-      writeOutput(
+      const message =
         result.reason === "credentials-missing"
           ? "No credentials found; daemon service setup is deferred until login."
-          : `Daemon service control is not supported on ${process.platform}; setup is deferred.`,
-      );
+          : `Daemon service control is not supported on ${process.platform}; setup is deferred.`;
+      if (options.json) {
+        writeOutput(JSON.stringify({ ok: true, result: { ...result, message } }));
+      } else writeOutput(message);
       return ENSURE_SERVICE_DEFERRED_EXIT_CODE;
     }
-    writeOutput(
+    const message =
       result.action === "restarted"
         ? `Daemon service ${result.service.serviceId} was restarted and is active.`
-        : `Daemon service ${result.service.serviceId} was installed or repaired and is active.`,
-    );
+        : `Daemon service ${result.service.serviceId} was installed or repaired and is active.`;
+    if (options.json) writeOutput(JSON.stringify({ ok: true, result: { ...result, message } }));
+    else writeOutput(message);
     return 0;
   } catch (error) {
+    if (options.json) {
+      return presentCommand(
+        { ok: false, error: toCommandError(error, "request"), exitCode: 1 },
+        { json: true, stderr: writeError },
+      );
+    }
     writeError(error instanceof Error ? error.message : String(error));
     return 1;
   }
@@ -38,7 +49,8 @@ export function registerDaemonEnsureServiceCommand(daemon: Command): void {
   daemon
     .command("ensure-service", { hidden: true })
     .description("Ensure the daemon service is installed and active when credentials already exist")
-    .action(async () => {
-      process.exitCode = await executeDaemonEnsureService();
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = await executeDaemonEnsureService({ json: options.json === true });
     });
 }

--- a/apps/cli/src/commands/daemon/ensure-service.ts
+++ b/apps/cli/src/commands/daemon/ensure-service.ts
@@ -1,23 +1,16 @@
 import type { Command } from "commander";
-import {
-  type CommandExitCode,
-  commandExitCode,
-  presentCommand,
-  redactSecrets,
-  toCommandError,
-} from "../../core/command/policy.js";
+import * as commandPolicy from "../../core/command/policy.js";
 import { type DaemonServiceReconcileResult, reconcileDaemonService } from "../../core/daemon/reconcile-service.js";
 
 export const ENSURE_SERVICE_DEFERRED_EXIT_CODE = 3;
+type EnsureErrorOption = { writeError?: (message: string) => void };
+type EnsureOutputOption = { writeOutput?: (message: string) => void };
+type EnsureJsonOption = { json?: boolean };
+type EnsureServiceCallbacks = EnsureErrorOption & EnsureOutputOption & EnsureJsonOption;
+type EnsureServiceOptions = { reconcileService?: () => Promise<DaemonServiceReconcileResult> } & EnsureServiceCallbacks;
+type EnsureServiceResult = Promise<commandPolicy.CommandExitCode>;
 
-export async function executeDaemonEnsureService(
-  options: {
-    reconcileService?: () => Promise<DaemonServiceReconcileResult>;
-    writeError?: (message: string) => void;
-    writeOutput?: (message: string) => void;
-    json?: boolean;
-  } = {},
-): Promise<CommandExitCode> {
+export async function executeDaemonEnsureService(options: EnsureServiceOptions = {}): EnsureServiceResult {
   const writeOutput = options.writeOutput ?? ((message: string) => process.stdout.write(`${message}\n`));
   const writeError = options.writeError ?? ((message: string) => process.stderr.write(`${message}\n`));
   try {
@@ -30,13 +23,13 @@ export async function executeDaemonEnsureService(
     return 0;
   } catch (error) {
     if (options.json) {
-      const commandError = toCommandError(error, "request");
-      return presentCommand(
-        { ok: false, error: commandError, exitCode: commandExitCode(commandError) },
+      const commandError = commandPolicy.toCommandError(error, "request");
+      return commandPolicy.presentCommand(
+        { ok: false, error: commandError, exitCode: commandPolicy.commandExitCode(commandError) },
         { json: true, stderr: writeError },
       );
     }
-    writeError(redactSecrets(error instanceof Error ? error.message : String(error)));
+    writeError(commandPolicy.redactSecrets(error instanceof Error ? error.message : String(error)));
     return 1;
   }
 }

--- a/apps/cli/src/commands/daemon/install.ts
+++ b/apps/cli/src/commands/daemon/install.ts
@@ -5,7 +5,10 @@ export function registerDaemonInstallCommand(daemon: Command): void {
   daemon
     .command("install")
     .description("Install or update and start the daemon service")
-    .action(async () => {
-      process.exitCode = await executeDaemonServiceCommand("installAndStart");
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = options.json
+        ? await executeDaemonServiceCommand("installAndStart", { json: true })
+        : await executeDaemonServiceCommand("installAndStart");
     });
 }

--- a/apps/cli/src/commands/daemon/restart.ts
+++ b/apps/cli/src/commands/daemon/restart.ts
@@ -5,7 +5,10 @@ export function registerDaemonRestartCommand(daemon: Command): void {
   daemon
     .command("restart")
     .description("Restart the installed daemon service")
-    .action(async () => {
-      process.exitCode = await executeDaemonServiceCommand("restart");
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = options.json
+        ? await executeDaemonServiceCommand("restart", { json: true })
+        : await executeDaemonServiceCommand("restart");
     });
 }

--- a/apps/cli/src/commands/daemon/shared.ts
+++ b/apps/cli/src/commands/daemon/shared.ts
@@ -1,4 +1,10 @@
-import { type CommandExitCode, presentCommand, toCommandError } from "../../core/command/policy.js";
+import {
+  type CommandExitCode,
+  commandExitCode,
+  presentCommand,
+  redactSecrets,
+  toCommandError,
+} from "../../core/command/policy.js";
 import {
   createDaemonServiceManager,
   type DaemonServiceManager,
@@ -19,21 +25,35 @@ export async function executeDaemonServiceCommand(
   try {
     const manager = options.manager ?? (await createDaemonServiceManager());
     const info = await manager[action]();
-    const output = options.json ? JSON.stringify({ ok: true, result: info }) : formatDaemonServiceInfo(info);
+    const output = renderDaemonServiceOutput(info, options.json === true);
     (options.writeOutput ?? ((message) => process.stdout.write(`${message}\n`)))(output);
-    if (action === "status") return info.state === "active" ? 0 : 1;
-    if (["installAndStart", "restart", "start"].includes(action)) return info.state === "active" ? 0 : 1;
-    if (action === "stop") return ["inactive", "not-installed"].includes(info.state) ? 0 : 1;
-    return info.state === "not-installed" ? 0 : 1;
+    return daemonServiceExitCode(action, info.state);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (options.json) {
+      const commandError = toCommandError(error, "request");
       return presentCommand(
-        { ok: false, error: toCommandError(error, "request"), exitCode: 1 },
+        { ok: false, error: commandError, exitCode: commandExitCode(commandError) },
         { json: true, stderr: options.writeError },
       );
     }
-    (options.writeError ?? ((value) => process.stderr.write(`${value}\n`)))(message);
+    (options.writeError ?? ((value) => process.stderr.write(`${value}\n`)))(redactSecrets(message));
     return 1;
   }
+}
+
+function renderDaemonServiceOutput(
+  info: Awaited<ReturnType<DaemonServiceManager[DaemonServiceAction]>>,
+  json: boolean,
+): string {
+  return json ? JSON.stringify({ ok: true, result: info }) : formatDaemonServiceInfo(info);
+}
+
+function daemonServiceExitCode(
+  action: DaemonServiceAction,
+  state: Awaited<ReturnType<DaemonServiceManager[DaemonServiceAction]>>["state"],
+): 0 | 1 {
+  if (action === "stop") return ["inactive", "not-installed"].includes(state) ? 0 : 1;
+  if (action === "uninstall") return state === "not-installed" ? 0 : 1;
+  return state === "active" ? 0 : 1;
 }

--- a/apps/cli/src/commands/daemon/shared.ts
+++ b/apps/cli/src/commands/daemon/shared.ts
@@ -1,3 +1,4 @@
+import { type CommandExitCode, presentCommand, toCommandError } from "../../core/command/policy.js";
 import {
   createDaemonServiceManager,
   type DaemonServiceManager,
@@ -12,18 +13,26 @@ export async function executeDaemonServiceCommand(
     manager?: DaemonServiceManager;
     writeError?: (message: string) => void;
     writeOutput?: (message: string) => void;
+    json?: boolean;
   } = {},
-): Promise<0 | 1> {
+): Promise<CommandExitCode> {
   try {
     const manager = options.manager ?? (await createDaemonServiceManager());
     const info = await manager[action]();
-    (options.writeOutput ?? ((message) => process.stdout.write(`${message}\n`)))(formatDaemonServiceInfo(info));
+    const output = options.json ? JSON.stringify({ ok: true, result: info }) : formatDaemonServiceInfo(info);
+    (options.writeOutput ?? ((message) => process.stdout.write(`${message}\n`)))(output);
     if (action === "status") return info.state === "active" ? 0 : 1;
     if (["installAndStart", "restart", "start"].includes(action)) return info.state === "active" ? 0 : 1;
     if (action === "stop") return ["inactive", "not-installed"].includes(info.state) ? 0 : 1;
     return info.state === "not-installed" ? 0 : 1;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      return presentCommand(
+        { ok: false, error: toCommandError(error, "request"), exitCode: 1 },
+        { json: true, stderr: options.writeError },
+      );
+    }
     (options.writeError ?? ((value) => process.stderr.write(`${value}\n`)))(message);
     return 1;
   }

--- a/apps/cli/src/commands/daemon/shared.ts
+++ b/apps/cli/src/commands/daemon/shared.ts
@@ -1,27 +1,19 @@
-import {
-  type CommandExitCode,
-  commandExitCode,
-  presentCommand,
-  redactSecrets,
-  toCommandError,
-} from "../../core/command/policy.js";
-import {
-  createDaemonServiceManager,
-  type DaemonServiceManager,
-  formatDaemonServiceInfo,
-} from "../../core/daemon/service/index.js";
+import * as commandPolicy from "../../core/command/policy.js";
+import type { DaemonServiceManager } from "../../core/daemon/service/index.js";
+import { createDaemonServiceManager, formatDaemonServiceInfo } from "../../core/daemon/service/index.js";
 
 export type DaemonServiceAction = "installAndStart" | "restart" | "start" | "status" | "stop" | "uninstall";
+type DaemonErrorOption = { writeError?: (message: string) => void };
+type DaemonOutputOption = { writeOutput?: (message: string) => void };
+type DaemonJsonOption = { json?: boolean };
+type DaemonServiceCallbacks = DaemonErrorOption & DaemonOutputOption & DaemonJsonOption;
+type DaemonServiceCommandOptions = { manager?: DaemonServiceManager } & DaemonServiceCallbacks;
+type DaemonServiceResult = Awaited<ReturnType<DaemonServiceManager[DaemonServiceAction]>>;
 
 export async function executeDaemonServiceCommand(
   action: DaemonServiceAction,
-  options: {
-    manager?: DaemonServiceManager;
-    writeError?: (message: string) => void;
-    writeOutput?: (message: string) => void;
-    json?: boolean;
-  } = {},
-): Promise<CommandExitCode> {
+  options: DaemonServiceCommandOptions = {},
+): Promise<commandPolicy.CommandExitCode> {
   try {
     const manager = options.manager ?? (await createDaemonServiceManager());
     const info = await manager[action]();
@@ -31,28 +23,22 @@ export async function executeDaemonServiceCommand(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (options.json) {
-      const commandError = toCommandError(error, "request");
-      return presentCommand(
-        { ok: false, error: commandError, exitCode: commandExitCode(commandError) },
+      const commandError = commandPolicy.toCommandError(error, "request");
+      return commandPolicy.presentCommand(
+        { ok: false, error: commandError, exitCode: commandPolicy.commandExitCode(commandError) },
         { json: true, stderr: options.writeError },
       );
     }
-    (options.writeError ?? ((value) => process.stderr.write(`${value}\n`)))(redactSecrets(message));
+    (options.writeError ?? ((value) => process.stderr.write(`${value}\n`)))(commandPolicy.redactSecrets(message));
     return 1;
   }
 }
 
-function renderDaemonServiceOutput(
-  info: Awaited<ReturnType<DaemonServiceManager[DaemonServiceAction]>>,
-  json: boolean,
-): string {
+function renderDaemonServiceOutput(info: DaemonServiceResult, json: boolean): string {
   return json ? JSON.stringify({ ok: true, result: info }) : formatDaemonServiceInfo(info);
 }
 
-function daemonServiceExitCode(
-  action: DaemonServiceAction,
-  state: Awaited<ReturnType<DaemonServiceManager[DaemonServiceAction]>>["state"],
-): 0 | 1 {
+function daemonServiceExitCode(action: DaemonServiceAction, state: DaemonServiceResult["state"]): 0 | 1 {
   if (action === "stop") return ["inactive", "not-installed"].includes(state) ? 0 : 1;
   if (action === "uninstall") return state === "not-installed" ? 0 : 1;
   return state === "active" ? 0 : 1;

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -5,7 +5,10 @@ export function registerDaemonStartCommand(daemon: Command): void {
   daemon
     .command("start")
     .description("Start the installed daemon service")
-    .action(async () => {
-      process.exitCode = await executeDaemonServiceCommand("start");
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = options.json
+        ? await executeDaemonServiceCommand("start", { json: true })
+        : await executeDaemonServiceCommand("start");
     });
 }

--- a/apps/cli/src/commands/daemon/status.ts
+++ b/apps/cli/src/commands/daemon/status.ts
@@ -5,7 +5,10 @@ export function registerDaemonStatusCommand(daemon: Command): void {
   daemon
     .command("status")
     .description("Show daemon service status")
-    .action(async () => {
-      process.exitCode = await executeDaemonServiceCommand("status");
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = options.json
+        ? await executeDaemonServiceCommand("status", { json: true })
+        : await executeDaemonServiceCommand("status");
     });
 }

--- a/apps/cli/src/commands/daemon/stop.ts
+++ b/apps/cli/src/commands/daemon/stop.ts
@@ -5,7 +5,10 @@ export function registerDaemonStopCommand(daemon: Command): void {
   daemon
     .command("stop")
     .description("Stop the daemon service")
-    .action(async () => {
-      process.exitCode = await executeDaemonServiceCommand("stop");
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = options.json
+        ? await executeDaemonServiceCommand("stop", { json: true })
+        : await executeDaemonServiceCommand("stop");
     });
 }

--- a/apps/cli/src/commands/daemon/uninstall.ts
+++ b/apps/cli/src/commands/daemon/uninstall.ts
@@ -5,7 +5,10 @@ export function registerDaemonUninstallCommand(daemon: Command): void {
   daemon
     .command("uninstall")
     .description("Remove the daemon service while preserving local data")
-    .action(async () => {
-      process.exitCode = await executeDaemonServiceCommand("uninstall");
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      process.exitCode = options.json
+        ? await executeDaemonServiceCommand("uninstall", { json: true })
+        : await executeDaemonServiceCommand("uninstall");
     });
 }

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -5,9 +5,17 @@ export function registerDoctorCommand(program: Command): void {
   program
     .command("doctor")
     .description("Run read-only baseline diagnostics for the selected OpenTag Home")
-    .action(async () => {
-      const result = await runDoctor();
-      console.log(result.message);
+    .option("--json", "print JSON")
+    .action(async (options: { json?: boolean }) => {
+      const result = await runDoctor().catch((error: unknown) => {
+        process.exitCode = 1;
+        throw error;
+      });
       process.exitCode = result.exitCode;
+      if (options.json) {
+        process.stdout.write(`${JSON.stringify({ ok: result.exitCode === 0, result })}\n`);
+      } else {
+        process.stdout.write(`${result.message}\n`);
+      }
     });
 }

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -6,11 +6,7 @@ import { channelConfig } from "../core/channel/config.js";
 import { resolveChannelEnvironment } from "../core/channel/environment.js";
 import { executeCommand } from "../core/command/policy.js";
 
-interface LoginCommandOptions {
-  home?: string;
-  server?: string;
-  json?: boolean;
-}
+type LoginCommandOptions = { home?: string; server?: string; json?: boolean };
 
 interface LoginCommandDependencies {
   login?: typeof runLogin;

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -3,10 +3,13 @@ import { resolveOpenTagHome } from "@opentag/client";
 import type { Command } from "commander";
 import { runLogin } from "../core/auth/login.js";
 import { channelConfig } from "../core/channel/config.js";
+import { resolveChannelEnvironment } from "../core/channel/environment.js";
+import { executeCommand } from "../core/command/policy.js";
 
 interface LoginCommandOptions {
   home?: string;
   server?: string;
+  json?: boolean;
 }
 
 interface LoginCommandDependencies {
@@ -20,10 +23,11 @@ export async function executeLoginCommand(
   options: LoginCommandOptions,
   dependencies: LoginCommandDependencies = {},
 ): Promise<0 | 1> {
-  const serverUrl = options.server ?? process.env.OPENTAG_SERVER_URL ?? channelConfig.defaultServerUrl;
+  const environment = resolveChannelEnvironment(process.env);
+  const serverUrl = options.server ?? environment.OPENTAG_SERVER_URL ?? channelConfig.defaultServerUrl;
   if (!serverUrl) throw new Error(`The ${channelConfig.channel} channel requires --server for login`);
   const writeOutput = dependencies.writeOutput ?? ((message: string) => process.stdout.write(`${message}\n`));
-  const home = resolve(options.home ?? resolveOpenTagHome(process.env));
+  const home = resolve(options.home ?? resolveOpenTagHome(environment));
   const result = await (dependencies.login ?? runLogin)({
     code,
     home,
@@ -40,7 +44,15 @@ export function registerLoginCommand(program: Command, dependencies: LoginComman
     .argument("<code>", "one-time Account login code")
     .option("--server <url>", "OpenTag server URL")
     .option("--home <path>", "OpenTag home directory")
+    .option("--json", "print JSON")
     .action(async (code: string, options: LoginCommandOptions) => {
-      process.exitCode = await executeLoginCommand(code, options, dependencies);
+      process.exitCode = await executeCommand(
+        async () => {
+          const output: string[] = [];
+          await executeLoginCommand(code, options, { ...dependencies, writeOutput: (message) => output.push(message) });
+          return output.join("\n");
+        },
+        { json: options.json === true, phase: "authentication" },
+      );
     });
 }

--- a/apps/cli/src/commands/session/index.ts
+++ b/apps/cli/src/commands/session/index.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { commandExitCode, presentCommand, toCommandError } from "../../core/command/policy.js";
 import {
   formatSessionCommandError,
   formatSessionCommandResult,
@@ -49,8 +50,20 @@ export function registerSessionCommand(program: Command): void {
     .option("--since <timestamp>", "include Sessions active since this ISO-8601 timestamp")
     .option("--json", "print JSON")
     .action(async (options) => {
-      const result = await runSessionList(options);
-      process.stdout.write(`${options.json ? JSON.stringify(result) : formatSessionList(result)}\n`);
+      try {
+        const result = await runSessionList(options);
+        if (options.json) {
+          process.stdout.write(`${JSON.stringify({ ok: true, result })}\n`);
+        } else {
+          process.stdout.write(`${formatSessionList(result)}\n`);
+        }
+      } catch (error) {
+        const commandError = toCommandError(error, "request");
+        process.exitCode = presentCommand(
+          { ok: false, error: commandError, exitCode: commandExitCode(commandError) },
+          { json: options.json === true },
+        );
+      }
     });
 }
 
@@ -66,9 +79,16 @@ async function runCommand(
   try {
     writeCommandResult(await operation(), options);
   } catch (error) {
-    if (!(error instanceof SessionCommandRequestError)) throw error;
-    process.stderr.write(`${formatSessionCommandError(error, options.json ?? false)}\n`);
-    process.exitCode = 1;
+    if (error instanceof SessionCommandRequestError) {
+      process.stderr.write(`${formatSessionCommandError(error, options.json ?? false)}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    const commandError = toCommandError(error, "request");
+    process.exitCode = presentCommand(
+      { ok: false, error: commandError, exitCode: commandExitCode(commandError) },
+      { json: options.json === true },
+    );
   }
 }
 

--- a/apps/cli/src/core/agent/context.ts
+++ b/apps/cli/src/core/agent/context.ts
@@ -1,4 +1,5 @@
-import { AccessTokenProvider, OpenTagApi, readCredentials, resolveOpenTagHome } from "@opentag/client";
+import type { OpenTagApi } from "@opentag/client";
+import { resolveCommandContext } from "../command/context.js";
 
 export interface AgentApiClient
   extends Pick<
@@ -31,14 +32,15 @@ export interface AgentCommandDependencies {
 export async function resolveAgentCommandContext(
   options: AgentCommandDependencies,
 ): Promise<{ accessToken: string; api: AgentApiClient }> {
-  if (options.api && options.accessToken) return { api: options.api, accessToken: options.accessToken };
-  if (options.api || options.accessToken) {
+  if ((options.api && !options.accessToken) || (options.accessToken && !options.api)) {
     throw new Error("Agent command test dependencies must provide both api and accessToken");
   }
-
-  const home = options.home ?? resolveOpenTagHome();
-  const credentials = await readCredentials(home);
-  if (!credentials) throw new Error("OpenTag is not logged in; run login first");
-  const accessToken = await new AccessTokenProvider({ home }).getAccessToken();
-  return { api: new OpenTagApi(credentials.serverUrl), accessToken };
+  const context = await resolveCommandContext({
+    accessToken: options.accessToken,
+    api: options.api as OpenTagApi | undefined,
+    home: options.home,
+    requireAuth: true,
+  });
+  if (!context.api || !context.accessToken) throw new Error("Command context did not resolve an authenticated API");
+  return { api: context.api, accessToken: context.accessToken };
 }

--- a/apps/cli/src/core/auth/login.ts
+++ b/apps/cli/src/core/auth/login.ts
@@ -1,12 +1,13 @@
 import {
   credentialsPath,
   normalizeServerUrl,
-  OpenTagApi,
+  type OpenTagApi,
   readComputerIdentity,
   resolveOpenTagHome,
   type StoredCredentials,
   writeCredentialsAtomically,
 } from "@opentag/client";
+import { resolveCommandContext } from "../command/context.js";
 
 export interface LoginOptions {
   api?: Pick<OpenTagApi, "exchangeConnectCode">;
@@ -29,7 +30,8 @@ export async function runLogin(options: LoginOptions): Promise<LoginResult> {
   if (computer && computer.serverUrl !== serverUrl) {
     throw new Error("This OpenTag home is bound to another server; choose a different OPENTAG_HOME");
   }
-  const api = options.api ?? new OpenTagApi(serverUrl);
+  const api = options.api ?? (await resolveCommandContext({ home, serverUrl })).api;
+  if (!api) throw new Error("Command context did not resolve an API");
   const response = await api.exchangeConnectCode(options.code);
   const credentials: StoredCredentials = {
     accessToken: response.accessToken,

--- a/apps/cli/src/core/channel/environment.ts
+++ b/apps/cli/src/core/channel/environment.ts
@@ -1,7 +1,12 @@
 import { channelConfig } from "./config.js";
 import { markChannelDefaultHomeApplied } from "./home-source.js";
 
-if (!process.env.OPENTAG_HOME) {
-  process.env.OPENTAG_HOME = channelConfig.defaultHome;
-  markChannelDefaultHomeApplied();
+/** Return the command environment with the channel home selected, without mutating process.env. */
+export function resolveChannelEnvironment(environment: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const result = { ...environment };
+  if (!result.OPENTAG_HOME) {
+    result.OPENTAG_HOME = channelConfig.defaultHome;
+    markChannelDefaultHomeApplied();
+  }
+  return result;
 }

--- a/apps/cli/src/core/command/context.ts
+++ b/apps/cli/src/core/command/context.ts
@@ -1,0 +1,45 @@
+import {
+  AccessTokenProvider,
+  OpenTagApi,
+  readCredentials,
+  resolveOpenTagHome,
+  type StoredCredentials,
+} from "@opentag/client";
+import { resolveChannelEnvironment } from "../channel/environment.js";
+
+export interface CommandContextOptions {
+  accessToken?: string;
+  api?: OpenTagApi;
+  environment?: NodeJS.ProcessEnv;
+  home?: string;
+  requireAuth?: boolean;
+  serverUrl?: string;
+}
+
+export interface CommandContext {
+  readonly accessToken?: string;
+  readonly api?: OpenTagApi;
+  readonly credentials?: StoredCredentials;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly home: string;
+}
+
+/** Resolve home, credentials, token, and API from one detached command context. */
+export async function resolveCommandContext(options: CommandContextOptions = {}): Promise<CommandContext> {
+  const environment = resolveChannelEnvironment(options.environment ?? process.env);
+  const home = options.home ?? resolveOpenTagHome(environment);
+  if (options.serverUrl) return { api: new OpenTagApi(options.serverUrl), environment, home };
+  if (!options.requireAuth && !options.api && !options.accessToken) {
+    return { environment, home };
+  }
+  if (options.api && options.accessToken) {
+    return { accessToken: options.accessToken, api: options.api, environment, home };
+  }
+  if (options.api || options.accessToken) {
+    throw new Error("Command context test dependencies must provide both api and accessToken");
+  }
+  const credentials = await readCredentials(home);
+  if (!credentials) throw new Error("OpenTag is not logged in; run login first");
+  const accessToken = await new AccessTokenProvider({ home }).getAccessToken();
+  return { accessToken, api: new OpenTagApi(credentials.serverUrl), credentials, environment, home };
+}

--- a/apps/cli/src/core/command/context.ts
+++ b/apps/cli/src/core/command/context.ts
@@ -1,34 +1,19 @@
-import {
-  AccessTokenProvider,
-  OpenTagApi,
-  readCredentials,
-  resolveOpenTagHome,
-  type StoredCredentials,
-} from "@opentag/client";
+import * as client from "@opentag/client";
 import { resolveChannelEnvironment } from "../channel/environment.js";
 
-export interface CommandContextOptions {
-  accessToken?: string;
-  api?: OpenTagApi;
-  environment?: NodeJS.ProcessEnv;
-  home?: string;
-  requireAuth?: boolean;
-  serverUrl?: string;
-}
-
-export interface CommandContext {
-  readonly accessToken?: string;
-  readonly api?: OpenTagApi;
-  readonly credentials?: StoredCredentials;
-  readonly environment: NodeJS.ProcessEnv;
-  readonly home: string;
-}
+type CommandContextAuthOptions = { accessToken?: string; api?: client.OpenTagApi; requireAuth?: boolean };
+type CommandContextLocationOptions = { environment?: NodeJS.ProcessEnv; home?: string; serverUrl?: string };
+export type CommandContextOptions = CommandContextAuthOptions & CommandContextLocationOptions;
+type CommandContextIdentityAccess = { readonly accessToken?: string; readonly api?: client.OpenTagApi };
+type CommandContextIdentity = CommandContextIdentityAccess & { readonly credentials?: client.StoredCredentials };
+type CommandContextLocation = { readonly environment: NodeJS.ProcessEnv; readonly home: string };
+export type CommandContext = CommandContextIdentity & CommandContextLocation;
 
 /** Resolve home, credentials, token, and API from one detached command context. */
 export async function resolveCommandContext(options: CommandContextOptions = {}): Promise<CommandContext> {
   const environment = resolveChannelEnvironment(options.environment ?? process.env);
-  const home = options.home ?? resolveOpenTagHome(environment);
-  if (options.serverUrl) return { api: new OpenTagApi(options.serverUrl), environment, home };
+  const home = options.home ?? client.resolveOpenTagHome(environment);
+  if (options.serverUrl) return { api: new client.OpenTagApi(options.serverUrl), environment, home };
   if (!options.requireAuth && !options.api && !options.accessToken) {
     return { environment, home };
   }
@@ -38,8 +23,8 @@ export async function resolveCommandContext(options: CommandContextOptions = {})
   if (options.api || options.accessToken) {
     throw new Error("Command context test dependencies must provide both api and accessToken");
   }
-  const credentials = await readCredentials(home);
+  const credentials = await client.readCredentials(home);
   if (!credentials) throw new Error("OpenTag is not logged in; run login first");
-  const accessToken = await new AccessTokenProvider({ home }).getAccessToken();
-  return { accessToken, api: new OpenTagApi(credentials.serverUrl), credentials, environment, home };
+  const accessToken = await new client.AccessTokenProvider({ home }).getAccessToken();
+  return { accessToken, api: new client.OpenTagApi(credentials.serverUrl), credentials, environment, home };
 }

--- a/apps/cli/src/core/command/environment.ts
+++ b/apps/cli/src/core/command/environment.ts
@@ -1,0 +1,16 @@
+/** Build a detached child-process environment without changing the parent process. */
+export function buildChildEnvironment(
+  baseEnvironment: NodeJS.ProcessEnv,
+  options: { keys?: readonly string[]; overrides?: NodeJS.ProcessEnv } = {},
+): NodeJS.ProcessEnv {
+  const keys = options.keys ?? Object.keys(baseEnvironment);
+  const environment: NodeJS.ProcessEnv = {};
+  for (const key of keys) {
+    const value = baseEnvironment[key];
+    if (value !== undefined) environment[key] = value;
+  }
+  for (const [key, value] of Object.entries(options.overrides ?? {})) {
+    if (value !== undefined) environment[key] = value;
+  }
+  return environment;
+}

--- a/apps/cli/src/core/command/policy.ts
+++ b/apps/cli/src/core/command/policy.ts
@@ -10,58 +10,34 @@ export const EXIT_CODES = {
 } as const;
 
 export type CommandExitCode = (typeof EXIT_CODES)[keyof typeof EXIT_CODES];
-export type CommandErrorCategory =
-  | "validation"
-  | "auth"
-  | "authorization"
-  | "unavailable"
-  | "timeout"
-  | "internal"
-  | "conflict"
-  | "not_found"
-  | "rate_limit"
-  | "protocol"
-  | "configuration"
-  | "cancelled"
-  | "dependency";
+type CommandErrorCategoryCore = "validation" | "auth" | "authorization" | "unavailable" | "timeout" | "internal";
+type CommandErrorCategoryExtraA = "conflict" | "not_found" | "rate_limit";
+type CommandErrorCategoryExtraB = "protocol" | "configuration" | "cancelled" | "dependency";
+type CommandErrorCategoryExtra = CommandErrorCategoryExtraA | CommandErrorCategoryExtraB;
+export type CommandErrorCategory = CommandErrorCategoryCore | CommandErrorCategoryExtra;
 export type CommandRetryability = "never" | "immediate" | "backoff" | "after_auth";
-export type CommandPhase =
-  | "validation"
-  | "authentication"
-  | "authorization"
-  | "configuration"
-  | "startup"
-  | "request"
-  | "transport"
-  | "provider"
-  | "persistence"
-  | "dispatch"
-  | "socket"
-  | "scheduler"
-  | "worker"
-  | "serialization"
-  | "shutdown"
-  | "unknown";
+type CommandPhaseCoreA = "validation" | "authentication" | "authorization" | "configuration" | "startup" | "request";
+type CommandPhaseCoreB = "transport" | "provider";
+type CommandPhaseCore = CommandPhaseCoreA | CommandPhaseCoreB;
+type CommandPhaseExtraA = "persistence" | "dispatch" | "socket" | "scheduler";
+type CommandPhaseExtraB = "worker" | "serialization" | "shutdown" | "unknown";
+type CommandPhaseExtra = CommandPhaseExtraA | CommandPhaseExtraB;
+export type CommandPhase = CommandPhaseCore | CommandPhaseExtra;
+
+type CommandErrorCodeFields = { code: string; category: CommandErrorCategory };
+type CommandErrorRetryFields = { retryability: CommandRetryability; phase: CommandPhase };
+type CommandErrorRequiredFields = CommandErrorCodeFields & CommandErrorRetryFields;
+type CommandErrorFields = CommandErrorRequiredFields & { requestId?: string };
 
 /** Structured, transport-neutral CLI failure metadata. The Error message is the human detail. */
 export class CommandError extends Error {
-  readonly code: string;
-  readonly category: CommandErrorCategory;
-  readonly retryability: CommandRetryability;
-  readonly phase: CommandPhase;
-  readonly requestId?: string;
+  declare readonly code: string;
+  declare readonly category: CommandErrorCategory;
+  declare readonly retryability: CommandRetryability;
+  declare readonly phase: CommandPhase;
+  declare readonly requestId?: string;
 
-  constructor(
-    fields: {
-      code: string;
-      category: CommandErrorCategory;
-      retryability: CommandRetryability;
-      phase: CommandPhase;
-      requestId?: string;
-    },
-    message: string,
-    options?: ErrorOptions,
-  ) {
+  constructor(fields: CommandErrorFields, message: string, options?: ErrorOptions) {
     super(redactSecrets(message), options);
     this.name = "CommandError";
     this.code = fields.code;
@@ -72,16 +48,14 @@ export class CommandError extends Error {
   }
 }
 
-export type CommandResult<T> =
-  | { ok: true; value: T; exitCode: typeof EXIT_CODES.success }
-  | { ok: false; error: CommandError; exitCode: Exclude<CommandExitCode, typeof EXIT_CODES.success> };
-
-export interface CommandPresentationOptions<T> {
-  json?: boolean;
-  formatValue?: (value: T) => string;
-  stdout?: (chunk: string) => void;
-  stderr?: (chunk: string) => void;
-}
+type SuccessCommandResult<T> = { ok: true; value: T; exitCode: typeof EXIT_CODES.success };
+type FailureCommandResultBase = { ok: false; error: CommandError };
+type FailureCommandResult = FailureCommandResultBase & { exitCode: Exclude<CommandExitCode, 0> };
+export type CommandResult<T> = SuccessCommandResult<T> | FailureCommandResult;
+type CommandFormatValueOptions<T> = { formatValue?: (value: T) => string };
+type CommandFormatWriterOptions = { stdout?: (chunk: string) => void; stderr?: (chunk: string) => void };
+type CommandFormatOptions<T> = CommandFormatValueOptions<T> & CommandFormatWriterOptions;
+export type CommandPresentationOptions<T> = { json?: boolean } & CommandFormatOptions<T>;
 
 /** Convert errors from Commander, Zod, the API, and Node into one local contract. */
 export function toCommandError(error: unknown, phase: CommandPhase = "unknown"): CommandError {
@@ -291,10 +265,13 @@ function redactUnknown(value: unknown, seen: WeakSet<object>): unknown {
   return output;
 }
 
+const SENSITIVE_KEY_PATTERNS = [
+  /(?:authorization|cookie|token|secret|credential|password|passwd)/iu,
+  /(?:api[_-]?key|private[_-]?key|request[_-]?body|response[_-]?body|payload|prompt)/iu,
+];
+
 function isSensitiveKey(key: string): boolean {
-  return /(?:authorization|cookie|token|secret|credential|password|passwd|api[_-]?key|private[_-]?key|request[_-]?body|response[_-]?body|payload|prompt)/iu.test(
-    key,
-  );
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));
 }
 
 export function redactSecrets(value: string): string {

--- a/apps/cli/src/core/command/policy.ts
+++ b/apps/cli/src/core/command/policy.ts
@@ -1,0 +1,293 @@
+import { OpenTagApiError } from "@opentag/client";
+
+/** Process exit values shared by every user-facing CLI command. */
+export const EXIT_CODES = {
+  success: 0,
+  failure: 1,
+  usage: 2,
+  serviceUnavailable: 3,
+  interrupted: 130,
+} as const;
+
+export type CommandExitCode = (typeof EXIT_CODES)[keyof typeof EXIT_CODES];
+export type CommandErrorCategory =
+  | "validation"
+  | "auth"
+  | "authorization"
+  | "unavailable"
+  | "timeout"
+  | "internal"
+  | "conflict"
+  | "not_found"
+  | "rate_limit"
+  | "protocol"
+  | "configuration"
+  | "cancelled"
+  | "dependency";
+export type CommandRetryability = "never" | "immediate" | "backoff" | "after_auth";
+export type CommandPhase =
+  | "validation"
+  | "authentication"
+  | "authorization"
+  | "configuration"
+  | "startup"
+  | "request"
+  | "transport"
+  | "provider"
+  | "persistence"
+  | "dispatch"
+  | "socket"
+  | "scheduler"
+  | "worker"
+  | "serialization"
+  | "shutdown"
+  | "unknown";
+
+/** Structured, transport-neutral CLI failure metadata. The Error message is the human detail. */
+export class CommandError extends Error {
+  readonly code: string;
+  readonly category: CommandErrorCategory;
+  readonly retryability: CommandRetryability;
+  readonly phase: CommandPhase;
+  readonly requestId?: string;
+
+  constructor(
+    fields: {
+      code: string;
+      category: CommandErrorCategory;
+      retryability: CommandRetryability;
+      phase: CommandPhase;
+      requestId?: string;
+    },
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(redactSecrets(message), options);
+    this.name = "CommandError";
+    this.code = fields.code;
+    this.category = fields.category;
+    this.retryability = fields.retryability;
+    this.phase = fields.phase;
+    if (fields.requestId) this.requestId = fields.requestId;
+  }
+}
+
+export type CommandResult<T> =
+  | { ok: true; value: T; exitCode: typeof EXIT_CODES.success }
+  | { ok: false; error: CommandError; exitCode: Exclude<CommandExitCode, typeof EXIT_CODES.success> };
+
+export interface CommandPresentationOptions<T> {
+  json?: boolean;
+  formatValue?: (value: T) => string;
+  stdout?: (chunk: string) => void;
+  stderr?: (chunk: string) => void;
+}
+
+/** Convert errors from Commander, Zod, the API, and Node into one local contract. */
+export function toCommandError(error: unknown, phase: CommandPhase = "unknown"): CommandError {
+  if (error instanceof CommandError) return error;
+  if (isInterrupted(error)) {
+    return new CommandError(
+      { code: "INTERRUPTED", category: "cancelled", retryability: "never", phase: "shutdown" },
+      "The operation was interrupted",
+      { cause: error },
+    );
+  }
+  if (isZodError(error)) {
+    return new CommandError(
+      { code: "VALIDATION_ERROR", category: "validation", retryability: "never", phase: "validation" },
+      error.issues.map((issue) => `${issue.path.join(".") || "input"}: ${issue.message}`).join("; "),
+      { cause: error },
+    );
+  }
+  if (error instanceof OpenTagApiError) {
+    const mapped = mapApiError(error);
+    return new CommandError(mapped, error.message, { cause: error });
+  }
+
+  const candidate = error as { code?: unknown; category?: unknown; requestId?: unknown; message?: unknown };
+  const code = typeof candidate.code === "string" && candidate.code.length > 0 ? candidate.code : "INTERNAL_ERROR";
+  const message = typeof candidate.message === "string" ? candidate.message : String(error);
+  if (candidate.category === "validation" || phase === "validation") {
+    return new CommandError({ code, category: "validation", retryability: "never", phase: "validation" }, message, {
+      cause: error,
+    });
+  }
+  if (candidate.category === "auth" || /^AUTH_/u.test(code) || /not logged in|authentication/iu.test(message)) {
+    return new CommandError(
+      {
+        code,
+        category: "auth",
+        retryability: "after_auth",
+        phase: "authentication",
+        ...(typeof candidate.requestId === "string" ? { requestId: candidate.requestId } : {}),
+      },
+      message,
+      { cause: error },
+    );
+  }
+  if (
+    candidate.category === "unavailable" ||
+    code === "SERVICE_UNAVAILABLE" ||
+    /(?:_UPSTREAM_)?UNAVAILABLE$/u.test(code) ||
+    /service unavailable|timed out|connection refused/iu.test(message)
+  ) {
+    return new CommandError(
+      {
+        code,
+        category: "unavailable",
+        retryability: "backoff",
+        phase: "transport",
+        ...(typeof candidate.requestId === "string" ? { requestId: candidate.requestId } : {}),
+      },
+      message,
+      { cause: error },
+    );
+  }
+  return new CommandError(
+    {
+      code,
+      category: "internal",
+      retryability: "never",
+      phase,
+      ...(typeof candidate.requestId === "string" ? { requestId: candidate.requestId } : {}),
+    },
+    message,
+    { cause: error },
+  );
+}
+
+/** Present a result once. Human successes use stdout; all failures use redacted stderr. */
+export function presentCommand<T>(
+  result: CommandResult<T>,
+  options: CommandPresentationOptions<T> = {},
+): CommandExitCode {
+  const stdout = options.stdout ?? ((chunk: string) => process.stdout.write(chunk));
+  const stderr = options.stderr ?? ((chunk: string) => process.stderr.write(chunk));
+  if (result.ok) {
+    const value = redactValue(result.value);
+    const output = options.json
+      ? JSON.stringify({ ok: true, result: value })
+      : (options.formatValue ?? ((item) => formatHumanValue(item)))(value);
+    stdout(`${output}\n`);
+    return EXIT_CODES.success;
+  }
+  const error = result.error;
+  const output = options.json
+    ? JSON.stringify({
+        ok: false,
+        error: {
+          code: error.code,
+          category: error.category,
+          retryability: error.retryability,
+          phase: error.phase,
+          ...(error.requestId ? { requestId: error.requestId } : {}),
+          message: error.message,
+        },
+      })
+    : `${error.code}: ${error.message}`;
+  stderr(`${output}\n`);
+  return result.exitCode;
+}
+
+/** Run an operation through the shared result and presentation path. */
+export async function executeCommand<T>(
+  operation: () => Promise<T>,
+  options: CommandPresentationOptions<T> & { phase?: CommandPhase } = {},
+): Promise<CommandExitCode> {
+  try {
+    return presentCommand({ ok: true, value: await operation(), exitCode: EXIT_CODES.success }, options);
+  } catch (error) {
+    const commandError = toCommandError(error, options.phase);
+    return presentCommand(
+      {
+        ok: false,
+        error: commandError,
+        exitCode: commandExitCode(commandError),
+      },
+      options,
+    );
+  }
+}
+
+function mapApiError(error: OpenTagApiError): Omit<ConstructorParameters<typeof CommandError>[0], never> {
+  switch (error.category) {
+    case "credential":
+      return { code: error.code, category: "auth", retryability: "after_auth", phase: "authentication" };
+    case "validation":
+      return { code: error.code, category: "validation", retryability: "never", phase: "validation" };
+    case "rate_limit":
+      return { code: error.code, category: "rate_limit", retryability: "backoff", phase: "request" };
+    case "transient":
+      return { code: error.code, category: "unavailable", retryability: "backoff", phase: "transport" };
+    default:
+      return { code: error.code, category: "internal", retryability: "never", phase: "request" };
+  }
+}
+
+function isZodError(
+  error: unknown,
+): error is { issues: readonly { path: readonly (string | number)[]; message: string }[] } {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    (error as { name?: unknown }).name === "ZodError" &&
+    Array.isArray((error as { issues?: unknown }).issues)
+  );
+}
+
+export function commandExitCode(error: CommandError): Exclude<CommandExitCode, typeof EXIT_CODES.success> {
+  if (error.category === "validation") return EXIT_CODES.usage;
+  if (error.category === "unavailable" || error.category === "timeout" || error.category === "dependency") {
+    return EXIT_CODES.serviceUnavailable;
+  }
+  if (error.category === "cancelled") return EXIT_CODES.interrupted;
+  return EXIT_CODES.failure;
+}
+
+function isInterrupted(error: unknown): boolean {
+  if (error instanceof Error && (error.name === "AbortError" || error.name === "CanceledError")) return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return /(?:^|\b)(?:aborted|abort|cancelled|canceled|interrupted)(?:\b|$)/iu.test(message);
+}
+
+function formatHumanValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value) ?? "null";
+}
+
+function redactValue<T>(value: T): T {
+  return redactUnknown(value, new WeakSet<object>()) as T;
+}
+
+function redactUnknown(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || value === undefined || typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "string") return redactSecrets(value);
+  if (typeof value !== "object") return `[${typeof value}]`;
+  if (seen.has(value)) return "[CIRCULAR]";
+  seen.add(value);
+  if (Array.isArray(value)) return value.slice(0, 64).map((entry) => redactUnknown(entry, seen));
+  const output: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value).slice(0, 64)) {
+    output[key] = isSensitiveKey(key) ? "[REDACTED]" : redactUnknown(child, seen);
+  }
+  return output;
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /(?:authorization|cookie|token|secret|credential|password|passwd|api[_-]?key|private[_-]?key|request[_-]?body|response[_-]?body|payload|prompt)/iu.test(
+    key,
+  );
+}
+
+export function redactSecrets(value: string): string {
+  return value
+    .replace(/\bBearer\s+[^\s,;}\]]+/giu, "Bearer [REDACTED]")
+    .replace(/(\b(?:authorization|proxy-authorization|cookie|set-cookie)\s*:\s*)[^\r\n]+/giu, "$1[REDACTED]")
+    .replace(
+      /([?&](?:access_token|refresh_token|client_secret|token|secret|password|api[_-]?key)=)[^&#\s]+/giu,
+      "$1[REDACTED]",
+    )
+    .replace(/(\b(?:token|secret|password|credential|api[_-]?key)\s*[:=]\s*)[^\s,;}\]]+/giu, "$1[REDACTED]")
+    .replace(/(postgres(?:ql)?:\/\/)[^\s/@]+(?::[^\s/@]*)?@/giu, "$1[REDACTED]@");
+}

--- a/apps/cli/src/core/command/policy.ts
+++ b/apps/cli/src/core/command/policy.ts
@@ -121,7 +121,7 @@ function classifyGenericError(error: unknown, phase: CommandPhase): CommandError
       cause: error,
     });
   }
-  if (candidate.category === "auth" || /^AUTH_/u.test(code) || /not logged in|authentication/iu.test(message)) {
+  if (isAuth(code, message, candidate.category)) {
     return new CommandError(
       {
         code,
@@ -152,6 +152,10 @@ function classifyGenericError(error: unknown, phase: CommandPhase): CommandError
     message,
     { cause: error },
   );
+}
+
+function isAuth(code: string, message: string, category: unknown): boolean {
+  return category === "auth" || /^AUTH_/u.test(code) || /not logged in|authentication/iu.test(message);
 }
 
 function isUnavailable(code: string, message: string, category: unknown): boolean {

--- a/apps/cli/src/core/command/policy.ts
+++ b/apps/cli/src/core/command/policy.ts
@@ -155,15 +155,22 @@ function classifyGenericError(error: unknown, phase: CommandPhase): CommandError
 }
 
 function isAuth(code: string, message: string, category: unknown): boolean {
-  return category === "auth" || /^AUTH_/u.test(code) || /not logged in|authentication/iu.test(message);
+  return (
+    category === "auth" ||
+    category === "authentication" ||
+    /^AUTH_/u.test(code) ||
+    /not logged in|authentication/iu.test(message)
+  );
 }
 
 function isUnavailable(code: string, message: string, category: unknown): boolean {
   return (
     category === "unavailable" ||
+    category === "service-unavailable" ||
+    category === "transient" ||
     code === "SERVICE_UNAVAILABLE" ||
     /(?:_UPSTREAM_)?UNAVAILABLE$/u.test(code) ||
-    /service unavailable|timed out|connection refused/iu.test(message)
+    /unavailable|timed out|connection refused/iu.test(message)
   );
 }
 

--- a/apps/cli/src/core/command/policy.ts
+++ b/apps/cli/src/core/command/policy.ts
@@ -105,9 +105,17 @@ export function toCommandError(error: unknown, phase: CommandPhase = "unknown"):
     return new CommandError(mapped, error.message, { cause: error });
   }
 
-  const candidate = error as { code?: unknown; category?: unknown; requestId?: unknown; message?: unknown };
+  return classifyGenericError(error, phase);
+}
+
+function classifyGenericError(error: unknown, phase: CommandPhase): CommandError {
+  const candidate =
+    error !== null && typeof error === "object"
+      ? (error as { code?: unknown; category?: unknown; requestId?: unknown; message?: unknown })
+      : {};
   const code = typeof candidate.code === "string" && candidate.code.length > 0 ? candidate.code : "INTERNAL_ERROR";
   const message = typeof candidate.message === "string" ? candidate.message : String(error);
+  const requestId = typeof candidate.requestId === "string" ? candidate.requestId : undefined;
   if (candidate.category === "validation" || phase === "validation") {
     return new CommandError({ code, category: "validation", retryability: "never", phase: "validation" }, message, {
       cause: error,
@@ -120,40 +128,38 @@ export function toCommandError(error: unknown, phase: CommandPhase = "unknown"):
         category: "auth",
         retryability: "after_auth",
         phase: "authentication",
-        ...(typeof candidate.requestId === "string" ? { requestId: candidate.requestId } : {}),
+        ...(requestId ? { requestId } : {}),
       },
       message,
       { cause: error },
     );
   }
-  if (
-    candidate.category === "unavailable" ||
-    code === "SERVICE_UNAVAILABLE" ||
-    /(?:_UPSTREAM_)?UNAVAILABLE$/u.test(code) ||
-    /service unavailable|timed out|connection refused/iu.test(message)
-  ) {
+  if (isUnavailable(code, message, candidate.category)) {
     return new CommandError(
       {
         code,
         category: "unavailable",
         retryability: "backoff",
         phase: "transport",
-        ...(typeof candidate.requestId === "string" ? { requestId: candidate.requestId } : {}),
+        ...(requestId ? { requestId } : {}),
       },
       message,
       { cause: error },
     );
   }
   return new CommandError(
-    {
-      code,
-      category: "internal",
-      retryability: "never",
-      phase,
-      ...(typeof candidate.requestId === "string" ? { requestId: candidate.requestId } : {}),
-    },
+    { code, category: "internal", retryability: "never", phase, ...(requestId ? { requestId } : {}) },
     message,
     { cause: error },
+  );
+}
+
+function isUnavailable(code: string, message: string, category: unknown): boolean {
+  return (
+    category === "unavailable" ||
+    code === "SERVICE_UNAVAILABLE" ||
+    /(?:_UPSTREAM_)?UNAVAILABLE$/u.test(code) ||
+    /service unavailable|timed out|connection refused/iu.test(message)
   );
 }
 

--- a/apps/cli/src/core/computer/connect.ts
+++ b/apps/cli/src/core/computer/connect.ts
@@ -3,12 +3,13 @@ import {
   allocateComputerIdentity,
   machineCredentialsPath,
   normalizeServerUrl,
-  OpenTagApi,
+  type OpenTagApi,
   resolveOpenTagHome,
   storeBoundAccountComputer,
   writeComputerIdentityAtomically,
 } from "@opentag/client";
 import { CLI_VERSION } from "../../build-info.js";
+import { resolveCommandContext } from "../command/context.js";
 import {
   createDaemonServiceManager,
   type DaemonServiceInfo,
@@ -52,7 +53,8 @@ export async function runComputerConnect(options: ComputerConnectOptions): Promi
   await manager?.preflight();
   const serviceBefore = await manager?.status();
   const identity = await allocateComputerIdentity(home, serverUrl);
-  const api = options.api ?? new OpenTagApi(serverUrl);
+  const api = options.api ?? (await resolveCommandContext({ home, serverUrl })).api;
+  if (!api) throw new Error("Command context did not resolve an API");
   const enrollment = await api.exchangeComputerConnectCode({
     code: options.code,
     computerId: identity.computerId,

--- a/apps/cli/src/core/computer/queries.ts
+++ b/apps/cli/src/core/computer/queries.ts
@@ -1,10 +1,8 @@
-import { AccessTokenProvider, OpenTagApi, readCredentials, resolveOpenTagHome } from "@opentag/client";
 import type { ListWorkspaceComputersResponse } from "@opentag/shared";
+import { resolveCommandContext } from "../command/context.js";
 
-export async function listComputers(home = resolveOpenTagHome()): Promise<ListWorkspaceComputersResponse> {
-  const credentials = await readCredentials(home);
-  if (!credentials) throw new Error("OpenTag is not logged in; run login first");
-  const accessToken = await new AccessTokenProvider({ home }).getAccessToken();
-  const api = new OpenTagApi(credentials.serverUrl);
-  return api.listAccountComputers(accessToken);
+export async function listComputers(home?: string): Promise<ListWorkspaceComputersResponse> {
+  const context = await resolveCommandContext({ home, requireAuth: true });
+  if (!context.api || !context.accessToken) throw new Error("Command context did not resolve an authenticated API");
+  return context.api.listAccountComputers(context.accessToken);
 }

--- a/apps/cli/src/core/daemon/environment.ts
+++ b/apps/cli/src/core/daemon/environment.ts
@@ -1,5 +1,6 @@
 import { lstat, readFile } from "node:fs/promises";
 import { validatePrivateDirectory } from "@opentag/client";
+import { resolveChannelEnvironment } from "../channel/environment.js";
 import { buildChildEnvironment } from "../command/environment.js";
 import { resolveDaemonPaths } from "./paths.js";
 import { DaemonServiceError } from "./service/types.js";
@@ -74,7 +75,7 @@ export async function applyDaemonEnvironment(
   home: string,
   environment: NodeJS.ProcessEnv = process.env,
 ): Promise<DaemonEnvironmentResult> {
-  return loadDaemonEnvironment(home, environment);
+  return loadDaemonEnvironment(home, resolveChannelEnvironment(environment));
 }
 
 /** Build the daemon child environment as a detached object. */

--- a/apps/cli/src/core/daemon/environment.ts
+++ b/apps/cli/src/core/daemon/environment.ts
@@ -1,6 +1,5 @@
 import { lstat, readFile } from "node:fs/promises";
 import { validatePrivateDirectory } from "@opentag/client";
-import { resolveChannelEnvironment } from "../channel/environment.js";
 import { buildChildEnvironment } from "../command/environment.js";
 import { resolveDaemonPaths } from "./paths.js";
 import { DaemonServiceError } from "./service/types.js";
@@ -75,7 +74,7 @@ export async function applyDaemonEnvironment(
   home: string,
   environment: NodeJS.ProcessEnv = process.env,
 ): Promise<DaemonEnvironmentResult> {
-  return loadDaemonEnvironment(home, resolveChannelEnvironment(environment));
+  return loadDaemonEnvironment(home, environment);
 }
 
 /** Build the daemon child environment as a detached object. */

--- a/apps/cli/src/core/daemon/environment.ts
+++ b/apps/cli/src/core/daemon/environment.ts
@@ -1,5 +1,6 @@
 import { lstat, readFile } from "node:fs/promises";
 import { validatePrivateDirectory } from "@opentag/client";
+import { buildChildEnvironment } from "../command/environment.js";
 import { resolveDaemonPaths } from "./paths.js";
 import { DaemonServiceError } from "./service/types.js";
 
@@ -73,11 +74,12 @@ export async function applyDaemonEnvironment(
   home: string,
   environment: NodeJS.ProcessEnv = process.env,
 ): Promise<DaemonEnvironmentResult> {
-  const result = await loadDaemonEnvironment(home, environment);
-  for (const [key, value] of Object.entries(result.env)) {
-    if (value !== undefined) environment[key] = value;
-  }
-  return result;
+  return loadDaemonEnvironment(home, environment);
+}
+
+/** Build the daemon child environment as a detached object. */
+export function buildDaemonChildEnvironment(result: DaemonEnvironmentResult): NodeJS.ProcessEnv {
+  return buildChildEnvironment(result.env);
 }
 
 function parseEnvironmentValue(rawValue: string): string | undefined {

--- a/apps/cli/src/core/daemon/process-lease.ts
+++ b/apps/cli/src/core/daemon/process-lease.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { lstat, open, readFile, rename, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { ensurePrivateDirectory, validatePrivateDirectory } from "@opentag/client";
+import { buildChildEnvironment } from "../command/environment.js";
 
 export interface ProcessLeaseRecord {
   pid: number;
@@ -287,7 +288,10 @@ export async function inspectDarwinProcessIdentity(
   pid: number,
   dependencies: DarwinProcessIdentityInspectionDependencies = {},
 ): Promise<ProcessIdentityInspection> {
-  const environment = { ...process.env, LANG: "C", LC_ALL: "C", TZ: "UTC" };
+  const environment = buildChildEnvironment(process.env, {
+    keys: ["LANG", "LC_ALL", "TZ"],
+    overrides: { LANG: "C", LC_ALL: "C", TZ: "UTC" },
+  });
   const startedAt = await (dependencies.readProcessStart ?? readDarwinProcessStart)(pid, environment);
   if (startedAt) return { id: `darwin:${startedAt}`, state: "identified" };
   return (dependencies.isProcessAlive ?? isProcessAlive)(pid) ? { state: "unverifiable" } : { state: "gone" };

--- a/apps/cli/src/core/daemon/reconcile-service.ts
+++ b/apps/cli/src/core/daemon/reconcile-service.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { readMachineCredentials, resolveBoundAccountComputer, resolveOpenTagHome } from "@opentag/client";
+import { resolveChannelEnvironment } from "../channel/environment.js";
 import { createDaemonServiceManager, type DaemonServiceInfo, type DaemonServiceManager } from "./service/index.js";
 import { DaemonServiceError } from "./service/types.js";
 
@@ -27,8 +28,9 @@ export async function reconcileDaemonService(
   const hasCredentials =
     options.hasCredentials ??
     (async () =>
-      resolveBoundAccountComputer(await readMachineCredentials(resolve(resolveOpenTagHome(process.env)))).status ===
-      "bound");
+      resolveBoundAccountComputer(
+        await readMachineCredentials(resolve(resolveOpenTagHome(resolveChannelEnvironment(process.env)))),
+      ).status === "bound");
   if (!(await hasCredentials())) {
     return { reason: "credentials-missing", service: current, status: "deferred" };
   }

--- a/apps/cli/src/core/daemon/runtime.ts
+++ b/apps/cli/src/core/daemon/runtime.ts
@@ -102,7 +102,7 @@ export async function runDaemonService(options: DaemonRuntimeOptions = {}): Prom
   let failure: unknown;
   let failed = false;
   try {
-    const environmentResult = await applyDaemonEnvironment(home, process.env);
+    const environmentResult = await applyDaemonEnvironment(home, resolveChannelEnvironment(process.env));
     const daemonEnvironment = buildDaemonChildEnvironment(environmentResult);
     if (daemonEnvironment.OPENTAG_SERVICE_MODE === "1") configureClientLoggerForService(paths.logs);
     const logger = (options.logger ?? createLogger("daemon")).child(baseBindings);

--- a/apps/cli/src/core/daemon/runtime.ts
+++ b/apps/cli/src/core/daemon/runtime.ts
@@ -170,6 +170,7 @@ export async function runDaemonService(options: DaemonRuntimeOptions = {}): Prom
       });
       const runtime = await createClientRuntime(connection, {
         home,
+        environment: daemonEnvironment,
         clientVersion: CLI_VERSION,
         cliCommand: channelConfig.binName,
         logger: runtimeLogger,

--- a/apps/cli/src/core/daemon/runtime.ts
+++ b/apps/cli/src/core/daemon/runtime.ts
@@ -5,7 +5,6 @@ import {
   configureClientLoggerForService,
   createClientRuntime,
   createLogger,
-  OpenTagApi,
   RuntimeConnection,
   RuntimeConnectionError,
   readMachineCredentials,
@@ -15,7 +14,9 @@ import {
 } from "@opentag/client";
 import { CLI_VERSION } from "../../build-info.js";
 import { channelConfig } from "../channel/config.js";
-import { applyDaemonEnvironment } from "./environment.js";
+import { resolveChannelEnvironment } from "../channel/environment.js";
+import { resolveCommandContext } from "../command/context.js";
+import { applyDaemonEnvironment, buildDaemonChildEnvironment } from "./environment.js";
 import { acquireDaemonOwner, DaemonOwnerStartupError } from "./ownership.js";
 import { resolveDaemonPaths } from "./paths.js";
 import { DaemonServiceError } from "./service/types.js";
@@ -75,7 +76,8 @@ export class DaemonRuntimeConfigurationError extends Error {
 }
 
 export async function runDaemonService(options: DaemonRuntimeOptions = {}): Promise<void> {
-  const home = options.home ?? resolveOpenTagHome();
+  const environment = resolveChannelEnvironment(process.env);
+  const home = options.home ?? resolveOpenTagHome(environment);
   const paths = resolveDaemonPaths(home);
   const signals = options.signals ?? process;
   const instanceId = randomUUID();
@@ -101,7 +103,8 @@ export async function runDaemonService(options: DaemonRuntimeOptions = {}): Prom
   let failed = false;
   try {
     const environmentResult = await applyDaemonEnvironment(home, process.env);
-    if (process.env.OPENTAG_SERVICE_MODE === "1") configureClientLoggerForService(paths.logs);
+    const daemonEnvironment = buildDaemonChildEnvironment(environmentResult);
+    if (daemonEnvironment.OPENTAG_SERVICE_MODE === "1") configureClientLoggerForService(paths.logs);
     const logger = (options.logger ?? createLogger("daemon")).child(baseBindings);
     lifecycleLogger = logger;
     terminalLogger = logger;
@@ -152,7 +155,9 @@ export async function runDaemonService(options: DaemonRuntimeOptions = {}): Prom
         instanceId: connectionInstanceId,
         workspaceComputerId: credential.workspaceComputerId,
       });
-      const api = new OpenTagApi(credential.serverUrl);
+      const apiContext = await resolveCommandContext({ home, serverUrl: credential.serverUrl });
+      if (!apiContext.api) throw new Error("Command context did not resolve an API");
+      const api = apiContext.api;
       const connection = new RuntimeConnection({
         arch: arch(),
         clientVersion: CLI_VERSION,

--- a/apps/cli/src/core/daemon/service/index.ts
+++ b/apps/cli/src/core/daemon/service/index.ts
@@ -4,6 +4,7 @@ import { readMachineCredentials, resolveBoundAccountComputer, resolveOpenTagHome
 import { getChannelConfig } from "@opentag/shared";
 import { CHANNEL } from "../../../build-info.js";
 import { channelConfig } from "../../channel/config.js";
+import { resolveChannelEnvironment } from "../../channel/environment.js";
 import { inspectDaemonOwner } from "../ownership.js";
 import { createLaunchdBackend } from "./launchd.js";
 import {
@@ -51,7 +52,7 @@ type DaemonServiceMutation = "install" | "restart" | "start" | "stop" | "uninsta
 export async function createDaemonServiceManager(
   options: CreateDaemonServiceManagerOptions = {},
 ): Promise<DaemonServiceManager> {
-  const environment = options.env ?? process.env;
+  const environment = resolveChannelEnvironment(options.env ?? process.env);
   const platform = options.platform ?? process.platform;
   const account = userInfo();
   const home = await canonicalizeServiceHome(resolve(options.home ?? resolveOpenTagHome(environment)));

--- a/apps/cli/src/core/daemon/service/shared.ts
+++ b/apps/cli/src/core/daemon/service/shared.ts
@@ -4,6 +4,7 @@ import { constants } from "node:fs";
 import { access, chmod, lstat, mkdir, open, readFile, realpath, rename, rm, stat } from "node:fs/promises";
 import { basename, delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { ensurePrivateDirectory } from "@opentag/client";
+import { buildChildEnvironment } from "../../command/environment.js";
 import { resolveDaemonPaths } from "../paths.js";
 import {
   acquireProcessFileLease,
@@ -48,7 +49,7 @@ export const defaultServiceRunner: ServiceRunner = {
         [...args],
         {
           encoding: "utf8",
-          env: options.env,
+          env: options.env ?? buildChildEnvironment(process.env),
           maxBuffer: 1024 * 1024,
           timeout: options.timeoutMs,
         },

--- a/apps/cli/src/core/session/index.ts
+++ b/apps/cli/src/core/session/index.ts
@@ -1,12 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import {
-  OpenTagApi,
-  OpenTagApiError,
-  readComputerIdentity,
-  readSessionCliProofFile,
-  resolveOpenTagHome,
-} from "@opentag/client";
+import { type OpenTagApi, OpenTagApiError, readComputerIdentity, readSessionCliProofFile } from "@opentag/client";
 import {
   SESSION_CLI_DEFAULT_LIMIT,
   type SessionCliCommandResponse,
@@ -15,6 +9,8 @@ import {
   type SessionCliListResponse,
   SessionCliSendRequestSchema,
 } from "@opentag/shared";
+import { resolveCommandContext } from "../command/context.js";
+import { redactSecrets } from "../command/policy.js";
 
 export interface SessionMessageOptions {
   message?: string;
@@ -44,7 +40,8 @@ async function context(environment: NodeJS.ProcessEnv = process.env): Promise<{ 
       "Session commands are available only inside an OpenTag-managed Agent Session (runtime context missing)",
     );
   }
-  const home = resolveOpenTagHome(environment);
+  const context = await resolveCommandContext({ environment });
+  const home = context.home;
   const identity = await readComputerIdentity(home);
   if (!identity) {
     throw new Error(
@@ -52,7 +49,9 @@ async function context(environment: NodeJS.ProcessEnv = process.env): Promise<{ 
     );
   }
   const proof = await readSessionCliProofFile(proofPath);
-  return { api: new OpenTagApi(identity.serverUrl), proof: proof.token };
+  const apiContext = await resolveCommandContext({ environment, home, serverUrl: identity.serverUrl });
+  if (!apiContext.api) throw new Error("Command context did not resolve an API");
+  return { api: apiContext.api, proof: proof.token };
 }
 
 export async function runSessionCreate(
@@ -122,7 +121,7 @@ export function formatSessionCommandError(error: SessionCommandRequestError, jso
     status: error.status,
     messageId: error.messageId,
     code: error.code,
-    message: error.message,
+    message: redactSecrets(error.message),
   };
   return json
     ? JSON.stringify(result)

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,3 +1,5 @@
+import * as commandPolicy from "./core/command/policy.js";
+
 export { CHANNEL, CLI_PACKAGE_NAME, CLI_VERSION } from "./build-info.js";
 export { createProgram } from "./cli/program.js";
 export { formatAgent, formatAgentCreated, formatAgentList } from "./core/agent/formatting.js";
@@ -13,14 +15,12 @@ export { channelConfig } from "./core/channel/config.js";
 export { resolveCommandContext } from "./core/command/context.js";
 export { buildChildEnvironment } from "./core/command/environment.js";
 export type { CommandResult } from "./core/command/policy.js";
-export {
-  CommandError,
-  commandExitCode,
-  EXIT_CODES,
-  executeCommand,
-  presentCommand,
-  toCommandError,
-} from "./core/command/policy.js";
+export const CommandError = commandPolicy.CommandError;
+export const commandExitCode = commandPolicy.commandExitCode;
+export const EXIT_CODES = commandPolicy.EXIT_CODES;
+export const executeCommand = commandPolicy.executeCommand;
+export const presentCommand = commandPolicy.presentCommand;
+export const toCommandError = commandPolicy.toCommandError;
 export { formatComputerList } from "./core/computer/formatting.js";
 export { listComputers } from "./core/computer/queries.js";
 export {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,9 +12,9 @@ export { type LoginOptions, type LoginResult, runLogin } from "./core/auth/login
 export { channelConfig } from "./core/channel/config.js";
 export { resolveCommandContext } from "./core/command/context.js";
 export { buildChildEnvironment } from "./core/command/environment.js";
+export type { CommandResult } from "./core/command/policy.js";
 export {
   CommandError,
-  type CommandResult,
   commandExitCode,
   EXIT_CODES,
   executeCommand,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -10,6 +10,17 @@ export {
 export { runAgentList, runAgentShow } from "./core/agent/queries.js";
 export { type LoginOptions, type LoginResult, runLogin } from "./core/auth/login.js";
 export { channelConfig } from "./core/channel/config.js";
+export { resolveCommandContext } from "./core/command/context.js";
+export { buildChildEnvironment } from "./core/command/environment.js";
+export {
+  CommandError,
+  type CommandResult,
+  commandExitCode,
+  EXIT_CODES,
+  executeCommand,
+  presentCommand,
+  toCommandError,
+} from "./core/command/policy.js";
 export { formatComputerList } from "./core/computer/formatting.js";
 export { listComputers } from "./core/computer/queries.js";
 export {


### PR DESCRIPTION
Implements backlog item **CLI-01 — Establish one CLI result, error, and environment policy**
(Phase 1: protect correctness and availability).

## What this adds

- `apps/cli/src/core/command/policy.ts`: typed `CommandResult` / `CommandError` with stable
  documented exit codes (`0` success, `1` failure, `2` usage/validation, `3` service unavailable,
  `130` interrupted; the daemon's command-specific deferred exit `3` non-failure outcome is
  preserved), API/Zod/Node error normalization, bounded recursive redaction, and a single
  human + `--json` presenter. Agent, Computer, Login, Daemon, and Session command surfaces all use
  it; the entrypoint converts otherwise-unhandled failures without printing raw stacks.
- Explicit environments: a detached `buildChildEnvironment` plus shared `resolveCommandContext` —
  channel defaults, daemon environment loading, Darwin process inspection, service manager setup,
  and runtime API creation no longer mutate the caller's `process.env`; child processes receive
  only intended keys.
- Local structured errors use the standard `code`/`category`/`retryability`/`phase`/`requestId`
  shape (unification with the shared taxonomy from #359 is a post-merge pass).
- Tests first: a command matrix over stdout/stderr/JSON shape and exit codes for success,
  validation, authentication, unavailable, and interrupted cases; environment-builder immutability
  tests. Exit-code contract documented in `apps/cli/README.md`.

## Checklist (final state)

- [x] Survey command registry, exit handling, env mutation sites
- [x] Command-matrix and environment tests first
- [x] Typed result/error policy + single presenter + redaction
- [x] Explicit child environments + one context/API resolution path
- [x] Exit-code documentation
- [x] Full verification

## Verification

Lane and orchestrator re-run (Node 24.19.0, pnpm 10.12.1): `pnpm check`, `pnpm typecheck`,
`pnpm test` (109 script tests plus all workspace suites; CLI 18 files / 229 tests).

## Provenance

Written by a Codex agent (dispatch run `9529da`, lane `cli-result-policy-6`) under bypassed
approvals in an isolated git worktree; verified and published by the orchestrating Claude session.
