### PR TITLE
fix(web): keep computer install commands on active channel

### DIFF
--- a/apps/web/src/features/computer-connect/computer-connect.test.tsx
+++ b/apps/web/src/features/computer-connect/computer-connect.test.tsx
@@ -80,6 +80,9 @@ describe("ComputerConnect", () => {
     const skeleton = document.querySelector('[data-ui="computer-connect-command-skeleton"]');
     expect(skeleton?.getAttribute("aria-hidden")).toBe("true");
     expect(skeleton?.classList.contains("ots-command-pending")).toBe(true);
+    expect(skeleton?.textContent).toContain("[connection command pending]");
+    expect(skeleton?.textContent).not.toContain("opentag.example.com");
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
     expect(screen.queryByRole("code")).toBeNull();
 
     issued.resolve({ connectCodeId: CONNECT_CODE_ID, bootstrapCommand: COMMAND, expiresIn: 900, issuedAt: NOW });
@@ -363,6 +366,8 @@ describe("ComputerConnect", () => {
     render(<ComputerConnect intent={{ mode: "create" }} />);
     await flushAsync();
     expect(screen.getByRole("alert").textContent).toContain("Issuance unavailable");
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+    expect(screen.queryByText("opentag.example.com")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
     await flushAsync();
     expect(commandIsShown(COMMAND)).toBe(true);

--- a/apps/web/src/features/computer-connect/computer-connect.tsx
+++ b/apps/web/src/features/computer-connect/computer-connect.tsx
@@ -6,7 +6,11 @@ import { CommandBlock, formatRemaining, readConnectCodeVerdict, useRemaining } f
 import { Banner, Button, Loader, StatusIndicator } from "../../ui/design-system.js";
 
 const COMPUTER_POLL_INTERVAL_MS = 1_500;
-const COMMAND_SKELETON = "opentag computer connect --server https://opentag.example.com -- preparing-command";
+/**
+ * A non-command placeholder shown while the Server-derived bootstrap command is being issued.
+ * Keeping this channel-neutral prevents a loading state from implying a production package or URL.
+ */
+export const COMPUTER_CONNECT_COMMAND_PLACEHOLDER = "[connection command pending]";
 
 export type ComputerConnectIntent =
   | { readonly mode: "create" }
@@ -369,7 +373,7 @@ function ComputerConnectPresentation({
       {state.kind === "issuing" ? (
         <div aria-hidden="true" className="ots-command-pending" data-ui="computer-connect-command-skeleton">
           <CommandBlock
-            command={COMMAND_SKELETON}
+            command={COMPUTER_CONNECT_COMMAND_PLACEHOLDER}
             comment={comment}
             copiedLabel={m.computer_connect_copied()}
             copyLabel={m.computer_connect_copy()}

--- a/apps/web/src/onboarding-v2/mock-backend.ts
+++ b/apps/web/src/onboarding-v2/mock-backend.ts
@@ -156,14 +156,6 @@ function connectCommand(code: string): string {
 }
 
 /**
- * A command of exactly the shape a real one has, for the moment before one has been issued. Built
- * from the same parts and the same code length, so the block it renders is the same height at any
- * width. That identity is what keeps the arrival of the real command from moving anything — there
- * is no reserved height doing the work, and none is needed.
- */
-export const PLACEHOLDER_CONNECT_COMMAND = connectCommand("0".repeat(32));
-
-/**
  * Matches the Server's connect code: `generateSecret(24)`, so 24 random bytes rendered base64url,
  * which is 32 characters. The exact shape matters here because it is what sets the length of the
  * command block the whole step is built around.

--- a/apps/web/src/onboarding-v2/steps.test.tsx
+++ b/apps/web/src/onboarding-v2/steps.test.tsx
@@ -23,6 +23,32 @@ describe("ComputerStep repair disclosure", () => {
     vi.useRealTimers();
   });
 
+  it("keeps the pending onboarding command channel-neutral", () => {
+    vi.useFakeTimers();
+    const adapter: ComputerConnectAdapter = {
+      issue: () => new Promise(() => undefined),
+      status: () => new Promise<ComputerConnectCodeStatus>(() => undefined),
+      computers: async () => ({ computers: [] }),
+    };
+
+    render(
+      <ComputerStep
+        adapter={adapter}
+        computer={undefined}
+        creation="idle"
+        draft={draft}
+        onComputerConnected={() => undefined}
+        onCreate={() => undefined}
+        readiness={undefined}
+      />,
+    );
+
+    const panel = document.querySelector('[data-ui="onboarding-v2-computer-connect"]');
+    expect(panel?.textContent).toContain("[connection command pending]");
+    expect(panel?.textContent).not.toContain("opentag.example.com");
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+  });
+
   it("requires a fresh repair action after availability or target changes", async () => {
     vi.useFakeTimers();
     const issue = vi.fn().mockResolvedValue({

--- a/apps/web/src/onboarding-v2/steps.tsx
+++ b/apps/web/src/onboarding-v2/steps.tsx
@@ -1,5 +1,6 @@
 import { type FormEvent, useEffect, useId, useState } from "react";
 import {
+  COMPUTER_CONNECT_COMMAND_PLACEHOLDER,
   type ComputerConnectAdapter,
   type ComputerConnectIntent,
   type ComputerConnectLifecycle,
@@ -41,7 +42,6 @@ import {
   tokenChoiceApplies,
   validateAgentName,
 } from "./flow.js";
-import { PLACEHOLDER_CONNECT_COMMAND } from "./mock-backend.js";
 
 /** One step's worth of vertical rhythm. Every gap on every step is one of 4, 12 or 24px. */
 const STEP = "flex flex-col gap-6";
@@ -1024,7 +1024,7 @@ function ConnectCommand({ lifecycle, repairTarget }: { lifecycle: ComputerConnec
     return (
       <div aria-hidden="true" className="ots-command-pending">
         <CommandBlock
-          command={PLACEHOLDER_CONNECT_COMMAND}
+          command={COMPUTER_CONNECT_COMMAND_PLACEHOLDER}
           comment={
             repairTarget
               ? m.onboarding_v2_connect_repair_command_comment({ computerName: repairTarget })

--- a/packages/server/src/__tests__/integration/computers.test.ts
+++ b/packages/server/src/__tests__/integration/computers.test.ts
@@ -535,7 +535,9 @@ describe("Computer enrollment persistence", () => {
         expect(issued.statusCode).toBe(201);
         expect(issued.headers["cache-control"]).toBe("no-store");
         const command = issued.json().bootstrapCommand as string;
-        expect(command).toContain("opentag-staging computer connect --server https://dev.example.com -- otcc_");
+        expect(command).toContain(
+          "npm i -g open-tag-staging && opentag-staging computer connect --server https://dev.example.com -- otcc_",
+        );
         const code = command.split(" -- ").at(-1);
         if (!code) throw new Error("Computer connect command did not contain a code");
 


### PR DESCRIPTION
Closes #210

## Summary

On a staging deployment the Computer onboarding/setup surfaces could show a copyable
production-style install command (`opentag computer connect --server https://opentag.example.com …`).
The server-side builder (`buildComputerConnectCommand`) already derives the package and binary from
the `OPENTAG_ENV`-resolved channel config, so the leak was client-side hardcoded placeholder text:

- `apps/web/src/features/computer-connect/computer-connect.tsx` (shared by the Computers page, Agent
  creation, Agent computer choice, and Agent settings recovery) hardcoded the production/example
  skeleton shown while the real command loads — and on issuance failure.
- `apps/web/src/onboarding-v2/steps.tsx` imported a production-shaped placeholder from the dev-only
  `mock-backend.ts` into the shared presentation.

Changes:

- Replaced the shared production/example skeleton with an inert, channel-neutral
  `[connection command pending]` placeholder; the pending and failure states render no production URL
  and no copy button until a server-issued command exists.
- Onboarding-v2 reuses the neutral placeholder; the placeholder export was removed from the dev-only
  mock backend. Real issued commands still come only from each adapter's server response.
- Strengthened the server integration assertion so the staging account route must issue a command
  containing both `npm i -g open-tag-staging` and `opentag-staging`.
- Added web regression tests for the neutral pending state and the initial issuance-failure state.

## Checklist

- [x] Trace every surface that renders the Computer bootstrap/install command and record findings
- [x] Remove the copyable production-style hardcode (channel-neutral skeleton, including failure path)
- [x] Server regression test: staging environment ⇒ `open-tag-staging` + `opentag-staging`
- [x] Audit and fix other staging-visible production-identity leaks found in the trace
- [x] Web tests for the changed rendering behavior
- [x] Full verification suite passes

## Verification

Run by the lane in its worktree (Node 24.19.0 toolchain, host-safe invocation):

- `pnpm check` — passed (third-party notices, workspace contract, migration drift, complexity
  ratchet all green)
- `pnpm typecheck` — passed (all tasks)
- `pnpm build` — passed including bundle report
- `pnpm test` — passed (135 script, 753 client, 559 web, 558 non-integration server, 252 CLI tests);
  the known host-specific `lefthook-stage-fixed` 1Password failure was rerun with
  `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` and passed

Independently re-run by the orchestrator before publishing: `pnpm check` and
`pnpm --filter @opentag/web --filter @opentag/server test` (559 web tests passed; server suite green).

Deviation note: the brief's exact `corepack pnpm` wrapper invocation hit a host-level nested-corepack
version mismatch; verification used the equivalent direct Node 24 toolchain invocation. This affects
only how the checks were invoked, not the code under review.

## Provenance

Automated change: written by a Codex CLI agent running with approvals and sandbox bypassed
(dispatch-codex run `tknr8y`, lane `staging-install-command-2`), then verified and published by the
supervising orchestrator. Single commit for a multi-item checklist — commit granularity is coarser
than repository convention.
