### PR TITLE
fix(web): prevent onboarding choice card clipping

### DIFF
--- a/apps/web/src/onboarding-v2/layout.test.ts
+++ b/apps/web/src/onboarding-v2/layout.test.ts
@@ -36,6 +36,15 @@ describe("onboarding flow layout", () => {
     expect(declarationValue(".otv2-choice", "white-space")).toBe("normal");
   });
 
+  it("lets destination and runtime choice cards grow beyond Kumo's single-line button height", () => {
+    expect(declarationValue(".otv2-shell .otv2-choice", "height")).toBe("auto");
+    expect(declarationValue(".otv2-shell .otv2-choice", "min-height")).toBe("80px");
+  });
+
+  it("keeps unavailable choice-card explanations readable", () => {
+    expect(declarationValue(".otv2-choice:disabled", "opacity")).toBe("1");
+  });
+
   it("answers a press with colour rather than shrinking the control", () => {
     // Nothing on this surface may shrink under a click.
     expect(declarationValue(".otv2-shell button:active", "transform")).toBe("none");

--- a/apps/web/src/onboarding-v2/onboarding-v2.css
+++ b/apps/web/src/onboarding-v2/onboarding-v2.css
@@ -61,6 +61,13 @@
     background 120ms ease;
 }
 
+/* Kumo's base Button is 36px tall. The shell scope gives this rule enough specificity to replace
+   that utility height: a choice is a two-line card and must grow with its copy. */
+.otv2-shell .otv2-choice {
+  height: auto;
+  min-height: 80px;
+}
+
 .otv2-choice:hover:not(:disabled) {
   background: var(--color-kumo-fill-hover);
 }
@@ -68,6 +75,9 @@
 .otv2-choice:disabled {
   background: var(--color-kumo-recessed);
   cursor: not-allowed;
+  /* Kumo dims disabled buttons as a whole. This card already communicates its unavailable state
+     through its surface and muted copy, so keep the explanatory text readable. */
+  opacity: 1;
 }
 
 .otv2-choice[aria-pressed="true"] {

--- a/apps/web/src/onboarding-v2/page.test.tsx
+++ b/apps/web/src/onboarding-v2/page.test.tsx
@@ -108,8 +108,10 @@ describe("OnboardingV2Page", () => {
     render(<OnboardingV2MockPage />);
     fireEvent.click(screen.getByRole("button", { name: /Local computer/ }));
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-    expect(screen.getByRole("button", { name: /Codex/ })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Claude Code/ })).toBeTruthy();
+    const codex = screen.getByRole("button", { name: /Codex/ });
+    const claudeCode = screen.getByRole("button", { name: /Claude Code/ });
+    expect(codex.classList).toContain("otv2-choice");
+    expect(claudeCode.classList).toContain("otv2-choice");
     expect(screen.getByText("More runtimes coming soon.")).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary

- Allow onboarding destination and runtime choice cards to grow beyond Kumo Button's fixed single-line height, preventing clipped copy.
- Preserve readable unavailable-card explanations while keeping the existing muted visual treatment.
- Add regression coverage for the destination card layout and the Codex/Claude Code runtime cards.

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/web exec vitest run src/onboarding-v2/layout.test.ts src/onboarding-v2/page.test.tsx --maxWorkers=1` (52 tests passed)
- Playwright browser verification at 1280px and 320px viewports; destination and runtime card content remains contained and runtime cards stack on narrow screens.
- `pnpm test` was run. The affected Web onboarding tests passed; two unrelated CLI daemon wrapper tests failed because the local Computer credentials file uses an unsupported format (expected exit code 3, received 1).
- The repository onboarding journey E2E was attempted but could not start because `127.0.0.1:5432` is occupied by `first-tree-hub-postgres`; no E2E test logic executed.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior; no documentation change is required.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (The first three pass; see the unrelated CLI failures above.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (not applicable).