### PR TITLE
fix(feishu): deduplicate inbound provider events at the dispatcher boundary

### DIFF
--- a/packages/server/src/__tests__/feishu-adapter.test.ts
+++ b/packages/server/src/__tests__/feishu-adapter.test.ts
@@ -194,6 +194,44 @@ describe("Feishu adapter", () => {
     expect(received[2]?.resources[0]).toMatchObject({ fileKey: "file_1" });
   });
 
+  it("deduplicates a repeated group/thread representation by provider event identity", async () => {
+    const received: NormalizedMessage[] = [];
+    const dispatcher = createReliableFeishuDispatcher((message) => {
+      received.push(message);
+    });
+    const groupThreadEvent = rawMessage("event-group-thread", "message-group-thread", "10");
+    groupThreadEvent.event.message.chat_id = "oc_example_group";
+    Object.assign(groupThreadEvent.event.message, { thread_id: "omt_example_thread" });
+
+    await Promise.all([
+      dispatcher.invoke(groupThreadEvent, { needCheck: false }),
+      dispatcher.invoke(structuredClone(groupThreadEvent), { needCheck: false }),
+    ]);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      chatId: "oc_example_group",
+      threadId: "omt_example_thread",
+      raw: { event_id: "event-group-thread", tenant_key: "workspace_1" },
+    });
+  });
+
+  it("keeps distinct messages in the same group chat and thread", async () => {
+    const received: NormalizedMessage[] = [];
+    const dispatcher = createReliableFeishuDispatcher((message) => {
+      received.push(message);
+    });
+    const first = rawMessage("event-distinct-1", "message-distinct-1", "11");
+    const second = rawMessage("event-distinct-2", "message-distinct-2", "12");
+    for (const event of [first, second]) {
+      event.event.message.chat_id = "oc_example_group";
+      Object.assign(event.event.message, { thread_id: "omt_example_thread" });
+      await dispatcher.invoke(event, { needCheck: false });
+    }
+
+    expect(received.map((message) => message.messageId)).toEqual(["message-distinct-1", "message-distinct-2"]);
+  });
+
   it("falls back to user sender ids and maps raw mentions", async () => {
     let received: NormalizedMessage | undefined;
     const dispatcher = createReliableFeishuDispatcher((message) => {

--- a/packages/server/src/__tests__/feishu-adapter.test.ts
+++ b/packages/server/src/__tests__/feishu-adapter.test.ts
@@ -202,10 +202,12 @@ describe("Feishu adapter", () => {
     const groupThreadEvent = rawMessage("event-group-thread", "message-group-thread", "10");
     groupThreadEvent.event.message.chat_id = "oc_example_group";
     Object.assign(groupThreadEvent.event.message, { thread_id: "omt_example_thread" });
+    const threadRepresentation = structuredClone(groupThreadEvent);
+    threadRepresentation.header.event_id = "event-thread-representation";
 
     await Promise.all([
       dispatcher.invoke(groupThreadEvent, { needCheck: false }),
-      dispatcher.invoke(structuredClone(groupThreadEvent), { needCheck: false }),
+      dispatcher.invoke(threadRepresentation, { needCheck: false }),
     ]);
 
     expect(received).toHaveLength(1);

--- a/packages/server/src/services/im-bindings/feishu/adapter.ts
+++ b/packages/server/src/services/im-bindings/feishu/adapter.ts
@@ -10,6 +10,7 @@ import {
   WSClient,
 } from "@larksuiteoapi/node-sdk";
 import { type NormalizedInboundImEvent, NormalizedInboundImEventSchema } from "@opentag/shared";
+import { emitRootSpan, imAttrs, outcomeAttrs } from "../../../observability/index.js";
 import { ExternalCallPolicy } from "../../im/external-call-policy.js";
 import { contentBlocksWithMentions } from "../mention-content.js";
 import type {
@@ -29,6 +30,7 @@ interface FeishuRawEnvelope {
 }
 
 interface RawFeishuMessageEvent {
+  header?: { event_id?: string; tenant_key?: string };
   event_id?: string;
   tenant_key?: string;
   sender: {
@@ -56,6 +58,7 @@ interface RawFeishuMessageEvent {
 }
 
 interface RawFeishuRecallEvent {
+  header?: { event_id?: string; tenant_key?: string };
   event_id?: string;
   tenant_key?: string;
   message_id?: string;
@@ -110,6 +113,84 @@ const REDACTING_SDK_LOGGER = {
   debug: () => undefined,
   trace: () => undefined,
 };
+
+const DEDUPLICATION_TTL_MS = 10 * 60 * 1000;
+const DEDUPLICATION_MAX_ENTRIES = 10_000;
+
+type FeishuRawInboundEvent = RawFeishuMessageEvent | RawFeishuRecallEvent;
+
+function providerEventIdentity(raw: FeishuRawInboundEvent): {
+  key: string;
+  providerEventId: string | null;
+  externalMessageId: string | null;
+} | null {
+  const providerEventId = raw.header?.event_id ?? raw.event_id ?? null;
+  if ("message" in raw) {
+    const externalMessageId = raw.message.message_id;
+    if (providerEventId) return { key: `event:${providerEventId}`, providerEventId, externalMessageId };
+    return {
+      key: `message:${externalMessageId}:${raw.message.create_time}`,
+      providerEventId: null,
+      externalMessageId,
+    };
+  }
+  const externalMessageId = raw.message_id ?? null;
+  if (!externalMessageId && !providerEventId) return null;
+  if (providerEventId) return { key: `event:${providerEventId}`, providerEventId, externalMessageId };
+  return {
+    key: `recall:${externalMessageId}:${raw.recall_time ?? "unknown"}`,
+    providerEventId: null,
+    externalMessageId,
+  };
+}
+
+function createFeishuInboundDeduplicator() {
+  const entries = new Map<string, { expiresAt: number; promise?: Promise<void> }>();
+
+  const prune = (now: number): void => {
+    for (const [key, entry] of entries) {
+      if (entry.expiresAt <= now) entries.delete(key);
+    }
+    while (entries.size > DEDUPLICATION_MAX_ENTRIES) {
+      const oldest = entries.keys().next().value;
+      if (oldest === undefined) break;
+      entries.delete(oldest);
+    }
+  };
+
+  return async (raw: FeishuRawInboundEvent, onMessage: () => Promise<void>): Promise<void> => {
+    const identity = providerEventIdentity(raw);
+    if (!identity) return onMessage();
+    const now = Date.now();
+    prune(now);
+    const existing = entries.get(identity.key);
+    if (existing) {
+      emitRootSpan("feishu.inbound.deduplicated", {
+        ...imAttrs({
+          provider: "feishu",
+          providerEventId: identity.providerEventId,
+          externalMessageId: identity.externalMessageId,
+          duplicate: true,
+        }),
+        ...outcomeAttrs("duplicate"),
+      });
+      if (existing.promise) await existing.promise;
+      return;
+    }
+    const promise = onMessage();
+    entries.set(identity.key, { expiresAt: now + DEDUPLICATION_TTL_MS, promise });
+    try {
+      await promise;
+    } catch (error) {
+      const current = entries.get(identity.key);
+      if (current?.promise === promise) entries.delete(identity.key);
+      throw error;
+    } finally {
+      const current = entries.get(identity.key);
+      if (current?.promise === promise) entries.set(identity.key, { expiresAt: current.expiresAt });
+    }
+  };
+}
 
 export function feishuDomainForWorkspaceBrand(teamBrand?: "feishu" | "lark" | null): Domain {
   return teamBrand === "lark" ? Domain.Lark : Domain.Feishu;
@@ -178,6 +259,8 @@ function parseRawContent(message: RawFeishuMessageEvent["message"]): {
 function rawReceiveToNormalized(raw: RawFeishuMessageEvent): NormalizedMessage {
   const parsed = parseRawContent(raw.message);
   const senderId = raw.sender.sender_id?.open_id ?? raw.sender.sender_id?.user_id ?? "system";
+  const eventId = raw.header?.event_id ?? raw.event_id;
+  const tenantKey = raw.header?.tenant_key ?? raw.tenant_key ?? raw.sender.tenant_key;
   return {
     messageId: raw.message.message_id,
     chatId: raw.message.chat_id,
@@ -200,8 +283,8 @@ function rawReceiveToNormalized(raw: RawFeishuMessageEvent): NormalizedMessage {
     replyToMessageId: raw.message.parent_id,
     createTime: Number(raw.message.create_time),
     raw: {
-      event_id: raw.event_id,
-      tenant_key: raw.tenant_key,
+      event_id: eventId,
+      tenant_key: tenantKey,
       event: { sender: { sender_type: raw.sender.sender_type, tenant_key: raw.sender.tenant_key } },
       opentagOperation: "created",
     } satisfies FeishuRawEnvelope,
@@ -223,8 +306,8 @@ function rawRecallToNormalized(raw: RawFeishuRecallEvent): NormalizedMessage | u
     mentionedBot: false,
     createTime: Number(raw.recall_time ?? Date.now()),
     raw: {
-      event_id: raw.event_id ?? `${raw.message_id}:${raw.recall_time ?? "unknown"}:recalled`,
-      tenant_key: raw.tenant_key,
+      event_id: raw.header?.event_id ?? raw.event_id ?? `${raw.message_id}:${raw.recall_time ?? "unknown"}:recalled`,
+      tenant_key: raw.header?.tenant_key ?? raw.tenant_key,
       opentagOperation: "deleted",
       opentagConversationKind: "unknown",
     } satisfies FeishuRawEnvelope,
@@ -303,15 +386,16 @@ export function createReliableFeishuDispatcher(
   onMessage: (message: NormalizedMessage) => Promise<void> | void,
 ): EventDispatcher {
   const dispatcher = new EventDispatcher({ logger: REDACTING_SDK_LOGGER, loggerLevel: LoggerLevel.error });
+  const deduplicate = createFeishuInboundDeduplicator();
   dispatcher.register({
     "im.message.receive_v1": async (raw: RawFeishuMessageEvent) => {
       // Deliberately bypass LarkChannel's SafetyPipeline. EventDispatcher
       // awaits this promise, and WSClient maps rejection to a 500 ACK.
-      await onMessage(rawReceiveToNormalized(raw));
+      await deduplicate(raw, async () => onMessage(rawReceiveToNormalized(raw)));
     },
     "im.message.recalled_v1": async (raw: RawFeishuRecallEvent) => {
       const normalized = rawRecallToNormalized(raw);
-      if (normalized) await onMessage(normalized);
+      if (normalized) await deduplicate(raw, async () => onMessage(normalized));
     },
   });
   return dispatcher;

--- a/packages/server/src/services/im-bindings/feishu/adapter.ts
+++ b/packages/server/src/services/im-bindings/feishu/adapter.ts
@@ -120,25 +120,31 @@ const DEDUPLICATION_MAX_ENTRIES = 10_000;
 type FeishuRawInboundEvent = RawFeishuMessageEvent | RawFeishuRecallEvent;
 
 function providerEventIdentity(raw: FeishuRawInboundEvent): {
-  key: string;
+  keys: string[];
   providerEventId: string | null;
   externalMessageId: string | null;
 } | null {
   const providerEventId = raw.header?.event_id ?? raw.event_id ?? null;
   if ("message" in raw) {
     const externalMessageId = raw.message.message_id;
-    if (providerEventId) return { key: `event:${providerEventId}`, providerEventId, externalMessageId };
+    const messageKey = `message:${externalMessageId}:${raw.message.create_time}`;
+    if (providerEventId) {
+      return { keys: [`event:${providerEventId}`, messageKey], providerEventId, externalMessageId };
+    }
     return {
-      key: `message:${externalMessageId}:${raw.message.create_time}`,
+      keys: [messageKey],
       providerEventId: null,
       externalMessageId,
     };
   }
   const externalMessageId = raw.message_id ?? null;
   if (!externalMessageId && !providerEventId) return null;
-  if (providerEventId) return { key: `event:${providerEventId}`, providerEventId, externalMessageId };
+  const messageKey = `recall:${externalMessageId}:${raw.recall_time ?? "unknown"}`;
+  if (providerEventId) {
+    return { keys: [`event:${providerEventId}`, messageKey], providerEventId, externalMessageId };
+  }
   return {
-    key: `recall:${externalMessageId}:${raw.recall_time ?? "unknown"}`,
+    keys: [messageKey],
     providerEventId: null,
     externalMessageId,
   };
@@ -163,7 +169,7 @@ function createFeishuInboundDeduplicator() {
     if (!identity) return onMessage();
     const now = Date.now();
     prune(now);
-    const existing = entries.get(identity.key);
+    const existing = identity.keys.map((key) => entries.get(key)).find((entry) => entry !== undefined);
     if (existing) {
       emitRootSpan("feishu.inbound.deduplicated", {
         ...imAttrs({
@@ -178,16 +184,21 @@ function createFeishuInboundDeduplicator() {
       return;
     }
     const promise = onMessage();
-    entries.set(identity.key, { expiresAt: now + DEDUPLICATION_TTL_MS, promise });
+    const entry = { expiresAt: now + DEDUPLICATION_TTL_MS, promise };
+    for (const key of identity.keys) entries.set(key, entry);
     try {
       await promise;
     } catch (error) {
-      const current = entries.get(identity.key);
-      if (current?.promise === promise) entries.delete(identity.key);
+      for (const key of identity.keys) {
+        const current = entries.get(key);
+        if (current?.promise === promise) entries.delete(key);
+      }
       throw error;
     } finally {
-      const current = entries.get(identity.key);
-      if (current?.promise === promise) entries.set(identity.key, { expiresAt: current.expiresAt });
+      for (const key of identity.keys) {
+        const current = entries.get(key);
+        if (current?.promise === promise) entries.set(key, { expiresAt: current.expiresAt });
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary

Fixes duplicate processing of inbound Feishu messages reported in #329 and #328 (the same bug reported twice: one interaction represented as a group message `oc_*` and its thread context `omt_*` was handled twice).

Root cause: the Feishu WebSocket `EventDispatcher` in `createReliableFeishuDispatcher` could invoke the message callback more than once for the same provider event — the callback had no event/message identity guard, so every invocation flowed into `ImMessageInbox.ingest` and duplicate handling.

The fix adds a bounded, provider-aware inbound deduplicator at the dispatcher boundary (`packages/server/src/services/im-bindings/feishu/adapter.ts`):

- Each `im.message.receive_v1` / `im.message.recalled_v1` event derives a stable identity with **two keys**: the envelope `event:${event_id}` and the representation-independent `message:${message_id}:${create_time}` (recalls use `recall:${message_id}:${recall_time}`). A duplicate is detected when **either** key matches, so a redelivered representation carrying a *different* envelope `event_id` but the same logical message is still deduplicated.
- Entries live in a 10-minute TTL cache capped at 10,000 entries. Concurrent duplicates await the first handler's promise (so the WS ACK still succeeds); a failed first attempt removes the entry so provider retry can proceed.
- Deduplicated events emit a redacted `feishu.inbound.deduplicated` span with provider event and external message identifiers for observability.
- Raw header event/tenant identifiers are preserved through normalization so the stable provider key also reaches the inbox's existing DB-backed dedup (unique indexes on provider event id and semantic revision), which remains the durable cross-instance guarantee underneath this guard.

## Regression coverage

- One callback for a repeated group/thread event delivered twice concurrently — including the case where the second representation carries a **different** `event_id` (the `oc_*`/`omt_*` pairing from the issues).
- Two callbacks for two genuinely distinct messages sharing the same group chat and thread (dedup never swallows distinct messages).

## Checklist

- [x] Trace the Feishu group/thread event flow
- [x] Add a failing duplicate-processing regression test
- [x] Implement provider-event deduplication
- [x] Add positive coverage for adjacent distinct events
- [x] Pass regression and repository verification

## Verification

- `pnpm check` — pass (workspace contract, migration drift)
- `pnpm typecheck` — pass
- `pnpm --filter @opentag/server test` — pass, 56 files / 545 tests
- `pnpm build` — pass
- `pnpm test` — pass (full repository suite)
- `pnpm --filter @opentag/server test:integration` — pass, 17 files / 295 tests
- `git status` clean; no `.dispatch/` content in the diff

Closes #329
Closes #328

## Provenance

Written by a codex agent (dispatch run `4bc5ff`, lane `dedupe-feishu-events-1`) under bypassed approvals in an isolated worktree; verified and published by the orchestrating session.
