### PR TITLE
fix(runtime): close Provider CLI post-merge acceptance gaps

### DIFF
--- a/docs/design/doctor-product-spec.md
+++ b/docs/design/doctor-product-spec.md
@@ -1,8 +1,8 @@
 # Doctor 产品需求与 P0 技术规格
 
-状态：提案
+状态：已实施（P0 基线及 Provider CLI 静态扩展）
 
-最后更新：2026-08-29
+最后更新：2026-09-01
 
 ## 1. 文档目的
 
@@ -70,7 +70,8 @@ type DoctorCheckScope =
   | "local-configuration"
   | "daemon-service"
   | "server"
-  | "agent-runtime";
+  | "agent-runtime"
+  | "provider-cli";
 
 interface DoctorCheck {
   code: string;
@@ -193,6 +194,8 @@ P0 只回答以下问题：
 3. 该 Home 记录的唯一 Server 是否通过公开 health endpoint 正常响应？
 4. 当前 CLI 诊断上下文能否找到至少一个受支持的本地 Agent Runtime CLI artifact，
    每个 artifact 从哪里找到？
+5. 当前操作系统账户下的 Feishu/Lark 与 Slack Provider CLI 是否已经存在有效的
+   account-global selection？
 
 第四项明确属于 **CLI 上下文中的安装观察**。它不能证明已安装 Daemon 拥有相同环境，
 也不能证明 Daemon 能执行该 artifact。输出必须明确说明这一点。
@@ -208,7 +211,7 @@ P0 决策如下：
 | Runtime 充分条件 | 至少安装一个受支持 Runtime | P0 没有权威的 Agent-to-Provider 分配视图；缺少其他 Provider 仍需展示，但不 blocking。 |
 | Runtime 观察权威 | 当前 CLI 上下文，并明确披露 | 准确判断已安装 Daemon 的 Provider 解析能力需要单独评审权威契约。 |
 | Runtime 认证 | 不检查 | 凭据存在、Provider 登录状态与可用的已认证执行是不同产品承诺。 |
-| Integration CLI | 不检查 | 尚未定义需要哪些 CLI、交互方式以及条件 blocking 策略。 |
+| Integration CLI | 只读报告 Feishu/Lark 与 Slack 的 account-global 安装选择，均为 non-blocking | Doctor 可以帮助定位第三方 CLI 安装状态，但不能从静态检查推断 active binding、凭证或真实 handoff readiness。 |
 | 自动修复 | 禁止 | 诊断必须保持安全、可重复和只读。 |
 
 ### 4.3 P0 Blocking 检查
@@ -329,6 +332,24 @@ app server、发起模型请求、安装 binary 或修改 Provider 配置。
 [#236](https://github.com/first-tree-ai/opentag/issues/236) 中的缺陷属于独立 Runtime
 正确性修复，不能成为 doctor 声称已检查 Claude Code 认证的理由。
 
+#### F. IM Provider CLI 静态安装状态
+
+Doctor 分别报告 Feishu/Lark CLI 与 Slack CLI 的 account-global selection。两项均为
+non-blocking：尚未绑定对应 IM provider 的账户不需要预先安装；active binding 对应的
+强制 readiness 由 Server 与 daemon 的 binding-driven reconcile 负责，不由 Doctor 推断。
+
+静态检查必须复用 `ProviderCliManager.inspect`，并遵守以下边界：
+
+- account home 只来自操作系统账户记录，不受调用方 `HOME`、`XDG_*` 或 `OPENTAG_HOME`
+  影响；调用方 `PATH` 只用于展示 global command shadowing，不决定已持久化 selection；
+- 允许执行既有 selection 的 bounded、无凭证 version/help probe；
+- 不得调用 `ensure`、下载或安装 artifact、创建/修复 launcher/shim、写入 selection；
+- 不得读取或投影 binding credential，不得调用 provider auth/message API；
+- `ready` 只表示本地 selection、fingerprint、launcher 与无凭证 probe 一致；不得表述为
+  credential、active binding 或 handoff ready；
+- 缺失 selection 显示为信息项；malformed、unsafe 或无法判断的状态保持可见，但不改变
+  P0 baseline 退出码。
+
 ### 4.4 必需输出
 
 人类可读报告采用固定 section 顺序，避免并发检查改变输出顺序：
@@ -338,8 +359,9 @@ app server、发起模型请求、安装 binary 或修改 Provider 配置。
 3. Daemon service
 4. Server
 5. Agent Runtime CLIs
-6. Summary
-7. Not evaluated
+6. IM Provider CLIs
+7. Summary
+8. Not evaluated
 
 示例结构如下。实际 CLI 文案保持英语：
 
@@ -358,6 +380,10 @@ Checks
   ✓ Codex CLI: installed at /Applications/ChatGPT.app/.../codex (desktop-app)
   - Claude Code CLI: not installed
 
+IM Provider CLIs
+  ✓ Lark CLI: managed 1.0.92 selected at /Users/alice/.opentag/provider-cli/...
+  - Slack CLI: not prepared for this account
+
 Baseline checks passed for this OpenTag Home.
 
 Not evaluated
@@ -365,7 +391,7 @@ Not evaluated
   - Agent Runtime version or protocol compatibility
   - Agent Runtime visibility from the installed daemon environment
   - machine-token authentication or WebSocket registration
-  - Integration CLI availability or authentication
+  - Integration CLI credential validity and active-binding readiness
   - end-to-end Turn or handoff delivery
 ```
 
@@ -401,6 +427,7 @@ apps/cli command
        -> existing CLI daemon service manager.status()
        -> client Server health checker
        -> client shared Runtime artifact resolver
+       -> client ProviderCliManager.inspect()
   -> apps/cli renderer
 ```
 
@@ -409,6 +436,7 @@ Doctor 可以并发协调检查，但依赖关系必须显式：
 - 先解析 target，再运行任何检查；
 - local configuration 与 Runtime artifact 检查可以相互独立地启动；
 - Daemon service status 不依赖 Server health；
+- Provider CLI 静态检查使用 account-global state，与 OpenTag Home 和 Server health 独立；
 - 只有解析出唯一权威 Server 后才启动 Server health；
 - renderer 等待所有独立检查结束，并按固定 section 顺序输出。
 
@@ -441,10 +469,13 @@ P0 check code 属于内部契约，也是未来 JSON 接口的基础：
 | `runtime.any-installed` | 是 | 至少找到一个受支持 Runtime artifact |
 | `runtime.codex.installation` | 否 | Codex artifact 观察结果 |
 | `runtime.claude-code.installation` | 否 | Claude Code artifact 观察结果 |
+| `provider-cli.feishu.installation` | 否 | Feishu/Lark account-global selection 观察结果 |
+| `provider-cli.slack.installation` | 否 | Slack account-global selection 观察结果 |
 
 ### 5.4 性能与安全预算
 
-- 不启动 Provider 子进程，不发起模型/API 请求。
+- Agent Runtime 检查不启动 Provider 子进程；Provider CLI 静态检查只允许 bounded、无凭证
+  version/help probe，不发起认证、消息、模型或其他 provider API 请求。
 - Server health deadline：5 秒。
 - Service manager 子进程使用既有显式 deadline。
 - 文件系统检查仅限当前 Home 和经过评审的安装根目录；不得递归扫描整个用户 Home。
@@ -477,6 +508,10 @@ P0 至少需要使用确定性测试覆盖以下场景：
 | 两个 Runtime 都未安装 | Runtime 汇总失败 |
 | 一个 Provider detector 报错，另一个找到 artifact | 仍报告已找到的 Provider；detector error 为 `unknown` |
 | Runtime 只从调用方 `PATH` 找到 | 来源标记为 `caller-path`；Daemon 可见性继续列为未检查 |
+| Provider CLI selection 缺失 | 对应 provider 显示 info；不 blocking，也不安装 |
+| Provider CLI selection ready | 显示 kind、version 与路径，但不声称凭证或 binding ready |
+| Provider CLI state malformed、unsafe 或 inspector 失败 | 显示 fail/unknown；不修复、不隐藏、不改变 baseline 退出码 |
+| Doctor 检查 Provider CLI | 不调用 `ensure`、不下载、不写 selection/launcher/shim、不调用 auth/message API |
 | 任意报告包含 credential | 测试失败 |
 | 所有 blocking P0 检查通过 | Exit `0`，并且只使用 baseline success 文案 |
 | 任意 blocking 检查失败或 unknown | Exit `1`，不得使用 readiness 文案 |
@@ -489,8 +524,8 @@ P0 至少需要使用确定性测试覆盖以下场景：
   ([#247](https://github.com/first-tree-ai/opentag/issues/247))；
 - Agent Runtime version 与 protocol compatibility；
 - 已安装 Daemon effective environment 内的权威 Provider resolution；
-- Integration CLI 的选择、安装、认证或交互
-  ([#248](https://github.com/first-tree-ai/opentag/issues/248))；
+- Integration CLI credential validity、active-binding readiness 的 Doctor 检查，以及任何
+  Doctor 主动安装/修复行为；
 - machine-token validation、WebSocket registration 或端到端 Turn/handoff delivery；
 - 自动安装、登录、重启、重新连接或修复；
 - 对外公开的 JSON 输出及其兼容性保证；
@@ -500,8 +535,9 @@ P0 至少需要使用确定性测试覆盖以下场景：
 
 ## 8. 对当前工作的影响
 
-OpenTag `main` 当前只实现调用方选择的 Server `/healthz` 检查，并接受 `--server-url` /
-`OPENTAG_SERVER_URL`。该行为不符合本规格。
+OpenTag `main` 已实现本文 P0 基线。后续 Provider CLI 产品集成又增加了本规格 F 节定义的
+non-blocking、只读 account-global installation 观察；它不改变 baseline 退出码，也不把
+credential 或 active-binding readiness 纳入 Doctor。
 
 PR [#246](https://github.com/first-tree-ai/opentag/pull/246) 在
 `1f241dc42097471e2e194a4efbf8fba8098ba00e` 上已将 Server 选择改为本地 enrollment，
@@ -516,8 +552,9 @@ PR [#246](https://github.com/first-tree-ai/opentag/pull/246) 在
 - 没有披露 Runtime detection 使用调用进程上下文；
 - 使用 `All required checks passed.` 作为汇总。
 
-后续实现应以本文作为 P0 source of truth，在合理情况下把共享 Runtime discovery 与 doctor
-presentation 拆分，并继续将 authentication 和 Integration 留在各自 follow-up issue 中。
+后续实现应以本文作为 Doctor source of truth，在合理情况下把共享 Runtime discovery 与 doctor
+presentation 拆分，并继续将 authentication、active-binding readiness 与修复行为留在
+binding-driven daemon 或各自 follow-up issue 中。
 Runtime discovery issue
 [#237](https://github.com/first-tree-ai/opentag/issues/237) 提供主要 artifact-resolution
 实现范围。Service manager issue #244 继续保持独立代码变更，但必须在 P0 service 结果

--- a/docs/direct-provider-cli.md
+++ b/docs/direct-provider-cli.md
@@ -9,6 +9,11 @@ authorized Turn receives OpenTag-projected credentials.
 
 OpenTag owns inbound IM routing, Integration credentials, temporary Client credential projection, and provider-native inbound references. It does not expose a message send, reply, Reaction, or upload API.
 
+An active Feishu/Lark or Slack binding is the requirement signal. The daemon may repair only the corresponding
+OpenTag-managed artifact and validates that exact CLI with the real bound credential before reporting it ready; it never
+replaces an external installation or foreign shim. `opentag doctor` and the portable installer only report static
+account-global installation state. They do not install, repair, validate credentials, or infer login/subscription state.
+
 For every valid visible Session Turn that may write to IM, including an IM delivery or an internal-collaboration callback,
 the Client creates a private `0600` environment file and passes only its path as `OPENTAG_PROVIDER_ENV_FILE`. The Agent
 sources that file and calls the official `lark-cli` or `slack api` command directly. The file is removed when the Turn

--- a/docs/zh-CN/direct-provider-cli.md
+++ b/docs/zh-CN/direct-provider-cli.md
@@ -8,6 +8,11 @@ Turn 才会取得 OpenTag 投影的临时凭证。
 
 OpenTag 负责 IM 入站路由、Integration 凭证、Client 临时凭证投影和 provider 原生入站引用，不提供消息发送、回复、Reaction 或上传 API。
 
+有效的 Feishu/Lark 或 Slack binding 才会产生对应依赖。Daemon 只可修复该 binding 所需的
+OpenTag-managed artifact，并在上报 ready 前用真实 binding 凭证验证同一个精确 CLI；不得替换
+外部安装或非 OpenTag shim。`opentag doctor` 与 portable installer 只报告 account-global
+静态安装状态，不安装、不修复、不验证凭证，也不推断登录或订阅状态。
+
 每个可以写入 IM 的有效可见 Session Turn（包括 IM delivery 与 Internal Session 协作回调）开始前，Client 创建私有的
 `0600` 环境文件，只通过 `OPENTAG_PROVIDER_ENV_FILE` 把文件路径交给 Agent。Agent source 该文件后直接调用官方
 `lark-cli` 或 `slack api`。Turn 完成时删除文件；若删除失败，会在 Session 或 Client 关闭时重试；Client 崩溃留下的

--- a/packages/client/src/__tests__/client-runtime-composition.test.ts
+++ b/packages/client/src/__tests__/client-runtime-composition.test.ts
@@ -3,7 +3,7 @@ import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } fro
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { homedir, tmpdir } from "node:os";
-import { delimiter, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   type DirectImMessageDeliveryRequest,
@@ -25,11 +25,9 @@ import {
   createClientRuntimeHandlers,
   createClientRuntimePreflight,
   createLoginShellDiscovery,
-  refreshImCliReadiness,
   resolveCodexHome,
   resolvedClaudeCodeFactory,
   resolvedCodexFactory,
-  resolveExecutable,
 } from "../runtime/client-runtime-composition.js";
 import { resetLoginShellPathDirsCache } from "../runtime/login-shell-path.js";
 import { RuntimeConnection } from "../runtime/runtime-connection.js";
@@ -73,99 +71,9 @@ describe("createClientRuntime production composition", () => {
     expect(includeLoginShell()).toBe(true);
   });
 
-  it("probes Feishu and Slack CLI readiness independently from Agent Runtime providers", async () => {
-    const home = await temporaryDirectory("opentag-im-cli-readiness-");
-    const lark = resolve(home, "lark-cli");
-    const slack = resolve(home, "slack");
-    const brokenSlack = resolve(home, "broken-slack");
-    await writeFile(
-      lark,
-      '#!/bin/sh\nif [ "$1" = "--version" ] || { [ "$1" = "im" ] && [ "$2" = "--help" ]; }; then exit 0; fi\nexit 1\n',
-      "utf8",
-    );
-    await writeFile(
-      slack,
-      '#!/bin/sh\nif [ "$1" = "version" ] || { [ "$1" = "api" ] && [ "$2" = "--help" ]; }; then exit 0; fi\nexit 1\n',
-      "utf8",
-    );
-    await writeFile(brokenSlack, "#!/bin/sh\nexit 1\n", "utf8");
-    await Promise.all([chmod(lark, 0o700), chmod(slack, 0o700), chmod(brokenSlack, 0o700)]);
-    const setImCliReadiness = vi.fn();
-
-    await refreshImCliReadiness({ setImCliReadiness } as never, "feishu", lark, {});
-    await refreshImCliReadiness({ setImCliReadiness } as never, "slack", slack, {});
-    await refreshImCliReadiness({ setImCliReadiness } as never, "slack", brokenSlack, {});
-    await refreshImCliReadiness({ setImCliReadiness } as never, "slack", resolve(home, "missing"), {});
-
-    expect(setImCliReadiness.mock.calls.map(([observation]) => observation)).toEqual([
-      { provider: "feishu", status: "checking" },
-      { provider: "feishu", status: "ready" },
-      { provider: "slack", status: "checking" },
-      { provider: "slack", status: "ready" },
-      { provider: "slack", status: "checking" },
-      { provider: "slack", status: "unavailable" },
-      { provider: "slack", status: "checking" },
-      { provider: "slack", status: "install" },
-    ]);
-
-    const abortedBeforeStart = new AbortController();
-    abortedBeforeStart.abort(new Error("stop before IM probe"));
-    await refreshImCliReadiness({ setImCliReadiness } as never, "feishu", lark, {}, abortedBeforeStart.signal);
-    expect(setImCliReadiness).toHaveBeenCalledTimes(8);
-
-    const abortAfterChecking = new AbortController();
-    const checkingUpdates = vi.fn((observation: { status: string }) => {
-      if (observation.status === "checking") abortAfterChecking.abort(new Error("stop after checking"));
-    });
-    await refreshImCliReadiness(
-      { setImCliReadiness: checkingUpdates } as never,
-      "feishu",
-      lark,
-      {},
-      abortAfterChecking.signal,
-    );
-    expect(checkingUpdates.mock.calls.map(([observation]) => observation)).toEqual([
-      { provider: "feishu", status: "checking" },
-    ]);
-
-    const slowLark = resolve(home, "slow-lark");
-    await writeFile(slowLark, "#!/bin/sh\nsleep 1\nexit 0\n", "utf8");
-    await chmod(slowLark, 0o700);
-    const abortDuringProbe = new AbortController();
-    const inFlightUpdates = vi.fn();
-    const inFlight = refreshImCliReadiness(
-      { setImCliReadiness: inFlightUpdates } as never,
-      "feishu",
-      slowLark,
-      {},
-      abortDuringProbe.signal,
-    );
-    await vi.waitFor(() => expect(inFlightUpdates).toHaveBeenCalledWith({ provider: "feishu", status: "checking" }));
-    abortDuringProbe.abort(new Error("stop during IM probe"));
-    await inFlight;
-    expect(inFlightUpdates).toHaveBeenCalledTimes(1);
-
-    let abortedReads = 0;
-    const abortAfterProbe = {
-      get aborted() {
-        abortedReads += 1;
-        return abortedReads >= 3;
-      },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    } as unknown as AbortSignal;
-    const postProbeUpdates = vi.fn();
-    await refreshImCliReadiness({ setImCliReadiness: postProbeUpdates } as never, "feishu", lark, {}, abortAfterProbe);
-    expect(postProbeUpdates.mock.calls.map(([observation]) => observation)).toEqual([
-      { provider: "feishu", status: "checking" },
-    ]);
-    expect(abortAfterProbe.addEventListener).toHaveBeenCalledOnce();
-    expect(abortAfterProbe.removeEventListener).toHaveBeenCalledOnce();
-  });
-
   it("does not publish ambient PATH IM CLI readiness from production composition", async () => {
     const home = await temporaryDirectory("opentag-im-cli-no-path-");
-    const { lark, slack } = await writeReadyImClis(home);
+    await writeReadyImClis(home);
     const connection = runtimeConnection();
     const imUpdates = vi.spyOn(connection, "setImCliReadiness");
     const runtime = await createClientRuntime(connection, {
@@ -173,8 +81,6 @@ describe("createClientRuntime production composition", () => {
       environment: { HOME: home, PATH: `${home}:${process.env.PATH ?? ""}` },
       factories: [readyFactory("codex", async () => ({ ready: true, issues: [] }))],
       home,
-      larkCliCommand: lark,
-      slackCliCommand: slack,
     });
     runtime.stop();
     expect(imUpdates).not.toHaveBeenCalled();
@@ -402,25 +308,10 @@ describe("createClientRuntime production composition", () => {
     defaultEnvironment.stop();
   });
 
-  it("tests executable resolution and the resolved factory readiness fence without a shell", async () => {
+  it("tests the resolved factory readiness fence without a shell", async () => {
     const home = await temporaryDirectory("opentag-client-executable-");
     const empty = resolve(home, "empty");
-    const bin = resolve(home, "bin");
     await mkdir(empty);
-    await mkdir(bin);
-    const command = resolve(bin, "codex-fixture");
-    await writeFile(command, "#!/bin/sh\nexit 0\n", "utf8");
-    await chmod(command, 0o755);
-    const canonicalCommand = await realpath(command);
-    await expect(resolveExecutable(command, {})).resolves.toBe(canonicalCommand);
-    await expect(resolveExecutable("codex-fixture", { PATH: `${delimiter}${empty}${delimiter}${bin}` })).resolves.toBe(
-      canonicalCommand,
-    );
-    await expect(resolveExecutable("missing", {})).rejects.toThrow("PATH is unavailable");
-    await expect(resolveExecutable("missing", { PATH: empty })).rejects.toThrow(
-      "compatible Agent Runtime provider executable",
-    );
-
     const factory = resolvedCodexFactory({
       clientVersion: "0.0.1",
       codexHome: home,
@@ -450,8 +341,6 @@ describe("createClientRuntime production composition", () => {
       codexCommand: "codex",
       environment: { HOME: home, PATH: empty, SHELL: fakeShell },
       home,
-      larkCliCommand: resolve(empty, "missing-lark"),
-      slackCliCommand: resolve(empty, "missing-slack"),
     });
     runtime.stop();
     await expect(readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
@@ -480,8 +369,6 @@ printf '__OT_SHELL_PATH____OT_SHELL_PATH____OT_SHELL_ENV__\n\n__OT_SHELL_ENV__'
       codexCommand: "opentag-missing-codex-post-connect",
       environment: { HOME: home, PATH: empty, SHELL: fakeShell },
       home,
-      larkCliCommand: resolve(empty, "missing-lark"),
-      slackCliCommand: resolve(empty, "missing-slack"),
     });
     await expect(readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await expect(
@@ -1118,7 +1005,6 @@ printf '__OT_SHELL_PATH____OT_SHELL_PATH____OT_SHELL_ENV__\n\n__OT_SHELL_ENV__'
 
   it("recovers other Provider and IM readiness when one periodic probe never settles", async () => {
     const home = await temporaryDirectory("opentag-client-hung-probe-");
-    const { lark, slack } = await writeReadyImClis(home);
     const server = await runtimeServer();
     cleanup.push(server.close);
     let currentTime = Date.now();
@@ -1181,8 +1067,6 @@ printf '__OT_SHELL_PATH____OT_SHELL_PATH____OT_SHELL_ENV__\n\n__OT_SHELL_ENV__'
       environment: { HOME: home, PATH: process.env.PATH },
       factories: [readyFactory("codex", codexProbe), readyFactory("claude-code", claudeProbe)],
       home,
-      larkCliCommand: lark,
-      slackCliCommand: slack,
     });
     expect(codexProbe).toHaveBeenCalledOnce();
     expect(claudeProbe).toHaveBeenCalledOnce();
@@ -1245,7 +1129,6 @@ printf '__OT_SHELL_PATH____OT_SHELL_PATH____OT_SHELL_ENV__\n\n__OT_SHELL_ENV__'
 
   it("settles shutdown without publishing late hung-probe results", async () => {
     const home = await temporaryDirectory("opentag-client-hung-stop-");
-    const { lark, slack } = await writeReadyImClis(home);
     const server = await runtimeServer();
     cleanup.push(server.close);
     const connection = runtimeConnection(server.url);
@@ -1301,8 +1184,6 @@ printf '__OT_SHELL_PATH____OT_SHELL_PATH____OT_SHELL_ENV__\n\n__OT_SHELL_ENV__'
       environment: { HOME: home, PATH: process.env.PATH },
       factory: countingFactory,
       home,
-      larkCliCommand: lark,
-      slackCliCommand: slack,
     });
     const running = runtime.run();
     await started;
@@ -2125,8 +2006,6 @@ async function composeClaudeCodeRuntime(options: {
     codexCommand: resolve(options.home, "missing-codex"),
     environment: options.environment,
     home: options.home,
-    larkCliCommand: resolve(options.home, "missing-lark"),
-    slackCliCommand: resolve(options.home, "missing-slack"),
   });
   return { capture: await readFile(capturePath, "utf8"), runtime };
 }

--- a/packages/client/src/__tests__/provider-cli-reconciler.test.ts
+++ b/packages/client/src/__tests__/provider-cli-reconciler.test.ts
@@ -307,6 +307,45 @@ describe("provider CLI reconciler", () => {
     ).toEqual(["11111111-1111-4111-8111-111111111111", "77777777-7777-4777-8777-777777777777"].sort());
   });
 
+  it("joins an in-flight managed repair before close and validation cleanup settle", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const inspect = vi
+      .fn()
+      .mockResolvedValueOnce({ readiness: "install", diagnostic: { code: "not_installed" } })
+      .mockResolvedValue(fixture.inspection);
+    const ensure = vi.fn(async () => {
+      await gate;
+      return { ok: true, action: "installed-managed" } as never;
+    });
+    const cleanupAll = vi.fn(async () => undefined);
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure, layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll },
+    });
+
+    const handling = runtime.emit(requirement);
+    await vi.waitFor(() => expect(ensure).toHaveBeenCalledOnce());
+    const closing = reconciler.close();
+    let settled = false;
+    void closing.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(cleanupAll).not.toHaveBeenCalled();
+
+    release();
+    await Promise.all([handling, closing]);
+    expect(cleanupAll).toHaveBeenCalledOnce();
+    expect(runtime.send.mock.calls.some((call) => call[0].status === "ready")).toBe(false);
+  });
+
   it("rejects stale, duplicate, and expired grants before spawning validation", async () => {
     const runtime = connection();
     const fixture = await externalReadyFixture();

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -1,16 +1,12 @@
-import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { constants } from "node:fs";
-import { access, mkdir, realpath } from "node:fs/promises";
+import { mkdir, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
-import { delimiter, isAbsolute, join, resolve } from "node:path";
-import { promisify } from "node:util";
+import { delimiter, join, resolve } from "node:path";
 import {
   type AgentRuntimeProvider,
   computeRuntimeSnapshotHashes,
   RUNTIME_CAPABILITY,
   RUNTIME_CLIENT_CAPABILITY_TTL_MS,
-  type RuntimeImCliReadinessObservation,
   type RuntimeProviderReadinessObservation,
 } from "@opentag/shared";
 import type {
@@ -80,7 +76,6 @@ import { TurnReportOwner } from "./turn-report-owner.js";
 
 const DEFAULT_CAPABILITY_REFRESH_INTERVAL_MS = Math.floor(RUNTIME_CLIENT_CAPABILITY_TTL_MS / 2);
 const DEFAULT_PROVIDER_PROBE_DEADLINE_MS = 10_000;
-const execFileAsync = promisify(execFile);
 
 interface SharedProviderRefresh {
   readonly controller: AbortController;
@@ -255,8 +250,6 @@ export interface CreateClientRuntimeOptions {
   readonly codexHome?: string;
   readonly claudeCodeCommand?: string;
   readonly claudeCodeHome?: string;
-  readonly larkCliCommand?: string;
-  readonly slackCliCommand?: string;
   readonly cliCommand?: string;
   readonly environment?: NodeJS.ProcessEnv;
   readonly factory?: AgentRuntimeFactory;
@@ -726,56 +719,6 @@ export function providerReadiness(
   return { provider, status: "unavailable" };
 }
 
-export async function refreshImCliReadiness(
-  connection: Pick<RuntimeConnection, "setImCliReadiness">,
-  provider: RuntimeImCliReadinessObservation["provider"],
-  configuredCommand: string,
-  environment: NodeJS.ProcessEnv,
-  signal?: AbortSignal,
-): Promise<void> {
-  if (signal?.aborted) return;
-  connection.setImCliReadiness({ provider, status: "checking" });
-  const probe = (async () => {
-    let command: string;
-    try {
-      command = await resolveExecutable(configuredCommand, environment);
-    } catch {
-      return "install" as const;
-    }
-    const execution = { env: environment, signal, timeout: 10_000, windowsHide: true } as const;
-    try {
-      if (provider === "feishu") {
-        await execFileAsync(command, ["--version"], execution);
-        await execFileAsync(command, ["im", "--help"], execution);
-      } else {
-        await execFileAsync(command, ["version"], execution);
-        await execFileAsync(command, ["api", "--help"], execution);
-      }
-      return "ready" as const;
-    } catch {
-      return "unavailable" as const;
-    }
-  })();
-  let onAbort: (() => void) | undefined;
-  const status = await (signal
-    ? Promise.race([
-        probe,
-        new Promise<"aborted">((resolve) => {
-          if (signal.aborted) {
-            resolve("aborted");
-            return;
-          }
-          onAbort = () => resolve("aborted");
-          signal.addEventListener("abort", onAbort, { once: true });
-        }),
-      ]).finally(() => {
-        if (onAbort) signal.removeEventListener("abort", onAbort);
-      })
-    : probe);
-  if (status === "aborted" || signal?.aborted) return;
-  connection.setImCliReadiness({ provider, status });
-}
-
 export interface ResolvedCodexFactoryOptions {
   readonly clientVersion: string;
   readonly codexHome: string;
@@ -1016,30 +959,6 @@ function requireReadyClaudeCodeFactory(
 
 export function resolveCodexHome(environment: NodeJS.ProcessEnv = process.env): string {
   return resolve(environment.CODEX_HOME ?? join(environment.HOME ?? homedir(), ".codex"));
-}
-
-export async function resolveExecutable(command: string, environment: NodeJS.ProcessEnv): Promise<string> {
-  if (isAbsolute(command)) {
-    await access(command, constants.X_OK);
-    return realpath(command);
-  }
-  const path = environment.PATH;
-  if (!path) throw new Error("PATH is unavailable while locating an Agent Runtime provider");
-  /* v8 ignore next -- executable suffix probing is a Windows-only branch. */
-  const extensions = process.platform === "win32" ? (environment.PATHEXT ?? ".EXE;.CMD;.BAT").split(";") : [""];
-  for (const directory of path.split(delimiter)) {
-    if (!directory) continue;
-    for (const extension of extensions) {
-      const candidate = join(directory, `${command}${extension}`);
-      try {
-        await access(candidate, constants.X_OK);
-        return await realpath(candidate);
-      } catch {
-        // Continue through the explicit PATH allowlist.
-      }
-    }
-  }
-  throw new Error("A compatible Agent Runtime provider executable is unavailable");
 }
 
 interface ClientRuntimePreflightDependencies {

--- a/packages/client/src/runtime/provider-cli/reconciler.ts
+++ b/packages/client/src/runtime/provider-cli/reconciler.ts
@@ -55,11 +55,13 @@ export class ProviderCliReconciler {
   readonly #grants = new Map<string, GrantState>();
   readonly #manager: ProviderCliReconcilerOptions["manager"];
   readonly #now: () => number;
+  readonly #frameJobs = new Set<Promise<void>>();
   readonly #providerJobs = new Map<ProviderCliProvider, Promise<ProviderCliArtifactStatusFrame["status"]>>();
   readonly #readySelection = new Map<ProviderCliProvider, ProviderCliReadySelection>();
   readonly #signal?: AbortSignal;
   readonly #unsubscribe: () => void;
   readonly #validation: ProviderCliReconcilerOptions["validation"];
+  #closePromise?: Promise<void>;
   #closed = false;
 
   constructor(options: ProviderCliReconcilerOptions) {
@@ -68,15 +70,28 @@ export class ProviderCliReconciler {
     this.#now = options.now ?? Date.now;
     this.#signal = options.signal;
     this.#validation = options.validation;
-    this.#unsubscribe = this.#connection.subscribeBusinessFrames((frame) => this.#handleFrame(frame));
+    this.#unsubscribe = this.#connection.subscribeBusinessFrames((frame) => this.#trackFrame(frame));
   }
 
-  async close(): Promise<void> {
-    if (this.#closed) return;
+  close(): Promise<void> {
+    this.#closePromise ??= this.#performClose();
+    return this.#closePromise;
+  }
+
+  async #performClose(): Promise<void> {
     this.#closed = true;
     this.#unsubscribe();
     this.#abortAll();
+    await Promise.allSettled([...this.#frameJobs]);
     await this.#validation.cleanupAll();
+  }
+
+  #trackFrame(frame: RuntimeBusinessFrame): Promise<void> {
+    const job = this.#handleFrame(frame).finally(() => {
+      this.#frameJobs.delete(job);
+    });
+    this.#frameJobs.add(job);
+    return job;
   }
 
   /**

--- a/packages/server/src/__tests__/im-binding-api.test.ts
+++ b/packages/server/src/__tests__/im-binding-api.test.ts
@@ -1040,6 +1040,13 @@ describe("ImBindingService persistence", () => {
       agentId: agent.id,
       workspaceComputerId: workspaceComputer.id,
     });
+    const slack = await service.activateSlack(slackInput(agent.id), "B1");
+    changed.mockClear();
+    await expect(service.requireReauthorization(slack.imBindingId, 1, "SLACK_TOKEN_REVOKED")).resolves.toBe(true);
+    expect(changed).toHaveBeenCalledWith({
+      agentId: agent.id,
+      workspaceComputerId: workspaceComputer.id,
+    });
   });
 
   it("fails closed when Provider CLI observation callbacks are omitted", async () => {

--- a/packages/server/src/services/im-bindings/im-binding-service.ts
+++ b/packages/server/src/services/im-bindings/im-binding-service.ts
@@ -1085,7 +1085,7 @@ export class ImBindingService {
   ): Promise<boolean> {
     const now = this.#now();
     const lastErrorCode = errorCode.slice(0, 120);
-    return this.#database.transaction(async (transaction) => {
+    const result = await this.#database.transaction(async (transaction) => {
       const [updated] = await transaction
         .update(slackInstallations)
         .set({ status: "reauthorization_required", lastErrorCode, updatedAt: now })
@@ -1096,8 +1096,8 @@ export class ImBindingService {
             eq(slackInstallations.credentialGeneration, generation),
           ),
         )
-        .returning({ id: slackInstallations.id });
-      if (!updated) return false;
+        .returning({ agentId: slackInstallations.agentId });
+      if (!updated) return { agentId: undefined, changed: false };
       await transaction
         .update(imBindings)
         .set({ status: "reauthorization_required", lastErrorCode, updatedAt: now })
@@ -1108,8 +1108,12 @@ export class ImBindingService {
             eq(imBindings.status, "active"),
           ),
         );
-      return true;
+      return { agentId: updated.agentId, changed: true };
     });
+    if (result.changed && result.agentId) {
+      await this.#notifyActiveBindingChanged(result.agentId).catch(() => undefined);
+    }
+    return result.changed;
   }
 
   async disableSlackInstallationFromProvider(installationId: string, generation: number): Promise<boolean> {


### PR DESCRIPTION
## 背景

PR #421 已合入后补做独立的对抗性审查、代码验收与本地测试。本 PR 仅修复验收发现的缺口，不扩展 Provider CLI 产品范围。

## 修复

- Daemon 关闭时加入所有已接收的 Provider CLI reconcile/validation frame，等待在途任务结束后再清理临时凭证。
- Slack token 被判定为 reauthorization_required 后，提交事务再通知 binding-driven reconcile owner，立即撤销对应 requirement/grant。
- 删除 #255 要求淘汰的 legacy PATH-only IM CLI 探测、resolveExecutable 以及无效 lark/slack command option。
- 将 Doctor source of truth 对齐现状：只读、non-blocking 地报告 account-global Provider CLI 静态安装状态；不安装、不修复、不验证凭证。

## 独立验收

- pnpm check
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm --filter @opentag/client test:agent-runtime:coverage
- pnpm --filter @opentag/server test:integration
- pnpm test:e2e:doctor-docker
- Provider CLI 专项：Client 172、运行时/凭证环境 51、CLI 54、Server 62，全部通过
- Docker doctor：26/26 真实场景通过
- 一次性 Linux/arm64 容器从官方 catalog 实际下载并验证 lark-cli 1.0.92 与 slack 4.7.0，均 catalog-verified 且 ready

未使用真实用户 binding credential；凭证有效性由已有确定性测试覆盖，本 PR 不把无凭证环境伪装成真实账户验收。