### PR TITLE
chore(quality): add scoreboard, doc-mirror check, and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/quality-scoreboard.yml
+++ b/.github/workflows/quality-scoreboard.yml
@@ -1,0 +1,125 @@
+name: Quality Scoreboard
+
+on:
+  schedule:
+    - cron: "23 3 * * 1"
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mirror-advisory:
+    name: Documentation Mirror Advisory
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+
+      - name: Check documentation mirrors (advisory)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-doc-mirrors.mjs --base "$BASE_SHA" --head "$HEAD_SHA"
+
+  scoreboard:
+    name: Generate Quality Scoreboard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.12.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --config.engine-strict=true
+
+      - name: Build and time tests
+        id: repository-tests
+        shell: bash
+        run: |
+          set +e
+          pnpm build
+          build_status=$?
+          started_ms=$(node -p 'Date.now()')
+          pnpm test
+          test_status=$?
+          finished_ms=$(node -p 'Date.now()')
+          set -e
+          duration_ms=$((finished_ms - started_ms))
+          printf '{"durationMs":%s}\n' "$duration_ms" > "$RUNNER_TEMP/test-duration.json"
+          printf '{"buildStatus":%s,"testStatus":%s}\n' "$build_status" "$test_status" > "$RUNNER_TEMP/quality-run-status.json"
+
+      - name: Collect open high-risk issues
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue list --state open --label high-risk --json number > "$RUNNER_TEMP/high-risk-items.json" || true
+
+      - name: Write quality scoreboard
+        if: always()
+        run: |
+          node scripts/quality-scoreboard.mjs \
+            --json-path "$RUNNER_TEMP/quality-scoreboard.json" \
+            --markdown-path "$RUNNER_TEMP/quality-scoreboard.md" \
+            --test-duration-path "$RUNNER_TEMP/test-duration.json" \
+            --high-risk-path "$RUNNER_TEMP/high-risk-items.json" \
+            --revision "$GITHUB_SHA"
+
+      - name: Append scoreboard summary
+        if: always()
+        run: cat "$RUNNER_TEMP/quality-scoreboard.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload scoreboard artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: quality-scoreboard-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/quality-scoreboard.json
+            ${{ runner.temp }}/quality-scoreboard.md
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Report build and test status
+        if: always()
+        run: |
+          node --input-type=module - "$RUNNER_TEMP/quality-run-status.json" <<'NODE'
+          import { readFileSync } from "node:fs";
+
+          const status = JSON.parse(readFileSync(process.argv[1], "utf8"));
+          if (status.buildStatus !== 0 || status.testStatus !== 0) {
+            console.error(`Build status: ${status.buildStatus}; test status: ${status.testStatus}`);
+            process.exit(1);
+          }
+          NODE

--- a/.github/workflows/quality-scoreboard.yml
+++ b/.github/workflows/quality-scoreboard.yml
@@ -117,7 +117,7 @@ jobs:
           node --input-type=module - "$RUNNER_TEMP/quality-run-status.json" <<'NODE'
           import { readFileSync } from "node:fs";
 
