### PR TITLE
fix(server): allow canonical credential revocation during workspace migration

### DIFF
--- a/packages/server/drizzle/0037_drop_workspace_ownership_persistence.sql
+++ b/packages/server/drizzle/0037_drop_workspace_ownership_persistence.sql
@@ -43,8 +43,11 @@ BEGIN
 		RAISE EXCEPTION 'Workspace ownership contract migration found a Computer whose owner or installation identity diverges';
 	END IF;
 
-	-- Every legacy credential must survive with identical id, Computer binding, secret hash, and
-	-- issue/revocation audit fields.
+	-- Every legacy credential must survive with identical immutable identity and issuance fields.
+	-- PR 5 stopped mutable credential-shadow writes, so the canonical credential may have advanced
+	-- from active to revoked while the frozen legacy shadow remains active. That one-way transition
+	-- is safe because the canonical row survives this migration. Any reverse or conflicting
+	-- revocation difference would discard state and must still fail closed.
 	IF EXISTS (
 		SELECT 1
 		FROM "workspace_computer_credentials" AS "legacy"
@@ -54,10 +57,20 @@ BEGIN
 			OR "canonical"."secret_hash" IS DISTINCT FROM "legacy"."secret_hash"
 			OR "canonical"."issued_by_user_id" IS DISTINCT FROM "legacy"."issued_by_user_id"
 			OR "canonical"."issued_at" IS DISTINCT FROM "legacy"."issued_at"
-			OR "canonical"."revoked_by_user_id" IS DISTINCT FROM "legacy"."revoked_by_user_id"
-			OR "canonical"."revoked_at" IS DISTINCT FROM "legacy"."revoked_at"
+			OR (
+				(
+					"canonical"."revoked_by_user_id" IS DISTINCT FROM "legacy"."revoked_by_user_id"
+					OR "canonical"."revoked_at" IS DISTINCT FROM "legacy"."revoked_at"
+				)
+				AND NOT (
+					"legacy"."revoked_by_user_id" IS NULL
+					AND "legacy"."revoked_at" IS NULL
+					AND "canonical"."revoked_by_user_id" IS NOT NULL
+					AND "canonical"."revoked_at" IS NOT NULL
+				)
+			)
 	) THEN
-		RAISE EXCEPTION 'Workspace ownership contract migration found a legacy Computer credential without an identical canonical credential';
+		RAISE EXCEPTION 'Workspace ownership contract migration found a legacy Computer credential without a safe canonical successor';
 	END IF;
 
 	-- A Slack installation's legacy scope must be its owning Agent's scope.

--- a/packages/server/drizzle/migration-hashes.json
+++ b/packages/server/drizzle/migration-hashes.json
@@ -189,7 +189,7 @@
     {
       "idx": 37,
       "tag": "0037_drop_workspace_ownership_persistence",
-      "sha256": "145f3d61201af749380bbcb565c3ba0bbb364c7571128194ca42c1abc49c2f4e"
+      "sha256": "e0ad8e2f6c4b8163a5a1a12c42120746d93f13f015b5cf7f8d016fc330a862ae"
     }
   ]
 }

--- a/packages/server/src/__tests__/integration/workspace-ownership-contract-migration.test.ts
+++ b/packages/server/src/__tests__/integration/workspace-ownership-contract-migration.test.ts
@@ -26,6 +26,7 @@ const COMP_A1 = "00000000-0000-4000-8000-0000000000c1";
 const COMP_A2 = "00000000-0000-4000-8000-0000000000c2";
 const CRED_ACTIVE = "00000000-0000-4000-8000-0000000000e1";
 const CRED_REVOKED = "00000000-0000-4000-8000-0000000000e2";
+const CRED_CANONICAL_ONLY = "00000000-0000-4000-8000-0000000000e3";
 const CODE_CREATE = "00000000-0000-4000-8000-0000000000f1";
 const CODE_REPAIR = "00000000-0000-4000-8000-0000000000f2";
 const CODE_OPEN = "00000000-0000-4000-8000-0000000000f3";
