### PR TITLE
feat(web): localize account, skills, and integrations copy

### DIFF
--- a/apps/web/messages/account/en.json
+++ b/apps/web/messages/account/en.json
@@ -1,5 +1,23 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "account_account_not_refreshed": "Account not refreshed",
+  "account_discard": "Discard",
+  "account_display_name": "Display name",
+  "account_display_name_description": "This identity is used throughout OpenTag.",
+  "account_email": "Email",
+  "account_email_description": "Your sign-in email cannot be changed here.",
+  "account_error_profile_save_failed": "Unable to save the account profile",
+  "account_error_refresh_failed": "Your display name was saved. OpenTag could not refresh the account, so the rest of the page still shows the previous name.",
+  "account_hint_read_only": "Read only",
   "account_language_description": "Choose the language used throughout OpenTag.",
-  "account_language_label": "Language"
+  "account_language_label": "Language",
+  "account_page_description": "Manage your personal account details.",
+  "account_page_title": "Account",
+  "account_profile_saved": "Account profile saved.",
+  "account_profile_title": "Account profile",
+  "account_refreshing": "Refreshing…",
+  "account_retry_refresh": "Retry refresh",
+  "account_save_profile": "Save account profile",
+  "account_saving": "Saving…",
+  "account_unsaved_changes": "Unsaved changes"
 }

--- a/apps/web/messages/account/zh.json
+++ b/apps/web/messages/account/zh.json
@@ -1,5 +1,23 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "account_account_not_refreshed": "账户未刷新",
+  "account_discard": "放弃更改",
+  "account_display_name": "显示名称",
+  "account_display_name_description": "此身份信息会显示在 OpenTag 的各处。",
+  "account_email": "邮箱",
+  "account_email_description": "此处无法修改登录邮箱。",
+  "account_error_profile_save_failed": "无法保存账户资料",
+  "account_error_refresh_failed": "显示名称已保存。OpenTag 无法刷新账户，因此页面其余部分仍显示之前的名称。",
+  "account_hint_read_only": "只读",
   "account_language_description": "选择 OpenTag 界面使用的语言。",
-  "account_language_label": "语言"
+  "account_language_label": "语言",
+  "account_page_description": "管理个人账户详情。",
+  "account_page_title": "账户",
+  "account_profile_saved": "账户资料已保存。",
+  "account_profile_title": "账户资料",
+  "account_refreshing": "刷新中…",
+  "account_retry_refresh": "重试刷新",
+  "account_save_profile": "保存账户资料",
+  "account_saving": "保存中…",
+  "account_unsaved_changes": "未保存的更改"
 }

--- a/apps/web/messages/integrations/en.json
+++ b/apps/web/messages/integrations/en.json
@@ -1,3 +1,14 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "integrations_cell_label": "{name}. {description}",
+  "integrations_column_category": "Category",
+  "integrations_column_name": "Name",
+  "integrations_column_status": "Status",
+  "integrations_demo": "Demo",
+  "integrations_demo_data": "Demo data",
+  "integrations_page_description": "Services OpenTag could work with to find context and complete work.",
+  "integrations_page_title": "Integrations",
+  "integrations_scroll_hint": "Scroll horizontally to see category and status.",
+  "integrations_table_name": "Demo Integrations",
+  "integrations_table_region": "Integrations table"
 }

--- a/apps/web/messages/integrations/zh.json
+++ b/apps/web/messages/integrations/zh.json
@@ -1,3 +1,14 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "integrations_cell_label": "{name}。{description}",
+  "integrations_column_category": "类别",
+  "integrations_column_name": "名称",
+  "integrations_column_status": "状态",
+  "integrations_demo": "演示",
+  "integrations_demo_data": "演示数据",
+  "integrations_page_description": "OpenTag 可以配合使用、用于查找上下文并完成工作的服务。",
+  "integrations_page_title": "集成",
+  "integrations_scroll_hint": "横向滚动以查看类别和状态。",
+  "integrations_table_name": "演示集成",
+  "integrations_table_region": "集成表格"
 }