-          const status = JSON.parse(readFileSync(process.argv[1], "utf8"));
+          const status = JSON.parse(readFileSync(process.argv[2], "utf8"));
           if (status.buildStatus !== 0 || status.testStatus !== 0) {
             console.error(`Build status: ${status.buildStatus}; test status: ${status.testStatus}`);
             process.exit(1);

--- a/scripts/__tests__/check-doc-mirrors.test.mjs
+++ b/scripts/__tests__/check-doc-mirrors.test.mjs
@@ -20,7 +20,7 @@ function fixture({ marker = false } = {}) {
   runGit(root, "config", "user.email", "test@example.invalid");
   runGit(root, "config", "user.name", "Doc Mirror Test");
   const canonical = marker
-    ? "# Guide\n\n## Intentional section\n\n<!-- doc-mirror: allow-divergence -->\n\nOriginal text.\n"
+    ? "# Guide\n\n## Intentional section\n\n<!-- doc-mirror: allow-divergence -->\n\nOriginal text.\n\n## Required mirror\n\nKeep mirrored.\n"
     : "# Guide\n\n## Section\n\nOriginal text.\n";
   writeFileSync(join(root, "guide.md"), canonical);
   writeFileSync(join(root, "guide.zh-CN.md"), "# 指南\n\n原始文本。\n");
@@ -30,10 +30,15 @@ function fixture({ marker = false } = {}) {
   return { root, base, canonicalPath: "guide.md", mirrorPath: "guide.zh-CN.md" };
 }
 
-function finishFixture(fixtureData, { changeMirror = false, text = "Updated text." } = {}) {
+function finishFixture(
+  fixtureData,
+  { changeMirror = false, changeOutsideMarker = false, text = "Updated text." } = {},
+) {
   const canonicalPath = join(fixtureData.root, fixtureData.canonicalPath);
   const current = readFileSync(canonicalPath, "utf8");
-  writeFileSync(canonicalPath, text.includes("\n") ? `${text}\n` : current.replace("Original text.", text));
+  const changed = text.includes("\n") ? text : current.replace("Original text.", text);
+  const updated = changeOutsideMarker ? changed.replace("Keep mirrored.", "Changed outside.") : changed;
+  writeFileSync(canonicalPath, updated.endsWith("\n") ? updated : `${updated}\n`);
   if (changeMirror) writeFileSync(join(fixtureData.root, fixtureData.mirrorPath), "# 指南\n\n更新文本。\n");
   runGit(fixtureData.root, "add", fixtureData.canonicalPath, ...(changeMirror ? [fixtureData.mirrorPath] : []));
   runGit(fixtureData.root, "commit", "--quiet", "-m", "change docs");
@@ -79,6 +84,18 @@ test("the divergence marker suppresses the mirror requirement for its section", 
     const head = finishFixture(fixtureData, { text: "Changed text." });
     const result = runChecker(fixtureData.root, fixtureData.base, head);
     assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  } finally {
+    rmSync(fixtureData.root, { recursive: true, force: true });
+  }
+});
+
+test("the divergence marker does not suppress an unmarked sibling section", () => {
+  const fixtureData = fixture({ marker: true });
+  try {
+    const head = finishFixture(fixtureData, { changeOutsideMarker: true });
+    const result = runChecker(fixtureData.root, fixtureData.base, head);
+    assert.notEqual(result.status, 0, `${result.stdout}${result.stderr}`);
+    assert.match(`${result.stdout}${result.stderr}`, /guide\.zh-CN\.md/);
   } finally {
     rmSync(fixtureData.root, { recursive: true, force: true });
   }

--- a/scripts/__tests__/check-doc-mirrors.test.mjs
+++ b/scripts/__tests__/check-doc-mirrors.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const SCRIPT = join(import.meta.dirname, "..", "check-doc-mirrors.mjs");
+
+function runGit(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" },
+  }).trim();
+}
+
+function fixture({ marker = false } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "opentag-doc-mirrors-"));
+  runGit(root, "init", "--quiet");
+  runGit(root, "config", "user.email", "test@example.invalid");
+  runGit(root, "config", "user.name", "Doc Mirror Test");
+  const canonical = marker
+    ? "# Guide\n\n## Intentional section\n\n<!-- doc-mirror: allow-divergence -->\n\nOriginal text.\n"
+    : "# Guide\n\n## Section\n\nOriginal text.\n";
+  writeFileSync(join(root, "guide.md"), canonical);
+  writeFileSync(join(root, "guide.zh-CN.md"), "# 指南\n\n原始文本。\n");
+  runGit(root, "add", "guide.md", "guide.zh-CN.md");
+  runGit(root, "commit", "--quiet", "-m", "initial");
+  const base = runGit(root, "rev-parse", "HEAD");
+  return { root, base, canonicalPath: "guide.md", mirrorPath: "guide.zh-CN.md" };
+}
+
+function finishFixture(fixtureData, { changeMirror = false, text = "Updated text." } = {}) {
+  const canonicalPath = join(fixtureData.root, fixtureData.canonicalPath);
+  const current = readFileSync(canonicalPath, "utf8");
+  writeFileSync(canonicalPath, text.includes("\n") ? `${text}\n` : current.replace("Original text.", text));
+  if (changeMirror) writeFileSync(join(fixtureData.root, fixtureData.mirrorPath), "# 指南\n\n更新文本。\n");
+  runGit(fixtureData.root, "add", fixtureData.canonicalPath, ...(changeMirror ? [fixtureData.mirrorPath] : []));
+  runGit(fixtureData.root, "commit", "--quiet", "-m", "change docs");
+  return runGit(fixtureData.root, "rev-parse", "HEAD");
+}
+
+function runChecker(root, base, head) {
+  return spawnSync(process.execPath, [SCRIPT, "--root", root, "--base", base, "--head", head], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" },
+  });
+}
+
+test("changed canonical document without its mirror fails and names both paths", () => {
+  const fixtureData = fixture();
+  try {
+    const head = finishFixture(fixtureData);
+    const result = runChecker(fixtureData.root, fixtureData.base, head);
+    assert.notEqual(result.status, 0, `${result.stdout}${result.stderr}`);
+    const output = `${result.stdout}${result.stderr}`;
+    assert.match(output, /guide\.md/);
+    assert.match(output, /guide\.zh-CN\.md/);
+  } finally {
+    rmSync(fixtureData.root, { recursive: true, force: true });
+  }
+});
+
+test("changing canonical and mirror documents together passes", () => {
+  const fixtureData = fixture();
+  try {
+    const head = finishFixture(fixtureData, { changeMirror: true });
+    const result = runChecker(fixtureData.root, fixtureData.base, head);
+    assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  } finally {
+    rmSync(fixtureData.root, { recursive: true, force: true });
+  }
+});
+
+test("the divergence marker suppresses the mirror requirement for its section", () => {
+  const fixtureData = fixture({ marker: true });
+  try {
+    const head = finishFixture(fixtureData, { text: "Changed text." });
+    const result = runChecker(fixtureData.root, fixtureData.base, head);
+    assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  } finally {
+    rmSync(fixtureData.root, { recursive: true, force: true });
+  }
+});

