### PR TITLE
feat(feishu): add durable deduplication for inbound Feishu events

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -56,6 +56,32 @@ Asynchronous jobs intentionally use independent roots. Search by stable attribut
 
 Message text, raw provider events, mentions, resources, sender identity, provider response bodies, prompts, model output, tool payloads, authorization headers, cookies, tokens, secrets, and credentials are excluded or scrubbed.
 
+## Feishu inbound deduplication
+
+Feishu inbound delivery has two independent deduplication keys:
+
+- The in-memory adapter fast path scopes an envelope event ID and the message/revision identity to the
+  tenant and conversation. It is bounded to 10 minutes and 10,000 entries, so it only protects a live
+  process from immediate WebSocket retries.
+- The durable receipt claim uses `(im_binding_id, event_id)`. The unique index on
+  `feishu_inbound_receipts` is the cross-instance winner election. A successful claim is marked
+  `processed` after inbox persistence, or `failed` with a bounded diagnostic code when processing
+  fails.
+- Inbox persistence independently enforces `(im_binding_id, channel_id, external_message_id,
+  provider_revision_key)`. Therefore a different envelope event ID cannot create a second revision of
+  the same logical message, while an edited or recalled revision remains actionable.
+
+Feishu does not always include an envelope `event_id`. In that case normalization creates a stable
+message/revision fallback for the inbox only; no durable receipt row is claimed. The binding and
+conversation-scoped semantic unique key remains the authority for retries without an envelope ID.
+Receipt rows are operational evidence and should be retained for 30 days. A scheduled database
+maintenance job may delete only `processed` or `failed` rows older than that window; never delete
+`processing` rows as part of routine cleanup, because they identify an in-flight delivery.
+
+Duplicate outcomes are redacted and stable: the `feishu.inbound.deduplicated` span records the binding,
+provider event ID when available, external message ID, and `duplicate=true`, but never tokens or message
+content. A duplicate is acknowledged without a second inbox write, Session run, Task, or context entry.
+
 ## Troubleshooting a silent Feishu Bot
 
 Start with current state:

--- a/docs/zh-CN/observability.md
+++ b/docs/zh-CN/observability.md
@@ -56,6 +56,28 @@ Server 自行管理显式的 OpenTelemetry trace provider 和 OTLP exporter，�
 
 消息正文、raw provider event、mentions、resources、sender identity、provider response body、prompt、模型输出、tool payload、authorization header、cookie、token、secret 和 credential 均不会上传或会被 scrub。
 
+## 飞书入站去重
+
+飞书入站投递有两个相互独立的去重键：
+
+- 内存 adapter 快速路径把 envelope event ID 以及 message/revision 身份按租户和会话隔离。它限制为
+  10 分钟、最多 10,000 条，只保护进程存活期间的即时 WebSocket 重试。
+- 持久化 receipt claim 使用 `(im_binding_id, event_id)`。`feishu_inbound_receipts` 上的唯一索引
+  负责跨实例选出唯一 winner。claim 成功后在 inbox 持久化完成时标记为 `processed`；处理失败时写入
+  受限长度的诊断 code 并标记为 `failed`。
+- inbox 持久化另外强制 `(im_binding_id, channel_id, external_message_id, provider_revision_key)`。
+  因此不同 envelope event ID 也不能为同一逻辑消息创建第二个 revision，同时编辑或撤回 revision
+  仍然可执行。
+
+飞书不一定提供 envelope `event_id`。这种情况下，规范化只为 inbox 创建稳定的 message/revision
+fallback，不 claim 持久化 receipt；binding 和会话范围内的语义唯一键仍负责没有 envelope ID 的重试。
+Receipt 行是运行证据，应保留 30 天。定时数据库维护任务可以只删除超过该期限的 `processed` 或 `failed`
+行；例行清理不得删除 `processing` 行，因为它们代表进行中的投递。
+
+重复结果是脱敏且稳定的：`feishu.inbound.deduplicated` span 记录 binding、可用时的 provider event
+ID、external message ID 和 `duplicate=true`，绝不记录 token 或消息内容。重复事件会被确认，不会再次写入
+inbox、启动 Session、创建 Task 或追加上下文。
+
 ## 排查飞书 Bot 无响应
 
 先查看当前状态：

--- a/packages/server/drizzle/0035_dark_devos.sql
+++ b/packages/server/drizzle/0035_dark_devos.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "public"."feishu_inbound_receipt_status" AS ENUM('processing', 'processed', 'failed');--> statement-breakpoint
+CREATE TABLE "feishu_inbound_receipts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"im_binding_id" uuid NOT NULL,
+	"credential_generation" bigint NOT NULL,
+	"event_id" text NOT NULL,
+	"status" "feishu_inbound_receipt_status" DEFAULT 'processing' NOT NULL,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"processed_at" timestamp with time zone,
+	"attempt_count" bigint DEFAULT 1 NOT NULL,
+	"last_error_code" text,
+	"last_error_at" timestamp with time zone,
+	CONSTRAINT "feishu_inbound_receipts_generation_nonnegative" CHECK ("feishu_inbound_receipts"."credential_generation" >= 1),
+	CONSTRAINT "feishu_inbound_receipts_event_id_bounded" CHECK (length("feishu_inbound_receipts"."event_id") between 1 and 512),
+	CONSTRAINT "feishu_inbound_receipts_failure_shape" CHECK (("feishu_inbound_receipts"."status" <> 'failed' and "feishu_inbound_receipts"."last_error_code" is null and "feishu_inbound_receipts"."last_error_at" is null)
+        or ("feishu_inbound_receipts"."status" = 'failed' and "feishu_inbound_receipts"."last_error_code" is not null and "feishu_inbound_receipts"."last_error_at" is not null)),
+	CONSTRAINT "feishu_inbound_receipts_processed_shape" CHECK (("feishu_inbound_receipts"."status" = 'processed' and "feishu_inbound_receipts"."processed_at" is not null)
+        or ("feishu_inbound_receipts"."status" <> 'processed'))
+);
+--> statement-breakpoint
+ALTER TABLE "feishu_inbound_receipts" ADD CONSTRAINT "feishu_inbound_receipts_im_binding_id_im_bindings_id_fk" FOREIGN KEY ("im_binding_id") REFERENCES "public"."im_bindings"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "feishu_inbound_receipts_identity_unique" ON "feishu_inbound_receipts" USING btree ("im_binding_id","event_id");--> statement-breakpoint
+CREATE INDEX "feishu_inbound_receipts_status_idx" ON "feishu_inbound_receipts" USING btree ("status","received_at");

