### PR TITLE
feat(workflows): auto-close pull requests idle for seven days

### DIFF
--- a/.github/workflows/stale-pull-requests.yml
+++ b/.github/workflows/stale-pull-requests.yml
@@ -1,0 +1,58 @@
+name: Stale Pull Requests
+
+# Review attention is the scarce resource. A pull request nobody has touched for
+# a week is noise in every listing and a false signal that work is in flight, so
+# the sweep notifies the people who can act on it and then closes it. Closing is
+# reversible: the branch survives and anyone with write access can reopen.
+on:
+  schedule:
+    - cron: "41 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report the decisions without commenting, labelling or closing; defaults to true for manual runs"
+        required: false
+        type: boolean
+        default: true
+
+# Never cancel a sweep in flight: it mutates pull requests one at a time, and a
+# half-applied run would leave a notice posted with no matching label.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    name: Notify And Close Stale Pull Requests
+    # Forks inherit the schedule; without this guard every fork would start
+    # closing its own pull requests.
+    if: github.repository == 'first-tree-ai/opentag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+
+      # The sweep imports only node: builtins, so there is nothing to install.
+      - name: Notify and close stale pull requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          STALE_PR_LOG_LEVEL: ${{ runner.debug == '1' && 'debug' || 'info' }}
+        run: |
+          set -euo pipefail
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            node scripts/stale-pull-requests.mjs --dry-run
+          else
+            node scripts/stale-pull-requests.mjs
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,12 @@ fix: classify client connection failures
 Pull requests should describe the change, its validation, any breaking behavior, and important non-goals. Keep unrelated
 refactors out of the same pull request. CI must pass before merge.
 
+Open pull requests are swept daily by the `Stale Pull Requests` workflow. A pull request with no activity for five days
+gets a comment naming its author and reviewers; if it is still untouched after seven days, and at least two days after
+that comment, the bot closes it. Pushing a commit, leaving a comment, or submitting a review resets the clock. Drafts are
+never swept, and the `keep-open` label exempts a pull request indefinitely. Closing is reversible: the branch survives
+and anyone with write access can reopen the pull request.
+
 All code, code comments, GitHub templates, and technical documentation use English as the canonical source. When a
 canonical document has a Chinese mirror, update both in the same pull request and refresh the mirror's sync date.
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,7 +1,7 @@
 # 为 OpenTag 贡献
 
 > Canonical source: [CONTRIBUTING.md](./CONTRIBUTING.md)
-> Last synced with: 2026-08-29
+> Last synced with: 2026-09-01
 
 OpenTag 处于 pre-alpha 阶段。请保持改动聚焦，说明其解决的用户或贡献者问题，并避免在没有既定设计时增加产品能力。
 
@@ -24,6 +24,10 @@ fix: classify client connection failures
 ## Pull Request
 
 Pull Request 应说明改动、验证方式、破坏性行为和重要非目标。无关重构不要混入同一个 Pull Request，合并前 CI 必须通过。
+
+`Stale Pull Requests` workflow 每天巡检所有开放的 Pull Request。静默五天的 Pull Request 会收到一条评论，@ 其作者与
+reviewer；若静默满七天，且距该评论已过至少两天，bot 会将其关闭。推送 commit、发表评论或提交 review 都会重置计时。
+草稿 Pull Request 不在巡检范围内，`keep-open` 标签可永久豁免。关闭是可逆的：分支不受影响，任何有写权限的人都可以重新打开。
 
 代码、代码注释、GitHub 模板和技术文档以英文为 canonical source。英文文档存在中文镜像时，应在同一个 Pull Request
 中同步更新，并刷新镜像的同步日期。

