### PR TITLE
chore(governance): add path ownership and pull request risk prompts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# Shared contracts
+/packages/shared/** @bestony
+
+# Client runtime
+/packages/client/src/runtime/** @bestony
+
+# Server runtime
+/packages/server/src/runtime/** @bestony
+
+# IM providers
+/packages/server/src/services/im-bindings/** @bestony
+
+# Web
+/apps/web/** @bestony
+
+# CLI
+/apps/cli/** @bestony
+
+# Migrations
+/packages/server/drizzle/** @bestony
+
+# CI and release
+/.github/** @bestony
+/scripts/** @bestony
+/turbo.json @bestony
+/Dockerfile @bestony

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,24 @@
 
 <!-- List the commands and manual checks you ran. -->
 
+## Risk review
+
+- [ ] Affected packages: <!-- List packages, apps, or repository areas. -->
+- [ ] Contract changes: <!-- Describe shared schema or API changes, or write "None". -->
+- [ ] Migration and rollback: <!-- Record migration impact and the rollback plan, or write "None". -->
+- [ ] Test layers exercised: <!-- List unit, integration, E2E, or manual layers. -->
+- [ ] Observability impact: <!-- Record logs, metrics, traces, or write "None". -->
+- [ ] Generated files touched: <!-- List generated files, or write "None". -->
+- [ ] Deployment evidence: <!-- Link CI, deployment, and live verification evidence, or write "None". -->
+
+## Maintainer branch rules (GitHub settings)
+
+- [ ] Require the branch to be up to date before merge (strict).
+- [ ] Dismiss stale approvals when new commits are pushed.
+- [ ] Require approval from someone other than the last pusher.
+- [ ] Require all review conversations to be resolved.
+- [ ] Require cross-owner approvals for changes spanning owned seams.
+
 ## Breaking changes
 
 <!-- Describe compatibility impact, or write "None". -->

--- a/scripts/__tests__/codeowners.test.mjs
+++ b/scripts/__tests__/codeowners.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const CODEOWNERS_PATH = join(REPOSITORY_ROOT, ".github", "CODEOWNERS");
+
+const REQUIRED_SEAMS = [
+  { name: "shared contracts", pattern: "/packages/shared/**" },
+  { name: "client runtime", pattern: "/packages/client/src/runtime/**" },
+  { name: "server runtime", pattern: "/packages/server/src/runtime/**" },
+  { name: "IM providers", pattern: "/packages/server/src/services/im-bindings/**" },
+  { name: "Web", pattern: "/apps/web/**" },
+  { name: "CLI", pattern: "/apps/cli/**" },
+  { name: "migrations", pattern: "/packages/server/drizzle/**" },
+  { name: "CI and release", pattern: "/.github/**" },
+  { name: "CI and release", pattern: "/scripts/**" },
+  { name: "CI and release", pattern: "/turbo.json" },
+  { name: "CI and release", pattern: "/Dockerfile" },
+];
+
+function readRules() {
+  const lines = readFileSync(CODEOWNERS_PATH, "utf8").split(/\r?\n/);
+  return lines.flatMap((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) return [];
+
+    const fields = trimmed.split(/\s+/);
+    assert.ok(fields.length >= 2, `CODEOWNERS line ${index + 1} has no owner: ${line}`);
+    return [{ line: index + 1, pattern: fields[0], owners: fields.slice(1) }];
+  });
+}
+
+function patternToRegExp(pattern) {
+  const source = pattern.startsWith("/") ? pattern.slice(1) : pattern;
+  let expression = "";
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+    if (character === "*" && source[index + 1] === "*") {
+      expression += ".*";
+      index += 1;
+    } else if (character === "*") {
+      expression += "[^/]*";
+    } else if (character === "?") {
+      expression += "[^/]";
+    } else {
+      expression += character.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${expression}$`);
+}
+
+function repositoryPaths() {
+  return execFileSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], {
+    cwd: REPOSITORY_ROOT,
+    encoding: "utf8",
+  })
+    .split(/\r?\n/)
+    .filter(Boolean);
+}
+
+test("CODEOWNERS parses with an owner on every rule", () => {
+  const rules = readRules();
+  assert.ok(rules.length > 0, "CODEOWNERS must contain at least one rule");
+  for (const rule of rules) {
+    assert.deepEqual(rule.owners, ["@bestony"], `CODEOWNERS line ${rule.line} must use @bestony only`);
+  }
+});
+
+test("every CODEOWNERS pattern matches an existing repository path", () => {
+  const paths = repositoryPaths();
+  for (const rule of readRules()) {
+    const matcher = patternToRegExp(rule.pattern);
+    assert.ok(
+      paths.some((path) => matcher.test(path)),
+      `CODEOWNERS pattern has no matching path: ${rule.pattern}`,
+    );
+  }
+});
+
+test("CODEOWNERS covers each approved high-risk seam", () => {
+  const patterns = new Set(readRules().map((rule) => rule.pattern));
+  for (const seam of REQUIRED_SEAMS) {
+    assert.ok(patterns.has(seam.pattern), `${seam.name} is missing ${seam.pattern}`);
+  }
+});


### PR DESCRIPTION
Implements the repository-content half of backlog item **COLLAB-01 — Add path ownership and
cross-owner review controls** (Phase 2: improve review and test collaboration).

## What this adds

- `.github/CODEOWNERS` restored (deleted in #337), grouped by high-risk seam with comments: shared
  contracts, client runtime, server runtime, IM providers, Web, CLI, migrations
  (`packages/server/drizzle/`), and CI/release surfaces (`.github/`, `scripts/`, `turbo.json`,
  `Dockerfile`). Every owner is `@bestony` per the backlog's no-invented-maintainers rule — future
  owners are one-line edits.
- `.github/PULL_REQUEST_TEMPLATE.md` extended with terse risk prompts: affected packages, contract
  changes, migration/rollback note, test layers exercised, observability impact, generated files
  touched, deployment evidence.
- `scripts/__tests__/codeowners.test.mjs` (Node built-ins): the file parses, every pattern matches
  at least one real repository path, and all high-risk seams above are covered — so ownership rot
  fails `pnpm test`.

## Maintainer follow-up (GitHub settings — cannot be done from the repository)

Branch protection for `main`: require CODEOWNERS review; strict up-to-date branches before merge;
dismiss stale approvals on new pushes; require approval of the most recent push; require
conversations resolved; and mark the required checks (CI fan-in, and Enforce Patch Coverage per
QG-01's still-open follow-up).

## Checklist (final state)

- [x] High-risk seam mapping (recorded)
- [x] Failing CODEOWNERS validation test first
- [x] CODEOWNERS grouped by seam (all @bestony)
- [x] PR template risk prompts
- [x] Maintainer branch-rules checklist
- [x] Full verification

## Verification

Lane and orchestrator re-run (Node 24.19.0, pnpm 10.12.1): `pnpm check`, `pnpm typecheck`,
`pnpm test` (including the new codeowners validation).

## Provenance

Written by a Codex agent (dispatch run `95a994`, lane `path-ownership-5`) under bypassed approvals
in an isolated git worktree; verified and published by the orchestrating Claude session.