--- a/packages/server/drizzle/meta/0035_snapshot.json
+++ b/packages/server/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,5505 @@
+{
+  "id": "e729788e-7696-4a12-86c0-36b98fc8ce16",
+  "prevId": "b203cb95-2fa0-41bc-819d-a0124e816082",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_runtime_configs": {
+      "name": "agent_runtime_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('runtime_config_revision_sequence')"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_duration_ms": {
+          "name": "max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_runtime_configs_agent_id_agents_id_fk": {
+          "name": "agent_runtime_configs_agent_id_agents_id_fk",
+          "tableFrom": "agent_runtime_configs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_runtime_configs_revision_safe_positive": {
+          "name": "agent_runtime_configs_revision_safe_positive",
+          "value": "\"agent_runtime_configs\".\"revision\" > 0 and \"agent_runtime_configs\".\"revision\" <= 9007199254740991"
+        },
+        "agent_runtime_configs_max_duration_valid": {
+          "name": "agent_runtime_configs_max_duration_valid",
+          "value": "\"agent_runtime_configs\".\"max_duration_ms\" is null or (\"agent_runtime_configs\".\"max_duration_ms\" > 0 and \"agent_runtime_configs\".\"max_duration_ms\" <= 86400000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_intent_id": {
+          "name": "creation_intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_intent_fingerprint": {
+          "name": "creation_intent_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "agent_runtime_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_mode": {
+          "name": "receive_mode",
+          "type": "agent_receive_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_message'"
+        },
+        "status": {
+          "name": "status",
+          "type": "agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_workspace_name_active_unique": {
+          "name": "agents_workspace_name_active_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"status\" <> 'deleted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_creation_intent_unique": {
+          "name": "agents_creation_intent_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"creation_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_id_idx": {
+          "name": "agents_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_created_by_user_id_idx": {
+          "name": "agents_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_workspace_computer_id_idx": {
+          "name": "agents_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_computer_id_idx": {
+          "name": "agents_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_workspace_id_workspaces_id_fk": {
+          "name": "agents_workspace_id_workspaces_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_created_by_user_id_users_id_fk": {
+          "name": "agents_created_by_user_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_computer_id_account_computers_id_fk": {
+          "name": "agents_computer_id_account_computers_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "agents_workspace_enrollment_fk": {
+          "name": "agents_workspace_enrollment_fk",
+          "tableFrom": "agents",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_creation_intent_pair": {
+          "name": "agents_creation_intent_pair",
+          "value": "(\"agents\".\"creation_intent_id\" is null) = (\"agents\".\"creation_intent_fingerprint\" is null)"
+        },
+        "agents_revision_positive": {
+          "name": "agents_revision_positive",
+          "value": "\"agents\".\"revision\" >= 1"
+        },
+        "agents_computer_matches_enrollment": {
+          "name": "agents_computer_matches_enrollment",
+          "value": "\"agents\".\"computer_id\" = \"agents\".\"workspace_computer_id\""
+        },
+        "agents_computer_pair": {
+          "name": "agents_computer_pair",
+          "value": "(\"agents\".\"computer_id\" is null) = (\"agents\".\"workspace_computer_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_cli_login_codes": {
+      "name": "account_cli_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_cli_login_codes_user_created_idx": {
+          "name": "account_cli_login_codes_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_cli_login_codes_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_cli_login_codes_issued_by_user_id_users_id_fk": {
+          "name": "account_cli_login_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "account_cli_login_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_cli_login_codes_token_hash_unique": {
+          "name": "account_cli_login_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_cli_login_codes_expiry": {
+          "name": "account_cli_login_codes_expiry",
+          "value": "\"account_cli_login_codes\".\"expires_at\" > \"account_cli_login_codes\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_admin_grants": {
+      "name": "workspace_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_admin_grants_active_workspace_user_unique": {
+          "name": "workspace_admin_grants_active_workspace_user_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_active_user_workspace_idx": {
+          "name": "workspace_admin_grants_active_user_workspace_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_admin_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_admin_grants_workspace_granted_idx": {
+          "name": "workspace_admin_grants_workspace_granted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_admin_grants_workspace_id_workspaces_id_fk": {
+          "name": "workspace_admin_grants_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_granted_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_admin_grants_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_admin_grants_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_admin_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_admin_grants_revocation_pair": {
+          "name": "workspace_admin_grants_revocation_pair",
+          "value": "(\"workspace_admin_grants\".\"revoked_by_user_id\" is null) = (\"workspace_admin_grants\".\"revoked_at\" is null)"
+        },
+        "workspace_admin_grants_revoked_after_granted": {
+          "name": "workspace_admin_grants_revoked_after_granted",
+          "value": "\"workspace_admin_grants\".\"revoked_at\" is null or \"workspace_admin_grants\".\"revoked_at\" >= \"workspace_admin_grants\".\"granted_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_completed_at": {
+          "name": "setup_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_name_unique": {
+          "name": "workspaces_name_unique",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_identities_provider_subject_unique": {
+          "name": "auth_identities_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_provider_unique": {
+          "name": "auth_identities_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_issuer_subject_unique": {
+          "name": "auth_identities_issuer_subject_unique",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_identities_user_id_idx": {
+          "name": "auth_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_user_id_idx": {
+          "name": "auth_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expires_at_idx": {
+          "name": "auth_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_users_id_fk": {
+          "name": "auth_sessions_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_verifications_expires_at_idx": {
+          "name": "auth_verifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_computers": {
+      "name": "account_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_installation_id": {
+          "name": "current_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_computers_owner_account_id_idx": {
+          "name": "account_computers_owner_account_id_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_computers_current_installation_id_idx": {
+          "name": "account_computers_current_installation_id_idx",
+          "columns": [
+            {
+              "expression": "current_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_computers_owner_account_id_users_id_fk": {
+          "name": "account_computers_owner_account_id_users_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "account_computers_current_installation_id_computers_id_fk": {
+          "name": "account_computers_current_installation_id_computers_id_fk",
+          "tableFrom": "account_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "current_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_connect_codes": {
+      "name": "computer_connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_account_id": {
+          "name": "issued_by_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "computer_connect_code_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_computer_id": {
+          "name": "target_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_workspace_computer_id": {
+          "name": "consumed_workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_computer_id": {
+          "name": "consumed_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_connect_codes_workspace_created_idx": {
+          "name": "computer_connect_codes_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_target_computer_id_idx": {
+          "name": "computer_connect_codes_target_computer_id_idx",
+          "columns": [
+            {
+              "expression": "target_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_connect_codes_consumed_computer_id_idx": {
+          "name": "computer_connect_codes_consumed_computer_id_idx",
+          "columns": [
+            {
+              "expression": "consumed_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_connect_codes_workspace_id_workspaces_id_fk": {
+          "name": "computer_connect_codes_workspace_id_workspaces_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_issued_by_account_id_users_id_fk": {
+          "name": "computer_connect_codes_issued_by_account_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_target_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_target_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "target_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_consumed_computer_id_account_computers_id_fk": {
+          "name": "computer_connect_codes_consumed_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "consumed_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_revoked_by_user_id_users_id_fk": {
+          "name": "computer_connect_codes_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_connect_codes_workspace_enrollment_fk": {
+          "name": "computer_connect_codes_workspace_enrollment_fk",
+          "tableFrom": "computer_connect_codes",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_id",
+            "consumed_workspace_computer_id"
+          ],
+          "columnsTo": [
+            "workspace_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_connect_codes_token_hash_unique": {
+          "name": "computer_connect_codes_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_connect_codes_expiry": {
+          "name": "computer_connect_codes_expiry",
+          "value": "\"computer_connect_codes\".\"expires_at\" > \"computer_connect_codes\".\"created_at\""
+        },
+        "computer_connect_codes_consumption_pair": {
+          "name": "computer_connect_codes_consumption_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_workspace_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_revocation_pair": {
+          "name": "computer_connect_codes_revocation_pair",
+          "value": "(\"computer_connect_codes\".\"revoked_by_user_id\" is null) = (\"computer_connect_codes\".\"revoked_at\" is null)"
+        },
+        "computer_connect_codes_terminal_state": {
+          "name": "computer_connect_codes_terminal_state",
+          "value": "not (\"computer_connect_codes\".\"consumed_at\" is not null and \"computer_connect_codes\".\"revoked_at\" is not null)"
+        },
+        "computer_connect_codes_issued_by_account_pair": {
+          "name": "computer_connect_codes_issued_by_account_pair",
+          "value": "\"computer_connect_codes\".\"issued_by_account_id\" = \"computer_connect_codes\".\"issued_by_user_id\""
+        },
+        "computer_connect_codes_consumed_computer_identity": {
+          "name": "computer_connect_codes_consumed_computer_identity",
+          "value": "\"computer_connect_codes\".\"consumed_computer_id\" is not distinct from \"computer_connect_codes\".\"consumed_workspace_computer_id\""
+        },
+        "computer_connect_codes_consumed_computer_pair": {
+          "name": "computer_connect_codes_consumed_computer_pair",
+          "value": "(\"computer_connect_codes\".\"consumed_computer_id\" is null) = (\"computer_connect_codes\".\"consumed_at\" is null)"
+        },
+        "computer_connect_codes_repair_target_pair": {
+          "name": "computer_connect_codes_repair_target_pair",
+          "value": "(\"computer_connect_codes\".\"mode\" = 'create') = (\"computer_connect_codes\".\"target_computer_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computer_credentials": {
+      "name": "computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "computer_credentials_active_computer_unique": {
+          "name": "computer_credentials_active_computer_unique",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "computer_credentials_computer_issued_idx": {
+          "name": "computer_credentials_computer_issued_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "computer_credentials_computer_id_account_computers_id_fk": {
+          "name": "computer_credentials_computer_id_account_computers_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "computer_credentials_secret_hash_unique": {
+          "name": "computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "computer_credentials_revocation_pair": {
+          "name": "computer_credentials_revocation_pair",
+          "value": "(\"computer_credentials\".\"revoked_by_user_id\" is null) = (\"computer_credentials\".\"revoked_at\" is null)"
+        },
+        "computer_credentials_revoked_after_issued": {
+          "name": "computer_credentials_revoked_after_issued",
+          "value": "\"computer_credentials\".\"revoked_at\" is null or \"computer_credentials\".\"revoked_at\" >= \"computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.computers": {
+      "name": "computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_computer_credentials": {
+      "name": "workspace_computer_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_computer_credentials_active_enrollment_unique": {
+          "name": "workspace_computer_credentials_active_enrollment_unique",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computer_credentials\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computer_credentials_enrollment_issued_idx": {
+          "name": "workspace_computer_credentials_enrollment_issued_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "workspace_computer_credentials_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_issued_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_issued_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computer_credentials_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computer_credentials_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computer_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computer_credentials_secret_hash_unique": {
+          "name": "workspace_computer_credentials_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computer_credentials_revocation_pair": {
+          "name": "workspace_computer_credentials_revocation_pair",
+          "value": "(\"workspace_computer_credentials\".\"revoked_by_user_id\" is null) = (\"workspace_computer_credentials\".\"revoked_at\" is null)"
+        },
+        "workspace_computer_credentials_revoked_after_issued": {
+          "name": "workspace_computer_credentials_revoked_after_issued",
+          "value": "\"workspace_computer_credentials\".\"revoked_at\" is null or \"workspace_computer_credentials\".\"revoked_at\" >= \"workspace_computer_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_computers": {
+      "name": "workspace_computers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "computer_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_version": {
+          "name": "client_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_by_user_id": {
+          "name": "enrolled_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_instance_id": {
+          "name": "current_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_computers_active_workspace_computer_unique": {
+          "name": "workspace_computers_active_workspace_computer_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_active_workspace_idx": {
+          "name": "workspace_computers_active_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workspace_computers\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_computers_computer_id_idx": {
+          "name": "workspace_computers_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_computers_workspace_id_workspaces_id_fk": {
+          "name": "workspace_computers_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_computer_id_computers_id_fk": {
+          "name": "workspace_computers_computer_id_computers_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_enrolled_by_user_id_users_id_fk": {
+          "name": "workspace_computers_enrolled_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "enrolled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_computers_revoked_by_user_id_users_id_fk": {
+          "name": "workspace_computers_revoked_by_user_id_users_id_fk",
+          "tableFrom": "workspace_computers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_computers_workspace_id_id_unique": {
+          "name": "workspace_computers_workspace_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_computers_revocation_pair": {
+          "name": "workspace_computers_revocation_pair",
+          "value": "(\"workspace_computers\".\"revoked_by_user_id\" is null) = (\"workspace_computers\".\"revoked_at\" is null)"
+        },
+        "workspace_computers_revoked_after_enrolled": {
+          "name": "workspace_computers_revoked_after_enrolled",
+          "value": "\"workspace_computers\".\"revoked_at\" is null or \"workspace_computers\".\"revoked_at\" >= \"workspace_computers\".\"enrolled_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.feishu_inbound_receipts": {
+      "name": "feishu_inbound_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "feishu_inbound_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feishu_inbound_receipts_identity_unique": {
+          "name": "feishu_inbound_receipts_identity_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feishu_inbound_receipts_status_idx": {
+          "name": "feishu_inbound_receipts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feishu_inbound_receipts_im_binding_id_im_bindings_id_fk": {
+          "name": "feishu_inbound_receipts_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "feishu_inbound_receipts",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "feishu_inbound_receipts_generation_nonnegative": {
+          "name": "feishu_inbound_receipts_generation_nonnegative",
+          "value": "\"feishu_inbound_receipts\".\"credential_generation\" >= 1"
+        },
+        "feishu_inbound_receipts_event_id_bounded": {
+          "name": "feishu_inbound_receipts_event_id_bounded",
+          "value": "length(\"feishu_inbound_receipts\".\"event_id\") between 1 and 512"
+        },
+        "feishu_inbound_receipts_failure_shape": {
+          "name": "feishu_inbound_receipts_failure_shape",
+          "value": "(\"feishu_inbound_receipts\".\"status\" <> 'failed' and \"feishu_inbound_receipts\".\"last_error_code\" is null and \"feishu_inbound_receipts\".\"last_error_at\" is null)\n        or (\"feishu_inbound_receipts\".\"status\" = 'failed' and \"feishu_inbound_receipts\".\"last_error_code\" is not null and \"feishu_inbound_receipts\".\"last_error_at\" is not null)"
+        },
+        "feishu_inbound_receipts_processed_shape": {
+          "name": "feishu_inbound_receipts_processed_shape",
+          "value": "(\"feishu_inbound_receipts\".\"status\" = 'processed' and \"feishu_inbound_receipts\".\"processed_at\" is not null)\n        or (\"feishu_inbound_receipts\".\"status\" <> 'processed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_bindings": {
+      "name": "im_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "im_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "im_binding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_brand": {
+          "name": "external_team_brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "setup_attempt_id": {
+          "name": "setup_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_intent": {
+          "name": "setup_intent",
+          "type": "feishu_setup_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_state": {
+          "name": "setup_state",
+          "type": "feishu_setup_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_instance_id": {
+          "name": "setup_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_owner_heartbeat_at": {
+          "name": "setup_owner_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_setup_context": {
+          "name": "encrypted_setup_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_expires_at": {
+          "name": "setup_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_installation_id": {
+          "name": "slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_route_kind": {
+          "name": "slack_route_kind",
+          "type": "slack_route_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacement_im_binding_id": {
+          "name": "replacement_im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_owner_instance_id": {
+          "name": "connection_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_fencing_epoch": {
+          "name": "connection_fencing_epoch",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "connection_lease_expires_at": {
+          "name": "connection_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_bindings_agent_current_unique": {
+          "name": "im_bindings_agent_current_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_feishu_app_current_unique": {
+          "name": "im_bindings_feishu_app_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_current_unique": {
+          "name": "im_bindings_slack_installation_current_unique",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_bindings_slack_installation_id_idx": {
+          "name": "im_bindings_slack_installation_id_idx",
+          "columns": [
+            {
+              "expression": "slack_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_agent_id_agents_id_fk": {
+          "name": "im_bindings_agent_id_agents_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_id_slack_installations_id_fk": {
+          "name": "im_bindings_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_bindings_replacement_im_binding_id_im_bindings_id_fk": {
+          "name": "im_bindings_replacement_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "replacement_im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "im_bindings_slack_installation_owner_fk": {
+          "name": "im_bindings_slack_installation_owner_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "agent_id",
+            "slack_installation_id"
+          ],
+          "columnsTo": [
+            "agent_id",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_bindings_credential_generation_nonnegative": {
+          "name": "im_bindings_credential_generation_nonnegative",
+          "value": "\"im_bindings\".\"credential_generation\" >= 0"
+        },
+        "im_bindings_connection_epoch_nonnegative": {
+          "name": "im_bindings_connection_epoch_nonnegative",
+          "value": "\"im_bindings\".\"connection_fencing_epoch\" >= 0"
+        },
+        "im_bindings_active_binding_shape": {
+          "name": "im_bindings_active_binding_shape",
+          "value": "\"im_bindings\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"im_bindings\".\"external_app_id\" is not null and\n        (\"im_bindings\".\"provider\" = 'feishu' or \"im_bindings\".\"external_team_id\" is not null) and\n        \"im_bindings\".\"external_bot_id\" is not null and \"im_bindings\".\"credential_schema_version\" is not null and\n        \"im_bindings\".\"credential_generation\" >= 1 and\n        \"im_bindings\".\"activated_at\" is not null and \"im_bindings\".\"disabled_at\" is null and\n        (\n          (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"encrypted_credential\" is not null and\n            \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null) or\n          (\"im_bindings\".\"provider\" = 'slack' and \"im_bindings\".\"encrypted_credential\" is null and\n            \"im_bindings\".\"slack_installation_id\" is not null and \"im_bindings\".\"slack_route_kind\" is not null)\n        )\n      )"
+        },
+        "im_bindings_disabled_secret_shape": {
+          "name": "im_bindings_disabled_secret_shape",
+          "value": "\"im_bindings\".\"status\" <> 'disabled' or (\n        \"im_bindings\".\"encrypted_credential\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"connection_owner_instance_id\" is null and\n        \"im_bindings\".\"connection_lease_expires_at\" is null and \"im_bindings\".\"disabled_at\" is not null\n      )"
+        },
+        "im_bindings_setup_owner_shape": {
+          "name": "im_bindings_setup_owner_shape",
+          "value": "(\"im_bindings\".\"setup_owner_instance_id\" is null and \"im_bindings\".\"setup_owner_heartbeat_at\" is null and\n        \"im_bindings\".\"encrypted_setup_context\" is null and \"im_bindings\".\"setup_expires_at\" is null)\n        or (\"im_bindings\".\"setup_attempt_id\" is not null and \"im_bindings\".\"setup_intent\" is not null and\n        \"im_bindings\".\"setup_state\" is not null and \"im_bindings\".\"setup_owner_instance_id\" is not null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is not null and \"im_bindings\".\"encrypted_setup_context\" is not null and\n        \"im_bindings\".\"setup_expires_at\" is not null)"
+        },
+        "im_bindings_connection_owner_shape": {
+          "name": "im_bindings_connection_owner_shape",
+          "value": "(\"im_bindings\".\"connection_owner_instance_id\" is null and \"im_bindings\".\"connection_lease_expires_at\" is null)\n        or (\"im_bindings\".\"provider\" = 'feishu' and \"im_bindings\".\"connection_owner_instance_id\" is not null and\n        \"im_bindings\".\"connection_lease_expires_at\" is not null)"
+        },
+        "im_bindings_slack_setup_fields_null": {
+          "name": "im_bindings_slack_setup_fields_null",
+          "value": "\"im_bindings\".\"provider\" <> 'slack' or (\n        \"im_bindings\".\"setup_attempt_id\" is null and \"im_bindings\".\"setup_intent\" is null and\n        \"im_bindings\".\"setup_state\" is null and \"im_bindings\".\"setup_owner_instance_id\" is null and\n        \"im_bindings\".\"setup_owner_heartbeat_at\" is null and \"im_bindings\".\"encrypted_setup_context\" is null and\n        \"im_bindings\".\"setup_expires_at\" is null\n      )"
+        },
+        "im_bindings_slack_route_fields": {
+          "name": "im_bindings_slack_route_fields",
+          "value": "\"im_bindings\".\"provider\" = 'slack' or (\n        \"im_bindings\".\"slack_installation_id\" is null and \"im_bindings\".\"slack_route_kind\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_message_deliveries": {
+      "name": "im_message_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attention": {
+          "name": "attention",
+          "type": "im_delivery_attention",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "im_delivery_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_request_id": {
+          "name": "dispatch_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_input_hash": {
+          "name": "dispatch_input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_payload": {
+          "name": "dispatch_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steer_target_delivery_id": {
+          "name": "steer_target_delivery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steered_at": {
+          "name": "steered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_owner_instance_id": {
+          "name": "report_owner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_hash": {
+          "name": "result_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_report": {
+          "name": "turn_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "im_message_deliveries_message_session_unique": {
+          "name": "im_message_deliveries_message_session_unique",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_session_id_idx": {
+          "name": "im_message_deliveries_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_steer_target_idx": {
+          "name": "im_message_deliveries_steer_target_idx",
+          "columns": [
+            {
+              "expression": "steer_target_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_pending_idx": {
+          "name": "im_message_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_dispatch_request_unique": {
+          "name": "im_message_deliveries_dispatch_request_unique",
+          "columns": [
+            {
+              "expression": "dispatch_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"dispatch_request_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_message_deliveries_turn_id_unique": {
+          "name": "im_message_deliveries_turn_id_unique",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_message_deliveries\".\"turn_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_message_deliveries_message_id_im_messages_id_fk": {
+          "name": "im_message_deliveries_message_id_im_messages_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_session_id_sessions_id_fk": {
+          "name": "im_message_deliveries_session_id_sessions_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk": {
+          "name": "im_message_deliveries_steer_target_delivery_id_im_message_deliveries_id_fk",
+          "tableFrom": "im_message_deliveries",
+          "tableTo": "im_message_deliveries",
+          "columnsFrom": [
+            "steer_target_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "im_message_deliveries_dispatch_shape": {
+          "name": "im_message_deliveries_dispatch_shape",
+          "value": "(\"im_message_deliveries\".\"dispatch_request_id\" is null and \"im_message_deliveries\".\"dispatch_input_hash\" is null and \"im_message_deliveries\".\"dispatch_payload\" is null)\n        or (\"im_message_deliveries\".\"dispatch_request_id\" is not null and \"im_message_deliveries\".\"dispatch_input_hash\" is not null\n          and (\"im_message_deliveries\".\"dispatch_payload\" is not null or \"im_message_deliveries\".\"state\" = 'accepted'))"
+        },
+        "im_message_deliveries_custody_shape": {
+          "name": "im_message_deliveries_custody_shape",
+          "value": "(\"im_message_deliveries\".\"state\" = 'accepted' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"turn_id\" is not null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is not null and \"im_message_deliveries\".\"accepted_at\" is not null\n          and \"im_message_deliveries\".\"steer_target_delivery_id\" is null and \"im_message_deliveries\".\"steered_at\" is null)\n        or (\"im_message_deliveries\".\"state\" = 'steered' and \"im_message_deliveries\".\"input_hash\" is not null and \"im_message_deliveries\".\"steer_target_delivery_id\" is not null\n          and \"im_message_deliveries\".\"steered_at\" is not null and \"im_message_deliveries\".\"turn_id\" is null and \"im_message_deliveries\".\"report_owner_instance_id\" is null\n          and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null\n          and \"im_message_deliveries\".\"result_hash\" is null)\n        or (\"im_message_deliveries\".\"state\" not in ('accepted', 'steered') and \"im_message_deliveries\".\"input_hash\" is null and \"im_message_deliveries\".\"turn_id\" is null\n          and \"im_message_deliveries\".\"report_owner_instance_id\" is null and \"im_message_deliveries\".\"accepted_at\" is null and \"im_message_deliveries\".\"steered_at\" is null\n          and \"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null and \"im_message_deliveries\".\"result_hash\" is null)"
+        },
+        "im_message_deliveries_report_shape": {
+          "name": "im_message_deliveries_report_shape",
+          "value": "(\"im_message_deliveries\".\"reported_at\" is null and \"im_message_deliveries\".\"turn_report\" is null)\n        or (\"im_message_deliveries\".\"reported_at\" is not null and \"im_message_deliveries\".\"turn_report\" is not null and \"im_message_deliveries\".\"result_hash\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.im_messages": {
+      "name": "im_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_revision_key": {
+          "name": "provider_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "im_message_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "im_message_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_external_id": {
+          "name": "reply_to_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "im_author_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_external_id": {
+          "name": "author_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_display_name": {
+          "name": "author_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_context": {
+          "name": "provider_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "im_messages_provider_event_unique": {
+          "name": "im_messages_provider_event_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"im_messages\".\"provider_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_semantic_revision_unique": {
+          "name": "im_messages_semantic_revision_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_revision_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_scope_occurred_idx": {
+          "name": "im_messages_scope_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "im_messages_external_occurred_idx": {
+          "name": "im_messages_external_occurred_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "im_messages_im_binding_id_im_bindings_id_fk": {
+          "name": "im_messages_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "im_messages",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_invitations": {
+      "name": "admin_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_invitations_workspace_created_idx": {
+          "name": "admin_invitations_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_invitations_workspace_id_workspaces_id_fk": {
+          "name": "admin_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_created_by_user_id_users_id_fk": {
+          "name": "admin_invitations_created_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_accepted_by_user_id_users_id_fk": {
+          "name": "admin_invitations_accepted_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "admin_invitations_revoked_by_user_id_users_id_fk": {
+          "name": "admin_invitations_revoked_by_user_id_users_id_fk",
+          "tableFrom": "admin_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_invitations_token_hash_unique": {
+          "name": "admin_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "admin_invitations_expiry": {
+          "name": "admin_invitations_expiry",
+          "value": "\"admin_invitations\".\"expires_at\" > \"admin_invitations\".\"created_at\""
+        },
+        "admin_invitations_acceptance_pair": {
+          "name": "admin_invitations_acceptance_pair",
+          "value": "(\"admin_invitations\".\"accepted_by_user_id\" is null) = (\"admin_invitations\".\"accepted_at\" is null)"
+        },
+        "admin_invitations_revocation_pair": {
+          "name": "admin_invitations_revocation_pair",
+          "value": "(\"admin_invitations\".\"revoked_by_user_id\" is null) = (\"admin_invitations\".\"revoked_at\" is null)"
+        },
+        "admin_invitations_terminal_state": {
+          "name": "admin_invitations_terminal_state",
+          "value": "not (\"admin_invitations\".\"accepted_at\" is not null and \"admin_invitations\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runtime_durable_work": {
+      "name": "runtime_durable_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "runtime_durable_work_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "runtime_durable_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runtime_durable_work_scope_key_unique": {
+          "name": "runtime_durable_work_scope_key_unique",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_durable_work_scope_status_idx": {
+          "name": "runtime_durable_work_scope_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runtime_durable_work_workspace_computer_id_account_computers_id_fk": {
+          "name": "runtime_durable_work_workspace_computer_id_account_computers_id_fk",
+          "tableFrom": "runtime_durable_work",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runtime_durable_work_key_shape": {
+          "name": "runtime_durable_work_key_shape",
+          "value": "\"runtime_durable_work\".\"record_key\" ~ '^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$'"
+        },
+        "runtime_durable_work_attempts_nonnegative": {
+          "name": "runtime_durable_work_attempts_nonnegative",
+          "value": "\"runtime_durable_work\".\"attempts\" >= 0"
+        },
+        "runtime_durable_work_accepted_at_nonnegative": {
+          "name": "runtime_durable_work_accepted_at_nonnegative",
+          "value": "\"runtime_durable_work\".\"accepted_at\" >= 0"
+        },
+        "runtime_durable_work_updated_at_nonnegative": {
+          "name": "runtime_durable_work_updated_at_nonnegative",
+          "value": "\"runtime_durable_work\".\"updated_at\" >= 0"
+        },
+        "runtime_durable_work_next_attempt_nonnegative": {
+          "name": "runtime_durable_work_next_attempt_nonnegative",
+          "value": "\"runtime_durable_work\".\"next_attempt_at\" is null or \"runtime_durable_work\".\"next_attempt_at\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_cli_proofs": {
+      "name": "session_cli_proofs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proof_id": {
+          "name": "proof_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_generation": {
+          "name": "placement_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_instance_id": {
+          "name": "connection_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_cli_proofs_computer_id_idx": {
+          "name": "session_cli_proofs_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_cli_proofs_session_id_sessions_id_fk": {
+          "name": "session_cli_proofs_session_id_sessions_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_cli_proofs_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cli_proofs_computer_id_account_computers_id_fk": {
+          "name": "session_cli_proofs_computer_id_account_computers_id_fk",
+          "tableFrom": "session_cli_proofs",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_cli_proofs_proof_id_unique": {
+          "name": "session_cli_proofs_proof_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proof_id"
+          ]
+        },
+        "session_cli_proofs_token_hash_unique": {
+          "name": "session_cli_proofs_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "session_cli_proofs_token_hash_shape": {
+          "name": "session_cli_proofs_token_hash_shape",
+          "value": "\"session_cli_proofs\".\"token_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_cli_proofs_generation_positive": {
+          "name": "session_cli_proofs_generation_positive",
+          "value": "\"session_cli_proofs\".\"placement_generation\" >= 1"
+        },
+        "session_cli_proofs_computer_matches_enrollment": {
+          "name": "session_cli_proofs_computer_matches_enrollment",
+          "value": "\"session_cli_proofs\".\"computer_id\" = \"session_cli_proofs\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_messages": {
+      "name": "session_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_outcome": {
+          "name": "last_outcome",
+          "type": "session_message_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_messages_target_created_idx": {
+          "name": "session_messages_target_created_idx",
+          "columns": [
+            {
+              "expression": "target_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_messages_source_created_idx": {
+          "name": "session_messages_source_created_idx",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_messages_source_session_id_sessions_id_fk": {
+          "name": "session_messages_source_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "source_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_messages_target_session_id_sessions_id_fk": {
+          "name": "session_messages_target_session_id_sessions_id_fk",
+          "tableFrom": "session_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_messages_content_hash_shape": {
+          "name": "session_messages_content_hash_shape",
+          "value": "\"session_messages\".\"content_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "session_messages_content_bounds": {
+          "name": "session_messages_content_bounds",
+          "value": "octet_length(\"session_messages\".\"content\") between 1 and 16384"
+        },
+        "session_messages_error_code_shape": {
+          "name": "session_messages_error_code_shape",
+          "value": "\"session_messages\".\"last_error_code\" is null or (\"session_messages\".\"last_error_code\" ~ '^[a-z][a-z0-9_]{0,127}$')"
+        },
+        "session_messages_attempt_count_nonnegative": {
+          "name": "session_messages_attempt_count_nonnegative",
+          "value": "\"session_messages\".\"attempt_count\" >= 0"
+        },
+        "session_messages_attempt_shape": {
+          "name": "session_messages_attempt_shape",
+          "value": "(\"session_messages\".\"attempt_count\" = 0 and \"session_messages\".\"last_attempt_at\" is null)\n        or (\"session_messages\".\"attempt_count\" > 0 and \"session_messages\".\"last_attempt_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_descendants": {
+      "name": "session_descendants",
+      "schema": "",
+      "columns": {
+        "ancestor_session_id": {
+          "name": "ancestor_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descendant_session_id": {
+          "name": "descendant_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_created_at": {
+          "name": "last_message_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_delivery_outcome": {
+          "name": "last_delivery_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_preview": {
+          "name": "task_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_descendants_ancestor_activity_idx": {
+          "name": "session_descendants_ancestor_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_ancestor_depth_activity_idx": {
+          "name": "session_descendants_ancestor_depth_activity_idx",
+          "columns": [
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_descendant_ancestor_idx": {
+          "name": "session_descendants_descendant_ancestor_idx",
+          "columns": [
+            {
+              "expression": "descendant_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ancestor_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_descendants_last_message_idx": {
+          "name": "session_descendants_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_descendants_ancestor_session_id_sessions_id_fk": {
+          "name": "session_descendants_ancestor_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "ancestor_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_descendants_descendant_session_id_sessions_id_fk": {
+          "name": "session_descendants_descendant_session_id_sessions_id_fk",
+          "tableFrom": "session_descendants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "descendant_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_descendants_ancestor_session_id_descendant_session_id_pk": {
+          "name": "session_descendants_ancestor_session_id_descendant_session_id_pk",
+          "columns": [
+            "ancestor_session_id",
+            "descendant_session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_descendants_depth_positive": {
+          "name": "session_descendants_depth_positive",
+          "value": "\"session_descendants\".\"depth\" >= 1"
+        },
+        "session_descendants_outcome_valid": {
+          "name": "session_descendants_outcome_valid",
+          "value": "\"session_descendants\".\"last_delivery_outcome\" in ('accepted', 'unreachable', 'unknown', 'rejected')"
+        },
+        "session_descendants_preview_bounds": {
+          "name": "session_descendants_preview_bounds",
+          "value": "char_length(\"session_descendants\".\"task_preview\") between 1 and 256"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_placements": {
+      "name": "session_placements",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_computer_id": {
+          "name": "workspace_computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computer_id": {
+          "name": "computer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_placements_workspace_computer_id_idx": {
+          "name": "session_placements_workspace_computer_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_placements_computer_id_idx": {
+          "name": "session_placements_computer_id_idx",
+          "columns": [
+            {
+              "expression": "computer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_placements_session_id_sessions_id_fk": {
+          "name": "session_placements_session_id_sessions_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_placements_workspace_computer_id_workspace_computers_id_fk": {
+          "name": "session_placements_workspace_computer_id_workspace_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "workspace_computers",
+          "columnsFrom": [
+            "workspace_computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "session_placements_computer_id_account_computers_id_fk": {
+          "name": "session_placements_computer_id_account_computers_id_fk",
+          "tableFrom": "session_placements",
+          "tableTo": "account_computers",
+          "columnsFrom": [
+            "computer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "session_placements_generation_positive": {
+          "name": "session_placements_generation_positive",
+          "value": "\"session_placements\".\"generation\" >= 1"
+        },
+        "session_placements_computer_matches_enrollment": {
+          "name": "session_placements_computer_matches_enrollment",
+          "value": "\"session_placements\".\"computer_id\" = \"session_placements\".\"workspace_computer_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "im_binding_id": {
+          "name": "im_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_kind": {
+          "name": "conversation_kind",
+          "type": "im_conversation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "session_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_model": {
+          "name": "runtime_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_reasoning_effort": {
+          "name": "runtime_reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_max_duration_ms": {
+          "name": "runtime_max_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_active_channel_unique": {
+          "name": "sessions_active_channel_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'channel' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_active_thread_unique": {
+          "name": "sessions_active_thread_unique",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"kind\" = 'thread' and \"sessions\".\"ended_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_im_binding_scope_idx": {
+          "name": "sessions_im_binding_scope_idx",
+          "columns": [
+            {
+              "expression": "im_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_creator_created_idx": {
+          "name": "sessions_creator_created_idx",
+          "columns": [
+            {
+              "expression": "created_by_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_im_binding_id_im_bindings_id_fk": {
+          "name": "sessions_im_binding_id_im_bindings_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "im_bindings",
+          "columnsFrom": [
+            "im_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sessions_created_by_session_id_sessions_id_fk": {
+          "name": "sessions_created_by_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "created_by_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sessions_shape_check": {
+          "name": "sessions_shape_check",
+          "value": "(\"sessions\".\"kind\" = 'channel' and \"sessions\".\"thread_key\" is null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'thread' and \"sessions\".\"thread_key\" is not null and \"sessions\".\"created_by_session_id\" is null and \"sessions\".\"runtime_model\" is null and \"sessions\".\"runtime_reasoning_effort\" is null and \"sessions\".\"runtime_max_duration_ms\" is null)\n        or (\"sessions\".\"kind\" = 'internal' and \"sessions\".\"created_by_session_id\" is not null)"
+        },
+        "sessions_runtime_max_duration_valid": {
+          "name": "sessions_runtime_max_duration_valid",
+          "value": "\"sessions\".\"runtime_max_duration_ms\" is null or (\"sessions\".\"runtime_max_duration_ms\" > 0 and \"sessions\".\"runtime_max_duration_ms\" <= 86400000)"
+        },
+        "sessions_runtime_model_bounds": {
+          "name": "sessions_runtime_model_bounds",
+          "value": "\"sessions\".\"runtime_model\" is null or octet_length(\"sessions\".\"runtime_model\") between 1 and 128"
+        },
+        "sessions_runtime_reasoning_effort_bounds": {
+          "name": "sessions_runtime_reasoning_effort_bounds",
+          "value": "\"sessions\".\"runtime_reasoning_effort\" is null or octet_length(\"sessions\".\"runtime_reasoning_effort\") between 1 and 64"
+        },
+        "sessions_revision_positive": {
+          "name": "sessions_revision_positive",
+          "value": "\"sessions\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_installations": {
+      "name": "slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "slack_installation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "external_app_id": {
+          "name": "external_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_id": {
+          "name": "external_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_enterprise_id": {
+          "name": "external_enterprise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_bot_id": {
+          "name": "external_bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_team_name": {
+          "name": "external_team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_display_name": {
+          "name": "bot_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_avatar_url": {
+          "name": "bot_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_schema_version": {
+          "name": "credential_schema_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "encrypted_credential": {
+          "name": "encrypted_credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_capabilities": {
+          "name": "granted_capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "replacement_slack_installation_id": {
+          "name": "replacement_slack_installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_connected_at": {
+          "name": "observed_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_installations_app_team_current_unique": {
+          "name": "slack_installations_app_team_current_unique",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slack_installations\".\"status\" <> 'disabled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_workspace_id_idx": {
+          "name": "slack_installations_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_agent_id_idx": {
+          "name": "slack_installations_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_installations_app_team_idx": {
+          "name": "slack_installations_app_team_idx",
+          "columns": [
+            {
+              "expression": "external_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_installations_workspace_id_workspaces_id_fk": {
+          "name": "slack_installations_workspace_id_workspaces_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_agent_id_agents_id_fk": {
+          "name": "slack_installations_agent_id_agents_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_installations_replacement_slack_installation_id_slack_installations_id_fk": {
+          "name": "slack_installations_replacement_slack_installation_id_slack_installations_id_fk",
+          "tableFrom": "slack_installations",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "replacement_slack_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_installations_agent_id_id_unique": {
+          "name": "slack_installations_agent_id_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_installations_credential_generation_nonnegative": {
+          "name": "slack_installations_credential_generation_nonnegative",
+          "value": "\"slack_installations\".\"credential_generation\" >= 0"
+        },
+        "slack_installations_active_shape": {
+          "name": "slack_installations_active_shape",
+          "value": "\"slack_installations\".\"status\" not in ('active', 'reauthorization_required') or (\n        \"slack_installations\".\"credential_schema_version\" is not null and\n        \"slack_installations\".\"credential_generation\" >= 1 and \"slack_installations\".\"encrypted_credential\" is not null and\n        \"slack_installations\".\"activated_at\" is not null and \"slack_installations\".\"disabled_at\" is null\n      )"
+        },
+        "slack_installations_disabled_secret_shape": {
+          "name": "slack_installations_disabled_secret_shape",
+          "value": "\"slack_installations\".\"status\" <> 'disabled' or (\n        \"slack_installations\".\"encrypted_credential\" is null and \"slack_installations\".\"disabled_at\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_oauth_nonces": {
+      "name": "slack_oauth_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_binding_id": {
+          "name": "expected_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_credential_generation": {
+          "name": "expected_credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_binding_hash": {
+          "name": "session_binding_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_oauth_nonces_user_agent_idx": {
+          "name": "slack_oauth_nonces_user_agent_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_oauth_nonces_expires_idx": {
+          "name": "slack_oauth_nonces_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_oauth_nonces_user_id_users_id_fk": {
+          "name": "slack_oauth_nonces_user_id_users_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_oauth_nonces_agent_id_agents_id_fk": {
+          "name": "slack_oauth_nonces_agent_id_agents_id_fk",
+          "tableFrom": "slack_oauth_nonces",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_oauth_nonces_nonce_hash_unique": {
+          "name": "slack_oauth_nonces_nonce_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slack_oauth_nonces_intent": {
+          "name": "slack_oauth_nonces_intent",
+          "value": "\"slack_oauth_nonces\".\"intent\" in ('create', 'reauthorize')"
+        },
+        "slack_oauth_nonces_expiry": {
+          "name": "slack_oauth_nonces_expiry",
+          "value": "\"slack_oauth_nonces\".\"expires_at\" > \"slack_oauth_nonces\".\"created_at\""
+        },
+        "slack_oauth_nonces_expected_binding_pair": {
+          "name": "slack_oauth_nonces_expected_binding_pair",
+          "value": "(\"slack_oauth_nonces\".\"expected_binding_id\" is null) = (\"slack_oauth_nonces\".\"expected_credential_generation\" is null)"
+        },
+        "slack_oauth_nonces_generation_positive": {
+          "name": "slack_oauth_nonces_generation_positive",
+          "value": "\"slack_oauth_nonces\".\"expected_credential_generation\" is null or \"slack_oauth_nonces\".\"expected_credential_generation\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.slack_webhook_receipts": {
+      "name": "slack_webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_generation": {
+          "name": "credential_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "slack_webhook_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slack_webhook_receipts_identity_unique": {
+          "name": "slack_webhook_receipts_identity_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "credential_generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_webhook_receipts_status_idx": {
+          "name": "slack_webhook_receipts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_webhook_receipts_installation_id_slack_installations_id_fk": {
+          "name": "slack_webhook_receipts_installation_id_slack_installations_id_fk",
+          "tableFrom": "slack_webhook_receipts",
+          "tableTo": "slack_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "slack_webhook_receipts_generation_nonnegative": {
+          "name": "slack_webhook_receipts_generation_nonnegative",
+          "value": "\"slack_webhook_receipts\".\"credential_generation\" >= 1"
+        },
+        "slack_webhook_receipts_event_id_bounded": {
+          "name": "slack_webhook_receipts_event_id_bounded",
+          "value": "length(\"slack_webhook_receipts\".\"event_id\") between 1 and 255"
+        },
+        "slack_webhook_receipts_failure_shape": {
+          "name": "slack_webhook_receipts_failure_shape",
+          "value": "(\"slack_webhook_receipts\".\"status\" <> 'failed' and \"slack_webhook_receipts\".\"last_error_code\" is null and \"slack_webhook_receipts\".\"last_error_at\" is null)\n        or (\"slack_webhook_receipts\".\"status\" = 'failed' and \"slack_webhook_receipts\".\"last_error_code\" is not null and \"slack_webhook_receipts\".\"last_error_at\" is not null)"
+        },
+        "slack_webhook_receipts_processed_shape": {
+          "name": "slack_webhook_receipts_processed_shape",
+          "value": "(\"slack_webhook_receipts\".\"status\" = 'processed' and \"slack_webhook_receipts\".\"processed_at\" is not null)\n        or (\"slack_webhook_receipts\".\"status\" <> 'processed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_receive_mode": {
+      "name": "agent_receive_mode",
+      "schema": "public",
+      "values": [
+        "all_message",
+        "mention_only"
+      ]
+    },
+    "public.agent_runtime_provider": {
+      "name": "agent_runtime_provider",
+      "schema": "public",
+      "values": [
+        "codex",
+        "claude-code"
+      ]
+    },
+    "public.agent_status": {
+      "name": "agent_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "suspended",
+        "deleted"
+      ]
+    },
+    "public.computer_connect_code_mode": {
+      "name": "computer_connect_code_mode",
+      "schema": "public",
+      "values": [
+        "create",
+        "repair"
+      ]
+    },
+    "public.computer_platform": {
+      "name": "computer_platform",
+      "schema": "public",
+      "values": [
+        "darwin",
+        "linux",
+        "win32"
+      ]
+    },
+    "public.feishu_inbound_receipt_status": {
+      "name": "feishu_inbound_receipt_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "processed",
+        "failed"
+      ]
+    },
+    "public.feishu_setup_intent": {
+      "name": "feishu_setup_intent",
+      "schema": "public",
+      "values": [
+        "create",
+        "reauthorize",
+        "replace"
+      ]
+    },
+    "public.feishu_setup_state": {
+      "name": "feishu_setup_state",
+      "schema": "public",
+      "values": [
+        "awaiting_user",
+        "validating",
+        "succeeded",
+        "failed",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.im_binding_status": {
+      "name": "im_binding_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "active",
+        "reauthorization_required",
+        "error",
+        "disabled"
+      ]
+    },
+    "public.im_conversation_kind": {
+      "name": "im_conversation_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "dm",
+        "group_dm"
+      ]
+    },
+    "public.im_provider": {
+      "name": "im_provider",
+      "schema": "public",
+      "values": [
+        "feishu",
+        "slack"
+      ]
+    },
+    "public.slack_route_kind": {
+      "name": "slack_route_kind",
+      "schema": "public",
+      "values": [
+        "default"
+      ]
+    },
+    "public.im_author_kind": {
+      "name": "im_author_kind",
+      "schema": "public",
+      "values": [
+        "human",
+        "bot",
+        "system"
+      ]
+    },
+    "public.im_delivery_attention": {
+      "name": "im_delivery_attention",
+      "schema": "public",
+      "values": [
+        "direct",
+        "ambient"
+      ]
+    },
+    "public.im_delivery_state": {
+      "name": "im_delivery_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "steered",
+        "terminal_rejected",
+        "expired"
+      ]
+    },
+    "public.im_message_direction": {
+      "name": "im_message_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.im_message_operation": {
+      "name": "im_message_operation",
+      "schema": "public",
+      "values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "public.runtime_durable_work_kind": {
+      "name": "runtime_durable_work_kind",
+      "schema": "public",
+      "values": [
+        "session-message",
+        "turn-report"
+      ]
+    },
+    "public.runtime_durable_work_status": {
+      "name": "runtime_durable_work_status",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "running",
+        "succeeded",
+        "retryable",
+        "failed",
+        "dead-letter"
+      ]
+    },
+    "public.session_message_outcome": {
+      "name": "session_message_outcome",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "accepted",
+        "unreachable",
+        "rejected"
+      ]
+    },
+    "public.session_kind": {
+      "name": "session_kind",
+      "schema": "public",
+      "values": [
+        "channel",
+        "thread",
+        "internal"
+      ]
+    },
+    "public.slack_installation_status": {
+      "name": "slack_installation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "reauthorization_required",
+        "disabled"
+      ]
+    },
+    "public.slack_webhook_receipt_status": {
+      "name": "slack_webhook_receipt_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {
+    "public.runtime_config_revision_sequence": {
+      "name": "runtime_config_revision_sequence",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9007199254740991",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1788208560698,
       "tag": "0034_legal_kat_farrell",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1788220725651,
+      "tag": "0035_dark_devos",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/migration-hashes.json
+++ b/packages/server/drizzle/migration-hashes.json
@@ -175,6 +175,11 @@
       "idx": 34,
       "tag": "0034_legal_kat_farrell",
       "sha256": "872e2b49d4597ebdc3fce4f1e83af4d682f6ea476e2d1991ff05c5d354c3803a"
+    },
+    {
+      "idx": 35,
+      "tag": "0035_dark_devos",
+      "sha256": "9c74656526572bc97d52a77261fe2d4ae6817585821d5141871a501c5c23b9cf"
     }
   ]
 }

--- a/packages/server/src/__tests__/feishu-adapter.test.ts
+++ b/packages/server/src/__tests__/feishu-adapter.test.ts
@@ -234,6 +234,19 @@ describe("Feishu adapter", () => {
     expect(received.map((message) => message.messageId)).toEqual(["message-distinct-1", "message-distinct-2"]);
   });
 
+  it("does not let an event ID from one conversation suppress another conversation", async () => {
+    const received: NormalizedMessage[] = [];
+    const dispatcher = createReliableFeishuDispatcher((message) => {
+      received.push(message);
+    });
+    const first = rawMessage("event-reused", "message-chat-a", "13");
+    const second = rawMessage("event-reused", "message-chat-b", "13");
+    second.event.message.chat_id = "oc_other_chat";
+    await dispatcher.invoke(first, { needCheck: false });
+    await dispatcher.invoke(second, { needCheck: false });
+    expect(received.map((message) => message.chatId)).toEqual(["oc_1", "oc_other_chat"]);
+  });
+
   it("falls back to user sender ids and maps raw mentions", async () => {
     let received: NormalizedMessage | undefined;
     const dispatcher = createReliableFeishuDispatcher((message) => {
@@ -603,6 +616,16 @@ describe("FeishuConnectionManager", () => {
     const inbox = {
       ingest: vi.fn().mockResolvedValue({ messageId: "msg-1", deliveryIds: ["delivery-1"], duplicate: false }),
     };
+    const receipts = {
+      claim: vi.fn().mockResolvedValue({
+        accepted: true,
+        duplicate: false,
+        receiptId: "receipt-1",
+        status: "processing",
+      }),
+      markProcessed: vi.fn().mockResolvedValue(undefined),
+      markFailed: vi.fn().mockResolvedValue(undefined),
+    };
     const diagnostics = vi.fn();
     const manager = new FeishuConnectionManager({
       database: connectionDatabase.database,
@@ -613,6 +636,7 @@ describe("FeishuConnectionManager", () => {
       runtimeReady: vi.fn().mockResolvedValue(true),
       onDiagnostic: diagnostics,
       leaseMs: 60_000,
+      receipts,
     });
     const verified = await manager.activateAtomicAttempt({
       attemptId,
@@ -677,6 +701,12 @@ describe("FeishuConnectionManager", () => {
       expect.objectContaining({ providerEventId: "ev_conn" }),
       expect.objectContaining({ provider: "feishu" }),
     );
+    expect(receipts.claim).toHaveBeenCalledWith({
+      bindingId: expect.any(String),
+      credentialGeneration: expect.any(Number),
+      eventId: "ev_conn",
+    });
+    expect(receipts.markProcessed).toHaveBeenCalledWith("receipt-1");
     inbox.ingest.mockRejectedValueOnce(new Error("database unavailable"));
     await expect(
       fake.getHandlers().message?.({
@@ -694,6 +724,67 @@ describe("FeishuConnectionManager", () => {
         raw: { header: { event_id: "ev_conn_error", tenant_key: "tenant_1" } },
       } as never),
     ).rejects.toThrow("database unavailable");
+    expect(receipts.markFailed).toHaveBeenCalledWith("receipt-1", "FEISHU_EVENT_PROCESSING_FAILED");
+    fake.adapter.normalizeInbound = vi.fn().mockReturnValue(
+      normalizeFeishuMessage({
+        appId: "cli_conn",
+        teamId: "tenant_1",
+        message: {
+          messageId: "om_missing_event",
+          chatId: "oc_conn",
+          chatType: "group",
+          senderId: "ou_human",
+          content: "hello",
+          rawContentType: "text",
+          resources: [],
+          mentions: [],
+          mentionAll: false,
+          mentionedBot: false,
+          createTime: 2,
+          raw: { header: { tenant_key: "tenant_1" } },
+        },
+      }),
+    );
+    const claimCountBeforeMissingEvent = receipts.claim.mock.calls.length;
+    await fake.getHandlers().message?.({
+      messageId: "om_missing_event",
+      chatId: "oc_conn",
+      chatType: "group",
+      senderId: "ou_human",
+      content: "hello",
+      rawContentType: "text",
+      resources: [],
+      mentions: [],
+      mentionAll: false,
+      mentionedBot: false,
+      createTime: 2,
+      raw: { header: { tenant_key: "tenant_1" } },
+    } as never);
+    expect(receipts.claim).toHaveBeenCalledTimes(claimCountBeforeMissingEvent);
+    receipts.claim.mockResolvedValueOnce({ accepted: false, duplicate: true, receiptId: "receipt-duplicate" });
+    const ingestCountBeforeDuplicate = inbox.ingest.mock.calls.length;
+    fake.adapter.normalizeInbound = vi.fn().mockReturnValue(
+      normalizeFeishuMessage({
+        appId: "cli_conn",
+        teamId: "tenant_1",
+        message: {
+          messageId: "om_duplicate_event",
+          chatId: "oc_conn",
+          chatType: "group",
+          senderId: "ou_human",
+          content: "hello",
+          rawContentType: "text",
+          resources: [],
+          mentions: [],
+          mentionAll: false,
+          mentionedBot: false,
+          createTime: 3,
+          raw: { header: { event_id: "ev_duplicate", tenant_key: "tenant_1" } },
+        },
+      }),
+    );
+    await fake.getHandlers().message?.({} as never);
+    expect(inbox.ingest).toHaveBeenCalledTimes(ingestCountBeforeDuplicate);
     await fake.getHandlers().reconnecting?.();
     await fake.getHandlers().reconnected?.();
     await fake.getHandlers().error?.(new FeishuOperationError("FEISHU_CONNECTION_LEASE_STALE"));

--- a/packages/server/src/__tests__/feishu-inbound-receipt-store.test.ts
+++ b/packages/server/src/__tests__/feishu-inbound-receipt-store.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DatabaseClient } from "../db/client.js";
+import {
+  FeishuInboundReceiptError,
+  FeishuInboundReceiptStore,
+} from "../services/im-bindings/feishu/inbound-receipt-store.js";
+
+interface ReceiptRow {
+  id: string;
+  imBindingId: string;
+  credentialGeneration: number;
+  eventId: string;
+  status: "processing" | "processed" | "failed";
+  receivedAt?: Date;
+  processedAt?: Date;
+  lastErrorCode?: string | null;
+  lastErrorAt?: Date | null;
+}
+
+function createReceiptDatabase(initial: ReceiptRow[] = []) {
+  const rows = [...initial];
+  let nextId = rows.length + 1;
+  const database = {
+    transaction: async (callback: (transaction: unknown) => unknown) => callback(database),
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Omit<ReceiptRow, "id">) => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(async () => {
+            const duplicate = rows.some(
+              (row) => row.imBindingId === values.imBindingId && row.eventId === values.eventId,
+            );
+            if (duplicate) return [];
+            const created: ReceiptRow = { ...values, id: `receipt-${nextId++}` };
+            rows.push(created);
+            return [{ id: created.id, status: created.status }];
+          }),
+        })),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => {
+            const row = rows[0];
+            return row ? [{ id: row.id, status: row.status }] : [];
+          }),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Partial<ReceiptRow>) => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => {
+            const row = rows[0];
+            if (!row) return [];
+            Object.assign(row, values);
+            return [{ id: row.id, bindingId: row.imBindingId, eventId: row.eventId }];
+          }),
+        })),
+      })),
+    })),
+  };
+  return { database: database as unknown as DatabaseClient, rows };
+}
+
+const claimInput = {
+  bindingId: "binding-1",
+  credentialGeneration: 3,
+  eventId: "event-1",
+};
+
+describe("FeishuInboundReceiptStore", () => {
+  it("rejects invalid event IDs and generations before touching the database", async () => {
+    const fake = createReceiptDatabase();
+    const store = new FeishuInboundReceiptStore(fake.database);
+
+    await expect(store.claim({ ...claimInput, eventId: "" })).rejects.toMatchObject({
+      code: "FEISHU_RECEIPT_EVENT_ID_INVALID",
+    });
+    await expect(store.claim({ ...claimInput, eventId: "x".repeat(513) })).rejects.toBeInstanceOf(
+      FeishuInboundReceiptError,
+    );
+    await expect(store.claim({ ...claimInput, eventId: "event\n1" })).rejects.toMatchObject({
+      code: "FEISHU_RECEIPT_EVENT_ID_INVALID",
+    });
+    await expect(store.claim({ ...claimInput, credentialGeneration: 0 })).rejects.toMatchObject({
+      code: "FEISHU_RECEIPT_GENERATION_INVALID",
+    });
+    expect(fake.database.insert).not.toHaveBeenCalled();
+  });
+
+  it("atomically claims one binding-scoped event and returns a stable duplicate result", async () => {
+    const now = new Date("2026-09-01T00:00:00.000Z");
+    const metrics: unknown[] = [];
+    const fake = createReceiptDatabase();
+    const store = new FeishuInboundReceiptStore(fake.database, {
+      now: () => now,
+      onMetric: (metric) => metrics.push(metric),
+    });
+
+    await expect(store.claim(claimInput)).resolves.toEqual({
+      accepted: true,
+      duplicate: false,
+      receiptId: "receipt-1",
+      status: "processing",
+    });
+    await expect(store.claim(claimInput)).resolves.toEqual({
+      accepted: false,
+      duplicate: true,
+      receiptId: "receipt-1",
+      status: "processing",
+    });
+    await expect(store.claim({ ...claimInput, bindingId: "binding-2" })).resolves.toMatchObject({
+      accepted: true,
+      duplicate: false,
+    });
+    expect(fake.rows).toHaveLength(2);
+    expect(metrics).toEqual([
+      { type: "receipt", bindingId: "binding-1", eventId: "event-1", status: "processing" },
+      { type: "duplicate", bindingId: "binding-1", eventId: "event-1", status: "processing" },
+      { type: "receipt", bindingId: "binding-2", eventId: "event-1", status: "processing" },
+    ]);
+  });
+
+  it("records processed and sanitized failed outcomes", async () => {
+    const now = new Date("2026-09-01T00:00:00.000Z");
+    const metrics: unknown[] = [];
+    const fake = createReceiptDatabase();
+    const store = new FeishuInboundReceiptStore(fake.database, {
+      now: () => now,
+      onMetric: (metric) => metrics.push(metric),
+    });
+
+    const claim = await store.claim(claimInput);
+    await store.markProcessed(claim.receiptId as string);
+    expect(fake.rows[0]).toMatchObject({
+      status: "processed",
+      processedAt: now,
+      lastErrorCode: null,
+      lastErrorAt: null,
+    });
+
+    await store.markFailed(claim.receiptId as string, "provider failure / token\nvalue");
+    expect(fake.rows[0]).toMatchObject({
+      status: "failed",
+      lastErrorCode: "provider_failure___token_value",
+      lastErrorAt: now,
+    });
+    expect(metrics).toEqual([
+      { type: "receipt", bindingId: "binding-1", eventId: "event-1", status: "processing" },
+      { type: "receipt", bindingId: "binding-1", eventId: "event-1", status: "processed" },
+      {
+        type: "receipt",
+        bindingId: "binding-1",
+        eventId: "event-1",
+        status: "failed",
+        errorCode: "provider_failure___token_value",
+      },
+    ]);
+  });
+});

--- a/packages/server/src/__tests__/integration/im-binding.test.ts
+++ b/packages/server/src/__tests__/integration/im-binding.test.ts
@@ -27,6 +27,7 @@ import {
   agentRuntimeConfigs,
   agents,
   computers,
+  feishuInboundReceipts,
   imBindings,
   imMessageDeliveries,
   imMessages,
@@ -49,6 +50,7 @@ import { ImMessageInbox, ImResourceService } from "../../services/im/index.js";
 import {
   type FeishuAdapter,
   FeishuConnectionManager,
+  FeishuInboundReceiptStore,
   type FeishuRegistration,
   type FeishuRegistrationGateway,
   FeishuSetupService,
@@ -1474,6 +1476,37 @@ describe("IM binding persistence", () => {
           expect.objectContaining({ messageId: edit.messageId, state: "pending" }),
         ]),
       );
+    } finally {
+      await value.sql.end();
+    }
+  });
+
+  it("elects one durable Feishu receipt winner under concurrent delivery", async () => {
+    const value = await fixture();
+    try {
+      const store = new FeishuInboundReceiptStore(value.database);
+      const claims = await Promise.all(
+        Array.from({ length: 8 }, () =>
+          store.claim({ bindingId: value.imBindingId, credentialGeneration: 1, eventId: "feishu-concurrent-event" }),
+        ),
+      );
+      expect(claims.filter((claim) => claim.accepted)).toHaveLength(1);
+      expect(claims.filter((claim) => claim.duplicate)).toHaveLength(7);
+      const receipts = await value.database
+        .select()
+        .from(feishuInboundReceipts)
+        .where(eq(feishuInboundReceipts.imBindingId, value.imBindingId));
+      expect(receipts).toHaveLength(1);
+      expect(receipts[0]).toMatchObject({ eventId: "feishu-concurrent-event", status: "processing" });
+      await store.markProcessed(receipts[0]?.id as string);
+      expect(
+        (
+          await value.database
+            .select({ status: feishuInboundReceipts.status })
+            .from(feishuInboundReceipts)
+            .where(eq(feishuInboundReceipts.imBindingId, value.imBindingId))
+        )[0]?.status,
+      ).toBe("processed");
     } finally {
       await value.sql.end();
     }

--- a/packages/server/src/__tests__/integration/setup-completion-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/setup-completion-backfill.test.ts
@@ -33,7 +33,7 @@ const LATE = new Date("2026-08-20T00:00:00.000Z");
 const THROUGH_0028_IDX = 28;
 const THROUGH_0028_COUNT = 29;
 const THROUGH_0030_COUNT = 31;
-const CURRENT_MIGRATION_COUNT = 35;
+const CURRENT_MIGRATION_COUNT = 36;
 
 type Journal = {
   version: string;

--- a/packages/server/src/db/schema/feishu-inbound-receipts.ts
+++ b/packages/server/src/db/schema/feishu-inbound-receipts.ts
@@ -1,0 +1,50 @@
+import { relations, sql } from "drizzle-orm";
+import { bigint, check, index, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { imBindings } from "./im-bindings.js";
+
+export const feishuInboundReceiptStatus = pgEnum("feishu_inbound_receipt_status", [
+  "processing",
+  "processed",
+  "failed",
+]);
+
+export const feishuInboundReceipts = pgTable(
+  "feishu_inbound_receipts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    imBindingId: uuid("im_binding_id")
+      .notNull()
+      .references(() => imBindings.id, { onDelete: "restrict" }),
+    credentialGeneration: bigint("credential_generation", { mode: "number" }).notNull(),
+    eventId: text("event_id").notNull(),
+    status: feishuInboundReceiptStatus("status").notNull().default("processing"),
+    receivedAt: timestamp("received_at", { withTimezone: true }).notNull().defaultNow(),
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+    attemptCount: bigint("attempt_count", { mode: "number" }).notNull().default(1),
+    lastErrorCode: text("last_error_code"),
+    lastErrorAt: timestamp("last_error_at", { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex("feishu_inbound_receipts_identity_unique").on(table.imBindingId, table.eventId),
+    index("feishu_inbound_receipts_status_idx").on(table.status, table.receivedAt),
+    check("feishu_inbound_receipts_generation_nonnegative", sql`${table.credentialGeneration} >= 1`),
+    check("feishu_inbound_receipts_event_id_bounded", sql`length(${table.eventId}) between 1 and 512`),
+    check(
+      "feishu_inbound_receipts_failure_shape",
+      sql`(${table.status} <> 'failed' and ${table.lastErrorCode} is null and ${table.lastErrorAt} is null)
+        or (${table.status} = 'failed' and ${table.lastErrorCode} is not null and ${table.lastErrorAt} is not null)`,
+    ),
+    check(
+      "feishu_inbound_receipts_processed_shape",
+      sql`(${table.status} = 'processed' and ${table.processedAt} is not null)
+        or (${table.status} <> 'processed')`,
+    ),
+  ],
+);
+
+export const feishuInboundReceiptsRelations = relations(feishuInboundReceipts, ({ one }) => ({
+  imBinding: one(imBindings, {
+    fields: [feishuInboundReceipts.imBindingId],
+    references: [imBindings.id],
+  }),
+}));

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -4,6 +4,7 @@ export * from "./auth.js";
 export * from "./auth-identities.js";
 export * from "./better-auth.js";
 export * from "./computers.js";
+export * from "./feishu-inbound-receipts.js";
 export * from "./im-bindings.js";
 export * from "./im-messages.js";
 export * from "./invitations.js";

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -35,6 +35,7 @@ import { ComputerService, MachineAuthService } from "./services/computers/index.
 import { ApplicationCipher } from "./services/crypto.js";
 import { ExternalCallPolicy } from "./services/im/external-call-policy.js";
 import { ImMessageInbox, ImResourceService } from "./services/im/index.js";
+import { FeishuInboundReceiptStore } from "./services/im-bindings/feishu/inbound-receipt-store.js";
 import {
   DefaultFeishuRegistrationGateway,
   FeishuConnectionManager,
@@ -199,6 +200,9 @@ export async function startServer(): Promise<void> {
     });
     const workspaceSetupService = new WorkspaceSetupService(database, imBindingService);
     const imMessageInbox = new ImMessageInbox(database);
+    const feishuInboundReceipts = new FeishuInboundReceiptStore(database, {
+      onMetric: (metric) => app?.log.info({ metric }, "Feishu inbound receipt metric"),
+    });
     const sessionService = new SessionService(database);
     const taskService = new TaskService(database);
     const runtimeSnapshotAssembler = new EffectiveRuntimeSnapshotAssembler(database);
@@ -236,6 +240,7 @@ export async function startServer(): Promise<void> {
       onDiagnostic: reportDiagnostic,
       policy: imCallPolicy,
       supervisor: backgroundFailureSupervisor,
+      receipts: feishuInboundReceipts,
     });
     const feishuSetupService = new FeishuSetupService({
       database,

--- a/packages/server/src/services/im-bindings/feishu/adapter.ts
+++ b/packages/server/src/services/im-bindings/feishu/adapter.ts
@@ -125,11 +125,13 @@ function providerEventIdentity(raw: FeishuRawInboundEvent): {
   externalMessageId: string | null;
 } | null {
   const providerEventId = raw.header?.event_id ?? raw.event_id ?? null;
+  const tenantKey = raw.header?.tenant_key ?? raw.tenant_key ?? ("sender" in raw ? raw.sender.tenant_key : null);
   if ("message" in raw) {
     const externalMessageId = raw.message.message_id;
-    const messageKey = `message:${externalMessageId}:${raw.message.create_time}`;
+    const scope = `${tenantKey ?? "unknown"}:${raw.message.chat_id}`;
+    const messageKey = `message:${scope}:${externalMessageId}:${raw.message.create_time}`;
     if (providerEventId) {
-      return { keys: [`event:${providerEventId}`, messageKey], providerEventId, externalMessageId };
+      return { keys: [`event:${scope}:${providerEventId}`, messageKey], providerEventId, externalMessageId };
     }
     return {
       keys: [messageKey],
@@ -139,9 +141,10 @@ function providerEventIdentity(raw: FeishuRawInboundEvent): {
   }
   const externalMessageId = raw.message_id ?? null;
   if (!externalMessageId && !providerEventId) return null;
-  const messageKey = `recall:${externalMessageId}:${raw.recall_time ?? "unknown"}`;
+  const scope = `${tenantKey ?? "unknown"}:${raw.chat_id ?? "unknown"}`;
+  const messageKey = `recall:${scope}:${externalMessageId}:${raw.recall_time ?? "unknown"}`;
   if (providerEventId) {
-    return { keys: [`event:${providerEventId}`, messageKey], providerEventId, externalMessageId };
+    return { keys: [`event:${scope}:${providerEventId}`, messageKey], providerEventId, externalMessageId };
   }
   return {
     keys: [messageKey],
@@ -391,6 +394,20 @@ export function normalizeFeishuMessage(input: VerifiedFeishuEnvelope): Normalize
       mentions,
     }),
   ];
+}
+
+/**
+ * Return the provider envelope event ID when one was supplied. Normalization retains a deterministic
+ * fallback in `providerEventId` for the inbox semantic key, but that fallback is not a delivery receipt.
+ */
+export function feishuEnvelopeEventId(event: NormalizedInboundImEvent): string | null {
+  const messageId = event.message.externalId;
+  const occurredAt = event.message.occurredAt.getTime();
+  const syntheticCreatedId = `${messageId}:${occurredAt}`;
+  const syntheticRecallId = `${messageId}:${occurredAt}:recalled`;
+  return event.providerEventId === syntheticCreatedId || event.providerEventId === syntheticRecallId
+    ? null
+    : event.providerEventId;
 }
 
 export function createReliableFeishuDispatcher(

--- a/packages/server/src/services/im-bindings/feishu/connection-manager.ts
+++ b/packages/server/src/services/im-bindings/feishu/connection-manager.ts
@@ -567,6 +567,18 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
               throw error;
             }
             if (receiptId) await this.#receipts?.markProcessed(receiptId);
+            if (result.duplicate) {
+              emitRootSpan("feishu.inbound.deduplicated", {
+                ...imAttrs({
+                  provider: "feishu",
+                  bindingId: handoff.imBindingId,
+                  providerEventId: receiptEventId ?? event.providerEventId,
+                  externalMessageId: event.message.externalId,
+                  duplicate: true,
+                }),
+                ...outcomeAttrs("duplicate"),
+              });
+            }
             setActiveSpanAttributes({
               ...imAttrs({
                 messageId: result.messageId,

--- a/packages/server/src/services/im-bindings/feishu/connection-manager.ts
+++ b/packages/server/src/services/im-bindings/feishu/connection-manager.ts
@@ -16,11 +16,13 @@ import {
 import { ExternalCallPolicy } from "../../im/external-call-policy.js";
 import { classifyImInboundPersistenceError, type ImMessageInbox } from "../../im/index.js";
 import type { ImBindingService, VerifiedFeishuBinding } from "../im-binding-service.js";
-import { FeishuAdapter } from "./adapter.js";
+import { FeishuAdapter, feishuEnvelopeEventId } from "./adapter.js";
 import { FeishuOperationError, safeFeishuConnectionErrorCode } from "./errors.js";
+import type { FeishuInboundReceiptStore } from "./inbound-receipt-store.js";
 import type { FeishuBindingActivation } from "./setup-service.js";
 
 type FeishuActivationInput = Parameters<FeishuBindingActivation["activateAtomicAttempt"]>[0];
+type FeishuInboundReceiptStoreLike = Pick<FeishuInboundReceiptStore, "claim" | "markProcessed" | "markFailed">;
 
 const DEFAULT_LEASE_MS = 30_000;
 const DEFAULT_MAINTENANCE_MS = 10_000;
@@ -55,6 +57,7 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
   readonly #supervisor?: BackgroundFailureSupervisor;
   readonly #runtimeReady: (agentId: string) => Promise<boolean>;
   readonly #policy: ExternalCallPolicy;
+  readonly #receipts: FeishuInboundReceiptStoreLike | undefined;
   readonly #maintenanceBackoffBaseMs: number;
   readonly #maintenanceBackoffMaxMs: number;
   readonly #now: () => Date;
@@ -84,6 +87,7 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
     runtimeReady?: (agentId: string) => Promise<boolean> | boolean;
     onDiagnostic?: (code: string) => void;
     supervisor?: BackgroundFailureSupervisor;
+    receipts?: FeishuInboundReceiptStoreLike;
     afterActivationAgentLocked?: () => Promise<void>;
     /* type-only */ policy?: ExternalCallPolicy;
     /* type-only */ maintenanceBackoffBaseMs?: number;
@@ -104,6 +108,7 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
     this.#now = input.now ?? (() => new Date());
     this.#onDiagnostic = input.onDiagnostic ?? (() => undefined);
     this.#supervisor = input.supervisor;
+    this.#receipts = input.receipts;
     this.#afterActivationAgentLocked = input.afterActivationAgentLocked;
   }
 
@@ -506,6 +511,39 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
                 externalMessageId: event.message.externalId,
               }),
             );
+            const receiptEventId = feishuEnvelopeEventId(event);
+            let receiptId: string | undefined;
+            if (this.#receipts && receiptEventId) {
+              setFailureCode("FEISHU_INBOUND_DATABASE_FAILED");
+              const claim = await this.#receipts.claim({
+                bindingId: handoff.imBindingId,
+                credentialGeneration: handoff.generation,
+                eventId: receiptEventId,
+              });
+              if (!claim.accepted || !claim.receiptId) {
+                emitRootSpan("feishu.inbound.deduplicated", {
+                  ...imAttrs({
+                    provider: "feishu",
+                    bindingId: handoff.imBindingId,
+                    providerEventId: receiptEventId,
+                    externalMessageId: event.message.externalId,
+                    duplicate: true,
+                  }),
+                  ...outcomeAttrs("duplicate"),
+                });
+                setActiveSpanAttributes({
+                  ...imAttrs({
+                    providerEventId: receiptEventId,
+                    externalMessageId: event.message.externalId,
+                    duplicate: true,
+                  }),
+                  ...outcomeAttrs("duplicate"),
+                });
+                continue;
+              }
+              receiptId = claim.receiptId;
+            }
+
             let result: Awaited<ReturnType<ImMessageInbox["ingest"]>>;
             try {
               setFailureCode("FEISHU_INBOUND_DATABASE_FAILED");
@@ -515,6 +553,9 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
                 fencingEpoch: handoff.epoch,
               });
             } catch (error) {
+              if (receiptId) {
+                await this.#receipts?.markFailed(receiptId, processingErrorCode(error)).catch(() => undefined);
+              }
               const code = classifyImInboundPersistenceError(error);
               setFailureCode(
                 code === "IM_INBOUND_FENCE_STALE" || code === "IM_INBOUND_BINDING_STALE"
@@ -525,6 +566,7 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
               );
               throw error;
             }
+            if (receiptId) await this.#receipts?.markProcessed(receiptId);
             setActiveSpanAttributes({
               ...imAttrs({
                 messageId: result.messageId,
@@ -672,6 +714,18 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
   }
 }
 
+function processingErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+  return "FEISHU_EVENT_PROCESSING_FAILED";
+}
+
+/**
+ * The Feishu adapter keeps a deterministic providerEventId when the envelope omits event_id so the
+ * inbox semantic key remains stable. That synthetic value is deliberately not claimed as a receipt:
+ * only a provider envelope event ID is a durable delivery receipt identity.
+ */
 function connectionOutcome(code: string): string {
   if (code.includes("STALE") || code.includes("FENCE") || code.includes("LEASE")) return "stale";
   if (code.includes("SCOPE") || code.includes("IDENTITY") || code.includes("CREDENTIAL")) {

--- a/packages/server/src/services/im-bindings/feishu/connection-manager.ts
+++ b/packages/server/src/services/im-bindings/feishu/connection-manager.ts
@@ -503,92 +503,7 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
           setFailureCode("FEISHU_INBOUND_NORMALIZE_FAILED");
           const events = adapter.normalizeInbound({ appId: handoff.appId, teamId: null, message });
           for (const event of events) {
-            setActiveSpanAttributes(
-              imAttrs({
-                provider: "feishu",
-                bindingId: handoff.imBindingId,
-                providerEventId: event.providerEventId,
-                externalMessageId: event.message.externalId,
-              }),
-            );
-            const receiptEventId = feishuEnvelopeEventId(event);
-            let receiptId: string | undefined;
-            if (this.#receipts && receiptEventId) {
-              setFailureCode("FEISHU_INBOUND_DATABASE_FAILED");
-              const claim = await this.#receipts.claim({
-                bindingId: handoff.imBindingId,
-                credentialGeneration: handoff.generation,
-                eventId: receiptEventId,
-              });
-              if (!claim.accepted || !claim.receiptId) {
-                emitRootSpan("feishu.inbound.deduplicated", {
-                  ...imAttrs({
-                    provider: "feishu",
-                    bindingId: handoff.imBindingId,
-                    providerEventId: receiptEventId,
-                    externalMessageId: event.message.externalId,
-                    duplicate: true,
-                  }),
-                  ...outcomeAttrs("duplicate"),
-                });
-                setActiveSpanAttributes({
-                  ...imAttrs({
-                    providerEventId: receiptEventId,
-                    externalMessageId: event.message.externalId,
-                    duplicate: true,
-                  }),
-                  ...outcomeAttrs("duplicate"),
-                });
-                continue;
-              }
-              receiptId = claim.receiptId;
-            }
-
-            let result: Awaited<ReturnType<ImMessageInbox["ingest"]>>;
-            try {
-              setFailureCode("FEISHU_INBOUND_DATABASE_FAILED");
-              result = await this.#inbox.ingest(handoff.imBindingId, handoff.generation, event, {
-                provider: "feishu",
-                holderInstanceId: this.#instanceId,
-                fencingEpoch: handoff.epoch,
-              });
-            } catch (error) {
-              if (receiptId) {
-                await this.#receipts?.markFailed(receiptId, processingErrorCode(error)).catch(() => undefined);
-              }
-              const code = classifyImInboundPersistenceError(error);
-              setFailureCode(
-                code === "IM_INBOUND_FENCE_STALE" || code === "IM_INBOUND_BINDING_STALE"
-                  ? "FEISHU_INBOUND_FENCE_STALE"
-                  : code === "IM_INBOUND_IDENTITY_MISMATCH"
-                    ? "FEISHU_INBOUND_IDENTITY_MISMATCH"
-                    : "FEISHU_INBOUND_DATABASE_FAILED",
-              );
-              throw error;
-            }
-            if (receiptId) await this.#receipts?.markProcessed(receiptId);
-            if (result.duplicate) {
-              emitRootSpan("feishu.inbound.deduplicated", {
-                ...imAttrs({
-                  provider: "feishu",
-                  bindingId: handoff.imBindingId,
-                  providerEventId: receiptEventId ?? event.providerEventId,
-                  externalMessageId: event.message.externalId,
-                  duplicate: true,
-                }),
-                ...outcomeAttrs("duplicate"),
-              });
-            }
-            setActiveSpanAttributes({
-              ...imAttrs({
-                messageId: result.messageId,
-                deliveryCount: result.deliveryIds.length,
-                duplicate: result.duplicate,
-              }),
-              ...outcomeAttrs(
-                result.duplicate ? "duplicate" : result.deliveryIds.length > 0 ? "persisted" : "no_delivery",
-              ),
-            });
+            await this.#processInboundEvent(event, handoff, setFailureCode);
           }
         });
       },
@@ -643,6 +558,91 @@ export class FeishuConnectionManager implements FeishuBindingActivation {
         }
       },
     });
+  }
+
+  async #processInboundEvent(
+    event: Parameters<ImMessageInbox["ingest"]>[2],
+    handoff: { imBindingId: string; epoch: number; generation: number; appId: string },
+    setFailureCode: (
+      code: "FEISHU_INBOUND_DATABASE_FAILED" | "FEISHU_INBOUND_FENCE_STALE" | "FEISHU_INBOUND_IDENTITY_MISMATCH",
+    ) => void,
+  ): Promise<void> {
+    setActiveSpanAttributes(
+      imAttrs({
+        provider: "feishu",
+        bindingId: handoff.imBindingId,
+        providerEventId: event.providerEventId,
+        externalMessageId: event.message.externalId,
+      }),
+    );
+    const receiptEventId = feishuEnvelopeEventId(event);
+    const receiptId = await this.#claimInboundReceipt(event, handoff, receiptEventId, setFailureCode);
+    if (receiptId === null) return;
+    const result = await this.#persistInboundEvent(event, handoff, receiptId, setFailureCode);
+    if (receiptId) await this.#receipts?.markProcessed(receiptId);
+    if (result.duplicate)
+      emitInboundDuplicate(handoff.imBindingId, receiptEventId ?? event.providerEventId, event.message.externalId);
+    setActiveSpanAttributes({
+      ...imAttrs({
+        messageId: result.messageId,
+        deliveryCount: result.deliveryIds.length,
+        duplicate: result.duplicate,
+      }),
+      ...outcomeAttrs(result.duplicate ? "duplicate" : result.deliveryIds.length > 0 ? "persisted" : "no_delivery"),
+    });
+  }
+
+  async #persistInboundEvent(
+    event: Parameters<ImMessageInbox["ingest"]>[2],
+    handoff: { imBindingId: string; epoch: number; generation: number; appId: string },
+    receiptId: string | undefined,
+    setFailureCode: (
+      code: "FEISHU_INBOUND_DATABASE_FAILED" | "FEISHU_INBOUND_FENCE_STALE" | "FEISHU_INBOUND_IDENTITY_MISMATCH",
+    ) => void,
+  ): Promise<Awaited<ReturnType<ImMessageInbox["ingest"]>>> {
+    try {
+      setFailureCode("FEISHU_INBOUND_DATABASE_FAILED");
+      return await this.#inbox.ingest(handoff.imBindingId, handoff.generation, event, {
+        provider: "feishu",
+        holderInstanceId: this.#instanceId,
+        fencingEpoch: handoff.epoch,
+      });
+    } catch (error) {
+      if (receiptId) await this.#receipts?.markFailed(receiptId, processingErrorCode(error)).catch(() => undefined);
+      const code = classifyImInboundPersistenceError(error);
+      setFailureCode(
+        code === "IM_INBOUND_FENCE_STALE" || code === "IM_INBOUND_BINDING_STALE"
+          ? "FEISHU_INBOUND_FENCE_STALE"
+          : code === "IM_INBOUND_IDENTITY_MISMATCH"
+            ? "FEISHU_INBOUND_IDENTITY_MISMATCH"
+            : "FEISHU_INBOUND_DATABASE_FAILED",
+      );
+      throw error;
+    }
+  }
+
+  async #claimInboundReceipt(
+    event: Parameters<ImMessageInbox["ingest"]>[2],
+    handoff: { imBindingId: string; epoch: number; generation: number; appId: string },
+    receiptEventId: string | null,
+    setFailureCode: (
+      code: "FEISHU_INBOUND_DATABASE_FAILED" | "FEISHU_INBOUND_FENCE_STALE" | "FEISHU_INBOUND_IDENTITY_MISMATCH",
+    ) => void,
+  ): Promise<string | null | undefined> {
+    if (!this.#receipts || !receiptEventId) return undefined;
+    setFailureCode("FEISHU_INBOUND_DATABASE_FAILED");
+    const claim = await this.#receipts.claim({
+      bindingId: handoff.imBindingId,
+      credentialGeneration: handoff.generation,
+      eventId: receiptEventId,
+    });
+    if (claim.accepted && claim.receiptId) return claim.receiptId;
+    emitInboundDuplicate(handoff.imBindingId, receiptEventId, event.message.externalId);
+    setActiveSpanAttributes({
+      ...imAttrs({ providerEventId: receiptEventId, externalMessageId: event.message.externalId, duplicate: true }),
+      ...outcomeAttrs("duplicate"),
+    });
+    return null;
   }
 
   async #observeConnected(imBindingId: string, epoch: number): Promise<void> {
@@ -733,11 +733,19 @@ function processingErrorCode(error: unknown): string {
   return "FEISHU_EVENT_PROCESSING_FAILED";
 }
 
-/**
- * The Feishu adapter keeps a deterministic providerEventId when the envelope omits event_id so the
- * inbox semantic key remains stable. That synthetic value is deliberately not claimed as a receipt:
- * only a provider envelope event ID is a durable delivery receipt identity.
- */
+function emitInboundDuplicate(bindingId: string, providerEventId: string, externalMessageId: string): void {
+  emitRootSpan("feishu.inbound.deduplicated", {
+    ...imAttrs({
+      provider: "feishu",
+      bindingId,
+      providerEventId,
+      externalMessageId,
+      duplicate: true,
+    }),
+    ...outcomeAttrs("duplicate"),
+  });
+}
+
 function connectionOutcome(code: string): string {
   if (code.includes("STALE") || code.includes("FENCE") || code.includes("LEASE")) return "stale";
   if (code.includes("SCOPE") || code.includes("IDENTITY") || code.includes("CREDENTIAL")) {

--- a/packages/server/src/services/im-bindings/feishu/inbound-receipt-store.ts
+++ b/packages/server/src/services/im-bindings/feishu/inbound-receipt-store.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+import { type StructuredError, StructuredErrorSchema } from "@opentag/shared";
+import { and, eq } from "drizzle-orm";
+import type { DatabaseClient } from "../../../db/client.js";
+import { feishuInboundReceipts } from "../../../db/schema/index.js";
+
+export class FeishuInboundReceiptError extends Error {
+  declare readonly code: string;
+  readonly structuredError: StructuredError;
+
+  constructor(code: string, requestId: string = randomUUID()) {
+    super(code);
+    this.name = "FeishuInboundReceiptError";
+    this.code = code;
+    this.structuredError = StructuredErrorSchema.parse({
+      code,
+      category: "validation",
+      retryability: "never",
+      phase: "request",
+      requestId,
+      message: code,
+    });
+  }
+
+  toStructuredError(): StructuredError {
+    return this.structuredError;
+  }
+}
+
+type FeishuInboundReceiptMetricCore = { type: "receipt" | "duplicate"; bindingId: string; eventId: string };
+type FeishuInboundReceiptMetricDetails = { status?: "processing" | "processed" | "failed"; errorCode?: string };
+export type FeishuInboundReceiptMetric = FeishuInboundReceiptMetricCore & FeishuInboundReceiptMetricDetails;
+
+type FeishuInboundReceiptClaimCore = { accepted: boolean; duplicate: boolean };
+type FeishuInboundReceiptClaimDetails = {
+  receiptId?: string;
+  status?: "processing" | "processed" | "failed";
+};
+export type FeishuInboundReceiptClaim = FeishuInboundReceiptClaimCore & FeishuInboundReceiptClaimDetails;
+
+export type FeishuInboundReceiptInput = {
+  bindingId: string;
+  credentialGeneration: number;
+  eventId: string;
+};
+
+export class FeishuInboundReceiptStore {
+  readonly #database: DatabaseClient;
+  readonly #now: () => Date;
+  readonly #onMetric: (metric: FeishuInboundReceiptMetric) => void;
+
+  constructor(
+    database: DatabaseClient,
+    options: { now?: () => Date; onMetric?: (metric: FeishuInboundReceiptMetric) => void } = {},
+  ) {
+    this.#database = database;
+    this.#now = options.now ?? (() => new Date());
+    this.#onMetric = options.onMetric ?? (() => undefined);
+  }
+
+  async claim(input: FeishuInboundReceiptInput): Promise<FeishuInboundReceiptClaim> {
+    if (!isValidEventId(input.eventId)) throw new FeishuInboundReceiptError("FEISHU_RECEIPT_EVENT_ID_INVALID");
+    if (!Number.isSafeInteger(input.credentialGeneration) || input.credentialGeneration < 1) {
+      throw new FeishuInboundReceiptError("FEISHU_RECEIPT_GENERATION_INVALID");
+    }
+    return this.#database.transaction(async (transaction) => {
+      const [created] = await transaction
+        .insert(feishuInboundReceipts)
+        .values({
+          imBindingId: input.bindingId,
+          credentialGeneration: input.credentialGeneration,
+          eventId: input.eventId,
+          status: "processing",
+          receivedAt: this.#now(),
+          attemptCount: 1,
+        })
+        .onConflictDoNothing({
+          target: [feishuInboundReceipts.imBindingId, feishuInboundReceipts.eventId],
+        })
+        .returning({ id: feishuInboundReceipts.id, status: feishuInboundReceipts.status });
+      if (created) {
+        this.#onMetric({ type: "receipt", bindingId: input.bindingId, eventId: input.eventId, status: "processing" });
+        return { accepted: true, duplicate: false, receiptId: created.id, status: created.status };
+      }
+
+      const [existing] = await transaction
+        .select({ id: feishuInboundReceipts.id, status: feishuInboundReceipts.status })
+        .from(feishuInboundReceipts)
+        .where(
+          and(eq(feishuInboundReceipts.imBindingId, input.bindingId), eq(feishuInboundReceipts.eventId, input.eventId)),
+        )
+        .limit(1);
+      this.#onMetric({
+        type: "duplicate",
+        bindingId: input.bindingId,
+        eventId: input.eventId,
+        ...(existing?.status ? { status: existing.status } : {}),
+      });
+      return {
+        accepted: false,
+        duplicate: true,
+        ...(existing?.id ? { receiptId: existing.id } : {}),
+        ...(existing?.status ? { status: existing.status } : {}),
+      };
+    });
+  }
+
+  async markProcessed(receiptId: string): Promise<void> {
+    const [updated] = await this.#database
+      .update(feishuInboundReceipts)
+      .set({ status: "processed", processedAt: this.#now(), lastErrorCode: null, lastErrorAt: null })
+      .where(eq(feishuInboundReceipts.id, receiptId))
+      .returning({
+        id: feishuInboundReceipts.id,
+        bindingId: feishuInboundReceipts.imBindingId,
+        eventId: feishuInboundReceipts.eventId,
+      });
+    if (updated)
+      this.#onMetric({ type: "receipt", bindingId: updated.bindingId, eventId: updated.eventId, status: "processed" });
+  }
+
+  async markFailed(receiptId: string, errorCode: string): Promise<void> {
+    const safeCode = sanitizeErrorCode(errorCode);
+    const [updated] = await this.#database
+      .update(feishuInboundReceipts)
+      .set({ status: "failed", lastErrorCode: safeCode, lastErrorAt: this.#now() })
+      .where(eq(feishuInboundReceipts.id, receiptId))
+      .returning({
+        id: feishuInboundReceipts.id,
+        bindingId: feishuInboundReceipts.imBindingId,
+        eventId: feishuInboundReceipts.eventId,
+      });
+    if (updated) {
+      this.#onMetric({
+        type: "receipt",
+        bindingId: updated.bindingId,
+        eventId: updated.eventId,
+        status: "failed",
+        errorCode: safeCode,
+      });
+    }
+  }
+}
+
+function isValidEventId(eventId: string): boolean {
+  return (
+    eventId.length >= 1 &&
+    eventId.length <= 512 &&
+    [...eventId].every((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code >= 0x21 && code <= 0x7e;
+    })
+  );
+}
+
+function sanitizeErrorCode(errorCode: string): string {
+  return errorCode.replace(/[^A-Za-z0-9_.:-]/g, "_").slice(0, 120) || "FEISHU_EVENT_PROCESSING_FAILED";
+}

--- a/packages/server/src/services/im-bindings/feishu/index.ts
+++ b/packages/server/src/services/im-bindings/feishu/index.ts
@@ -1,5 +1,5 @@
 export type { VerifiedFeishuEnvelope } from "./adapter.js";
-export { FeishuAdapter, normalizeFeishuMessage } from "./adapter.js";
+export { FeishuAdapter, feishuEnvelopeEventId, normalizeFeishuMessage } from "./adapter.js";
 export { FeishuConnectionManager } from "./connection-manager.js";
 export {
   FeishuOperationError,
@@ -11,6 +11,13 @@ export {
   safeFeishuConnectionErrorCode,
   safeFeishuSetupErrorCode,
 } from "./errors.js";
+export {
+  type FeishuInboundReceiptClaim,
+  FeishuInboundReceiptError,
+  type FeishuInboundReceiptInput,
+  type FeishuInboundReceiptMetric,
+  FeishuInboundReceiptStore,
+} from "./inbound-receipt-store.js";
 export type {
   FeishuAppProfile,
   FeishuRegistration,


### PR DESCRIPTION
Closes #218

## Summary

Adds explicit, provider-aware deduplication for inbound Feishu messages so retries, reconnects, and
duplicate event deliveries cannot create duplicate persisted messages or duplicate Task deliveries.
Builds on the in-memory dispatcher-boundary dedup from #379, which stays as the fast path but is
process-local and cannot protect across restarts or instances.

- **Durable receipt claim (new first layer).** A new `0035_dark_devos` migration adds a Feishu event
  receipt table storing binding, credential generation, event ID, processing status, timestamps, and
  sanitized failure state, with a unique `(im_binding_id, event_id)` constraint and a foreign key
  preventing orphan receipts. `FeishuInboundReceiptStore` claims the row with
  `INSERT ... ON CONFLICT DO NOTHING` inside a transaction, so concurrent duplicate deliveries across
  multiple server instances elect exactly one winner (mirroring the Slack webhook receipt store
  pattern).
- **Wiring.** `FeishuConnectionManager` claims only real envelope event IDs, acknowledges durable
  duplicates without calling the inbox, and marks winners processed or failed around ingestion.
- **Logical layer preserved.** The inbox's existing
  `(im_binding_id, channel_id, external_message_id, provider_revision_key)` unique index remains the
  second layer, so a repeated `message_id` under a *different* envelope `event_id` is still a
  duplicate, while legitimate edit/recall revisions stay distinct and actionable.
- **Missing envelope ID.** Events without an envelope event ID are not inserted into the receipt
  table; they fall back to the inbox message/revision dedup (documented).
- **Observability.** A redacted, stable duplicate outcome (span contract) with bounded identifiers
  and no tokens or message content; English and Chinese observability docs describe the adapter and
  database keys, the 30-day terminal-row retention policy, and the fallback behavior.

## Checklist

- [x] Study existing adapter deduplicator, Slack receipt store, inbound inbox, and Feishu tests
- [x] DB schema and migration for binding-scoped Feishu event receipts with a unique constraint
- [x] Transaction-safe receipt claim wired into the Feishu inbound path
- [x] Logical dedup by binding + conversation + message ID + revision; edit/recall stay actionable
- [x] Redacted, stable duplicate outcome for logs and observability
- [x] Unit tests: duplicate IDs, retries/reconnects, concurrency, edit/recall, binding scope,
      missing event IDs
- [x] Integration tests using the existing migrated test database pattern (concurrent claims elect
      exactly one winner)
- [x] Documentation of key, retention/cleanup policy, and missing-event-ID behavior
- [x] Full verification suite

## Verification

Run by the lane in its worktree (Node 24.19.0 toolchain):

- Affected Feishu unit tests — 26 tests passed; migrated concurrent receipt integration test passed
- `pnpm check` — passed (migration drift: 36 migrations; complexity ratchet green)
- `pnpm typecheck` — passed
- `pnpm build` — passed including bundle report
- Full `pnpm test` — passed (135 root tests plus all 8 Turbo package suites)

Independently re-run by the orchestrator before publishing: `pnpm check` (36-migration drift check
passed, complexity ratchet passed with 1 improvement) and `pnpm --filter @opentag/server test`
(60 files, 562 tests passed).

Deviation note: none from the confirmed approach. The brief's exact `corepack pnpm` wrapper hit the
known host-level nested-corepack version mismatch during `build`; the pinned toolchain invoked
directly completed the same build successfully. This affects only how checks were invoked, not the
code under review.

## Provenance

Automated change: written by a Codex CLI agent running with approvals and sandbox bypassed
(dispatch-codex run `tknr8y`, lane `feishu-inbound-dedup-1`), then verified and published by the
supervising orchestrator.