@@ -579,16 +580,38 @@ const FAIL_CASES: Array<{
   },
   {
     name: "a legacy credential without a canonical mirror",
-    error: /without an identical canonical credential/,
+    error: /without a safe canonical successor/,
     inject: async (sql) => {
       await sql`delete from computer_credentials where id = ${CRED_REVOKED}`;
     },
   },
   {
     name: "a credential hash mismatch",
-    error: /without an identical canonical credential/,
+    error: /without a safe canonical successor/,
     inject: async (sql) => {
       await sql`update computer_credentials set secret_hash = ${"0".repeat(64)} where id = ${CRED_ACTIVE}`;
+    },
+  },
+  {
+    name: "a legacy-only credential revocation",
+    error: /without a safe canonical successor/,
+    inject: async (sql) => {
+      await sql`
+        update workspace_computer_credentials
+        set revoked_by_user_id = ${ACCOUNT_A}, revoked_at = ${LATE}
+        where id = ${CRED_ACTIVE}
+      `;
+    },
+  },
+  {
+    name: "conflicting canonical and legacy credential revocations",
+    error: /without a safe canonical successor/,
+    inject: async (sql) => {
+      await sql`
+        update computer_credentials
+        set revoked_by_user_id = ${ACCOUNT_B}
+        where id = ${CRED_REVOKED}
+      `;
     },
   },
   {
@@ -673,6 +696,65 @@ describe("workspace ownership contract migration", () => {
         await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
         await expectFinalSchema(sql, journal.entries.length);
         await expectCanonicalDataPreserved(sql);
+      } finally {
+        await sql.end();
+      }
+    } finally {
+      await rm(through0036, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves canonical-only credentials and canonical revocations newer than frozen legacy shadows", async () => {
+    const journal = await readJournal();
+    const through0036 = await truncatedMigrations(36);
+    try {
+      await migrateDatabase(databaseUrl, through0036);
+      const sql = postgres(databaseUrl, { max: 1, onnotice: () => undefined });
+      try {
+        await populateActive0036(sql);
+        await sql`
+          update workspace_computer_credentials
+          set revoked_by_user_id = ${ACCOUNT_A}, revoked_at = ${LATE}
+          where id = ${CRED_ACTIVE}
+        `;
+        await sql`
+          update computer_credentials
+          set revoked_by_user_id = ${ACCOUNT_A}, revoked_at = ${LATE}
+          where id = ${CRED_ACTIVE}
+        `;
+        await sql`
+          update workspace_computer_credentials
+          set revoked_by_user_id = null, revoked_at = null
+          where id = ${CRED_REVOKED}
+        `;
+        await sql`
+          insert into computer_credentials (id, computer_id, secret_hash, issued_by_user_id, issued_at)
+          values (${CRED_CANONICAL_ONLY}, ${COMP_A1}, ${"c".repeat(64)}, ${ACCOUNT_A}, ${LATE})
+        `;
+
+        await migrateDatabase(databaseUrl, migrationsFolder);
+        await expect(verifyDatabaseMigrations(databaseUrl, migrationsFolder)).resolves.toBeUndefined();
+        const shape = await finalShape(sql);
+        expect(shape).toMatchObject({
+          migrations: journal.entries.length,
+          legacy_tables: 0,
+          legacy_columns: 0,
+          computers: 2,
+          credentials: 3,
+        });
+        const credentials = await sql<{ id: string; revokedBy: string | null; revokedAt: Date | null }[]>`
+          select
+            id::text as id,
+            revoked_by_user_id::text as "revokedBy",
+            revoked_at as "revokedAt"
+          from computer_credentials
+          where id in (${CRED_REVOKED}, ${CRED_CANONICAL_ONLY})
+          order by id
+        `;
+        expect(credentials).toEqual([
+          { id: CRED_REVOKED, revokedBy: ACCOUNT_A, revokedAt: LATE },
+          { id: CRED_CANONICAL_ONLY, revokedBy: null, revokedAt: null },
+        ]);
       } finally {
         await sql.end();
       }
@@ -769,7 +851,7 @@ describe("workspace ownership contract migration", () => {
         await populateActive0036(sql);
         await sql`delete from computer_credentials where id = ${CRED_REVOKED}`;
         await expect(migrateDatabase(databaseUrl, migrationsFolder)).rejects.toThrow(
-          /without an identical canonical credential/,
+          /without a safe canonical successor/,
         );
         const [rolledBack] = await sql<{ migrations: number; computers: string | null }[]>`
           select


### PR DESCRIPTION
## Summary

- correct the unapplied 0037 preflight so a frozen active legacy credential may have a revoked canonical successor
- retain exact equality for immutable identity, Computer binding, secret hash, and issuance fields
- continue failing closed for legacy-only, conflicting, or partial revocation states
- update the version-controlled migration hash and add positive and negative integration coverage

## Staging diagnosis

The prior deployment rolled the migration transaction back cleanly. The journal remains at 37 applied migrations, with 0037 absent. The only preflight divergence is the expected one-way state created after credential-shadow writes stopped: three canonical credentials are revoked while their frozen legacy shadows remain active. No canonical row, binding, hash, or issuance data is missing or mismatched.

0037 has not been applied in the managed staging environment, so correcting that migration before first application is required; an appended migration cannot run before a failing 0037.

## Exact-head local acceptance

Accepted head: d4f378c55f360327a0571ec923da837e6d088b6c
Base: 0b401a15b68b94c779cdadd85c0aa3eb9c9c8437

- pnpm check
- pnpm build
- pnpm typecheck
- pnpm test
- pnpm test:coverage (94.23% total line coverage)
- pnpm --filter @opentag/client test:agent-runtime:coverage (100%)
- pnpm --filter @opentag/server test:integration (313 tests)
- targeted workspace ownership migration integration tests (18 tests)
- legacy persistence allowlist test
- pnpm --filter @opentag/server db:generate (no schema changes)
- git diff --check
