### PR TITLE
test(web): enforce responsive browser contract

### DIFF
--- a/apps/web/src/ui/KUMO.md
+++ b/apps/web/src/ui/KUMO.md
@@ -86,6 +86,7 @@ pnpm check
 pnpm build
 pnpm typecheck
 pnpm test
+pnpm test:e2e:smoke
 ```
 
 Static contract tests reject legacy stylesheet imports, legacy token and class

--- a/docs/design/web-ui-contract.md
+++ b/docs/design/web-ui-contract.md
@@ -149,6 +149,11 @@ Tests should cross the same interface as product callers:
 - feature tests cover domain states and user-visible outcomes; and
 - Playwright checks representative keyboard, axe, responsive, and stable visual paths against local fixtures.
 
+The pull-request Browser Smoke maps the four representative widths to stable acceptance paths rather than multiplying
+every page by every viewport: 320px sign-in, 390px touch dialog behavior, the 768px Account layout transition, and the
+1440px bounded desktop content frame. These checks enforce page-level overflow and axe acceptance; feature-specific
+responsive tests remain responsible for intrinsically wide regions and specialized compositions.
+
 When a pull request changes rendered UI, its `UI validation` section records desktop and mobile evidence, the states that
 were exercised, keyboard or accessibility checks, and any new reusable block, theme value, or CSS exception. A change
 that cannot render at one of the representative widths should state why rather than silently omitting that check.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -24,7 +24,10 @@ The pull-request smoke path is intentionally separate from that serial journey:
 pnpm test:e2e:smoke
 ```
 
-It runs the four read-only browser smoke flows with four workers. Run only this package after a build with
+It runs read-only browser smoke flows with four workers. The responsive contract maps the four product acceptance widths
+to one stable purpose each: minimum-width sign-in at 320px, touch dialog behavior at 390px, the Account layout transition
+at 768px, and the bounded desktop content frame at 1440px. Each path checks page overflow and axe accessibility in
+addition to its width-specific behavior. Run only this package after a build with
 `pnpm --filter @opentag/e2e test:e2e:smoke` or `pnpm --filter @opentag/e2e e2e:journey`. Set `OPENTAG_E2E_CHROMIUM` only
 when a specific Chromium executable is required. The default uses the Chromium binary managed by Playwright.
 

--- a/e2e/tests/browser-contract.ts
+++ b/e2e/tests/browser-contract.ts
@@ -1,0 +1,32 @@
+import { AxeBuilder } from "@axe-core/playwright";
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "./fixtures.js";
+
+export async function expectAccessible(page: Page): Promise<void> {
+  const results = await new AxeBuilder({ page }).analyze();
+  const violations = results.violations.map(
+    (violation) => `${violation.id}: ${violation.nodes.map((node) => node.target.join(", ")).join(" | ")}`,
+  );
+  expect(violations, "axe accessibility violations").toEqual([]);
+}
+
+export async function expectNoPageOverflow(page: Page): Promise<void> {
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.scrollWidth, "page-level horizontal overflow").toBeLessThanOrEqual(dimensions.clientWidth);
+}
+
+export async function expectWithinViewport(locator: Locator): Promise<void> {
+  await expect(locator).toBeVisible();
+  const [box, viewport] = await Promise.all([locator.boundingBox(), locator.page().viewportSize()]);
+  expect(box, "element layout box").not.toBeNull();
+  expect(viewport, "browser viewport").not.toBeNull();
+  if (!box || !viewport) throw new Error("Expected the element and viewport to have layout dimensions");
+
+  expect(box.x, "element left edge").toBeGreaterThanOrEqual(0);
+  expect(box.y, "element top edge").toBeGreaterThanOrEqual(0);
+  expect(box.x + box.width, "element right edge").toBeLessThanOrEqual(viewport.width);
+  expect(box.y + box.height, "element bottom edge").toBeLessThanOrEqual(viewport.height);
+}

--- a/e2e/tests/browser-smoke.spec.ts
+++ b/e2e/tests/browser-smoke.spec.ts
@@ -1,5 +1,4 @@
-import { AxeBuilder } from "@axe-core/playwright";
-import type { Page } from "@playwright/test";
+import { expectAccessible } from "./browser-contract.js";
 import { expect, smokeTest as test } from "./fixtures.js";
 
 test.describe.configure({ mode: "parallel" });
@@ -77,11 +76,3 @@ test("the Account menu has named keyboard destinations", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Account", exact: true })).toBeVisible();
   await expectAccessible(page);
 });
-
-async function expectAccessible(page: Page): Promise<void> {
-  const results = await new AxeBuilder({ page }).analyze();
-  const violations = results.violations.map(
-    (violation) => `${violation.id}: ${violation.nodes.map((node) => node.target.join(", ")).join(" | ")}`,
-  );
-  expect(violations, "axe accessibility violations").toEqual([]);
-}

