### PR TITLE
fix(client): surface fatal transport and durability failures

### DIFF
--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -363,6 +363,45 @@ describe("AgentTurnRunner", () => {
     );
   });
 
+  it("logs an unknown reason for a non-Error Turn Report submission rejection", async () => {
+    const logs: RecordedLog[] = [];
+    const submit = vi.fn(() => Promise.reject("boom"));
+    const create = vi.fn((input) => ({
+      ...input,
+      type: "turn:report",
+      requestId: randomUUID(),
+      resultHash: "g".repeat(64),
+    }));
+    const runner = new AgentTurnRunner({
+      bindingStore: {
+        updateUnresolved: vi.fn(async () => {
+          throw new Error("disk failed");
+        }),
+      } as unknown as SessionBindingStore,
+      connection: { send: vi.fn(async () => undefined) },
+      custody: { markReporting: vi.fn(async () => undefined), recordResult: vi.fn() } as unknown as TurnCustodyOwner,
+      logger: recordingLogger(logs),
+      reportOwner: { create, submit } as unknown as TurnReportOwner,
+      runtimeManager: {} as SessionRuntimeManager,
+      credentialEnvironment: credentialEnvironment(),
+    });
+
+    runner.start(liveOwner({ ...delivery(), deliveryId: "delivery-non-error" }));
+    await runner.settled();
+    await vi.waitFor(() =>
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          level: "warn",
+          message: "Turn Report submission failed",
+          fields: expect.objectContaining({
+            deliveryId: "delivery-non-error",
+            reason: "Unknown Turn Report submission failure",
+          }),
+        }),
+      ),
+    );
+  });
+
   it("keeps unresolved custody when the reporting transition fails", async () => {
     let observer: AgentRuntimeEventSink | undefined;
     const onRuntimeEvent = vi.fn(async () => undefined);

--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -22,6 +22,7 @@ import type { RecordedSteerInput, SessionBindingStore } from "../runtime/session
 import { ClientRuntimeProviderStartError, type SessionRuntimeManager } from "../runtime/session-runtime-manager.js";
 import type { LiveTurnOwner, TurnCustodyOwner } from "../runtime/turn-custody-owner.js";
 import type { TurnReportOwner } from "../runtime/turn-report-owner.js";
+import { type RecordedLog, recordingLogger } from "./recording-logger.js";
 
 describe("AgentTurnRunner", () => {
   it("compiles only dynamic Session, message, history, and resource context into AgentInput", () => {
@@ -308,6 +309,58 @@ describe("AgentTurnRunner", () => {
     runner.stop();
     runner.start({ ...owner, turnId: "stopped" });
     expect(runner.activeCount).toBe(0);
+  });
+
+  it("logs a failed Turn Report submission without blocking Turn completion", async () => {
+    const logs: RecordedLog[] = [];
+    let rejectSubmit!: (error: Error) => void;
+    const submit = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSubmit = reject;
+        }),
+    );
+    const create = vi.fn((input) => ({
+      ...input,
+      type: "turn:report",
+      requestId: randomUUID(),
+      resultHash: "f".repeat(64),
+    }));
+    const runner = new AgentTurnRunner({
+      bindingStore: {
+        updateUnresolved: vi.fn(async () => {
+          throw new Error("disk failed");
+        }),
+      } as unknown as SessionBindingStore,
+      connection: { send: vi.fn(async () => undefined) },
+      custody: { markReporting: vi.fn(async () => undefined), recordResult: vi.fn() } as unknown as TurnCustodyOwner,
+      logger: recordingLogger(logs),
+      reportOwner: { create, submit } as unknown as TurnReportOwner,
+      runtimeManager: {} as SessionRuntimeManager,
+      credentialEnvironment: credentialEnvironment(),
+    });
+
+    runner.start(liveOwner(delivery()));
+    await runner.settled();
+    expect(submit).toHaveBeenCalledOnce();
+    expect(logs.some((entry) => entry.message === "Turn Report submission failed")).toBe(false);
+
+    rejectSubmit(new Error("report transport failed"));
+    await vi.waitFor(() =>
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          level: "warn",
+          message: "Turn Report submission failed",
+          fields: expect.objectContaining({
+            agentId: "agent-1",
+            deliveryId: "delivery-1",
+            sessionId: "session-1",
+            turnId: "turn-1",
+            reason: "report transport failed",
+          }),
+        }),
+      ),
+    );
   });
 
   it("keeps unresolved custody when the reporting transition fails", async () => {

--- a/packages/client/src/__tests__/runtime-durability.test.ts
+++ b/packages/client/src/__tests__/runtime-durability.test.ts
@@ -100,6 +100,10 @@ describe("runtime durability primitives", () => {
       );
       await expect(store.list("turn-report")).resolves.toMatchObject([{ key: "turn-1", status: "accepted" }]);
       await writeFile(path, JSON.stringify({ invalid: true }));
+      await expect(store.list("turn-report")).rejects.toThrow(
+        "Runtime storage contains data that does not match its schema",
+      );
+      await writeFile(path, "{ invalid");
       await expect(store.list("turn-report")).rejects.toThrow("Runtime storage contains invalid JSON");
     } finally {
       await rm(home, { recursive: true, force: true });

--- a/packages/client/src/__tests__/runtime.test.ts
+++ b/packages/client/src/__tests__/runtime.test.ts
@@ -190,6 +190,57 @@ describe("RuntimeConnection", () => {
     }
   });
 
+  it("logs distinct redacted reasons for fatal protocol rejection", async () => {
+    const scenarios = [
+      {
+        send: (socket: ControlledWebSocket, _auth: Record<string, unknown>) =>
+          socket.receive({
+            type: "auth:result",
+            requestId: randomUUID(),
+            ok: true,
+            computerId: randomUUID(),
+            installationId: randomUUID(),
+          }),
+        expectedError: "unmatched auth result",
+      },
+      {
+        send: (socket: ControlledWebSocket, auth: Record<string, unknown>) =>
+          socket.receive({
+            type: "error",
+            requestId: auth.requestId,
+            code: "AUTH_INVALID_TOKEN",
+            message: "Authorization: Bearer close-secret",
+          }),
+        expectedError: "Authorization: Bearer close-secret",
+      },
+    ];
+    const reasons: unknown[] = [];
+    for (const scenario of scenarios) {
+      const socket = new ControlledWebSocket();
+      const logs: RecordedLog[] = [];
+      const connection = new RuntimeConnection({
+        ...controlledOptions(socket),
+        logger: recordingLogger(logs),
+      });
+      const running = connection.run();
+      await vi.waitFor(() => expect(socket.listenerCount("open")).toBeGreaterThan(0));
+      socket.open();
+      await vi.waitFor(() => expect(socket.frame("auth")).toBeDefined());
+      scenario.send(socket, socket.frame("auth") ?? {});
+      await expect(running).rejects.toThrow(scenario.expectedError);
+      const rejection = logs.find((entry) => entry.message === "Runtime connection was rejected");
+      expect(rejection).toMatchObject({
+        level: "error",
+        fields: { attempt: 1, category: "protocol", state: "authenticating" },
+      });
+      reasons.push(rejection?.fields.reason);
+    }
+    expect(reasons[0]).toBe("The server returned an unmatched auth result");
+    expect(reasons[1]).toBe("Authorization: [REDACTED]");
+    expect(reasons[1]).not.toContain("close-secret");
+    expect(reasons[0]).not.toBe(reasons[1]);
+  });
+
   it("rejects malformed and oversized inbound frames and stale business fences", async () => {
     const cases: Array<{ label: string; receive: (socket: ControlledWebSocket) => void; parser?: boolean }> = [
       { label: "invalid JSON", receive: (socket) => socket.receiveData("not-json") },

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -6,6 +6,7 @@ import {
   RUNTIME_FINAL_TEXT_MAX_BYTES,
   type RuntimeImSteerRequest,
   type RuntimeImSteerResult,
+  redactForLog,
   type TurnFailureReason,
   type TurnReportHashInput,
   type TurnReportRequest,
@@ -309,7 +310,15 @@ export class AgentTurnRunner {
     }
     void this.#reportOwner
       .submit(report, () => this.#custody.recordResult(owner.turnId, report.resultHash))
-      .catch(() => undefined);
+      .catch((error: unknown) => {
+        this.#logger.warn(
+          {
+            ...fields,
+            reason: redactForLog(error instanceof Error ? error.message : "Unknown Turn Report submission failure"),
+          },
+          "Turn Report submission failed",
+        );
+      });
   }
 }
 

--- a/packages/client/src/runtime/runtime-connection-helpers.ts
+++ b/packages/client/src/runtime/runtime-connection-helpers.ts
@@ -5,6 +5,7 @@ import {
   type RuntimeChannelTarget,
   type RuntimeNegotiatedCapabilities,
   type RuntimeProtocolVersion,
+  redactForLog,
 } from "@opentag/shared";
 import type { RawData } from "ws";
 import type { ClientLogger } from "../observability/logger.js";
@@ -44,4 +45,12 @@ export function safeJson(value: string): unknown {
   } catch {
     return undefined;
   }
+}
+
+export function redactRuntimeReason(message: string): string {
+  return redactForLog(message);
+}
+
+export function protocolRejectionFields(attempt: number, state: string, message: string) {
+  return { attempt: attempt + 1, category: "protocol", reason: redactRuntimeReason(message), state };
 }

--- a/packages/client/src/runtime/runtime-connection.ts
+++ b/packages/client/src/runtime/runtime-connection.ts
@@ -34,7 +34,7 @@ import { OpenTagApiError } from "../api.js";
 import { type ClientLogger, createLogger } from "../observability/logger.js";
 import { RuntimeStorageError } from "../storage/durable-file.js";
 import type { ComputerIdentity } from "./computer-identity.js";
-import { notifyTarget, rawDataBuffer, safeJson } from "./runtime-connection-helpers.js";
+import { notifyTarget, protocolRejectionFields, rawDataBuffer, safeJson } from "./runtime-connection-helpers.js";
 
 const SERVER_CONTROL_FRAME_TYPES = new Set([
   "server:welcome",
@@ -368,7 +368,7 @@ export class RuntimeConnection {
           }
           if (error instanceof RuntimeConnectionError && error.fatal) {
             this.#logger.error(
-              { attempt: attempt + 1, category: "protocol", state: this.#state },
+              protocolRejectionFields(attempt, this.#state, error.message),
               "Runtime connection was rejected",
             );
             throw error;

--- a/packages/client/src/storage/durable-file.ts
+++ b/packages/client/src/storage/durable-file.ts
@@ -75,11 +75,17 @@ export async function readSecureFile(path: string): Promise<string | undefined> 
 export async function readDurableJson<T>(path: string, validate: (value: unknown) => T): Promise<T | undefined> {
   const content = await readSecureFile(path);
   if (content === undefined) return undefined;
+  let parsed: unknown;
   try {
-    return validate(JSON.parse(content));
+    parsed = JSON.parse(content);
+  } catch {
+    throw new RuntimeStorageError("invalid", "Runtime storage contains invalid JSON");
+  }
+  try {
+    return validate(parsed);
   } catch (error) {
     if (error instanceof RuntimeStorageError) throw error;
-    throw new RuntimeStorageError("invalid", "Runtime storage contains invalid JSON");
+    throw new RuntimeStorageError("invalid", "Runtime storage contains data that does not match its schema");
   }
 }
 


### PR DESCRIPTION
Three failures in the daemon's transport and durability layer were invisible or actively mislabelled.
Two of the three had the log saying something untrue.

## Checklist

- [x] 1. The fatal close reason reaches the log, redacted via `redactForLog`
- [x] 2. Existing fields (`attempt`, `category`, `state`) preserved
- [x] 3. The turn-report submit rejection is logged and still non-blocking
- [x] 4. `readDurableJson` distinguishes a parse failure from a validation failure
- [x] 5. `runtime-connection.ts` still at most 1073 lines
- [x] 6. Tests cover all three
- [x] 7. Progress recorded

## What changed

**The fatal close reason never reached the log.** `runtime-connection.ts:369` logged
`{attempt, category:"protocol", state}` and threw — a throw that **permanently terminates the
daemon's connection loop**. Every fatal cause funnels through it: `failProtocol` at `:496` builds a
`RuntimeConnectionError` for roughly twenty protocol violations, and `:770-772` builds one from a
server rejection frame. The only thing separating them is `error.message`, which was never emitted.
"My daemon connects and drops" was a total black box. The line now carries a redacted `reason`.

**The turn result submission was fire-and-forget.** `agent-turn-runner.ts:312` was
`void this.#reportOwner.submit(...).catch(() => undefined)`. The agent may already have replied in
IM, but if that submit failed the server never learned the outcome, the Task never settled, and
`client.log` showed a clean completion followed by nothing. Note the asymmetry it sat next to: the
line above already warned when the turn failed to *enter* the reporting phase — the failure that
actually loses the result was the silent one. It now warns, and stays non-blocking.

**Schema drift was reported as file corruption.** `durable-file.ts` ran `validate(JSON.parse(...))`
inside one `try`, so **every** schema failure surfaced as "Runtime storage contains invalid JSON" —
a version drift after an upgrade was actively described to the user as a corrupt file. Parse and
validate are now separate, with distinct messages.

**On the size ratchet:** `runtime-connection.ts` sits at exactly its `file-size-exceptions.json`
entry (1073, against a global limit of 500), so there was zero headroom. The new field builder went
into `runtime-connection-helpers.ts`; the touched file is a 2-line substitution and is **still exactly
1073 lines**. The exception value is unchanged.

## Verified by the orchestrator, not self-reported

| Criterion | Result |
| --- | --- |
| `pnpm check` / `pnpm typecheck` / `pnpm build` | exit 0 |
| `pnpm test` (root) | exit 0 — 311/311 |
| `pnpm --filter @opentag/client test` | exit 0 — **67 files, 887 tests** (see the flake note) |
| `wc -l runtime-connection.ts` | **1073** — at the cap, not over |
| `scripts/file-size-exceptions.json` | no diff |
| Two fatal causes distinguishable from the log alone | **probed directly**: `Unsupported protocol frame: server:bogus` vs `credential is no longer active` — distinct, with `attempt`/`category`/`state` intact |
| No credential in the emitted close reason | **probed directly**: a message carrying `token="sk-secret-abc123"` and `cookie=sid=zzz` emits neither |
| Schema failure is not called invalid JSON | **probed directly**: `Runtime storage contains invalid JSON` vs `Runtime storage contains data that does not match its schema` |
| Turn-report failure logged, still non-blocking | covered by the new `agent-turn-runner.test.ts` cases; `void` retained at the call site |
| No drizzle migration | no diff under `packages/server/drizzle` |

**One flake, investigated rather than waved through.** The first full client run failed one test:
`claude-code-agent-runtime-exhaustive.test.ts` timed out at **5005 ms against a 5000 ms limit**. That
file is not in this diff and exercises none of the changed modules. Re-run alone: 36/36 pass. Re-run
of the whole suite: 887/887 pass. It is timing contention on the dev machine (three agents were
running concurrently), not a regression from this change.

---

*Dispatched as run `337683`, lane `client-runtime-transport-2`. Written by codex under bypassed
approvals in an isolated worktree; verified and published by the orchestrator.*
