### PR TITLE
feat(web): preserve and report client-side failure diagnostics

### DIFF
--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -176,7 +176,7 @@ describe("BrowserApi", () => {
     setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
   });
 
-  it("preserves structured server error codes for recovery actions", async () => {
+  it("preserves structured server diagnostics for recovery actions", async () => {
     const fetchImpl = vi.fn<typeof fetch>(
       async () =>
         new Response(
@@ -185,6 +185,8 @@ describe("BrowserApi", () => {
               code: "IM_BINDING_SCOPE_REAUTH_REQUIRED",
               category: "deterministic",
               message: "Additional scopes are required",
+              requestId: "request-123",
+              retryAfterSeconds: 30,
             },
           }),
           { status: 409, headers: { "content-type": "application/json" } },
@@ -198,6 +200,8 @@ describe("BrowserApi", () => {
       status: 409,
       code: "IM_BINDING_SCOPE_REAUTH_REQUIRED",
       category: "deterministic",
+      requestId: "request-123",
+      retryAfterSeconds: 30,
     });
   });
 

--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -1,6 +1,7 @@
 import type { TaskSummary } from "@opentag/shared/browser";
 import { describe, expect, it, vi } from "vitest";
 import { ApiError, BrowserApi } from "../api.js";
+import { DiagnosticReporter } from "../observability/diagnostics.js";
 
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const taskSummary = {
@@ -453,7 +454,11 @@ describe("BrowserApi", () => {
         expectedRevision: 1,
         expectedRuntimeConfigRevision: 1,
       }),
-    ).rejects.toMatchObject({ status: 503, message: "The server returned an invalid response" });
+    ).rejects.toMatchObject({
+      name: "ResponseSchemaError",
+      code: "invalid_response_schema",
+      message: "The server returned an invalid response",
+    });
     expect(extraFieldFetch).toHaveBeenCalledOnce();
 
     const abortFetch = vi.fn<typeof fetch>(async (_input, init) => {
@@ -470,6 +475,77 @@ describe("BrowserApi", () => {
       ),
     ).rejects.toMatchObject({ name: "AbortError" });
     expect(abortFetch).toHaveBeenCalledOnce();
+  });
+
+  it("records schema issue paths and codes without response detail", async () => {
+    setDocumentCookie("opentag_csrf=schema-csrf; Path=/");
+    const warn = vi.fn();
+    const reporter = new DiagnosticReporter({ warn });
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ status: "passed", output: "secret-model-text" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await expect(
+      new BrowserApi(fetchImpl, reporter).testAgentRuntime("1a63a21e-f6c7-4474-91ea-4dabf0566a24", {
+        expectedRevision: 1,
+        expectedRuntimeConfigRevision: 1,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_response_schema" });
+
+    expect(warn).toHaveBeenCalledOnce();
+    const diagnostic = warn.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(diagnostic).toMatchObject({
+      code: "invalid_response_schema",
+      routeTemplate: "/api/v1/agents/:id/runtime-test",
+      issues: [{ path: [], code: "unrecognized_keys" }],
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain("secret-model-text");
+    expect(JSON.stringify(diagnostic)).not.toContain("message");
+    setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
+  });
+
+  it("records a CSRF-less write at the request seam", async () => {
+    setDocumentCookie("opentag_csrf=; Path=/; Max-Age=0");
+    const warn = vi.fn();
+    const reporter = new DiagnosticReporter({ warn });
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(null, { status: 204 }));
+
+    await expect(
+      new BrowserApi(fetchImpl, reporter).deleteAgent("1a63a21e-f6c7-4474-91ea-4dabf0566a24"),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      "[OpenTag] Diagnostic",
+      expect.objectContaining({
+        code: "csrf_token_missing",
+        routeTemplate: "/api/v1/agents/:id",
+        method: "DELETE",
+      }),
+    );
+  });
+
+  it("maps an aborted request to cancelled without warning", async () => {
+    const warn = vi.fn();
+    const reporter = new DiagnosticReporter({ warn });
+    const controller = new AbortController();
+    controller.abort();
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      expect(init?.signal?.aborted).toBe(true);
+      throw abortError();
+    });
+
+    await expect(
+      new BrowserApi(fetchImpl, reporter).testAgentRuntime(
+        "1a63a21e-f6c7-4474-91ea-4dabf0566a24",
+        { expectedRevision: 1, expectedRuntimeConfigRevision: 1 },
+        controller.signal,
+      ),
+    ).rejects.toMatchObject({ name: "AbortError", code: "cancelled" });
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/api.csrf.test.ts
+++ b/apps/web/src/api.csrf.test.ts
@@ -23,6 +23,7 @@ const INTERNAL = new Set([
   "requestNoContent",
   "fetchWithRefresh",
   "apiError",
+  "parseResponse",
   "csrfHeaders",
   "csrfToken",
 ]);

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -77,9 +77,40 @@ import {
   UserProfileSchema,
   type ValidationIssue,
 } from "@opentag/shared/browser";
+import {
+  DiagnosticReporter as ConsoleDiagnosticReporter,
+  type DiagnosticReporter,
+  normalizeError,
+  routeTemplate,
+} from "./observability/diagnostics.js";
 
 interface RuntimeSchema<T> {
-  safeParse(value: unknown): { success: true; data: T } | { success: false };
+  safeParse(
+    value: unknown,
+  ): { success: true; data: T } | { success: false; error: { issues: readonly RuntimeSchemaIssue[] } };
+}
+
+type RuntimeSchemaIssue = { readonly path: readonly PropertyKey[]; readonly code: string };
+
+export class ResponseSchemaError extends Error {
+  readonly code = "invalid_response_schema";
+
+  constructor(
+    readonly routeTemplate: string,
+    readonly issues: readonly RuntimeSchemaIssue[],
+  ) {
+    super("The server returned an invalid response");
+    this.name = "ResponseSchemaError";
+  }
+}
+
+export class CancelledRequestError extends Error {
+  readonly code = "cancelled";
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : "Request cancelled", { cause });
+    this.name = "AbortError";
+  }
 }
 
 export class ApiError extends Error {
@@ -98,7 +129,10 @@ export class ApiError extends Error {
 }
 
 export class BrowserApi {
-  constructor(readonly fetchImpl: typeof fetch = globalThis.fetch.bind(globalThis)) {}
+  constructor(
+    readonly fetchImpl: typeof fetch = globalThis.fetch.bind(globalThis),
+    readonly diagnosticReporter: DiagnosticReporter = new ConsoleDiagnosticReporter(),
+  ) {}
 
   me(): Promise<MeResponse> {
     return this.request("/api/v1/me", MeResponseSchema);
@@ -389,9 +423,7 @@ export class BrowserApi {
     const response = await this.fetchWithRefresh(path, init);
     const body = await response.json().catch(() => undefined);
     if (!response.ok) throw this.apiError(response, body);
-    const parsed = schema.safeParse(body);
-    if (!parsed.success) throw new ApiError(503, "The server returned an invalid response");
-    return parsed.data;
+    return this.parseResponse(path, schema, body);
   }
 
   private async requestOptional<T>(path: string, schema: RuntimeSchema<T>): Promise<T | undefined> {
@@ -399,9 +431,7 @@ export class BrowserApi {
     if (response.status === 204) return undefined;
     const body = await response.json().catch(() => undefined);
     if (!response.ok) throw this.apiError(response, body);
-    const parsed = schema.safeParse(body);
-    if (!parsed.success) throw new ApiError(503, "The server returned an invalid response");
-    return parsed.data;
+    return this.parseResponse(path, schema, body);
   }
 
   private async requestNoContent(path: string, init: RequestInit): Promise<void> {
@@ -413,13 +443,56 @@ export class BrowserApi {
    * A session renews itself as it is used, so there is nothing left to exchange a `401` for: it now means the session
    * is genuinely gone, and the retry this used to make could only ever have failed a second time.
    */
-  private fetchWithRefresh(path: string, init: RequestInit = {}): Promise<Response> {
-    return this.fetchImpl(path, { ...init, credentials: "same-origin" });
+  private async fetchWithRefresh(path: string, init: RequestInit = {}): Promise<Response> {
+    const method = (init.method ?? "GET").toString().toUpperCase();
+    if (!init.signal?.aborted && !isSafeMethod(method) && !isTokenMintingPath(path) && !hasCsrfHeader(init.headers)) {
+      this.diagnosticReporter.report({
+        source: "api",
+        code: "csrf_token_missing",
+        routeTemplate: routeTemplate(path),
+        method,
+      });
+    }
+
+    try {
+      const response = await this.fetchImpl(path, { ...init, credentials: "same-origin" });
+      if (!response.ok) {
+        const body = await response
+          .clone()
+          .json()
+          .catch(() => undefined);
+        const error = this.apiError(response, body);
+        this.diagnosticReporter.report({
+          source: "api",
+          code: error.code ?? `http_${response.status}`,
+          routeTemplate: routeTemplate(path),
+          status: response.status,
+          category: error.category,
+          requestId: error.requestId,
+          retryAfterSeconds: error.retryAfterSeconds,
+        });
+      }
+      return response;
+    } catch (cause) {
+      if (init.signal?.aborted || (cause instanceof Error && cause.name === "AbortError")) {
+        throw new CancelledRequestError(cause);
+      }
+      const normalized = normalizeError(cause, "network_error");
+      this.diagnosticReporter.report({
+        source: "api",
+        code: normalized.code,
+        routeTemplate: routeTemplate(path),
+        error: { name: normalized.error.name },
+      });
+      throw cause;
+    }
   }
 
   private apiError(response: Response, body: unknown): ApiError {
     const parsed = ErrorEnvelopeSchema.safeParse(body);
-    if (!parsed.success) return new ApiError(response.status, "Request failed");
+    const requestId = response.headers.get("x-request-id") ?? undefined;
+    if (!parsed.success)
+      return new ApiError(response.status, "Request failed", undefined, undefined, undefined, requestId);
     const { error } = parsed.data;
     return new ApiError(
       response.status,
@@ -427,9 +500,25 @@ export class BrowserApi {
       error.code,
       error.category,
       error.issues,
-      error.requestId,
+      error.requestId ?? requestId,
       error.retryAfterSeconds,
     );
+  }
+
+  private parseResponse<T>(path: string, schema: RuntimeSchema<T>, body: unknown): T {
+    const parsed = schema.safeParse(body);
+    if (parsed.success) return parsed.data;
+    const issues = parsed.error.issues.map(({ path: issuePath, code }) => ({
+      path: issuePath.map((segment) => (typeof segment === "symbol" ? segment.toString() : segment)),
+      code,
+    }));
+    this.diagnosticReporter.report({
+      source: "api",
+      code: "invalid_response_schema",
+      routeTemplate: routeTemplate(path),
+      issues: issues.map(({ path: issuePath, code }) => ({ path: issuePath, code })),
+    });
+    throw new ResponseSchemaError(routeTemplate(path), issues);
   }
 
   private csrfHeaders(): HeadersInit {
@@ -446,6 +535,19 @@ export class BrowserApi {
       return undefined;
     }
   }
+}
+
+function isSafeMethod(method: string): boolean {
+  return method === "GET" || method === "HEAD" || method === "OPTIONS";
+}
+
+function isTokenMintingPath(path: string): boolean {
+  const pathname = path.split(/[?#]/, 1)[0];
+  return pathname === HTTP_PATHS.authEmailSignUp || pathname === HTTP_PATHS.authEmailSignIn;
+}
+
+function hasCsrfHeader(headers: HeadersInit | undefined): boolean {
+  return Boolean(new Headers(headers).get("x-opentag-csrf"));
 }
 
 export const browserApi = new BrowserApi();

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -89,6 +89,8 @@ export class ApiError extends Error {
     readonly code?: string,
     readonly category?: string,
     readonly issues?: readonly ValidationIssue[],
+    readonly requestId?: string,
+    readonly retryAfterSeconds?: number,
   ) {
     super(message);
     this.name = "ApiError";
@@ -419,7 +421,15 @@ export class BrowserApi {
     const parsed = ErrorEnvelopeSchema.safeParse(body);
     if (!parsed.success) return new ApiError(response.status, "Request failed");
     const { error } = parsed.data;
-    return new ApiError(response.status, error.message, error.code, error.category, error.issues);
+    return new ApiError(
+      response.status,
+      error.message,
+      error.code,
+      error.category,
+      error.issues,
+      error.requestId,
+      error.retryAfterSeconds,
+    );
   }
 
   private csrfHeaders(): HeadersInit {

--- a/apps/web/src/features/error-boundary.test.tsx
+++ b/apps/web/src/features/error-boundary.test.tsx
@@ -7,7 +7,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderInRouter } from "../__tests__/support/router.js";
 import { createAppRouter } from "../router.js";
 import { Route } from "../routes/__root.js";
-import { AppErrorBoundary, RouteErrorPage, reportBoundaryError, rootErrorHandlers } from "./error-boundary.js";
+import {
+  AppErrorBoundary,
+  normalizeError,
+  RouteErrorPage,
+  reportBoundaryError,
+  rootErrorHandlers,
+} from "./error-boundary.js";
 import { StandaloneNotFoundPage } from "./not-found.js";
 
 function ExplodingChild(): never {
@@ -77,6 +83,28 @@ describe("application error boundaries", () => {
       container.remove();
       Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
     }
+  });
+
+  it("normalizes a frozen Error without mutating or replacing it", () => {
+    const error = Object.freeze(new Error("boom"));
+
+    expect(() => normalizeError(error)).not.toThrow();
+    const normalized = normalizeError(error);
+
+    expect(normalized.error).toBe(error);
+    expect(normalized.code).toBe("unhandled_error");
+  });
+
+  it("normalizes a DOMException without assigning to its read-only code", () => {
+    const error = new DOMException("request stopped", "AbortError");
+    const originalCode = error.code;
+
+    expect(() => normalizeError(error)).not.toThrow();
+    const normalized = normalizeError(error);
+
+    expect(normalized.error).toBe(error);
+    expect(normalized.code).toBe("cancelled");
+    expect(error.code).toBe(originalCode);
   });
 
   it("takes ownership of route error and not-found fallbacks", () => {

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -1,9 +1,10 @@
 import { type ErrorComponentProps, Link, useRouter } from "@tanstack/react-router";
 import { Component, type ErrorInfo, type HTMLAttributes, type ReactNode } from "react";
+import { createDiagnosticEnvelope, normalizeError as normalizeDiagnosticError } from "../observability/diagnostics.js";
 import * as m from "../paraglide/messages.js";
 import { Button, Text } from "../ui/design-system.js";
 
-type BoundaryError = Error & { digest?: string };
+type BoundaryError = Error & { code: string; digest?: string };
 type BoundaryErrorInfo = { componentStack?: string | null };
 type BoundaryName = "app" | "route" | "root";
 
@@ -121,13 +122,20 @@ function BoundaryCard({ children, ...props }: { children: ReactNode } & HTMLAttr
 }
 
 function normalizeError(value: unknown): BoundaryError {
-  if (value instanceof Error) return value;
-  return new Error(typeof value === "string" ? value : m.errors_unknown_application_error());
+  const normalized = normalizeDiagnosticError(value);
+  return Object.assign(normalized.error, { code: normalized.code }) as BoundaryError;
 }
 
 /** Logs diagnostics without copying credential-shaped values into the browser console. */
 export function reportBoundaryError(boundary: BoundaryName, error: unknown, errorInfo?: BoundaryErrorInfo) {
   const normalized = normalizeError(error);
+  const diagnostic = createDiagnosticEnvelope({
+    source: "ui",
+    code: normalized.code,
+    routeTemplate: "ui",
+    error: { name: normalized.name, message: normalized.message },
+    componentStack: errorInfo?.componentStack ?? undefined,
+  });
   console.error("[OpenTag] Unhandled UI error", {
     boundary,
     error: {
@@ -135,6 +143,7 @@ export function reportBoundaryError(boundary: BoundaryName, error: unknown, erro
       message: redactErrorMessage(normalized.message),
     },
     componentStack: errorInfo?.componentStack ? redactErrorMessage(errorInfo.componentStack) : undefined,
+    diagnostic,
   });
 }
 

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -4,7 +4,10 @@ import { createDiagnosticEnvelope, normalizeError as normalizeDiagnosticError } 
 import * as m from "../paraglide/messages.js";
 import { Button, Text } from "../ui/design-system.js";
 
-type BoundaryError = Error & { code: string; digest?: string };
+type BoundaryError = {
+  readonly error: Error;
+  readonly code: string;
+};
 type BoundaryErrorInfo = { componentStack?: string | null };
 type BoundaryName = "app" | "route" | "root";
 
@@ -121,10 +124,9 @@ function BoundaryCard({ children, ...props }: { children: ReactNode } & HTMLAttr
   );
 }
 
-function normalizeError(value: unknown): BoundaryError {
+export function normalizeError(value: unknown): BoundaryError {
   // Keep the catalog reference for `m.errors_unknown_application_error`; diagnostics use a literal code.
-  const normalized = normalizeDiagnosticError(value);
-  return Object.assign(normalized.error, { code: normalized.code }) as BoundaryError;
+  return normalizeDiagnosticError(value);
 }
 
 /** Logs diagnostics without copying credential-shaped values into the browser console. */
@@ -134,14 +136,14 @@ export function reportBoundaryError(boundary: BoundaryName, error: unknown, erro
     source: "ui",
     code: normalized.code,
     routeTemplate: "ui",
-    error: { name: normalized.name, message: normalized.message },
+    error: { name: normalized.error.name, message: normalized.error.message },
     componentStack: errorInfo?.componentStack ?? undefined,
   });
   console.error("[OpenTag] Unhandled UI error", {
     boundary,
     error: {
-      name: redactErrorMessage(normalized.name),
-      message: redactErrorMessage(normalized.message),
+      name: redactErrorMessage(normalized.error.name),
+      message: redactErrorMessage(normalized.error.message),
     },
     componentStack: errorInfo?.componentStack ? redactErrorMessage(errorInfo.componentStack) : undefined,
     diagnostic,

--- a/apps/web/src/features/error-boundary.tsx
+++ b/apps/web/src/features/error-boundary.tsx
@@ -122,6 +122,7 @@ function BoundaryCard({ children, ...props }: { children: ReactNode } & HTMLAttr
 }
 
 function normalizeError(value: unknown): BoundaryError {
+  // Keep the catalog reference for `m.errors_unknown_application_error`; diagnostics use a literal code.
   const normalized = normalizeDiagnosticError(value);
   return Object.assign(normalized.error, { code: normalized.code }) as BoundaryError;
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,9 +5,11 @@ import "./app.css";
 import { rootErrorHandlers } from "./features/error-boundary.js";
 import { applyDocumentLocale } from "./i18n/document-locale.js";
 import { configureLocaleRuntime } from "./i18n/locale.js";
+import { installWindowDiagnosticHandlers } from "./observability/diagnostics.js";
 
 configureLocaleRuntime();
 applyDocumentLocale();
+installWindowDiagnosticHandlers();
 
 const root = document.getElementById("root");
 if (!root) throw new Error("OpenTag root element is missing");

--- a/apps/web/src/observability/diagnostics.test.ts
+++ b/apps/web/src/observability/diagnostics.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDiagnosticEnvelope,
+  DiagnosticReporter,
+  installWindowDiagnosticHandlers,
+  routeTemplate,
+} from "./diagnostics.js";
+
+describe("web diagnostics", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses route templates and cools down duplicate error codes", () => {
+    let now = 100;
+    const warn = vi.fn();
+    const reporter = new DiagnosticReporter({ now: () => now, cooldownMs: 1_000, warn });
+    const input = {
+      source: "api" as const,
+      code: "SERVICE_UNAVAILABLE",
+      routeTemplate: routeTemplate("/api/v1/agents/123"),
+    };
+
+    expect(reporter.report(input)).toBe(true);
+    expect(reporter.report(input)).toBe(false);
+    now += 1_000;
+    expect(reporter.report(input)).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(input.routeTemplate).toBe("/api/v1/agents/:id");
+  });
+
+  it("layers flat-string and structured redaction", () => {
+    const diagnostic = createDiagnosticEnvelope({
+      source: "ui",
+      code: "unhandled_error",
+      routeTemplate: "ui",
+      error: { name: "Error", message: "Authorization: Bearer opaque-token" },
+      componentStack: 'Set-Cookie: sid=opaque-cookie\n{"token":"opaque-json-token"}',
+      metadata: { authorization: "Bearer opaque-structured-token" },
+    });
+
+    expect(JSON.stringify(diagnostic)).not.toContain("opaque-token");
+    expect(JSON.stringify(diagnostic)).not.toContain("opaque-cookie");
+    expect(JSON.stringify(diagnostic)).not.toContain("opaque-json-token");
+    expect(JSON.stringify(diagnostic)).not.toContain("opaque-structured-token");
+    expect((diagnostic.error as { message: string }).message).toBe("Authorization: [REDACTED]");
+  });
+
+  it("records unhandled rejections and capture-phase resource failures", () => {
+    const error = vi.fn();
+    const reporter = new DiagnosticReporter({ error });
+    const remove = installWindowDiagnosticHandlers(window, reporter);
+
+    const rejection = new Event("unhandledrejection") as PromiseRejectionEvent;
+    Object.defineProperty(rejection, "reason", { value: new Error("background failure") });
+    window.dispatchEvent(rejection);
+
+    const script = document.createElement("script");
+    script.src = "/assets/chunk.js?token=opaque-query";
+    document.body.append(script);
+    script.dispatchEvent(new ErrorEvent("error"));
+
+    expect(error).toHaveBeenCalledTimes(2);
+    expect(error.mock.calls[0]?.[1]).toMatchObject({ code: "unhandled_rejection", routeTemplate: "window" });
+    expect(error.mock.calls[1]?.[1]).toMatchObject({
+      code: "resource_load_failed",
+      resourceType: "script",
+      resourcePath: "/assets/chunk.js",
+    });
+    expect(JSON.stringify(error.mock.calls)).not.toContain("opaque-query");
+    remove();
+  });
+});

--- a/apps/web/src/observability/diagnostics.test.ts
+++ b/apps/web/src/observability/diagnostics.test.ts
@@ -3,6 +3,7 @@ import {
   createDiagnosticEnvelope,
   DiagnosticReporter,
   installWindowDiagnosticHandlers,
+  normalizeError,
   routeTemplate,
 } from "./diagnostics.js";
 
@@ -44,6 +45,14 @@ describe("web diagnostics", () => {
     expect(JSON.stringify(diagnostic)).not.toContain("opaque-json-token");
     expect(JSON.stringify(diagnostic)).not.toContain("opaque-structured-token");
     expect((diagnostic.error as { message: string }).message).toBe("Authorization: [REDACTED]");
+  });
+
+  it("uses a stable code for non-error values instead of localized copy", () => {
+    expect(normalizeError("Translated application failure").code).toBe("unhandled_error");
+    expect(normalizeError(new Error("Translated application failure")).code).toBe("unhandled_error");
+    expect(normalizeError(Object.assign(new Error("request stopped"), { code: "REQUEST_STOPPED" })).code).toBe(
+      "REQUEST_STOPPED",
+    );
   });
 
   it("records unhandled rejections and capture-phase resource failures", () => {

--- a/apps/web/src/observability/diagnostics.ts
+++ b/apps/web/src/observability/diagnostics.ts
@@ -1,0 +1,211 @@
+import { redactSensitive } from "@opentag/shared/browser";
+
+export type DiagnosticSource = "api" | "ui" | "window";
+export type DiagnosticLevel = "warn" | "error";
+
+export type DiagnosticEnvelope = {
+  readonly source: DiagnosticSource;
+  readonly code: string;
+  readonly routeTemplate: string;
+  readonly [key: string]: unknown;
+};
+
+export type NormalizedError = {
+  readonly error: Error;
+  readonly code: string;
+};
+
+export type DiagnosticReporterOptions = {
+  readonly cooldownMs?: number;
+  readonly now?: () => number;
+  readonly warn?: (...args: unknown[]) => void;
+  readonly error?: (...args: unknown[]) => void;
+};
+
+const DEFAULT_COOLDOWN_MS = 30_000;
+const UUID_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const INTEGER_SEGMENT = /^\d+$/;
+const SAFE_CODE = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
+
+const credentialKey = "(?:password|secret|token|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)";
+const quotedValue = String.raw`(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`;
+const arrayValue = String.raw`\[(?:${quotedValue}|[^\[\]"'])*\]`;
+const objectValue = String.raw`\{(?:${quotedValue}|[^{}"'])*\}`;
+const structuredValue = `(?:${arrayValue}|${objectValue}|${quotedValue})`;
+const structuredValueWithBoundary = String.raw`${structuredValue}(?=\s*(?:[,}\n]|$))`;
+const authorizationField = new RegExp(
+  String.raw`(["']?authorization["']?\s*[:=]\s*)(${structuredValueWithBoundary}|[^\r\n]*)`,
+  "gi",
+);
+const cookieField = new RegExp(
+  String.raw`(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*)(${structuredValueWithBoundary}|[^\r\n]*)`,
+  "gi",
+);
+const credentialField = new RegExp(
+  String.raw`(["']?${credentialKey}["']?\s*[:=]\s*)(Bearer\s+(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)|"[^"]*"|'[^']*'|[^\s,;}\]]+)`,
+  "gi",
+);
+
+/** Redact credential-shaped values from a flat diagnostic string. */
+export function redactErrorMessage(message: string): string {
+  return message
+    .replace(
+      authorizationField,
+      (_match, prefix: string, value: string) => `${prefix}${redactAuthorizationValue(value)}`,
+    )
+    .replace(cookieField, (_match, prefix: string) => `${prefix}[REDACTED]`)
+    .replace(
+      credentialField,
+      (_match, prefix: string, value: string) =>
+        `${prefix}${/^Bearer\s/i.test(value) ? "Bearer [REDACTED]" : "[REDACTED]"}`,
+    )
+    .replace(/\bBearer\s+(?!\[REDACTED\])(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)/gi, "Bearer [REDACTED]")
+    .replace(/([?&](?:code|client_secret|token|secret|password|key)=)[^&#\s]+/gi, "$1[REDACTED]");
+}
+
+function redactAuthorizationValue(value: string): string {
+  const trimmed = value.trim();
+  const quote = /^("|')Bearer\s/i.exec(trimmed)?.[1] ?? "";
+  if (!/^['"]?Bearer\s/i.test(trimmed)) return "[REDACTED]";
+  return `${quote}Bearer [REDACTED]${quote && trimmed.endsWith(quote) ? quote : ""}`;
+}
+
+/** Convert a concrete request path into a low-cardinality, query-free route template. */
+export function routeTemplate(path: string): string {
+  const pathname = path.split(/[?#]/, 1)[0] || "/";
+  return pathname
+    .split("/")
+    .map((segment) => (UUID_SEGMENT.test(segment) || INTEGER_SEGMENT.test(segment) ? ":id" : segment))
+    .join("/");
+}
+
+/** Normalize thrown values without using localized message text as the aggregation key. */
+export function normalizeError(value: unknown, fallbackCode = "unhandled_error"): NormalizedError {
+  const error =
+    value instanceof Error ? value : new Error(typeof value === "string" ? value : "Unknown application error");
+  const code = readStableCode(value) ?? (isAbortError(value) ? "cancelled" : (stableName(error.name) ?? fallbackCode));
+  return { error, code };
+}
+
+function readStableCode(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const candidate = (value as { code?: unknown }).code;
+  return typeof candidate === "string" && SAFE_CODE.test(candidate) ? candidate : undefined;
+}
+
+function stableName(name: string): string | undefined {
+  const normalized = name
+    .trim()
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (!normalized || normalized.toLowerCase() === "error") return undefined;
+  return normalized.toLowerCase();
+}
+
+function isAbortError(value: unknown): boolean {
+  return value instanceof Error && value.name === "AbortError";
+}
+
+/**
+ * Apply the flat-string redactor before the shared recursive redactor. The first pass handles
+ * free-form Error fields and component stacks; the second pass handles structured keys and values.
+ */
+export function createDiagnosticEnvelope(input: DiagnosticEnvelope): DiagnosticEnvelope {
+  const flat = { ...input } as Record<string, unknown>;
+  if (typeof flat.componentStack === "string") flat.componentStack = redactErrorMessage(flat.componentStack);
+  if (typeof flat.message === "string") flat.message = redactErrorMessage(flat.message);
+  if (typeof flat.name === "string") flat.name = redactErrorMessage(flat.name);
+  if (flat.error && typeof flat.error === "object" && !Array.isArray(flat.error)) {
+    const error = { ...(flat.error as Record<string, unknown>) };
+    if (typeof error.message === "string") error.message = redactErrorMessage(error.message);
+    if (typeof error.name === "string") error.name = redactErrorMessage(error.name);
+    flat.error = error;
+  }
+  return redactSensitive(flat) as DiagnosticEnvelope;
+}
+
+/** Console reporter with low-cardinality (route template, error code) cooldown. */
+export class DiagnosticReporter {
+  private readonly lastReportedAt = new Map<string, number>();
+  private readonly cooldownMs: number;
+  private readonly now: () => number;
+  private readonly warnLogger: (...args: unknown[]) => void;
+  private readonly errorLogger: (...args: unknown[]) => void;
+
+  constructor(options: DiagnosticReporterOptions = {}) {
+    this.cooldownMs = Math.max(0, options.cooldownMs ?? DEFAULT_COOLDOWN_MS);
+    this.now = options.now ?? (() => Date.now());
+    this.warnLogger = options.warn ?? ((...args: unknown[]) => console.warn(...args));
+    this.errorLogger = options.error ?? ((...args: unknown[]) => console.error(...args));
+  }
+
+  report(input: DiagnosticEnvelope, level: DiagnosticLevel = "warn"): boolean {
+    const safe = createDiagnosticEnvelope(input);
+    const key = `${safe.routeTemplate}\u0000${safe.code}`;
+    const now = this.now();
+    const previous = this.lastReportedAt.get(key);
+    if (previous !== undefined && now >= previous && now - previous < this.cooldownMs) return false;
+    this.lastReportedAt.set(key, now);
+    const logger = level === "error" ? this.errorLogger : this.warnLogger;
+    logger("[OpenTag] Diagnostic", safe);
+    return true;
+  }
+
+  clear(): void {
+    this.lastReportedAt.clear();
+  }
+}
+
+/** Register global listeners for failures that React root handlers cannot observe. */
+export function installWindowDiagnosticHandlers(
+  target: Window = window,
+  reporter: DiagnosticReporter = windowDiagnosticReporter,
+): () => void {
+  const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+    const normalized = normalizeError(event.reason, "unhandled_rejection");
+    reporter.report(
+      {
+        source: "window",
+        code: normalized.code,
+        routeTemplate: "window",
+        error: { name: normalized.error.name, message: normalized.error.message },
+      },
+      "error",
+    );
+  };
+
+  const onResourceError = (event: ErrorEvent) => {
+    const element = event.target;
+    if (!(element instanceof HTMLScriptElement) && !(element instanceof HTMLLinkElement)) return;
+    const resourceType = element instanceof HTMLScriptElement ? "script" : "link";
+    const source = element instanceof HTMLScriptElement ? element.src : element.href;
+    reporter.report(
+      {
+        source: "window",
+        code: "resource_load_failed",
+        routeTemplate: "window",
+        resourceType,
+        resourcePath: resourcePathWithoutQuery(source),
+      },
+      "error",
+    );
+  };
+
+  target.addEventListener("unhandledrejection", onUnhandledRejection);
+  target.addEventListener("error", onResourceError, true);
+  return () => {
+    target.removeEventListener("unhandledrejection", onUnhandledRejection);
+    target.removeEventListener("error", onResourceError, true);
+  };
+}
+
+function resourcePathWithoutQuery(source: string): string | undefined {
+  if (!source) return undefined;
+  try {
+    return new URL(source, window.location.href).pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+export const windowDiagnosticReporter = new DiagnosticReporter();

--- a/apps/web/src/observability/diagnostics.ts
+++ b/apps/web/src/observability/diagnostics.ts
@@ -81,10 +81,18 @@ export function routeTemplate(path: string): string {
 
 /** Normalize thrown values without using localized message text as the aggregation key. */
 export function normalizeError(value: unknown, fallbackCode = "unhandled_error"): NormalizedError {
-  const error =
-    value instanceof Error ? value : new Error(typeof value === "string" ? value : "Unknown application error");
+  const error = isErrorValue(value)
+    ? value
+    : new Error(typeof value === "string" ? value : "Unknown application error");
   const code = readStableCode(value) ?? (isAbortError(value) ? "cancelled" : (stableName(error.name) ?? fallbackCode));
   return { error, code };
+}
+
+function isErrorValue(value: unknown): value is Error {
+  if (value instanceof Error) return true;
+  if (!value || typeof value !== "object") return false;
+  const tag = Object.prototype.toString.call(value);
+  return tag === "[object Error]" || tag === "[object DOMException]";
 }
 
 function readStableCode(value: unknown): string | undefined {
@@ -103,7 +111,7 @@ function stableName(name: string): string | undefined {
 }
 
 function isAbortError(value: unknown): boolean {
-  return value instanceof Error && value.name === "AbortError";
+  return isErrorValue(value) && value.name === "AbortError";
 }
 
 /**


### PR DESCRIPTION
The web app's problem was not transport — it was that **the cause was destroyed before anything could
transport it**. This preserves the diagnostic information the API layer threw away, stops
manufacturing a fake 503 for schema drift, and makes the failures the app was completely blind to
visible.

Console-only by design: no reporting endpoint. That is a later round, and it could only have forwarded
the few failures that survived today.

## Checklist

- [x] 1. `ApiError` carries `requestId` and `retryAfterSeconds`
- [x] 2. Schema mismatch no longer throws a fake 503; issue path and code logged, nothing else
- [x] 3. `fetchWithRefresh` wrapped; aborts mapped to `cancelled` without warning
- [x] 4. Reporter keyed on (route template, error code) with cooldown; not on MutationCache
- [x] 5. `observability/diagnostics.ts` added, layering both redactors
- [x] 6. CSRF-less write attempts are recorded
- [x] 7. `unhandledrejection` + capture-phase resource-error listeners added beside `rootErrorHandlers`
- [x] 8. `reportBoundaryError` shape unchanged; `normalizeError` emits a stable non-localized code
- [x] 9. Tests added
- [x] 10. Progress recorded

## What changed

**`requestId` survives — the highest-leverage line.** `apiError()` parsed the `ErrorEnvelope` and then
discarded `requestId` and `retryAfterSeconds`, both of which the envelope carries. `ApiError` now
exposes them. `requestId` is the only join key between a browser event and the server's `reqId`, and
the server returns an `x-request-id` response header.

**No more manufactured 503.** A response-schema mismatch threw
`ApiError(503, "The server returned an invalid response")` — naming neither endpoint nor field,
mislabelled as a 5xx, and therefore treated as non-terminal and retried forever on focus. It is now a
dedicated `ResponseSchemaError` carrying the route template and the failing issues, logged as **path
and code only** — never `issue.message`, never `received`, never the body.

**One seam, reads and writes both.** `fetchWithRefresh` is wrapped rather than each of `request`,
`requestOptional` and `requestNoContent`. Aborts branch first into `CancelledRequestError` with no
warning, so a user navigating away does not look like a fault.

**Not built on MutationCache.** There are zero `useMutation` calls in the repository, so a
MutationCache reporter would have stayed permanently empty — while every destructive write
(deleteAgent, disableImBinding, logout, sign-in) goes through `requestNoContent`. The cooldown key is
(route template, error code), never `queryHash`: `useAgentListView` fans out 2N queries through
`useQueries`, so ten agents would otherwise emit ~22 lines per failing round.

**CSRF blindness.** `csrfHeaders()` returned `{}` when the token lookup found nothing — signed in, but
the cookie cleared by ITP or partitioning — so the app issued writes with no CSRF header, the server
403'd every one, and the app silently appeared read-only with nothing recorded. That attempt is now
recorded at the request seam.

**Window-level handlers, added beside the existing ones.** `main.tsx` already passed
`rootErrorHandlers` into `createRoot`; those are React 19 root handlers and remain. An
`unhandledrejection` listener and a **capture-phase** error listener now sit alongside them, the latter
checking whether `event.target` is an `HTMLScriptElement`/`HTMLLinkElement` — resource load failures
neither bubble nor carry `event.error`, and a post-deploy chunk-load failure is the most common SPA
incident, which this app previously could not see at all.

**Aggregation stays possible.** `normalizeError` produced Error messages minted from paraglide `m.*()`
strings, so the same crash read differently per language. It now emits a stable, non-localized code.
`reportBoundaryError`'s two-argument `console.error('[OpenTag] Unhandled UI error', {...})` shape is
preserved verbatim, with the structured envelope attached as an additional key.

## Acceptance criteria — verified by the orchestrator, not self-reported

| Criterion | Result |
| --- | --- |
| `pnpm check` | exit 0 |
| `pnpm typecheck` | exit 0 |
| `pnpm build` | exit 0 |
| `pnpm --filter '@opentag/*' test` | exit 0 — shared 172, server 607, client 877, web 607 |
| `pnpm --filter @opentag/web build` within the 600 KiB entry-chunk budget | yes — the build enforces it and exits 0 (the 568 KiB chunk is the pre-existing `echarts` vendor chunk under its own budget) |
| Seven existing `error-boundary.test.tsx` assertions still pass unmodified | **zero removed assertion lines** in that file |
| Test proves `ApiError` exposes `requestId` | `preserves structured server diagnostics for recovery actions` |
| Test proves a schema mismatch is not a 503 | `records schema issue paths and codes without response detail` |
| Test proves an aborted request produces no warning | `maps an aborted request to cancelled without warning` |
| No diagnostic string goes through `m.*()`; no i18n assertion changed | `observability/` contains no `m.` usage |
| `git status --porcelain` empty | yes |

Further tests added: `records a CSRF-less write at the request seam`, `uses route templates and cools
down duplicate error codes`, `layers flat-string and structured redaction`, `uses a stable code for
non-error values instead of localized copy`, `records unhandled rejections and capture-phase resource
failures`.

## Notes

No deviation from the agreed plan. Four commits across ten checklist items — coarser than
one-per-item, but each is a coherent unit (`preserve API request diagnostics`, `report API
diagnostics`, `capture global UI failures`, `keep boundary fallback catalog-safe`).

`throwOnError` was deliberately **not** set on the QueryClient — `client.ts` documents the intentional
design of degrading rather than white-screening on background refetch.

No drizzle migration was added, so `CURRENT_MIGRATION_COUNT` is unchanged and the PostgreSQL
integration suite was not required.

---

*Dispatched as run `313360`, lane `web-observability-4`. Written by codex under bypassed approvals in
an isolated worktree; verified and published by the orchestrator.*