--- a/scripts/__tests__/stale-pull-requests.test.mjs
+++ b/scripts/__tests__/stale-pull-requests.test.mjs
@@ -1,0 +1,768 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  CLOSED_MARKER,
+  collectMentions,
+  findNotice,
+  NOTICE_MARKER,
+  normalizePullRequest,
+} from "../stale-pull-requests/activity.mjs";
+import { createPullRequestActions, executeDecisions } from "../stale-pull-requests/executor.mjs";
+import { createGitHubClient } from "../stale-pull-requests/github.mjs";
+import { createLogger } from "../stale-pull-requests/logger.mjs";
+import {
+  ACTION_CLOSE,
+  ACTION_NONE,
+  ACTION_SKIP,
+  ACTION_WARN,
+  decidePullRequest,
+} from "../stale-pull-requests/policy.mjs";
+import { PULL_REQUESTS_QUERY } from "../stale-pull-requests/query.mjs";
+import { buildConfig, parseRepository, planSweep } from "../stale-pull-requests.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const workflowPath = join(repoRoot, ".github", "workflows", "stale-pull-requests.yml");
+
+const NOW = "2026-09-01T00:00:00.000Z";
+const MS_PER_DAY = 86_400_000;
+
+function daysAgo(days) {
+  return new Date(Date.parse(NOW) - days * MS_PER_DAY).toISOString();
+}
+
+function config(overrides = {}) {
+  return {
+    warnAfterDays: 5,
+    closeAfterDays: 7,
+    graceHours: 48,
+    staleLabel: "stale",
+    exemptLabels: ["keep-open"],
+    exemptAuthors: [],
+    botLogins: ["github-actions"],
+    exemptDrafts: true,
+    maxNotices: 25,
+    maxCloses: 10,
+    ...overrides,
+  };
+}
+
+function pullRequest(overrides = {}) {
+  return {
+    number: 1,
+    title: "Add a thing",
+    url: "https://github.com/first-tree-ai/opentag/pull/1",
+    isDraft: false,
+    authorLogin: "alice",
+    authorKey: "alice",
+    labels: [],
+    hasStaleLabel: false,
+    createdAt: daysAgo(30),
+    lastActivityAt: daysAgo(1),
+    activityTruncated: false,
+    notice: null,
+    hasFarewell: false,
+    mentions: ["alice"],
+    requestedTeamCount: 0,
+    ...overrides,
+  };
+}
+
+function decide(overrides, configOverrides = {}) {
+  return decidePullRequest({ pullRequest: pullRequest(overrides), config: config(configOverrides), now: NOW });
+}
+
+const silentLogger = createLogger({
+  level: "error",
+  sink: {
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+});
+
+function recordingActions(failOn = new Set()) {
+  const calls = [];
+  const record = async (kind, ...args) => {
+    if (failOn.has(`${kind}:${args[0]}`)) {
+      throw new Error(`${kind} failed`);
+    }
+    calls.push([kind, ...args]);
+  };
+  return {
+    calls,
+    comment: (number, body) => record("comment", number, body),
+    addLabel: (number, label) => record("addLabel", number, label),
+    removeLabel: (number, label) => record("removeLabel", number, label),
+    close: (number) => record("close", number),
+    createLabel: (name) => record("createLabel", name),
+  };
+}
+
+// --- Policy -----------------------------------------------------------------
+
+test("a pull request touched inside the notice window is left alone", () => {
+  const decision = decide({ lastActivityAt: daysAgo(4.9) });
+  assert.equal(decision.action, ACTION_NONE);
+  assert.equal(decision.desiredStaleLabel, false);
+});
+
+test("a pull request idle past the notice window is notified and marked stale", () => {
+  const decision = decide({ lastActivityAt: daysAgo(5.1) });
+  assert.equal(decision.action, ACTION_WARN);
+  assert.equal(decision.desiredStaleLabel, true);
+});
+
+test("a notified pull request is not notified again while it is inside the close window", () => {
+  const decision = decide({
+    lastActivityAt: daysAgo(6),
+    notice: { commentId: "c1", postedAt: daysAgo(1) },
+  });
+  assert.equal(decision.action, ACTION_NONE);
+  assert.equal(decision.desiredStaleLabel, true);
+});
+
+test("a notified pull request past the close window is closed once the grace period elapses", () => {
+  const decision = decide({
+    lastActivityAt: daysAgo(8),
+    hasStaleLabel: true,
+    notice: { commentId: "c1", postedAt: daysAgo(3) },
+  });
+  assert.equal(decision.action, ACTION_CLOSE);
+  assert.equal(decision.idleDays, 8);
+});
+
+test("a backlog pull request is notified first and can only be closed on a later run", () => {
+  // The whole point of the grace period: a pull request idle for a month must
+  // still get a notice and a real window to answer it, not a same-run close.
+  const firstRun = decide({ lastActivityAt: daysAgo(30) });
+  assert.equal(firstRun.action, ACTION_WARN);
+
+  const sameDayRerun = decide({
+    lastActivityAt: daysAgo(30),
+    hasStaleLabel: true,
+    notice: { commentId: "c1", postedAt: daysAgo(0.1) },
+  });
+  assert.equal(sameDayRerun.action, ACTION_NONE);
+  assert.match(sameDayRerun.reason, /grace period/);
+});
+
+test("activity after a notice supersedes it and clears the stale label", () => {
+  const decision = decide({
+    lastActivityAt: daysAgo(1),
+    hasStaleLabel: true,
+    notice: { commentId: "c1", postedAt: daysAgo(3) },
+  });
+  assert.equal(decision.action, ACTION_NONE);
+  assert.equal(decision.desiredStaleLabel, false);
+});
+
+test("a notice older than the last activity is superseded rather than counted", () => {
+  // Reached inside the stale branch, where supersession actually decides
+  // between notifying afresh and closing. Idle 8 days would close if the stale
+  // notice still counted.
+  const superseded = decide({
+    lastActivityAt: daysAgo(6),
+    notice: { commentId: "c1", postedAt: daysAgo(7) },
+  });
+  assert.equal(superseded.action, ACTION_WARN);
+
+  const stillValid = decide({
+    lastActivityAt: daysAgo(8),
+    notice: { commentId: "c1", postedAt: daysAgo(3) },
+  });
+  assert.equal(stillValid.action, ACTION_CLOSE);
+});
+
+test("a notice posted in the same instant as the last activity still counts", () => {
+  const decision = decide({
+    lastActivityAt: daysAgo(8),
+    notice: { commentId: "c1", postedAt: daysAgo(8) },
+  });
+  assert.equal(decision.action, ACTION_CLOSE, "an equal timestamp must not be treated as superseded");
+});
+
+test("a revived pull request that goes quiet again is notified afresh instead of closed", () => {
+  const decision = decide({
+    lastActivityAt: daysAgo(8),
+    hasStaleLabel: true,
+    notice: { commentId: "c1", postedAt: daysAgo(20) },
+  });
+  assert.equal(decision.action, ACTION_WARN);
+});
+
+test("drafts are exempt", () => {
+  const decision = decide({ isDraft: true, lastActivityAt: daysAgo(90) });
+  assert.equal(decision.action, ACTION_SKIP);
+  assert.match(decision.reason, /draft/);
+});
+
+test("an exempt label keeps a long-idle pull request open and drops the stale label", () => {
+  const decision = decide({
+    labels: ["keep-open", "stale"],
+    hasStaleLabel: true,
+    lastActivityAt: daysAgo(90),
+  });
+  assert.equal(decision.action, ACTION_SKIP);
+  assert.equal(decision.desiredStaleLabel, false);
+});
+
+test("an exempt author is never notified or closed", () => {
+  const decision = decide({ authorKey: "dependabot", lastActivityAt: daysAgo(90) }, { exemptAuthors: ["dependabot"] });
+  assert.equal(decision.action, ACTION_SKIP);
+  assert.match(decision.reason, /exempt author/);
+});
+
+test("a truncated activity history leaves the pull request exactly as it is", () => {
+  const decision = decide({ activityTruncated: true, hasStaleLabel: true, lastActivityAt: daysAgo(90) });
+  assert.deepEqual(decision, {
+    action: ACTION_SKIP,
+    reason: "activity history is truncated; last human activity cannot be dated",
+    idleDays: null,
+    desiredStaleLabel: true,
+  });
+});
+
+test("a close window at or below the notice window is rejected", () => {
+  assert.throws(() => decide({}, { closeAfterDays: 5 }), /closeAfterDays/);
+  assert.throws(() => decide({}, { graceHours: 0 }), /graceHours/);
+});
+
+// --- Activity resolution ----------------------------------------------------
+
+function graphqlNode(overrides = {}) {
+  return {
+    id: "PR_1",
+    number: 7,
+    title: "Add a thing",
+    url: "https://github.com/first-tree-ai/opentag/pull/7",
+    createdAt: daysAgo(30),
+    isDraft: false,
+    author: { __typename: "User", login: "alice" },
+    labels: { nodes: [] },
+    reviewRequests: { nodes: [] },
+    latestReviews: { nodes: [] },
+    comments: { nodes: [] },
+    reviewThreads: { nodes: [] },
+    timelineItems: { pageInfo: { hasPreviousPage: false }, nodes: [] },
+    ...overrides,
+  };
+}
+
+function noticeComment(postedAt) {
+  return {
+    id: "IC_notice",
+    createdAt: postedAt,
+    body: `${NOTICE_MARKER}\n@alice — this pull request has had no activity.`,
+    author: { __typename: "Bot", login: "github-actions" },
+  };
+}
+
+test("the sweep's own notice never counts as activity, so a notified pull request still closes", () => {
+  // The regression this whole design exists to prevent: the notice bumps
+  // updatedAt, and a sweep that trusted updatedAt would reset its own clock and
+  // never close anything.
+  const node = graphqlNode({
+    comments: { nodes: [noticeComment(daysAgo(3))] },
+    timelineItems: {
+      pageInfo: { hasPreviousPage: false },
+      nodes: [
+        { __typename: "IssueComment", createdAt: daysAgo(10), author: { __typename: "User", login: "bob" } },
+        { __typename: "IssueComment", createdAt: daysAgo(3), author: { __typename: "Bot", login: "github-actions" } },
+        {
+          __typename: "LabeledEvent",
+          createdAt: daysAgo(3),
+          actor: { __typename: "Bot", login: "github-actions" },
+        },
+      ],
+    },
+  });
+
+  const [{ pullRequest, decision }] = planSweep({ nodes: [node], config: config(), now: NOW });
+  assert.equal(pullRequest.lastActivityAt, daysAgo(10));
+  assert.equal(decision.action, ACTION_CLOSE);
+});
+
+test("another bot's activity still counts, so a maintained pull request is not closed", () => {
+  const node = graphqlNode({
+    timelineItems: {
+      pageInfo: { hasPreviousPage: false },
+      nodes: [
+        { __typename: "IssueComment", createdAt: daysAgo(1), author: { __typename: "Bot", login: "dependabot" } },
+      ],
+    },
+  });
+
+  const [{ decision }] = planSweep({ nodes: [node], config: config(), now: NOW });
+  assert.equal(decision.action, ACTION_NONE);
+});
+
+test("commit activity uses the later of the committed and authored dates", () => {
+  // A rebase rewrites committedDate and can move it either way; taking the max
+  // keeps a freshly pushed branch from looking abandoned.
+  const node = graphqlNode({
+    timelineItems: {
+      pageInfo: { hasPreviousPage: false },
+      nodes: [
+        {
+          __typename: "PullRequestCommit",
+          commit: {
+            committedDate: daysAgo(20),
+            authoredDate: daysAgo(2),
+            author: { user: { login: "alice" } },
+            committer: { user: null },
+          },
+        },
+      ],
+    },
+  });
+
+  const normalized = normalizePullRequest(node, { botLogins: ["github-actions"], staleLabel: "stale", now: NOW });
+  assert.equal(normalized.lastActivityAt, daysAgo(2));
+});
+
+test("a review thread reply counts as activity even with nothing on the timeline", () => {
+  // A reply typed into an existing review thread frequently produces no
+  // PullRequestReview timeline item at all, so review threads must be read from
+  // their own connection. Without this the pull request below looks 30 days
+  // idle and gets closed while a review is actively in progress.
+  const node = graphqlNode({
+    reviewThreads: {
+      nodes: [
+        { comments: { nodes: [{ createdAt: daysAgo(40), author: { __typename: "User", login: "bob" } }] } },
+        { comments: { nodes: [{ createdAt: daysAgo(2), author: { __typename: "User", login: "carol" } }] } },
+      ],
+    },
+  });
+
+  const [{ pullRequest, decision }] = planSweep({ nodes: [node], config: config(), now: NOW });
+  assert.equal(pullRequest.lastActivityAt, daysAgo(2));
+  assert.equal(decision.action, ACTION_NONE);
+});
+
+test("the sweep's own review thread comment does not count as activity", () => {
+  const node = graphqlNode({
+    reviewThreads: {
+      nodes: [
+        { comments: { nodes: [{ createdAt: daysAgo(1), author: { __typename: "Bot", login: "github-actions" } }] } },
+      ],
+    },
+  });
+
+  const normalized = normalizePullRequest(node, { botLogins: ["github-actions"], staleLabel: "stale", now: NOW });
+  assert.equal(normalized.lastActivityAt, daysAgo(30), "must fall back to createdAt");
+});
+
+test("a future-dated commit cannot pin a pull request open forever", () => {
+  // authoredDate is whatever the contributor's clock said, so it is not trusted
+  // past `now`.
+  const node = graphqlNode({
+    createdAt: daysAgo(60),
+    timelineItems: {
+      pageInfo: { hasPreviousPage: false },
+      nodes: [
+        {
+          __typename: "PullRequestCommit",
+          commit: {
+            committedDate: daysAgo(40),
+            authoredDate: daysAgo(-3650),
+            author: { user: { login: "alice" } },
+            committer: { user: null },
+          },
+        },
+      ],
+    },
+  });
+
+  const normalized = normalizePullRequest(node, { botLogins: ["github-actions"], staleLabel: "stale", now: NOW });
+  assert.equal(normalized.lastActivityAt, daysAgo(40));
+});
+
+test("a pull request with no activity at all falls back to its creation date", () => {
+  const node = graphqlNode({ createdAt: daysAgo(60) });
+  const normalized = normalizePullRequest(node, { botLogins: ["github-actions"], staleLabel: "stale", now: NOW });
+  assert.equal(normalized.lastActivityAt, daysAgo(60));
+  assert.equal(normalized.activityTruncated, false);
+});
+
+test("a deleted account's comment still counts as human activity", () => {
+  const node = graphqlNode({
+    timelineItems: {
+      pageInfo: { hasPreviousPage: false },
+      nodes: [{ __typename: "IssueComment", createdAt: daysAgo(2), author: null }],
+    },
+  });
+
+  const normalized = normalizePullRequest(node, { botLogins: ["github-actions"], staleLabel: "stale", now: NOW });
+  assert.equal(normalized.lastActivityAt, daysAgo(2));
+  assert.equal(normalized.activityTruncated, false);
+});
+
+test("a newest timeline page made entirely of sweep events is reported as truncated", () => {
+  const node = graphqlNode({
+    timelineItems: {
+      pageInfo: { hasPreviousPage: true },
+      nodes: [
+        { __typename: "LabeledEvent", createdAt: daysAgo(1), actor: { __typename: "Bot", login: "github-actions" } },
+      ],
+    },
+  });
+
+  const normalized = normalizePullRequest(node, { botLogins: ["github-actions"], staleLabel: "stale", now: NOW });
+  assert.equal(normalized.activityTruncated, true);
+});
+
+test("the newest notice wins and only a bot-authored marker counts", () => {
+  const notice = findNotice([
+    noticeComment(daysAgo(9)),
+    { id: "IC_human", createdAt: daysAgo(1), body: NOTICE_MARKER, author: { __typename: "User", login: "mallory" } },
+    { ...noticeComment(daysAgo(4)), id: "IC_recent" },
+  ]);
+  assert.deepEqual(notice, { commentId: "IC_recent", postedAt: daysAgo(4) });
+});
+
+test("mentions cover the author, requested reviewers and past reviewers, but never teams or bots", () => {
+  const mentions = collectMentions(
+    {
+      author: { __typename: "User", login: "alice" },
+      reviewRequests: {
+        nodes: [
+          { requestedReviewer: { __typename: "User", login: "bob" } },
+          { requestedReviewer: { __typename: "Team" } },
+          { requestedReviewer: { __typename: "Bot", login: "dependabot" } },
+        ],
+      },
+      latestReviews: {
+        nodes: [{ author: { __typename: "User", login: "carol" } }, { author: { __typename: "User", login: "alice" } }],
+      },
+    },
+    { botLogins: ["github-actions"] },
+  );
+  assert.deepEqual(mentions, ["alice", "bob", "carol"]);
+});
+
+// --- Execution --------------------------------------------------------------
+
+function entryFor(overrides, decisionOverrides) {
+  const pr = pullRequest(overrides);
+  return {
+    pullRequest: pr,
+    decision: { ...decidePullRequest({ pullRequest: pr, config: config(), now: NOW }), ...decisionOverrides },
+  };
+}
+
+test("a dry run decides everything and mutates nothing", async () => {
+  const actions = recordingActions();
+  const execution = await executeDecisions({
+    entries: [entryFor({ number: 11, lastActivityAt: daysAgo(9), notice: { commentId: "c", postedAt: daysAgo(3) } })],
+    actions,
+    config: config(),
+    logger: silentLogger,
+    dryRun: true,
+    sleepImpl: async () => {},
+  });
+
+  assert.deepEqual(actions.calls, []);
+  assert.equal(execution.closed, 1);
+});
+
+test("the close cap defers the remaining pull requests to the next run", async () => {
+  const entries = [12, 13, 14].map((number) =>
+    entryFor({ number, lastActivityAt: daysAgo(9), notice: { commentId: "c", postedAt: daysAgo(3) } }),
+  );
+  const actions = recordingActions();
+  const execution = await executeDecisions({
+    entries,
+    actions,
+    config: config({ maxCloses: 2 }),
+    logger: silentLogger,
+    sleepImpl: async () => {},
+  });
+
+  assert.equal(execution.closed, 2);
+  assert.deepEqual(execution.cappedNumbers, [14]);
+  assert.deepEqual(
+    actions.calls.filter(([kind]) => kind === "close").map(([, number]) => number),
+    [12, 13],
+  );
+});
+
+test("closing announces itself first, with the farewell marker and not the notice marker", async () => {
+  const actions = recordingActions();
+  await executeDecisions({
+    entries: [entryFor({ number: 41, lastActivityAt: daysAgo(9), notice: { commentId: "c", postedAt: daysAgo(3) } })],
+    actions,
+    config: config(),
+    logger: silentLogger,
+    sleepImpl: async () => {},
+  });
+
+  const [comment, close] = actions.calls;
+  assert.equal(comment[0], "comment");
+  assert.equal(close[0], "close");
+  assert.ok(comment[2].includes(CLOSED_MARKER), "the farewell must carry the closed marker");
+  assert.ok(!comment[2].includes(NOTICE_MARKER), "the farewell must not be mistaken for a notice");
+});
+
+test("a close that already announced itself is not announced again", async () => {
+  // The close failed on an earlier run after the farewell landed; retrying must
+  // not post a second identical farewell every day thereafter.
+  const actions = recordingActions();
+  await executeDecisions({
+    entries: [
+      entryFor({
+        number: 42,
+        lastActivityAt: daysAgo(9),
+        notice: { commentId: "c", postedAt: daysAgo(3) },
+        hasFarewell: true,
+      }),
+    ],
+    actions,
+    config: config(),
+    logger: silentLogger,
+    sleepImpl: async () => {},
+  });
+
+  assert.deepEqual(actions.calls, [
+    ["close", 42],
+    ["addLabel", 42, "stale"],
+  ]);
+});
+
+test("mutations are spaced by the configured delay, and a dry run never sleeps", async () => {
+  const delays = [];
+  const entries = [entryFor({ number: 51, lastActivityAt: daysAgo(6) })];
+  await executeDecisions({
+    entries,
+    actions: recordingActions(),
+    config: config(),
+    logger: silentLogger,
+    delayMillis: 1500,
+    sleepImpl: async (ms) => delays.push(ms),
+  });
+  assert.deepEqual(delays, [1500], "one gap between the two mutations, none before the first");
+
+  const dryDelays = [];
+  await executeDecisions({
+    entries,
+    actions: recordingActions(),
+    config: config(),
+    logger: silentLogger,
+    delayMillis: 1500,
+    dryRun: true,
+    sleepImpl: async (ms) => dryDelays.push(ms),
+  });
+  assert.deepEqual(dryDelays, []);
+});
+
+test("a failure on one pull request does not strand the rest of the sweep", async () => {
+  const actions = recordingActions(new Set(["close:21"]));
+  const execution = await executeDecisions({
+    entries: [21, 22].map((number) =>
+      entryFor({ number, lastActivityAt: daysAgo(9), notice: { commentId: "c", postedAt: daysAgo(3) } }),
+    ),
+    actions,
+    config: config(),
+    logger: silentLogger,
+    sleepImpl: async () => {},
+  });
+
+  assert.deepEqual(
+    execution.results.map((result) => result.outcome),
+    ["failed", ACTION_CLOSE],
+  );
+});
+
+test("the stale label is reconciled in both directions", async () => {
+  const actions = recordingActions();
+  await executeDecisions({
+    entries: [
+      entryFor({ number: 31, lastActivityAt: daysAgo(6) }),
+      entryFor({ number: 32, lastActivityAt: daysAgo(1), hasStaleLabel: true }),
+    ],
+    actions,
+    config: config(),
+    logger: silentLogger,
+    sleepImpl: async () => {},
+  });
+
+  assert.deepEqual(
+    actions.calls.filter(([kind]) => kind !== "comment"),
+    [
+      ["addLabel", 31, "stale"],
+      ["removeLabel", 32, "stale"],
+    ],
+  );
+});
+
+// --- GitHub client ----------------------------------------------------------
+
+function fakeResponse({ status = 200, body = {}, headers = {} }) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name) => headers[name.toLowerCase()] ?? null },
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function scriptedClient(steps, options = {}) {
+  const calls = [];
+  const sleeps = [];
+  const client = createGitHubClient({
+    token: "t",
+    logger: silentLogger,
+    sleepImpl: async (ms) => {
+      sleeps.push(ms);
+    },
+    fetchImpl: async (url, init) => {
+      calls.push(`${init.method} ${url}`);
+      const step = steps[Math.min(calls.length - 1, steps.length - 1)];
+      if (step instanceof Error) {
+        throw step;
+      }
+      return fakeResponse(step);
+    },
+    ...options,
+  });
+  return { client, calls, sleeps };
+}
+
+test("a transient 502 is retried until it succeeds", async () => {
+  const { client, calls } = scriptedClient([{ status: 502 }, { status: 502 }, { status: 200, body: { ok: true } }]);
+  assert.deepEqual(await client.rest("GET", "/x"), { ok: true });
+  assert.equal(calls.length, 3);
+});
+
+test("a 403 that is a permission failure is thrown at once, not retried", async () => {
+  const { client, calls, sleeps } = scriptedClient([
+    { status: 403, headers: { "x-ratelimit-remaining": "4832" }, body: { message: "Resource not accessible" } },
+  ]);
+  await assert.rejects(() => client.rest("PATCH", "/x"), /403/);
+  assert.equal(calls.length, 1, "a permission failure must not be hammered");
+  assert.deepEqual(sleeps, []);
+});
+
+test("a secondary rate limit is retried on the strength of retry-after alone", async () => {
+  // The abuse limit leaves the quota untouched, so remaining is not "0"; the
+  // retry-after header is the only signal that this is throttling, not denial.
+  const { client, calls, sleeps } = scriptedClient([
+    { status: 403, headers: { "retry-after": "2", "x-ratelimit-remaining": "4832" } },
+    { status: 200, body: { ok: true } },
+  ]);
+  await client.rest("GET", "/x");
+  assert.equal(calls.length, 2);
+  assert.deepEqual(sleeps, [2000]);
+});
+
+test("a request that never reached GitHub is retried", async () => {
+  const { client, calls } = scriptedClient([new TypeError("fetch failed"), { status: 200, body: { ok: true } }]);
+  await client.rest("GET", "/x");
+  assert.equal(calls.length, 2);
+});
+
+test("retries are capped and the last failure is rethrown", async () => {
+  const { client, calls } = scriptedClient([{ status: 503 }]);
+  await assert.rejects(() => client.rest("GET", "/x"), /503/);
+  assert.equal(calls.length, 4, "one attempt plus the three configured retries");
+});
+
+test("a non-idempotent call can opt out of retrying entirely", async () => {
+  const { client, calls } = scriptedClient([{ status: 502 }]);
+  const actions = createPullRequestActions({ client, owner: "o", name: "r" });
+  await assert.rejects(() => actions.comment(7, "hello"), /502/);
+  assert.equal(calls.length, 1, "GitHub may have committed the comment; a retry would duplicate it");
+});
+
+test("a GraphQL timeout arrives as HTTP 200 and is still retried", async () => {
+  const { client, calls } = scriptedClient([
+    { status: 200, body: { errors: [{ type: "SERVICE_UNAVAILABLE", message: "Something went wrong" }] } },
+    { status: 200, body: { data: { ok: true } } },
+  ]);
+  assert.deepEqual(await client.graphql("query {}", {}), { ok: true });
+  assert.equal(calls.length, 2);
+});
+
+test("a malformed GraphQL query fails immediately instead of being retried", async () => {
+  const { client, calls } = scriptedClient([
+    { status: 200, body: { errors: [{ type: "INVALID", message: "Field 'nope' doesn't exist" }] } },
+  ]);
+  await assert.rejects(() => client.graphql("query {}", {}), /doesn't exist/);
+  assert.equal(calls.length, 1);
+});
+
+// --- Query ------------------------------------------------------------------
+
+test("the query reads the newest page of every connection it depends on", () => {
+  // timelineItems is ordered oldest-first, so `first:` would silently return
+  // ancient history and make a busy pull request look abandoned.
+  assert.match(PULL_REQUESTS_QUERY, /timelineItems\(last: \d+/);
+  assert.match(PULL_REQUESTS_QUERY, /comments\(last: \d+\)/);
+  assert.match(PULL_REQUESTS_QUERY, /reviewThreads\(last: \d+\)/);
+  assert.match(PULL_REQUESTS_QUERY, /pullRequests\(states: OPEN, first: \d+/);
+  assert.match(PULL_REQUESTS_QUERY, /hasPreviousPage/, "truncation is detected with pageInfo, not totalCount");
+});
+
+test("the query asks for no Team subfield, which GITHUB_TOKEN cannot read", () => {
+  assert.doesNotMatch(PULL_REQUESTS_QUERY, /\.\.\. on Team \{/);
+  assert.doesNotMatch(PULL_REQUESTS_QUERY, /pushedDate/, "Commit.pushedDate no longer exists in the schema");
+});
+
+// --- Configuration ----------------------------------------------------------
+
+test("the defaults implement the documented five-then-seven day policy", () => {
+  const parsed = buildConfig([]);
+  assert.equal(parsed.warnAfterDays, 5);
+  assert.equal(parsed.closeAfterDays, 7);
+  assert.equal(parsed.exemptDrafts, true);
+  assert.deepEqual(parsed.exemptLabels, ["keep-open"]);
+  assert.deepEqual(parsed.botLogins, ["github-actions"]);
+  assert.equal(parsed.dryRun, false);
+});
+
+test("bot and author logins are matched with or without the [bot] suffix", () => {
+  const parsed = buildConfig(["--exempt-author", "Dependabot[bot]", "--bot-login", "GitHub-Actions[bot]"]);
+  assert.deepEqual(parsed.exemptAuthors, ["dependabot"]);
+  assert.deepEqual(parsed.botLogins, ["github-actions"]);
+});
+
+test("a repository must be given as owner/name", () => {
+  assert.deepEqual(parseRepository("first-tree-ai/opentag"), { owner: "first-tree-ai", name: "opentag" });
+  assert.throws(() => parseRepository("opentag"), /owner\/name/);
+  assert.throws(() => parseRepository(undefined), /owner\/name/);
+});
+
+// --- Workflow -----------------------------------------------------------------
+
+test("the sweep runs on a schedule and manually, never on pull request events", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  assert.match(workflow, /^ {4}- cron: "[^"]+"$/m, "the sweep must be scheduled");
+  assert.match(workflow, /^ {2}workflow_dispatch:$/m, "the sweep must be startable by hand");
+  assert.doesNotMatch(workflow, /^ {2}pull_request(_target)?:/m, "a write-scoped sweep must not run on pull requests");
+  assert.doesNotMatch(workflow, /cron: "(17|23) 3 \* \* 1"/, "the cron must not collide with the Monday 03:0x jobs");
+});
+
+test("write access is scoped to the sweep job and forks are excluded", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  assert.match(workflow, /^permissions:\n {2}contents: read\n/m, "the workflow default must stay read-only");
+  assert.match(workflow, /if: github\.repository == 'first-tree-ai\/opentag'/, "forks must not close their own PRs");
+  assert.match(workflow, /permissions:\n {6}contents: read\n {6}pull-requests: write\n/);
+  assert.doesNotMatch(workflow, /issues: write/, "the sweep only touches pull requests");
+});
+
+test("every action is pinned to a full commit SHA", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  for (const line of workflow.split(/\r?\n/).filter((candidate) => candidate.includes("uses: "))) {
+    assert.match(line, /uses: [^@]+@[0-9a-f]{40} # v\d/, `unpinned action: ${line.trim()}`);
+  }
+});
+
+test("no expression is interpolated straight into the shell", async () => {
+  // actionlint rejects it as a script-injection risk; every value must arrive
+  // through the step env block instead.
+  const workflow = await readFile(workflowPath, "utf8");
+  const runBlock = workflow.slice(workflow.indexOf("run: |"));
+  assert.doesNotMatch(runBlock, /\$\{\{/, "run: blocks must read values from env, not from expressions");
+});

--- a/scripts/stale-pull-requests.mjs
+++ b/scripts/stale-pull-requests.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+import { appendFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+import { normalizeLogin, normalizePullRequest } from "./stale-pull-requests/activity.mjs";
+import { createPullRequestActions, ensureLabels, executeDecisions } from "./stale-pull-requests/executor.mjs";
+import { createGitHubClient } from "./stale-pull-requests/github.mjs";
+import { createLogger } from "./stale-pull-requests/logger.mjs";
+import { assertPolicyConfig, decidePullRequest } from "./stale-pull-requests/policy.mjs";
+import { fetchOpenPullRequests } from "./stale-pull-requests/query.mjs";
+import { renderSummary } from "./stale-pull-requests/report.mjs";
+
+const CLI_OPTIONS = {
+  "warn-after-days": { type: "string" },
+  "close-after-days": { type: "string" },
+  "grace-hours": { type: "string" },
+  "stale-label": { type: "string" },
+  "exempt-label": { type: "string", multiple: true },
+  "exempt-author": { type: "string", multiple: true },
+  "bot-login": { type: "string", multiple: true },
+  "include-drafts": { type: "boolean" },
+  "max-notices": { type: "string" },
+  "max-closes": { type: "string" },
+  "mutation-delay-ms": { type: "string" },
+  repository: { type: "string" },
+  "dry-run": { type: "boolean" },
+};
+
+const DEFAULTS = {
+  warnAfterDays: 5,
+  closeAfterDays: 7,
+  graceHours: 48,
+  staleLabel: "stale",
+  exemptLabels: ["keep-open"],
+  exemptAuthors: [],
+  botLogins: ["github-actions"],
+  exemptDrafts: true,
+  maxNotices: 25,
+  maxCloses: 10,
+  mutationDelayMs: 1500,
+};
+
+function parseNumber(raw, field, fallback) {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new TypeError(`--${field} must be a number, received ${JSON.stringify(raw)}`);
+  }
+  return value;
+}
+
+function normalizeLogins(values) {
+  return values.map((value) => normalizeLogin(value)).filter((value) => value !== null);
+}
+
+/** Turns argv into the immutable configuration the rest of the sweep reads. */
+export function buildConfig(argv) {
+  const { values } = parseArgs({ args: argv, options: CLI_OPTIONS, allowPositionals: false });
+  const config = {
+    warnAfterDays: parseNumber(values["warn-after-days"], "warn-after-days", DEFAULTS.warnAfterDays),
+    closeAfterDays: parseNumber(values["close-after-days"], "close-after-days", DEFAULTS.closeAfterDays),
+    graceHours: parseNumber(values["grace-hours"], "grace-hours", DEFAULTS.graceHours),
+    staleLabel: values["stale-label"] ?? DEFAULTS.staleLabel,
+    exemptLabels: values["exempt-label"] ?? DEFAULTS.exemptLabels,
+    exemptAuthors: normalizeLogins(values["exempt-author"] ?? DEFAULTS.exemptAuthors),
+    botLogins: normalizeLogins(values["bot-login"] ?? DEFAULTS.botLogins),
+    exemptDrafts: values["include-drafts"] !== true,
+    maxNotices: parseNumber(values["max-notices"], "max-notices", DEFAULTS.maxNotices),
+    maxCloses: parseNumber(values["max-closes"], "max-closes", DEFAULTS.maxCloses),
+    mutationDelayMs: parseNumber(values["mutation-delay-ms"], "mutation-delay-ms", DEFAULTS.mutationDelayMs),
+    dryRun: values["dry-run"] === true,
+    repository: values.repository,
+  };
+  assertPolicyConfig(config);
+  return config;
+}
+
+export function parseRepository(value) {
+  const [owner, name, ...rest] = String(value ?? "").split("/");
+  if (!owner || !name || rest.length > 0) {
+    throw new TypeError(`Repository must be given as "owner/name", received ${JSON.stringify(value)}`);
+  }
+  return { owner, name };
+}
+
+/**
+ * Turns raw GraphQL nodes into decisions. Pure on purpose: every policy question
+ * ("would this pull request be closed today?") is answerable without a network.
+ */
+export function planSweep({ nodes, config, now }) {
+  return nodes.map((node) => {
+    const pullRequest = normalizePullRequest(node, {
+      botLogins: config.botLogins,
+      staleLabel: config.staleLabel,
+      now,
+    });
+    return { pullRequest, decision: decidePullRequest({ pullRequest, config, now }) };
+  });
+}
+
+async function publishSummary(summary, summaryPath, logger) {
+  process.stdout.write(`${summary}\n`);
+  if (!summaryPath) {
+    return;
+  }
+  try {
+    await appendFile(summaryPath, summary);
+  } catch (error) {
+    logger.warn("Could not write the job summary", { message: error?.message });
+  }
+}
+
+function logPlan(entries, logger) {
+  for (const { pullRequest, decision } of entries) {
+    logger.debug("Decision", {
+      number: pullRequest.number,
+      action: decision.action,
+      idleDays: decision.idleDays,
+      lastActivityAt: pullRequest.lastActivityAt,
+      noticePostedAt: pullRequest.notice?.postedAt ?? null,
+      reason: decision.reason,
+    });
+  }
+}
+
+async function run({ config, env, logger, now }) {
+  const { owner, name } = parseRepository(config.repository ?? env.GITHUB_REPOSITORY);
+  const client = createGitHubClient({ token: env.GH_TOKEN ?? env.GITHUB_TOKEN, logger });
+  const actions = createPullRequestActions({ client, owner, name });
+
+  const nodes = await fetchOpenPullRequests(client, { owner, name, logger });
+  logger.info("Collected open pull requests", { repository: `${owner}/${name}`, count: nodes.length });
+
+  const entries = planSweep({ nodes, config, now });
+  logPlan(entries, logger);
+
+  if (!config.dryRun) {
+    await ensureLabels({ actions, config, logger });
+  }
+  const execution = await executeDecisions({
+    entries,
+    actions,
+    config,
+    logger,
+    dryRun: config.dryRun,
+    delayMillis: config.mutationDelayMs,
+  });
+  logger.info("Sweep finished", {
+    dryRun: config.dryRun,
+    warned: execution.warned,
+    closed: execution.closed,
+    capped: execution.cappedNumbers.length,
+  });
+
+  const summary = renderSummary({
+    repository: `${owner}/${name}`,
+    config,
+    dryRun: config.dryRun,
+    results: execution.results,
+    cappedNumbers: execution.cappedNumbers,
+  });
+  await publishSummary(summary, env.GITHUB_STEP_SUMMARY, logger);
+
+  return execution.results.some((result) => result.outcome === "failed") ? 1 : 0;
+}
+
+async function main() {
+  const env = process.env;
+  const config = buildConfig(process.argv.slice(2));
+  const logger = createLogger({ level: env.STALE_PR_LOG_LEVEL ?? (env.RUNNER_DEBUG === "1" ? "debug" : "info") });
+  logger.debug("Resolved configuration", config);
+  return run({ config, env, logger, now: new Date().toISOString() });
+}
+
+const isMain = process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+
+if (isMain) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      process.stderr.write(`[stale-pr] ERROR ${error?.stack ?? error}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/stale-pull-requests/activity.mjs
+++ b/scripts/stale-pull-requests/activity.mjs
@@ -1,0 +1,201 @@
+/**
+ * Hidden marker carried by every notice this sweep posts. It is the durable
+ * state of the workflow: the label is cosmetic and can be removed by hand, but
+ * the marker survives, so a run that finds it knows the author was already told.
+ */
+export const NOTICE_MARKER = "<!-- opentag-stale-pull-requests:notice -->";
+
+/** Marks the farewell comment, so a close that failed halfway is not re-announced. */
+export const CLOSED_MARKER = "<!-- opentag-stale-pull-requests:closed -->";
+
+const COMMIT_ITEM = "PullRequestCommit";
+
+/**
+ * GraphQL reports the Actions identity as `github-actions` while REST reports
+ * `github-actions[bot]`. Normalizing both ways is what keeps the sweep from
+ * treating its own notice as human activity and resetting its own clock.
+ */
+export function normalizeLogin(login) {
+  if (typeof login !== "string" || login.length === 0) {
+    return null;
+  }
+  return login.toLowerCase().replace(/\[bot\]$/, "");
+}
+
+export function isSweepActor(actor, botLogins) {
+  const login = normalizeLogin(actor?.login);
+  return login !== null && botLogins.includes(login);
+}
+
+function commitActivity(item) {
+  const commit = item.commit ?? {};
+  return {
+    actor: commit.author?.user ?? commit.committer?.user ?? null,
+    // `committedDate` is a rewrite timestamp that a rebase can move backwards,
+    // so the later of the two is the honest "someone worked on this" signal.
+    timestamps: [commit.committedDate, commit.authoredDate],
+  };
+}
+
+/**
+ * Newest comment on one review thread. Replies typed into a thread do not
+ * reliably produce a `PullRequestReview` timeline item -- a reply days after the
+ * original review often produces none at all -- so review threads are read from
+ * their own connection rather than from the timeline.
+ */
+export function reviewThreadActivity(thread) {
+  const comment = thread?.comments?.nodes?.at(-1) ?? null;
+  return { actor: comment?.author ?? null, timestamps: [comment?.createdAt] };
+}
+
+function eventActivity(item) {
+  return {
+    // Event items expose `actor`, comments and reviews expose `author`; a null
+    // actor is a deleted account, which must still count as a human.
+    actor: item.actor ?? item.author ?? null,
+    // `submittedAt` is null on a pending review, hence the `createdAt` fallback.
+    timestamps: [item.submittedAt, item.createdAt],
+  };
+}
+
+/** Extracts the actor and candidate timestamps for one timeline item. */
+export function timelineActivity(item) {
+  if (item?.__typename === COMMIT_ITEM) {
+    return commitActivity(item);
+  }
+  return eventActivity(item ?? {});
+}
+
+function humanTimestamps(nodes, botLogins, extract) {
+  const timestamps = [];
+  for (const node of nodes) {
+    const activity = extract(node);
+    if (isSweepActor(activity.actor, botLogins)) {
+      continue;
+    }
+    timestamps.push(...activity.timestamps.filter((value) => typeof value === "string"));
+  }
+  return timestamps;
+}
+
+function newerTimestamp(left, right) {
+  return Date.parse(left) >= Date.parse(right) ? left : right;
+}
+
+/**
+ * Resolves the last activity that was not this sweep's own bookkeeping.
+ *
+ * The timeline is queried newest-first, so truncation can only hide old items,
+ * which cannot change a maximum. The single exception is a timeline whose newest
+ * page is entirely this sweep's own events: then the real activity is off-page
+ * and the result is reported as truncated so the caller leaves it alone.
+ *
+ * Timestamps after `now` are discarded: `authoredDate` is whatever the
+ * contributor's clock said, so a future-dated commit would otherwise pin a pull
+ * request open forever.
+ */
+export function resolveLastActivity({ createdAt, timelineNodes, reviewThreadNodes, hasOlderTimeline, botLogins, now }) {
+  const nowMillis = Date.parse(now);
+  const timeline = humanTimestamps(timelineNodes ?? [], botLogins, timelineActivity);
+  const threads = humanTimestamps(reviewThreadNodes ?? [], botLogins, reviewThreadActivity);
+  const usable = [...timeline, ...threads].filter((value) => Date.parse(value) <= nowMillis);
+  return {
+    lastActivityAt: usable.reduce(newerTimestamp, createdAt),
+    activityTruncated: timeline.length === 0 && hasOlderTimeline === true,
+  };
+}
+
+function isMarkedComment(comment, marker) {
+  return typeof comment?.body === "string" && comment.body.includes(marker) && comment.author?.__typename === "Bot";
+}
+
+/** Finds the most recent bot comment carrying `marker`, or null if there is none. */
+export function findMarkedComment(commentNodes, marker) {
+  let newest = null;
+  for (const comment of commentNodes ?? []) {
+    if (!isMarkedComment(comment, marker)) {
+      continue;
+    }
+    if (newest === null || Date.parse(comment.createdAt) > Date.parse(newest.createdAt)) {
+      newest = comment;
+    }
+  }
+  return newest === null ? null : { commentId: newest.id, postedAt: newest.createdAt };
+}
+
+/** Finds the most recent notice this sweep posted, or null if there is none. */
+export function findNotice(commentNodes, { marker = NOTICE_MARKER } = {}) {
+  return findMarkedComment(commentNodes, marker);
+}
+
+function pushUserLogin(target, actor) {
+  if (actor?.__typename === "User" && typeof actor.login === "string") {
+    target.push(actor.login);
+  }
+}
+
+/**
+ * Collects the people worth @-mentioning: the author, anyone with an open review
+ * request, and anyone who already reviewed. Teams are deliberately excluded --
+ * a team mention posted by a GitHub App renders as plain text and notifies
+ * nobody, and the review request itself already notified the team.
+ */
+export function collectMentions(node, { botLogins = [] } = {}) {
+  const logins = [];
+  pushUserLogin(logins, node.author);
+  for (const request of node.reviewRequests?.nodes ?? []) {
+    pushUserLogin(logins, request?.requestedReviewer);
+  }
+  for (const review of node.latestReviews?.nodes ?? []) {
+    pushUserLogin(logins, review?.author);
+  }
+  const seen = new Set(botLogins);
+  return logins.filter((login) => {
+    const key = normalizeLogin(login);
+    if (key === null || seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function countRequestedTeams(node) {
+  return (node.reviewRequests?.nodes ?? []).filter((request) => request?.requestedReviewer?.__typename === "Team")
+    .length;
+}
+
+/** Projects one GraphQL pull request node onto the flat facts the policy needs. */
+export function normalizePullRequest(node, { botLogins, staleLabel, now, marker = NOTICE_MARKER }) {
+  const labels = (node.labels?.nodes ?? []).map((label) => label.name);
+  const comments = node.comments?.nodes;
+  const activity = resolveLastActivity({
+    createdAt: node.createdAt,
+    timelineNodes: node.timelineItems?.nodes,
+    reviewThreadNodes: node.reviewThreads?.nodes,
+    hasOlderTimeline: node.timelineItems?.pageInfo?.hasPreviousPage,
+    botLogins,
+    now,
+  });
+
+  return {
+    id: node.id,
+    number: node.number,
+    title: node.title,
+    url: node.url,
+    isDraft: node.isDraft === true,
+    authorLogin: node.author?.login ?? null,
+    authorKey: normalizeLogin(node.author?.login),
+    labels,
+    hasStaleLabel: labels.includes(staleLabel),
+    createdAt: node.createdAt,
+    lastActivityAt: activity.lastActivityAt,
+    activityTruncated: activity.activityTruncated,
+    notice: findMarkedComment(comments, marker),
+    // A close that failed after its farewell was posted must not re-announce
+    // itself on every later run.
+    hasFarewell: findMarkedComment(comments, CLOSED_MARKER) !== null,
+    mentions: collectMentions(node, { botLogins }),
+    requestedTeamCount: countRequestedTeams(node),
+  };
+}

--- a/scripts/stale-pull-requests/executor.mjs
+++ b/scripts/stale-pull-requests/executor.mjs
@@ -1,0 +1,188 @@
+import { sleep } from "./github.mjs";
+import { renderClosingNotice, renderNotice } from "./notice.mjs";
+import { ACTION_CLOSE, ACTION_WARN } from "./policy.mjs";
+
+/** GitHub asks for at least one second between mutating requests. */
+export const DEFAULT_MUTATION_DELAY_MS = 1500;
+
+const STALE_LABEL_COLOR = "ededed";
+const STALE_LABEL_DESCRIPTION = "No activity for long enough that the sweep will close it";
+const EXEMPT_LABEL_COLOR = "0e8a16";
+const EXEMPT_LABEL_DESCRIPTION = "Never auto-closed by the stale pull request sweep";
+
+function encodePath(value) {
+  return encodeURIComponent(value);
+}
+
+/**
+ * Wraps the four repository mutations the sweep performs. `pull-requests: write`
+ * covers all of them, including creating a label.
+ */
+export function createPullRequestActions({ client, owner, name }) {
+  const repositoryPath = `/repos/${encodePath(owner)}/${encodePath(name)}`;
+
+  return {
+    // Comment creation is not idempotent: GitHub can commit the comment and
+    // still answer 5xx, so this one call opts out of the retry loop and lets the
+    // next scheduled run re-post instead of duplicating it inside this one.
+    comment: (number, body) =>
+      client.rest("POST", `${repositoryPath}/issues/${number}/comments`, { body }, { retries: 0 }),
+    addLabel: (number, label) => client.rest("POST", `${repositoryPath}/issues/${number}/labels`, { labels: [label] }),
+    removeLabel: (number, label) =>
+      client.rest("DELETE", `${repositoryPath}/issues/${number}/labels/${encodePath(label)}`),
+    close: (number) => client.rest("PATCH", `${repositoryPath}/pulls/${number}`, { state: "closed" }),
+    createLabel: (name_, color, description) =>
+      client.rest("POST", `${repositoryPath}/labels`, { name: name_, color, description }),
+  };
+}
+
+/**
+ * Creates the labels the policy references. A label that already exists comes
+ * back as 422, which is the expected outcome on every run after the first; any
+ * other failure is logged and tolerated because labels are cosmetic -- the
+ * hidden notice marker is the sweep's real state.
+ */
+export async function ensureLabels({ actions, config, logger }) {
+  const wanted = [
+    { name: config.staleLabel, color: STALE_LABEL_COLOR, description: STALE_LABEL_DESCRIPTION },
+    ...config.exemptLabels.map((label) => ({
+      name: label,
+      color: EXEMPT_LABEL_COLOR,
+      description: EXEMPT_LABEL_DESCRIPTION,
+    })),
+  ];
+
+  for (const label of wanted) {
+    try {
+      await actions.createLabel(label.name, label.color, label.description);
+      logger.info("Created missing label", { label: label.name });
+    } catch (error) {
+      if (error?.status === 422) {
+        logger.debug("Label already exists", { label: label.name });
+        continue;
+      }
+      logger.warn("Could not provision label", { label: label.name, status: error?.status, message: error?.message });
+    }
+  }
+}
+
+function noticeBody(pullRequest, decision, config) {
+  return renderNotice({
+    idleDays: decision.idleDays,
+    warnAfterDays: config.warnAfterDays,
+    closeAfterDays: config.closeAfterDays,
+    exemptLabels: config.exemptLabels,
+    mentions: pullRequest.mentions,
+    requestedTeamCount: pullRequest.requestedTeamCount,
+  });
+}
+
+async function reconcileStaleLabel({ pullRequest, decision, actions, config, run }) {
+  if (decision.desiredStaleLabel && !pullRequest.hasStaleLabel) {
+    await run(() => actions.addLabel(pullRequest.number, config.staleLabel));
+    return "added";
+  }
+  if (!decision.desiredStaleLabel && pullRequest.hasStaleLabel) {
+    await run(() => actions.removeLabel(pullRequest.number, config.staleLabel));
+    return "removed";
+  }
+  return "unchanged";
+}
+
+async function applyWarn({ pullRequest, decision, actions, config, run }) {
+  await run(() => actions.comment(pullRequest.number, noticeBody(pullRequest, decision, config)));
+}
+
+async function applyClose({ pullRequest, decision, actions, config, run }) {
+  // A close that failed after its farewell was posted leaves the pull request
+  // open and eligible again tomorrow; without this guard it would collect one
+  // identical farewell per run for as long as the close keeps failing.
+  if (!pullRequest.hasFarewell) {
+    const body = renderClosingNotice({
+      idleDays: decision.idleDays,
+      closeAfterDays: config.closeAfterDays,
+      exemptLabels: config.exemptLabels,
+    });
+    await run(() => actions.comment(pullRequest.number, body));
+  }
+  await run(() => actions.close(pullRequest.number));
+}
+
+function overCap(action, counts, config) {
+  if (action === ACTION_WARN) {
+    return counts.warned >= config.maxNotices;
+  }
+  if (action === ACTION_CLOSE) {
+    return counts.closed >= config.maxCloses;
+  }
+  return false;
+}
+
+function buildRunner({ dryRun, delayMillis, sleepImpl }) {
+  let mutated = false;
+  return async (operation) => {
+    if (dryRun) {
+      return;
+    }
+    if (mutated) {
+      await sleepImpl(delayMillis);
+    }
+    mutated = true;
+    await operation();
+  };
+}
+
+async function applyOne({ entry, actions, config, run, counts, logger }) {
+  const { pullRequest, decision } = entry;
+  if (overCap(decision.action, counts, config)) {
+    logger.warn("Skipped by the per-run cap", { number: pullRequest.number, action: decision.action });
+    counts.cappedNumbers.push(pullRequest.number);
+    return { ...entry, outcome: "capped" };
+  }
+
+  if (decision.action === ACTION_WARN) {
+    await applyWarn({ pullRequest, decision, actions, config, run });
+    counts.warned += 1;
+  } else if (decision.action === ACTION_CLOSE) {
+    await applyClose({ pullRequest, decision, actions, config, run });
+    counts.closed += 1;
+  }
+
+  const label = await reconcileStaleLabel({ pullRequest, decision, actions, config, run });
+  return { ...entry, outcome: decision.action, label };
+}
+
+/**
+ * Applies every decision in order, honouring the dry-run switch, the per-run
+ * caps and the inter-mutation delay. A failure on one pull request is recorded
+ * and the sweep continues, so one unlucky pull request cannot strand the rest.
+ */
+export async function executeDecisions({
+  entries,
+  actions,
+  config,
+  logger,
+  dryRun = false,
+  delayMillis = DEFAULT_MUTATION_DELAY_MS,
+  sleepImpl = sleep,
+}) {
+  const run = buildRunner({ dryRun, delayMillis, sleepImpl });
+  const counts = { warned: 0, closed: 0, cappedNumbers: [] };
+  const results = [];
+
+  for (const entry of entries) {
+    try {
+      results.push(await applyOne({ entry, actions, config, run, counts, logger }));
+    } catch (error) {
+      logger.error("Failed to apply decision", {
+        number: entry.pullRequest.number,
+        action: entry.decision.action,
+        message: error?.message,
+        status: error?.status,
+      });
+      results.push({ ...entry, outcome: "failed", error: error?.message ?? String(error) });
+    }
+  }
+
+  return { results, warned: counts.warned, closed: counts.closed, cappedNumbers: counts.cappedNumbers };
+}

--- a/scripts/stale-pull-requests/github.mjs
+++ b/scripts/stale-pull-requests/github.mjs
@@ -1,0 +1,207 @@
+const DEFAULT_API_URL = "https://api.github.com";
+const DEFAULT_USER_AGENT = "opentag-stale-pull-requests";
+const RETRYABLE_STATUSES = new Set([403, 429, 500, 502, 503, 504]);
+const MAX_RETRY_DELAY_MS = 60_000;
+
+/** GraphQL error types that mean "try again", as opposed to "this query is wrong". */
+const TRANSIENT_GRAPHQL_TYPES = new Set(["RATE_LIMITED", "SERVICE_UNAVAILABLE"]);
+
+export class GitHubRequestError extends Error {
+  constructor(message, { status, body, headers, retryable, cause }) {
+    super(message, { cause });
+    this.name = "GitHubRequestError";
+    this.status = status;
+    this.body = body;
+    this.headers = headers;
+    // Set when the status alone cannot classify the failure: a transport error
+    // that never reached GitHub, or a 200 carrying a GraphQL errors array.
+    this.retryable = retryable;
+  }
+}
+
+export function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function retryAfterMillis(headers) {
+  const retryAfter = Number(headers?.get?.("retry-after"));
+  if (Number.isFinite(retryAfter) && retryAfter > 0) {
+    return Math.min(retryAfter * 1000, MAX_RETRY_DELAY_MS);
+  }
+  return null;
+}
+
+/**
+ * A 403 from GitHub is either "you may not do this" or "you are going too fast".
+ * Only the latter is worth retrying. An exhausted quota says so in the remaining
+ * header; a secondary (abuse) limit says so with `retry-after` and leaves the
+ * quota untouched, so both signals have to be honoured.
+ */
+function isRateLimited(status, headers) {
+  if (status === 429) {
+    return true;
+  }
+  if (status !== 403) {
+    return false;
+  }
+  return headers?.get?.("x-ratelimit-remaining") === "0" || typeof headers?.get?.("retry-after") === "string";
+}
+
+function retryDelayMillis(error, attempt) {
+  const explicit = retryAfterMillis(error.headers);
+  if (explicit !== null) {
+    return explicit;
+  }
+  if (isRateLimited(error.status, error.headers)) {
+    return MAX_RETRY_DELAY_MS;
+  }
+  return Math.min(1000 * 2 ** attempt, MAX_RETRY_DELAY_MS);
+}
+
+function isRetryable(error) {
+  if (!(error instanceof GitHubRequestError)) {
+    return false;
+  }
+  if (typeof error.retryable === "boolean") {
+    return error.retryable;
+  }
+  if (error.status === 403) {
+    return isRateLimited(error.status, error.headers);
+  }
+  return RETRYABLE_STATUSES.has(error.status);
+}
+
+async function withRetry(operation, { retries, logger, sleepImpl }) {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= retries || !isRetryable(error)) {
+        throw error;
+      }
+      const delay = retryDelayMillis(error, attempt);
+      logger.warn("Retrying GitHub request", { attempt: attempt + 1, delayMs: delay, status: error.status });
+      await sleepImpl(delay);
+      attempt += 1;
+    }
+  }
+}
+
+function isTransientGraphqlFailure(errors) {
+  return errors.every(
+    (entry) => TRANSIENT_GRAPHQL_TYPES.has(entry?.type) || /timed?\s?out/i.test(entry?.message ?? ""),
+  );
+}
+
+/** GraphQL reports failures as HTTP 200 plus an `errors` array. */
+export function assertNoGraphqlErrors(payload) {
+  const errors = payload?.errors;
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return;
+  }
+  throw new GitHubRequestError(`GitHub GraphQL query failed: ${errors.map((entry) => entry.message).join("; ")}`, {
+    status: 200,
+    body: payload,
+    headers: null,
+    retryable: isTransientGraphqlFailure(errors),
+  });
+}
+
+async function readBody(response) {
+  const text = await response.text();
+  if (text.length === 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Minimal GitHub client built on the platform `fetch`. The repository forbids
+ * undeclared dependencies in `scripts/`, so there is no Octokit here; `fetchImpl`
+ * and `sleepImpl` are injected so tests never touch the network or the clock.
+ */
+export function createGitHubClient({
+  token,
+  apiUrl = DEFAULT_API_URL,
+  fetchImpl = fetch,
+  sleepImpl = sleep,
+  logger,
+  retries = 3,
+  userAgent = DEFAULT_USER_AGENT,
+}) {
+  if (typeof token !== "string" || token.length === 0) {
+    throw new TypeError("A GitHub token is required; set GH_TOKEN in the workflow environment");
+  }
+
+  const baseHeaders = {
+    accept: "application/vnd.github+json",
+    authorization: `Bearer ${token}`,
+    "content-type": "application/json",
+    "user-agent": userAgent,
+    "x-github-api-version": "2022-11-28",
+  };
+
+  async function send(method, url, body) {
+    let response;
+    try {
+      response = await fetchImpl(url, {
+        method,
+        headers: baseHeaders,
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+    } catch (cause) {
+      // The request never reached GitHub, so nothing was applied and retrying
+      // it is always safe, whatever the method.
+      throw new GitHubRequestError(`${method} ${url} failed before a response arrived`, {
+        status: null,
+        body: null,
+        headers: null,
+        retryable: true,
+        cause,
+      });
+    }
+    const payload = await readBody(response);
+    if (!response.ok) {
+      throw new GitHubRequestError(`${method} ${url} failed with ${response.status}`, {
+        status: response.status,
+        body: payload,
+        headers: response.headers,
+      });
+    }
+    return payload;
+  }
+
+  /**
+   * `options.retries` exists so a non-idempotent call can opt out: GitHub may
+   * commit a comment and still answer 5xx, and a blind retry would post it twice.
+   */
+  async function rest(method, path, body, options = {}) {
+    logger.debug("GitHub REST request", { method, path });
+    return withRetry(() => send(method, `${apiUrl}${path}`, body), {
+      retries: options.retries ?? retries,
+      logger,
+      sleepImpl,
+    });
+  }
+
+  async function graphql(query, variables) {
+    // The errors array is inspected inside the retried operation: GraphQL
+    // answers a timeout with HTTP 200 and an errors array, which is exactly the
+    // case worth retrying.
+    return withRetry(
+      async () => {
+        const payload = await send("POST", `${apiUrl}/graphql`, { query, variables });
+        assertNoGraphqlErrors(payload);
+        return payload?.data ?? {};
+      },
+      { retries, logger, sleepImpl },
+    );
+  }
+
+  return { graphql, rest };
+}

--- a/scripts/stale-pull-requests/logger.mjs
+++ b/scripts/stale-pull-requests/logger.mjs
@@ -1,0 +1,54 @@
+const LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
+const DEFAULT_LEVEL = "info";
+const PREFIX = "[stale-pr]";
+
+/**
+ * Normalizes an arbitrary level string, falling back to `info` so a typo in the
+ * workflow environment degrades to the default instead of silencing the sweep.
+ */
+export function resolveLogLevel(rawLevel) {
+  const normalized = String(rawLevel ?? "")
+    .trim()
+    .toLowerCase();
+  return Object.hasOwn(LEVELS, normalized) ? normalized : DEFAULT_LEVEL;
+}
+
+function formatDetails(details) {
+  if (details === undefined) {
+    return "";
+  }
+  try {
+    return ` ${JSON.stringify(details)}`;
+  } catch {
+    return " [unserializable details]";
+  }
+}
+
+/**
+ * Creates a level-aware logger. Production runs stay at `info`; re-running the
+ * workflow with debug logging enabled raises it to `debug`, which prints every
+ * per-pull-request decision and the GraphQL rate-limit budget.
+ */
+export function createLogger({ level = DEFAULT_LEVEL, sink = console } = {}) {
+  const resolved = resolveLogLevel(level);
+  const threshold = LEVELS[resolved];
+
+  const emit = (name, write, message, details) => {
+    if (LEVELS[name] > threshold) {
+      return;
+    }
+    write(`${PREFIX} ${name.toUpperCase()} ${message}${formatDetails(details)}`);
+  };
+
+  const log = (...args) => sink.log(...args);
+  const warn = typeof sink.warn === "function" ? (...args) => sink.warn(...args) : log;
+  const error = typeof sink.error === "function" ? (...args) => sink.error(...args) : log;
+
+  return {
+    level: resolved,
+    error: (message, details) => emit("error", error, message, details),
+    warn: (message, details) => emit("warn", warn, message, details),
+    info: (message, details) => emit("info", log, message, details),
+    debug: (message, details) => emit("debug", log, message, details),
+  };
+}

--- a/scripts/stale-pull-requests/notice.mjs
+++ b/scripts/stale-pull-requests/notice.mjs
@@ -1,0 +1,49 @@
+import { CLOSED_MARKER, NOTICE_MARKER } from "./activity.mjs";
+
+const POLICY_LINK = "https://github.com/first-tree-ai/opentag/blob/main/CONTRIBUTING.md#pull-requests";
+
+function renderMentions(mentions) {
+  if (mentions.length === 0) {
+    return "";
+  }
+  return `${mentions.map((login) => `@${login}`).join(" ")} — `;
+}
+
+function renderTeamHint(requestedTeamCount) {
+  if (requestedTeamCount === 0) {
+    return "";
+  }
+  const plural = requestedTeamCount === 1 ? "team" : "teams";
+  return `\n\n${requestedTeamCount} requested reviewer ${plural} could not be mentioned here; the original review request still stands.`;
+}
+
+/**
+ * The notice has to be actionable on its own: it names the people who can move
+ * the pull request, states the deadline, and lists every way to stop the clock.
+ */
+export function renderNotice({ idleDays, warnAfterDays, closeAfterDays, exemptLabels, mentions, requestedTeamCount }) {
+  const remainingDays = Math.max(closeAfterDays - warnAfterDays, 0);
+  const escapeHatch = exemptLabels.map((label) => `\`${label}\``).join(" or ");
+
+  return `${NOTICE_MARKER}
+${renderMentions(mentions)}this pull request has had no activity for ${idleDays} day(s).
+
+OpenTag closes pull requests after **${closeAfterDays} days** without activity, so this one is scheduled to close in about ${remainingDays} day(s). Any of these resets the clock:
+
+- push a commit
+- leave a comment
+- submit a review
+
+To keep it open indefinitely, add the ${escapeHatch} label, or convert it to a draft.
+
+See [the pull request policy](${POLICY_LINK}).${renderTeamHint(requestedTeamCount)}`;
+}
+
+export function renderClosingNotice({ idleDays, closeAfterDays, exemptLabels }) {
+  const escapeHatch = exemptLabels.map((label) => `\`${label}\``).join(" or ");
+
+  return `${CLOSED_MARKER}
+Closing this pull request: it has had no activity for ${idleDays} day(s), past the ${closeAfterDays}-day limit, and the inactivity notice above went unanswered.
+
+Nothing here is lost — the branch is untouched and anyone with write access can reopen the pull request. If the work is still wanted but simply needs more time, reopen it and add the ${escapeHatch} label.`;
+}

--- a/scripts/stale-pull-requests/policy.mjs
+++ b/scripts/stale-pull-requests/policy.mjs
@@ -1,0 +1,139 @@
+const MS_PER_DAY = 86_400_000;
+const MS_PER_HOUR = 3_600_000;
+
+/** The pull request is out of scope for the sweep (draft, exempt label, exempt author). */
+export const ACTION_SKIP = "skip";
+/** The pull request is in scope but nothing needs to happen this run. */
+export const ACTION_NONE = "none";
+/** Post the inactivity notice and mark the pull request stale. */
+export const ACTION_WARN = "warn";
+/** Close the pull request; the notice was posted and the grace period has elapsed. */
+export const ACTION_CLOSE = "close";
+
+export function toMillis(value, field) {
+  const millis = Date.parse(String(value));
+  if (Number.isNaN(millis)) {
+    throw new TypeError(`${field} must be an ISO 8601 timestamp, received ${JSON.stringify(value)}`);
+  }
+  return millis;
+}
+
+function assertPositiveNumber(value, field) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new TypeError(`${field} must be a positive finite number, received ${JSON.stringify(value)}`);
+  }
+}
+
+/**
+ * Rejects a configuration that would let a pull request be closed without ever
+ * having been warned, which is the one outcome this policy must never produce.
+ */
+export function assertPolicyConfig(config) {
+  assertPositiveNumber(config.warnAfterDays, "warnAfterDays");
+  assertPositiveNumber(config.closeAfterDays, "closeAfterDays");
+  assertPositiveNumber(config.graceHours, "graceHours");
+  if (config.closeAfterDays <= config.warnAfterDays) {
+    throw new RangeError(
+      `closeAfterDays (${config.closeAfterDays}) must be greater than warnAfterDays (${config.warnAfterDays})`,
+    );
+  }
+}
+
+function roundDays(millis) {
+  return Math.round((millis / MS_PER_DAY) * 10) / 10;
+}
+
+function matchedExemptLabel(pullRequest, config) {
+  return pullRequest.labels.find((label) => config.exemptLabels.includes(label)) ?? null;
+}
+
+function exemptionReason(pullRequest, config) {
+  if (config.exemptDrafts && pullRequest.isDraft) {
+    return "draft pull request";
+  }
+  const label = matchedExemptLabel(pullRequest, config);
+  if (label !== null) {
+    return `carries the exempt label "${label}"`;
+  }
+  if (pullRequest.authorKey !== null && config.exemptAuthors.includes(pullRequest.authorKey)) {
+    return `opened by the exempt author "${pullRequest.authorKey}"`;
+  }
+  return null;
+}
+
+/**
+ * A notice only counts while nobody has touched the pull request since it was
+ * posted. Any human activity supersedes it, which is what resets the clock and
+ * lets a revived pull request be warned again from scratch later.
+ */
+function effectiveNotice(pullRequest) {
+  const notice = pullRequest.notice ?? null;
+  if (notice === null) {
+    return null;
+  }
+  const postedAt = toMillis(notice.postedAt, "notice.postedAt");
+  return postedAt >= toMillis(pullRequest.lastActivityAt, "lastActivityAt") ? notice : null;
+}
+
+function decideStalePullRequest({ pullRequest, config, nowMillis, idleMillis, idleDays }) {
+  const notice = effectiveNotice(pullRequest);
+  const base = { idleDays, desiredStaleLabel: true };
+
+  if (notice === null) {
+    return { ...base, action: ACTION_WARN, reason: `idle for ${idleDays} day(s) with no active notice` };
+  }
+  if (idleMillis < config.closeAfterDays * MS_PER_DAY) {
+    return { ...base, action: ACTION_NONE, reason: `idle for ${idleDays} day(s); notified at ${notice.postedAt}` };
+  }
+  const sinceNoticeMillis = nowMillis - toMillis(notice.postedAt, "notice.postedAt");
+  if (sinceNoticeMillis < config.graceHours * MS_PER_HOUR) {
+    return {
+      ...base,
+      action: ACTION_NONE,
+      reason: `notified at ${notice.postedAt}; holding for the ${config.graceHours}h grace period`,
+    };
+  }
+  return { ...base, action: ACTION_CLOSE, reason: `idle for ${idleDays} day(s); notified at ${notice.postedAt}` };
+}
+
+/**
+ * Decides what should happen to a single pull request. The result is a pure
+ * function of the pull request facts, the configuration and `now`, so the whole
+ * policy is testable without touching the network.
+ *
+ * `desiredStaleLabel` is reconciled by the caller rather than expressed as an
+ * action, so the label always converges on the truth even when a run is
+ * interrupted between the comment and the label call.
+ */
+export function decidePullRequest({ pullRequest, config, now }) {
+  assertPolicyConfig(config);
+  const nowMillis = toMillis(now, "now");
+
+  // Truncation means the last human activity is undatable, so the only safe
+  // move is to leave the pull request exactly as it is.
+  if (pullRequest.activityTruncated) {
+    return {
+      action: ACTION_SKIP,
+      reason: "activity history is truncated; last human activity cannot be dated",
+      idleDays: null,
+      desiredStaleLabel: pullRequest.hasStaleLabel,
+    };
+  }
+
+  const idleMillis = nowMillis - toMillis(pullRequest.lastActivityAt, "lastActivityAt");
+  const idleDays = roundDays(idleMillis);
+
+  const exemption = exemptionReason(pullRequest, config);
+  if (exemption !== null) {
+    return { action: ACTION_SKIP, reason: exemption, idleDays, desiredStaleLabel: false };
+  }
+  if (idleMillis < config.warnAfterDays * MS_PER_DAY) {
+    return {
+      action: ACTION_NONE,
+      reason: `active ${idleDays} day(s) ago`,
+      idleDays,
+      desiredStaleLabel: false,
+    };
+  }
+  return decideStalePullRequest({ pullRequest, config, nowMillis, idleMillis, idleDays });
+}

--- a/scripts/stale-pull-requests/query.mjs
+++ b/scripts/stale-pull-requests/query.mjs
@@ -1,0 +1,269 @@
+const PULL_REQUESTS_PER_PAGE = 25;
+
+/**
+ * Timeline item types that count as somebody working on the pull request.
+ * Merge/close/deploy events are deliberately absent: they are outcomes, not
+ * signs that the pull request still has a human behind it.
+ */
+const ACTIVITY_ITEM_TYPES = [
+  "PULL_REQUEST_COMMIT",
+  "HEAD_REF_FORCE_PUSHED_EVENT",
+  "ISSUE_COMMENT",
+  "PULL_REQUEST_REVIEW",
+  "READY_FOR_REVIEW_EVENT",
+  "CONVERT_TO_DRAFT_EVENT",
+  "REOPENED_EVENT",
+  "RENAMED_TITLE_EVENT",
+  "LABELED_EVENT",
+  "UNLABELED_EVENT",
+  "REVIEW_REQUESTED_EVENT",
+  "REVIEW_REQUEST_REMOVED_EVENT",
+  "ASSIGNED_EVENT",
+  "UNASSIGNED_EVENT",
+].join("\n            ");
+
+/**
+ * `timelineItems` is ordered oldest-first, so `last:` is what returns the newest
+ * page -- `first:` would silently read ancient history on a busy pull request.
+ * `totalCount` ignores the `itemTypes` filter and is therefore useless as a
+ * truncation signal, so `pageInfo.hasPreviousPage` is queried instead.
+ *
+ * `reviewRequests` intentionally selects no `Team` subfields: GITHUB_TOKEN is
+ * repository-scoped with no organization read, and asking for a team's name
+ * fails the whole query.
+ *
+ * `reviewThreads` is queried separately rather than through the timeline: a
+ * reply typed into an existing review thread frequently produces no
+ * `PullRequestReview` timeline item at all, and `PULL_REQUEST_REVIEW_THREAD`
+ * never materialises as a timeline node, so the timeline alone would miss the
+ * one kind of activity that means a review is actively in progress.
+ */
+export const PULL_REQUESTS_QUERY = `query StalePullRequests($owner: String!, $name: String!, $cursor: String) {
+  rateLimit {
+    cost
+    remaining
+    resetAt
+    nodeCount
+  }
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: OPEN, first: ${PULL_REQUESTS_PER_PAGE}, after: $cursor, orderBy: { field: UPDATED_AT, direction: DESC }) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        number
+        title
+        url
+        createdAt
+        isDraft
+        author {
+          __typename
+          login
+        }
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
+        reviewRequests(first: 20) {
+          nodes {
+            requestedReviewer {
+              __typename
+              ... on User {
+                login
+              }
+              ... on Bot {
+                login
+              }
+              ... on Mannequin {
+                login
+              }
+            }
+          }
+        }
+        latestReviews(first: 20) {
+          nodes {
+            author {
+              __typename
+              login
+            }
+          }
+        }
+        comments(last: 30) {
+          nodes {
+            id
+            createdAt
+            body
+            author {
+              __typename
+              login
+            }
+          }
+        }
+        reviewThreads(last: 100) {
+          nodes {
+            comments(last: 1) {
+              nodes {
+                createdAt
+                author {
+                  __typename
+                  login
+                }
+              }
+            }
+          }
+        }
+        timelineItems(last: 100, itemTypes: [
+            ${ACTIVITY_ITEM_TYPES}
+        ]) {
+          pageInfo {
+            hasPreviousPage
+          }
+          nodes {
+            __typename
+            ... on PullRequestCommit {
+              commit {
+                committedDate
+                authoredDate
+                author {
+                  user {
+                    login
+                  }
+                }
+                committer {
+                  user {
+                    login
+                  }
+                }
+              }
+            }
+            ... on IssueComment {
+              createdAt
+              author {
+                __typename
+                login
+              }
+            }
+            ... on PullRequestReview {
+              createdAt
+              submittedAt
+              author {
+                __typename
+                login
+              }
+            }
+            ... on HeadRefForcePushedEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on ReadyForReviewEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on ConvertToDraftEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on ReopenedEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on RenamedTitleEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on LabeledEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on UnlabeledEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on ReviewRequestedEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on ReviewRequestRemovedEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on AssignedEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+            ... on UnassignedEvent {
+              createdAt
+              actor {
+                __typename
+                login
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * Walks every page of open pull requests. The page cap exists so a malformed
+ * cursor response cannot spin forever inside a scheduled job.
+ */
+export async function fetchOpenPullRequests(client, { owner, name, logger, maxPages = 40 }) {
+  const nodes = [];
+  let cursor = null;
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const data = await client.graphql(PULL_REQUESTS_QUERY, { owner, name, cursor });
+    const connection = data.repository?.pullRequests;
+    if (!connection) {
+      throw new Error(`Repository ${owner}/${name} returned no pull request connection`);
+    }
+    nodes.push(...(connection.nodes ?? []));
+    logger.debug("Fetched pull request page", {
+      page: page + 1,
+      received: connection.nodes?.length ?? 0,
+      rateLimit: data.rateLimit,
+    });
+    if (connection.pageInfo?.hasNextPage !== true) {
+      return nodes;
+    }
+    cursor = connection.pageInfo.endCursor;
+  }
+
+  logger.warn("Stopped paginating open pull requests at the page cap", { maxPages, collected: nodes.length });
+  return nodes;
+}

--- a/scripts/stale-pull-requests/report.mjs
+++ b/scripts/stale-pull-requests/report.mjs
@@ -1,0 +1,78 @@
+import { ACTION_CLOSE, ACTION_NONE, ACTION_SKIP, ACTION_WARN } from "./policy.mjs";
+
+const ACTION_LABELS = {
+  [ACTION_WARN]: "Notified",
+  [ACTION_CLOSE]: "Closed",
+  [ACTION_NONE]: "No change",
+  [ACTION_SKIP]: "Exempt",
+  capped: "Deferred (cap)",
+  failed: "Failed",
+};
+
+function escapeCell(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function countByOutcome(results) {
+  const counts = new Map();
+  for (const result of results) {
+    counts.set(result.outcome, (counts.get(result.outcome) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function renderRow(result) {
+  const { pullRequest, decision, outcome } = result;
+  const idle = decision.idleDays === null ? "unknown" : `${decision.idleDays}`;
+  return `| [#${pullRequest.number}](${pullRequest.url}) | ${escapeCell(pullRequest.title)} | ${idle} | ${
+    ACTION_LABELS[outcome] ?? outcome
+  } | ${escapeCell(decision.reason)} |`;
+}
+
+function renderTable(results) {
+  const acted = results.filter((result) => result.outcome !== ACTION_NONE && result.outcome !== ACTION_SKIP);
+  if (acted.length === 0) {
+    return "No pull request needed a notice or a close this run.";
+  }
+  const header = ["| Pull request | Title | Idle days | Outcome | Reason |", "| --- | --- | --- | --- | --- |"];
+  return [...header, ...acted.map(renderRow)].join("\n");
+}
+
+function renderCounts(results) {
+  const counts = countByOutcome(results);
+  const parts = [...counts.entries()].map(([outcome, count]) => `${ACTION_LABELS[outcome] ?? outcome}: ${count}`);
+  return parts.length === 0 ? "No open pull requests." : parts.join(" · ");
+}
+
+/**
+ * Renders the run report written to the job summary. It is the only durable
+ * record of a scheduled sweep, so it states the policy that produced the
+ * outcome, not just the outcome.
+ */
+export function renderSummary({ repository, config, dryRun, results, cappedNumbers }) {
+  const lines = [
+    "## Stale pull requests",
+    "",
+    `Repository: \`${repository}\``,
+    `Policy: notify after **${config.warnAfterDays} days** of inactivity, close after **${config.closeAfterDays} days**, with a **${config.graceHours}h** grace period between the two.`,
+    `Exempt: ${config.exemptDrafts ? "drafts, " : ""}\`${config.exemptLabels.join("`, `")}\`${
+      config.exemptAuthors.length > 0 ? `, authors \`${config.exemptAuthors.join("`, `")}\`` : ""
+    }.`,
+    "",
+  ];
+
+  if (dryRun) {
+    lines.push("**Dry run** — no comment, label or close was applied.", "");
+  }
+  lines.push(renderCounts(results), "", renderTable(results));
+
+  if (cappedNumbers.length > 0) {
+    const deferred = cappedNumbers.map((number) => `#${number}`).join(", ");
+    lines.push(
+      "",
+      `Per-run caps (${config.maxNotices} notices, ${config.maxCloses} closes) deferred ${cappedNumbers.length} pull request(s) to the next run: ${deferred}.`,
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}


