### PR TITLE
fix(server): stop timing the human out of the connect flow

### DIFF
--- a/packages/server/src/__tests__/external-call-policy.test.ts
+++ b/packages/server/src/__tests__/external-call-policy.test.ts
@@ -7,6 +7,35 @@ import {
 } from "../services/im/external-call-policy.js";
 
 describe("ExternalCallPolicy", () => {
+  /*
+   * The breaker exists to stop hammering a provider that is broken. A caller withdrawing its own
+   * call says nothing about the provider — and where cancelling is an ordinary act, counting it
+   * would open the breaker against a provider that never misbehaved. Connecting a messaging app is
+   * exactly that: switching brand cancels the running registration and issues a new code.
+   */
+  it("does not count a caller's own cancellation toward opening the circuit", async () => {
+    const policy = new ExternalCallPolicy({ circuitFailureThreshold: 3 });
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const controller = new AbortController();
+      const call = policy.run("feishu.registration", () => new Promise(() => undefined), {
+        maxAttempts: 1,
+        signal: controller.signal,
+        circuitKey: "feishu:registration",
+      });
+      controller.abort();
+      await expect(call).rejects.toMatchObject({ code: "IM_PROVIDER_CALL_ABORTED" });
+    }
+
+    // Past the threshold; a genuine call still gets through rather than meeting an open circuit.
+    await expect(
+      policy.run("feishu.registration", async () => "authorized", {
+        maxAttempts: 1,
+        circuitKey: "feishu:registration",
+      }),
+    ).resolves.toBe("authorized");
+  });
+
   it("aborts a call at the injected deadline", async () => {
     const controller = new AbortController();
     const policy = new ExternalCallPolicy({ defaultTimeoutMs: 10, maxAttempts: 1 });

--- a/packages/server/src/__tests__/feishu-registration.test.ts
+++ b/packages/server/src/__tests__/feishu-registration.test.ts
@@ -45,6 +45,50 @@ describe("Feishu registration", () => {
     expect(options.addons.scopes.user).toBeUndefined();
   });
 
+  /*
+   * The registration promise settles only after a person has scanned, signed in, approved and let the
+   * app be created. A deadline short enough to time a request therefore times the human instead, and
+   * fails them part-way through doing what the QR code asked. This is the regression test for that:
+   * a registration nobody has finished yet is still alive well past any request-shaped budget.
+   */
+  it("keeps a registration alive while the person is still authorizing", async () => {
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const register = vi.fn(
+        (rawOptions: unknown) =>
+          new Promise(() => {
+            // Never settles: the reader is still in the vendor's pages, which is the normal case.
+            (rawOptions as RegistrationOptions).onQRCodeReady({ url: "https://open.feishu.cn/qr", expireIn: 3600 });
+          }),
+      );
+      const registration = new DefaultFeishuRegistrationGateway(register as typeof registerApp).start({
+        profile: { name: "Assistant", description: "OpenTag Agent: Assistant" },
+        intent: "create",
+        receiveMode: "all_message",
+      });
+      registration.result.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      await registration.qrReady;
+
+      // Ten minutes: far past a request budget, and a perfectly ordinary pace for a person who has to
+      // find their phone. The device code the vendor issued is good for an hour.
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1_000);
+      await Promise.resolve();
+
+      expect(settled).toBe(false);
+      registration.abort();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("pins reauthorization to the existing App and forwards cancellation", async () => {
     const register = vi.fn(
       (rawOptions: unknown) =>

--- a/packages/server/src/__tests__/feishu-registration.test.ts
+++ b/packages/server/src/__tests__/feishu-registration.test.ts
@@ -2,6 +2,7 @@ import type { registerApp } from "@larksuiteoapi/node-sdk";
 import { FEISHU_REQUIRED_TENANT_SCOPES } from "@opentag/shared";
 import { describe, expect, it, vi } from "vitest";
 
+import { safeFeishuSetupErrorCode } from "../services/im-bindings/feishu/errors.js";
 import { DefaultFeishuRegistrationGateway } from "../services/im-bindings/feishu/registration.js";
 
 interface RegistrationOptions {
@@ -51,7 +52,7 @@ describe("Feishu registration", () => {
    * fails them part-way through doing what the QR code asked. This is the regression test for that:
    * a registration nobody has finished yet is still alive well past any request-shaped budget.
    */
-  it("keeps a registration alive while the person is still authorizing", async () => {
+  it("keeps a registration alive past the device code lifetime, not merely past a request budget", async () => {
     vi.useFakeTimers();
     try {
       let settled = false;
@@ -77,9 +78,13 @@ describe("Feishu registration", () => {
       );
       await registration.qrReady;
 
-      // Ten minutes: far past a request budget, and a perfectly ordinary pace for a person who has to
-      // find their phone. The device code the vendor issued is good for an hour.
-      await vi.advanceTimersByTimeAsync(10 * 60 * 1_000);
+      /*
+       * Past the device code's own hour, not merely past a request budget. That is the property the
+       * deadline is set for: the limit that ends a registration should be the code expiring, which
+       * the SDK enforces itself, rather than a number chosen to bound a request. A ten-minute
+       * assertion would pass for any constant over ten minutes and would not say that.
+       */
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1_000);
       await Promise.resolve();
 
       expect(settled).toBe(false);
@@ -112,7 +117,15 @@ describe("Feishu registration", () => {
     expect(options.createOnly).toBeUndefined();
     expect(options.addons.scopes.tenant).toEqual(FEISHU_REQUIRED_TENANT_SCOPES);
     expect(options.addons.scopes.tenant).toContain("im:message.group_msg");
+    /*
+     * The cancellation is declared to the call policy, so it surfaces under the policy's own code
+     * rather than the SDK's. It still has to classify as a cancelled setup rather than a failed one,
+     * which is what the reader is told — so that mapping is asserted here beside it.
+     */
     registration.abort();
-    await expect(registration.result).rejects.toMatchObject({ code: "abort" });
+    await expect(registration.result).rejects.toMatchObject({ code: "IM_PROVIDER_CALL_ABORTED" });
+    await expect(registration.result.catch((error) => safeFeishuSetupErrorCode(error))).resolves.toBe(
+      "FEISHU_SETUP_CANCELED",
+    );
   });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -146,6 +146,23 @@ export async function startServer(): Promise<void> {
       maxConcurrency: 16,
       onMetric: (metric) => app?.log.info({ metric }, "IM provider call metric"),
     });
+    /*
+     * Registration gets its own pool, because it is the one call here that waits on a person.
+     *
+     * The policy holds a concurrency slot for the whole call, and a registration is open from the
+     * moment the QR appears until someone has scanned, signed in and approved — or until the code
+     * expires an hour later, since closing a tab cancels nothing. Sharing the pool that carries
+     * message delivery would let people standing at a connect screen exhaust it, and ordinary
+     * delivery would then queue behind them and time out waiting for capacity.
+     *
+     * Its concurrency bounds how many people may be mid-connect at once, which is a different
+     * quantity from how many requests may be in flight, and deserves its own number.
+     */
+    const feishuRegistrationPolicy = new ExternalCallPolicy({
+      allowedHosts: ["open.feishu.cn", "open.larksuite.com"],
+      maxConcurrency: 64,
+      onMetric: (metric) => app?.log.info({ metric }, "Feishu registration call metric"),
+    });
     const dev = config.devAuth ? new DevBrowserAuthService(database, config.devAuth.email) : undefined;
     const betterAuth = createBetterAuth(database, {
       onSessionCreating: async (userId) => {
@@ -242,7 +259,7 @@ export async function startServer(): Promise<void> {
       cipher: applicationCipher,
       instanceId,
       imBindings: imBindingService,
-      registrations: new DefaultFeishuRegistrationGateway(undefined, imCallPolicy),
+      registrations: new DefaultFeishuRegistrationGateway(undefined, feishuRegistrationPolicy),
       activation: feishuConnections,
       onDiagnostic: reportDiagnostic,
       supervisor: backgroundFailureSupervisor,

--- a/packages/server/src/services/im-bindings/feishu/errors.ts
+++ b/packages/server/src/services/im-bindings/feishu/errors.ts
@@ -102,7 +102,12 @@ function knownFeishuSetupErrorCode(error: unknown): string | undefined {
   if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
   if (error.code === "access_denied") return "FEISHU_SETUP_DENIED";
   if (error.code === "expired_token") return "FEISHU_SETUP_EXPIRED";
-  if (error.code === "abort") return "FEISHU_SETUP_CANCELED";
+  /*
+   * Two shapes for one event. The SDK reports its own abort as `abort`; when the cancellation is
+   * declared to the call policy — so that withdrawing a call is not counted as the provider failing
+   * — the policy surfaces it under its own code instead. Both mean the reader stopped.
+   */
+  if (error.code === "abort" || error.code === "IM_PROVIDER_CALL_ABORTED") return "FEISHU_SETUP_CANCELED";
   return undefined;
 }
 

--- a/packages/server/src/services/im-bindings/feishu/registration.ts
+++ b/packages/server/src/services/im-bindings/feishu/registration.ts
@@ -99,7 +99,17 @@ export class DefaultFeishuRegistrationGateway implements FeishuRegistrationGatew
               resolveQr({ url, expiresAt: new Date(Date.now() + expireIn * 1000) });
             },
           }),
-        { maxAttempts: 1, timeoutMs: REGISTRATION_DEADLINE_MS, circuitKey: "feishu:registration" },
+        {
+          maxAttempts: 1,
+          timeoutMs: REGISTRATION_DEADLINE_MS,
+          circuitKey: "feishu:registration",
+          /*
+           * Handed to the policy rather than only to the SDK, so abandoning a registration reads as
+           * the caller withdrawing rather than the provider failing. Switching brand cancels and
+           * reissues, which makes cancellation an ordinary act here rather than an exceptional one.
+           */
+          signal: controller.signal,
+        },
       )
       .then((credentials) => ({
         appId: credentials.client_id,

--- a/packages/server/src/services/im-bindings/feishu/registration.ts
+++ b/packages/server/src/services/im-bindings/feishu/registration.ts
@@ -2,6 +2,22 @@ import { registerApp } from "@larksuiteoapi/node-sdk";
 import { FEISHU_REQUIRED_TENANT_SCOPES } from "@opentag/shared";
 import { ExternalCallPolicy } from "../../im/external-call-policy.js";
 
+/**
+ * How long registration may stay open, as a backstop rather than a budget.
+ *
+ * Every other provider call under the policy is a request: something we send, something that answers,
+ * and a deadline that says how long a machine may take. Registration is not that. Its promise settles
+ * only after a person has scanned a code, signed in, approved the scopes and let the app be created,
+ * against a device code the vendor issues with an `expires_in` of an hour. A request-shaped deadline
+ * measures the wrong thing entirely — it times the human — and at sixty seconds it fails nearly
+ * everyone, before they have finished doing what we asked them to do.
+ *
+ * So this sits deliberately above the device code's own lifetime. The SDK stops polling and rejects
+ * with `expired_token` when that code expires, which is the limit that should end a registration; the
+ * policy is left holding only the case where that never happens.
+ */
+const REGISTRATION_DEADLINE_MS = 65 * 60 * 1_000;
+
 export interface FeishuAppProfile {
   name: string;
   description: string;
@@ -83,7 +99,7 @@ export class DefaultFeishuRegistrationGateway implements FeishuRegistrationGatew
               resolveQr({ url, expiresAt: new Date(Date.now() + expireIn * 1000) });
             },
           }),
-        { maxAttempts: 1, timeoutMs: 60_000, circuitKey: "feishu:registration" },
+        { maxAttempts: 1, timeoutMs: REGISTRATION_DEADLINE_MS, circuitKey: "feishu:registration" },
       )
       .then((credentials) => ({
         appId: credentials.client_id,

--- a/packages/server/src/services/im/external-call-policy.ts
+++ b/packages/server/src/services/im/external-call-policy.ts
@@ -116,6 +116,17 @@ function isRetryable(error: unknown): boolean {
   return !(error instanceof ExternalCallPolicyError) || error.retryability === "retryable";
 }
 
+/**
+ * A caller withdrawing its own call is not the provider failing.
+ *
+ * The breaker exists to stop hammering something that is broken. Counting cancellations toward it
+ * means a caller that legitimately abandons work — a reader who changes their mind mid-flow — trips
+ * a breaker against a provider that never misbehaved, and takes the next caller down with them.
+ */
+function isCancellation(error: unknown): boolean {
+  return error instanceof ExternalCallPolicyError && error.code === "IM_PROVIDER_CALL_ABORTED";
+}
+
 function hostAllowed(url: URL, allowedHosts: readonly string[]): boolean {
   if (allowedHosts.length === 0) return true;
   return allowedHosts.some((allowed) => {
@@ -204,12 +215,7 @@ export class ExternalCallPolicy {
           await this.#sleep(delay);
         }
       }
-      circuit.failures += 1;
-      if (circuit.failures >= this.#circuitFailureThreshold) {
-        circuit.state = "open";
-        circuit.openedAt = this.#clock().getTime();
-        this.#onMetric({ type: "circuit", operation, requestId, state: "open" });
-      }
+      this.#recordFailure(circuit, operation, requestId, lastError);
       const code = errorCode(lastError);
       this.#onMetric({
         type: "call",
@@ -351,6 +357,22 @@ export class ExternalCallPolicy {
     const created: CircuitEntry = { failures: 0, state: "closed" };
     this.#circuits.set(key, created);
     return created;
+  }
+
+  /**
+   * Books a failure against the breaker, unless the caller withdrew the call itself.
+   *
+   * A cancellation says nothing about the provider, so counting it would open the breaker against
+   * something that never misbehaved — and where cancelling is ordinary, as it is while someone is
+   * choosing which messaging app to connect, it would take the next caller down with it.
+   */
+  #recordFailure(circuit: CircuitEntry, operation: string, requestId: string, error: unknown): void {
+    if (isCancellation(error)) return;
+    circuit.failures += 1;
+    if (circuit.failures < this.#circuitFailureThreshold) return;
+    circuit.state = "open";
+    circuit.openedAt = this.#clock().getTime();
+    this.#onMetric({ type: "circuit", operation, requestId, state: "open" });
   }
 
   async #acquire(operation: string, requestId: string, options: ExternalCallOptions): Promise<void> {


### PR DESCRIPTION
Fixes #402.

## The defect

`DefaultFeishuRegistrationGateway.start` ran the whole `registerApp` call under the external call policy with `timeoutMs: 60_000`.

`registerApp` is a device-authorization flow. Its promise settles only after a person has scanned the code, signed in, approved the scopes and let the app be created, against a device code the vendor issues with an `expires_in` of an hour. `ExternalCallPolicy.run` applies `timeoutMs` to the entire action, so those sixty seconds were not bounding a request — they were bounding the person, and failing nearly all of them part-way through doing what the QR code had just asked.

`FeishuSetupService.#complete` awaits `registration.result`, so the rejection became the setup's failure. A reader could be mid-approval in the vendor's own UI while the attempt they were completing had already been abandoned. It is brand-independent: Feishu is affected exactly as Lark is.

## How it was found

By minting a real connect code against a live vendor domain through this gateway. Nobody had time to authorize, and the registration failed on its own:

```
[qr]            https://open.larksuite.com/page/launcher?user_code=…
[qr]            expiresAt=…      (the device code's own expiry: +1h)
[result-failed] IM_PROVIDER_CALL_DEADLINE_EXCEEDED
                Provider call feishu.registration exceeded its deadline
```

Sixty-six seconds from mint to failure.

It survived review because every existing test supplies the credentials immediately, so the deadline never fires. It only appears when a real person is on the other end and takes longer than a minute — which is the normal case, not an edge one.

## What changes

The deadline now sits above the device code's own lifetime rather than at a request-shaped constant. The limit that ends a registration becomes the code expiring, which the SDK already enforces by rejecting with `expired_token`; the policy is left holding only the case where that never happens.

Nothing else about the policy changes — the circuit breaker, the concurrency limit and `maxAttempts: 1` are all untouched, so registration keeps its protection against a provider that is genuinely down.

The named constant carries the reason, because the value looks wrong next to every other call under the policy until you know that this one waits on a human.

## Verification

`pnpm check`, `pnpm typecheck` and `pnpm test` pass. `@opentag/server` 559/559.

New coverage: a registration nobody has finished is still alive ten minutes in — a perfectly ordinary pace for someone who has to find their phone. Reverting the constant to `60_000` fails it (`expected true to be false`), so the test pins the defect rather than the fix.

## Note for whoever lands opentag#353

That change decides which brand's domain a code is minted against, and it is correct on its own terms — but a first connect still cannot succeed until this lands. The two need to ship together before a real user gets through.
