### PR TITLE
fix(web): align Task filters on desktop

### DIFF
--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -125,6 +125,10 @@ describe("Tasks view", () => {
     expect(screen.queryByText("Read-only debug view")).toBeNull();
     expect(screen.queryByText("Demo data")).toBeNull();
     expect(screen.queryByRole("button", { name: "Edit title" })).toBeNull();
+    const toolbar = screen.getByRole("form", { name: "Filter Tasks" });
+    expect(toolbar.outerHTML).toContain("@min-[48rem]/content:flex-row");
+    expect(toolbar.outerHTML).toContain("@min-[36rem]/content:w-44");
+    expect(toolbar.outerHTML).not.toContain("/workspace");
 
     fireEvent.click(screen.getByRole("combobox", { name: "Filter by status" }));
     const failedOption = await screen.findByRole("option", { name: "Failed" });

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -108,7 +108,7 @@ export function TasksPage({ agentId, showExamples = false }: { agentId?: string;
        */}
       {terminalTasksError ? null : (
         <form
-          className="flex flex-col gap-3 @min-[48rem]/workspace:flex-row @min-[48rem]/workspace:items-center"
+          className="flex flex-col gap-3 @min-[48rem]/content:flex-row @min-[48rem]/content:items-center"
           aria-label={m.tasks_filter_tasks()}
           data-ui="task-toolbar"
           onSubmit={(event) => event.preventDefault()}
@@ -125,7 +125,7 @@ export function TasksPage({ agentId, showExamples = false }: { agentId?: string;
               onChange={(event) => setQuery(event.target.value)}
             />
           </div>
-          <div className="flex w-full flex-col gap-3 @min-[36rem]/workspace:flex-row @min-[48rem]/workspace:ml-auto @min-[48rem]/workspace:w-auto">
+          <div className="flex w-full flex-col gap-3 @min-[36rem]/content:flex-row @min-[48rem]/content:ml-auto @min-[48rem]/content:w-auto">
             {!agentId ? (
               <TaskSelect
                 label={m.tasks_filter_by_agent()}
@@ -556,7 +556,7 @@ function TaskSelect({
   value: string;
 }) {
   return (
-    <div className="w-full @min-[36rem]/workspace:w-44">
+    <div className="w-full @min-[36rem]/content:w-44">
       <Select
         aria-label={label}
         className="w-full"


### PR DESCRIPTION
## Summary
- target the actual named `content` container used by the Task page
- align search and compact filters in one desktop toolbar
- preserve stacked controls on narrow content widths
- add a regression assertion that rejects the nonexistent `workspace` container namespace

## Validation
- 55 related Web tests
- Web production build, including generated `@container content` rules
- `pnpm check`
- pre-push format, lint, typecheck, and check gates