### PR TITLE
fix(web): align usage navigation and filters

### DIFF
--- a/apps/web/messages/usage/en.json
+++ b/apps/web/messages/usage/en.json
@@ -28,7 +28,7 @@
   "usage_retry": "Try again",
   "usage_title": "Usage",
   "usage_trend_title": "Token usage over time",
-  "usage_view_details": "View details",
+  "usage_view_usage": "View Usage",
   "usage_window_24_hours": "Last 24 hours",
   "usage_window_days": "Last {days} days"
 }

--- a/apps/web/messages/usage/zh.json
+++ b/apps/web/messages/usage/zh.json
@@ -28,7 +28,7 @@
   "usage_retry": "重试",
   "usage_title": "用量",
   "usage_trend_title": "Token 用量趋势",
-  "usage_view_details": "查看详情",
+  "usage_view_usage": "查看用量",
   "usage_window_24_hours": "过去 24 小时",
   "usage_window_days": "过去 {days} 天"
 }

--- a/apps/web/src/__tests__/agent-home.test.tsx
+++ b/apps/web/src/__tests__/agent-home.test.tsx
@@ -15,7 +15,7 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("heading", { name: "Usage" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Tasks" })).toBeTruthy();
     expect(await screen.findByRole("link", { name: "Investigate the failed deployment" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "View details" }).getAttribute("href")).toBe(`/agents/${agentId}/usage`);
+    expect(screen.getByRole("link", { name: "View Usage" }).getAttribute("href")).toBe(`/agents/${agentId}/usage`);
     /*
      * Status sits beside Usage without adding another visible card title. Its two rows name the
      * execution environment and messaging dependency directly, so Settings remains the header's only trailing
@@ -53,10 +53,27 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByText(/Managed by/)).toBeNull();
   });
 
-  it.each([
-    ["View details", "Usage"],
-    ["Settings", "Agent settings"],
-  ])("keeps Agent context visible while opening %s", async (linkName, destinationHeading) => {
+  it("opens Usage as a sibling Agent section without rereading the full Agent detail", async () => {
+    let agentReads = 0;
+    installApi({
+      agentRead: () => {
+        agentReads += 1;
+      },
+      bound: true,
+    });
+    window.history.replaceState({}, "", `/agents/${agentId}`);
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: "View Usage" }));
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Usage" })).toBeTruthy();
+    expect(agentReads).toBe(1);
+    const agentNavigation = screen.getByRole("navigation", { name: "Agent" });
+    expect(within(agentNavigation).getByRole("button", { name: "Usage" }).getAttribute("aria-current")).toBe("page");
+  });
+
+  it("keeps Agent context visible while opening Settings", async () => {
     let agentReads = 0;
     let releaseAgentRead = () => {};
     const pendingAgentRead = new Promise<void>((resolve) => {
@@ -73,9 +90,9 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("link", { name: linkName }));
+    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
 
-    expect(await screen.findByRole("heading", { name: destinationHeading })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Agent settings" })).toBeTruthy();
     expect(screen.queryByRole("navigation", { name: "Account Agents" })).toBeNull();
     await waitFor(() => expect(agentReads).toBe(2));
     expect(screen.queryByLabelText("Loading current server state")).toBeNull();
@@ -95,8 +112,8 @@ describe("OpenTag Web App Shell", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("link", { name: "View details" }));
-    expect(await screen.findByRole("heading", { name: "Usage" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
+    expect(await screen.findByRole("heading", { name: "Agent settings" })).toBeTruthy();
     await waitFor(() => expect(agentReads).toBe(2));
     expect((await screen.findByRole("alert")).textContent).toContain("Agent unavailable");
     expect(screen.queryByRole("heading", { name: "Reviewer" })).toBeNull();

--- a/apps/web/src/__tests__/agent-usage.test.tsx
+++ b/apps/web/src/__tests__/agent-usage.test.tsx
@@ -11,7 +11,8 @@ describe("OpenTag Web App Shell", () => {
     window.history.replaceState({}, "", `/agents/${agentId}/usage`);
     render(<App />);
 
-    expect(await screen.findByRole("heading", { name: "Usage" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { level: 1, name: "Usage" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Reviewer" })).toBeNull();
     expect(await screen.findByRole("img", { name: /428K Tokens used · Last 30 days/ })).toBeTruthy();
     expect(screen.getByText("Total tokens")).toBeTruthy();
     expect(screen.queryByText("Failed Tasks")).toBeNull();

--- a/apps/web/src/__tests__/app-shell.test.tsx
+++ b/apps/web/src/__tests__/app-shell.test.tsx
@@ -62,6 +62,9 @@ describe("OpenTag Web App Shell", () => {
     const accountAgentsNavigation = screen.getByRole("navigation", { name: "Account Agents" });
     const backToAgents = within(accountAgentsNavigation).getByRole("link", { name: "Agents" });
     expect(backToAgents.getAttribute("href")).toBe("/agents");
+    const mobileAgentHome = document.querySelector('[data-ui="agent-mobile-home"]');
+    expect(mobileAgentHome?.textContent).toContain("Reviewer");
+    expect(mobileAgentHome?.getAttribute("href")).toBe(`/agents/${agentId}`);
     const switcher = screen.getByRole("button", { name: "Switch Agent, current Agent Reviewer" });
     expect(switcher.closest('[data-sidebar="header"]')).toBeTruthy();
     const workspaceNavigation = screen.getByRole("navigation", { name: "Agent" });

--- a/apps/web/src/features/agent-usage.test.tsx
+++ b/apps/web/src/features/agent-usage.test.tsx
@@ -50,6 +50,7 @@ describe("AgentUsageOverview", () => {
 
     await renderInRouter(<AgentUsageTab agentId="agent-1" />);
 
+    expect(screen.getByRole("heading", { level: 1, name: "Usage" })).toBeTruthy();
     expect(await screen.findByRole("heading", { name: "Token usage over time" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Token breakdown" })).toBeTruthy();
     expect(screen.getByRole("combobox", { name: "Usage period" }).textContent).toBe("Last 30 days");
@@ -72,6 +73,10 @@ describe("AgentUsageOverview", () => {
     expect(await screen.findByText("Partial data")).toBeTruthy();
     expect(screen.getAllByText("Partial data")).toHaveLength(1);
     expect(loadUsage).toHaveBeenCalledTimes(1);
+    for (const period of screen.getAllByRole("combobox", { name: "Usage period" })) {
+      expect(period.classList.contains("w-full")).toBe(true);
+      expect(period.closest(".ml-auto")).toBeTruthy();
+    }
   });
 
   it("keeps the failure reason visible and retries the same usage request", async () => {

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -8,6 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { type ComponentProps, lazy, Suspense, useCallback, useState } from "react";
 import { browserApi } from "../api.js";
+import { PageHeader } from "../components/kumo/page-header/page-header.js";
 import { formatCompactNumber, formatDay, formatNumber, formatPercent } from "../i18n/format.js";
 import * as m from "../paraglide/messages.js";
 import { queryKeys } from "../query/keys.js";
@@ -24,7 +25,6 @@ import {
   Text,
   TimeseriesChart,
 } from "../ui/design-system.js";
-import type { AgentDetailView } from "./agents/agent-model.js";
 import { isTerminalResourceError } from "./resource/resource-state.js";
 
 const LazyTimeseriesChart = lazy(async () => {
@@ -48,14 +48,7 @@ export function usageWindowLabel(days: AgentUsageWindowDays): string {
   return days === 1 ? m.usage_window_24_hours() : m.usage_window_days({ days });
 }
 
-export function AgentUsageOverview({
-  agent,
-  agentId,
-}: {
-  /** Carried into history state so the usage page opens with the Agent already on screen. */
-  agent?: AgentDetailView;
-  agentId: string;
-}) {
+export function AgentUsageOverview({ agentId }: { agentId: string }) {
   const [windowDays, setWindowDays] = useState<AgentUsageWindowDays>(AGENT_USAGE_WINDOW_DAYS);
   const { retry, state } = useAgentUsage(agentId, windowDays);
   return (
@@ -75,10 +68,9 @@ export function AgentUsageOverview({
       <Link
         className="inline-flex items-center justify-self-end gap-1 text-sm text-kumo-link"
         params={{ agentId }}
-        state={{ agent }}
         to="/agents/$agentId/usage"
       >
-        {m.usage_view_details()}
+        {m.usage_view_usage()}
         <Icon className="size-3.5" name="chevron-right" />
       </Link>
     </LayerCard>
@@ -95,9 +87,10 @@ function UsageWindowSelect({
   value: AgentUsageWindowDays;
 }) {
   return (
-    <div className="w-40 shrink-0">
+    <div className="ml-auto w-40 shrink-0">
       <Select
         aria-label={m.usage_period_label()}
+        className="w-full"
         renderValue={(days) => usageWindowLabel(days)}
         size="sm"
         value={value}
@@ -120,17 +113,9 @@ export function AgentUsageTab({ agentId }: { agentId: string }) {
   const { retry, state } = useAgentUsage(agentId, windowDays);
   return (
     <div className="grid gap-6" data-ui="usage-tab">
-      <div className="flex flex-wrap items-end justify-between gap-4" data-ui="usage-toolbar">
-        <div className="grid max-w-prose gap-1">
-          <Text as="h2" id="agent-usage-page-heading" variant="heading">
-            {m.usage_title()}
-          </Text>
-          <Text as="p" variant="secondary">
-            {m.usage_description()}
-          </Text>
-        </div>
+      <PageHeader description={m.usage_description()} title={m.usage_title()} titleId="agent-usage-page-heading">
         <UsageWindowSelect options={AGENT_USAGE_WINDOW_OPTIONS} value={windowDays} onChange={setWindowDays} />
-      </div>
+      </PageHeader>
       <UsageSummaryState state={state} onRetry={retry} />
     </div>
   );

--- a/apps/web/src/features/agents/agent-detail-page.tsx
+++ b/apps/web/src/features/agents/agent-detail-page.tsx
@@ -34,7 +34,7 @@ export function AgentDetailPage({ agentId }: { agentId: string }) {
              * dependency belongs beside the work it is stopping rather than in a banner above it.
              */}
             <div className="grid gap-6 @min-[48rem]/workspace:grid-cols-2">
-              <AgentUsageOverview agent={agent} agentId={agent.id} />
+              <AgentUsageOverview agentId={agent.id} />
               <AgentStatusCard agent={agent} />
             </div>
             <AgentTasksSection agentId={agent.id} />

--- a/apps/web/src/features/agents/agent-usage-page.tsx
+++ b/apps/web/src/features/agents/agent-usage-page.tsx
@@ -1,21 +1,5 @@
-import { useRouterState } from "@tanstack/react-router";
 import { AgentUsageTab } from "../../features/agent-usage.js";
-import { AsyncState } from "../resource/resource-state.js";
-import { AgentObjectHeader } from "./agent-detail-page.js";
-import { useAgentDetailView } from "./agent-queries.js";
 
 export function AgentUsagePage({ agentId }: { agentId: string }) {
-  const routeState = useRouterState({ select: (state) => state.location.state });
-  const initialAgent = routeState.agent?.id === agentId ? routeState.agent : undefined;
-  const state = useAgentDetailView(agentId, { initialAgent });
-  return (
-    <AsyncState state={state}>
-      {(agent) => (
-        <section className="grid gap-6">
-          <AgentObjectHeader agent={agent} backToSettings />
-          <AgentUsageTab agentId={agent.id} />
-        </section>
-      )}
-    </AsyncState>
-  );
+  return <AgentUsageTab agentId={agentId} />;
 }

--- a/apps/web/src/features/shell/agent-shell.tsx
+++ b/apps/web/src/features/shell/agent-shell.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
+import { Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { type ReactNode, useSyncExternalStore } from "react";
 import { initials } from "../../i18n/format.js";
 import * as m from "../../paraglide/messages.js";
@@ -176,9 +176,14 @@ function AgentShellContent({
       </Sidebar>
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-kumo-canvas md:ml-2" data-ui="app-main">
         <header className="app-mobile-header shrink-0 items-center justify-between border-b border-kumo-line bg-kumo-base px-4 py-3">
-          <span className="min-w-0 truncate font-semibold text-kumo-strong">
-            {agent?.displayName ?? m.shell_agent()}
-          </span>
+          <Link
+            className="inline-flex min-w-0 items-center gap-2 rounded-sm font-semibold text-kumo-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand"
+            data-ui="agent-mobile-home"
+            {...agentDetailLink(agentId)}
+          >
+            <Icon className="shrink-0" name="home" />
+            <span className="truncate">{agent?.displayName ?? m.shell_agent()}</span>
+          </Link>
           <SidebarTrigger aria-label={m.shell_open_agent_navigation()} title={m.shell_open_agent_navigation()} />
         </header>
         <ShellMain>


### PR DESCRIPTION
## Summary

- align the Usage period selector to the right edge in both the Agent overview card and detailed Usage page
- make Usage a standard sibling section with its own page header and rename the dashboard CTA to “View Usage”
- add a direct mobile Agent Home link while keeping desktop sibling navigation in the sidebar
- update English/Chinese copy and regression coverage

## Testing

Passed:

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `OPENTAG_HOME=<isolated-temp-home> pnpm test`
- `OPENTAG_HOME=<isolated-temp-home> pnpm --filter @opentag/client test:agent-runtime:coverage` (340/340, 100% coverage)
- `pnpm --filter @opentag/server exec vitest run src/__tests__/integration --maxWorkers=1` (300/301; the remaining migration test completed in 5.3s but exceeded its fixed 5s timeout)
- `pnpm --filter @opentag/server exec vitest run src/__tests__/integration/account-ownership-expansion.test.ts --maxWorkers=1 --testTimeout=10000` (7/7)

Environment note: the standard `pnpm --filter @opentag/server test:integration` command was attempted twice. The local Docker VM was heavily loaded and many unrelated PostgreSQL tests crossed their fixed 5-second timeout. Serial execution reduced this to the single 5.3-second migration case documented above; its targeted rerun passed with a 10-second timeout.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English and Chinese user-facing copy are synchronized.