### PR TITLE
fix(web): refine desktop workspace spacing

### DIFF
--- a/apps/web/src/__tests__/app-shell.test.tsx
+++ b/apps/web/src/__tests__/app-shell.test.tsx
@@ -70,6 +70,9 @@ describe("OpenTag Web App Shell", () => {
     const switcher = screen.getByRole("button", { name: "Switch Agent, current Agent Reviewer" });
     expect(switcher.closest('[data-sidebar="header"]')).toBeTruthy();
     const workspaceNavigation = screen.getByRole("navigation", { name: "Agent" });
+    expect(workspaceNavigation.closest('[data-sidebar="content"]')?.className).toContain(
+      "md:[&_[data-sidebar=viewport]]:pt-2",
+    );
     expect(
       within(workspaceNavigation)
         .getAllByRole("button")

--- a/apps/web/src/features/shell/agent-shell.tsx
+++ b/apps/web/src/features/shell/agent-shell.tsx
@@ -115,7 +115,7 @@ function AgentShellContent({
           </Sidebar.Menu>
           <Sidebar.Close className="sm:hidden" />
         </Sidebar.Header>
-        <Sidebar.Content>
+        <Sidebar.Content className="md:[&_[data-sidebar=viewport]]:pt-2">
           <nav aria-label={m.shell_agent()}>
             <Sidebar.Group>
               <Sidebar.Menu>

--- a/apps/web/src/ui/kumo-contract.test.ts
+++ b/apps/web/src/ui/kumo-contract.test.ts
@@ -204,7 +204,7 @@ describe("Kumo integration contract", () => {
       .map((file) => readFileSync(resolve(root, "features/shell", file), "utf8"))
       .join("\n");
     expect(shell).toContain('<Sidebar.Header className="border-b-0">');
-    expect(shell).toContain("<Sidebar.Content>");
+    expect(shell).toMatch(/<Sidebar\.Content(?:\s|>)/);
     expect(shell).toContain("<Sidebar.Menu>");
     expect(shell).toContain("<Sidebar.MenuButton");
     expect(shell).toContain("<Sidebar.Footer>");


### PR DESCRIPTION
## Summary
- reduce the desktop gap between the Agent switcher and Home from 12px to 8px while preserving mobile spacing
- align the Task search and compact filters in one desktop toolbar by targeting the actual `content` container
- keep the Task controls stacked on narrow content widths
- make the Kumo sidebar contract accept configured compound components

## Validation
- 55 related Web tests
- full Web suite: 65 files, 579 tests
- Web typecheck and production build
- `pnpm check`
- pre-push format, lint, typecheck, and check gates