### PR TITLE
fix(web): rebalance interface color hierarchy

### DIFF
--- a/apps/web/src/__tests__/agent-creation.test.tsx
+++ b/apps/web/src/__tests__/agent-creation.test.tsx
@@ -185,7 +185,9 @@ describe("OpenTag Web App Shell", () => {
     });
 
     expect(agentCreationPosts()).toHaveLength(0);
-    expect(screen.getByRole("button", { name: /Zulu Tower/ }).getAttribute("aria-pressed")).toBe("true");
+    const selectedComputer = screen.getByRole("button", { name: /Zulu Tower/ });
+    expect(selectedComputer.getAttribute("aria-pressed")).toBe("true");
+    expect(selectedComputer.className).toContain("data-[selected=true]:!bg-(--brand-soft)");
   });
 
   it("does not resume a stored creation intent onto a Runtime the form is not offering", async () => {

--- a/apps/web/src/__tests__/agent-home.test.tsx
+++ b/apps/web/src/__tests__/agent-home.test.tsx
@@ -131,6 +131,7 @@ describe("OpenTag Web App Shell", () => {
     expect(within(dangerZone).getByRole("heading", { name: "Danger zone" })).toBeTruthy();
     expect(dangerZone.className).not.toContain("border-t");
     expect(screen.getByRole("link", { name: /^Pause or delete/ })).toBeTruthy();
+    expect(dangerZone.querySelector('[data-ui="agent-settings-entry-icon"]')?.className).toContain("text-kumo-danger");
     expect(screen.queryByRole("heading", { name: "How it works" })).toBeNull();
     const instructionsLink = screen.getByRole("link", { name: /^Instructions / });
     expect(instructionsLink.className).toContain("focus-visible:ring-2");

--- a/apps/web/src/agent-creation/agent-creation-flow.tsx
+++ b/apps/web/src/agent-creation/agent-creation-flow.tsx
@@ -509,10 +509,7 @@ function RuntimeRouteSection({
   // task. A sentence here would only say those labels again, which is one more line between the
   // Account and the single action this step asks for.
   return (
-    <section
-      aria-labelledby="agent-runtime-heading"
-      className="grid gap-4 rounded-lg bg-kumo-recessed p-4 ring ring-kumo-line"
-    >
+    <section aria-labelledby="agent-runtime-heading" className="grid gap-4 border-t border-kumo-line pt-5">
       <header className="flex items-start justify-between gap-3">
         <div>
           <Text as="h3" id="agent-runtime-heading" variant="heading">
@@ -613,11 +610,12 @@ function RuntimeRouteSection({
                   return (
                     <Button
                       aria-pressed={computer.id === displayedComputer.id}
-                      className="h-auto w-full justify-between text-left"
+                      className="h-auto w-full justify-between text-left data-[selected=true]:!bg-(--brand-soft) data-[selected=true]:ring-kumo-brand"
                       data-selected={computer.id === displayedComputer.id ? "true" : undefined}
                       disabled={submitting || refreshing}
                       key={computer.id}
                       type="button"
+                      variant="secondary"
                       onClick={() => onChangeComputer(computer)}
                     >
                       <span className="grid gap-1">
@@ -686,11 +684,12 @@ function RuntimeRouteSection({
                   return (
                     <Button
                       aria-pressed={provider.provider === displayedProvider?.provider}
-                      className="h-auto w-full justify-between text-left"
+                      className="h-auto w-full justify-between text-left data-[selected=true]:!bg-(--brand-soft) data-[selected=true]:ring-kumo-brand"
                       data-selected={provider.provider === displayedProvider?.provider ? "true" : undefined}
                       disabled={submitting || refreshing || route === undefined}
                       key={provider.provider}
                       type="button"
+                      variant="secondary"
                       onClick={() => onChangeRuntime(provider)}
                     >
                       <strong>{providerLabel(provider.provider)}</strong>
@@ -703,7 +702,7 @@ function RuntimeRouteSection({
           ) : null}
 
           {selectedRoute ? (
-            <div aria-live="polite" className="rounded-md bg-kumo-base p-3" role="status">
+            <div aria-live="polite" className="px-1" role="status">
               <StatusIndicator label={m.agent_create_ready_to_run_status()} tone="success" />
             </div>
           ) : displayedComputer.connectionStatus === "offline" ? (

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -16,9 +16,13 @@
   --brand: #8fdd14; /* logo green — fills, color blocks, icons ONLY; never a text color */
   --brand-display: #649a0e; /* display green — text at >= 24px only (large headings) */
   --brand-ink: #3a5c04; /* body-level green — green text at normal sizes uses this */
-  --brand-100: #f1f8e1; /* light brand tint — backgrounds/edges */
+  --brand-soft: #edf5dc; /* selected/current surfaces only; never a generic hover or stripe */
   --bg: #f8f7f0; /* main app background (warm off-white, NOT pure white) */
   --card: #fdfcf6; /* card / surface background */
+  --surface-elevated: #fbfaf4; /* raised surfaces between the canvas and cards */
+  --surface-recessed: #f0efe7; /* code, disabled, and inset surfaces */
+  --surface-tint: #f6f5ee; /* table stripes and quiet neutral emphasis */
+  --surface-hover: #eeede5; /* transient hover/pressed feedback */
   --fg: #16211b; /* primary text */
   --fg-2: #3a453e; /* secondary text */
   --muted-fg: #626b60; /* muted text */
@@ -33,16 +37,16 @@
 :root[data-theme="opentag"],
 [data-theme="opentag"] {
   --color-kumo-canvas: var(--bg);
-  --color-kumo-elevated: var(--card);
-  --color-kumo-recessed: var(--brand-100);
+  --color-kumo-elevated: var(--surface-elevated);
+  --color-kumo-recessed: var(--surface-recessed);
   --color-kumo-base: var(--card);
-  --color-kumo-tint: var(--brand-100);
+  --color-kumo-tint: var(--surface-tint);
   --color-kumo-contrast: var(--fg);
   --color-kumo-overlay: var(--card);
   --color-kumo-control: var(--card);
   --color-kumo-interact: var(--border-strong);
   --color-kumo-fill: var(--border);
-  --color-kumo-fill-hover: var(--brand-100);
+  --color-kumo-fill-hover: var(--surface-hover);
   --color-kumo-line: var(--border);
   --color-kumo-hairline: var(--border);
   --color-kumo-focus: var(--brand-ink);

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -236,20 +236,11 @@ function UsageMetricSkeleton() {
 function UsageMetrics({ compact = false, usage }: { compact?: boolean; usage: AgentUsageDetail }) {
   return (
     <dl
-      className={
-        compact
-          ? "grid gap-3 @min-[36rem]/workspace:grid-cols-2"
-          : "grid divide-y divide-kumo-line @min-[36rem]/workspace:grid-cols-2 @min-[36rem]/workspace:divide-x @min-[36rem]/workspace:divide-y-0"
-      }
+      className="grid divide-y divide-kumo-line @min-[36rem]/workspace:grid-cols-2 @min-[36rem]/workspace:divide-x @min-[36rem]/workspace:divide-y-0"
       aria-label={m.usage_metrics_label({ window: usageWindowLabel(usage.windowDays) })}
       data-ui="usage-metrics"
     >
-      <Metric
-        compact={compact}
-        label={m.usage_metric_total_tokens()}
-        value={formatCompactNumber(usage.tokens)}
-        primary
-      />
+      <Metric compact={compact} label={m.usage_metric_total_tokens()} value={formatCompactNumber(usage.tokens)} />
       <Metric compact={compact} label={m.usage_metric_tasks()} value={formatCompactNumber(usage.tasks)} />
     </dl>
   );
@@ -277,21 +268,13 @@ function UsageCoverage({ usage }: { usage: AgentUsageDetail }) {
   );
 }
 
-function Metric({
-  compact = false,
-  label,
-  primary = false,
-  value,
-}: {
-  compact?: boolean;
-  label: string;
-  primary?: boolean;
-  value: string;
-}) {
+function Metric({ compact = false, label, value }: { compact?: boolean; label: string; value: string }) {
   return (
     <div
       className={
-        compact ? `grid gap-1 rounded-md p-3 ${primary ? "bg-kumo-tint" : "bg-kumo-recessed"}` : "grid gap-1 p-5"
+        compact
+          ? "grid gap-1 py-2.5 first:pt-0 last:pb-0 @min-[36rem]/workspace:px-4 @min-[36rem]/workspace:py-0 @min-[36rem]/workspace:first:pl-0 @min-[36rem]/workspace:last:pr-0"
+          : "grid gap-1 p-5"
       }
     >
       <Text as="dt" size="sm" variant="secondary">

--- a/apps/web/src/features/agents/agent-computer-choice.tsx
+++ b/apps/web/src/features/agents/agent-computer-choice.tsx
@@ -167,7 +167,9 @@ export function AgentComputerChoice({
       {error ? <Banner variant="error" role="alert" description={error} /> : null}
       {enrolled.length > 0 ? (
         <div className="grid gap-2">
-          <Text variant="heading">{m.agents_computer_choice_existing_heading()}</Text>
+          <Text as="h3" variant="heading">
+            {m.agents_computer_choice_existing_heading()}
+          </Text>
           <ul className="grid gap-2">
             {enrolled.map((computer) => (
               <li className="flex flex-wrap items-center justify-between gap-3" key={computer.computerId}>
@@ -191,7 +193,7 @@ export function AgentComputerChoice({
         </div>
       ) : null}
       <div className="grid gap-2">
-        <Text variant="heading">
+        <Text as="h3" variant="heading">
           {enrolled.length > 0 ? m.agents_computer_choice_connect_new() : m.agents_computer_choice_connect_first()}
         </Text>
         {/*

--- a/apps/web/src/features/agents/agent-detail-page.tsx
+++ b/apps/web/src/features/agents/agent-detail-page.tsx
@@ -244,7 +244,7 @@ export function AgentLifecycleNotice({ agent }: { agent: AgentDetailView }) {
   const recovery = agentAvailabilityRecovery(agent);
   return (
     <section
-      className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-kumo-tint p-4"
+      className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-kumo-recessed p-4 ring ring-kumo-line"
       aria-label={m.agents_lifecycle_aria({ status: status.label })}
       data-ui="agent-lifecycle-notice"
     >

--- a/apps/web/src/features/agents/agent-presentation.ts
+++ b/apps/web/src/features/agents/agent-presentation.ts
@@ -5,16 +5,6 @@ import type { AgentAvailability, AgentDetailView, AgentListItem, AgentStatusSour
 import { type AgentSettingsSectionLink, agentSettingsSectionLink } from "./agent-routes.js";
 import type { AgentSettingsSection } from "./agent-settings/sections.js";
 
-export const agentAvatarTones = ["brand", "amber", "blue", "neutral"] as const;
-
-export function agentAvatarTone(agentId: string): (typeof agentAvatarTones)[number] {
-  let hash = 0;
-  for (let index = 0; index < agentId.length; index += 1) {
-    hash = (hash * 31 + agentId.charCodeAt(index)) >>> 0;
-  }
-  return agentAvatarTones[hash % agentAvatarTones.length] ?? "brand";
-}
-
 /**
  * The card states what is true and how urgent it is; it carries no exit of its own. Opening the
  * Agent is the single follow-up, and the Agent page is where each failed dependency is explained.

--- a/apps/web/src/features/agents/agent-settings/agent-computer-settings.test.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-computer-settings.test.tsx
@@ -220,7 +220,8 @@ describe("An Agent with no Computer", () => {
 
     await renderInRouter(<AgentComputerSettings agent={unbound()} onAgentChanged={onAgentChanged} />);
 
-    expect(await screen.findByText("Choose the Computer this Agent should run on")).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "Choose the Computer this Agent should run on" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Connect another Computer" })).toBeTruthy();
     // Nothing is decided for the reader while the question is open.
     expect(rebind).not.toHaveBeenCalled();
 

--- a/apps/web/src/features/agents/agent-settings/agent-settings-page.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-settings-page.tsx
@@ -145,7 +145,11 @@ export function AgentSettingsOverview({ agent }: { agent: AgentDetailView }) {
                         const content = (
                           <>
                             <span
-                              className="grid size-8 shrink-0 place-items-center rounded-md bg-kumo-tint"
+                              className={
+                                item.group === "danger"
+                                  ? "grid size-8 shrink-0 place-items-center text-kumo-danger"
+                                  : "grid size-8 shrink-0 place-items-center text-kumo-subtle"
+                              }
                               aria-hidden="true"
                               data-ui="agent-settings-entry-icon"
                             >

--- a/apps/web/src/features/shell/agent-shell.tsx
+++ b/apps/web/src/features/shell/agent-shell.tsx
@@ -305,6 +305,7 @@ function AgentNavItem({
     <Sidebar.MenuButton
       active={active}
       aria-current={active ? "page" : undefined}
+      className="data-[active]:bg-(--brand-soft)"
       icon={
         <span className="flex w-8 shrink-0 items-center justify-center" aria-hidden="true">
           <Icon name={icon} />

--- a/apps/web/src/onboarding-v2/layout.test.ts
+++ b/apps/web/src/onboarding-v2/layout.test.ts
@@ -49,6 +49,12 @@ describe("onboarding flow layout", () => {
     });
   });
 
+  it("distinguishes selected choices from neutral hover and disabled states", () => {
+    expect(declarationValue('.otv2-choice[aria-pressed="true"]', "background")).toBe("var(--brand-soft)");
+    expect(declarationValue(".otv2-choice:hover:not(:disabled)", "background")).toBe("var(--color-kumo-fill-hover)");
+    expect(declarationValue(".otv2-choice:disabled", "background")).toBe("var(--color-kumo-recessed)");
+  });
+
   /*
    * The reserved heights are declarations again: this app compiles no utilities of its own, so a
    * bracketed class would be inert. They are still measurements the flow depends on — each is the

--- a/apps/web/src/onboarding-v2/onboarding-v2.css
+++ b/apps/web/src/onboarding-v2/onboarding-v2.css
@@ -72,13 +72,13 @@
 
 .otv2-choice[aria-pressed="true"] {
   border-color: var(--color-kumo-brand);
-  background: var(--color-kumo-tint);
+  background: var(--brand-soft);
 }
 
 /* Nothing here shrinks under a click; it answers with colour instead. */
 .otv2-choice:active:not(:disabled) {
   transform: none;
-  background: var(--color-kumo-tint);
+  background: var(--color-kumo-fill-hover);
 }
 
 .otv2-shell button:active {

--- a/apps/web/src/setup/layout.test.ts
+++ b/apps/web/src/setup/layout.test.ts
@@ -42,6 +42,14 @@ describe("setup piece layout", () => {
     });
   });
 
+  it("keeps the expired-command action legible over its dark scrim", () => {
+    expect(declarationValue(".ots-command__expired button", "color")).toBe("var(--on-dark)");
+    expect(declarationValue(".ots-command__expired button:hover", "background")).toBe(
+      "color-mix(in srgb, var(--on-dark) 14%, transparent)",
+    );
+    expect(declarationValue(".ots-command__expired button:hover", "color")).toBe("var(--on-dark)");
+  });
+
   /*
    * The reserved heights are declarations rather than utilities: this app compiles none of its own,
    * so a bracketed class would be inert. They are still measurements the surfaces depend on — each

--- a/apps/web/src/setup/setup.css
+++ b/apps/web/src/setup/setup.css
@@ -153,10 +153,11 @@
 }
 
 .ots-command__expired button {
-  color: var(--brand-100);
+  color: var(--on-dark);
 }
 
 .ots-command__expired button:hover {
+  background: color-mix(in srgb, var(--on-dark) 14%, transparent);
   color: var(--on-dark);
 }
 

--- a/apps/web/src/ui/KUMO.md
+++ b/apps/web/src/ui/KUMO.md
@@ -42,11 +42,13 @@ required by the browser file picker.
 
 `kumo-theme.tokens.ts` is the source configuration. `kumo-theme.css` is its
 generated output and only overrides Kumo semantic variables. OpenTag keeps the
-existing green direction (`#385a04`, `#4e7a06`, and `#90de14`) while Kumo
-success, warning, danger, and info tokens remain independent. Dark hover uses
-`#a8ec45`, which is a lightness adjustment on the same green direction. The
-theme contrast test verifies normal-text WCAG AA against the relevant light and
-dark foregrounds.
+existing green direction for brand emphasis while Kumo success, warning,
+danger, and info tokens remain independent. Generic recessed, tint, table-row,
+disabled, and hover surfaces stay in one warm-neutral family; `--brand-soft` is
+reserved for explicit selected and current states. Kumo lightens emphasis
+buttons at runtime, so the adapter replaces that mix with reviewed primary and
+danger gradients. The theme contrast test verifies every rendered gradient
+endpoint for normal-text WCAG AA, not only the source accent.
 
 The theme uses explicit `data-theme="opentag"` and `data-mode="light|dark"`
 attributes. Brand values were chosen for readable text and button contrast in

--- a/apps/web/src/ui/design-system.test.tsx
+++ b/apps/web/src/ui/design-system.test.tsx
@@ -29,6 +29,19 @@ describe("Kumo semantic adapter", () => {
     expect(screen.getByRole("button", { name: "Disconnect" }).className).toContain("text-kumo-danger");
   });
 
+  it("overrides Kumo's lightened emphasis mix with accessible button surfaces", () => {
+    render(
+      <>
+        <Button variant="primary">Create</Button>
+        <Button variant="danger">Delete</Button>
+      </>,
+    );
+    const primary = screen.getByRole("button", { name: "Create" });
+    const danger = screen.getByRole("button", { name: "Delete" });
+    expect(primary.style.getPropertyValue("--kumo-button-emphasis-bg")).toBe("var(--opentag-button-primary-bg)");
+    expect(danger.style.getPropertyValue("--kumo-button-emphasis-bg")).toBe("var(--opentag-button-danger-bg)");
+  });
+
   it("provides labelled Kumo tabs and settings rows", () => {
     render(
       <>

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -69,6 +69,7 @@ import {
 import {
   Children,
   type ComponentPropsWithoutRef,
+  type CSSProperties,
   cloneElement,
   forwardRef,
   type HTMLAttributes,
@@ -167,18 +168,42 @@ export function buttonClassName({
 } = {}): string {
   return classes(
     buttonVariants({ variant: kumoButtonVariant(variant), size: size === "compact" ? "sm" : "base" }),
+    variant === "primary" &&
+      "[--kumo-button-emphasis-bg:var(--opentag-button-primary-bg)] [--kumo-button-emphasis-ring:var(--opentag-button-primary-ring)]",
+    variant === "danger" &&
+      "[--kumo-button-emphasis-bg:var(--opentag-button-danger-bg)] [--kumo-button-emphasis-ring:var(--opentag-button-danger-ring)]",
     className,
   );
 }
 
+type EmphasisButtonStyle = CSSProperties & {
+  "--kumo-button-emphasis-bg": string;
+  "--kumo-button-emphasis-gradient-end": string;
+  "--kumo-button-emphasis-gradient-start": string;
+  "--kumo-button-emphasis-ring": string;
+};
+
+function emphasisButtonStyle(variant: ButtonVariant): EmphasisButtonStyle | undefined {
+  const intent = variant === "primary" ? "primary" : variant === "danger" ? "danger" : undefined;
+  if (!intent) return undefined;
+  return {
+    "--kumo-button-emphasis-bg": `var(--opentag-button-${intent}-bg)`,
+    "--kumo-button-emphasis-gradient-end": `var(--opentag-button-${intent}-gradient-end)`,
+    "--kumo-button-emphasis-gradient-start": `var(--opentag-button-${intent}-gradient-start)`,
+    "--kumo-button-emphasis-ring": `var(--opentag-button-${intent}-ring)`,
+  };
+}
+
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { className, size = "default", variant = "primary", type = "button", ...props },
+  { className, size = "default", style, variant = "primary", type = "button", ...props },
   ref,
 ) {
+  const emphasisStyle = emphasisButtonStyle(variant);
   const kumoProps: KumoButtonProps = {
     ...props,
     className: buttonClassName({ className, size, variant }),
     size: size === "compact" ? "sm" : "base",
+    style: emphasisStyle ? { ...style, ...emphasisStyle } : style,
     type,
     variant: kumoButtonVariant(variant),
   };

--- a/apps/web/src/ui/kumo-contract.test.ts
+++ b/apps/web/src/ui/kumo-contract.test.ts
@@ -34,6 +34,13 @@ describe("Kumo integration contract", () => {
     );
   });
 
+  it("keeps generic Kumo surfaces neutral and reserves brand soft for selection", () => {
+    expect(appCss).toContain("--color-kumo-recessed: var(--surface-recessed)");
+    expect(appCss).toContain("--color-kumo-tint: var(--surface-tint)");
+    expect(appCss).toContain("--color-kumo-fill-hover: var(--surface-hover)");
+    expect(appCss).not.toMatch(/--color-kumo-(?:recessed|tint|fill-hover): var\(--brand-soft\)/);
+  });
+
   it("uses the semantic adapter and real Kumo controls", () => {
     const adapter = readFileSync(resolve(root, "ui/design-system.tsx"), "utf8");
     expect(adapter).toContain("@cloudflare/kumo");

--- a/apps/web/src/ui/kumo-theme.css
+++ b/apps/web/src/ui/kumo-theme.css
@@ -5,7 +5,15 @@
   --color-kumo-brand-hover: #2f4a03;
   --text-color-kumo-brand: #3a5c04;
   --kumo-button-emphasis-bg: #3a5c04;
-  --kumo-button-emphasis-ring: #3a5c04;
+  --kumo-button-emphasis-ring: #2f4a03;
+  --opentag-button-primary-bg: #3a5c04;
+  --opentag-button-primary-gradient-start: #4b7308;
+  --opentag-button-primary-gradient-end: #3a5c04;
+  --opentag-button-primary-ring: #2f4a03;
+  --opentag-button-danger-bg: #b42318;
+  --opentag-button-danger-gradient-start: #c12c20;
+  --opentag-button-danger-gradient-end: #a61b13;
+  --opentag-button-danger-ring: #88180f;
 }
 
 :root[data-theme="opentag"][data-mode="dark"],
@@ -14,6 +22,14 @@
   --color-kumo-brand: #8fdd14;
   --color-kumo-brand-hover: #a8ec45;
   --text-color-kumo-brand: #8fdd14;
-  --kumo-button-emphasis-bg: #8fdd14;
+  --kumo-button-emphasis-bg: #466d05;
   --kumo-button-emphasis-ring: #8fdd14;
+  --opentag-button-primary-bg: #466d05;
+  --opentag-button-primary-gradient-start: #527f08;
+  --opentag-button-primary-gradient-end: #466d05;
+  --opentag-button-primary-ring: #8fdd14;
+  --opentag-button-danger-bg: #b42318;
+  --opentag-button-danger-gradient-start: #c12c20;
+  --opentag-button-danger-gradient-end: #a61b13;
+  --opentag-button-danger-ring: #e65a4f;
 }

--- a/apps/web/src/ui/kumo-theme.tokens.test.ts
+++ b/apps/web/src/ui/kumo-theme.tokens.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import postcss, { type Root } from "postcss";
 import { describe, expect, it } from "vitest";
 import { kumoThemeTokens } from "./kumo-theme.tokens.js";
 
@@ -5,20 +9,79 @@ const WHITE = "#ffffff";
 const DARK_INVERSE_TEXT = "#333333";
 const DARK_CANVAS = "#1a1a1a";
 const WCAG_AA_NORMAL_TEXT = 4.5;
+const stylesheet: Root = postcss.parse(
+  readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), "kumo-theme.css"), "utf8"),
+);
+
+type ThemeMode = keyof typeof kumoThemeTokens;
+type ThemeTokenName = keyof (typeof kumoThemeTokens)[ThemeMode];
+type RuntimeThemeTokens = Record<ThemeTokenName, string>;
+
+const runtimeVariableByToken = {
+  brand: "--color-kumo-brand",
+  brandHover: "--color-kumo-brand-hover",
+  brandText: "--text-color-kumo-brand",
+  buttonBackground: "--opentag-button-primary-bg",
+  buttonGradientEnd: "--opentag-button-primary-gradient-end",
+  buttonGradientStart: "--opentag-button-primary-gradient-start",
+  buttonRing: "--opentag-button-primary-ring",
+  dangerButtonBackground: "--opentag-button-danger-bg",
+  dangerButtonGradientEnd: "--opentag-button-danger-gradient-end",
+  dangerButtonGradientStart: "--opentag-button-danger-gradient-start",
+  dangerButtonRing: "--opentag-button-danger-ring",
+} satisfies Record<ThemeTokenName, string>;
 
 describe("OpenTag Kumo theme contrast", () => {
-  it("keeps light brand text and emphasis backgrounds above WCAG AA", () => {
-    expect(contrast(kumoThemeTokens.light.brand, WHITE)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
-    expect(contrast(kumoThemeTokens.light.brandHover, WHITE)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
-    expect(contrast(kumoThemeTokens.light.brandText, WHITE)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+  it("keeps the light runtime CSS synced and above WCAG AA", () => {
+    const runtime = runtimeThemeTokens("light");
+    expect(runtime).toEqual(kumoThemeTokens.light);
+    expect(contrast(runtime.brand, WHITE)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+    expect(contrast(runtime.brandHover, WHITE)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+    expect(contrast(runtime.brandText, WHITE)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+    expectButtonSurfacesToPass(runtime);
   });
 
-  it("keeps dark brand text and emphasis backgrounds above WCAG AA", () => {
-    expect(contrast(kumoThemeTokens.dark.brand, DARK_INVERSE_TEXT)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
-    expect(contrast(kumoThemeTokens.dark.brandHover, DARK_INVERSE_TEXT)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
-    expect(contrast(kumoThemeTokens.dark.brandText, DARK_CANVAS)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+  it("keeps the dark runtime CSS synced and above WCAG AA", () => {
+    const runtime = runtimeThemeTokens("dark");
+    expect(runtime).toEqual(kumoThemeTokens.dark);
+    expect(contrast(runtime.brand, DARK_INVERSE_TEXT)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+    expect(contrast(runtime.brandHover, DARK_INVERSE_TEXT)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+    expect(contrast(runtime.brandText, DARK_CANVAS)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+    expectButtonSurfacesToPass(runtime);
   });
 });
+
+function runtimeThemeTokens(mode: ThemeMode): RuntimeThemeTokens {
+  const declarations = new Map<string, string>();
+  stylesheet.walkRules((rule) => {
+    if (!rule.selectors.some((selector) => selector.includes('[data-theme="opentag"]'))) return;
+    const darkRule = rule.selectors.some((selector) => selector.includes('[data-mode="dark"]'));
+    if (darkRule !== (mode === "dark")) return;
+    rule.walkDecls((declaration) => {
+      declarations.set(declaration.prop, declaration.value);
+    });
+  });
+  return Object.fromEntries(
+    Object.entries(runtimeVariableByToken).map(([token, variable]) => {
+      const value = declarations.get(variable);
+      if (!value) throw new Error(`Missing ${variable} for ${mode} mode`);
+      return [token, value];
+    }),
+  ) as RuntimeThemeTokens;
+}
+
+function expectButtonSurfacesToPass(tokens: RuntimeThemeTokens): void {
+  for (const color of [
+    tokens.buttonBackground,
+    tokens.buttonGradientStart,
+    tokens.buttonGradientEnd,
+    tokens.dangerButtonBackground,
+    tokens.dangerButtonGradientStart,
+    tokens.dangerButtonGradientEnd,
+  ]) {
+    expect(contrast(color, WHITE)).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT);
+  }
+}
 
 function contrast(left: string, right: string): number {
   const brighter = Math.max(luminance(left), luminance(right));

--- a/apps/web/src/ui/kumo-theme.tokens.ts
+++ b/apps/web/src/ui/kumo-theme.tokens.ts
@@ -12,13 +12,27 @@ export const kumoThemeTokens = {
     // is intentionally reserved for headings at 24px and above, so it is not used here.
     brandHover: "#2f4a03",
     brandText: "#3a5c04",
-    buttonRing: "#3a5c04",
+    buttonBackground: "#3a5c04",
+    buttonGradientStart: "#4b7308",
+    buttonGradientEnd: "#3a5c04",
+    buttonRing: "#2f4a03",
+    dangerButtonBackground: "#b42318",
+    dangerButtonGradientStart: "#c12c20",
+    dangerButtonGradientEnd: "#a61b13",
+    dangerButtonRing: "#88180f",
   },
   dark: {
     brand: "#8fdd14",
     brandHover: "#a8ec45",
     brandText: "#8fdd14",
+    buttonBackground: "#466d05",
+    buttonGradientStart: "#527f08",
+    buttonGradientEnd: "#466d05",
     buttonRing: "#8fdd14",
+    dangerButtonBackground: "#b42318",
+    dangerButtonGradientStart: "#c12c20",
+    dangerButtonGradientEnd: "#a61b13",
+    dangerButtonRing: "#e65a4f",
   },
 } as const;
 

--- a/apps/web/src/ui/typography.css
+++ b/apps/web/src/ui/typography.css
@@ -6,10 +6,7 @@
   h4,
   h5,
   h6,
-  [role="heading"],
-  /* Kumo's heading variant renders a span with this stable semantic class pair when `as` is not
-   * supplied. Keep those heading-level UI labels on the display face as well. */
-  [class~="text-kumo-default"][class~="font-semibold"] {
+  [role="heading"] {
     font-family:
       "Sora", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", ui-sans-serif, system-ui, -apple-system,
       BlinkMacSystemFont, "Segoe UI", sans-serif;


### PR DESCRIPTION
## Summary

- replace decorative per-row, metric, and settings-icon colors with neutral surfaces so color communicates state and action
- reserve the OpenTag brand color for primary actions, active navigation, selection, focus, and compact status signals
- simplify Agent creation and onboarding hierarchy while preserving selected and disabled affordances
- harden Kumo primary/danger contrast, runtime CSS token synchronization, heading semantics, and selected-option hover behavior

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/web test` — 64 files, 565 tests passed
- isolated `@opentag/client` test run — 58 files, 753 tests passed
- isolated CLI daemon regression run — 15 tests passed
- production CSS inspection confirmed selected options compile with `background-color: var(--brand-soft) !important`

A root `pnpm test` run exposed two pre-existing local-environment sensitivities outside this Web change: daemon tests read the caller's real OpenTag home, and provider probe tests can exceed their 5-second timeout under monorepo concurrency. The affected suites pass when run with an isolated OpenTag home and without competing workspace load.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (`pnpm test` has the environment/concurrency caveat documented above.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
