### PR TITLE
feat(server): classify silent domain service verdicts

### DIFF
--- a/packages/server/src/__tests__/credential-material.test.ts
+++ b/packages/server/src/__tests__/credential-material.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CredentialDecodeOptions,
+  decodeFeishuCredential,
+  decodeSlackCredential,
+} from "../services/im-bindings/credential-material.js";
+
+const bindingId = "binding-1";
+const ciphertext = "ciphertext-secret";
+const credentialSecret = "app-secret-value";
+
+const decoders = [
+  {
+    name: "Feishu",
+    decode: decodeFeishuCredential,
+    validPayload: JSON.stringify({ appId: "app-id", appSecret: credentialSecret, grantedScopes: ["scope-a"] }),
+  },
+  {
+    name: "Slack",
+    decode: decodeSlackCredential,
+    validPayload: JSON.stringify({
+      botAccessToken: "xoxb-token-value",
+      botId: "bot-id",
+      grantedScopes: ["scope-a"],
+      signingSecret: "signing-secret-value",
+    }),
+  },
+] as const;
+
+describe("credential material decoding", () => {
+  it.each(decoders)("classifies $name decrypt, parse, and schema failures from logs", ({ decode, validPayload }) => {
+    const logger = { warn: vi.fn() };
+    const options: CredentialDecodeOptions = { bindingId, logger };
+
+    expect(
+      decode(
+        {
+          decrypt: () => {
+            throw new Error("wrong key");
+          },
+        } as never,
+        ciphertext,
+        options,
+      ),
+    ).toBeUndefined();
+    expect(decode({ decrypt: () => "not-json" } as never, ciphertext, options)).toBeUndefined();
+    expect(
+      decode({ decrypt: () => validPayload.replace('["scope-a"]', '"not-an-array"') } as never, ciphertext, options),
+    ).toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledTimes(3);
+    expect(logger.warn.mock.calls.map(([payload]) => payload.code)).toEqual([
+      "IM_BINDING_CREDENTIAL_DECRYPT_FAILED",
+      "IM_BINDING_CREDENTIAL_PAYLOAD_INVALID",
+      "IM_BINDING_CREDENTIAL_SCHEMA_INVALID",
+    ]);
+    for (const [payload, message] of logger.warn.mock.calls) {
+      expect(payload).toMatchObject({ bindingId });
+      expect(JSON.stringify({ payload, message })).not.toContain(ciphertext);
+      expect(JSON.stringify({ payload, message })).not.toContain(credentialSecret);
+      expect(JSON.stringify({ payload, message })).not.toContain("not-an-array");
+    }
+  });
+
+  it("returns decoded credentials when all stages succeed", () => {
+    const logger = { warn: vi.fn() };
+    const result = decodeFeishuCredential(
+      {
+        decrypt: () => JSON.stringify({ appId: "app-id", appSecret: credentialSecret, grantedScopes: ["scope-a"] }),
+      } as never,
+      ciphertext,
+      { bindingId, logger },
+    );
+
+    expect(result).toEqual({ appId: "app-id", appSecret: credentialSecret, grantedScopes: ["scope-a"] });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/__tests__/credential-material.test.ts
+++ b/packages/server/src/__tests__/credential-material.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
+import type { slackInstallations } from "../db/schema/index.js";
 import {
   type CredentialDecodeOptions,
   decodeFeishuCredential,
   decodeSlackCredential,
+  inspectCredentialMaterial,
+  slackInstallationInspectionInput,
 } from "../services/im-bindings/credential-material.js";
 
 const bindingId = "binding-1";
@@ -74,5 +77,41 @@ describe("credential material decoding", () => {
 
     expect(result).toEqual({ appId: "app-id", appSecret: credentialSecret, grantedScopes: ["scope-a"] });
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the Slack installation id out of bindingId on installation decrypt failure", () => {
+    const installation = {
+      id: "slack-installation-1",
+      encryptedCredential: ciphertext,
+      externalAppId: "app-id",
+      externalBotId: "bot-id",
+      externalTeamId: "team-id",
+      credentialGeneration: 1,
+      credentialSchemaVersion: 1,
+      grantedCapabilities: ["scope-a"],
+    } as typeof slackInstallations.$inferSelect;
+    const logger = { warn: vi.fn() };
+    const input = slackInstallationInspectionInput(installation);
+
+    expect(input).toMatchObject({ slackInstallationId: installation.id });
+    expect(input).not.toHaveProperty("bindingId");
+    expect(
+      inspectCredentialMaterial(
+        {
+          decrypt: () => {
+            throw new Error("wrong key");
+          },
+        } as never,
+        input,
+        { logger },
+      ),
+    ).toMatchObject({ status: "invalid" });
+
+    const payload = logger.warn.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      code: "IM_BINDING_CREDENTIAL_DECRYPT_FAILED",
+      slackInstallationId: installation.id,
+    });
+    expect(payload.bindingId).toBeUndefined();
   });
 });

--- a/packages/server/src/__tests__/session-collaboration-service.test.ts
+++ b/packages/server/src/__tests__/session-collaboration-service.test.ts
@@ -36,6 +36,25 @@ describe("SessionCollaborationService", () => {
     });
   });
 
+  it("logs an assembler failure while preserving the runtime_not_ready response", async () => {
+    const fixture = serviceFixture();
+    fixture.assembler.assembleForSession.mockRejectedValue(new Error("assembler failed"));
+
+    await expect(fixture.service.send(sendRequest(fixture), fixture.source)).resolves.toMatchObject({
+      status: "unreachable",
+      code: "runtime_not_ready",
+    });
+    expect(fixture.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "SESSION_COLLABORATION_RUNTIME_ASSEMBLY_FAILED",
+        messageId: fixture.messageId,
+        sessionId: fixture.targetSessionId,
+        targetSessionId: fixture.targetSessionId,
+      }),
+      "Session collaboration internal failure",
+    );
+  });
+
   it("records a busy target as unreachable capacity", async () => {
     const fixture = serviceFixture();
     fixture.domain.requestSessionMessageDelivery.mockResolvedValue({
@@ -100,6 +119,14 @@ describe("SessionCollaborationService", () => {
       status: "unknown",
       code: "outcome_write_failed",
     });
+    expect(fixture.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "SESSION_COLLABORATION_OUTCOME_WRITE_FAILED",
+        messageId: fixture.messageId,
+        outcome: "unknown",
+      }),
+      "Session collaboration internal failure",
+    );
     expect(fixture.sessions.recordMessageOutcome).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: "unknown", errorCode: "delivery_timeout" }),
     );
@@ -205,25 +232,30 @@ function serviceFixture(
     }),
   };
   const onDiagnostic = vi.fn();
+  const logger = { error: vi.fn() };
   const registry = {
     capabilityVersion: vi.fn().mockReturnValue(2),
     currentInstanceId: vi.fn().mockReturnValue(instanceId),
     supportsCapability: vi.fn().mockReturnValue(true),
   };
+  const assembler = { assembleForSession: vi.fn().mockResolvedValue(snapshot(agentId)) };
   return {
+    assembler,
     domain,
     messageId,
     onDiagnostic,
+    logger,
     registry,
     sessions,
     source,
     targetSessionId,
     service: new SessionCollaborationService({
-      assembler: { assembleForSession: vi.fn().mockResolvedValue(snapshot(agentId)) },
+      assembler,
       domain: domain as never,
       onDiagnostic,
       registry,
       sessions: sessions as never,
+      logger,
     }),
   };
 }

