### PR TITLE
feat(web): apply OpenTag brand palette and typography

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@cloudflare/kumo": "2.12.0",
+    "@fontsource/dm-sans": "5.3.0",
+    "@fontsource/sora": "5.3.0",
     "@opentag/shared": "workspace:*",
     "@phosphor-icons/react": "2.1.10",
     "@tanstack/react-query": "^5.102.8",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -3,6 +3,25 @@
 @import "./ui/kumo-theme.css";
 @source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
 
+/* OpenTag brand tokens. Keep usage constraints next to the values so a new surface does not
+ * accidentally turn an inaccessible accent into body copy. */
+:root[data-theme="opentag"],
+[data-theme="opentag"] {
+  --brand: #8fdd14; /* logo green — fills, color blocks, icons ONLY; never a text color */
+  --brand-display: #649a0e; /* display green — text at >= 24px only (large headings) */
+  --brand-ink: #3a5c04; /* body-level green — green text at normal sizes uses this */
+  --brand-100: #f1f8e1; /* light brand tint — backgrounds/edges */
+  --bg: #f8f7f0; /* main app background (warm off-white, NOT pure white) */
+  --card: #fdfcf6; /* card / surface background */
+  --fg: #16211b; /* primary text */
+  --fg-2: #3a453e; /* secondary text */
+  --muted-fg: #626b60; /* muted text */
+  --border: #e0e2d3; /* default border */
+  --border-strong: #c9ccbb; /* strong border */
+  --dark: #0b101d; /* dark section background */
+  --on-dark: #f8f7f0; /* text on dark sections */
+}
+
 /* OpenTag application boundary. Component styling belongs to Kumo. */
 :root {
   color: var(--text-color-kumo-default);

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -22,6 +22,33 @@
   --on-dark: #f8f7f0; /* text on dark sections */
 }
 
