### PR TITLE
fix(web): decide the automatic Computer bind from a fresh read

### DIFF
--- a/apps/web/src/features/agents/agent-computer-choice.test.tsx
+++ b/apps/web/src/features/agents/agent-computer-choice.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * The automatic bind must be decided from a read this mount made, never from what another page
+ * left in the cache. The cache is served immediately on mount while a re-read runs, and with the
+ * repository's `staleTime: 0` a mounted observer always looks fresh; a bind taken from it picks the
+ * one Computer the Account had before a second was connected elsewhere, or one it no longer has.
+ */
+
+import type { AccountComputerSummary, AgentAdminConfig } from "@opentag/shared/browser";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { browserApi } from "../../api.js";
+import { createQueryClient } from "../../query/client.js";
+import { queryKeys } from "../../query/keys.js";
+import { AgentComputerChoice } from "./agent-computer-choice.js";
+
+const AGENT_ID = "3f1d3a2c-1f2e-4a1b-9c3d-5e6f70819a2b";
+const COMPUTER_ID = "8c2b1d4e-5a6f-4b7c-8d9e-0f1a2b3c4d5e";
+const OTHER_COMPUTER_ID = "9d3c2e5f-6b7a-4c8d-9e0f-1a2b3c4d5e6f";
+
+const cachedComputer: AccountComputerSummary = {
+  computerId: COMPUTER_ID,
+  displayName: "Ada's Mac",
+  platform: "darwin",
+  connectionStatus: "online",
+  connectedAt: "2026-08-20T00:00:00.000Z",
+  lastSeenAt: "2026-08-20T00:01:00.000Z",
+  observedAt: "2026-08-20T00:01:00.000Z",
+  createdAt: "2026-08-19T00:00:00.000Z",
+  agentIds: [],
+};
+
+const spareComputer: AccountComputerSummary = {
+  ...cachedComputer,
+  computerId: OTHER_COMPUTER_ID,
+  displayName: "Spare",
+};
+
+const boundConfig: AgentAdminConfig = {
+  id: AGENT_ID,
+  createdByUserId: "9a8b7c6d-5e4f-4a3b-8c1d-0e9f8a7b6c5d",
+  computerId: COMPUTER_ID,
+  name: "reviewer",
+  displayName: "Reviewer",
+  runtimeProvider: "codex",
+  receiveMode: "mention_only",
+  status: "active",
+  revision: 2,
+  runtimeConfig: { revision: 1, model: null, reasoningEffort: null, instructions: "", maxDurationMs: null },
+  createdAt: "2026-08-20T00:00:00.000Z",
+  updatedAt: "2026-08-20T00:00:00.000Z",
+};
+
+/** A read this mount will make, held open until the test releases it. */
+function heldRead() {
+  let release: (computers: AccountComputerSummary[]) => void = () => undefined;
+  const read = new Promise<{ computers: AccountComputerSummary[] }>((resolve) => {
+    release = (computers) => resolve({ computers });
+  });
+  vi.spyOn(browserApi, "computers").mockReturnValue(read);
+  return release;
+}
+
+/** Mounts the choice over a cache another page already filled with one Computer. */
+function renderOverCachedInventory() {
+  const queryClient = createQueryClient();
+  queryClient.setQueryData(queryKeys.computers(), { computers: [cachedComputer] });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentComputerChoice agentId={AGENT_ID} onBound={() => undefined} />
+    </QueryClientProvider>,
+  );
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("AgentComputerChoice over a cached inventory", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not bind the cached Computer while this mount's own read is still open", async () => {
+    const release = heldRead();
+    const rebind = vi.spyOn(browserApi, "rebindAgentComputer").mockResolvedValue(boundConfig);
+
+    renderOverCachedInventory();
+    await flush();
+
+    // The cache says one Computer; that is exactly the answer an automatic bind would take.
+    expect(rebind).not.toHaveBeenCalled();
+    expect(screen.getByText("Checking which Computers this Account has…")).toBeTruthy();
+
+    // The Account has since connected a second machine: the question is now the reader's.
+    await act(async () => release([cachedComputer, spareComputer]));
+
+    expect(await screen.findByRole("button", { name: "Use Spare" })).toBeTruthy();
+    expect(rebind).not.toHaveBeenCalled();
+  });
+
+  it("offers enrolment when the fresh read says the cached Computer is gone", async () => {
+    const release = heldRead();
+    const rebind = vi.spyOn(browserApi, "rebindAgentComputer").mockResolvedValue(boundConfig);
+    vi.spyOn(browserApi, "issueComputerConnectCode").mockReturnValue(new Promise(() => undefined));
+
+    renderOverCachedInventory();
+    await flush();
+    await act(async () => release([]));
+
+    expect(await screen.findByText("Connect a Computer")).toBeTruthy();
+    expect(rebind).not.toHaveBeenCalled();
+  });
+
+  it("still binds by itself once the fresh read confirms the one Computer", async () => {
+    const release = heldRead();
+    const rebind = vi.spyOn(browserApi, "rebindAgentComputer").mockResolvedValue(boundConfig);
+
+    renderOverCachedInventory();
+    await flush();
+    expect(rebind).not.toHaveBeenCalled();
+
+    await act(async () => release([cachedComputer]));
+
+    await waitFor(() => expect(rebind).toHaveBeenCalledWith(AGENT_ID, COMPUTER_ID));
+    expect(rebind).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/agents/agent-computer-choice.tsx
+++ b/apps/web/src/features/agents/agent-computer-choice.tsx
@@ -10,6 +10,23 @@ import { useComputersQuery } from "./agent-queries.js";
 type BindTarget = { computerId: string; displayName: string };
 
 /**
+ * The Account's Computers, from a read this mount made and no other.
+ *
+ * Only a successful read speaks for the Account: answering a failed one with "connect a Computer"
+ * would send someone to enrol a machine they already own -- the same conflation the Agent's
+ * availability refuses to make one layer up.
+ *
+ * And only a read made after this mount. The cache is served on mount while the re-read runs, and
+ * it is filled by whichever page the reader came from: a bind decided from it can pick the one
+ * Computer the Account had before a second was connected elsewhere, or one it no longer has -- a
+ * durable placement the reader never chose. The re-read is what the automatic bind waits for, so
+ * until it lands there is nothing to bind from.
+ */
+function computersReadAfterMount(query: ReturnType<typeof useComputersQuery>) {
+  return query.isSuccess && query.isFetchedAfterMount ? query.data.computers : undefined;
+}
+
+/**
  * Giving an Agent a Computer to run on.
  *
  * An Account may hold no Computers, one, or several, and the surface answers each honestly. With
@@ -48,10 +65,7 @@ export function AgentComputerChoice({
   // A bind is attempted once per Agent-and-Computer pair, so a failure is not restarted by every
   // render it causes. The Agent belongs in the key because this surface outlives any one of them.
   const attempted = useRef<string | undefined>(undefined);
-  // Only a successful read speaks for the Account. Answering a failed one with "connect a Computer"
-  // would send someone to enrol a machine they already own -- the same conflation the Agent's
-  // availability refuses to make one layer up.
-  const connected = computersQuery.isSuccess ? computersQuery.data.computers : undefined;
+  const connected = computersReadAfterMount(computersQuery);
   const sole = connected?.length === 1 ? connected[0] : undefined;
   const soleTarget = sole ? `${agentId}:${sole.computerId}` : undefined;
 


### PR DESCRIPTION
## Summary

`AgentComputerChoice` binds an unbound Agent by itself when the Account has exactly one Computer. It decided that from `useComputersQuery().isSuccess`, which with the repository's `staleTime: 0` is true the moment the observer mounts, served from whatever the previous page left in the cache while the re-read is still in flight. A cache that says one Computer therefore bound the Agent before the current inventory arrived: to the one machine the Account had before a second was connected elsewhere, or to one it no longer has. Either is a durable placement the reader never chose, and the context tree forbids a surface from resolving the Account's Computers down to one on the reader's behalf.

The inventory now counts only once a read made after this mount has landed (`isFetchedAfterMount`). Until then the surface shows its loading line; a failed re-read still shows the read failure and its retry. Manual choice and the connect step are unchanged.

The component is shared by Agent Settings on `main` today and by the exact-Agent setup page in #469 / #473, so this lands on `main` rather than on that stack. The same defect was raised as a P1 in the review of #477 against the copy of this surface mounted there.

## Testing

- `apps/web/src/features/agents/agent-computer-choice.test.tsx` (new): cached one Computer, fresh read returns two → no bind, the choice is offered; cached one, fresh read returns zero → no bind, enrolment is offered; cached one, fresh read confirms one → binds exactly once.
- `pnpm --filter @opentag/web test` — 73 files, 618 tests
- `pnpm --filter @opentag/web typecheck`
- `pnpm check` — complexity ratchet reports one improvement (`AgentComputerChoice` 16 → below baseline after extracting the read guard)
- `pnpm build`

## UI validation

- Desktop evidence: jsdom component tests above; the only visible change is that the loading line ("Checking which Computers this Account has…") now stays until this mount's read lands instead of a cached inventory being shown and acted on.
- Mobile evidence: N/A, no layout change.
- Widths checked (`320px` / `390px` / `768px` / `1440px`; explain any N/A): N/A, no layout or composition change.
- States verified: loading over a stale cache, fresh read with several Computers, fresh read with none, fresh read confirming one, read failure with retry (existing `agent-computer-settings` suite).
- Keyboard/accessibility checks: no new controls.
- New reusable block, theme value, or CSS exception: none.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