### PR DESCRIPTION
## Summary

Adds a daily `Stale Pull Requests` sweep:

- **5 days** with no human activity → one comment naming the author and reviewers, plus a `stale` label
- **7 days** idle → closed, provided the notice exists, has not been superseded, and is at least **48h** old
- Drafts and the `keep-open` label are exempt; any human activity resets the clock and drops the label

Policy lives in `scripts/stale-pull-requests/policy.mjs` as a pure function of the pull request facts, the config and `now`. The workflow uses only `node:` builtins, so it needs no install step.

### Three things that were not obvious

- **The bot must not reset its own clock.** Its notice bumps `updatedAt`, so staleness is computed from the timeline with this bot's events excluded — keyed on the GraphQL identity `github-actions`. GraphQL has no `[bot]` suffix, so matching `github-actions[bot]` would never match and nothing would ever close.
- **Review-thread replies are invisible on the timeline.** A reply typed into an existing thread often produces no `PullRequestReview` item, and `PULL_REQUEST_REVIEW_THREAD` never materialises as a timeline node (checked against 125 open PRs across five repositories, plus three cli/cli PRs where a thread reply has no same-day review). Review threads are therefore read from their own connection — without this, actively reviewed pull requests would be closed.
- **The 48h grace period is what makes rollout safe.** A pull request idle for a month is notified first and can only be closed on a later run, so switching this on cannot close a backlog in one go.