+/* Kumo semantic base. These aliases make the application canvas, surfaces, text, and borders
+ * inherit the OpenTag palette without changing Kumo component internals. */
+:root[data-theme="opentag"],
+[data-theme="opentag"] {
+  --color-kumo-canvas: var(--bg);
+  --color-kumo-elevated: var(--card);
+  --color-kumo-recessed: var(--brand-100);
+  --color-kumo-base: var(--card);
+  --color-kumo-tint: var(--brand-100);
+  --color-kumo-contrast: var(--fg);
+  --color-kumo-overlay: var(--card);
+  --color-kumo-control: var(--card);
+  --color-kumo-interact: var(--border-strong);
+  --color-kumo-fill: var(--border);
+  --color-kumo-fill-hover: var(--brand-100);
+  --color-kumo-line: var(--border);
+  --color-kumo-hairline: var(--border);
+  --color-kumo-focus: var(--brand-ink);
+  --text-color-kumo-default: var(--fg);
+  --text-color-kumo-inverse: var(--on-dark);
+  --text-color-kumo-strong: var(--fg);
+  --text-color-kumo-subtle: var(--fg-2);
+  --text-color-kumo-inactive: var(--muted-fg);
+  --text-color-kumo-placeholder: var(--muted-fg);
+  --text-color-kumo-link: var(--brand-ink);
+}
+
 /* OpenTag application boundary. Component styling belongs to Kumo. */
 :root {
   color: var(--text-color-kumo-default);

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,6 +1,12 @@
+@import "@fontsource/dm-sans/400.css";
+@import "@fontsource/dm-sans/500.css";
+@import "@fontsource/dm-sans/600.css";
+@import "@fontsource/sora/600.css";
+@import "@fontsource/sora/700.css";
 @import "@cloudflare/kumo/styles/tailwind";
 @import "tailwindcss";
 @import "./ui/kumo-theme.css";
+@import "./ui/typography.css";
 @source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
 
 /* OpenTag brand tokens. Keep usage constraints next to the values so a new surface does not
@@ -54,8 +60,8 @@
   color: var(--text-color-kumo-default);
   background: var(--color-kumo-canvas);
   font-family:
-    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei",
-    "Noto Sans SC", sans-serif;
+    "DM Sans", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
 }
 

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -57,8 +57,8 @@
 
 /* OpenTag application boundary. Component styling belongs to Kumo. */
 :root {
-  color: var(--text-color-kumo-default);
-  background: var(--color-kumo-canvas);
+  color: var(--fg);
+  background: var(--bg);
   font-family:
     "DM Sans", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -75,8 +75,8 @@ body,
 
 body {
   margin: 0;
-  background: var(--color-kumo-canvas);
-  color: var(--text-color-kumo-default);
+  background: var(--bg);
+  color: var(--fg);
   font-size: 14px;
   line-height: 1.5;
 }

--- a/apps/web/src/onboarding-v2/onboarding-v2.css
+++ b/apps/web/src/onboarding-v2/onboarding-v2.css
@@ -20,9 +20,9 @@
  * invalid, so the mark would fall back to solid black rather than to a sensible colour.
  */
 :root {
-  --otv2-mark-tint: var(--color-kumo-tint);
-  --otv2-mark-surface: var(--color-kumo-base);
-  --otv2-mark-ink: var(--text-color-kumo-strong);
+  --otv2-mark-tint: var(--brand);
+  --otv2-mark-surface: var(--card);
+  --otv2-mark-ink: var(--brand-ink);
 }
 
 /* Codex follows OpenTag's explicit theme, not the operating system's colour preference. */

--- a/apps/web/src/setup/setup.css
+++ b/apps/web/src/setup/setup.css
@@ -61,14 +61,14 @@
  */
 .ots-command__body {
   position: relative;
-  background: #0b101d;
-  border-color: var(--color-kumo-hairline);
+  background: var(--dark);
+  border-color: var(--border);
   transition: opacity 160ms ease;
 }
 
 .ots-command__code {
   margin: 0;
-  color: #e6e9e0;
+  color: var(--on-dark);
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, "PingFang SC", monospace;
   font-size: 13px;
   line-height: 1.55;
@@ -111,7 +111,7 @@
   background: transparent;
 
   /* The same value the command itself is set in, so the control is as legible as what it copies. */
-  color: #e6e9e0;
+  color: var(--on-dark);
 }
 
 .ots-command__copy svg {
@@ -120,12 +120,12 @@
 }
 
 .ots-command__copy:hover:not(:disabled) {
-  background: rgb(230 233 224 / 14%);
-  color: #fff;
+  background: color-mix(in srgb, var(--on-dark) 14%, transparent);
+  color: var(--on-dark);
 }
 
 .ots-command__copy:active:not(:disabled) {
-  background: rgb(230 233 224 / 22%);
+  background: color-mix(in srgb, var(--on-dark) 22%, transparent);
 }
 
 /* The block's shape while its command is still being issued: same box, nothing legible in it. */
@@ -148,16 +148,16 @@
 .ots-command__expired {
   position: absolute;
   inset: 0;
-  background: rgb(11 16 29 / 78%);
-  color: #e6e9e0;
+  background: color-mix(in srgb, var(--dark) 78%, transparent);
+  color: var(--on-dark);
 }
 
 .ots-command__expired button {
-  color: #cfe3a6;
+  color: var(--brand-100);
 }
 
 .ots-command__expired button:hover {
-  color: #e8f5cd;
+  color: var(--on-dark);
 }
 
 /* Measurements ----------------------------------------------------------- */

--- a/apps/web/src/ui/kumo-theme.css
+++ b/apps/web/src/ui/kumo-theme.css
@@ -1,19 +1,19 @@
 /* Generated from kumo-theme.tokens.ts. Do not edit node_modules Kumo styles. */
 :root[data-theme="opentag"],
 [data-theme="opentag"] {
-  --color-kumo-brand: #385a04;
-  --color-kumo-brand-hover: #4e7a06;
-  --text-color-kumo-brand: #385a04;
-  --kumo-button-emphasis-bg: #385a04;
-  --kumo-button-emphasis-ring: #385a04;
+  --color-kumo-brand: #3a5c04;
+  --color-kumo-brand-hover: #2f4a03;
+  --text-color-kumo-brand: #3a5c04;
+  --kumo-button-emphasis-bg: #3a5c04;
+  --kumo-button-emphasis-ring: #3a5c04;
 }
 
 :root[data-theme="opentag"][data-mode="dark"],
 [data-theme="opentag"][data-mode="dark"],
 [data-theme="opentag"] [data-mode="dark"] {
-  --color-kumo-brand: #90de14;
+  --color-kumo-brand: #8fdd14;
   --color-kumo-brand-hover: #a8ec45;
-  --text-color-kumo-brand: #90de14;
-  --kumo-button-emphasis-bg: #90de14;
-  --kumo-button-emphasis-ring: #90de14;
+  --text-color-kumo-brand: #8fdd14;
+  --kumo-button-emphasis-bg: #8fdd14;
+  --kumo-button-emphasis-ring: #8fdd14;
 }

--- a/apps/web/src/ui/kumo-theme.tokens.ts
+++ b/apps/web/src/ui/kumo-theme.tokens.ts
@@ -7,16 +7,18 @@
  */
 export const kumoThemeTokens = {
   light: {
-    brand: "#385a04",
-    brandHover: "#4e7a06",
-    brandText: "#385a04",
-    buttonRing: "#385a04",
+    brand: "#3a5c04",
+    // Keep normal-size brand text comfortably above WCAG AA on a light surface. The display green
+    // is intentionally reserved for headings at 24px and above, so it is not used here.
+    brandHover: "#2f4a03",
+    brandText: "#3a5c04",
+    buttonRing: "#3a5c04",
   },
   dark: {
-    brand: "#90de14",
+    brand: "#8fdd14",
     brandHover: "#a8ec45",
-    brandText: "#90de14",
-    buttonRing: "#90de14",
+    brandText: "#8fdd14",
+    buttonRing: "#8fdd14",
   },
 } as const;
 

--- a/apps/web/src/ui/typography.css
+++ b/apps/web/src/ui/typography.css
@@ -5,7 +5,10 @@ h3,
 h4,
 h5,
 h6,
-[role="heading"] {
+[role="heading"],
+/* Kumo's heading variant renders a span with this stable semantic class pair when `as` is not
+ * supplied. Keep those heading-level UI labels on the display face as well. */
+.text-kumo-default.font-semibold {
   font-family:
     "Sora", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;

--- a/apps/web/src/ui/typography.css
+++ b/apps/web/src/ui/typography.css
@@ -1,15 +1,17 @@
 /* OpenTag typography. Font files are imported by app.css so Vite self-hosts them with the app. */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-[role="heading"],
-/* Kumo's heading variant renders a span with this stable semantic class pair when `as` is not
- * supplied. Keep those heading-level UI labels on the display face as well. */
-.text-kumo-default.font-semibold {
-  font-family:
-    "Sora", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", ui-sans-serif, system-ui, -apple-system,
-    BlinkMacSystemFont, "Segoe UI", sans-serif;
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  [role="heading"],
+  /* Kumo's heading variant renders a span with this stable semantic class pair when `as` is not
+   * supplied. Keep those heading-level UI labels on the display face as well. */
+  [class~="text-kumo-default"][class~="font-semibold"] {
+    font-family:
+      "Sora", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", ui-sans-serif, system-ui, -apple-system,
+      BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
 }

--- a/apps/web/src/ui/typography.css
+++ b/apps/web/src/ui/typography.css
@@ -1,0 +1,12 @@
+/* OpenTag typography. Font files are imported by app.css so Vite self-hosts them with the app. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+[role="heading"] {
+  font-family:
+    "Sora", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,12 @@ importers:
       '@cloudflare/kumo':
         specifier: 2.12.0
         version: 2.12.0(@date-fns/tz@1.5.0)(@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(date-fns@4.4.0)(echarts@6.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      '@fontsource/dm-sans':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource/sora':
+        specifier: 5.3.0
+        version: 5.3.0
       '@opentag/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1121,6 +1127,12 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@fontsource/dm-sans@5.3.0':
+    resolution: {integrity: sha512-lYJtMXXO28q1z+yz+z8XKd0s4hXaa9QdkETzkyD760sidCv5heI86weYA0sx0Nc4pAMAQTUuyf4gO44cYKKS9g==}
+
+  '@fontsource/sora@5.3.0':
+    resolution: {integrity: sha512-SqW3OpKxxfKvxDLPlbdrWf2KooPfbd+W3jaYn483o+Y/JrmU87vjFPNptDqwP428c3vY+gnranLhjcbRaXB0Jw==}
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
@@ -5277,6 +5289,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.12': {}
+
+  '@fontsource/dm-sans@5.3.0': {}
+
+  '@fontsource/sora@5.3.0': {}
 
   '@grpc/grpc-js@1.14.4':
     dependencies:


### PR DESCRIPTION
## Summary

Lands the OpenTag brand design tokens and brand typography in `apps/web`, wired through the
existing token architecture (`kumo-theme.tokens.ts` as the semantic source of truth with its
generated CSS mirror, and `app.css` for the global base).

- Adds the full brand palette as CSS custom properties in the `data-theme="opentag"` scope of
  `apps/web/src/app.css`, with usage-rule comments preserved: `--brand` #8FDD14 is a fill/accent
  only (never a text color), `--brand-display` #649A0E is display-size text only (>= 24px), and
  `--brand-ink` #3A5C04 is the green for normal-size text.
- Aligns Kumo semantic brand tokens: light brand text uses the WCAG-AA-safe `#3a5c04` family,
  dark-mode brand emphasis uses `#8fdd14`; the contrast test in `kumo-theme.tokens.test.ts`
  passes unchanged (no assertions weakened).
- Rewires the global ground: app background `--bg` #F8F7F0 (warm off-white), surfaces `--card`,
  text `--fg`/`--fg-2`/`--muted-fg`, borders `--border`/`--border-strong`, dark sections
  `--dark`/`--on-dark`.
- Adds self-hosted typography via `@fontsource/sora` and `@fontsource/dm-sans`: Sora for
  semantic and ARIA headings, DM Sans for body, keeping the CJK fallbacks ("PingFang SC",
  "Microsoft YaHei", "Noto Sans SC") and `font-synthesis: none`. No runtime Google Fonts
  dependency.
- Migrates setup command surfaces and the onboarding mark to the tokens. Deliberately left
  as-is: operational status colors (passed/failed markers), the terminal comment tint, and the
  monospace code font — these are not brand tokens.

## Checklist

- [x] Add the OpenTag brand token set to the global stylesheet layer.
- [x] Align Kumo semantic brand tokens and the generated CSS mirror.
- [x] Wire the global canvas, surface, text, and border base tokens.
- [x] Add self-hosted Sora and DM Sans typography.
- [x] Sweep setup and onboarding styles for clear token mappings.
- [x] Run all required verification commands and confirm a clean worktree.

## Verification

Re-run independently by the orchestrator on the final branch state:

- `pnpm check` — passed
- `pnpm typecheck` — passed (8 Turbo tasks)
- `pnpm --filter @opentag/web test` — passed (55 files, 558 tests)
- `pnpm build` — passed (6 build tasks)

Worktree clean; branch merges clean against current `origin/main` (`git merge-tree` verified).

## Provenance

Written by a codex agent under bypassed approvals (dispatch run `rcbgjj`, lane `brand-theme-1`),
verified and published by the orchestrator. The branch was rebased once onto `origin/main`
before verification, prior to any push.