--- a/e2e/tests/responsive-smoke.spec.ts
+++ b/e2e/tests/responsive-smoke.spec.ts
@@ -1,0 +1,94 @@
+import { expectAccessible, expectNoPageOverflow, expectWithinViewport } from "./browser-contract.js";
+import { expect, smokeTest as test } from "./fixtures.js";
+
+test.describe.configure({ mode: "parallel" });
+
+test.describe("320px minimum supported width", () => {
+  test.use({ storageState: { cookies: [], origins: [] }, viewport: { width: 320, height: 720 } });
+
+  test("keeps sign-in visible, keyboard ordered, and free of page overflow", async ({ page }) => {
+    await page.goto("/agents", { waitUntil: "networkidle" });
+    await expect(page).toHaveURL(/\/login\?next=%2Fagents$/);
+    await expect(page.getByRole("heading", { name: "Welcome back", exact: true })).toBeVisible();
+    await expectWithinViewport(page.locator('[data-ui="login-card"]'));
+    await expectNoPageOverflow(page);
+
+    const email = page.getByLabel("Email", { exact: true });
+    const password = page.getByLabel("Password", { exact: true });
+    await email.focus();
+    await page.keyboard.press("Tab");
+    await expect(password).toBeFocused();
+    await expectAccessible(page);
+  });
+});
+
+test.describe("390px primary mobile width", () => {
+  test.use({ hasTouch: true, viewport: { width: 390, height: 844 } });
+
+  test("keeps the primary action and touch dialog inside the viewport", async ({ page }) => {
+    await page.goto("/agents", { waitUntil: "networkidle" });
+    await expect(page.getByRole("heading", { name: "Agents", exact: true })).toBeVisible();
+    const trigger = page.getByRole("button", { name: "New Agent", exact: true });
+    await expectWithinViewport(trigger);
+    await expectNoPageOverflow(page);
+
+    await trigger.tap();
+    const dialog = page.getByRole("dialog", { name: "New Agent" });
+    await expectWithinViewport(dialog);
+    await expectNoPageOverflow(page);
+    await expectAccessible(page);
+
+    await dialog.getByRole("button", { name: "Close new Agent dialog", exact: true }).tap();
+    await expect(dialog).toHaveCount(0);
+  });
+});
+
+test.describe("768px layout transition width", () => {
+  test.use({ viewport: { width: 768, height: 900 } });
+
+  test("keeps Account settings readable in the wide row composition", async ({ page }) => {
+    await page.goto("/account", { waitUntil: "networkidle" });
+    await expect(page.getByRole("heading", { name: "Account", exact: true })).toBeVisible();
+    await expectNoPageOverflow(page);
+
+    const firstRow = page.locator('[data-ui="settings-row"]').first();
+    const copy = firstRow.locator(":scope > div").nth(0);
+    const control = firstRow.locator(":scope > div").nth(1);
+    const [copyBox, controlBox] = await Promise.all([copy.boundingBox(), control.boundingBox()]);
+    expect(copyBox, "settings copy layout box").not.toBeNull();
+    expect(controlBox, "settings control layout box").not.toBeNull();
+    if (!copyBox || !controlBox) throw new Error("Expected Account settings to have layout dimensions");
+    expect(controlBox.x, "settings control column").toBeGreaterThan(copyBox.x + copyBox.width);
+
+    const displayName = page.getByLabel("Display name", { exact: true });
+    await displayName.focus();
+    await expect(displayName).toBeFocused();
+    await expectAccessible(page);
+  });
+});
+
+test.describe("1440px desktop width", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("centers the bounded content frame and preserves the page hierarchy", async ({ page }) => {
+    await page.goto("/agents", { waitUntil: "networkidle" });
+    const heading = page.getByRole("heading", { name: "Agents", exact: true });
+    const action = page.getByRole("button", { name: "New Agent", exact: true });
+    await expect(heading).toBeVisible();
+    await expect(action).toBeVisible();
+    await expectNoPageOverflow(page);
+
+    const frame = page.locator('[data-ui="content-page-frame"]');
+    const frameBox = await frame.boundingBox();
+    expect(frameBox, "desktop content frame layout box").not.toBeNull();
+    if (!frameBox) throw new Error("Expected the desktop content frame to have layout dimensions");
+    expect(frameBox.width, "desktop content frame width").toBeLessThanOrEqual(1024);
+    expect(frameBox.x + frameBox.width / 2, "desktop content frame center").toBeCloseTo(720, 0);
+
+    const [headingBox, actionBox] = await Promise.all([heading.boundingBox(), action.boundingBox()]);
+    if (!headingBox || !actionBox) throw new Error("Expected the page header to have layout dimensions");
+    const alignmentOffset = Math.abs(actionBox.y + actionBox.height / 2 - (headingBox.y + headingBox.height / 2));
+    expect(alignmentOffset, "desktop page action alignment").toBeLessThanOrEqual(8);
+    await expectAccessible(page);
+  });
+});


### PR DESCRIPTION
## Summary

- add pull-request Browser Smoke coverage for the four representative Web widths: 320px sign-in, 390px touch dialog behavior, 768px Account layout transition, and 1440px bounded desktop framing
- share axe, page-overflow, and viewport-bound assertions across browser smoke tests
- document the width-to-purpose mapping in the Web UI contract, E2E guide, and KUMO verification commands

The implementation keeps the agreed representative-path strategy instead of multiplying every page by every viewport. One calibration was made during real-browser validation: desktop heading/action center alignment allows an 8px tolerance so equivalent subpixel/font layout does not create a false failure.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `OPENTAG_HOME=<isolated-temp-home> pnpm test`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (100%)
- `pnpm --filter @opentag/server test:integration` (313 tests)
- `pnpm test:e2e:smoke` with an isolated local PostgreSQL port (8 tests)
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit`

Rendered UI is unchanged.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.