### PR TITLE
fix(client): validate external Feishu credentials without auth

### DIFF
--- a/packages/client/src/__tests__/provider-cli-validation.test.ts
+++ b/packages/client/src/__tests__/provider-cli-validation.test.ts
@@ -1,9 +1,8 @@
-import { chmod, mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
-  classifyLarkAuthStatus,
   classifySlackAuthTest,
   deriveProviderCliValidationRequestKey,
   exchangeFeishuTenantToken,
@@ -11,6 +10,8 @@ import {
   FeishuTokenExchangeError,
   ProviderCliValidationRunner,
 } from "../index.js";
+import { classifyLarkBotInfo, classifyLarkWhoami } from "../runtime/provider-cli/validation-classify.js";
+import { validateFeishuBotIdentity } from "../runtime/provider-cli/validation-runner.js";
 
 const slackIdentity = { provider: "slack" as const, teamId: "T1", botUserId: "U1", botId: "B1" };
 const feishuIdentity = {
@@ -25,6 +26,16 @@ const feishuGrant = {
   appSecret: "secret",
   teamBrand: "feishu" as const,
 };
+const feishuWhoami = {
+  profile: "external",
+  appId: "cli_app",
+  brand: "feishu",
+  defaultAs: "bot",
+  identity: "bot",
+  identitySource: "flag",
+  available: true,
+  tokenStatus: "ready",
+};
 
 const fence = {
   requestId: "11111111-1111-4111-8111-111111111111",
@@ -33,6 +44,19 @@ const fence = {
   integrationId: "33333333-3333-4333-8333-333333333333",
   credentialGeneration: 1,
 };
+const feishuFence = { ...fence, provider: "feishu" as const };
+
+function feishuValidationRequest() {
+  return {
+    expectedFingerprint: "v1:test",
+    expectedIdentity: feishuIdentity,
+    expiresAt: new Date(Date.now() + 15_000).toISOString(),
+    grant: feishuGrant,
+    requestId: fence.requestId,
+    targetPath: "/bin/true",
+    version: "1.0.92",
+  };
+}
 
 async function fakeCli(home: string, script: string): Promise<string> {
   const path = join(home, "cli");
@@ -59,34 +83,42 @@ describe("provider CLI validation classification", () => {
     expect(classifySlackAuthTest("not-json", slackIdentity)).toEqual({ status: "needs_attention" });
   });
 
-  it("requires an explicit Lark brand and fails closed on missing brand or unknown schema", () => {
-    expect(
-      classifyLarkAuthStatus(
-        {
-          identity: { app_id: "cli_app", brand: "feishu", bot_open_id: "ou_bot" },
-          identities: { bot: { available: true, verified: true, open_id: "ou_bot" } },
-          _notice: { update: true },
-        },
-        feishuIdentity,
-      ),
-    ).toEqual({ status: "ready" });
-    expect(
-      classifyLarkAuthStatus(
-        {
-          identity: { app_id: "cli_app", bot_open_id: "ou_bot" },
-          identities: { bot: { available: true, verified: true, open_id: "ou_bot" } },
-        },
-        feishuIdentity,
-      ),
-    ).toEqual({ status: "needs_attention" });
-    expect(classifyLarkAuthStatus("not-json", feishuIdentity)).toEqual({ status: "needs_attention" });
-    expect(classifyLarkAuthStatus({ error: "rate_limited" }, feishuIdentity)).toEqual({
+  it("requires whoami to report the expected bot app, brand, availability, and ready token", () => {
+    expect(classifyLarkWhoami(feishuWhoami, feishuIdentity)).toEqual({ status: "ready" });
+    expect(classifyLarkWhoami({ ...feishuWhoami, appId: "cli_other" }, feishuIdentity)).toEqual({
+      status: "needs_attention",
+      reason: "identity_mismatch",
+    });
+    expect(classifyLarkWhoami({ ...feishuWhoami, brand: "lark" }, feishuIdentity)).toEqual({
+      status: "needs_attention",
+      reason: "identity_mismatch",
+    });
+    expect(classifyLarkWhoami({ ...feishuWhoami, available: false, tokenStatus: "missing" }, feishuIdentity)).toEqual({
+      status: "needs_attention",
+      reason: "credential_rejected",
+    });
+    expect(classifyLarkWhoami("not-json", feishuIdentity)).toEqual({ status: "needs_attention" });
+    expect(classifyLarkWhoami({ error: "rate_limited" }, feishuIdentity)).toEqual({
       status: "retrying",
       reason: "rate_limited",
     });
-    expect(classifyLarkAuthStatus({ error: "internal_error" }, feishuIdentity)).toEqual({
+    expect(classifyLarkWhoami({ error: "internal_error" }, feishuIdentity)).toEqual({
       status: "retrying",
       reason: "provider_unreachable",
+    });
+  });
+
+  it("matches the live Feishu bot open ID independently of whoami", () => {
+    expect(classifyLarkBotInfo({ code: 0, msg: "ok", bot: { open_id: "ou_bot" } }, feishuIdentity)).toEqual({
+      status: "ready",
+    });
+    expect(classifyLarkBotInfo({ code: 0, msg: "ok", bot: { open_id: "ou_other" } }, feishuIdentity)).toEqual({
+      status: "needs_attention",
+      reason: "identity_mismatch",
+    });
+    expect(classifyLarkBotInfo({ code: 99991663, msg: "invalid token" }, feishuIdentity)).toEqual({
+      status: "needs_attention",
+      reason: "credential_rejected",
     });
   });
 
@@ -159,6 +191,123 @@ describe("Feishu tenant token exchange", () => {
 });
 
 describe("provider CLI validation runner", () => {
+  it("validates external Feishu credentials with whoami and a separate live bot identity request", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-validation-feishu-"));
+    const execFile = vi.fn(async (_file, args, options) => {
+      expect(args).toEqual(["whoami", "--as", "bot", "--json"]);
+      expect(args[0]).not.toBe("auth");
+      expect(options.env.LARKSUITE_CLI_APP_ID).toBe("cli_app");
+      expect(options.env.LARKSUITE_CLI_APP_SECRET).toBe("secret");
+      expect(options.env.LARKSUITE_CLI_BRAND).toBe("feishu");
+      expect(options.env.LARKSUITE_CLI_TENANT_ACCESS_TOKEN).toBe("tenant-token");
+      expect(options.env.LARKSUITE_CLI_USER_ACCESS_TOKEN).toBeUndefined();
+      return { stdout: JSON.stringify(feishuWhoami), stderr: "" };
+    });
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/open-apis/auth/v3/tenant_access_token/internal")) {
+        expect(init?.method).toBe("POST");
+        return new Response(JSON.stringify({ code: 0, tenant_access_token: "tenant-token" }));
+      }
+      expect(url).toBe("https://open.feishu.cn/open-apis/bot/v3/info");
+      expect(init?.method).toBe("GET");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer tenant-token");
+      return new Response(JSON.stringify({ code: 0, msg: "ok", bot: { open_id: "ou_bot" } }));
+    }) as typeof fetch;
+    const runner = new ProviderCliValidationRunner({
+      home,
+      execFile,
+      fetch: fetchImpl,
+      verifyTarget: async () => true,
+    });
+
+    await expect(runner.run(feishuValidationRequest(), feishuFence)).resolves.toEqual({
+      ...feishuFence,
+      status: "ready",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(await readdir(join(home, "data", "runtime", "provider-cli-validation"))).toEqual([]);
+  });
+
+  it.each([
+    ["app", { ...feishuWhoami, appId: "cli_other" }, "identity_mismatch"],
+    ["brand", { ...feishuWhoami, brand: "lark" }, "identity_mismatch"],
+    ["identity", { ...feishuWhoami, identity: "user" }, "identity_mismatch"],
+    ["availability", { ...feishuWhoami, available: false, tokenStatus: "missing" }, "credential_rejected"],
+    ["token status", { ...feishuWhoami, tokenStatus: "expired" }, "credential_rejected"],
+  ])("fails closed on the wrong Feishu whoami %s", async (_case, payload, reason) => {
+    const fetchImpl = vi.fn();
+    const runner = new ProviderCliValidationRunner({
+      home: await mkdtemp(join(tmpdir(), "opentag-validation-feishu-whoami-")),
+      exchangeFeishuToken: async () => "tenant-token",
+      execFile: vi.fn(async () => ({ stdout: JSON.stringify(payload), stderr: "" })),
+      fetch: fetchImpl,
+      verifyTarget: async () => true,
+    });
+    await expect(runner.run(feishuValidationRequest(), feishuFence)).resolves.toMatchObject({
+      status: "needs_attention",
+      reason,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "token",
+      new Response(JSON.stringify({ code: 99991663, msg: "invalid token" }), { status: 401 }),
+      "credential_rejected",
+    ],
+    ["bot", new Response(JSON.stringify({ code: 0, msg: "ok", bot: { open_id: "ou_other" } })), "identity_mismatch"],
+  ])("rejects a wrong Feishu %s after whoami succeeds", async (_case, response, reason) => {
+    const fetchImpl = vi.fn(async () => response) as typeof fetch;
+    const runner = new ProviderCliValidationRunner({
+      home: await mkdtemp(join(tmpdir(), "opentag-validation-feishu-live-")),
+      exchangeFeishuToken: async () => "tenant-token",
+      execFile: vi.fn(async () => ({ stdout: JSON.stringify(feishuWhoami), stderr: "" })),
+      fetch: fetchImpl,
+      verifyTarget: async () => true,
+    });
+    await expect(runner.run(feishuValidationRequest(), feishuFence)).resolves.toMatchObject({
+      status: "needs_attention",
+      reason,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the live Feishu bot request with its own timeout", async () => {
+    const hangingFetch = vi.fn(
+      async (_input: string | URL | Request, init?: RequestInit) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), {
+            once: true,
+          });
+        }),
+    ) as typeof fetch;
+    await expect(
+      validateFeishuBotIdentity("tenant-token", feishuIdentity, undefined, hangingFetch, 5),
+    ).resolves.toEqual({
+      status: "retrying",
+      reason: "provider_unreachable",
+    });
+  });
+
+  it("cleans up the Feishu validation directory after a CLI timeout", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-validation-feishu-timeout-"));
+    const runner = new ProviderCliValidationRunner({
+      home,
+      exchangeFeishuToken: async () => "tenant-token",
+      execFile: vi.fn(async () => {
+        throw Object.assign(new Error("timeout"), { killed: true, stdout: "", stderr: "" });
+      }),
+      verifyTarget: async () => true,
+    });
+    await expect(runner.run(feishuValidationRequest(), feishuFence)).resolves.toMatchObject({
+      status: "retrying",
+      reason: "provider_unreachable",
+    });
+    expect(await readdir(join(home, "data", "runtime", "provider-cli-validation"))).toEqual([]);
+  });
+
   it("runs the Slack auth.test argv in an isolated env and never persists the grant", async () => {
     const home = await mkdtemp(join(tmpdir(), "opentag-validation-"));
     const targetPath = await fakeCli(

--- a/packages/client/src/runtime/provider-cli/validation-classify.ts
+++ b/packages/client/src/runtime/provider-cli/validation-classify.ts
@@ -48,7 +48,7 @@ export function classifySlackAuthTest(
   return { status: "ready" };
 }
 
-export function classifyLarkAuthStatus(
+export function classifyLarkWhoami(
   payload: unknown,
   expected: Extract<ProviderCliExpectedIdentity, { provider: "feishu" }>,
 ): ProviderCliValidationClassification {
@@ -58,18 +58,44 @@ export function classifyLarkAuthStatus(
     payload.missing_scopes,
   );
   if (failure) return failure;
-  if (!isRecord(payload.identity) || !isRecord(payload.identities)) return { status: "needs_attention" };
-  if (!isRecord(payload.identities.bot)) return { status: "needs_attention" };
-  const bot = payload.identities.bot;
-  if (typeof bot.available !== "boolean" || typeof bot.verified !== "boolean") return { status: "needs_attention" };
-  if (!bot.available || !bot.verified) return { status: "needs_attention", reason: "credential_rejected" };
-  const identity = larkIdentity(payload.identity, bot);
-  if (!identity) return { status: "needs_attention" };
-  if (
-    identity.appId !== expected.appId ||
-    identity.botOpenId !== expected.botOpenId ||
-    identity.brand !== expected.teamBrand
-  ) {
+  const appId = stringField(payload, ["appId", "app_id"]);
+  const brand = stringField(payload, ["brand", "teamBrand", "team_brand"]);
+  if (!appId || (brand !== "lark" && brand !== "feishu")) return { status: "needs_attention" };
+  if (payload.identity !== "bot" || appId !== expected.appId || brand !== expected.teamBrand) {
+    return { status: "needs_attention", reason: "identity_mismatch" };
+  }
+  if (typeof payload.available !== "boolean" || typeof payload.tokenStatus !== "string") {
+    return { status: "needs_attention" };
+  }
+  if (!payload.available || payload.tokenStatus !== "ready") {
+    return { status: "needs_attention", reason: "credential_rejected" };
+  }
+  return { status: "ready" };
+}
+
+/** @deprecated Retained for compatibility; Feishu validation now classifies `whoami` output. */
+export function classifyLarkAuthStatus(
+  payload: unknown,
+  expected: Extract<ProviderCliExpectedIdentity, { provider: "feishu" }>,
+): ProviderCliValidationClassification {
+  return classifyLarkWhoami(payload, expected);
+}
+
+export function classifyLarkBotInfo(
+  payload: unknown,
+  expected: Extract<ProviderCliExpectedIdentity, { provider: "feishu" }>,
+): ProviderCliValidationClassification {
+  if (!isRecord(payload)) return { status: "needs_attention" };
+  const failure = classifyProviderFailure(
+    [stringifyUnknown(payload.error), stringifyUnknown(payload.code)],
+    payload.missing_scopes,
+  );
+  if (failure) return failure;
+  if (payload.code !== 0) return { status: "needs_attention", reason: "credential_rejected" };
+  if (!isRecord(payload.bot) || typeof payload.bot.open_id !== "string" || payload.bot.open_id.length === 0) {
+    return { status: "needs_attention" };
+  }
+  if (payload.bot.open_id !== expected.botOpenId) {
     return { status: "needs_attention", reason: "identity_mismatch" };
   }
   return { status: "ready" };
@@ -96,20 +122,6 @@ function slackIdentity(
   if (typeof payload.user_id !== "string") return undefined;
   if (typeof payload.bot_id !== "string") return undefined;
   return { botId: payload.bot_id, teamId: payload.team_id, userId: payload.user_id };
-}
-
-function larkIdentity(
-  identity: Record<string, unknown>,
-  bot: Record<string, unknown>,
-): { readonly appId: string; readonly botOpenId: string; readonly brand: "feishu" | "lark" } | undefined {
-  const appId = stringField(identity, ["app_id", "appId"]) ?? stringField(bot, ["app_id"]);
-  const brand = stringField(identity, ["brand", "team_brand", "teamBrand"]);
-  const botOpenId =
-    stringField(identity, ["bot_open_id", "botOpenId", "open_id", "openId"]) ??
-    stringField(bot, ["bot_open_id", "open_id", "openId"]);
-  if (!appId || !botOpenId) return undefined;
-  if (brand !== "lark" && brand !== "feishu") return undefined;
-  return { appId, botOpenId, brand };
 }
 
 export function classifySpawnFailure(error: unknown): ProviderCliValidationClassification {

--- a/packages/client/src/runtime/provider-cli/validation-runner.ts
+++ b/packages/client/src/runtime/provider-cli/validation-runner.ts
@@ -18,7 +18,8 @@ import { findProviderCliCatalogEntry } from "./catalog.js";
 import { computeFileIdentity, computeTargetFingerprint } from "./fingerprint.js";
 import { providerCliProbeEnvironment } from "./probe.js";
 import {
-  classifyLarkAuthStatus,
+  classifyLarkBotInfo,
+  classifyLarkWhoami,
   classifySlackAuthTest,
   classifySpawnFailure,
   extractBoundedJson,
@@ -81,6 +82,7 @@ export class FeishuTokenExchangeError extends Error {
 export class ProviderCliValidationRunner {
   readonly #exchangeFeishuToken: NonNullable<ProviderCliValidationRunnerOptions["exchangeFeishuToken"]>;
   readonly #execFile: ProviderCliValidationExecFile;
+  readonly #fetch: typeof fetch;
   readonly #home: string;
   readonly #now: () => number;
   readonly #root: string;
@@ -89,9 +91,9 @@ export class ProviderCliValidationRunner {
   readonly #startupCleanup: Promise<void>;
 
   constructor(options: ProviderCliValidationRunnerOptions) {
+    this.#fetch = options.fetch ?? fetch;
     this.#exchangeFeishuToken =
-      options.exchangeFeishuToken ??
-      ((grant, signal) => exchangeFeishuTenantToken(grant, signal, options.fetch ?? fetch));
+      options.exchangeFeishuToken ?? ((grant, signal) => exchangeFeishuTenantToken(grant, signal, this.#fetch));
     this.#execFile = options.execFile ?? defaultExecFile;
     this.#now = options.now ?? Date.now;
     this.#verifyTarget = options.verifyTarget ?? verifyTargetFingerprint;
@@ -188,18 +190,20 @@ export class ProviderCliValidationRunner {
     env.LARKSUITE_CLI_BRAND = request.grant.teamBrand;
     env.LARKSUITE_CLI_TENANT_ACCESS_TOKEN = tenantAccessToken;
     delete env.LARKSUITE_CLI_USER_ACCESS_TOKEN;
-    return this.#runProcess(
+    const expected = request.expectedIdentity as Extract<ProviderCliExpectedIdentity, { provider: "feishu" }>;
+    const whoami = await this.#runProcess(
       request.targetPath,
-      ["auth", "status", "--verify", "--json"],
+      ["whoami", "--as", "bot", "--json"],
       env,
       workDir,
-      (payload) =>
-        classifyLarkAuthStatus(
-          payload,
-          request.expectedIdentity as Extract<ProviderCliExpectedIdentity, { provider: "feishu" }>,
-        ),
+      (payload) => classifyLarkWhoami(payload, expected),
       signal,
     );
+    if (whoami.status !== "ready") return whoami;
+    if (Date.parse(request.expiresAt) <= this.#now()) {
+      return { status: "retrying", reason: "validation_expired" };
+    }
+    return validateFeishuBotIdentity(tenantAccessToken, expected, signal, this.#fetch);
   }
 
   async cleanupAll(): Promise<void> {
@@ -416,7 +420,11 @@ export async function exchangeFeishuTenantToken(
   }
   if (response.status === 429) throw new FeishuTokenExchangeError("rate_limited");
   if (response.status >= 500) throw new FeishuTokenExchangeError("provider_unreachable");
-  const buffer = await readBoundedResponseBody(response, RUNTIME_PROVIDER_CLI_VALIDATION_MAX_OUTPUT_BYTES);
+  const buffer = await readBoundedResponseBody(
+    response,
+    RUNTIME_PROVIDER_CLI_VALIDATION_MAX_OUTPUT_BYTES,
+    () => new FeishuTokenExchangeError("invalid"),
+  );
   let body: unknown;
   try {
     body = JSON.parse(new TextDecoder().decode(buffer));
@@ -430,7 +438,58 @@ export async function exchangeFeishuTenantToken(
   return body.tenant_access_token;
 }
 
-async function readBoundedResponseBody(response: Response, maxBytes: number): Promise<Uint8Array> {
+export async function validateFeishuBotIdentity(
+  tenantAccessToken: string,
+  expected: Extract<ProviderCliExpectedIdentity, { provider: "feishu" }>,
+  signal?: AbortSignal,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = RUNTIME_PROVIDER_CLI_VALIDATION_TIMEOUT_MS,
+): Promise<ProviderCliValidationClassification> {
+  if (signal?.aborted) throw abortError();
+  const timeout = AbortSignal.timeout(timeoutMs);
+  const combined = signal ? AbortSignal.any([signal, timeout]) : timeout;
+  const origin = expected.teamBrand === "lark" ? "https://open.larksuite.com" : "https://open.feishu.cn";
+  let response: Response;
+  try {
+    response = await fetchImpl(`${origin}/open-apis/bot/v3/info`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${tenantAccessToken}` },
+      redirect: "error",
+      signal: combined,
+    });
+  } catch {
+    if (signal?.aborted) throw abortError();
+    return { status: "retrying", reason: "provider_unreachable" };
+  }
+  if (response.status === 429) return { status: "retrying", reason: "rate_limited" };
+  if (response.status >= 500) return { status: "retrying", reason: "provider_unreachable" };
+  if (!response.ok) return { status: "needs_attention", reason: "credential_rejected" };
+  let buffer: Uint8Array;
+  try {
+    buffer = await readBoundedResponseBody(
+      response,
+      RUNTIME_PROVIDER_CLI_VALIDATION_MAX_OUTPUT_BYTES,
+      () => new Error("Feishu bot info response exceeded the output limit"),
+    );
+  } catch {
+    if (signal?.aborted) throw abortError();
+    if (combined.aborted) return { status: "retrying", reason: "provider_unreachable" };
+    return { status: "needs_attention" };
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(new TextDecoder().decode(buffer));
+  } catch {
+    return { status: "needs_attention" };
+  }
+  return classifyLarkBotInfo(body, expected);
+}
+
+async function readBoundedResponseBody(
+  response: Response,
+  maxBytes: number,
+  outputTooLarge: () => Error,
+): Promise<Uint8Array> {
   if (!response.body) return new Uint8Array();
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
@@ -440,7 +499,7 @@ async function readBoundedResponseBody(response: Response, maxBytes: number): Pr
       const { done, value } = await reader.read();
       if (done) break;
       total += value.byteLength;
-      if (total > maxBytes) throw new FeishuTokenExchangeError("invalid");
+      if (total > maxBytes) throw outputTooLarge();
       chunks.push(value);
     }
   } finally {


### PR DESCRIPTION
## Summary

- Replace the unsupported external-credential Feishu auth status invocation with lark-cli whoami --as bot --json.
- Require the expected app ID, regional brand, bot identity, availability, and ready token status, then independently call GET /open-apis/bot/v3/info with the exchanged tenant token and compare bot.open_id.
- Preserve the isolated HOME/XDG directories, output bounds, timeout and abort behavior, target fingerprint fence, and cleanup without logging credentials.
- Add regression coverage for argv safety, successful validation, wrong app/brand/identity/token status, invalid token, wrong bot, timeout, and cleanup.

Fixes #433

## Testing

- pnpm --filter @opentag/client exec vitest run src/__tests__/provider-cli-validation.test.ts
- pnpm check
- pnpm build
- pnpm typecheck
- pnpm test
- pnpm --filter @opentag/client test:agent-runtime:coverage
- pnpm --filter @opentag/server test:integration

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] pnpm check, pnpm build, pnpm typecheck, and pnpm test pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.