### PR TITLE
feat(web): refine agent sidebar

### DIFF
--- a/apps/web/src/features/shell/agent-shell.tsx
+++ b/apps/web/src/features/shell/agent-shell.tsx
@@ -1,5 +1,5 @@
 import { Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import { type ReactNode, useSyncExternalStore } from "react";
+import { type CSSProperties, type ReactNode, useSyncExternalStore } from "react";
 import { initials } from "../../i18n/format.js";
 import { useInternalNavigationVisibility } from "../../internal/navigation-visibility.js";
 import * as m from "../../paraglide/messages.js";
@@ -26,6 +26,7 @@ import { AgentReturnEntry } from "./agent-return-entry.js";
 import { ShellMain } from "./shell-main.js";
 
 const AGENT_SIDEBAR_MOBILE_QUERY = "(max-width: 767px)";
+const AGENT_SIDEBAR_WIDTH = "15rem";
 
 export default function AgentShell({
   agentId,
@@ -41,6 +42,7 @@ export default function AgentShell({
       className="h-full min-h-0 overflow-hidden bg-kumo-canvas"
       collapsible={isMobileAgentShell ? "icon" : "none"}
       defaultOpen
+      style={{ "--sidebar-width": AGENT_SIDEBAR_WIDTH } as CSSProperties}
       variant="floating"
     >
       <AgentShellContent agentId={agentId} renderAccountMenu={renderAccountMenu} />
@@ -89,28 +91,32 @@ function AgentShellContent({
     void navigate(agentDetailLink(targetAgentId));
   }
 
+  function openAllAgents() {
+    closeMobile();
+    void navigate({ to: "/agents" });
+  }
+
+  function openNewAgent() {
+    closeMobile();
+    void navigate({ to: "/agents/new" });
+  }
+
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-1 bg-kumo-canvas" data-ui="agent-shell">
       <Sidebar
         aria-label={m.shell_agent_navigation()}
-        className="bg-kumo-canvas md:m-2 md:mr-0 md:h-[calc(100%-1rem)] md:rounded-lg md:shadow-xs"
-        contentClassName="bg-kumo-canvas md:rounded-lg"
+        className="bg-kumo-base md:m-3 md:mr-0 md:h-[calc(100%-1.5rem)] md:rounded-xl md:shadow-xs"
+        contentClassName="bg-kumo-base md:rounded-xl"
         fullScreenOnMobile
       >
-        <Sidebar.Header className="border-b-0">
+        <Sidebar.Header className="h-16 border-b-0 px-3">
           <Sidebar.Menu className="min-w-0 flex-1">
             <Sidebar.MenuItem>
               <AgentSwitcher
                 agent={agent}
                 agents={agents}
-                onAllAgents={() => {
-                  closeMobile();
-                  void navigate({ to: "/agents" });
-                }}
-                onNewAgent={() => {
-                  closeMobile();
-                  void navigate({ to: "/agents/new" });
-                }}
+                onAllAgents={openAllAgents}
+                onNewAgent={openNewAgent}
                 onOpenAgent={openAgent}
               />
             </Sidebar.MenuItem>
@@ -119,8 +125,8 @@ function AgentShellContent({
         </Sidebar.Header>
         <Sidebar.Content className="md:[&_[data-sidebar=viewport]]:pt-0">
           <nav aria-label={m.shell_agent()}>
-            <Sidebar.Group>
-              <Sidebar.Menu>
+            <Sidebar.Group className="pt-1">
+              <Sidebar.Menu className="gap-1">
                 <AgentNavItem
                   active={isAgentSectionActive(pathname, agentId, "home")}
                   icon="home"
@@ -174,7 +180,7 @@ function AgentShellContent({
             </Sidebar.Group>
           </nav>
         </Sidebar.Content>
-        <Sidebar.Footer>
+        <Sidebar.Footer className="h-14 px-3">
           <Sidebar.Menu className="min-w-0 flex-1">
             <Sidebar.MenuItem>{renderAccountMenu(closeMobile)}</Sidebar.MenuItem>
           </Sidebar.Menu>
@@ -236,6 +242,7 @@ function AgentSwitcher({
             aria-label={
               agent ? m.shell_switch_agent_current({ currentAgent: agent.displayName }) : m.shell_switch_agent()
             }
+            className="min-h-11 rounded-lg px-2 hover:bg-kumo-fill-hover"
             icon={
               <span
                 className="grid size-8 shrink-0 place-items-center rounded-full bg-kumo-tint text-sm font-semibold group-data-[state=collapsed]/sidebar:size-4 group-data-[state=collapsed]/sidebar:text-xs"
@@ -247,9 +254,9 @@ function AgentSwitcher({
             tooltip={agent?.displayName ?? m.shell_agent()}
           >
             <span className="min-w-0 flex-1 text-left">
-              <strong className="block truncate">{agent?.displayName ?? m.shell_agent()}</strong>
+              <strong className="block truncate text-sm font-semibold">{agent?.displayName ?? m.shell_agent()}</strong>
             </span>
-            <Icon name="chevron-down" />
+            <Icon className="size-3.5 text-kumo-subtle" name="chevron-down" />
           </Sidebar.MenuButton>
         }
       />
@@ -303,15 +310,15 @@ function AgentNavItem({
     <Sidebar.MenuButton
       active={active}
       aria-current={active ? "page" : undefined}
-      className="data-[active]:bg-(--brand-soft)"
+      className="min-h-10 rounded-lg px-3 data-[active]:bg-(--brand-soft)"
       icon={
-        <span className="flex w-8 shrink-0 items-center justify-center" aria-hidden="true">
-          <Icon name={icon} />
+        <span className="grid size-7 shrink-0 place-items-center text-kumo-subtle" aria-hidden="true">
+          <Icon className="size-4.5" name={icon} />
         </span>
       }
       onClick={onClick}
     >
-      {label}
+      <span className={active ? "font-semibold text-kumo-strong" : undefined}>{label}</span>
     </Sidebar.MenuButton>
   );
 }

--- a/apps/web/src/ui/kumo-contract.test.ts
+++ b/apps/web/src/ui/kumo-contract.test.ts
@@ -203,11 +203,11 @@ describe("Kumo integration contract", () => {
     const shell = ["app-shell.tsx", "agent-shell.tsx", "shell-main.tsx"]
       .map((file) => readFileSync(resolve(root, "features/shell", file), "utf8"))
       .join("\n");
-    expect(shell).toContain('<Sidebar.Header className="border-b-0">');
+    expect(shell).toContain('<Sidebar.Header className="h-16 border-b-0 px-3">');
     expect(shell).toMatch(/<Sidebar\.Content(?:\s|>)/);
-    expect(shell).toContain("<Sidebar.Menu>");
+    expect(shell).toContain('<Sidebar.Menu className="gap-1">');
     expect(shell).toContain("<Sidebar.MenuButton");
-    expect(shell).toContain("<Sidebar.Footer>");
+    expect(shell).toContain('<Sidebar.Footer className="h-14 px-3">');
     expect(shell).toContain("<DropdownMenu.LinkItem");
     expect(shell).toContain("<DropdownMenu.Separator />");
     expect(shell).toContain("selected={candidate.id === agent?.id}");
@@ -221,7 +221,7 @@ describe("Kumo integration contract", () => {
     expect(shell).toContain('className="h-full min-h-0 overflow-hidden bg-kumo-canvas"');
     expect(shell).toContain('className="flex h-full min-h-0 min-w-0 flex-1 bg-kumo-canvas"');
     expect(shell).toContain(
-      'className="bg-kumo-canvas md:m-2 md:mr-0 md:h-[calc(100%-1rem)] md:rounded-lg md:shadow-xs"',
+      'className="bg-kumo-base md:m-3 md:mr-0 md:h-[calc(100%-1.5rem)] md:rounded-xl md:shadow-xs"',
     );
     expect(shell).toContain('className="flex min-h-0 min-w-0 flex-1 flex-col bg-kumo-canvas md:ml-2"');
     expect(shell).toContain("min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto");


### PR DESCRIPTION
## Summary

- Set the desktop Agent sidebar to a fixed 240px width and keep it non-collapsible.
- Refine the sidebar surface, outer spacing, radius, header/footer density, agent switcher, and navigation rhythm.
- Use a soft-green selected state with semibold text and no left indicator.
- Preserve the existing account menu, Agents return control, and mobile behavior.
- Update the Kumo shell contract to cover the finalized sidebar structure.

## Testing

- `pnpm check` — passed
- `pnpm build` — passed
- `pnpm typecheck` — passed
- Focused web tests — 42 passed
- `pnpm test` — passed in GitHub CI; the local full concurrent run initially hit two unrelated Provider CLI probe flakes (one timeout and one temporary-file race)
- Isolated local rerun of both transient failures — 56 passed

## UI validation

- Desktop evidence: reviewed interactively on the local Agent detail page with the requester; finalized Scheme A.
- Mobile evidence: behavior is unchanged; the desktop visual refinements remain behind the existing medium breakpoint.
- Widths checked (`320px` / `390px` / `768px` / `1440px`; explain any N/A): 1440px checked; 320px, 390px, and 768px are N/A for the desktop-only refinement.
- States verified: selected navigation, hover treatments, agent switcher, and account menu spacing.
- Keyboard/accessibility checks: interaction semantics and keyboard behavior are unchanged; existing button/menu primitives are retained.
- New reusable block, theme value, or CSS exception: none.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (`pnpm test` is green in GitHub CI; see the local transient-failure note above.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

