### PR TITLE
test(web): require every mutating BrowserApi call to carry the CSRF token

### DIFF
--- a/apps/web/src/api.csrf.test.ts
+++ b/apps/web/src/api.csrf.test.ts
@@ -118,6 +118,13 @@ describe("BrowserApi mutations", () => {
         }
         if (headerValue(init) !== "probe-token") missing.push(name);
       }
+
+      /*
+       * A method that never reaches `fetch` would assert nothing above and pass vacuously, which
+       * reads identically to a real pass. Every method here makes a request today; requiring it
+       * keeps a future short-circuit from silently dropping out of the invariant.
+       */
+      if (calls.length === 0) missing.push(`${name} (made no request)`);
     }
 
     expect(missing).toEqual([]);

--- a/apps/web/src/api.csrf.test.ts
+++ b/apps/web/src/api.csrf.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Every mutation the browser sends carries the double-submit token.
+ *
+ * The browser authenticates by cookie, and the Server requires `x-opentag-csrf` on every non-safe
+ * method for that transport. A method that forgets the header does not fail loudly: it gets a 403
+ * that a caller's `catch` can quietly turn into "nothing happened". So the invariant is asserted
+ * over the whole class rather than per feature — one method at a time is how it was missed.
+ *
+ * The table is compared against the class itself, so a new method cannot be added without either
+ * being exercised here or being named as an exemption.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { BrowserApi } from "./api.js";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/** Request plumbing, not part of the surface a page calls. */
+const INTERNAL = new Set([
+  "constructor",
+  "request",
+  "requestOptional",
+  "requestNoContent",
+  "fetchWithRefresh",
+  "apiError",
+  "csrfHeaders",
+  "csrfToken",
+]);
+
+/*
+ * Signing up and signing in are the requests that mint the token, so a browser making them has
+ * none to send. The Server fences those two on the request origin instead.
+ */
+const NO_TOKEN_BY_DESIGN = new Set(["signUpWithPassword", "signInWithPassword"]);
+
+const ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
+
+/*
+ * Called by name with argument arrays rather than as typed calls: what is under test is the shape
+ * of the request each method puts on the wire, and driving them uniformly is what lets the table be
+ * checked against the class for completeness.
+ */
+const INVOCATIONS: Record<string, readonly unknown[]> = {
+  me: [],
+  updateProfile: [{ displayName: "Ada" }],
+  authProviders: [],
+  completeSetup: [ID],
+  agents: [],
+  tasks: [{}],
+  task: [ID],
+  agent: [ID],
+  agentUsage: [ID, 7],
+  agentConfig: [ID],
+  createAgent: [{ name: "a", displayName: "A", runtimeProvider: "codex" }],
+  updateAgent: [ID, { displayName: "A" }],
+  suspendAgent: [ID],
+  reactivateAgent: [ID],
+  deleteAgent: [ID],
+  imBinding: [ID],
+  imBindingHandoff: [ID],
+  imBindingConfig: [ID],
+  createFeishuSetupAttempt: [ID, "create", "lark"],
+  feishuSetupAttempt: [ID],
+  cancelFeishuSetupAttempt: [ID],
+  startSlackOAuth: [ID, { intent: "create" }],
+  imBindingDiagnostics: [ID],
+  disableImBinding: [ID],
+  computers: [],
+  internalNavigationVisibility: [],
+  updateInternalNavigationVisibility: [{ tasks: true }],
+  updateTaskTitle: [ID, { title: "A task" }],
+  computerConnectCodeStatus: [ID],
+  rebindAgentComputer: [ID, ID],
+  testAgentRuntime: [ID, { provider: "codex" }],
+  internalToolsOffered: [],
+  resetAccountSetup: ["reboard"],
+  issueComputerConnectCode: [],
+  health: ["/healthz"],
+  signUpWithPassword: [{ email: "a@example.com", password: "pw", displayName: "Ada" }],
+  signInWithPassword: [{ email: "a@example.com", password: "pw" }],
+  logout: [],
+};
+
+function headerValue(init: RequestInit | undefined): string | undefined {
+  return new Headers(init?.headers).get("x-opentag-csrf") ?? undefined;
+}
+
+describe("BrowserApi mutations", () => {
+  it("exercises every method the class exposes", () => {
+    const exposed = Object.getOwnPropertyNames(BrowserApi.prototype).filter((name) => !INTERNAL.has(name));
+    expect(new Set(exposed)).toEqual(new Set(Object.keys(INVOCATIONS)));
+  });
+
+  it("sends the double-submit token on every non-safe request", async () => {
+    document.cookie = "opentag_csrf=probe-token";
+    const missing: string[] = [];
+
+    for (const [name, args] of Object.entries(INVOCATIONS)) {
+      const calls: [string, RequestInit | undefined][] = [];
+      const fetchImpl = vi.fn(async (input: unknown, init?: RequestInit) => {
+        calls.push([String(input), init]);
+        return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+      }) as unknown as typeof fetch;
+      const api = new BrowserApi(fetchImpl);
+
+      // The response is deliberately not a valid body for any of these, so the call rejects after
+      // the request has been made. What it returns is not what is under test.
+      await (api as unknown as Record<string, (...a: unknown[]) => Promise<unknown>>)
+        [name]?.(...args)
+        .catch(() => undefined);
+
+      for (const [, init] of calls) {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (SAFE_METHODS.has(method)) continue;
+        if (NO_TOKEN_BY_DESIGN.has(name)) {
+          expect(headerValue(init)).toBeUndefined();
+          continue;
+        }
+        if (headerValue(init) !== "probe-token") missing.push(name);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/scripts/complexity-baseline.json
+++ b/scripts/complexity-baseline.json
@@ -90,7 +90,7 @@
       "id": "apps/web/src/__tests__/support/app-fixtures.tsx#callback",
       "path": "apps/web/src/__tests__/support/app-fixtures.tsx",
       "symbol": "callback",
-      "complexity": 193
+      "complexity": 186
     },
     {
       "id": "apps/web/src/agent-creation/agent-creation-flow.tsx#AgentCreationFlow",
@@ -109,6 +109,12 @@
       "path": "apps/web/src/agent-creation/agent-creation-flow.tsx",
       "symbol": "RuntimeRouteSection",
       "complexity": 56
+    },
+    {
+      "id": "apps/web/src/api.csrf.test.ts#it",
+      "path": "apps/web/src/api.csrf.test.ts",
+      "symbol": "it",
+      "complexity": 18
     },
     {
       "id": "apps/web/src/features/agents/agent-computer-choice.tsx#AgentComputerChoice",
@@ -918,7 +924,7 @@
       "id": "packages/server/src/services/im/external-call-policy.ts#callback",
       "path": "packages/server/src/services/im/external-call-policy.ts",
       "symbol": "callback",
-      "complexity": 19
+      "complexity": 18
     },
     {
       "id": "packages/server/src/services/im/im-message-inbox.ts#callback",

--- a/scripts/complexity-baseline.json
+++ b/scripts/complexity-baseline.json
@@ -114,7 +114,7 @@
       "id": "apps/web/src/api.csrf.test.ts#it",
       "path": "apps/web/src/api.csrf.test.ts",
       "symbol": "it",
-      "complexity": 18
+      "complexity": 21
     },
     {
       "id": "apps/web/src/features/agents/agent-computer-choice.tsx#AgentComputerChoice",


### PR DESCRIPTION
## Why

The browser authenticates by cookie, so `createUserAuthPreHandler` requires `x-opentag-csrf` on every non-safe method. A `BrowserApi` method that omits it does not fail loudly — it gets a 403, and a caller's `catch` can turn that into "nothing happened".

That shipped once. In a branch that has since been closed, `cancelFeishuSetupAttempt` was the only mutating method without the header; every call silently 403'd, both call sites swallowed it, and the feature built on it looked like it worked while doing nothing. It was found by driving the real class from a test, not by reading the diff.

## What this adds

One test file, no product change.

The invariant is asserted over the **whole class** rather than per feature, because one method at a time is how it was missed. The table of invocations is compared against `BrowserApi.prototype`, so a new method has to be either exercised here or explicitly named an exemption before this passes — the check fails closed on additions rather than silently not covering them.

`signUpWithPassword` and `signInWithPassword` are the two exemptions, with the reason stated: a browser making them has no token yet, and the Server fences those on request origin instead.

## Verification

`pnpm check` and `pnpm typecheck` pass; the file's two tests pass.

Mutation-checked rather than assumed, and I checked that the mutation actually applied before trusting the result:

- Removing `csrfHeaders()` from `resetAccountSetup` fails the token test.
- The completeness test already earned its place while porting this: it flagged `internalNavigationVisibility` and `updateInternalNavigationVisibility` as unexercised on `main`. Both already carry the token — the test now proves that rather than assuming it.

It records one new complexity baseline entry for itself, through the script's own `--accept-current`.

## Note on the exemption list

Two entries is the whole of it, and it should stay small. Adding a method to it is a claim that the Server does not require the token for that route — worth a second look in review, which is why they sit in a named constant rather than being skipped inline.
