### PR TITLE
fix(cli): make Account login reachable after Computer onboarding

### DIFF
--- a/apps/cli/src/__tests__/agent.test.ts
+++ b/apps/cli/src/__tests__/agent.test.ts
@@ -671,6 +671,24 @@ describe("Agent CLI core", () => {
     }
   });
 
+  it("presents unauthenticated Agent bind failures without a rejected Commander action", async () => {
+    const bindSpy = vi
+      .spyOn(agentMutations, "runAgentBind")
+      .mockRejectedValue(new Error("OpenTag is not logged in; run login first"));
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await createProgram().parseAsync(["node", "opentag", "agent", "bind", agentId]);
+      expect(process.exitCode).toBe(1);
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining("OpenTag is not logged in; run login first"));
+    } finally {
+      process.exitCode = previousExitCode;
+      stderr.mockRestore();
+      bindSpy.mockRestore();
+    }
+  });
+
   it("deletes the explicit Agent without an interactive prompt", async () => {
     const client = api();
     await expect(runAgentDelete(agentId, { accessToken: "access", api: client })).resolves.toBe(

--- a/apps/cli/src/__tests__/computer-connect.test.ts
+++ b/apps/cli/src/__tests__/computer-connect.test.ts
@@ -8,10 +8,12 @@ import {
   readComputerIdentity,
   readCredentials,
   readMachineCredentials,
+  resolveComputerIdentity,
   writeCredentialsAtomically,
 } from "@opentag/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createProgram } from "../cli/program.js";
+import { resolveCommandContext } from "../core/command/context.js";
 import * as computerCore from "../core/computer/connect.js";
 import { runComputerConnect } from "../core/computer/connect.js";
 import { formatComputerList } from "../core/computer/formatting.js";
@@ -154,6 +156,25 @@ describe("computer connect", () => {
     }
   });
 
+  it("presents an unauthenticated Computer list as a clean non-zero command result", async () => {
+    const listSpy = vi
+      .spyOn(computerQueries, "listComputers")
+      .mockRejectedValue(new Error("OpenTag is not logged in; run login first"));
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await createProgram().parseAsync(["node", "opentag", "computer", "list"]);
+      expect(process.exitCode).toBe(1);
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining("OpenTag is not logged in; run login first"));
+      expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining("at listComputers"));
+    } finally {
+      process.exitCode = previousExitCode;
+      stderr.mockRestore();
+      listSpy.mockRestore();
+    }
+  });
+
   it("lists Computers through the authenticated Account client", async () => {
     const home = await temporaryHome();
     const response = {
@@ -190,6 +211,19 @@ describe("computer connect", () => {
   it("requires Account login before listing Computers", async () => {
     const home = await temporaryHome();
     await expect(listComputers(home)).rejects.toThrow("OpenTag is not logged in; run login first");
+  });
+
+  it("explains how to finish Account login after Computer onboarding", async () => {
+    const home = await temporaryHome();
+    await resolveComputerIdentity(home, "https://opentag.example");
+
+    await expect(resolveCommandContext({ home, requireAuth: true })).rejects.toThrow(
+      "machine credentials (computer-credentials.json/computer.json) but no Account credentials (credentials.json)",
+    );
+    await expect(resolveCommandContext({ home, requireAuth: true })).rejects.toThrow(
+      "opentag-dev login --server https://opentag.example -- <code>",
+    );
+    await expect(resolveCommandContext({ home, requireAuth: true })).rejects.toThrow("POST /api/v1/me/connect-codes");
   });
 
   it("stores machine authority separately from Account credentials and binds one Account Computer", async () => {

--- a/apps/cli/src/__tests__/login.test.ts
+++ b/apps/cli/src/__tests__/login.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { credentialsPath, readCredentials, resolveComputerIdentity } from "@opentag/client";
+import { getChannelConfig } from "@opentag/shared";
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { executeLoginCommand, registerLoginCommand } from "../commands/login.js";
@@ -16,6 +17,49 @@ afterEach(async () => {
 });
 
 describe("runLogin", () => {
+  it("defaults the server to the bound Computer identity", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-login-"));
+    temporaryDirectories.push(home);
+    await resolveComputerIdentity(home, "https://staging.example");
+    const login = vi.fn().mockResolvedValue({ credentialsPath: "/private/credentials.json", message: "Logged in" });
+
+    await expect(executeLoginCommand("one-time-code", { home }, { login })).resolves.toBe(0);
+
+    expect(login).toHaveBeenCalledWith({
+      code: "one-time-code",
+      home,
+      serverUrl: "https://staging.example",
+    });
+  });
+
+  it("requires an explicit server for a channel without a default or bound Computer", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-login-"));
+    temporaryDirectories.push(home);
+    const login = vi.fn();
+    const staging = getChannelConfig("staging", "/tmp");
+
+    await expect(
+      executeLoginCommand("one-time-code", { home }, { channelConfig: staging, environment: {}, login }),
+    ).rejects.toThrow("The staging channel has no server URL; pass --server <url> to opentag-staging login");
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it("keeps an explicit server override for runLogin validation", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-login-"));
+    temporaryDirectories.push(home);
+    await resolveComputerIdentity(home, "https://staging.example");
+    const login = vi.fn().mockResolvedValue({ credentialsPath: "/private/credentials.json", message: "Logged in" });
+
+    await expect(
+      executeLoginCommand("one-time-code", { home, server: "https://other.example" }, { login }),
+    ).resolves.toBe(0);
+    expect(login).toHaveBeenCalledWith({
+      code: "one-time-code",
+      home,
+      serverUrl: "https://other.example",
+    });
+  });
+
   it("parses a leading-hyphen connect code after the option terminator", async () => {
     const login = vi.fn().mockResolvedValue({ credentialsPath: "/private/credentials.json", message: "Logged in" });
     const program = new Command().name("opentag").exitOverride();

--- a/apps/cli/src/commands/agent/bind.ts
+++ b/apps/cli/src/commands/agent/bind.ts
@@ -1,15 +1,22 @@
 import type { Command } from "commander";
 import { formatAgentBound } from "../../core/agent/formatting.js";
 import { runAgentBind } from "../../core/agent/mutations.js";
+import { executeCommand, redactSecrets } from "../../core/command/policy.js";
 
 export function registerAgentBindCommand(agent: Command): void {
   agent
     .command("bind <agent-id>")
     .description("Bind an Agent to a Computer enrolled by this Account")
     .option("--computer <uuid>", "Computer enrolled by this Account")
+    .option("--json", "print JSON")
     .action(async (agentId, options) => {
-      const result = await runAgentBind(agentId, { computerId: options.computer });
-      if (result.warning) process.stderr.write(`${result.warning}\n`);
-      process.stdout.write(`${formatAgentBound(result)}\n`);
+      process.exitCode = await executeCommand(
+        async () => {
+          const result = await runAgentBind(agentId, { computerId: options.computer });
+          if (result.warning) process.stderr.write(`${redactSecrets(result.warning)}\n`);
+          return result;
+        },
+        { json: options.json === true, formatValue: formatAgentBound, phase: "request" },
+      );
     });
 }

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,14 +1,17 @@
 import { resolve } from "node:path";
-import { resolveOpenTagHome } from "@opentag/client";
+import { readComputerIdentity, resolveOpenTagHome } from "@opentag/client";
+import type { ChannelConfig } from "@opentag/shared";
 import type { Command } from "commander";
 import { runLogin } from "../core/auth/login.js";
-import { channelConfig } from "../core/channel/config.js";
+import { channelConfig as defaultChannelConfig } from "../core/channel/config.js";
 import { resolveChannelEnvironment } from "../core/channel/environment.js";
 import { executeCommand } from "../core/command/policy.js";
 
 type LoginCommandOptions = { home?: string; server?: string; json?: boolean };
 
 interface LoginCommandDependencies {
+  channelConfig?: ChannelConfig;
+  environment?: NodeJS.ProcessEnv;
   login?: typeof runLogin;
   writeError?: (message: string) => void;
   writeOutput?: (message: string) => void;
@@ -19,11 +22,18 @@ export async function executeLoginCommand(
   options: LoginCommandOptions,
   dependencies: LoginCommandDependencies = {},
 ): Promise<0 | 1> {
-  const environment = resolveChannelEnvironment(process.env);
-  const serverUrl = options.server ?? environment.OPENTAG_SERVER_URL ?? channelConfig.defaultServerUrl;
-  if (!serverUrl) throw new Error(`The ${channelConfig.channel} channel requires --server for login`);
-  const writeOutput = dependencies.writeOutput ?? ((message: string) => process.stdout.write(`${message}\n`));
+  const environment = resolveChannelEnvironment(dependencies.environment ?? process.env);
   const home = resolve(options.home ?? resolveOpenTagHome(environment));
+  const computer = await readComputerIdentity(home);
+  const activeChannelConfig = dependencies.channelConfig ?? defaultChannelConfig;
+  const serverUrl =
+    options.server ?? computer?.serverUrl ?? environment.OPENTAG_SERVER_URL ?? activeChannelConfig.defaultServerUrl;
+  if (!serverUrl) {
+    throw new Error(
+      `The ${activeChannelConfig.channel} channel has no server URL; pass --server <url> to ${activeChannelConfig.binName} login`,
+    );
+  }
+  const writeOutput = dependencies.writeOutput ?? ((message: string) => process.stdout.write(`${message}\n`));
   const result = await (dependencies.login ?? runLogin)({
     code,
     home,

--- a/apps/cli/src/core/command/context.ts
+++ b/apps/cli/src/core/command/context.ts
@@ -1,4 +1,5 @@
 import * as client from "@opentag/client";
+import { channelConfig } from "../channel/config.js";
 import { resolveChannelEnvironment } from "../channel/environment.js";
 
 type CommandContextAuthOptions = { accessToken?: string; api?: client.OpenTagApi; requireAuth?: boolean };
@@ -24,7 +25,19 @@ export async function resolveCommandContext(options: CommandContextOptions = {})
     throw new Error("Command context test dependencies must provide both api and accessToken");
   }
   const credentials = await client.readCredentials(home);
-  if (!credentials) throw new Error("OpenTag is not logged in; run login first");
+  if (!credentials) {
+    const [computerIdentity, machineCredentials] = await Promise.all([
+      client.readComputerIdentity(home),
+      client.readMachineCredentials(home),
+    ]);
+    const recordedServerUrl = computerIdentity?.serverUrl ?? machineCredentials?.computer.serverUrl;
+    if (recordedServerUrl) {
+      throw new Error(
+        `OpenTag is not logged in: this OpenTag home has machine credentials (computer-credentials.json/computer.json) but no Account credentials (credentials.json). Get an Account login code issued by the server (today via POST /api/v1/me/connect-codes), then run ${channelConfig.binName} login --server ${recordedServerUrl} -- <code>.`,
+      );
+    }
+    throw new Error("OpenTag is not logged in; run login first");
+  }
   const accessToken = await new client.AccessTokenProvider({ home }).getAccessToken();
   return { accessToken, api: new client.OpenTagApi(credentials.serverUrl), credentials, environment, home };
 }


### PR DESCRIPTION
Closes #207

## Summary

After a fully successful Computer onboarding, `computer list` (and sibling authenticated commands)
crashed with a raw Node stack trace, and the remediation it suggested was a dead end on staging:
`login` demanded `--server` (the staging channel has no `defaultServerUrl`), never said which server,
and never said where an Account login code comes from.

CLI-side fixes (per the confirmed scope, this lane is CLI-only):

- **`login` defaults `--server` from the bound `computer.json`.** An explicit `--server` still works
  and is still validated against the bound identity; channel `defaultServerUrl` remains the fallback;
  when no source exists the failure names the exact `--server <url>` remedy. Staging is no longer a
  dead end on a connected machine — no `defaultServerUrl` was added to `channel-config.json`
  (a connected `computer.json` is the staging server source, by design).
- **Half-credentialed state detection.** Authenticated context resolution now recognizes the exact
  state onboarding leaves users in — `computer-credentials.json`/`computer.json` present, Account
  `credentials.json` absent — and reports the channel bin name, the recorded server URL, the exact
  login command to run, and where the Account code is issued (`POST /api/v1/me/connect-codes`).
- **Clean exits.** Routine unauthenticated/misconfigured states print a clean message and exit
  non-zero through the shared command presenter — no more unhandled rejections with Node stack
  traces; `agent bind` was wrapped in the same presenter.

Intentionally out of scope (recorded during planning): the web "Connect the CLI" panel
(suggested fix #1 in the issue). The CLI now explains the existing server-issued Account-code flow;
the UI affordance remains follow-up work.

## Checklist

- [x] Study the login/credentials flow and record a design note
- [x] `login` defaults `--server` from `computer.json`; explicit flag validated; helpful failure;
      unit tests including the staging channel
- [x] Half-credentialed state detection with channel-aware, actionable error; unit tests
- [x] Routine auth errors exit cleanly and non-zero through Commander across auth-requiring
      commands; unit tests
- [x] Out-of-scope web panel decision recorded for the PR body
- [x] Full verification suite passes

## Verification

Run by the lane in its worktree (Node 24.19.0 toolchain, host-safe invocation):

- `pnpm --filter open-tag test` — 20 files, 258 tests passed
- `pnpm check` — passed (complexity ratchet: 171 baseline warnings, no regressions)
- `pnpm typecheck` — all 8 tasks passed
- `pnpm build` — all 6 build tasks passed
- Full `pnpm test` — all 8 tasks passed (host-specific 1Password git quirk isolated with
  `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` as documented)

Independently re-run by the orchestrator before publishing: `pnpm check` and
`pnpm --filter open-tag test` (258 tests passed).

Deviation note: the brief's exact `corepack pnpm` wrapper invocation hit a host-level nested-corepack
version mismatch; verification used the equivalent direct Node 24 toolchain invocation. This affects
only how the checks were invoked, not the code under review.

## Provenance

Automated change: written by a Codex CLI agent running with approvals and sandbox bypassed
(dispatch-codex run `tknr8y`, lane `account-login-access-3`), then verified and published by the
supervising orchestrator. Single commit for a multi-item checklist — commit granularity is coarser
than repository convention.
