### PR TITLE
feat(web): add UI governance contract

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,17 @@
 
 <!-- List the commands and manual checks you ran. -->
 
+## UI validation
+
+<!-- Complete this section only when the pull request changes rendered UI. Remove it otherwise. -->
+
+- Desktop evidence:
+- Mobile evidence:
+- Widths checked (`320px` / `390px` / `768px` / `1440px`; explain any N/A):
+- States verified:
+- Keyboard/accessibility checks:
+- New reusable block, theme value, or CSS exception:
+
 ## Breaking changes
 
 <!-- Describe compatibility impact, or write "None". -->

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "remark-gfm": "4.0.1"
   },
   "devDependencies": {
+    "@babel/parser": "7.29.8",
     "@inlang/paraglide-js": "2.25.0",
     "@inlang/plugin-message-format": "4.4.3",
     "@tailwindcss/vite": "^4.3.3",

--- a/apps/web/src/components/kumo/page-header/page-header.tsx
+++ b/apps/web/src/components/kumo/page-header/page-header.tsx
@@ -1,4 +1,4 @@
-import { cn, Tabs, type TabsItem, Text } from "@cloudflare/kumo";
+import { cn, Tabs, Text } from "@cloudflare/kumo";
 import type { ReactNode } from "react";
 
 export const KUMO_PAGE_HEADER_VARIANTS = {
@@ -28,6 +28,11 @@ export interface KumoPageHeaderVariantsProps {
   spacing?: KumoPageHeaderSpacing;
 }
 
+export interface PageHeaderTab {
+  value: string;
+  label: ReactNode;
+}
+
 export function pageHeaderVariants({
   spacing = KUMO_PAGE_HEADER_DEFAULT_VARIANTS.spacing,
 }: KumoPageHeaderVariantsProps = {}) {
@@ -40,7 +45,7 @@ export interface PageHeaderProps extends KumoPageHeaderVariantsProps {
   title?: string;
   description?: string;
   titleId?: string;
-  tabs?: TabsItem[];
+  tabs?: PageHeaderTab[];
   defaultTab?: string;
   onValueChange?: (value: string) => void;
   className?: string;

--- a/apps/web/src/ui/KUMO.md
+++ b/apps/web/src/ui/KUMO.md
@@ -1,5 +1,9 @@
 # OpenTag Kumo UI
 
+The canonical product composition and acceptance rules live in
+[`docs/design/web-ui-contract.md`](../../../../docs/design/web-ui-contract.md). This document records the Kumo-specific
+implementation choices behind that interface.
+
 OpenTag uses Kumo `2.12.0` with Tailwind CSS v4. `src/app.css` is the only
 application stylesheet entry: it registers Kumo's distribution as a Tailwind
 source, imports Kumo's Tailwind styles before Tailwind itself, then loads the
@@ -15,7 +19,8 @@ table, code, or log surface rather than the application scroll viewport.
 
 ## Component boundary
 
-`design-system.tsx` is the semantic adapter used by product pages. It maps the
+Product pages use two parallel seams: `design-system.tsx` for semantic primitives
+and `src/components/kumo` for deeper owned blocks. The semantic adapter maps the
 existing product vocabulary to Kumo primitives:
 
 - `Button` maps `danger` to Kumo `destructive`, `compact` to `sm`, and `inline`
@@ -38,6 +43,13 @@ Use Kumo `Input`, `InputArea`, `Select`, `Checkbox`, `Switch`, `Table`,
 for new controls. The only native control exception is the hidden file input
 required by the browser file picker.
 
+Feature modules do not import `@cloudflare/kumo` directly. Direct imports belong
+to application provider wiring, `design-system.tsx`, and owned blocks under
+`src/components/kumo`; tests may provide their own provider wiring. Add an owned
+block only when it hides meaningful shared behavior, not merely to forward Kumo
+props or utility classes. Owned-block interfaces use OpenTag types and do not
+expose Kumo-specific types or composition to callers.
+
 ## Theme
 
 `kumo-theme.tokens.ts` is the source configuration. `kumo-theme.css` is its
@@ -51,8 +63,10 @@ danger gradients. The theme contrast test verifies every rendered gradient
 endpoint for normal-text WCAG AA, not only the source accent.
 
 The theme uses explicit `data-theme="opentag"` and `data-mode="light|dark"`
-attributes. Brand values were chosen for readable text and button contrast in
-both modes; do not add raw colour literals to page components.
+attributes. The product currently ships light mode; dark values remain available
+for compatibility and future completion, not as a supported product theme.
+Brand values were chosen for readable text and button contrast in both modes;
+do not add raw colour literals to page components.
 
 ## Router links and overlays
 
@@ -76,5 +90,6 @@ pnpm test
 
 Static contract tests reject legacy stylesheet imports, legacy token and class
 names, tracking utility classes, `font-bold`, application-level interactive
-HTML controls, and page-level CSS. Browser visual and accessibility checks must
-use local fixtures and must not call public services.
+HTML controls, feature-level Kumo imports, and unreviewed stylesheet seams.
+Browser visual and accessibility checks must use local fixtures and must not call
+public services.

--- a/apps/web/src/ui/kumo-contract.test.ts
+++ b/apps/web/src/ui/kumo-contract.test.ts
@@ -1,16 +1,101 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parse } from "@babel/parser";
+import postcss from "postcss";
 import { describe, expect, it } from "vitest";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const sourceFiles = readdirSync(root, { recursive: true, withFileTypes: true })
-  .filter((entry) => entry.isFile() && entry.name.endsWith(".tsx") && !entry.name.includes(".test."))
+const moduleSourceFiles = readdirSync(root, { recursive: true, withFileTypes: true })
+  .filter((entry) => entry.isFile() && /\.tsx?$/.test(entry.name) && !entry.name.includes(".test."))
   .map((entry) => resolve(entry.parentPath, entry.name));
+const sourceFiles = moduleSourceFiles.filter((file) => file.endsWith(".tsx"));
 const source = sourceFiles.map((file) => readFileSync(resolve(root, file), "utf8")).join("\n");
 const appCss = readFileSync(resolve(root, "app.css"), "utf8");
 const main = readFileSync(resolve(root, "main.tsx"), "utf8");
 const viteConfig = readFileSync(resolve(root, "..", "vite.config.ts"), "utf8");
+const productModules = moduleSourceFiles
+  .map((file) => {
+    const content = readFileSync(file, "utf8");
+    const path = sourcePath(file);
+    return { content, imports: moduleSpecifiers(content, path), path };
+  })
+  .filter((entry) => !entry.path.startsWith("__tests__/"));
+const stylesheets = readdirSync(root, { recursive: true, withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith(".css"))
+  .map((entry) => {
+    const file = resolve(entry.parentPath, entry.name);
+    return { content: readFileSync(file, "utf8"), path: sourcePath(file) };
+  });
+
+function sourcePath(file: string): string {
+  return relative(root, file).replaceAll("\\", "/");
+}
+
+function moduleSpecifiers(content: string, path = "contract-fixture.tsx"): string[] {
+  const syntax = parse(content, {
+    createImportExpressions: true,
+    plugins: ["typescript", "jsx"],
+    sourceFilename: path,
+    sourceType: "module",
+  });
+  const specifiers: string[] = [];
+
+  walkSyntax(syntax, (node) => {
+    if (
+      node.type === "ImportDeclaration" ||
+      node.type === "ExportNamedDeclaration" ||
+      node.type === "ExportAllDeclaration" ||
+      node.type === "ImportExpression"
+    ) {
+      const specifier = stringNodeValue(node.source);
+      if (specifier) specifiers.push(specifier);
+    }
+  });
+
+  return specifiers;
+}
+
+function walkSyntax(value: unknown, visit: (node: Record<string, unknown>) => void): void {
+  if (Array.isArray(value)) {
+    for (const item of value) walkSyntax(item, visit);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+
+  const node = value as Record<string, unknown>;
+  if (typeof node.type === "string") visit(node);
+  for (const [key, child] of Object.entries(node)) {
+    if (key === "loc" || key === "extra") continue;
+    walkSyntax(child, visit);
+  }
+}
+
+function stringNodeValue(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const candidate = (value as Record<string, unknown>).value;
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function stylesheetImportSpecifiers(content: string, path = "contract-fixture.css"): string[] {
+  const specifiers: string[] = [];
+  postcss.parse(content, { from: path }).walkAtRules("import", (atRule) => {
+    const match = atRule.params.match(/^\s*(?:url\(\s*)?["']([^"']+)["']|^\s*url\(\s*([^\s)]+)\s*\)|^\s*([^\s;]+)/);
+    const specifier = match?.[1] ?? match?.[2] ?? match?.[3];
+    specifiers.push(specifier ?? `<unresolved: ${atRule.params}>`);
+  });
+  return specifiers;
+}
+
+function isStylesheetSpecifier(specifier: string): boolean {
+  return (specifier.split(/[?#]/, 1)[0] ?? "").endsWith(".css");
+}
+
+function hasRawColorLiteral(content: string): boolean {
+  const hex = /#(?:[\da-f]{8}|[\da-f]{6}|[\da-f]{4}|[\da-f]{3})(?![\da-f])/i;
+  const functional = /(?:^|[^\w-])(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\(\s*[^)]/i;
+  return hex.test(content) || functional.test(content);
+}
 
 describe("Kumo integration contract", () => {
   it("compiles application and Kumo utilities through Tailwind", () => {
@@ -49,6 +134,69 @@ describe("Kumo integration contract", () => {
     expect(adapter).toContain("onOpenChange");
     expect(adapter).toContain("@phosphor-icons/react");
     expect(source).not.toMatch(/data-kumo-component|kumo-select/);
+  });
+
+  it("keeps direct Kumo imports behind the approved product seams", () => {
+    const violations = productModules
+      .filter(({ imports }) => imports.some((specifier) => /^@cloudflare\/kumo(?:\/|$)/.test(specifier)))
+      .map(({ path }) => path)
+      .filter((path) => path !== "app.tsx" && path !== "ui/design-system.tsx" && !path.startsWith("components/kumo/"));
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps module-owned stylesheet imports at reviewed seams", () => {
+    const allowedImports = new Set([
+      "main.tsx -> ./app.css",
+      "onboarding-v2/page.tsx -> ./onboarding-v2.css",
+      "setup/command-block.tsx -> ./setup.css",
+      "setup/components.tsx -> ./setup.css",
+      "app.css -> @fontsource/dm-sans/400.css",
+      "app.css -> @fontsource/dm-sans/500.css",
+      "app.css -> @fontsource/dm-sans/600.css",
+      "app.css -> @fontsource/sora/600.css",
+      "app.css -> @fontsource/sora/700.css",
+      "app.css -> @cloudflare/kumo/styles/tailwind",
+      "app.css -> tailwindcss",
+      "app.css -> ./ui/kumo-theme.css",
+      "app.css -> ./ui/typography.css",
+    ]);
+    const moduleImports = productModules.flatMap(({ imports, path }) =>
+      imports.filter(isStylesheetSpecifier).map((specifier) => `${path} -> ${specifier}`),
+    );
+    const cssImports = stylesheets.flatMap(({ content, path }) =>
+      stylesheetImportSpecifiers(content, path).map((specifier) => `${path} -> ${specifier}`),
+    );
+    const violations = [...moduleImports, ...cssImports].filter((entry) => !allowedImports.has(entry));
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps raw colors at the theme seam or an explicitly reviewed module stylesheet", () => {
+    const allowedFiles = new Set(["app.css", "setup/setup.css", "ui/kumo-theme.css", "ui/kumo-theme.tokens.ts"]);
+    const violations = [...productModules, ...stylesheets]
+      .filter(({ content }) => hasRawColorLiteral(content))
+      .map(({ path }) => path)
+      .filter((path) => !allowedFiles.has(path));
+
+    expect(violations).toEqual([]);
+  });
+
+  it("recognizes alternate module, stylesheet, and color syntax before enforcing seams", () => {
+    expect(
+      moduleSpecifiers(`
+        export type { ButtonProps } from "@cloudflare/kumo";
+        const loadKumo = () => import("@cloudflare/kumo");
+        import styles from "./feature.css?inline";
+      `),
+    ).toEqual(["@cloudflare/kumo", "@cloudflare/kumo", "./feature.css?inline"]);
+    expect(stylesheetImportSpecifiers('@import url("./feature.css") layer(feature);')).toEqual(["./feature.css"]);
+    expect(isStylesheetSpecifier("./feature.css?inline")).toBe(true);
+    expect(hasRawColorLiteral("color: rgb(1 2 3)")).toBe(true);
+    expect(hasRawColorLiteral("color: oklch(50% .2 120)")).toBe(true);
+    expect(hasRawColorLiteral("color: var(--text-color); background: color-mix(in srgb, var(--a), var(--b))")).toBe(
+      false,
+    );
   });
 
   it("uses the Kumo compound sidebar layout for the application shell", () => {

--- a/docs/design/web-ui-contract.md
+++ b/docs/design/web-ui-contract.md
@@ -1,0 +1,154 @@
+# Web UI contract
+
+This document defines the interface that OpenTag Web feature code uses to build consistent, accessible product UI. It
+complements the implementation notes in [`apps/web/src/ui/KUMO.md`](../../apps/web/src/ui/KUMO.md). Kumo owns the visual
+primitives; this contract owns OpenTag's product semantics, composition rules, and acceptance criteria.
+
+## Ownership and dependency seam
+
+The Web UI has one third-party implementation and two product-facing seams:
+
+```text
+                         ┌─ src/ui/design-system.tsx semantic adapter ─┐
+@cloudflare/kumo ────────┤                                               ├─ src/features
+                         └─ src/components/kumo owned reusable blocks ──┘
+                                  ▲
+                                  └─ may reuse the semantic adapter
+```
+
+- Kumo owns primitive appearance, spacing, radii, shadows, and baseline interaction behavior.
+- `src/ui/design-system.tsx` is the semantic adapter and the normal interface for product code. It owns OpenTag intent
+  names, accessibility corrections, compatibility behavior, icon registration, and other rules that must remain
+  consistent across callers.
+- `src/components/kumo` contains reusable blocks whose behavior is deeper than a primitive, such as `PageHeader`. Their
+  interfaces use OpenTag-owned types and must not expose Kumo-specific types or composition to callers.
+- Feature modules compose either approved seam. They own domain state and copy, not new primitive conventions.
+
+Feature modules must not import `@cloudflare/kumo` directly. Direct imports are limited to the application provider
+wiring, the semantic adapter, and owned Kumo blocks. Tests may install their own provider wiring.
+
+## Choosing where behavior belongs
+
+Use an existing Kumo primitive through the semantic adapter when it already expresses the required behavior. Add or
+deepen an adapter when OpenTag must consistently translate a product intent, repair accessibility, or hide Kumo-specific
+composition from every caller.
+
+Create an owned reusable block when either condition is true:
+
+- the same product composition has at least three real callers; or
+- the interaction or accessibility behavior is important and easy for callers to implement inconsistently.
+
+Do not create a wrapper that only renames props or forwards styling. A reusable block should hide meaningful behavior
+behind a smaller interface. Test it through that interface rather than through Kumo implementation details.
+
+## Page and interaction states
+
+A data-backed surface must deliberately handle every state that its domain can enter. The relevant set normally includes:
+
+- initial loading;
+- content;
+- empty content;
+- partial or unavailable data;
+- recoverable failure with a retry path; and
+- terminal failure with a useful next action.
+
+An interactive action must deliberately handle the relevant default, hover, focus-visible, disabled, busy, success, and
+failure states. Busy actions must prevent duplicate submission. Feedback must remain associated with the action or field
+that caused it, and a failure must not erase valid user input.
+
+Use Kumo `Loader` or `SkeletonLine` for loading, `Empty` for a genuine empty result, `Banner` for contextual status, and
+the shared route or resource-state modules for failures. Do not use an empty table, a disabled action without an
+explanation, or layout movement as the only indication that state changed.
+
+Irreversible, high-impact, or uncertain-scope destructive actions require an explicit confirmation surface, a clear
+description of impact, a non-destructive default focus target, and an execution state that cannot be dismissed while the
+outcome is uncertain. A low-impact action may execute immediately only when it is reliably reversible and offers a clear,
+keyboard-accessible Undo path for long enough to recover.
+
+## Layout and responsive acceptance
+
+Authenticated pages use the named `content` container and the shared content frame documented in `KUMO.md`. Prefer
+container queries for page composition because the Sidebar changes the space available to the route without changing
+the viewport. Add a breakpoint because content stops working at that width, not to reproduce a device catalogue.
+
+UI changes must be checked at these representative widths when the surface can render there:
+
+| Width | Acceptance purpose |
+| --- | --- |
+| 320px | Minimum supported width; no page-level horizontal scrolling |
+| 390px | Primary mobile composition and touch interaction |
+| 768px | Navigation and compact-to-wide layout transition |
+| 1440px | Desktop hierarchy, density, and maximum content width |
+
+Horizontal overflow belongs to the nearest table, code, log, or other intrinsically wide region. That region must be
+keyboard focusable and have an accessible name when keyboard users need to scroll it.
+
+Use Kumo and Tailwind spacing and type utilities. Arbitrary measurements are allowed only for a demonstrated content or
+layout constraint and should carry a short explanation when the reason is not evident from the interface.
+
+## Accessibility acceptance
+
+OpenTag Web targets WCAG 2.2 AA for product UI:
+
+- normal text contrast is at least 4.5:1;
+- large text and meaningful non-text UI contrast are at least 3:1;
+- every interactive control has a visible focus indicator with at least 3:1 contrast against adjacent colors;
+- keyboard order follows the visual and task order;
+- Enter and Space activate controls according to their native semantics;
+- Escape closes dismissible overlays, and focus returns to the control that opened them;
+- icon-only controls have an accessible name, while decorative icons are hidden from assistive technology;
+- validation identifies the field, describes the problem, and exposes the update to assistive technology; and
+- non-essential animation and transition are removed when `prefers-reduced-motion: reduce` is active.
+
+Automated axe checks are required for representative browser flows, but they do not replace keyboard testing or review
+of contrast, focus order, accessible names, and task completion.
+
+## Theme, color, and motion
+
+OpenTag currently ships light mode as the supported product theme. Dark theme values may remain for Kumo compatibility
+or future work, but their presence does not make dark mode a supported acceptance target. A future dark-mode change must
+define complete surface, text, status, illustration, chart, and browser-level behavior before changing this policy.
+
+Feature code must use Kumo semantic utilities or the OpenTag variables defined at the theme seam. Raw color literals are
+limited to theme sources and explicitly reviewed module-owned styles. Brand green communicates brand or selection; it
+must not replace success, warning, danger, or informational status colors.
+
+Motion must communicate a state change or spatial relationship. Prefer transform and opacity, avoid perpetual animation
+outside an active progress state, and provide a reduced-motion result that communicates the same information without
+movement.
+
+## CSS exceptions
+
+`src/app.css` is the application stylesheet entry. Product layout and appearance normally use Kumo and Tailwind
+utilities. A module-owned stylesheet is an exception reserved for behavior that utilities cannot express clearly, such
+as attribute-driven state, measured layout stability, or a specialized terminal surface.
+
+Every module-owned stylesheet must:
+
+- be imported by the module that owns the behavior;
+- use a module-specific class prefix;
+- explain non-obvious measurements or raw colors next to the rule;
+- avoid styling unrelated pages or Kumo internals globally; and
+- be added to the static stylesheet seam allowlist in `src/ui/kumo-contract.test.ts`.
+
+## Internationalization and copy
+
+User-facing copy goes through Paraglide messages. English and Simplified Chinese message catalogues must remain complete
+and synchronized as described in `DEVELOPMENT.md`. UI review must include the locale most likely to stress the changed
+layout; do not assume English is always the longest representation.
+
+Controls use concise action labels. Errors explain what happened and what the user can do next. Do not rely on color,
+placeholder text, an icon, or a tooltip as the only communication of essential information.
+
+## Verification and pull request evidence
+
+Tests should cross the same interface as product callers:
+
+- adapter and owned-block tests verify public behavior and accessibility semantics;
+- static contract tests enforce the Kumo import, interactive-element, token, and stylesheet seams;
+- feature tests cover domain states and user-visible outcomes; and
+- Playwright checks representative keyboard, axe, responsive, and stable visual paths against local fixtures.
+
+When a pull request changes rendered UI, its `UI validation` section records desktop and mobile evidence, the states that
+were exercised, keyboard or accessibility checks, and any new reusable block, theme value, or CSS exception. A change
+that cannot render at one of the representative widths should state why rather than silently omitting that check.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
         specifier: 4.0.1
         version: 4.0.1
     devDependencies:
+      '@babel/parser':
+        specifier: 7.29.8
+        version: 7.29.8
       '@inlang/paraglide-js':
         specifier: 2.25.0
         version: 2.25.0(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

- define the canonical English Web UI contract for component ownership, responsive acceptance, accessibility, theme scope, CSS exceptions, and PR evidence
- establish the semantic adapter and owned Kumo blocks as parallel product seams, with OpenTag-owned PageHeader tab types
- enforce Kumo imports, stylesheet imports, and raw color literals through parsed TypeScript/TSX and CSS contract tests
- add conditional UI validation fields to the pull request template

Rendered UI is unchanged.

## Testing

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `OPENTAG_HOME=<isolated-temp-dir> pnpm test`
- `pnpm --filter @opentag/web test`

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.