### PR TITLE
fix(web): align account form controls

### DIFF
--- a/apps/web/messages/account/en.json
+++ b/apps/web/messages/account/en.json
@@ -8,7 +8,6 @@
   "account_email_description": "Your sign-in email cannot be changed here.",
   "account_error_profile_save_failed": "Unable to save the account profile",
   "account_error_refresh_failed": "Your display name was saved. OpenTag could not refresh the account, so the rest of the page still shows the previous name.",
-  "account_hint_read_only": "Read only",
   "account_language_description": "Choose the language used throughout OpenTag.",
   "account_language_label": "Language",
   "account_page_description": "Manage your personal account details.",

--- a/apps/web/messages/account/zh.json
+++ b/apps/web/messages/account/zh.json
@@ -8,7 +8,6 @@
   "account_email_description": "此处无法修改登录邮箱。",
   "account_error_profile_save_failed": "无法保存账户资料",
   "account_error_refresh_failed": "显示名称已保存。OpenTag 无法刷新账户，因此页面其余部分仍显示之前的名称。",
-  "account_hint_read_only": "只读",
   "account_language_description": "选择 OpenTag 界面使用的语言。",
   "account_language_label": "语言",
   "account_page_description": "管理个人账户详情。",

--- a/apps/web/src/__tests__/account.test.tsx
+++ b/apps/web/src/__tests__/account.test.tsx
@@ -15,8 +15,12 @@ describe("OpenTag Web App Shell", () => {
     const displayName = screen.getByLabelText("Display name") as HTMLInputElement;
     expect(email.value).toBe("ada@example.com");
     expect(email.readOnly).toBe(true);
+    expect(email.getAttribute("aria-describedby")).toBeNull();
+    expect(screen.queryByText("Read only")).toBeNull();
     expect(email.closest('[data-ui="field"]')).toBeTruthy();
     expect(displayName.closest('[data-ui="field"]')).toBeTruthy();
+    expect(email.closest('[data-ui="field"]')?.querySelector("label")?.classList.contains("sr-only")).toBe(true);
+    expect(displayName.closest('[data-ui="field"]')?.querySelector("label")?.classList.contains("sr-only")).toBe(true);
     fireEvent.change(displayName, { target: { value: "  Ada Lovelace  " } });
     fireEvent.click(await screen.findByRole("button", { name: "Save account profile" }));
 

--- a/apps/web/src/features/account/account-page.test.tsx
+++ b/apps/web/src/features/account/account-page.test.tsx
@@ -18,6 +18,11 @@ describe("AccountSettings language selector", () => {
 
     const selector = screen.getByRole("combobox", { name: "Language" });
     expect(selector.textContent).toContain(locale.LOCALE_LABELS[locale.getLocale()]);
+    expect(selector.className.split(/\s+/)).toContain("w-full");
+    expect(selector.className.split(/\s+/)).not.toContain("w-max");
+    expect(selector.getAttribute("aria-labelledby")).toBe("account-language-label");
+    expect(selector.getAttribute("aria-label")).toBeNull();
+    expect(selector.closest('[data-ui="field"]')?.querySelector("label")?.classList.contains("sr-only")).toBe(true);
 
     fireEvent.click(selector);
     const options = await screen.findAllByRole("option");

--- a/apps/web/src/features/account/account-page.tsx
+++ b/apps/web/src/features/account/account-page.tsx
@@ -105,24 +105,12 @@ export function AccountSettings({
       </Text>
       <SettingsList>
         <SettingsRow label={m.account_email()} description={m.account_email_description()}>
-          <Field
-            hint={m.account_hint_read_only()}
-            hintId="account-email-hint"
-            htmlFor="account-email"
-            label={m.account_email()}
-          >
-            <KumoInputControl
-              aria-describedby="account-email-hint"
-              id="account-email"
-              name="email"
-              readOnly
-              type="email"
-              value={user.email}
-            />
+          <Field hideLabel htmlFor="account-email" label={m.account_email()}>
+            <KumoInputControl id="account-email" name="email" readOnly type="email" value={user.email} />
           </Field>
         </SettingsRow>
         <SettingsRow label={m.account_display_name()} description={m.account_display_name_description()}>
-          <Field htmlFor="account-display-name" label={m.account_display_name()}>
+          <Field hideLabel htmlFor="account-display-name" label={m.account_display_name()}>
             <KumoInputControl
               autoComplete="name"
               // Editing during a refresh-only retry could open a save that races it.
@@ -141,9 +129,9 @@ export function AccountSettings({
           </Field>
         </SettingsRow>
         <SettingsRow label={m.account_language_label()} description={m.account_language_description()}>
-          <Field htmlFor="account-language" label={m.account_language_label()}>
+          <Field hideLabel htmlFor="account-language" label={m.account_language_label()}>
             <Select
-              aria-label={m.account_language_label()}
+              className="w-full"
               id="account-language"
               renderValue={(locale) => LOCALE_LABELS[locale]}
               value={getLocale()}

--- a/apps/web/src/ui/design-system.test.tsx
+++ b/apps/web/src/ui/design-system.test.tsx
@@ -10,6 +10,7 @@ import {
   Icon,
   type KumoInputControlProps,
   KumoSelectControl,
+  Select,
   SettingsList,
   SettingsRow,
   StatusIndicator,
@@ -78,6 +79,20 @@ describe("Kumo semantic adapter", () => {
       </KumoSelectControl>,
     );
     expect(screen.getByRole("combobox", { name: "Usage period" })).toBeTruthy();
+  });
+
+  it("associates a direct Kumo select with the visible Field label", () => {
+    render(
+      <Field htmlFor="locale" label="Language">
+        <Select id="locale" value="en">
+          <Select.Option value="en">English</Select.Option>
+          <Select.Option value="zh">简体中文</Select.Option>
+        </Select>
+      </Field>,
+    );
+    const selector = screen.getByRole("combobox", { name: "Language" });
+    expect(selector.getAttribute("aria-labelledby")).toBe("locale-label");
+    expect(selector.getAttribute("aria-label")).toBeNull();
   });
 
   it("normalizes non-string option identities for controlled selection", () => {

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -275,6 +275,7 @@ export function Field({
   className,
   error,
   errorId,
+  hideLabel = false,
   hint,
   hintId,
   htmlFor: _htmlFor,
@@ -284,6 +285,7 @@ export function Field({
   className?: string;
   error?: ReactNode;
   errorId?: string;
+  hideLabel?: boolean;
   hint?: ReactNode;
   hintId?: string;
   htmlFor: string;
@@ -296,14 +298,21 @@ export function Field({
   };
   const child = isValidElement<LabelableControlProps>(children) ? children : undefined;
   const isKumoControl =
-    child?.type === KumoInputControl || child?.type === KumoInputAreaControl || child?.type === KumoSelectControl;
+    child?.type === KumoInputControl ||
+    child?.type === KumoInputAreaControl ||
+    child?.type === KumoSelect ||
+    child?.type === KumoSelectControl;
   const labelledChildren =
     isKumoControl && !child.props["aria-label"] && !child.props["aria-labelledby"]
       ? cloneElement(child, { "aria-labelledby": labelId })
       : children;
   return (
     <div className={classes("min-w-0", className)} data-ui="field">
-      <label className="mb-1 block text-sm font-medium text-kumo-default" htmlFor={_htmlFor} id={labelId}>
+      <label
+        className={classes(hideLabel ? "sr-only" : "mb-1 block text-sm font-medium text-kumo-default")}
+        htmlFor={_htmlFor}
+        id={labelId}
+      >
         {label}
       </label>
       <KumoField


### PR DESCRIPTION
## Summary

- make the Account language selector fill the settings control column
- keep direct Kumo Select controls associated with Field labels
- remove redundant visible field labels and read-only helper copy while preserving accessible and native read-only semantics
- add layout and accessibility regression coverage

## Testing

- pnpm --filter @opentag/web exec vitest run src/__tests__/account.test.tsx src/features/account/account-page.test.tsx src/ui/design-system.test.tsx src/__tests__/i18n-catalog.test.ts
- pnpm check
- pnpm typecheck
- targeted Chromium E2E at desktop and 390px mobile viewport