### PR TITLE
fix: restore onboarding controls and Slack button

### DIFF
--- a/apps/web/src/onboarding-v2/lab-controls.tsx
+++ b/apps/web/src/onboarding-v2/lab-controls.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useId, useRef, useState } from "react";
 import * as m from "../paraglide/messages.js";
 import { Button, KumoSelectControl } from "../ui/design-system.js";
 import type { MockBackend, MockInventory, MockScenario, MockSpeed } from "./mock-backend.js";
@@ -38,6 +38,7 @@ export function LabControls({
   const scenarioId = useId();
   const inventoryId = useId();
   const panelId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
 
   const pending = backend.pending;
 
@@ -68,11 +69,13 @@ export function LabControls({
           className="flex w-72 flex-col gap-3 rounded-xl bg-kumo-base p-4 ring ring-kumo-line"
           hidden={!open}
           id={panelId}
+          ref={panelRef}
         >
           <label className="text-xs font-medium text-kumo-strong" htmlFor={scenarioId}>
             {m.onboarding_v2_lab_readiness_outcome()}
           </label>
           <KumoSelectControl
+            container={panelRef}
             id={scenarioId}
             onChange={(event) => {
               const next = SCENARIOS.find((candidate) => candidate.id === event.target.value);
@@ -93,10 +96,10 @@ export function LabControls({
             <div className="flex gap-1">
               {MOCK_SPEEDS.map((candidate) => (
                 <Button
-                  variant="ghost"
                   aria-pressed={speed === candidate}
                   key={candidate}
                   onClick={() => onSpeedChange(candidate)}
+                  variant={speed === candidate ? "secondary" : "ghost"}
                 >
                   {candidate}
                 </Button>
@@ -109,6 +112,7 @@ export function LabControls({
               {m.onboarding_v2_lab_computers_on_account()}
             </label>
             <KumoSelectControl
+              container={panelRef}
               id={inventoryId}
               onChange={(event) => onInventoryChange(event.target.value as MockInventory)}
               value={inventory}
@@ -127,7 +131,7 @@ export function LabControls({
             className="justify-start"
             onClick={() => onCloudAvailableChange(!cloudAvailable)}
             size="compact"
-            variant="outline"
+            variant={cloudAvailable ? "secondary" : "outline"}
           >
             {m.onboarding_v2_lab_offer_cloud_computer()}
           </Button>

--- a/apps/web/src/onboarding-v2/page.test.tsx
+++ b/apps/web/src/onboarding-v2/page.test.tsx
@@ -86,6 +86,38 @@ describe("OnboardingV2Page", () => {
     expect(cloud.textContent).toContain("Coming soon");
   });
 
+  it("keeps mock choices interactive above the fixed lab panel", () => {
+    render(<OnboardingV2MockPage />);
+    openLab();
+
+    const controls = screen.getByRole("button", { name: "Mock controls" });
+    const panel = document.getElementById(controls.getAttribute("aria-controls") ?? "");
+    expect(panel).toBeTruthy();
+
+    const manual = screen.getByRole("button", { name: "manual" });
+    const fast = screen.getByRole("button", { name: "fast" });
+    expect(manual.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(fast);
+    expect(manual.getAttribute("aria-pressed")).toBe("false");
+    expect(fast.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(screen.getByLabelText("Readiness outcome"));
+    expect(panel?.contains(screen.getByRole("listbox"))).toBe(true);
+    const scenario = screen.getByRole("option", { name: "Runtime not installed" });
+    fireEvent.pointerDown(scenario);
+    fireEvent.pointerUp(scenario);
+    fireEvent.click(scenario);
+    expect(screen.getByText("The chosen agent CLI is missing, so sign-in cannot be answered yet.")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Computers on the account"));
+    expect(screen.getAllByRole("listbox").every((listbox) => panel?.contains(listbox))).toBe(true);
+    const inventory = screen.getByRole("option", { name: "Several" });
+    fireEvent.pointerDown(inventory);
+    fireEvent.pointerUp(inventory);
+    fireEvent.click(inventory);
+    expect(screen.getByLabelText("Computers on the account").textContent).toContain("Several");
+  });
+
   it("shows no progress rail until the branch is known", () => {
     render(<OnboardingV2MockPage />);
     // How many steps follow depends on this step's answer, so there is no honest length to show.

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -475,6 +475,7 @@ type SelectControlChangeProps = {
 
 export type KumoSelectControlProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, "onChange" | "size" | "value"> &
   SelectControlChangeProps & {
+    container?: KumoSelectProps["container"];
     size?: KumoSelectProps["size"];
     value?: string;
     onValueChange?: (value: string) => void;

--- a/packages/server/src/__tests__/web-app-static.test.ts
+++ b/packages/server/src/__tests__/web-app-static.test.ts
@@ -24,6 +24,7 @@ describe("Web App static serving", () => {
       expect(spa.statusCode).toBe(200);
       expect(spa.body).toContain("OpenTag");
       expect(spa.headers["content-security-policy"]).toContain("frame-ancestors 'none'");
+      expect(spa.headers["content-security-policy"]).toContain("img-src 'self' data: https://platform.slack-edge.com");
       expect(spa.headers["cache-control"]).toBe("no-store");
 
       const asset = await app.inject({ method: "GET", url: "/assets/app.js" });

--- a/packages/server/src/web-app.ts
+++ b/packages/server/src/web-app.ts
@@ -15,7 +15,7 @@ export function registerWebApp(app: FastifyInstance, root: string): void {
     if (path.startsWith("/api/") || path === "/healthz" || path === "/readyz") return;
     reply.header(
       "content-security-policy",
-      "default-src 'self'; connect-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
+      "default-src 'self'; connect-src 'self'; img-src 'self' data: https://platform.slack-edge.com; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
     );
     reply.header("x-content-type-options", "nosniff");
     reply.header("x-frame-options", "DENY");


### PR DESCRIPTION
## Summary

- Allow the official Slack badge CDN in the web app CSP so the Add to Slack image renders.
- Keep Kumo select portals inside the fixed Mock controls panel so readiness and inventory options remain clickable.
- Add visible selected states for mock speed and cloud-computer controls, plus regressions for the affected behavior.

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `OPENTAG_HOME=<isolated temp> pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage`
- `pnpm --filter @opentag/server exec vitest run src/__tests__/integration --maxWorkers=1` (18 files, 301 tests)
- Built-app Playwright smoke test through the Fastify static handler: changed readiness, inventory, speed, and cloud availability; completed the cloud → agent → messaging → Slack path; verified the Slack badge loaded at its natural size.

The repository-level `pnpm test:e2e` could not start its Docker Compose PostgreSQL because the host port 5432 is already owned by the existing `first-tree-hub-postgres` container. The targeted built-app browser flow above covered both fixes with the production CSP active.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.