### PR TITLE
fix(client): validate external Feishu credentials through CLI

### DIFF
--- a/packages/client/src/__tests__/provider-cli-validation.test.ts
+++ b/packages/client/src/__tests__/provider-cli-validation.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -33,6 +33,19 @@ const fence = {
   integrationId: "33333333-3333-4333-8333-333333333333",
   credentialGeneration: 1,
 };
+const feishuFence = { ...fence, provider: "feishu" as const };
+
+function feishuValidationRequest() {
+  return {
+    expectedFingerprint: "v1:test",
+    expectedIdentity: feishuIdentity,
+    expiresAt: new Date(Date.now() + 15_000).toISOString(),
+    grant: feishuGrant,
+    requestId: fence.requestId,
+    targetPath: "/bin/true",
+    version: "1.0.92",
+  };
+}
 
 async function fakeCli(home: string, script: string): Promise<string> {
   const path = join(home, "cli");
@@ -59,35 +72,71 @@ describe("provider CLI validation classification", () => {
     expect(classifySlackAuthTest("not-json", slackIdentity)).toEqual({ status: "needs_attention" });
   });
 
-  it("requires an explicit Lark brand and fails closed on missing brand or unknown schema", () => {
+  it("accepts raw v1.0.92 and forward-compatible normalized Feishu bot info", () => {
+    expect(classifyLarkAuthStatus({ code: 0, msg: "ok", bot: { open_id: "ou_bot" } }, feishuIdentity)).toEqual({
+      status: "ready",
+    });
     expect(
       classifyLarkAuthStatus(
-        {
-          identity: { app_id: "cli_app", brand: "feishu", bot_open_id: "ou_bot" },
-          identities: { bot: { available: true, verified: true, open_id: "ou_bot" } },
-          _notice: { update: true },
-        },
+        { ok: true, identity: "bot", data: { bot: { open_id: "ou_bot", app_name: "OpenTag" } } },
         feishuIdentity,
       ),
     ).toEqual({ status: "ready" });
+    expect(classifyLarkAuthStatus({ code: 0, msg: "ok", bot: { open_id: "ou_other" } }, feishuIdentity)).toEqual({
+      status: "needs_attention",
+      reason: "identity_mismatch",
+    });
     expect(
-      classifyLarkAuthStatus(
-        {
-          identity: { app_id: "cli_app", bot_open_id: "ou_bot" },
-          identities: { bot: { available: true, verified: true, open_id: "ou_bot" } },
-        },
-        feishuIdentity,
-      ),
-    ).toEqual({ status: "needs_attention" });
+      classifyLarkAuthStatus({ ok: true, identity: "user", data: { bot: { open_id: "ou_bot" } } }, feishuIdentity),
+    ).toEqual({ status: "needs_attention", reason: "identity_mismatch" });
+    expect(classifyLarkAuthStatus({ ok: true, identity: "bot", data: {} }, feishuIdentity)).toEqual({
+      status: "needs_attention",
+    });
+    expect(classifyLarkAuthStatus({ code: 0, msg: "ok" }, feishuIdentity)).toEqual({
+      status: "needs_attention",
+    });
     expect(classifyLarkAuthStatus("not-json", feishuIdentity)).toEqual({ status: "needs_attention" });
-    expect(classifyLarkAuthStatus({ error: "rate_limited" }, feishuIdentity)).toEqual({
-      status: "retrying",
-      reason: "rate_limited",
-    });
-    expect(classifyLarkAuthStatus({ error: "internal_error" }, feishuIdentity)).toEqual({
-      status: "retrying",
-      reason: "provider_unreachable",
-    });
+  });
+
+  it.each([
+    [
+      "authentication",
+      { ok: false, error: { type: "authentication", subtype: "token_invalid", code: 99991663 } },
+      { status: "needs_attention", reason: "credential_rejected" },
+    ],
+    [
+      "authorization",
+      { ok: false, error: { type: "authorization", subtype: "permission_denied" } },
+      { status: "needs_attention", reason: "scope_missing" },
+    ],
+    [
+      "missing scopes",
+      { ok: false, error: { type: "api", missing_scopes: ["im:message"] } },
+      { status: "needs_attention", reason: "scope_missing" },
+    ],
+    [
+      "rate limit",
+      { ok: false, error: { type: "api", subtype: "rate_limit", code: 429, retryable: true } },
+      { status: "retrying", reason: "rate_limited" },
+    ],
+    [
+      "network",
+      { ok: false, error: { type: "network", subtype: "timeout", retryable: true } },
+      { status: "retrying", reason: "provider_unreachable" },
+    ],
+    [
+      "server",
+      { ok: false, error: { type: "api", subtype: "server_error", code: 503, retryable: true } },
+      { status: "retrying", reason: "provider_unreachable" },
+    ],
+    [
+      "CLI compatibility",
+      { ok: false, error: { type: "validation", subtype: "invalid_argument" } },
+      { status: "needs_attention", reason: "upgrade_required" },
+    ],
+    ["unknown", { ok: false, error: { type: "api", subtype: "unknown" } }, { status: "needs_attention" }],
+  ])("classifies structured Feishu %s failures", (_case, payload, expected) => {
+    expect(classifyLarkAuthStatus(payload, feishuIdentity)).toEqual(expected);
   });
 
   it("extracts one bounded JSON envelope and rejects oversize input", () => {
@@ -159,6 +208,119 @@ describe("Feishu tenant token exchange", () => {
 });
 
 describe("provider CLI validation runner", () => {
+  it("runs one live Feishu bot-info probe through lark-cli without projecting the app secret", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-validation-feishu-"));
+    const execFile = vi.fn(async (_file, args, options) => {
+      expect(args).toEqual(["api", "GET", "/open-apis/bot/v3/info", "--as", "bot", "--format", "ndjson"]);
+      expect(args[0]).not.toBe("auth");
+      expect(options.env.LARKSUITE_CLI_APP_ID).toBe("cli_app");
+      expect(options.env.LARKSUITE_CLI_APP_SECRET).toBeUndefined();
+      expect(options.env.LARKSUITE_CLI_BRAND).toBe("feishu");
+      expect(options.env.LARKSUITE_CLI_TENANT_ACCESS_TOKEN).toBe("tenant-token");
+      expect(options.env.LARKSUITE_CLI_USER_ACCESS_TOKEN).toBeUndefined();
+      return { stdout: '{"code":0,"msg":"ok","bot":{"open_id":"ou_bot"}}', stderr: "" };
+    });
+    const runner = new ProviderCliValidationRunner({
+      home,
+      exchangeFeishuToken: async () => "tenant-token",
+      execFile,
+      verifyTarget: async () => true,
+    });
+
+    await expect(runner.run(feishuValidationRequest(), feishuFence)).resolves.toEqual({
+      ...feishuFence,
+      status: "ready",
+    });
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(await readdir(join(home, "data", "runtime", "provider-cli-validation"))).toEqual([]);
+  });
+
+  it.each([
+    ["app", { ...feishuGrant, appId: "cli_other" }],
+    ["brand", { ...feishuGrant, teamBrand: "lark" as const }],
+  ])("rejects a Feishu grant with the wrong %s before token exchange or spawn", async (_case, grant) => {
+    const exchangeFeishuToken = vi.fn(async () => "tenant-token");
+    const execFile = vi.fn();
+    const runner = new ProviderCliValidationRunner({
+      home: await mkdtemp(join(tmpdir(), "opentag-validation-feishu-identity-")),
+      exchangeFeishuToken,
+      execFile,
+      verifyTarget: async () => true,
+    });
+
+    await expect(runner.run({ ...feishuValidationRequest(), grant }, feishuFence)).resolves.toMatchObject({
+      status: "needs_attention",
+      reason: "identity_mismatch",
+    });
+    expect(exchangeFeishuToken).not.toHaveBeenCalled();
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("classifies a nested lark-cli error returned by a non-zero process", async () => {
+    const error = Object.assign(new Error("lark-cli exited with code 3"), {
+      stdout: JSON.stringify({
+        ok: false,
+        identity: "bot",
+        error: { type: "authentication", subtype: "token_invalid", code: 99991663 },
+      }),
+      stderr: "",
+    });
+    const runner = new ProviderCliValidationRunner({
+      home: await mkdtemp(join(tmpdir(), "opentag-validation-feishu-error-")),
+      exchangeFeishuToken: async () => "tenant-token",
+      execFile: vi.fn(async () => {
+        throw error;
+      }),
+      verifyTarget: async () => true,
+    });
+
+    await expect(runner.run(feishuValidationRequest(), feishuFence)).resolves.toMatchObject({
+      status: "needs_attention",
+      reason: "credential_rejected",
+    });
+  });
+
+  it("executes the Feishu probe in a real isolated child process", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-validation-feishu-process-"));
+    const targetPath = await fakeCli(
+      home,
+      `#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "GET" ] && [ "$3" = "/open-apis/bot/v3/info" ] && [ "$4" = "--as" ] && [ "$5" = "bot" ] && [ "$6" = "--format" ] && [ "$7" = "ndjson" ] && [ "$LARKSUITE_CLI_APP_ID" = "cli_app" ] && [ "$LARKSUITE_CLI_BRAND" = "feishu" ] && [ "$LARKSUITE_CLI_TENANT_ACCESS_TOKEN" = "tenant-token" ] && [ -z "$LARKSUITE_CLI_APP_SECRET" ] && [ -z "$LARKSUITE_CLI_USER_ACCESS_TOKEN" ]; then
+  echo '{"code":0,"msg":"ok","bot":{"open_id":"ou_bot"}}'
+  exit 0
+fi
+exit 1
+`,
+    );
+    const runner = new ProviderCliValidationRunner({
+      home,
+      exchangeFeishuToken: async () => "tenant-token",
+      verifyTarget: async () => true,
+    });
+
+    await expect(runner.run({ ...feishuValidationRequest(), targetPath }, feishuFence)).resolves.toMatchObject({
+      status: "ready",
+    });
+  });
+
+  it("cleans up after a Feishu CLI timeout", async () => {
+    const home = await mkdtemp(join(tmpdir(), "opentag-validation-feishu-timeout-"));
+    const runner = new ProviderCliValidationRunner({
+      home,
+      exchangeFeishuToken: async () => "tenant-token",
+      execFile: vi.fn(async () => {
+        throw Object.assign(new Error("timeout"), { killed: true, stdout: "", stderr: "" });
+      }),
+      verifyTarget: async () => true,
+    });
+
+    await expect(runner.run(feishuValidationRequest(), feishuFence)).resolves.toMatchObject({
+      status: "retrying",
+      reason: "provider_unreachable",
+    });
+    expect(await readdir(join(home, "data", "runtime", "provider-cli-validation"))).toEqual([]);
+  });
+
   it("runs the Slack auth.test argv in an isolated env and never persists the grant", async () => {
     const home = await mkdtemp(join(tmpdir(), "opentag-validation-"));
     const targetPath = await fakeCli(

--- a/packages/client/src/runtime/provider-cli/validation-classify.ts
+++ b/packages/client/src/runtime/provider-cli/validation-classify.ts
@@ -53,26 +53,53 @@ export function classifyLarkAuthStatus(
   expected: Extract<ProviderCliExpectedIdentity, { provider: "feishu" }>,
 ): ProviderCliValidationClassification {
   if (!isRecord(payload)) return { status: "needs_attention" };
-  const failure = classifyProviderFailure(
-    [stringifyUnknown(payload.error), stringifyUnknown(payload.code)],
-    payload.missing_scopes,
-  );
+  const failure = classifyLarkFailure(payload);
   if (failure) return failure;
-  if (!isRecord(payload.identity) || !isRecord(payload.identities)) return { status: "needs_attention" };
-  if (!isRecord(payload.identities.bot)) return { status: "needs_attention" };
-  const bot = payload.identities.bot;
-  if (typeof bot.available !== "boolean" || typeof bot.verified !== "boolean") return { status: "needs_attention" };
-  if (!bot.available || !bot.verified) return { status: "needs_attention", reason: "credential_rejected" };
-  const identity = larkIdentity(payload.identity, bot);
-  if (!identity) return { status: "needs_attention" };
-  if (
-    identity.appId !== expected.appId ||
-    identity.botOpenId !== expected.botOpenId ||
-    identity.brand !== expected.teamBrand
-  ) {
+
+  const rawSuccess = payload.code === 0;
+  const normalizedSuccess = payload.ok === true;
+  if (!rawSuccess && !normalizedSuccess) return { status: "needs_attention" };
+  if (normalizedSuccess && payload.identity !== "bot") {
+    return typeof payload.identity === "string"
+      ? { status: "needs_attention", reason: "identity_mismatch" }
+      : { status: "needs_attention" };
+  }
+
+  const container = normalizedSuccess && isRecord(payload.data) ? payload.data : payload;
+  if (!isRecord(container.bot) || typeof container.bot.open_id !== "string" || container.bot.open_id.length === 0) {
+    return { status: "needs_attention" };
+  }
+  if (container.bot.open_id !== expected.botOpenId) {
     return { status: "needs_attention", reason: "identity_mismatch" };
   }
   return { status: "ready" };
+}
+
+function classifyLarkFailure(payload: Record<string, unknown>): ProviderCliValidationClassification | undefined {
+  const error = isRecord(payload.error) ? payload.error : undefined;
+  const type = normalizedField(error?.type);
+  const subtype = normalizedField(error?.subtype);
+  const code = error?.code ?? payload.code;
+  const missingScopes = error?.missing_scopes ?? payload.missing_scopes;
+
+  if (hasMissingScopes(missingScopes) || type === "authorization" || isScopeFailure(subtype)) {
+    return { status: "needs_attention", reason: "scope_missing" };
+  }
+  if (isRateLimitFailure(type, subtype, code)) {
+    return { status: "retrying", reason: "rate_limited" };
+  }
+  if (type === "authentication") {
+    return { status: "needs_attention", reason: "credential_rejected" };
+  }
+  if (type === "validation" && isCliCompatibilityFailure(subtype)) {
+    return { status: "needs_attention", reason: "upgrade_required" };
+  }
+  if (isProviderFailure(type, subtype, code, error?.retryable)) {
+    return { status: "retrying", reason: "provider_unreachable" };
+  }
+
+  const scalarError = error ? undefined : stringifyUnknown(payload.error);
+  return classifyProviderFailure([scalarError, stringifyUnknown(payload.code)], payload.missing_scopes);
 }
 
 function classifyProviderFailure(
@@ -98,20 +125,6 @@ function slackIdentity(
   return { botId: payload.bot_id, teamId: payload.team_id, userId: payload.user_id };
 }
 
-function larkIdentity(
-  identity: Record<string, unknown>,
-  bot: Record<string, unknown>,
-): { readonly appId: string; readonly botOpenId: string; readonly brand: "feishu" | "lark" } | undefined {
-  const appId = stringField(identity, ["app_id", "appId"]) ?? stringField(bot, ["app_id"]);
-  const brand = stringField(identity, ["brand", "team_brand", "teamBrand"]);
-  const botOpenId =
-    stringField(identity, ["bot_open_id", "botOpenId", "open_id", "openId"]) ??
-    stringField(bot, ["bot_open_id", "open_id", "openId"]);
-  if (!appId || !botOpenId) return undefined;
-  if (brand !== "lark" && brand !== "feishu") return undefined;
-  return { appId, botOpenId, brand };
-}
-
 export function classifySpawnFailure(error: unknown): ProviderCliValidationClassification {
   if (isAbortError(error)) throw error;
   const code = errorCode(error);
@@ -132,6 +145,59 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function hasMissingScopes(value: unknown): boolean {
   if (Array.isArray(value)) return value.length > 0;
   return typeof value === "string" ? value.length > 0 : false;
+}
+
+function normalizedField(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value.toLowerCase() : undefined;
+}
+
+function isScopeFailure(subtype: string | undefined): boolean {
+  return (
+    subtype === "missing_scope" ||
+    subtype === "app_scope_not_applied" ||
+    subtype === "token_scope_insufficient" ||
+    subtype === "permission_denied"
+  );
+}
+
+function isRateLimitFailure(type: string | undefined, subtype: string | undefined, code: unknown): boolean {
+  return (
+    type === "rate_limit" ||
+    type === "rate_limited" ||
+    subtype === "rate_limit" ||
+    subtype === "rate_limited" ||
+    String(code) === "429"
+  );
+}
+
+function isProviderFailure(
+  type: string | undefined,
+  subtype: string | undefined,
+  code: unknown,
+  retryable: unknown,
+): boolean {
+  if (retryable === true) return true;
+  if (type === "network" || type === "transport") return true;
+  if (
+    subtype === "timeout" ||
+    subtype === "dns" ||
+    subtype === "tls" ||
+    subtype === "server_error" ||
+    subtype === "service_unavailable"
+  ) {
+    return true;
+  }
+  const status = Number(code);
+  return Number.isInteger(status) && status >= 500 && status < 600;
+}
+
+function isCliCompatibilityFailure(subtype: string | undefined): boolean {
+  return (
+    subtype === "invalid_argument" ||
+    subtype === "command_unavailable" ||
+    subtype === "unsupported_command" ||
+    subtype === "unsupported_flag"
+  );
 }
 
 function isRateLimited(error: string | undefined): boolean {
@@ -164,16 +230,14 @@ function isCredentialRejected(error: string | undefined): boolean {
   );
 }
 
-function stringField(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === "string" && value.length > 0) return value;
-  }
-  return undefined;
-}
-
 function stringifyUnknown(value: unknown): string | undefined {
-  return typeof value === "string" || typeof value === "number" ? String(value) : undefined;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value);
+  if (value === null || typeof value !== "object") return undefined;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
 }
 
 function errorCode(error: unknown): string | undefined {

--- a/packages/client/src/runtime/provider-cli/validation-runner.ts
+++ b/packages/client/src/runtime/provider-cli/validation-runner.ts
@@ -178,26 +178,29 @@ export class ProviderCliValidationRunner {
     signal?: AbortSignal,
   ): Promise<ProviderCliValidationClassification> {
     if (request.grant.provider !== "feishu") return { status: "needs_attention" };
+    if (request.expectedIdentity.provider !== "feishu") {
+      return { status: "needs_attention", reason: "identity_mismatch" };
+    }
+    const expectedIdentity = request.expectedIdentity;
+    if (request.grant.appId !== expectedIdentity.appId || request.grant.teamBrand !== expectedIdentity.teamBrand) {
+      return { status: "needs_attention", reason: "identity_mismatch" };
+    }
     const tenantAccessToken = await this.#exchangeFeishuToken(request.grant, signal);
     if (Date.parse(request.expiresAt) <= this.#now()) {
       return { status: "retrying", reason: "validation_expired" };
     }
     env.LARKSUITE_CLI_APP_ID = request.grant.appId;
-    env.LARKSUITE_CLI_APP_SECRET = request.grant.appSecret;
     env.LARKSUITE_CLI_CONFIG_DIR = join(workDir, "config");
     env.LARKSUITE_CLI_BRAND = request.grant.teamBrand;
     env.LARKSUITE_CLI_TENANT_ACCESS_TOKEN = tenantAccessToken;
+    delete env.LARKSUITE_CLI_APP_SECRET;
     delete env.LARKSUITE_CLI_USER_ACCESS_TOKEN;
     return this.#runProcess(
       request.targetPath,
-      ["auth", "status", "--verify", "--json"],
+      ["api", "GET", "/open-apis/bot/v3/info", "--as", "bot", "--format", "ndjson"],
       env,
       workDir,
-      (payload) =>
-        classifyLarkAuthStatus(
-          payload,
-          request.expectedIdentity as Extract<ProviderCliExpectedIdentity, { provider: "feishu" }>,
-        ),
+      (payload) => classifyLarkAuthStatus(payload, expectedIdentity),
       signal,
     );
   }


### PR DESCRIPTION
## Summary

- replace the unsupported `lark-cli auth status --verify --json` call with one live, read-only `api GET /open-apis/bot/v3/info --as bot --format ndjson` probe through the selected managed CLI
- verify the injected app/brand against the expected identity before token exchange, then verify the provider-returned bot `open_id`
- classify the structured `{ ok, identity, error: { type, subtype, code } }` failure envelope and fail closed on unknown or malformed success payloads
- stop projecting the Feishu app secret into the child after the tenant token exchange
- add subprocess, environment isolation, timeout cleanup, success-shape, identity mismatch, and structured-error regression coverage

The `ndjson` choice is intentional. In lark-cli v1.0.92, non-JSON formats receive the raw API result, while the default JSON success envelope extracts only a `data` field. The official SDK parses this endpoint's success response as top-level `bot.open_id`:

- https://github.com/larksuite/cli/blob/v1.0.92/internal/client/response.go
- https://github.com/larksuite/oapi-sdk-go/blob/b059ee1824d45444306559b5c33c3f268c0de10d/channel/channel.go#L208-L248

Fixes #433

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (root 186; server 595; CLI 308; web 577; all workspace tasks passed)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (344 tests; 100% statements/branches/functions/lines)
- `pnpm --filter @opentag/server test:integration` (301 tests)
- focused provider CLI validation suite (26 tests)
- sanitized managed lark-cli v1.0.92 fake-token probe: command accepted, reached the provider, and returned the expected nested authentication envelope
