### PR TITLE
docs(agents): document the migration count ratchet and integration gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,20 @@ depend on the public network, external providers, or a running PostgreSQL instan
 the root coverage configuration or investigating repository-wide coverage gaps; the scheduled `Unit Coverage` workflow
 owns the recurring baseline measurement.
 
+## Database migrations
+
+Adding a migration under `packages/server/drizzle` requires two extra steps, or CI fails even when
+`pnpm check` passes locally:
+
+- Bump `CURRENT_MIGRATION_COUNT` in `packages/server/src/__tests__/integration/setup-completion-backfill.test.ts`
+  by one. The constant is a deliberate ratchet over the migration journal; the migration drift check
+  in `pnpm check` does not cover it, only the PostgreSQL integration suite does.
+- Run `pnpm --filter @opentag/server test:integration` (Docker with testcontainers) before opening
+  the pull request.
+
+Two concurrent pull requests that each add a migration also collide on the migration number itself:
+whichever merges second must renumber its migration and journal entry, then bump the count again.
+
 ## Code and Git conventions
 
 - Use English for code, comments, GitHub files, and canonical repository documentation.


### PR DESCRIPTION
## Summary

Documents a CI gate that is easy to miss: adding a migration under `packages/server/drizzle`
requires bumping `CURRENT_MIGRATION_COUNT` in
`packages/server/src/__tests__/integration/setup-completion-backfill.test.ts`. The constant is a
deliberate ratchet over the migration journal, and neither `pnpm check`'s migration drift gate nor
the unit suites cover it — only the PostgreSQL integration suite does, so agents (and humans) that
verified with check/typecheck/build/test still fail CI.

Adds a "Database migrations" section to `AGENTS.md` stating the two extra steps (bump the ratchet,
run `pnpm --filter @opentag/server test:integration` before opening the PR) and the
concurrent-migration collision rule (the second PR to merge renumbers its migration and bumps the
count again).

Context: both migration-adding lanes of a recent dispatch run (#412, #414) passed every local gate
and then failed CI on exactly this assertion.

## Verification

- `pnpm check` — passed (docs-only change)

## Provenance

Written and published by the supervising orchestrator of dispatch-codex run `tknr8y` at the user's
request.