--- a/scripts/__tests__/quality-scoreboard.test.mjs
+++ b/scripts/__tests__/quality-scoreboard.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  createScoreboard,
+  parseHighRiskItems,
+  renderMarkdown,
+  summarizeCoverage,
+  writeScoreboard,
+} from "../quality-scoreboard.mjs";
+
+test("summarizeCoverage aggregates Istanbul coverage-final data", () => {
+  const summary = summarizeCoverage({
+    "src/example.ts": {
+      statementMap: {
+        0: { start: { line: 1 }, end: { line: 1 } },
+        1: { start: { line: 2 }, end: { line: 2 } },
+      },
+      s: { 0: 2, 1: 0 },
+      f: { 0: 1, 1: 0 },
+      b: { 0: [1, 0] },
+    },
+  });
+  assert.deepEqual(summary.statements, { total: 2, covered: 1, percent: 50 });
+  assert.deepEqual(summary.functions, { total: 2, covered: 1, percent: 50 });
+  assert.deepEqual(summary.branches, { total: 2, covered: 1, percent: 50 });
+  assert.deepEqual(summary.lines, { total: 2, covered: 1, percent: 50 });
+});
+
+test("parseHighRiskItems counts open entries and ignores closed entries", () => {
+  assert.equal(
+    parseHighRiskItems({
+      items: [
+        { id: "open", status: "open" },
+        { id: "closed", status: "closed" },
+        { id: "explicit", open: true },
+      ],
+    }),
+    2,
+  );
+  assert.equal(parseHighRiskItems({ count: 4 }), 4);
+});
+
+test("createScoreboard preserves measured and skipped metric provenance", () => {
+  const scoreboard = createScoreboard({
+    repositoryRoot: "/repo",
+    generatedAt: "2026-09-01T00:00:00.000Z",
+    revision: "abc123",
+    complexityWarnings: 3,
+    coverage: null,
+    testDurationMs: 1200,
+    bundleReport: { totalBytes: 4096, chunks: [{ file: "app.js", bytes: 4096 }] },
+    largestFiles: [{ path: "pnpm-lock.yaml", bytes: 2048 }],
+    openHighRiskItems: 2,
+  });
+  assert.equal(scoreboard.version, 1);
+  assert.equal(scoreboard.commit, "abc123");
+  assert.deepEqual(scoreboard.metrics.complexityWarnings, { value: 3, status: "measured" });
+  assert.deepEqual(scoreboard.metrics.unitCoverage, {
+    value: null,
+    status: "skipped",
+    note: "coverage-final.json was not found",
+  });
+  assert.deepEqual(scoreboard.metrics.testDurationMs, { value: 1200, status: "measured" });
+});
+
+test("writeScoreboard emits JSON and a readable markdown summary", () => {
+  const root = mkdtempSync(join(tmpdir(), "opentag-quality-scoreboard-"));
+  try {
+    const scoreboard = createScoreboard({
+      repositoryRoot: root,
+      generatedAt: "2026-09-01T00:00:00.000Z",
+      revision: "abc123",
+      complexityWarnings: 0,
+      coverage: null,
+      testDurationMs: null,
+      bundleReport: null,
+      largestFiles: [],
+      openHighRiskItems: null,
+    });
+    const output = writeScoreboard(scoreboard, {
+      jsonPath: join(root, "scoreboard.json"),
+      markdownPath: join(root, "summary.md"),
+    });
+    assert.deepEqual(JSON.parse(readFileSync(output.jsonPath, "utf8")), scoreboard);
+    const markdown = readFileSync(output.markdownPath, "utf8");
+    assert.match(markdown, /Quality scoreboard/);
+    assert.match(markdown, /coverage-final\.json was not found/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("renderMarkdown includes bundle and largest-file details", () => {
+  const markdown = renderMarkdown(
+    createScoreboard({
+      repositoryRoot: "/repo",
+      generatedAt: "2026-09-01T00:00:00.000Z",
+      revision: "abc123",
+      complexityWarnings: 1,
+      coverage: null,
+      testDurationMs: 100,
+      bundleReport: { totalBytes: 10, chunks: [{ file: "app.js", bytes: 10 }] },
+      largestFiles: [{ path: "README.md", bytes: 20 }],
+      openHighRiskItems: 0,
+    }),
+  );
+  assert.match(markdown, /app\.js/);
+  assert.match(markdown, /README\.md/);
+});

--- a/scripts/check-doc-mirrors.mjs
+++ b/scripts/check-doc-mirrors.mjs
@@ -1,0 +1,250 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const DIVERGENCE_MARKER = "<!-- doc-mirror: allow-divergence -->";
+
+const ROOT_CANONICAL_EXCLUSIONS = new Set(["AGENTS.md"]);
+
+function toPosix(path) {
+  return path.split(sep).join("/");
+}
+
+function walkMarkdownFiles(directory, root = directory) {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...walkMarkdownFiles(path, root));
+    else if (entry.isFile() && entry.name.endsWith(".md")) files.push(toPosix(relative(root, path)));
+  }
+  return files;
+}
+
+/** Return the canonical file and its expected mirror for every mirror candidate in the checkout. */
+export function discoverMirrorPairs(repositoryRoot) {
+  const root = resolve(repositoryRoot);
+  const pairs = new Map();
+
+  for (const path of walkMarkdownFiles(root)) {
+    if (!path.endsWith(".zh-CN.md") || path.includes("/")) continue;
+    const canonical = path.replace(/\.zh-CN\.md$/, ".md");
+    pairs.set(canonical, path);
+  }
+
+  const docsMirrorRoot = join(root, "docs", "zh-CN");
+  if (existsSync(docsMirrorRoot)) {
+    for (const path of walkMarkdownFiles(docsMirrorRoot, docsMirrorRoot)) {
+      const mirror = `docs/zh-CN/${path}`;
+      pairs.set(`docs/${path}`, mirror);
+    }
+  }
+
+  return pairs;
+}
+
+/** Return the mirror path for a canonical Markdown path, when this repository treats it as translatable. */
+export function expectedMirrorPath(canonicalPath) {
+  if (!canonicalPath.endsWith(".md")) return null;
+  if (canonicalPath.endsWith(".zh-CN.md")) return null;
+  if (canonicalPath.includes("/zh-CN/") || canonicalPath.startsWith("docs/zh-CN/")) return null;
+  if (canonicalPath.startsWith("docs/design/")) return null;
+  if (!canonicalPath.includes("/")) {
+    if (ROOT_CANONICAL_EXCLUSIONS.has(canonicalPath)) return null;
+    return canonicalPath.replace(/\.md$/, ".zh-CN.md");
+  }
+  if (canonicalPath.startsWith("docs/")) return `docs/zh-CN/${canonicalPath.slice("docs/".length)}`;
+  return null;
+}
+
+function parseDiff(diff) {
+  const files = new Map();
+  let current = null;
+  for (const line of diff.split("\n")) {
+    const header = /^diff --git a\/(.*) b\/(.*)$/.exec(line);
+    if (header) {
+      current = { oldPath: header[1], newPath: header[2], hunks: [] };
+      files.set(current.newPath, current);
+      continue;
+    }
+    if (!current) continue;
+    const hunk = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(line);
+    if (hunk) {
+      current.hunks.push({
+        newStart: Number(hunk[3]),
+        newCount: Number(hunk[4] ?? 1),
+      });
+    }
+  }
+  return files;
+}
+
+function changedLineRanges(file) {
+  return file.hunks.map(({ newStart, newCount }) => {
+    const start = newCount === 0 ? Math.max(1, newStart) : newStart;
+    return { start, end: start + Math.max(newCount, 1) - 1 };
+  });
+}
+
+function markedSectionRanges(content) {
+  const lines = content.split("\n");
+  const headings = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = /^(#{1,6})\s+/.exec(lines[index]);
+    if (heading) headings.push({ level: heading[1].length, line: index + 1 });
+  }
+
+  const ranges = [];
+  for (const heading of headings) {
+    const next = headings.find((candidate) => candidate.line > heading.line && candidate.level <= heading.level);
+    const end = (next?.line ?? lines.length + 1) - 1;
+    const hasMarker = lines.slice(heading.line - 1, end).some((line) => line.trim() === DIVERGENCE_MARKER);
+    if (hasMarker) ranges.push({ start: heading.line, end });
+  }
+  return ranges;
+}
+
+function rangesCoveredByMarkers(content, ranges) {
+  const marked = markedSectionRanges(content);
+  return ranges.every(({ start, end }) => marked.some((section) => start >= section.start && end <= section.end));
+}
+
+function gitDiff(repositoryRoot, base, head) {
+  try {
+    return execFileSync(
+      "git",
+      ["-C", repositoryRoot, "diff", "--unified=0", "--no-color", "--find-renames", `${base}...${head}`],
+      { encoding: "utf8" },
+    );
+  } catch (error) {
+    const detail = error.stderr?.toString().trim() || error.message;
+    throw new Error(`Unable to read Git diff for ${base}...${head}: ${detail}`);
+  }
+}
+
+function mirrorCandidates(changedFiles, pairs) {
+  const candidates = new Map(pairs);
+  for (const canonicalPath of changedFiles.keys()) {
+    const mirrorPath = expectedMirrorPath(canonicalPath);
+    if (mirrorPath) candidates.set(canonicalPath, mirrorPath);
+  }
+  return candidates;
+}
+
+function findChangedCanonicalWithoutMirror(root, changedFiles, candidates) {
+  const missing = [];
+  for (const [canonicalPath, mirrorFromDiscovery] of candidates) {
+    const mirrorPath = mirrorFromDiscovery ?? expectedMirrorPath(canonicalPath);
+    if (!mirrorPath) continue;
+    const canonicalDiff = changedFiles.get(canonicalPath);
+    if (!canonicalDiff) continue;
+    const mirrorDiff = changedFiles.get(mirrorPath);
+    if (mirrorDiff) continue;
+
+    const canonicalAbsolutePath = join(root, canonicalPath);
+    const canonicalExists = existsSync(canonicalAbsolutePath);
+    const content = canonicalExists ? readFileSync(canonicalAbsolutePath, "utf8") : "";
+    const changedRanges = changedLineRanges(canonicalDiff);
+    if (canonicalExists && rangesCoveredByMarkers(content, changedRanges)) continue;
+    missing.push({ canonical: canonicalPath, mirror: mirrorPath });
+  }
+  return missing;
+}
+
+function findOrphanMirrors(root, pairs) {
+  const missing = [];
+  for (const [canonicalPath, mirrorPath] of pairs) {
+    if (!existsSync(join(root, canonicalPath))) {
+      missing.push({ canonical: canonicalPath, mirror: mirrorPath, orphan: true });
+    }
+  }
+
+  return missing;
+}
+
+export function checkDocMirrors({ repositoryRoot = process.cwd(), base, head = "HEAD" }) {
+  if (!base) throw new Error("A base Git revision is required (pass --base <revision>)");
+  const root = resolve(repositoryRoot);
+  const changedFiles = parseDiff(gitDiff(root, base, head));
+  const pairs = discoverMirrorPairs(root);
+  const candidates = mirrorCandidates(changedFiles, pairs);
+  const missing = [
+    ...findChangedCanonicalWithoutMirror(root, changedFiles, candidates),
+    ...findOrphanMirrors(root, pairs),
+  ];
+  return { checked: changedFiles.size, missing, pairs: pairs.size };
+}
+
+function applyArgument(argument, value, options, positional) {
+  if (argument === "--root" || argument === "--base" || argument === "--head") {
+    options[argument.slice(2)] = value;
+    return;
+  }
+  if (argument === "--range") {
+    const match = /^(.*?)\.\.\.(.*)$/.exec(value);
+    if (!match) throw new Error("--range must use base...head syntax");
+    options.base = match[1];
+    options.head = match[2];
+    return;
+  }
+  positional.push(argument);
+}
+
+const VALUE_ARGUMENTS = new Set(["--root", "--base", "--head", "--range"]);
+
+function parseArgumentAt(argv, index, options, positional) {
+  const argument = argv[index];
+  if (argument === "--help" || argument === "-h") {
+    options.help = true;
+    return index;
+  }
+  if (VALUE_ARGUMENTS.has(argument)) {
+    const value = argv[index + 1];
+    if (!value) throw new Error(`${argument} requires a value`);
+    applyArgument(argument, value, options, positional);
+    return index + 1;
+  }
+  applyArgument(argument, undefined, options, positional);
+  return index;
+}
+
+function parseArguments(argv) {
+  const options = { root: process.cwd(), head: "HEAD" };
+  const positional = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    index = parseArgumentAt(argv, index, options, positional);
+  }
+  if (!options.base && positional[0]) options.base = positional[0];
+  if (positional[1]) options.head = positional[1];
+  return options;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv);
+  if (options.help) {
+    process.stdout.write(
+      "Usage: node scripts/check-doc-mirrors.mjs --base <revision> [--head <revision>] [--root <path>]\n",
+    );
+    return 0;
+  }
+  const result = checkDocMirrors(options);
+  if (result.missing.length > 0) {
+    process.stderr.write("Documentation mirror check failed:\n");
+    for (const item of result.missing) {
+      if (item.orphan) process.stderr.write(`- mirror ${item.mirror} has no canonical file ${item.canonical}\n`);
+      else process.stderr.write(`- canonical ${item.canonical} changed without mirror ${item.mirror}\n`);
+    }
+    return 1;
+  }
+  process.stdout.write(`Documentation mirror check passed (${result.pairs} pairs discovered).\n`);
+  return 0;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-doc-mirrors.mjs
+++ b/scripts/check-doc-mirrors.mjs
@@ -169,10 +169,12 @@ export function checkDocMirrors({ repositoryRoot = process.cwd(), base, head = "
   const changedFiles = parseDiff(gitDiff(root, base, head));
   const pairs = discoverMirrorPairs(root);
   const candidates = mirrorCandidates(changedFiles, pairs);
-  const missing = [
-    ...findChangedCanonicalWithoutMirror(root, changedFiles, candidates),
-    ...findOrphanMirrors(root, pairs),
-  ];
+  const changedMissing = findChangedCanonicalWithoutMirror(root, changedFiles, candidates);
+  const changedKeys = new Set(changedMissing.map((item) => `${item.canonical}\0${item.mirror}`));
+  const orphanMissing = findOrphanMirrors(root, pairs).filter(
+    (item) => !changedKeys.has(`${item.canonical}\0${item.mirror}`),
+  );
+  const missing = [...changedMissing, ...orphanMissing];
   return { checked: changedFiles.size, missing, pairs: pairs.size };
 }
 
@@ -215,7 +217,15 @@ function parseArguments(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     index = parseArgumentAt(argv, index, options, positional);
   }
-  if (!options.base && positional[0]) options.base = positional[0];
+  if (!options.base && positional[0]) {
+    const range = /^(.*?)\.\.\.(.*)$/.exec(positional[0]);
+    if (range) {
+      options.base = range[1];
+      options.head = range[2];
+    } else {
+      options.base = positional[0];
+    }
+  }
   if (positional[1]) options.head = positional[1];
   return options;
 }

--- a/scripts/check-doc-mirrors.mjs
+++ b/scripts/check-doc-mirrors.mjs
@@ -95,11 +95,12 @@ function markedSectionRanges(content) {
   }
 
   const ranges = [];
-  for (const heading of headings) {
-    const next = headings.find((candidate) => candidate.line > heading.line && candidate.level <= heading.level);
-    const end = (next?.line ?? lines.length + 1) - 1;
-    const hasMarker = lines.slice(heading.line - 1, end).some((line) => line.trim() === DIVERGENCE_MARKER);
-    if (hasMarker) ranges.push({ start: heading.line, end });
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trim() !== DIVERGENCE_MARKER) continue;
+    const owner = [...headings].reverse().find((heading) => heading.line <= index + 1);
+    if (!owner) continue;
+    const next = headings.find((candidate) => candidate.line > owner.line && candidate.level <= owner.level);
+    ranges.push({ start: owner.line, end: (next?.line ?? lines.length + 1) - 1 });
   }
   return ranges;
 }

