### PR TITLE
feat(web): refine Agent settings UX

### DIFF
--- a/apps/web/messages/agent-settings/en.json
+++ b/apps/web/messages/agent-settings/en.json
@@ -18,6 +18,12 @@
   "agent_settings_computer_not_ready": "Not ready",
   "agent_settings_computer_offline": "Offline",
   "agent_settings_computer_online": "Online",
+  "agent_settings_computer_recovery_offline": "OpenTag is not running on {computerName}. Start it there to bring it back online.",
+  "agent_settings_computer_recovery_provider_checking": "OpenTag is still checking {providerName} on {computerName}.",
+  "agent_settings_computer_recovery_provider_not_installed": "{providerName} is not installed on {computerName}.",
+  "agent_settings_computer_recovery_provider_not_signed_in": "{providerName} is not signed in on {computerName}.",
+  "agent_settings_computer_recovery_provider_unavailable": "{providerName} is unavailable on {computerName}.",
+  "agent_settings_computer_recovery_unconfirmed": "OpenTag could not confirm this Computer's current connection.",
   "agent_settings_computer_repair_hide": "Hide repair command",
   "agent_settings_computer_repair_show": "Need to reinstall? Generate a repair command.",
   "agent_settings_computer_unconfirmed": "Unable to confirm",
@@ -50,6 +56,7 @@
   "agent_settings_instructions_saved": "Instructions saved.",
   "agent_settings_instructions_title": "Instructions",
   "agent_settings_keep_active": "Keep active",
+  "agent_settings_keep_editing": "Keep editing",
   "agent_settings_last_seen": "Last seen {relative} · {date}",
   "agent_settings_loading_title": "Loading Agent settings",
   "agent_settings_model": "Model",
@@ -127,5 +134,7 @@
   "agent_settings_status_working_description": "This Agent is handling a request. Pausing stops new requests; the current request may continue until a safe stopping point.",
   "agent_settings_title": "Agent settings",
   "agent_settings_troubleshooting": "Troubleshooting",
-  "agent_settings_unsaved_changes": "Unsaved changes"
+  "agent_settings_unsaved_changes": "Unsaved changes",
+  "agent_settings_unsaved_confirm_description": "If you leave this page, your unsaved changes will be lost.",
+  "agent_settings_unsaved_confirm_title": "Discard unsaved changes?"
 }

--- a/apps/web/messages/agent-settings/zh.json
+++ b/apps/web/messages/agent-settings/zh.json
@@ -18,6 +18,12 @@
   "agent_settings_computer_not_ready": "未就绪",
   "agent_settings_computer_offline": "离线",
   "agent_settings_computer_online": "在线",
+  "agent_settings_computer_recovery_offline": "{computerName} 上的 OpenTag 未运行。请在该电脑上启动 OpenTag 以恢复在线。",
+  "agent_settings_computer_recovery_provider_checking": "OpenTag 正在检查 {computerName} 上的 {providerName}。",
+  "agent_settings_computer_recovery_provider_not_installed": "{computerName} 上未安装 {providerName}。",
+  "agent_settings_computer_recovery_provider_not_signed_in": "{computerName} 上的 {providerName} 尚未登录。",
+  "agent_settings_computer_recovery_provider_unavailable": "{computerName} 上的 {providerName} 不可用。",
+  "agent_settings_computer_recovery_unconfirmed": "OpenTag 无法确认此电脑当前的连接状态。",
   "agent_settings_computer_repair_hide": "隐藏修复命令",
   "agent_settings_computer_repair_show": "需要重新安装？生成修复命令。",
   "agent_settings_computer_unconfirmed": "无法确认",
@@ -50,6 +56,7 @@
   "agent_settings_instructions_saved": "指令已保存。",
   "agent_settings_instructions_title": "指令",
   "agent_settings_keep_active": "保持活跃",
+  "agent_settings_keep_editing": "继续编辑",
   "agent_settings_last_seen": "上次看到于 {relative} · {date}",
   "agent_settings_loading_title": "正在加载 Agent 设置",
   "agent_settings_model": "模型",