--- a/packages/server/src/__tests__/session-services.unit.test.ts
+++ b/packages/server/src/__tests__/session-services.unit.test.ts
@@ -252,7 +252,8 @@ describe("SessionService with the unit database", () => {
   });
 
   it("admits only valid collaboration authorities and releases admission on dispatch", async () => {
-    const service = new SessionService(db.database);
+    const logger = { info: vi.fn() };
+    const service = new SessionService(db.database, { logger });
     const source = await service.ensureChatSession(
       { imBindingId: fixture.bindingId, channelId: "C1", conversationKind: "dm" },
       "channel",
@@ -300,9 +301,34 @@ describe("SessionService with the unit database", () => {
       .set({ ownerAccountId: otherUserId })
       .where(eq(computers.id, fixture.computerId));
     await expect(service.withCollaborationDispatchAdmission(route, operation)).resolves.toEqual({ admitted: false });
+    expect(logger.info).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        agentId: route.agentId,
+        code: "SESSION_COLLABORATION_ADMISSION_COMPUTER_OWNERSHIP_INVALID",
+        imBindingId: route.imBindingId,
+        sourceComputerId: route.sourceComputerId,
+        sourceSessionId: route.sourceSessionId,
+        targetComputerId: route.targetComputerId,
+        targetSessionId: route.targetSessionId,
+      }),
+      "Session collaboration dispatch admission rejected",
+    );
     await db.database
       .update(computers)
       .set({ ownerAccountId: fixture.userId })
+      .where(eq(computers.id, fixture.computerId));
+    await db.database
+      .update(computers)
+      .set({ currentInstanceId: randomUUID() })
+      .where(eq(computers.id, fixture.computerId));
+    await expect(service.withCollaborationDispatchAdmission(route, operation)).resolves.toEqual({ admitted: false });
+    expect(logger.info).toHaveBeenLastCalledWith(
+      expect.objectContaining({ code: "SESSION_COLLABORATION_ADMISSION_SOURCE_INSTANCE_STALE" }),
+      "Session collaboration dispatch admission rejected",
+    );
+    await db.database
+      .update(computers)
+      .set({ currentInstanceId: fixture.instanceId })
       .where(eq(computers.id, fixture.computerId));
     await expect(
       service.withCollaborationDispatchAdmission(route, () => {
@@ -316,21 +342,37 @@ describe("SessionService with the unit database", () => {
     await expect(rejected.result).rejects.toThrow("async dispatch failed");
     await db.database.update(agents).set({ status: "suspended" }).where(eq(agents.id, fixture.agentId));
     await expect(service.withCollaborationDispatchAdmission(route, operation)).resolves.toEqual({ admitted: false });
+    expect(logger.info).toHaveBeenLastCalledWith(
+      expect.objectContaining({ code: "SESSION_COLLABORATION_ADMISSION_AGENT_INACTIVE" }),
+      "Session collaboration dispatch admission rejected",
+    );
     await db.database.update(agents).set({ status: "active" }).where(eq(agents.id, fixture.agentId));
     await db.database.update(imBindings).set({ status: "error" }).where(eq(imBindings.id, fixture.bindingId));
     await expect(service.withCollaborationDispatchAdmission(route, operation)).resolves.toEqual({ admitted: false });
+    expect(logger.info).toHaveBeenLastCalledWith(
+      expect.objectContaining({ code: "SESSION_COLLABORATION_ADMISSION_BINDING_INVALID" }),
+      "Session collaboration dispatch admission rejected",
+    );
     await db.database.update(imBindings).set({ status: "active" }).where(eq(imBindings.id, fixture.bindingId));
     await db.database
       .update(sessionPlacements)
       .set({ generation: 2 })
       .where(eq(sessionPlacements.sessionId, target.session.id));
     await expect(service.withCollaborationDispatchAdmission(route, operation)).resolves.toEqual({ admitted: false });
+    expect(logger.info).toHaveBeenLastCalledWith(
+      expect.objectContaining({ code: "SESSION_COLLABORATION_ADMISSION_PLACEMENT_INVALID" }),
+      "Session collaboration dispatch admission rejected",
+    );
     await db.database
       .update(sessionPlacements)
       .set({ generation: 1 })
       .where(eq(sessionPlacements.sessionId, target.session.id));
     await db.database.update(sessions).set({ endedAt: fixture.now }).where(eq(sessions.id, target.session.id));
     await expect(service.withCollaborationDispatchAdmission(route, operation)).resolves.toEqual({ admitted: false });
+    expect(logger.info).toHaveBeenLastCalledWith(
+      expect.objectContaining({ code: "SESSION_COLLABORATION_ADMISSION_AUTHORITY_SESSION_INVALID" }),
+      "Session collaboration dispatch admission rejected",
+    );
   });
 
   it("moves and asserts placements while fencing uncertain custody", async () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -271,13 +271,14 @@ export async function startServer(): Promise<void> {
           : { status: "unconfirmed" };
       },
       onActiveBindingChanged: (input) => providerCliReconcileOwner?.onActiveBindingChanged(input),
+      logger: serviceLogger("im-binding"),
     });
     const accountSetupService = new AccountSetupService(database, imBindingService);
     const imMessageInbox = new ImMessageInbox(database);
     const feishuInboundReceipts = new FeishuInboundReceiptStore(database, {
       onMetric: (metric) => app?.log.info({ metric }, "Feishu inbound receipt metric"),
     });
-    const sessionService = new SessionService(database);
+    const sessionService = new SessionService(database, { logger: serviceLogger("session") });
     const taskService = new TaskService(database);
     const runtimeSnapshotAssembler = new EffectiveRuntimeSnapshotAssembler(database);
     const sessionCliProofService = new SessionCliProofService(database, registry, config.encryptionKey);
@@ -296,6 +297,7 @@ export async function startServer(): Promise<void> {
       onDiagnostic: reportDiagnostic,
       registry,
       sessions: sessionService,
+      logger: serviceLogger("session-collaboration"),
     });
     const agentService = new AgentService(database, {
       onDiagnostic: (code) => app?.log.error({ code }, "Agent lifecycle diagnostic"),

--- a/packages/server/src/services/im-bindings/credential-material.ts
+++ b/packages/server/src/services/im-bindings/credential-material.ts
@@ -32,7 +32,7 @@ export interface CredentialInspection {
 }
 
 export interface CredentialMaterialInput {
-  bindingId?: string;
+  slackInstallationId?: string | null;
   provider: "feishu" | "slack";
   encryptedCredential: string | null;
   externalAppId: string | null;
@@ -45,6 +45,7 @@ export interface CredentialMaterialInput {
 
 export interface CredentialDecodeOptions {
   bindingId?: string;
+  slackInstallationId?: string;
   logger?: Pick<ServiceLogger, "warn">;
 }
 
@@ -67,7 +68,11 @@ export function decodeFeishuCredential(
     plaintext = cipher.decrypt(encryptedCredential);
   } catch {
     options.logger?.warn(
-      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_DECRYPT_FAILED" },
+      {
+        bindingId: options.bindingId,
+        slackInstallationId: options.slackInstallationId,
+        code: "IM_BINDING_CREDENTIAL_DECRYPT_FAILED",
+      },
       "Feishu credential decrypt failed",
     );
     return undefined;
@@ -77,7 +82,11 @@ export function decodeFeishuCredential(
     payload = JSON.parse(plaintext);
   } catch {
     options.logger?.warn(
-      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_PAYLOAD_INVALID" },
+      {
+        bindingId: options.bindingId,
+        slackInstallationId: options.slackInstallationId,
+        code: "IM_BINDING_CREDENTIAL_PAYLOAD_INVALID",
+      },
       "Feishu credential payload parse failed",
     );
     return undefined;
@@ -86,7 +95,11 @@ export function decodeFeishuCredential(
     return FeishuCredentialSchema.parse(payload);
   } catch {
     options.logger?.warn(
-      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_SCHEMA_INVALID" },
+      {
+        bindingId: options.bindingId,
+        slackInstallationId: options.slackInstallationId,
+        code: "IM_BINDING_CREDENTIAL_SCHEMA_INVALID",
+      },
       "Feishu credential schema validation failed",
     );
     return undefined;
@@ -104,7 +117,11 @@ export function decodeSlackCredential(
     plaintext = cipher.decrypt(encryptedCredential);
   } catch {
     options.logger?.warn(
-      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_DECRYPT_FAILED" },
+      {
+        bindingId: options.bindingId,
+        slackInstallationId: options.slackInstallationId,
+        code: "IM_BINDING_CREDENTIAL_DECRYPT_FAILED",
+      },
       "Slack credential decrypt failed",
     );
     return undefined;
@@ -114,7 +131,11 @@ export function decodeSlackCredential(
     payload = JSON.parse(plaintext);
   } catch {
     options.logger?.warn(
-      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_PAYLOAD_INVALID" },
+      {
+        bindingId: options.bindingId,
+        slackInstallationId: options.slackInstallationId,
+        code: "IM_BINDING_CREDENTIAL_PAYLOAD_INVALID",
+      },
       "Slack credential payload parse failed",
     );
     return undefined;
@@ -123,7 +144,11 @@ export function decodeSlackCredential(
     return SlackCredentialSchema.parse(payload);
   } catch {
     options.logger?.warn(
-      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_SCHEMA_INVALID" },
+      {
+        bindingId: options.bindingId,
+        slackInstallationId: options.slackInstallationId,
+        code: "IM_BINDING_CREDENTIAL_SCHEMA_INVALID",
+      },
       "Slack credential schema validation failed",
     );
     return undefined;
@@ -134,7 +159,7 @@ export function slackInstallationInspectionInput(
   installation: typeof slackInstallations.$inferSelect,
 ): CredentialMaterialInput & { provider: "slack" } {
   return {
-    bindingId: installation.id,
+    slackInstallationId: installation.id,
     provider: "slack",
     encryptedCredential: installation.encryptedCredential,
     externalAppId: installation.externalAppId,
@@ -184,7 +209,8 @@ export function inspectCredentialMaterial(
   if (!materialEnvelopeValid(input)) return invalidInspection(storedCapabilities, requiredCapabilities);
   if (input.provider === "feishu") {
     const credential = decodeFeishuCredential(cipher, input.encryptedCredential, {
-      bindingId: options.bindingId ?? input.bindingId,
+      bindingId: options.bindingId,
+      slackInstallationId: options.slackInstallationId ?? input.slackInstallationId ?? undefined,
       logger: options.logger,
     });
     if (!credential) return invalidInspection(storedCapabilities, requiredCapabilities);
@@ -202,7 +228,8 @@ export function inspectCredentialMaterial(
     };
   }
   const credential = decodeSlackCredential(cipher, input.encryptedCredential, {
-    bindingId: options.bindingId ?? input.bindingId,
+    bindingId: options.bindingId,
+    slackInstallationId: options.slackInstallationId ?? input.slackInstallationId ?? undefined,
     logger: options.logger,
   });
   if (!credential) return invalidInspection(storedCapabilities, requiredCapabilities);
@@ -229,16 +256,19 @@ export function inspectBindingCredentials(
   installation: typeof slackInstallations.$inferSelect | null | undefined,
   options: CredentialDecodeOptions = {},
 ): CredentialInspection {
-  const bindingId = options.bindingId ?? binding.bindingId;
+  const bindingId = options.bindingId;
   if (binding.provider !== "slack") {
-    return inspectCredentialMaterial(cipher, binding, { bindingId, logger: options.logger });
+    return inspectCredentialMaterial(cipher, binding, {
+      bindingId,
+      slackInstallationId: options.slackInstallationId,
+      logger: options.logger,
+    });
   }
   return inspectCredentialMaterial(
     cipher,
     installation
       ? slackInstallationInspectionInput(installation)
       : {
-          bindingId,
           provider: "slack",
           encryptedCredential: null,
           externalAppId: binding.externalAppId,
@@ -248,6 +278,6 @@ export function inspectBindingCredentials(
           credentialSchemaVersion: binding.credentialSchemaVersion,
           grantedCapabilities: binding.grantedCapabilities,
         },
-    { bindingId, logger: options.logger },
+    { bindingId, slackInstallationId: options.slackInstallationId, logger: options.logger },
   );
 }

--- a/packages/server/src/services/im-bindings/credential-material.ts
+++ b/packages/server/src/services/im-bindings/credential-material.ts
@@ -1,6 +1,7 @@
 import { FEISHU_REQUIRED_TENANT_SCOPES, hasRequiredSlackBotScopes, SLACK_REQUIRED_BOT_SCOPES } from "@opentag/shared";
 import { z } from "zod";
 import type { slackInstallations } from "../../db/schema/index.js";
+import type { ServiceLogger } from "../../observability/service-logger.js";
 import type { ApplicationCipher } from "../crypto.js";
 
 export const FeishuCredentialSchema = z
@@ -31,6 +32,7 @@ export interface CredentialInspection {
 }
 
 export interface CredentialMaterialInput {
+  bindingId?: string;
   provider: "feishu" | "slack";
   encryptedCredential: string | null;
   externalAppId: string | null;
@@ -39,6 +41,11 @@ export interface CredentialMaterialInput {
   credentialGeneration: number;
   credentialSchemaVersion: number | null;
   grantedCapabilities: string[];
+}
+
+export interface CredentialDecodeOptions {
+  bindingId?: string;
+  logger?: Pick<ServiceLogger, "warn">;
 }
 
 function uniqueSorted(values: readonly string[]): string[] {
@@ -52,11 +59,36 @@ function requiredCapabilitiesFor(provider: "feishu" | "slack"): string[] {
 export function decodeFeishuCredential(
   cipher: ApplicationCipher,
   encryptedCredential: string | null,
+  options: CredentialDecodeOptions = {},
 ): FeishuCredential | undefined {
   if (!encryptedCredential) return undefined;
+  let plaintext: string;
   try {
-    return FeishuCredentialSchema.parse(JSON.parse(cipher.decrypt(encryptedCredential)));
+    plaintext = cipher.decrypt(encryptedCredential);
   } catch {
+    options.logger?.warn(
+      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_DECRYPT_FAILED" },
+      "Feishu credential decrypt failed",
+    );
+    return undefined;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(plaintext);
+  } catch {
+    options.logger?.warn(
+      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_PAYLOAD_INVALID" },
+      "Feishu credential payload parse failed",
+    );
+    return undefined;
+  }
+  try {
+    return FeishuCredentialSchema.parse(payload);
+  } catch {
+    options.logger?.warn(
+      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_SCHEMA_INVALID" },
+      "Feishu credential schema validation failed",
+    );
     return undefined;
   }
 }
@@ -64,11 +96,36 @@ export function decodeFeishuCredential(
 export function decodeSlackCredential(
   cipher: ApplicationCipher,
   encryptedCredential: string | null,
+  options: CredentialDecodeOptions = {},
 ): SlackCredential | undefined {
   if (!encryptedCredential) return undefined;
+  let plaintext: string;
   try {
-    return SlackCredentialSchema.parse(JSON.parse(cipher.decrypt(encryptedCredential)));
+    plaintext = cipher.decrypt(encryptedCredential);
   } catch {
+    options.logger?.warn(
+      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_DECRYPT_FAILED" },
+      "Slack credential decrypt failed",
+    );
+    return undefined;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(plaintext);
+  } catch {
+    options.logger?.warn(
+      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_PAYLOAD_INVALID" },
+      "Slack credential payload parse failed",
+    );
+    return undefined;
+  }
+  try {
+    return SlackCredentialSchema.parse(payload);
+  } catch {
+    options.logger?.warn(
+      { bindingId: options.bindingId, code: "IM_BINDING_CREDENTIAL_SCHEMA_INVALID" },
+      "Slack credential schema validation failed",
+    );
     return undefined;
   }
 }
@@ -77,6 +134,7 @@ export function slackInstallationInspectionInput(
   installation: typeof slackInstallations.$inferSelect,
 ): CredentialMaterialInput & { provider: "slack" } {
   return {
+    bindingId: installation.id,
     provider: "slack",
     encryptedCredential: installation.encryptedCredential,
     externalAppId: installation.externalAppId,
@@ -119,12 +177,16 @@ function capabilitiesMatch(left: readonly string[], right: readonly string[]): b
 export function inspectCredentialMaterial(
   cipher: ApplicationCipher,
   input: CredentialMaterialInput,
+  options: CredentialDecodeOptions = {},
 ): CredentialInspection {
   const requiredCapabilities = requiredCapabilitiesFor(input.provider);
   const storedCapabilities = uniqueSorted(input.grantedCapabilities);
   if (!materialEnvelopeValid(input)) return invalidInspection(storedCapabilities, requiredCapabilities);
   if (input.provider === "feishu") {
-    const credential = decodeFeishuCredential(cipher, input.encryptedCredential);
+    const credential = decodeFeishuCredential(cipher, input.encryptedCredential, {
+      bindingId: options.bindingId ?? input.bindingId,
+      logger: options.logger,
+    });
     if (!credential) return invalidInspection(storedCapabilities, requiredCapabilities);
     const credentialCapabilities = uniqueSorted(credential.grantedScopes);
     if (credential.appId !== input.externalAppId || !capabilitiesMatch(credentialCapabilities, storedCapabilities)) {
@@ -139,7 +201,10 @@ export function inspectCredentialMaterial(
       missingCapabilities: requiredCapabilities.filter((capability) => !storedCapabilities.includes(capability)),
     };
   }
-  const credential = decodeSlackCredential(cipher, input.encryptedCredential);
+  const credential = decodeSlackCredential(cipher, input.encryptedCredential, {
+    bindingId: options.bindingId ?? input.bindingId,
+    logger: options.logger,
+  });
   if (!credential) return invalidInspection(storedCapabilities, requiredCapabilities);
   const credentialCapabilities = uniqueSorted(credential.grantedScopes);
   const missingCapabilities = requiredCapabilities.filter(
@@ -162,13 +227,18 @@ export function inspectBindingCredentials(
   cipher: ApplicationCipher,
   binding: CredentialMaterialInput,
   installation: typeof slackInstallations.$inferSelect | null | undefined,
+  options: CredentialDecodeOptions = {},
 ): CredentialInspection {
-  if (binding.provider !== "slack") return inspectCredentialMaterial(cipher, binding);
+  const bindingId = options.bindingId ?? binding.bindingId;
+  if (binding.provider !== "slack") {
+    return inspectCredentialMaterial(cipher, binding, { bindingId, logger: options.logger });
+  }
   return inspectCredentialMaterial(
     cipher,
     installation
       ? slackInstallationInspectionInput(installation)
       : {
+          bindingId,
           provider: "slack",
           encryptedCredential: null,
           externalAppId: binding.externalAppId,
@@ -178,5 +248,6 @@ export function inspectBindingCredentials(
           credentialSchemaVersion: binding.credentialSchemaVersion,
           grantedCapabilities: binding.grantedCapabilities,
         },
+    { bindingId, logger: options.logger },
   );
 }

--- a/packages/server/src/services/im-bindings/im-binding-provider-cli.ts
+++ b/packages/server/src/services/im-bindings/im-binding-provider-cli.ts
@@ -14,6 +14,7 @@ import { hasRequiredFeishuTenantScopes, hasRequiredSlackBotScopes } from "@opent
 import { and, eq } from "drizzle-orm";
 import type { DatabaseClient } from "../../db/client.js";
 import { agents, computers, imBindings, slackInstallations } from "../../db/schema/index.js";
+import type { ServiceLogger } from "../../observability/service-logger.js";
 import type { ApplicationCipher } from "../crypto.js";
 import { decodeFeishuCredential, decodeSlackCredential } from "./credential-material.js";
 
@@ -83,6 +84,7 @@ function expectedIdentity(
   cipher: ApplicationCipher,
   binding: BindingRow,
   installation: SlackInstallationRow | null,
+  logger?: Pick<ServiceLogger, "warn">,
 ): ProviderCliExpectedIdentity | undefined {
   if (binding.provider === "feishu") {
     if (!binding.externalAppId || !binding.externalBotId) return undefined;
@@ -94,7 +96,10 @@ function expectedIdentity(
     };
   }
   if (!installation?.externalTeamId || !installation.externalBotId) return undefined;
-  const credential = decodeSlackCredential(cipher, installation.encryptedCredential);
+  const credential = decodeSlackCredential(cipher, installation.encryptedCredential, {
+    bindingId: binding.id,
+    logger,
+  });
   if (!credential) return undefined;
   return {
     provider: "slack",
@@ -107,8 +112,9 @@ function expectedIdentity(
 function requirementFromRow(
   cipher: ApplicationCipher,
   row: { binding: BindingRow; slackInstallation: SlackInstallationRow | null },
+  logger?: Pick<ServiceLogger, "warn">,
 ): ProviderCliRequirement | undefined {
-  const identity = expectedIdentity(cipher, row.binding, row.slackInstallation);
+  const identity = expectedIdentity(cipher, row.binding, row.slackInstallation, logger);
   if (!identity) return undefined;
   return {
     agentId: row.binding.agentId,
@@ -186,9 +192,10 @@ function feishuValidationGrant(
   binding: BindingRow,
   identity: ProviderCliExpectedIdentity,
   generation: number,
+  logger?: Pick<ServiceLogger, "warn">,
 ): { expectedIdentity: ProviderCliExpectedIdentity; grant: ProviderCliValidationGrantFrame["grant"] } | undefined {
   if (binding.credentialGeneration !== generation) return undefined;
-  const credential = decodeFeishuCredential(cipher, binding.encryptedCredential);
+  const credential = decodeFeishuCredential(cipher, binding.encryptedCredential, { bindingId: binding.id, logger });
   if (!credential || credential.appId !== binding.externalAppId) return undefined;
   return {
     expectedIdentity: identity,
@@ -203,14 +210,16 @@ function feishuValidationGrant(
 
 function slackValidationGrant(
   cipher: ApplicationCipher,
+  bindingId: string,
   installation: SlackInstallationRow | null,
   identity: ProviderCliExpectedIdentity,
   generation: number,
+  logger?: Pick<ServiceLogger, "warn">,
 ): { expectedIdentity: ProviderCliExpectedIdentity; grant: ProviderCliValidationGrantFrame["grant"] } | undefined {
   if (!installation || installation.status !== "active" || installation.credentialGeneration !== generation) {
     return undefined;
   }
-  const credential = decodeSlackCredential(cipher, installation.encryptedCredential);
+  const credential = decodeSlackCredential(cipher, installation.encryptedCredential, { bindingId, logger });
   if (!credential || !hasRequiredSlackBotScopes(credential.grantedScopes)) return undefined;
   return { expectedIdentity: identity, grant: { provider: "slack", botAccessToken: credential.botAccessToken } };
 }
@@ -220,6 +229,7 @@ export class ImBindingProviderCli {
   readonly #cipher: ApplicationCipher;
   readonly #artifactReadiness: ArtifactReadinessReader;
   readonly #credentialReadiness: ReadinessReader;
+  readonly #logger?: Pick<ServiceLogger, "warn">;
 
   constructor(
     database: DatabaseClient,
@@ -227,12 +237,14 @@ export class ImBindingProviderCli {
     options: {
       artifactReadiness: ArtifactReadinessReader;
       credentialReadiness: ReadinessReader;
+      logger?: Pick<ServiceLogger, "warn">;
     },
   ) {
     this.#database = database;
     this.#cipher = cipher;
     this.#artifactReadiness = options.artifactReadiness;
     this.#credentialReadiness = options.credentialReadiness;
+    this.#logger = options.logger;
   }
 
   async listActiveRequirements(computerId: string): Promise<readonly ProviderCliRequirement[]> {
@@ -243,7 +255,7 @@ export class ImBindingProviderCli {
       .leftJoin(slackInstallations, eq(slackInstallations.id, imBindings.slackInstallationId))
       .where(and(eq(agents.computerId, computerId), eq(agents.status, "active"), eq(imBindings.status, "active")));
     return rows.flatMap((row) => {
-      const requirement = requirementFromRow(this.#cipher, row);
+      const requirement = requirementFromRow(this.#cipher, row, this.#logger);
       return requirement ? [requirement] : [];
     });
   }
@@ -277,11 +289,18 @@ export class ImBindingProviderCli {
     ) {
       return undefined;
     }
-    const identity = expectedIdentity(this.#cipher, row.binding, row.slackInstallation);
+    const identity = expectedIdentity(this.#cipher, row.binding, row.slackInstallation, this.#logger);
     if (!identity) return undefined;
     return row.binding.provider === "feishu"
-      ? feishuValidationGrant(this.#cipher, row.binding, identity, input.credentialGeneration)
-      : slackValidationGrant(this.#cipher, row.slackInstallation, identity, input.credentialGeneration);
+      ? feishuValidationGrant(this.#cipher, row.binding, identity, input.credentialGeneration, this.#logger)
+      : slackValidationGrant(
+          this.#cipher,
+          row.binding.id,
+          row.slackInstallation,
+          identity,
+          input.credentialGeneration,
+          this.#logger,
+        );
   }
 
   async readiness(

--- a/packages/server/src/services/im-bindings/im-binding-service.ts
+++ b/packages/server/src/services/im-bindings/im-binding-service.ts
@@ -31,8 +31,10 @@ import {
   sessions,
   slackInstallations,
 } from "../../db/schema/index.js";
+import type { ServiceLogger } from "../../observability/service-logger.js";
 import type { ApplicationCipher } from "../crypto.js";
 import {
+  type CredentialMaterialInput,
   decodeFeishuCredential,
   decodeSlackCredential,
   type FeishuCredential,
@@ -50,6 +52,7 @@ import {
 } from "./im-binding-provider-cli.js";
 
 type QueryExecutor = Pick<DatabaseClient, "select">;
+type CredentialMaterialWithId = CredentialMaterialInput & { id?: string };
 
 export interface VerifiedFeishuBinding {
   agentId: string;
@@ -293,6 +296,7 @@ export class ImBindingService {
   readonly #onActiveBindingChanged:
     | ((input: { agentId: string; computerId: string }) => Promise<void> | void)
     | undefined;
+  readonly #logger?: Pick<ServiceLogger, "warn">;
 
   constructor(
     database: DatabaseClient,
@@ -316,12 +320,14 @@ export class ImBindingService {
         | Promise<{ status: IntegrationCredentialExecutionStatus; reason?: IntegrationCredentialExecutionReason }>
         | { status: IntegrationCredentialExecutionStatus; reason?: IntegrationCredentialExecutionReason };
       onActiveBindingChanged?: (input: { agentId: string; computerId: string }) => Promise<void> | void;
+      logger?: Pick<ServiceLogger, "warn">;
     } = {},
   ) {
     this.#database = database;
     this.#afterMutationAuthorityLocked = options.afterMutationAuthorityLocked;
     this.#cipher = cipher;
     this.#now = options.now ?? (() => new Date());
+    this.#logger = options.logger;
     this.#agentRuntimeReadiness = async (agentId) => (await options.agentRuntimeReadiness?.(agentId)) ?? "ready";
     this.#providerCli = new ImBindingProviderCli(database, cipher, {
       artifactReadiness: async (agentId, provider, integrationId, credentialGeneration) =>
@@ -330,6 +336,7 @@ export class ImBindingService {
         (await options.credentialExecutionReadiness?.(agentId, provider, integrationId, credentialGeneration)) ?? {
           status: "unconfirmed",
         },
+      logger: this.#logger,
     });
     this.#onActiveBindingChanged = options.onActiveBindingChanged;
   }
@@ -416,7 +423,7 @@ export class ImBindingService {
       return rejected("credential_stale");
     }
     const issueFeishuGrant = async (): Promise<RuntimeImCredentialGrantResult> => {
-      const credential = this.#decodeFeishuCredential(binding.encryptedCredential);
+      const credential = this.#decodeFeishuCredential(binding.encryptedCredential, binding.id);
       if (!credential || credential.appId !== binding.externalAppId) return rejected("credential_stale");
       if (
         !(await this.#runtimeProviderCliReady(
@@ -456,10 +463,12 @@ export class ImBindingService {
       ) {
         return rejected("binding_inactive");
       }
-      if (this.#inspectCredentialMaterial(slackInstallationInspectionInput(installation)).status !== "valid") {
+      if (
+        this.#inspectCredentialMaterial(slackInstallationInspectionInput(installation), binding.id).status !== "valid"
+      ) {
         return rejected("credential_stale");
       }
-      const credential = this.#decodeSlackCredential(installation.encryptedCredential);
+      const credential = this.#decodeSlackCredential(installation.encryptedCredential, binding.id);
       if (!credential || !hasRequiredSlackBotScopes(credential.grantedScopes)) return rejected("credential_stale");
       if (
         !(await this.#runtimeProviderCliReady(
@@ -576,7 +585,7 @@ export class ImBindingService {
 
   async findSlackInstallationIngressForAgent(agentId: string): Promise<SlackInstallationIngress | undefined> {
     const [row] = await this.#database
-      .select({ installation: slackInstallations })
+      .select({ installation: slackInstallations, bindingId: imBindings.id })
       .from(imBindings)
       .innerJoin(agents, eq(agents.id, imBindings.agentId))
       .innerJoin(slackInstallations, eq(slackInstallations.id, imBindings.slackInstallationId))
@@ -591,7 +600,7 @@ export class ImBindingService {
         ),
       )
       .limit(1);
-    return this.#slackInstallationIngressFromRow(row?.installation);
+    return this.#slackInstallationIngressFromRow(row?.installation, row?.bindingId);
   }
 
   async resolveSlackDefaultRoute(installationId: string): Promise<SlackInboundRoute | undefined> {
@@ -638,9 +647,9 @@ export class ImBindingService {
     if (!row?.installation.observedConnectedAt) {
       return undefined;
     }
-    const ingress = this.#slackInstallationIngressFromRow(row.installation);
+    const ingress = this.#slackInstallationIngressFromRow(row.installation, row.imBinding.id);
     if (!ingress) return undefined;
-    const credential = this.#decodeSlackCredential(row.installation.encryptedCredential);
+    const credential = this.#decodeSlackCredential(row.installation.encryptedCredential, row.imBinding.id);
     if (!credential) return undefined;
     return {
       imBindingId,
@@ -680,7 +689,7 @@ export class ImBindingService {
     const imBinding = await this.#activeMaterial(imBindingId, "feishu", transaction);
     if (!imBinding?.externalAppId || !imBinding.externalBotId) return undefined;
     if (this.#inspectCredentialMaterial(imBinding).status !== "valid") return undefined;
-    const credential = this.#decodeFeishuCredential(imBinding.encryptedCredential);
+    const credential = this.#decodeFeishuCredential(imBinding.encryptedCredential, imBindingId);
     if (!credential) return undefined;
     return {
       imBindingId,
@@ -1190,18 +1199,11 @@ export class ImBindingService {
   ): T & { credentialStatus: "valid" | "invalid" } {
     return { ...imBinding, credentialStatus };
   }
-
-  #inspectCredentialMaterial(input: {
-    provider: "feishu" | "slack";
-    encryptedCredential: string | null;
-    externalAppId: string | null;
-    externalBotId: string | null;
-    externalTeamId: string | null;
-    credentialGeneration: number;
-    credentialSchemaVersion: number | null;
-    grantedCapabilities: string[];
-  }): CredentialInspection {
-    return inspectCredentialMaterial(this.#cipher, input);
+  #inspectCredentialMaterial(input: CredentialMaterialWithId, bindingId?: string): CredentialInspection {
+    return inspectCredentialMaterial(this.#cipher, input, {
+      bindingId: bindingId ?? input.bindingId ?? input.id,
+      logger: this.#logger,
+    });
   }
 
   async notifyProviderCliRequirementChanged(agentId: string): Promise<void> {
@@ -1215,40 +1217,35 @@ export class ImBindingService {
     await this.#onActiveBindingChanged({ agentId, computerId });
   }
 
-  #decodeFeishuCredential(encryptedCredential: string | null): FeishuCredential | undefined {
-    return decodeFeishuCredential(this.#cipher, encryptedCredential);
+  #decodeFeishuCredential(encryptedCredential: string | null, bindingId?: string): FeishuCredential | undefined {
+    return decodeFeishuCredential(this.#cipher, encryptedCredential, { bindingId, logger: this.#logger });
   }
 
-  #decodeSlackCredential(encryptedCredential: string | null): SlackCredential | undefined {
-    return decodeSlackCredential(this.#cipher, encryptedCredential);
+  #decodeSlackCredential(encryptedCredential: string | null, bindingId?: string): SlackCredential | undefined {
+    return decodeSlackCredential(this.#cipher, encryptedCredential, { bindingId, logger: this.#logger });
   }
 
   #inspectBindingCredentials(
-    binding: {
-      provider: "feishu" | "slack";
-      encryptedCredential: string | null;
-      externalAppId: string | null;
-      externalBotId: string | null;
-      externalTeamId: string | null;
-      credentialGeneration: number;
-      credentialSchemaVersion: number | null;
-      grantedCapabilities: string[];
-    },
+    binding: CredentialMaterialWithId,
     installation: typeof slackInstallations.$inferSelect | null | undefined,
   ): CredentialInspection {
-    return inspectBindingCredentials(this.#cipher, binding, installation);
+    return inspectBindingCredentials(this.#cipher, binding, installation, {
+      bindingId: binding.bindingId ?? binding.id,
+      logger: this.#logger,
+    });
   }
 
   #slackInstallationIngressFromRow(
     installation: typeof slackInstallations.$inferSelect | undefined,
+    bindingId?: string,
   ): SlackInstallationIngress | undefined {
     if (
       !installation ||
-      this.#inspectCredentialMaterial(slackInstallationInspectionInput(installation)).status !== "valid"
+      this.#inspectCredentialMaterial(slackInstallationInspectionInput(installation), bindingId).status !== "valid"
     ) {
       return undefined;
     }
-    const credential = this.#decodeSlackCredential(installation.encryptedCredential);
+    const credential = this.#decodeSlackCredential(installation.encryptedCredential, bindingId ?? installation.id);
     if (!credential || !hasRequiredSlackBotScopes(credential.grantedScopes)) return undefined;
     return {
       installationId: installation.id,
@@ -1447,7 +1444,10 @@ export class ImBindingService {
       }
       const existingInstallation = currentAppTeamInstallation ?? currentSameAgentInstallation;
       if (existingInstallation) {
-        const currentCredential = this.#decodeSlackCredential(existingInstallation.encryptedCredential);
+        const currentCredential = this.#decodeSlackCredential(
+          existingInstallation.encryptedCredential,
+          configuredRoute?.id,
+        );
         const sameIdentity =
           existingInstallation.externalAppId === input.appId &&
           existingInstallation.externalTeamId === input.teamId &&

--- a/packages/server/src/services/im-bindings/im-binding-service.ts
+++ b/packages/server/src/services/im-bindings/im-binding-service.ts
@@ -419,7 +419,7 @@ export class ImBindingService {
     const binding = row.binding;
     const sessionKind = row.sessionKind;
     if (binding.status !== "active") return rejected("binding_inactive");
-    if (binding.provider !== "slack" && this.#inspectCredentialMaterial(binding).status !== "valid") {
+    if (binding.provider !== "slack" && this.#inspectCredentialMaterial(binding, binding.id).status !== "valid") {
       return rejected("credential_stale");
     }
     const issueFeishuGrant = async (): Promise<RuntimeImCredentialGrantResult> => {
@@ -580,7 +580,7 @@ export class ImBindingService {
         ),
       )
       .limit(1);
-    return this.#slackInstallationIngressFromRow(row);
+    return this.#slackInstallationIngressFromRow(row, undefined, row?.id);
   }
 
   async findSlackInstallationIngressForAgent(agentId: string): Promise<SlackInstallationIngress | undefined> {
@@ -600,7 +600,7 @@ export class ImBindingService {
         ),
       )
       .limit(1);
-    return this.#slackInstallationIngressFromRow(row?.installation, row?.bindingId);
+    return this.#slackInstallationIngressFromRow(row?.installation, row?.bindingId, row?.installation.id);
   }
 
   async resolveSlackDefaultRoute(installationId: string): Promise<SlackInboundRoute | undefined> {
@@ -647,7 +647,7 @@ export class ImBindingService {
     if (!row?.installation.observedConnectedAt) {
       return undefined;
     }
-    const ingress = this.#slackInstallationIngressFromRow(row.installation, row.imBinding.id);
+    const ingress = this.#slackInstallationIngressFromRow(row.installation, row.imBinding.id, row.installation.id);
     if (!ingress) return undefined;
     const credential = this.#decodeSlackCredential(row.installation.encryptedCredential, row.imBinding.id);
     if (!credential) return undefined;
@@ -688,7 +688,7 @@ export class ImBindingService {
   ): Promise<FeishuConnectionMaterial | undefined> {
     const imBinding = await this.#activeMaterial(imBindingId, "feishu", transaction);
     if (!imBinding?.externalAppId || !imBinding.externalBotId) return undefined;
-    if (this.#inspectCredentialMaterial(imBinding).status !== "valid") return undefined;
+    if (this.#inspectCredentialMaterial(imBinding, imBinding.id).status !== "valid") return undefined;
     const credential = this.#decodeFeishuCredential(imBinding.encryptedCredential, imBindingId);
     if (!credential) return undefined;
     return {
@@ -1200,12 +1200,9 @@ export class ImBindingService {
     return { ...imBinding, credentialStatus };
   }
   #inspectCredentialMaterial(input: CredentialMaterialWithId, bindingId?: string): CredentialInspection {
-    return inspectCredentialMaterial(this.#cipher, input, {
-      bindingId: bindingId ?? input.bindingId ?? input.id,
-      logger: this.#logger,
-    });
+    const options = { bindingId, slackInstallationId: input.slackInstallationId ?? undefined };
+    return inspectCredentialMaterial(this.#cipher, input, { ...options, logger: this.#logger });
   }
-
   async notifyProviderCliRequirementChanged(agentId: string): Promise<void> {
     await this.#notifyActiveBindingChanged(agentId);
   }
@@ -1221,8 +1218,9 @@ export class ImBindingService {
     return decodeFeishuCredential(this.#cipher, encryptedCredential, { bindingId, logger: this.#logger });
   }
 
-  #decodeSlackCredential(encryptedCredential: string | null, bindingId?: string): SlackCredential | undefined {
-    return decodeSlackCredential(this.#cipher, encryptedCredential, { bindingId, logger: this.#logger });
+  #decodeSlackCredential(encryptedCredential: string | null, bindingId?: string, slackInstallationId?: string) {
+    const options = { bindingId, slackInstallationId };
+    return decodeSlackCredential(this.#cipher, encryptedCredential, { ...options, logger: this.#logger });
   }
 
   #inspectBindingCredentials(
@@ -1230,7 +1228,7 @@ export class ImBindingService {
     installation: typeof slackInstallations.$inferSelect | null | undefined,
   ): CredentialInspection {
     return inspectBindingCredentials(this.#cipher, binding, installation, {
-      bindingId: binding.bindingId ?? binding.id,
+      bindingId: binding.id,
       logger: this.#logger,
     });
   }
@@ -1238,6 +1236,7 @@ export class ImBindingService {
   #slackInstallationIngressFromRow(
     installation: typeof slackInstallations.$inferSelect | undefined,
     bindingId?: string,
+    slackInstallationId?: string,
   ): SlackInstallationIngress | undefined {
     if (
       !installation ||
@@ -1245,7 +1244,7 @@ export class ImBindingService {
     ) {
       return undefined;
     }
-    const credential = this.#decodeSlackCredential(installation.encryptedCredential, bindingId ?? installation.id);
+    const credential = this.#decodeSlackCredential(installation.encryptedCredential, bindingId, slackInstallationId);
     if (!credential || !hasRequiredSlackBotScopes(credential.grantedScopes)) return undefined;
     return {
       installationId: installation.id,
@@ -1447,6 +1446,7 @@ export class ImBindingService {
         const currentCredential = this.#decodeSlackCredential(
           existingInstallation.encryptedCredential,
           configuredRoute?.id,
+          existingInstallation.id,
         );
         const sameIdentity =
           existingInstallation.externalAppId === input.appId &&

--- a/packages/server/src/services/sessions/session-collaboration-service.ts
+++ b/packages/server/src/services/sessions/session-collaboration-service.ts
@@ -9,6 +9,7 @@ import {
   type SessionMessageDeliveryResult,
   type SessionReconcileResult,
 } from "@opentag/shared";
+import type { ServiceLogger } from "../../observability/service-logger.js";
 import type { ConnectionRegistry } from "../../runtime/connection-registry.js";
 import { type RuntimeDomainOwner, RuntimeDomainRequestError } from "../../runtime/runtime-domain-owner.js";
 import type { EffectiveRuntimeSnapshotAssembler } from "../runtime-config/index.js";
@@ -27,6 +28,7 @@ export interface SessionCollaborationServiceOptions {
     | "withCollaborationDispatchAdmission"
   >;
   onDiagnostic?: (code: string) => void;
+  logger?: Pick<ServiceLogger, "error">;
 }
 
 export class SessionCollaborationService {
@@ -35,6 +37,7 @@ export class SessionCollaborationService {
   readonly #registry: SessionCollaborationServiceOptions["registry"];
   readonly #sessions: SessionCollaborationServiceOptions["sessions"];
   readonly #onDiagnostic: SessionCollaborationServiceOptions["onDiagnostic"];
+  readonly #logger: SessionCollaborationServiceOptions["logger"];
 
   constructor(options: SessionCollaborationServiceOptions) {
     this.#assembler = options.assembler;
@@ -42,6 +45,7 @@ export class SessionCollaborationService {
     this.#registry = options.registry;
     this.#sessions = options.sessions;
     this.#onDiagnostic = options.onDiagnostic;
+    this.#logger = options.logger;
   }
 
   async create(input: SessionCliCreateRequest, source: SessionCliSourceContext): Promise<SessionCliCommandResponse> {
@@ -97,6 +101,11 @@ export class SessionCollaborationService {
     try {
       runtime = await this.#assembler.assembleForSession(attempt.route.targetSessionId);
     } catch {
+      this.#logInternalFailure("SESSION_COLLABORATION_RUNTIME_ASSEMBLY_FAILED", {
+        messageId: attempt.message.id,
+        sessionId,
+        targetSessionId: attempt.route.targetSessionId,
+      });
       return this.#record(
         response(attempt.message.id, "unreachable", sessionId, "runtime_not_ready"),
         attempt.attemptCount,
@@ -211,7 +220,18 @@ export class SessionCollaborationService {
     } catch {
       // The durable outcome remains unknown; commands never replay automatically.
     }
+    this.#logInternalFailure("SESSION_COLLABORATION_OUTCOME_WRITE_FAILED", {
+      attemptCount,
+      code: result.code,
+      messageId: result.messageId,
+      outcome: result.status,
+      sessionId: result.sessionId,
+    });
     return response(result.messageId, "unknown", result.sessionId, "outcome_write_failed");
+  }
+
+  #logInternalFailure(code: string, bindings: Record<string, unknown>): void {
+    this.#logger?.error({ ...bindings, code }, "Session collaboration internal failure");
   }
 
   #failure(messageId: string, error: unknown): SessionCliCommandResponse {

--- a/packages/server/src/services/sessions/session-service.ts
+++ b/packages/server/src/services/sessions/session-service.ts
@@ -21,6 +21,7 @@ import {
   sessionPlacements,
   sessions,
 } from "../../db/schema/index.js";
+import type { ServiceLogger } from "../../observability/service-logger.js";
 
 type SessionRow = typeof sessions.$inferSelect;
 type PlacementRow = typeof sessionPlacements.$inferSelect;
@@ -37,6 +38,16 @@ interface ActiveSessionAuthority {
 
 function hashSessionMessage(content: string): string {
   return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function internalSessionInputMatches(target: SessionRow, input: CreateInternalSessionWithMessageInput): boolean {
+  return (
+    target.kind === "internal" &&
+    target.createdBySessionId === input.creatorSessionId &&
+    target.runtimeModel === (input.overrides?.model ?? null) &&
+    target.runtimeReasoningEffort === (input.overrides?.reasoningEffort ?? null) &&
+    target.runtimeMaxDurationMs === (input.overrides?.maxDurationMs ?? null)
+  );
 }
 
 export interface EnsureChatSessionInTransactionInput {
@@ -140,11 +151,20 @@ export class SessionService {
   readonly #database: DatabaseClient;
   readonly #afterPlacementLock: (() => Promise<void>) | undefined;
   readonly #now: () => Date;
+  readonly #logger?: Pick<ServiceLogger, "info">;
 
-  constructor(database: DatabaseClient, options: { afterPlacementLock?: () => Promise<void>; now?: () => Date } = {}) {
+  constructor(
+    database: DatabaseClient,
+    options: {
+      afterPlacementLock?: () => Promise<void>;
+      now?: () => Date;
+      logger?: Pick<ServiceLogger, "info">;
+    } = {},
+  ) {
     this.#database = database;
     this.#afterPlacementLock = options.afterPlacementLock;
     this.#now = options.now ?? (() => new Date());
+    this.#logger = options.logger;
   }
 
   async ensureChatSession(
@@ -223,13 +243,7 @@ export class SessionService {
       if (existing) {
         this.#assertMessageIdentity(existing, input.creatorSessionId, existing.targetSessionId, input.initialMessage);
         const target = await this.#activeTarget(transaction, existing.targetSessionId, creator.session);
-        if (
-          target.session.kind !== "internal" ||
-          target.session.createdBySessionId !== input.creatorSessionId ||
-          target.session.runtimeModel !== (input.overrides?.model ?? null) ||
-          target.session.runtimeReasoningEffort !== (input.overrides?.reasoningEffort ?? null) ||
-          target.session.runtimeMaxDurationMs !== (input.overrides?.maxDurationMs ?? null)
-        ) {
+        if (!internalSessionInputMatches(target.session, input)) {
           throw new SessionServiceError("SESSION_MESSAGE_CONFLICT", "The Session message ID has conflicting input");
         }
         const attempt = await this.#beginAttempt(transaction, existing);
@@ -417,7 +431,10 @@ export class SessionService {
         .where(eq(agents.id, route.agentId))
         .limit(1)
         .for("update");
-      if (agent?.status !== "active") return { admitted: false } as const;
+      if (agent?.status !== "active") {
+        this.#logAdmissionRejection(route, "SESSION_COLLABORATION_ADMISSION_AGENT_INACTIVE");
+        return { admitted: false } as const;
+      }
 
       const [binding] = await transaction
         .select({ agentId: imBindings.agentId, status: imBindings.status })
@@ -425,7 +442,10 @@ export class SessionService {
         .where(eq(imBindings.id, route.imBindingId))
         .limit(1)
         .for("update");
-      if (binding?.agentId !== route.agentId || binding.status !== "active") return { admitted: false } as const;
+      if (binding?.agentId !== route.agentId || binding.status !== "active") {
+        this.#logAdmissionRejection(route, "SESSION_COLLABORATION_ADMISSION_BINDING_INVALID");
+        return { admitted: false } as const;
+      }
 
       const authoritySessionIds = [...new Set([route.sourceSessionId, route.targetSessionId])].sort();
       const authoritySessions = await transaction
@@ -438,6 +458,7 @@ export class SessionService {
         authoritySessions.length !== authoritySessionIds.length ||
         authoritySessions.some(({ endedAt, imBindingId }) => endedAt !== null || imBindingId !== route.imBindingId)
       ) {
+        this.#logAdmissionRejection(route, "SESSION_COLLABORATION_ADMISSION_AUTHORITY_SESSION_INVALID");
         return { admitted: false } as const;
       }
 
@@ -461,6 +482,7 @@ export class SessionService {
         targetPlacement?.computerId !== route.targetComputerId ||
         targetPlacement.generation !== route.targetPlacementGeneration
       ) {
+        this.#logAdmissionRejection(route, "SESSION_COLLABORATION_ADMISSION_PLACEMENT_INVALID");
         return { admitted: false } as const;
       }
 
@@ -475,6 +497,7 @@ export class SessionService {
         placementComputers.length !== placementComputerIds.length ||
         placementComputers.some(({ ownerAccountId }) => ownerAccountId !== agent.createdByUserId)
       ) {
+        this.#logAdmissionRejection(route, "SESSION_COLLABORATION_ADMISSION_COMPUTER_OWNERSHIP_INVALID");
         return { admitted: false } as const;
       }
 
@@ -487,6 +510,7 @@ export class SessionService {
         .limit(1)
         .for("update");
       if (!sourceComputer || sourceComputer.currentInstanceId !== route.sourceConnectionInstanceId) {
+        this.#logAdmissionRejection(route, "SESSION_COLLABORATION_ADMISSION_SOURCE_INSTANCE_STALE");
         return { admitted: false } as const;
       }
 
@@ -505,6 +529,21 @@ export class SessionService {
       await dispatched;
       return { admitted: true, result } as const;
     });
+  }
+
+  #logAdmissionRejection(route: AuthorizedSessionMessageRoute, code: string): void {
+    this.#logger?.info(
+      {
+        agentId: route.agentId,
+        code,
+        imBindingId: route.imBindingId,
+        sourceComputerId: route.sourceComputerId,
+        sourceSessionId: route.sourceSessionId,
+        targetComputerId: route.targetComputerId,
+        targetSessionId: route.targetSessionId,
+      },
+      "Session collaboration dispatch admission rejected",
+    );
   }
 
   async recordMessageOutcome(input: {


### PR DESCRIPTION
## What this changes

`packages/server/src/services/**` had 73 catch sites, 18 of them bare `catch {}`, and 6 logging call
sites in total. Its dominant failure mode was not a thrown error but a **silent verdict**:
semantically distinct authorization and decode failures collapsing into one indistinguishable value.

This makes those verdicts legible. **Response contracts are unchanged** — every return shape, every
status code and every existing service test is untouched. Logging is observation only.

### 1. Credential decode: three unrelated causes, one `undefined`

`decodeFeishuCredential` / `decodeSlackCredential` wrapped
`Schema.parse(JSON.parse(cipher.decrypt(...)))` in a single `catch {}`. One key rotation disconnects
every Feishu channel at once and returns `credential_stale` everywhere, with nothing in the log to
tell "wrong key" from "schema drift". The three causes are now separated, each with its own code:

| cause | code |
| --- | --- |
| `cipher.decrypt` throws — wrong or rotated `OPENTAG_ENCRYPTION_KEY` | `IM_BINDING_CREDENTIAL_DECRYPT_FAILED` |
| `JSON.parse` throws — stored ciphertext corrupt | `IM_BINDING_CREDENTIAL_PAYLOAD_INVALID` |
| `Schema.parse` throws — credential schema drift | `IM_BINDING_CREDENTIAL_SCHEMA_INVALID` |

The `undefined` return is preserved. Nothing from the payload is logged — no ciphertext, no decrypted
field, no `appSecret`, no Zod `received` value; only the failure class and the binding id.

### 2. Six admission gates, one boolean

`SessionService.withCollaborationDispatchAdmission` returned `{ admitted: false }` from six
semantically different places, all silent. Each now emits an `info` line with a distinct
discriminator plus the ids already in scope. The return shape is still exactly
`{ admitted: false } as const`.

`SESSION_COLLABORATION_ADMISSION_AGENT_INACTIVE` · `_BINDING_INVALID` ·
`_AUTHORITY_SESSION_INVALID` · `_PLACEMENT_INVALID` · `_COMPUTER_OWNERSHIP_INVALID` ·
`_SOURCE_INSTANCE_STALE`

### 3. The inverted diagnostic in session collaboration

The service reported the wrong half of its failures: a benign business rejection fired a diagnostic,
while `#deliver`'s bare `catch {}` turned an assembler exception into the tidy outcome
`runtime_not_ready`, and `#record`'s bare `catch {}` swallowed a durable outcome-write failure — a
data-loss shaped event. Both internal failures now log
(`SESSION_COLLABORATION_RUNTIME_ASSEMBLY_FAILED`, `SESSION_COLLABORATION_OUTCOME_WRITE_FAILED`);
the existing benign diagnostic is kept as it was.

### 4. Wired through the existing port

Services receive the logger via the `serviceLogger(...)` port already exposed in `index.ts` — one
property per construction site. No second logging mechanism, no direct pino import.

### 5. Follow-up: `bindingId` no longer carries a substitute id (`9bbee4ee`)

Orchestrator verification caught a defect in the first commit before this branch was published:
`slackInstallationInspectionInput` populated the field named `bindingId` from
`slack_installations.id`, and two fallbacks (`bindingId ?? installation.id`,
`?? input.id`) propagated it. An operator grepping that value against `im_bindings` would have found
nothing — the log stating something untrue is exactly the failure class this change exists to
remove. `slackInstallationId` is now its own key, the substitute-id fallbacks are gone, and
`bindingId` is either a genuine `im_bindings.id` or absent.

## Checklist

- [x] 1. Credential decode distinguishes decrypt / parse / schema failures; return stays `undefined`
- [x] 2. No ciphertext, credential field, `appSecret` or Zod `received` value reaches a log
- [x] 3. All six admission gates emit a distinct discriminator; return shape unchanged
- [x] 4. `#deliver` and `#record` internal failures are logged
- [x] 5. Services receive the logger via `serviceLogger(...)`, one property per construction site
- [x] 6. `agent-service.ts` background helpers untouched
- [x] 7. Tests cover every new discriminator
- [x] 8. One concept, one key — `bindingId` and `slackInstallationId` never substitute for each other

## Acceptance criteria — verified by the orchestrator, not self-reported

| criterion | outcome |
| --- | --- |
| `pnpm check` | exit 0 |
| `pnpm typecheck` | exit 0 |
| `pnpm build` | exit 0 |
| `pnpm --filter @opentag/server test` | exit 0 — 64 files, 628 tests |
| `pnpm test` (root) | **exit 1, environmental** — see below |
| A test distinguishes all three credential-decode failure classes from the log alone | pass — `credential-material.test.ts`, both providers |
| A test proves a credential value, ciphertext and `appSecret` never appear in the log output | pass — asserted against ciphertext, `appSecret` and the Zod `received` value |
| A test asserts each of the six admission gates by its own discriminator | pass — all six present in `session-services.unit.test.ts` |
| A test proves an outcome-write failure in `#record` is no longer silent | pass — `SESSION_COLLABORATION_OUTCOME_WRITE_FAILED` asserted |
| Response contracts unchanged — existing service tests pass unmodified | pass — the two touched test files removed no assertion; the only deletions are constructor fixtures |
| No drizzle migration; `CURRENT_MIGRATION_COUNT` untouched | pass — 0 migration files, constant untouched |
| `git status --porcelain` empty | pass |

**On the root `pnpm test` exit 1.** The only failure is
`scripts/__tests__/lefthook-stage-fixed.test.mjs`, which makes a signing commit and dies with
`error: 1Password: failed to fill whole buffer` / `fatal: failed to write commit object`. The same
failure reproduces identically on clean `main` at `e299cea4`, which contains none of this work, and
this branch touches no file under `scripts/`. It is the verifying host's 1Password agent being
locked (`ssh-add -l` reports no identities), not a defect in this change. CI signs nothing, so the
job is expected to pass there.

## Deviation from the confirmed plan

None. The plan explicitly forbade wrapping `agent-service.ts`'s `#stopSessionsBestEffort` /
`#notifyProviderCliPlacement` in `BackgroundFailureSupervisor`, and that file is untouched.

## Commit granularity

Two commits for an eight-item checklist — the first commit is coarser than the commit policy asks
for. Noted rather than rewritten: rebasing a verified branch risks the work for a tidier history.

---

*Provenance: written by codex under `/dispatch-codex` run `337683`, lane `server-domain-services-1`,
running with approvals and sandbox bypassed inside an isolated git worktree. Verified and published
by the orchestrator; the acceptance table above records checks the orchestrator re-ran itself.*