--- a/scripts/quality-scoreboard.mjs
+++ b/scripts/quality-scoreboard.mjs
@@ -1,0 +1,340 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BUNDLE_REPORT_SCRIPT = "scripts/report-bundle-sizes.mjs";
+const DEFAULT_COVERAGE_PATH = "coverage/unit/coverage-final.json";
+const DEFAULT_BUNDLE_DIRECTORY = "apps/web/dist/assets";
+const DEFAULT_TEST_DURATION_PATH = "quality/test-duration.json";
+const DEFAULT_HIGH_RISK_PATH = ".github/high-risk-items.json";
+const IGNORED_DIRECTORY_NAMES = new Set([".git", ".turbo", "coverage", "dist", "node_modules"]);
+
+function measured(value, note) {
+  return note ? { value, status: "measured", note } : { value, status: "measured" };
+}
+
+function skipped(note) {
+  return { value: null, status: "skipped", note };
+}
+
+function percentage(covered, total) {
+  return total === 0 ? 100 : Number(((covered / total) * 100).toFixed(2));
+}
+
+function coverageMetric(total = 0, covered = 0) {
+  return { total, covered, percent: percentage(covered, total) };
+}
+
+function normalizeCoverageSummary(total) {
+  return {
+    lines: coverageMetric(Number(total.lines?.total ?? 0), Number(total.lines?.covered ?? 0)),
+    statements: coverageMetric(Number(total.statements?.total ?? 0), Number(total.statements?.covered ?? 0)),
+    functions: coverageMetric(Number(total.functions?.total ?? 0), Number(total.functions?.covered ?? 0)),
+    branches: coverageMetric(Number(total.branches?.total ?? 0), Number(total.branches?.covered ?? 0)),
+  };
+}
+
+function isNormalizedCoverage(value) {
+  return Boolean(value?.lines && value?.statements && value?.functions && value?.branches);
+}
+
+function countValues(values) {
+  const counts = Object.values(values ?? {});
+  return { total: counts.length, covered: counts.filter((count) => Number(count) > 0).length };
+}
+
+function aggregateCoverageFile(file, totals, lines) {
+  for (const [key, value] of Object.entries(countValues(file.s))) totals.statements[key] += value;
+  for (const [key, value] of Object.entries(countValues(file.f))) totals.functions[key] += value;
+  const branchValues = Object.values(file.b ?? {}).flat();
+  const branchCount = countValues(Object.fromEntries(branchValues.map((value, index) => [index, value])));
+  totals.branches.total += branchCount.total;
+  totals.branches.covered += branchCount.covered;
+  for (const [key, mapEntry] of Object.entries(file.statementMap ?? {})) {
+    const line = Number(mapEntry.start?.line);
+    if (Number.isInteger(line) && line > 0) {
+      lines.set(line, Math.max(lines.get(line) ?? 0, Number(file.s?.[key] ?? 0)));
+    }
+  }
+}
+
+/** Aggregate either an Istanbul coverage-final map or a coverage-summary total object. */
+export function summarizeCoverage(coverage) {
+  if (isNormalizedCoverage(coverage)) return coverage;
+  if (coverage?.total) return normalizeCoverageSummary(coverage.total);
+  const totals = {
+    statements: { total: 0, covered: 0 },
+    functions: { total: 0, covered: 0 },
+    branches: { total: 0, covered: 0 },
+  };
+  const lines = new Map();
+  for (const file of Object.values(coverage ?? {})) aggregateCoverageFile(file, totals, lines);
+  const lineCounts = countValues(Object.fromEntries(lines));
+  return {
+    lines: { ...lineCounts, percent: percentage(lineCounts.covered, lineCounts.total) },
+    statements: { ...totals.statements, percent: percentage(totals.statements.covered, totals.statements.total) },
+    functions: { ...totals.functions, percent: percentage(totals.functions.covered, totals.functions.total) },
+    branches: { ...totals.branches, percent: percentage(totals.branches.covered, totals.branches.total) },
+  };
+}
+
+export function parseHighRiskItems(input) {
+  if (typeof input === "number" && Number.isFinite(input)) return input;
+  if (Array.isArray(input)) return input.filter(isOpenRiskItem).length;
+  if (input && typeof input === "object") {
+    if (Number.isFinite(Number(input.count))) return Number(input.count);
+    if (Array.isArray(input.items)) return input.items.filter(isOpenRiskItem).length;
+  }
+  if (typeof input === "string") {
+    return input
+      .split("\n")
+      .filter((line) => /^\s*[-*]\s+\[\s\]/.test(line) && /high[- ]risk|security|critical/i.test(line)).length;
+  }
+  return null;
+}
+
+function isOpenRiskItem(item) {
+  if (!item || typeof item !== "object") return true;
+  if (item.open === false || item.state === "closed") return false;
+  return !["closed", "resolved", "done"].includes(String(item.status ?? "").toLowerCase());
+}
+
+export function countComplexityWarnings(report) {
+  const parsed = typeof report === "string" ? JSON.parse(report) : report;
+  return (parsed?.diagnostics ?? []).filter(
+    (diagnostic) => diagnostic.severity === "warning" && String(diagnostic.category ?? "").includes("complexity"),
+  ).length;
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function runBiome(repositoryRoot) {
+  const result = spawnSync("pnpm", ["exec", "biome", "check", ".", "--reporter=json"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.stdout) {
+    try {
+      const value = countComplexityWarnings(result.stdout);
+      return measured(value, result.status === 0 ? undefined : `Biome exited with status ${result.status}`);
+    } catch {
+      // Fall through to an explicit skip note when the reporter output is incomplete.
+    }
+  }
+  return skipped("Biome JSON reporter was unavailable");
+}
+
+function runBundleReport(repositoryRoot, bundleDirectory) {
+  const directory = resolve(repositoryRoot, bundleDirectory);
+  const script = resolve(repositoryRoot, BUNDLE_REPORT_SCRIPT);
+  if (!existsSync(directory)) return skipped(`${bundleDirectory} was not found`);
+  const result = spawnSync(process.execPath, [script, bundleDirectory], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  if (result.status !== 0) return skipped("bundle-size report script failed");
+  try {
+    return measured(JSON.parse(result.stdout));
+  } catch {
+    return skipped("bundle-size report was not valid JSON");
+  }
+}
+
+function collectLargestFiles(repositoryRoot, limit = 10) {
+  const files = [];
+  function visit(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isDirectory() && !IGNORED_DIRECTORY_NAMES.has(entry.name)) visit(join(directory, entry.name));
+      else if (entry.isFile()) {
+        const path = join(directory, entry.name);
+        files.push({ path: toPosix(relative(repositoryRoot, path)), bytes: statSync(path).size });
+      }
+    }
+  }
+  visit(repositoryRoot);
+  return files.sort((left, right) => right.bytes - left.bytes || left.path.localeCompare(right.path)).slice(0, limit);
+}
+
+function toPosix(path) {
+  return path.split(sep).join("/");
+}
+
+function readTestDuration(repositoryRoot, path) {
+  const value = readJson(resolve(repositoryRoot, path));
+  const duration = typeof value === "number" ? value : value?.durationMs;
+  return Number.isFinite(Number(duration)) ? measured(Number(duration)) : skipped(`${path} was not found`);
+}
+
+function readHighRisk(repositoryRoot, path) {
+  const input = readJson(resolve(repositoryRoot, path));
+  const count = parseHighRiskItems(input);
+  return count === null ? skipped(`${path} was not found`) : measured(count);
+}
+
+function readCoverage(repositoryRoot, path) {
+  const absolutePath = resolve(repositoryRoot, path);
+  const input = readJson(absolutePath);
+  if (!input) return skipped(`${path} was not found`);
+  return measured(input);
+}
+
+function gitRevision(repositoryRoot) {
+  const result = spawnSync("git", ["-C", repositoryRoot, "rev-parse", "HEAD"], { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "unknown";
+}
+
+export function createScoreboard({
+  repositoryRoot,
+  generatedAt = new Date().toISOString(),
+  revision = "unknown",
+  complexityWarnings,
+  coverage,
+  testDurationMs,
+  bundleReport,
+  largestFiles = [],
+  openHighRiskItems,
+}) {
+  return {
+    version: 1,
+    generatedAt,
+    commit: revision,
+    repository: repositoryRoot,
+    metrics: {
+      complexityWarnings:
+        complexityWarnings === undefined
+          ? skipped("Biome JSON reporter was unavailable")
+          : measured(complexityWarnings),
+      unitCoverage:
+        coverage === null || coverage === undefined
+          ? skipped("coverage-final.json was not found")
+          : measured(summarizeCoverage(coverage)),
+      testDurationMs:
+        testDurationMs === null || testDurationMs === undefined
+          ? skipped("test duration artifact was not found")
+          : measured(testDurationMs),
+      bundleSizes:
+        bundleReport === null || bundleReport === undefined
+          ? skipped("bundle-size report was unavailable")
+          : measured(bundleReport),
+      largestFiles: measured(largestFiles),
+      openHighRiskItems:
+        openHighRiskItems === null || openHighRiskItems === undefined
+          ? skipped("high-risk item source was not found")
+          : measured(openHighRiskItems),
+    },
+  };
+}
+
+function displayValue(name, metric) {
+  if (metric.status === "skipped") return "Skipped";
+  if (name === "unitCoverage") return `${metric.value.lines.percent.toFixed(2)}% lines`;
+  if (name === "bundleSizes") return `${metric.value.totalBytes} bytes (${metric.value.chunks.length} chunks)`;
+  if (name === "largestFiles") return `${metric.value.length} files`;
+  if (name === "testDurationMs") return `${metric.value} ms`;
+  return String(metric.value);
+}
+
+export function renderMarkdown(scoreboard) {
+  const rows = Object.entries(scoreboard.metrics)
+    .map(([name, metric]) => `| ${name} | ${displayValue(name, metric)} | ${metric.status} | ${metric.note ?? ""} |`)
+    .join("\n");
+  const bundle = scoreboard.metrics.bundleSizes.value;
+  const chunks = bundle?.chunks?.length
+    ? `\n### Bundle chunks\n\n| File | Bytes |\n| --- | ---: |\n${bundle.chunks.map((chunk) => `| ${chunk.file} | ${chunk.bytes} |`).join("\n")}\n`
+    : "";
+  const largest = scoreboard.metrics.largestFiles.value;
+  const largestTable = largest?.length
+    ? `\n### Largest files\n\n| File | Bytes |\n| --- | ---: |\n${largest.map((file) => `| ${file.path} | ${file.bytes} |`).join("\n")}\n`
+    : "";
+  return `# Quality scoreboard\n\nGenerated: ${scoreboard.generatedAt}\n\nCommit: ${scoreboard.commit}\n\n| Metric | Value | Status | Note |\n| --- | --- | --- | --- |\n${rows}\n${chunks}${largestTable}`;
+}
+
+export function writeScoreboard(scoreboard, { jsonPath, markdownPath }) {
+  mkdirSync(dirname(jsonPath), { recursive: true });
+  mkdirSync(dirname(markdownPath), { recursive: true });
+  writeFileSync(jsonPath, `${JSON.stringify(scoreboard, null, 2)}\n`);
+  writeFileSync(markdownPath, `${renderMarkdown(scoreboard)}\n`);
+  return { jsonPath, markdownPath };
+}
+
+function collectScoreboard(repositoryRoot, options) {
+  const biome = runBiome(repositoryRoot);
+  const coverage = readCoverage(repositoryRoot, options.coveragePath);
+  const testDuration = readTestDuration(repositoryRoot, options.testDurationPath);
+  const bundle = runBundleReport(repositoryRoot, options.bundleDirectory);
+  const highRisk = readHighRisk(repositoryRoot, options.highRiskPath);
+  return createScoreboard({
+    repositoryRoot,
+    revision: options.revision || gitRevision(repositoryRoot),
+    complexityWarnings: biome.status === "skipped" ? undefined : biome.value,
+    coverage: coverage.status === "skipped" ? null : coverage.value,
+    testDurationMs: testDuration.status === "skipped" ? null : testDuration.value,
+    bundleReport: bundle.status === "skipped" ? null : bundle.value,
+    largestFiles: collectLargestFiles(repositoryRoot),
+    openHighRiskItems: highRisk.status === "skipped" ? null : highRisk.value,
+  });
+}
+
+function parseArguments(argv) {
+  const options = {
+    root: process.cwd(),
+    jsonPath: "quality-scoreboard.json",
+    markdownPath: "quality-scoreboard.md",
+    coveragePath: DEFAULT_COVERAGE_PATH,
+    bundleDirectory: DEFAULT_BUNDLE_DIRECTORY,
+    testDurationPath: DEFAULT_TEST_DURATION_PATH,
+    highRiskPath: DEFAULT_HIGH_RISK_PATH,
+    revision: "",
+  };
+  const names = new Set(Object.keys(options));
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (!argument?.startsWith("--")) throw new Error(`Unexpected argument: ${argument}`);
+    const name = argument.slice(2).replaceAll("-", "");
+    const key = [...names].find((candidate) => candidate.replaceAll("-", "").toLowerCase() === name.toLowerCase());
+    if (!key) throw new Error(`Unknown option: ${argument}`);
+    const value = argv[++index];
+    if (!value) throw new Error(`${argument} requires a value`);
+    options[key] = value;
+  }
+  return options;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv);
+  if (options.help) {
+    process.stdout.write(
+      "Usage: node scripts/quality-scoreboard.mjs [--root <path>] [--json-path <path>] [--markdown-path <path>]\n",
+    );
+    return 0;
+  }
+  const root = resolve(options.root);
+  writeScoreboard(collectScoreboard(root, options), {
+    jsonPath: resolve(root, options.jsonPath),
+    markdownPath: resolve(root, options.markdownPath),
+  });
+  process.stdout.write(`Quality scoreboard written to ${options.jsonPath} and ${options.markdownPath}\n`);
+  return 0;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
Implements backlog item **COLLAB-02 — Publish a quality scoreboard and automated
documentation/dependency checks** (Phase 2).

## What this adds

- `scripts/quality-scoreboard.mjs`: gathers cheaply computable metrics (Biome warning count via
  reporter, coverage totals from coverage-final.json when present, bundle sizes via the existing
  report script, largest-file sizes) into one JSON trend artifact + a markdown summary; unit tests
  with fixtures.
- `scripts/check-doc-mirrors.mjs`: git-range-based canonical-vs-mirror consistency check for
  `*.zh-CN.md` and `docs/zh-CN/` — a canonical doc changed without its mirror fails naming both
  paths; heading-scoped divergence markers suppress intentional drift. Tests first (temp-dir
  fixtures).
- `.github/workflows/quality-scoreboard.yml` (new file; no existing workflow touched): weekly +
  manual dispatch, least-privilege, uploads the trend artifact and appends the summary; a
  PR-triggered mirror-check job lives in this same workflow as a non-required advisory.
- `.github/dependabot.yml`: npm + github-actions ecosystems, weekly, grouped (dev/prod/actions) so
  updates stay reviewable and cannot silently alter workspace contracts.
- Both new scripts were run against the real repository and their outputs recorded in-lane.

## Checklist (final state)

- [x] Mirror-check contract designed + recorded
- [x] Failing mirror-checker tests first
- [x] Mirror checker implementation
- [x] Scoreboard metrics + artifact + tests
- [x] Scheduled workflow (new file, least-privilege)
- [x] Grouped dependabot config
- [x] Full verification + real-repo runs

## Verification

Lane and orchestrator re-run (Node 24.19.0, pnpm 10.12.1): `pnpm check`, `pnpm typecheck`,
`pnpm test`.

## Provenance

Written by a Codex agent (dispatch run `95a994`, lane `quality-scoreboard-6`) under bypassed
approvals in an isolated git worktree; verified and published by the orchestrating Claude session.