@@ -127,5 +134,7 @@
   "agent_settings_status_working_description": "此 Agent 正在处理请求。暂停会停止接收新请求，但当前请求可能会继续，直到安全停止点。",
   "agent_settings_title": "Agent 设置",
   "agent_settings_troubleshooting": "故障排除",
-  "agent_settings_unsaved_changes": "有未保存的更改"
+  "agent_settings_unsaved_changes": "有未保存的更改",
+  "agent_settings_unsaved_confirm_description": "离开此页面将丢失尚未保存的更改。",
+  "agent_settings_unsaved_confirm_title": "放弃未保存的更改？"
 }

--- a/apps/web/src/__tests__/app-shell.test.tsx
+++ b/apps/web/src/__tests__/app-shell.test.tsx
@@ -71,7 +71,7 @@ describe("OpenTag Web App Shell", () => {
     expect(switcher.closest('[data-sidebar="header"]')).toBeTruthy();
     const workspaceNavigation = screen.getByRole("navigation", { name: "Agent" });
     expect(workspaceNavigation.closest('[data-sidebar="content"]')?.className).toContain(
-      "md:[&_[data-sidebar=viewport]]:pt-2",
+      "md:[&_[data-sidebar=viewport]]:pt-0",
     );
     expect(
       within(workspaceNavigation)

--- a/apps/web/src/features/agents/agent-presentation.ts
+++ b/apps/web/src/features/agents/agent-presentation.ts
@@ -61,15 +61,21 @@ export function computerRecoveryMessage(agent: AgentDetailView): string {
   if (agent.availability.reason === "runtime_unavailable") {
     const { provider, status } = agent.availability.dependencies.runtime;
     const providerName = provider === "codex" ? "Codex" : "Claude Code";
-    if (status === "install") return `${providerName} is not installed on ${computerName}.`;
-    if (status === "sign-in") return `${providerName} is not signed in on ${computerName}.`;
-    if (status === "checking") return `OpenTag is still checking ${providerName} on ${computerName}.`;
-    return `${providerName} is unavailable on ${computerName}.`;
+    if (status === "install") {
+      return m.agent_settings_computer_recovery_provider_not_installed({ computerName, providerName });
+    }
+    if (status === "sign-in") {
+      return m.agent_settings_computer_recovery_provider_not_signed_in({ computerName, providerName });
+    }
+    if (status === "checking") {
+      return m.agent_settings_computer_recovery_provider_checking({ computerName, providerName });
+    }
+    return m.agent_settings_computer_recovery_provider_unavailable({ computerName, providerName });
   }
   if (agent.availability.dependencies.computer.state !== "action_required") {
-    return "OpenTag could not confirm this Computer's current connection.";
+    return m.agent_settings_computer_recovery_unconfirmed();
   }
-  return `OpenTag is not running on ${computerName}. Start it there to bring it back online.`;
+  return m.agent_settings_computer_recovery_offline({ computerName });
 }
 
 export function imBindingStateLabel(binding: ImBindingSummary): string {

--- a/apps/web/src/features/agents/agent-settings/agent-computer-settings.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-computer-settings.tsx
@@ -6,6 +6,7 @@ import { ComputerConnect } from "../../computer-connect/computer-connect.js";
 import { AgentComputerChoice } from "../agent-computer-choice.js";
 import type { AgentDetailView } from "../agent-model.js";
 import { computerRecoveryMessage, platformLabel } from "../agent-presentation.js";
+import { AgentSettingsPageHeader } from "./settings-layout.js";
 
 /**
  * The panel an Agent that has no Computer gets. It is a distinct screen rather than the repair flow
@@ -16,9 +17,7 @@ import { computerRecoveryMessage, platformLabel } from "../agent-presentation.js
 function AgentComputerBinding({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChanged: () => void }) {
   return (
     <div className="grid gap-6">
-      <Text as="h1" id="computer-heading" size="lg" variant="heading">
-        {m.agents_status_computer()}
-      </Text>
+      <AgentSettingsPageHeader id="computer-heading" title={m.agents_status_computer()} />
       <section
         aria-labelledby="computer-heading"
         className="grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
@@ -61,9 +60,7 @@ export function AgentComputerSettings({
   if (!agent.computer) return <AgentComputerBinding agent={agent} onAgentChanged={onAgentChanged} />;
   return (
     <div className="grid gap-6">
-      <Text as="h1" id="computer-heading" size="lg" variant="heading">
-        {m.agents_status_computer()}
-      </Text>
+      <AgentSettingsPageHeader id="computer-heading" title={m.agents_status_computer()} />
       <section
         aria-labelledby="computer-device-heading"
         className="grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
@@ -72,11 +69,13 @@ export function AgentComputerSettings({
           <span aria-hidden="true" className="grid size-8 shrink-0 place-items-center rounded-md bg-kumo-tint">
             <Icon name="laptop" />
           </span>
-          <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
-            <Text as="h2" id="computer-device-heading" variant="heading">
-              {agent.computer.displayName}
-            </Text>
-            <span aria-hidden="true" className="text-sm text-kumo-subtle">
+          <div className="grid min-w-0 gap-0.5 @min-[32rem]/content:flex @min-[32rem]/content:items-baseline @min-[32rem]/content:gap-x-1.5">
+            <div className="min-w-0 break-words @min-[32rem]/content:truncate">
+              <Text as="h2" id="computer-device-heading" variant="heading">
+                {agent.computer.displayName}
+              </Text>
+            </div>
+            <span aria-hidden="true" className="hidden text-sm text-kumo-subtle @min-[32rem]/content:inline">
               ·
             </span>
             <span className="text-sm text-kumo-subtle">{platformLabel(agent.computer.platform)}</span>

--- a/apps/web/src/features/agents/agent-settings/agent-manage-settings.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-manage-settings.tsx
@@ -13,9 +13,9 @@ import {
   KumoInputControl,
   SettingsList,
   SettingsRow,
-  Text,
 } from "../../../ui/design-system.js";
 import type { AgentDetailView } from "../agent-model.js";
+import { AgentSettingsPageHeader } from "./settings-layout.js";
 
 export function AgentManageSettings({
   agent,
@@ -107,21 +107,17 @@ export function AgentManageSettings({
 
   return (
     <section className="grid gap-6">
-      <header className="grid gap-2">
-        <Text as="h1" size="lg" variant="heading">
-          {m.agent_settings_pause_or_delete()}
-        </Text>
-      </header>
+      <AgentSettingsPageHeader title={m.agent_settings_pause_or_delete()} />
 
       <SettingsList>
         <SettingsRow
           description={<span id={statusDescriptionId}>{statusDescription}</span>}
           label={m.agent_settings_agent_status()}
         >
-          <div className="flex justify-start @min-[44rem]/workspace:justify-end">
+          <div className="flex justify-start @min-[44rem]/content:justify-end">
             <Button
               aria-describedby={statusDescriptionId}
-              className="w-full @min-[44rem]/workspace:w-auto"
+              className="w-full @min-[44rem]/content:w-auto"
               disabled={busy}
               ref={pauseButtonRef}
               variant={active ? "secondary" : "primary"}
@@ -155,10 +151,10 @@ export function AgentManageSettings({
           }
           label={m.agent_settings_delete_button()}
         >
-          <div className="flex justify-start @min-[44rem]/workspace:justify-end">
+          <div className="flex justify-start @min-[44rem]/content:justify-end">
             <Button
               aria-describedby={deleteDescriptionId}
-              className="w-full @min-[44rem]/workspace:w-auto"
+              className="w-full @min-[44rem]/content:w-auto"
               disabled={active}
               ref={deleteButtonRef}
               variant="danger"

--- a/apps/web/src/features/agents/agent-settings/agent-settings-page.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-settings-page.tsx
@@ -16,6 +16,7 @@ import { ImTab } from "./im-tab.js";
 import { RuntimeConfigurationForm } from "./runtime-configuration.js";
 import type { AgentSettingsSection } from "./sections.js";
 import { agentSettingsGroups, agentSettingsSections, agentSettingsSummary } from "./sections.js";
+import { AgentSettingsPageHeader } from "./settings-layout.js";
 
 export function AgentSettingsPage({ agentId, section }: { agentId: string; section?: string }) {
   const routeState = useRouterState({ select: (state) => state.location.state });
@@ -116,11 +117,7 @@ export function AgentSettingsOverview({ agent }: { agent: AgentDetailView }) {
   );
   return (
     <div className="grid gap-6">
-      <header className="grid gap-2">
-        <Text as="h1" size="lg" variant="heading">
-          {m.agent_settings_title()}
-        </Text>
-      </header>
+      <AgentSettingsPageHeader title={m.agent_settings_title()} />
       <AsyncState loading={<AgentSettingsDirectoryLoading />} state={configState}>
         {(config) => (
           <div className="grid gap-6">

--- a/apps/web/src/features/agents/agent-settings/general-config-form.test.tsx
+++ b/apps/web/src/features/agents/agent-settings/general-config-form.test.tsx
@@ -36,7 +36,11 @@ describe("GeneralConfigForm", () => {
     const onAgentChanged = vi.fn();
     render(<GeneralConfigForm initialConfig={config} onAgentChanged={onAgentChanged} />);
 
-    fireEvent.submit(screen.getByRole("heading", { name: "Name" }).closest("form") as HTMLFormElement);
+    expect(screen.getByRole("heading", { name: "Name" }).closest("form")).toBeNull();
+    const displayName = screen.getByLabelText("Display name");
+    expect(displayName.parentElement?.className).toContain("[&>input]:w-full");
+    const form = displayName.closest("form") as HTMLFormElement;
+    fireEvent.submit(form);
     expect(updateAgent).not.toHaveBeenCalled();
     fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Reviewer Bot" } });
     expect(screen.getByText("Unsaved changes")).toBeTruthy();

--- a/apps/web/src/features/agents/agent-settings/general-config-form.tsx
+++ b/apps/web/src/features/agents/agent-settings/general-config-form.tsx
@@ -2,7 +2,8 @@ import type { AgentAdminConfig } from "@opentag/shared/browser";
 import { type FormEvent, useState } from "react";
 import { browserApi } from "../../../api.js";
 import * as m from "../../../paraglide/messages.js";
-import { Button, Field, KumoInputControl, Text } from "../../../ui/design-system.js";
+import { KumoInputControl, SettingsList, SettingsRow } from "../../../ui/design-system.js";
+import { AgentSettingsPageHeader, SettingsSaveActions, UnsavedChangesGuard } from "./settings-layout.js";
 
 export function GeneralConfigForm({
   initialConfig,
@@ -34,45 +35,38 @@ export function GeneralConfigForm({
     }
   }
   return (
-    <form className="grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line" onSubmit={submit}>
-      <header className="grid gap-2">
-        <Text as="h1" size="lg" variant="heading">
-          {m.agent_settings_name_title()}
-        </Text>
-      </header>
-      <Field htmlFor="agent-display-name" label={m.agent_settings_display_name_label()}>
-        <KumoInputControl
-          id="agent-display-name"
-          name="displayName"
-          required
-          value={displayName}
-          onChange={(event) => {
-            setDisplayName(event.currentTarget.value);
-            setMessage(undefined);
-          }}
-        />
-      </Field>
-      {dirty ? (
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-kumo-line pt-3">
-          <span className="text-sm text-kumo-subtle">{m.agent_settings_unsaved_changes()}</span>
-          <div className="flex flex-wrap justify-end gap-2">
-            <Button
-              disabled={saving}
-              variant="ghost"
-              onClick={() => {
-                setDisplayName(config.displayName);
-                setMessage(undefined);
-              }}
-            >
-              {m.agent_settings_discard_action()}
-            </Button>
-            <Button disabled={saving} type="submit">
-              {saving ? m.agent_settings_saving_action() : m.agent_settings_save_changes_action()}
-            </Button>
-          </div>
-        </div>
-      ) : null}
-      {message ? <p role="status">{message}</p> : null}
-    </form>
+    <div className="grid gap-6">
+      <AgentSettingsPageHeader title={m.agent_settings_name_title()} />
+      <UnsavedChangesGuard when={dirty} />
+      <form className="grid gap-4" onSubmit={submit}>
+        <SettingsList>
+          <SettingsRow label={m.agent_settings_display_name_label()}>
+            <div className="w-full [&>input]:w-full @min-[44rem]/content:ml-auto @min-[44rem]/content:max-w-80">
+              <KumoInputControl
+                aria-label={m.agent_settings_display_name_label()}
+                id="agent-display-name"
+                name="displayName"
+                required
+                value={displayName}
+                onChange={(event) => {
+                  setDisplayName(event.currentTarget.value);
+                  setMessage(undefined);
+                }}
+              />
+            </div>
+          </SettingsRow>
+        </SettingsList>
+        {dirty ? (
+          <SettingsSaveActions
+            busy={saving}
+            onDiscard={() => {
+              setDisplayName(config.displayName);
+              setMessage(undefined);
+            }}
+          />
+        ) : null}
+        {message ? <p role="status">{message}</p> : null}
+      </form>
+    </div>
   );
 }

--- a/apps/web/src/features/agents/agent-settings/runtime-configuration.tsx
+++ b/apps/web/src/features/agents/agent-settings/runtime-configuration.tsx
@@ -8,7 +8,6 @@ import { type FormEvent, useState } from "react";
 import * as m from "../../../paraglide/messages.js";
 import {
   Banner,
-  Button,
   InputArea,
   KumoInputControl,
   Select,
@@ -17,6 +16,7 @@ import {
   Text,
 } from "../../../ui/design-system.js";
 import { RuntimeTestAction } from "./runtime-test-action.js";
+import { AgentSettingsPageHeader, SettingsSaveActions, UnsavedChangesGuard } from "./settings-layout.js";
 
 const CUSTOM_MODEL_OPTION = "__custom_model__";
 const PROVIDER_DEFAULT_OPTION = "__provider_default__";
@@ -68,8 +68,6 @@ function RuntimeConfigurationEditor({
   const [saving, setSaving] = useState<"runtime" | "instructions">();
   const fieldId = (name: string) => `runtime-${name}-${config.id}`;
   const providerName = config.runtimeProvider === "codex" ? "Codex" : "Claude Code";
-  const ExecutionHeading = section === "execution" ? "h1" : "h3";
-  const InstructionsHeading = section === "instructions" ? "h1" : "h3";
   const TroubleshootingHeading = section === "execution" ? "h2" : "h3";
   const runtimeOptions = getRuntimeConfigurationOptions(config.runtimeProvider);
   const hasHistoricalReasoningDraft =
@@ -135,9 +133,16 @@ function RuntimeConfigurationEditor({
 
   return (
     <div className="grid gap-6" data-ui={section === "all" ? "runtime-settings" : "settings-section"}>
+      <UnsavedChangesGuard when={runtimeDirty || instructionsDirty} />
       {section !== "instructions" ? (
-        <section aria-labelledby="execution-heading" className="grid gap-4">
-          <ExecutionHeading id="execution-heading">{m.agent_settings_model()}</ExecutionHeading>
+        <section aria-labelledby="execution-heading" className={section === "execution" ? "grid gap-6" : "grid gap-4"}>
+          {section === "execution" ? (
+            <AgentSettingsPageHeader id="execution-heading" title={m.agent_settings_model()} />
+          ) : (
+            <Text as="h3" id="execution-heading" variant="heading">
+              {m.agent_settings_model()}
+            </Text>
+          )}
           <form className="grid gap-4" onSubmit={saveRuntime}>
             <SettingsList>
               <SettingsRow description={m.agent_settings_runtime_fixed()} label={m.agent_settings_runtime()}>
@@ -220,17 +225,11 @@ function RuntimeConfigurationEditor({
               </SettingsRow>
             </SettingsList>
             {runtimeDirty ? (
-              <div className="flex flex-wrap items-center justify-between gap-3 border-t border-kumo-line pt-3">
-                <span className="text-sm text-kumo-subtle">{m.agent_settings_unsaved_changes()}</span>
-                <div className="flex flex-wrap justify-end gap-2">
-                  <Button disabled={Boolean(saving)} variant="ghost" onClick={discardRuntimeChanges}>
-                    {m.agent_settings_discard()}
-                  </Button>
-                  <Button disabled={Boolean(saving) || customModelInvalid} type="submit">
-                    {saving === "runtime" ? m.agent_settings_saving() : m.agent_settings_save_changes()}
-                  </Button>
-                </div>
-              </div>
+              <SettingsSaveActions
+                busy={Boolean(saving)}
+                saveDisabled={customModelInvalid}
+                onDiscard={discardRuntimeChanges}
+              />
             ) : null}
           </form>
           {message?.section === "runtime" ? <SaveMessage message={message} /> : null}
@@ -258,13 +257,24 @@ function RuntimeConfigurationEditor({
       ) : null}
 
       {section !== "execution" ? (
-        <section aria-labelledby="agent-instructions-heading" className="grid gap-4">
-          <header className="grid gap-2">
-            <InstructionsHeading id="agent-instructions-heading">
-              {m.agent_settings_instructions_title()}
-            </InstructionsHeading>
-            <p className="text-sm text-kumo-subtle">{m.agent_settings_instructions_description()}</p>
-          </header>
+        <section
+          aria-labelledby="agent-instructions-heading"
+          className={section === "instructions" ? "grid gap-6" : "grid gap-4"}
+        >
+          {section === "instructions" ? (
+            <AgentSettingsPageHeader
+              description={m.agent_settings_instructions_description()}
+              id="agent-instructions-heading"
+              title={m.agent_settings_instructions_title()}
+            />
+          ) : (
+            <header className="grid gap-2">
+              <Text as="h3" id="agent-instructions-heading" variant="heading">
+                {m.agent_settings_instructions_title()}
+              </Text>
+              <p className="text-sm text-kumo-subtle">{m.agent_settings_instructions_description()}</p>
+            </header>
+          )}
           <form className="grid gap-4" onSubmit={saveInstructions}>
             <InputArea
               aria-label={m.agent_settings_instructions_title()}
@@ -281,24 +291,13 @@ function RuntimeConfigurationEditor({
               }}
             />
             {instructionsDirty ? (
-              <div className="flex flex-wrap items-center justify-between gap-3 border-t border-kumo-line pt-3">
-                <span className="text-sm text-kumo-subtle">{m.agent_settings_unsaved_changes()}</span>
-                <div className="flex flex-wrap justify-end gap-2">
-                  <Button
-                    disabled={Boolean(saving)}
-                    variant="ghost"
-                    onClick={() => {
-                      setInstructionsDraft(config.runtimeConfig.instructions);
-                      setMessage(undefined);
-                    }}
-                  >
-                    {m.agent_settings_discard()}
-                  </Button>
-                  <Button disabled={Boolean(saving)} type="submit">
-                    {saving === "instructions" ? m.agent_settings_saving() : m.agent_settings_save_changes()}
-                  </Button>
-                </div>
-              </div>
+              <SettingsSaveActions
+                busy={Boolean(saving)}
+                onDiscard={() => {
+                  setInstructionsDraft(config.runtimeConfig.instructions);
+                  setMessage(undefined);
+                }}
+              />
             ) : null}
           </form>
           {message?.section === "instructions" ? <SaveMessage message={message} /> : null}

--- a/apps/web/src/features/agents/agent-settings/settings-layout.test.tsx
+++ b/apps/web/src/features/agents/agent-settings/settings-layout.test.tsx
@@ -1,0 +1,35 @@
+import { Link, useRouterState } from "@tanstack/react-router";
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderInRouter } from "../../../__tests__/support/router.js";
+import { UnsavedChangesGuard } from "./settings-layout.js";
+
+function LocationProbe() {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  return <output>{pathname}</output>;
+}
+
+describe("UnsavedChangesGuard", () => {
+  it("keeps an edited settings page in place until the reader explicitly discards changes", async () => {
+    await renderInRouter(
+      <>
+        <UnsavedChangesGuard when />
+        <Link to="/account">Leave</Link>
+        <LocationProbe />
+      </>,
+      { path: "/settings" },
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Leave" }));
+    expect(await screen.findByRole("dialog", { name: "Discard unsaved changes?" })).toBeTruthy();
+    expect(screen.getByText("/settings")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.getByText("/settings")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("link", { name: "Leave" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Discard" }));
+    expect(await screen.findByText("/account")).toBeTruthy();
+  });
+});

--- a/apps/web/src/features/agents/agent-settings/settings-layout.tsx
+++ b/apps/web/src/features/agents/agent-settings/settings-layout.tsx
@@ -1,0 +1,95 @@
+import { useRouter } from "@tanstack/react-router";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import * as m from "../../../paraglide/messages.js";
+import { Button, Dialog, Text } from "../../../ui/design-system.js";
+
+export function AgentSettingsPageHeader({
+  description,
+  id,
+  title,
+}: {
+  description?: ReactNode;
+  id?: string;
+  title: ReactNode;
+}) {
+  return (
+    <header className="grid gap-2">
+      <Text as="h1" id={id} size="lg" variant="heading">
+        {title}
+      </Text>
+      {description ? <p className="text-sm text-kumo-subtle">{description}</p> : null}
+    </header>
+  );
+}
+
+export function SettingsSaveActions({
+  busy,
+  onDiscard,
+  saveDisabled = false,
+}: {
+  busy: boolean;
+  onDiscard: () => void;
+  saveDisabled?: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-kumo-line pt-3">
+      <span className="text-sm text-kumo-subtle">{m.agent_settings_unsaved_changes()}</span>
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button disabled={busy} type="button" variant="ghost" onClick={onDiscard}>
+          {m.agent_settings_discard_action()}
+        </Button>
+        <Button disabled={busy || saveDisabled} type="submit">
+          {busy ? m.agent_settings_saving_action() : m.agent_settings_save_changes_action()}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function UnsavedChangesGuard({ when }: { when: boolean }) {
+  const router = useRouter({ warn: false });
+  const resolverRef = useRef<((blocked: boolean) => void) | undefined>(undefined);
+  const [confirming, setConfirming] = useState(false);
+
+  useEffect(() => {
+    if (!when || !router) return;
+    const unblock = router.history.block({
+      blockerFn: ({ currentLocation, nextLocation }) => {
+        if (currentLocation.href === nextLocation.href) return false;
+        return new Promise<boolean>((resolve) => {
+          resolverRef.current = resolve;
+          setConfirming(true);
+        });
+      },
+      enableBeforeUnload: true,
+    });
+    return () => {
+      unblock();
+      resolverRef.current?.(true);
+      resolverRef.current = undefined;
+    };
+  }, [router, when]);
+
+  function settle(blocked: boolean) {
+    resolverRef.current?.(blocked);
+    resolverRef.current = undefined;
+    setConfirming(false);
+  }
+
+  return confirming ? (
+    <Dialog
+      description={m.agent_settings_unsaved_confirm_description()}
+      title={m.agent_settings_unsaved_confirm_title()}
+      onClose={() => settle(true)}
+    >
+      <div className="flex flex-wrap justify-end gap-3">
+        <Button variant="ghost" onClick={() => settle(true)}>
+          {m.agent_settings_keep_editing()}
+        </Button>
+        <Button variant="secondary" onClick={() => settle(false)}>
+          {m.agent_settings_discard_action()}
+        </Button>
+      </div>
+    </Dialog>
+  ) : null;
+}

--- a/apps/web/src/features/shell/agent-shell.tsx
+++ b/apps/web/src/features/shell/agent-shell.tsx
@@ -115,7 +115,7 @@ function AgentShellContent({
           </Sidebar.Menu>
           <Sidebar.Close className="sm:hidden" />
         </Sidebar.Header>
-        <Sidebar.Content className="md:[&_[data-sidebar=viewport]]:pt-2">
+        <Sidebar.Content className="md:[&_[data-sidebar=viewport]]:pt-0">
           <nav aria-label={m.shell_agent()}>
             <Sidebar.Group>
               <Sidebar.Menu>


### PR DESCRIPTION
## Summary

- tighten the Agent switcher-to-navigation spacing without adding a divider
- unify Agent Settings page headings, settings rows, and save actions while keeping explanatory copy intentionally sparse
- protect unsaved name, runtime, and instruction edits with an accessible localized confirmation dialog
- improve desktop and narrow-screen sizing for identity, management actions, and Computer details
- localize Computer recovery guidance

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @opentag/web test` — 66 files, 580 tests
- repository Playwright smoke suite, including responsive and axe checks
- real-browser review of all seven Settings routes at 1440px, 390px, and 320px
- verified unsaved-navigation guard, pause/resume lifecycle, delete confirmation, offline Computer state, and zero horizontal overflow
- separately reran the cross-package Claude runtime fixture after a load-related full-suite race — 36/36 passed