Closing is reversible: the branch survives and anyone with write access can reopen.

### Rollout

`workflow_dispatch` defaults to **dry run**, so the first manual run only reports. Scheduled runs are live. Per-run caps (25 notices, 10 closes) bound the blast radius and are reported in the job summary.

The sweep creates the `stale` and `keep-open` labels on its first live run; neither exists on the repository today.

### Note on Dependabot

Dependabot pull requests are **not** exempt, as requested. Closing one is a one-way door — it is equivalent to `@dependabot close`, Dependabot will not recreate it, and `@dependabot reopen` was removed on 2026-01-27. To exempt them later, pass `--exempt-author dependabot` in the workflow step.

## Testing

- `node --test scripts/__tests__/stale-pull-requests.test.mjs` — 49 tests
- `pnpm test` — 186 tests, `pnpm check`, `actionlint`, `node scripts/check-doc-mirrors.mjs`
- Live dry run against this repository: GraphQL query valid (cost 27, 9775 nodes), 7 open pull requests, `#168` correctly identified as idle; its computed last activity matches the newest human timeline event exactly
- Mutation-checked: dropping the review-thread source, the farewell guard, the comment retry opt-out, the `retry-after` handling, or flipping supersession `>=` to `>` each fail the suite

## Breaking changes

None. New workflow and scripts only; `CONTRIBUTING.md` and its Chinese mirror document the policy.

## Checklist

- [x] The change is focused and explains the problem it solves.
- [x] Tests and documentation are updated.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials or build output are committed.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.