--- a/apps/web/messages/skills/en.json
+++ b/apps/web/messages/skills/en.json
@@ -1,3 +1,35 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "skills_agent_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{count} Agent",
+        "countPlural=other": "{count} Agents"
+      }
+    }
+  ],
+  "skills_all_skills": "All skills",
+  "skills_available": "Available skills",
+  "skills_built_by_opentag": "Built by OpenTag",
+  "skills_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{count} skill",
+        "countPlural=other": "{count} skills"
+      }
+    }
+  ],
+  "skills_demo_data": "Demo data",
+  "skills_instructions_preview": "Instructions preview",
+  "skills_page_description": "Reusable playbooks that give Agents the context and methods they need to do specialized work.",
+  "skills_page_title": "Skills",
+  "skills_preview": "Preview",
+  "skills_upload": "Upload skill",
+  "skills_upload_file": "Skill file",
+  "skills_upload_status": "{fileName} selected · Demo only, not uploaded",
+  "skills_used_by": "Used by"
 }

--- a/apps/web/messages/skills/zh.json
+++ b/apps/web/messages/skills/zh.json
@@ -1,3 +1,35 @@
 {
-  "$schema": "https://inlang.com/schema/inlang-message-format"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "skills_agent_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{count} 个 Agent",
+        "countPlural=other": "{count} 个 Agent"
+      }
+    }
+  ],
+  "skills_all_skills": "全部 Skill",
+  "skills_available": "可用 Skill",
+  "skills_built_by_opentag": "由 OpenTag 构建",
+  "skills_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{count} 个 Skill",
+        "countPlural=other": "{count} 个 Skill"
+      }
+    }
+  ],
+  "skills_demo_data": "演示数据",
+  "skills_instructions_preview": "指令预览",
+  "skills_page_description": "可复用的工作手册，为 Agent 提供完成专业工作所需的上下文和方法。",
+  "skills_page_title": "Skill",
+  "skills_preview": "预览",
+  "skills_upload": "上传 Skill",
+  "skills_upload_file": "Skill 文件",
+  "skills_upload_status": "{fileName} 已选择 · 仅为演示，未上传",
+  "skills_used_by": "使用者"
 }

