### PR TITLE
feat(web): add a language switcher to the account settings page

### DIFF
--- a/apps/web/messages/account/en.json
+++ b/apps/web/messages/account/en.json
@@ -1,3 +1,5 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "account_language_description": "Choose the language used throughout OpenTag.",
+  "account_language_label": "Language"
 }

--- a/apps/web/messages/account/zh.json
+++ b/apps/web/messages/account/zh.json
@@ -1,3 +1,5 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "account_language_description": "选择 OpenTag 界面使用的语言。",
+  "account_language_label": "语言"
 }

--- a/apps/web/src/features/account/account-page.test.tsx
+++ b/apps/web/src/features/account/account-page.test.tsx
@@ -1,0 +1,47 @@
+import type { MeResponse } from "@opentag/shared/browser";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as locale from "../../i18n/locale.js";
+import { AccountSettings } from "./account-page.js";
+
+const user: MeResponse["user"] = {
+  id: "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e",
+  email: "tester@company.example",
+  displayName: "Tester",
+};
+
+describe("AccountSettings language selector", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders every locale with its self-named label and selects the current locale", async () => {
+    render(<AccountSettings refreshMe={vi.fn().mockResolvedValue({ user, setupCompletedAt: null })} user={user} />);
+
+    const selector = screen.getByRole("combobox", { name: "Language" });
+    expect(selector.textContent).toContain(locale.LOCALE_LABELS[locale.getLocale()]);
+
+    fireEvent.click(selector);
+    const options = await screen.findAllByRole("option");
+    expect(options.map((option) => option.textContent?.trim())).toEqual(
+      locale.locales.map((availableLocale) => locale.LOCALE_LABELS[availableLocale]),
+    );
+    const currentOption = options.find(
+      (option) => option.textContent?.trim() === locale.LOCALE_LABELS[locale.getLocale()],
+    );
+    expect(currentOption?.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("passes a normalized locale to Paraglide when the selection changes", async () => {
+    const setLocale = vi.spyOn(locale, "setLocale");
+    render(<AccountSettings refreshMe={vi.fn().mockResolvedValue({ user, setupCompletedAt: null })} user={user} />);
+
+    const selector = screen.getByRole("combobox", { name: "Language" });
+    fireEvent.click(selector);
+    const option = await screen.findByRole("option", { name: locale.LOCALE_LABELS.zh });
+    fireEvent.pointerMove(option, { pointerType: "mouse" });
+    fireEvent.pointerDown(option, { pointerType: "mouse" });
+    fireEvent.pointerUp(option, { pointerType: "mouse" });
+    fireEvent.click(option);
+
+    await waitFor(() => expect(setLocale).toHaveBeenCalledWith("zh"));
+  });
+});

--- a/apps/web/src/features/account/account-page.tsx
+++ b/apps/web/src/features/account/account-page.tsx
@@ -1,7 +1,9 @@
 import type { MeResponse } from "@opentag/shared/browser";
 import { type FormEvent, useEffect, useRef, useState } from "react";
 import { browserApi } from "../../api.js";
-import { Button, Field, KumoInputControl, SettingsList, SettingsRow, Text } from "../../ui/design-system.js";
+import { getLocale, isLocale, LOCALE_LABELS, locales, setLocale, toLocale } from "../../i18n/locale.js";
+import * as m from "../../paraglide/messages.js";
+import { Button, Field, KumoInputControl, Select, SettingsList, SettingsRow, Text } from "../../ui/design-system.js";
 import { Page } from "../layout/page.js";
 import { useAccount } from "../session/session-context.js";
 
@@ -133,6 +135,26 @@ export function AccountSettings({
               required
               value={displayName}
             />
+          </Field>
+        </SettingsRow>
+        <SettingsRow label={m.account_language_label()} description={m.account_language_description()}>
+          <Field htmlFor="account-language" label={m.account_language_label()}>
+            <Select
+              aria-label={m.account_language_label()}
+              id="account-language"
+              renderValue={(locale) => LOCALE_LABELS[locale]}
+              value={getLocale()}
+              onValueChange={(value) => {
+                const locale = toLocale(value);
+                if (locale && isLocale(locale)) setLocale(locale);
+              }}
+            >
+              {locales.map((locale) => (
+                <Select.Option key={locale} value={locale}>
+                  {LOCALE_LABELS[locale]}
+                </Select.Option>
+              ))}
+            </Select>
           </Field>
         </SettingsRow>
       </SettingsList>


### PR DESCRIPTION
## Summary

Adds a language switcher to the personal account settings page, built on the Paraglide i18n foundation that landed in #292. The account page gains a settings row with a Kumo `Select` whose options come from the runtime `locales` plus `LOCALE_LABELS` (each language named in its own language), whose current value comes from `getLocale()`, and whose changes are validated (`isLocale`) before calling Paraglide's `setLocale()` — which persists the choice via the built-in localStorage strategy and reloads so all messages re-resolve. No custom persistence and no new state store.

## Changes

- `apps/web/messages/account/{en,zh}.json` — sorted message keys for the language-setting row label and description.
- `apps/web/src/features/account/account-page.tsx` — the language selector row, composed with the existing `Field`/`SettingsList` layout; an explicit accessible label is supplied because the direct Kumo `Select` is not one of the compatibility controls cloned by `Field`.
- `apps/web/src/features/account/account-page.test.tsx` — direct `AccountSettings` mounts covering every locale option, the current selection display, and the `setLocale` invocation on change (using the shared jsdom setup's no-reload locale runtime override).

## Checklist

- [x] Read the locale adapter, account page, design-system Select exports, localized feature idioms, and account message files
- [x] Add account language-setting messages in English and Chinese
- [x] Add the Paraglide-backed language selector to the account settings page
- [x] Add direct component tests for locale options, current value, and `setLocale` calls
- [x] Run all required checks with a clean worktree

## Verification

- `pnpm check` — pass (workspace contract, migration drift, notices verified)
- `pnpm typecheck` — pass, all 6 workspaces
- `pnpm --filter @opentag/web test` — pass, 50 files / 563 tests
- `pnpm build` — pass, all workspaces, bundle report generated
- `pnpm test` — pass (full repository suite; one unrelated transient client temporary-marker ENOENT on first run passed on retry and in the focused suite)
- `git status` clean; no `.dispatch/` content in the diff

## Provenance

Written by a codex agent (dispatch run `bceef2`, lane `account-language-switcher-1`) under bypassed approvals in an isolated worktree; verified and published by the orchestrating session.