--- a/apps/web/src/features/account/account-page.tsx
+++ b/apps/web/src/features/account/account-page.tsx
@@ -10,7 +10,7 @@ import { useAccount } from "../session/session-context.js";
 export function AccountPage() {
   const { me, refreshMe } = useAccount();
   return (
-    <Page title="Account" description="Manage your personal account details.">
+    <Page title={m.account_page_title()} description={m.account_page_description()}>
       <AccountSettings refreshMe={refreshMe} user={me.user} />
     </Page>
   );
@@ -63,7 +63,7 @@ export function AccountSettings({
       // Only the write can fail here; syncAccount reports its own failure. Fall back to the last
       // confirmed value, which is the saved one when an earlier save is still unsynchronized.
       setDisplayName(confirmedDisplayName);
-      setError(cause instanceof Error ? cause.message : "Unable to save the account profile");
+      setError(cause instanceof Error ? cause.message : m.account_error_profile_save_failed());
     } finally {
       saveInFlight.current = false;
       setSaving(false);
@@ -82,13 +82,11 @@ export function AccountSettings({
       await refreshMe();
       setUnsyncedDisplayName(undefined);
       setError(undefined);
-      setMessage("Account profile saved.");
+      setMessage(m.account_profile_saved());
     } catch {
       setUnsyncedDisplayName(savedDisplayName);
       setMessage(undefined);
-      setError(
-        "Your display name was saved. OpenTag could not refresh the account, so the rest of the page still shows the previous name.",
-      );
+      setError(m.account_error_refresh_failed());
     } finally {
       syncInFlight.current = false;
       setSyncing(false);
@@ -103,11 +101,16 @@ export function AccountSettings({
   return (
     <form className="grid gap-4" onSubmit={submit}>
       <Text as="h2" variant="heading">
-        Account profile
+        {m.account_profile_title()}
       </Text>
       <SettingsList>
-        <SettingsRow label="Email" description="Your sign-in email cannot be changed here.">
-          <Field hint="Read only" hintId="account-email-hint" htmlFor="account-email" label="Email">
+        <SettingsRow label={m.account_email()} description={m.account_email_description()}>
+          <Field
+            hint={m.account_hint_read_only()}
+            hintId="account-email-hint"
+            htmlFor="account-email"
+            label={m.account_email()}
+          >
             <KumoInputControl
               aria-describedby="account-email-hint"
               id="account-email"
@@ -118,8 +121,8 @@ export function AccountSettings({
             />
           </Field>
         </SettingsRow>
-        <SettingsRow label="Display name" description="This identity is used throughout OpenTag.">
-          <Field htmlFor="account-display-name" label="Display name">
+        <SettingsRow label={m.account_display_name()} description={m.account_display_name_description()}>
+          <Field htmlFor="account-display-name" label={m.account_display_name()}>
             <KumoInputControl
               autoComplete="name"
               // Editing during a refresh-only retry could open a save that races it.
@@ -160,7 +163,7 @@ export function AccountSettings({
       </SettingsList>
       {dirty ? (
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-kumo-line pt-3">
-          <span className="text-sm text-kumo-subtle">Unsaved changes</span>
+          <span className="text-sm text-kumo-subtle">{m.account_unsaved_changes()}</span>
           <div className="flex flex-wrap justify-end gap-2">
             <Button
               disabled={saving}
@@ -171,10 +174,10 @@ export function AccountSettings({
                 setError(undefined);
               }}
             >
-              Discard
+              {m.account_discard()}
             </Button>
             <Button disabled={saving} type="submit">
-              {saving ? "Saving…" : "Save account profile"}
+              {saving ? m.account_saving() : m.account_save_profile()}
             </Button>
           </div>
         </div>
@@ -183,10 +186,10 @@ export function AccountSettings({
         // The value is saved, so this offers only the step that failed: no Save that would repeat
         // the write, and no Discard that would replace the saved name with the stale projection.
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-kumo-line pt-3">
-          <span className="text-sm text-kumo-subtle">Account not refreshed</span>
+          <span className="text-sm text-kumo-subtle">{m.account_account_not_refreshed()}</span>
           <div className="flex flex-wrap justify-end gap-2">
             <Button disabled={syncing} onClick={() => void retrySync()}>
-              {syncing ? "Refreshing…" : "Retry refresh"}
+              {syncing ? m.account_refreshing() : m.account_retry_refresh()}
             </Button>
           </div>
         </div>

--- a/apps/web/src/features/integrations-page.tsx
+++ b/apps/web/src/features/integrations-page.tsx
@@ -6,6 +6,7 @@ import notionMark from "../assets/integration-notion.svg";
 import sentryMark from "../assets/integration-sentry.svg";
 import { PageHeader } from "../components/kumo/page-header/page-header.js";
 import { integrationPreviews } from "../mock/capability-data.js";
+import * as m from "../paraglide/messages.js";
 import { Badge, LayerCard, Table, Text } from "../ui/design-system.js";
 
 const integrationMarks: Readonly<Record<string, string>> = {
@@ -42,30 +43,35 @@ export function IntegrationsPage() {
   return (
     <section className="grid gap-6" aria-labelledby="integrations-page-title" data-ui="integrations-page">
       <PageHeader
-        description="Services OpenTag could work with to find context and complete work."
-        title="Integrations"
+        description={m.integrations_page_description()}
+        title={m.integrations_page_title()}
         titleId="integrations-page-title"
       >
         <Text as="span" data-ui="integrations-demo-note" variant="secondary">
-          Demo data
+          {m.integrations_demo_data()}
         </Text>
       </PageHeader>
 
       <div className="grid min-w-0 gap-2">
         <div className="@min-[36rem]/workspace:hidden" id="integrations-scroll-hint">
           <Text as="p" size="sm" variant="secondary">
-            Scroll horizontally to see category and status.
+            {m.integrations_scroll_hint()}
           </Text>
         </div>
         <LayerCard className="p-0" data-ui="integrations-card">
           <section
             aria-describedby="integrations-scroll-hint"
-            aria-label="Integrations table"
+            aria-label={m.integrations_table_region()}
             className="min-w-0 overflow-x-auto rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand focus-visible:ring-inset"
             // biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users need to focus the horizontal scroll region.
             tabIndex={0}
           >
-            <Table aria-label="Demo Integrations" className="min-w-[36rem]" data-ui="integrations-table" layout="fixed">
+            <Table
+              aria-label={m.integrations_table_name()}
+              className="min-w-[36rem]"
+              data-ui="integrations-table"
+              layout="fixed"
+            >
               <colgroup>
                 <col />
                 <col className="w-40" />
@@ -73,15 +79,20 @@ export function IntegrationsPage() {
               </colgroup>
               <Table.Header>
                 <Table.Row>
-                  <Table.Head>Name</Table.Head>
-                  <Table.Head>Category</Table.Head>
-                  <Table.Head>Status</Table.Head>
+                  <Table.Head>{m.integrations_column_name()}</Table.Head>
+                  <Table.Head>{m.integrations_column_category()}</Table.Head>
+                  <Table.Head>{m.integrations_column_status()}</Table.Head>
                 </Table.Row>
               </Table.Header>
               <Table.Body>
                 {integrationPreviews.map((integration) => (
                   <Table.Row key={integration.id}>
-                    <Table.Cell aria-label={`${integration.name}. ${integration.description}`}>
+                    <Table.Cell
+                      aria-label={m.integrations_cell_label({
+                        name: integration.name,
+                        description: integration.description,
+                      })}
+                    >
                       <span className="flex min-w-0 items-start gap-3">
                         <IntegrationMark abbreviation={integration.abbreviation} id={integration.id} />
                         <span className="grid min-w-0 gap-0.5">
@@ -96,7 +107,7 @@ export function IntegrationsPage() {
                     </Table.Cell>
                     <Table.Cell>{integration.category}</Table.Cell>
                     <Table.Cell>
-                      <Badge variant="neutral">Demo</Badge>
+                      <Badge variant="neutral">{m.integrations_demo()}</Badge>
                     </Table.Cell>
                   </Table.Row>
                 ))}

--- a/apps/web/src/features/skills-page.tsx
+++ b/apps/web/src/features/skills-page.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { PageHeader } from "../components/kumo/page-header/page-header.js";
 import { skillPreviews } from "../mock/capability-data.js";
+import * as m from "../paraglide/messages.js";
 import { Button, Collapsible, Text } from "../ui/design-system.js";
 
 export function SkillsPage() {
@@ -9,30 +10,26 @@ export function SkillsPage() {
 
   return (
     <section className="grid gap-6" aria-labelledby="skills-page-title" data-ui="skills-page">
-      <PageHeader
-        description="Reusable playbooks that give Agents the context and methods they need to do specialized work."
-        title="Skills"
-        titleId="skills-page-title"
-      >
+      <PageHeader description={m.skills_page_description()} title={m.skills_page_title()} titleId="skills-page-title">
         <div className="flex flex-wrap items-center gap-3" data-ui="skills-header-actions">
           <Text as="span" data-ui="skills-demo-note" variant="secondary">
-            Demo data
+            {m.skills_demo_data()}
           </Text>
           <div className="grid gap-2" data-ui="skills-upload-entry">
             <Button size="compact" variant="secondary" type="button" onClick={() => uploadInputRef.current?.click()}>
-              Upload skill
+              {m.skills_upload()}
             </Button>
             <input
               ref={uploadInputRef}
               hidden
               accept=".md,.zip"
-              aria-label="Skill file"
+              aria-label={m.skills_upload_file()}
               type="file"
               onChange={(event) => setSelectedFileName(event.currentTarget.files?.[0]?.name ?? null)}
             />
             {selectedFileName ? (
               <Text as="span" data-ui="skills-upload-status" role="status" variant="secondary">
-                {selectedFileName} selected · Demo only, not uploaded
+                {m.skills_upload_status({ fileName: selectedFileName })}
               </Text>
             ) : null}
           </div>
@@ -42,14 +39,14 @@ export function SkillsPage() {
       <section className="grid gap-4" aria-labelledby="skills-catalog-title" data-ui="skills-catalog">
         <div className="flex items-baseline justify-between gap-3" data-ui="skills-catalog-heading">
           <Text as="h2" id="skills-catalog-title" variant="heading">
-            All skills
+            {m.skills_all_skills()}
           </Text>
           <Text as="p" variant="secondary">
-            {skillPreviews.length} skills
+            {m.skills_count({ count: skillPreviews.length })}
           </Text>
         </div>
 
-        <ul className="grid gap-3" aria-label="Available skills" data-ui="skills-list">
+        <ul className="grid gap-3" aria-label={m.skills_available()} data-ui="skills-list">
           {skillPreviews.map((skill) => (
             <li key={skill.name}>
               <article className="rounded-lg bg-kumo-base ring ring-kumo-line" data-ui="skill-row">
@@ -65,24 +62,22 @@ export function SkillsPage() {
                         </Text>
                         <span className="text-sm text-kumo-subtle">{skill.status}</span>
                         {skill.source === "OpenTag" ? (
-                          <span className="text-sm text-kumo-subtle">Built by OpenTag</span>
+                          <span className="text-sm text-kumo-subtle">{m.skills_built_by_opentag()}</span>
                         ) : null}
                       </div>
                       <p>{skill.description}.</p>
                     </div>
                     <dl className="text-sm text-kumo-subtle" data-ui="skill-row-meta">
                       <div>
-                        <dt>Used by</dt>
-                        <dd>
-                          {skill.agentCount} {skill.agentCount === 1 ? "Agent" : "Agents"}
-                        </dd>
+                        <dt>{m.skills_used_by()}</dt>
+                        <dd>{m.skills_agent_count({ count: skill.agentCount })}</dd>
                       </div>
                     </dl>
-                    <span className="text-sm text-kumo-link">Preview</span>
+                    <span className="text-sm text-kumo-link">{m.skills_preview()}</span>
                   </Collapsible.Trigger>
                   <Collapsible.Panel className="grid gap-2 border-t border-kumo-line p-4" data-ui="skill-preview-panel">
                     <Text as="h4" variant="heading">
-                      Instructions preview
+                      {m.skills_instructions_preview()}
                     </Text>
                     <p>{skill.instructions}</p>
                   </Collapsible.Panel>


### PR DESCRIPTION
## Summary

Migrates the remaining hardcoded copy on the account page (the language-selector row from #377 already used `m.*()`), the skills page, and the integrations page to Paraglide `m.*()`, filling the `account`, `skills`, and `integrations` catalogs with paired English and Chinese entries. English stays byte-identical.

Commits: one per page — account, skills, integrations.

## Verification

- `pnpm check` — pass (workspace contract, migration drift)
- `pnpm typecheck` — pass
- `pnpm --filter @opentag/web test` — pass
- `pnpm build` — pass
- `pnpm test` — pass except `scripts/__tests__/lefthook-stage-fixed.test.mjs`, a documented host-environment failure (global `commit.gpgsign` + 1Password signer breaks inside the test's temp repo, git exit 128); it passes with `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` in this same checkout and is unaffected in CI
- `git status` clean; English rendering is byte-identical (`en` is the base locale and the vitest setup pins it), so no existing test assertion was modified

## Provenance

Written by a codex agent (dispatch run `ffb2c7`, lane `i18n-account-pages-5`) under bypassed approvals in an isolated worktree; verified and published by the orchestrating session. Part of a five-PR series filling the Chinese message catalogs on top of the Paraglide foundation from #292; each PR covers a disjoint file set.
