### PR TITLE
chore(github): exempt dependency manifests from code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,13 +14,34 @@
 *                           @bestony @yuezengwu
 
 # Territory carve-outs: routine chores, owner-author self-merges on green CI.
-/pnpm-lock.yaml             @bestony @yuezengwu
 /.editorconfig              @bestony @yuezengwu
 /.gitignore                 @bestony @yuezengwu
 /LICENSE                    @bestony @yuezengwu
 
 # Docs fast lane: territory. Overrides the gate for markdown anywhere outside web.
 *.md                        @yuezengwu @bestony @Gandy2025 @liuchao-001
+
+# Exempt: dependency manifests, no owners on purpose. GitHub auto-requests a
+# review from the owners of every file a pull request touches, which put a human
+# on the reviewer list of every dependabot bump. Ownerless is the only lever
+# that reaches that behaviour: the auto-request runs off this file alone and
+# cannot tell dependabot from anyone else.
+#
+# `package.json` is depth-agnostic because dependabot bumps the workspace
+# manifests, not only the root one.
+#
+# The block sits BETWEEN *.md and the gate pins, and both edges are load-bearing.
+# Below *.md: a manifest inside a directory whose name ends in .md would
+# otherwise be reached by *.md but named by this rule, and the gate resolves that
+# disagreement by falling back to gate mode over an ownerless rule -- a red check
+# no approval can clear. Above the pins: a manifest ever added under .github/ or
+# packages/server/drizzle/ keeps the pin's gate instead of escaping through here.
+#
+# This does not make a dependabot pull request self-mergeable. The ownership
+# gate separately requires an owner approval from any author without write
+# access, bots included, whatever files the pull request touches.
+package.json
+/pnpm-lock.yaml
 
 # Gate pins. Both sit BELOW *.md because the markdown fast lane would otherwise
 # win for the one markdown file each of them contains, and a pin that a later

--- a/.github/ownership-modes.json
+++ b/.github/ownership-modes.json
@@ -3,11 +3,12 @@
   "documentation": "Review mode per .github/CODEOWNERS rule pattern, enforced by the ownership-gate check. gate = mutual review, no author self-exemption. territory = an owner may self-merge on green CI, anyone else needs an owner approval. exempt = the rule deliberately lists no owners and requires nothing. Patterns must match .github/CODEOWNERS exactly; check-ownership-policy.mjs fails on drift in either direction. A pattern missing from this file resolves to gate at runtime, so the failure mode is fail-safe.",
   "rules": [
     { "pattern": "*", "mode": "gate" },
-    { "pattern": "/pnpm-lock.yaml", "mode": "territory" },
     { "pattern": "/.editorconfig", "mode": "territory" },
     { "pattern": "/.gitignore", "mode": "territory" },
     { "pattern": "/LICENSE", "mode": "territory" },
     { "pattern": "*.md", "mode": "territory" },
+    { "pattern": "package.json", "mode": "exempt" },
+    { "pattern": "/pnpm-lock.yaml", "mode": "exempt" },
     { "pattern": "/.github/", "mode": "gate" },
     { "pattern": "/packages/server/drizzle/", "mode": "gate" },
     { "pattern": "/AGENTS.md", "mode": "gate" },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,14 @@ Markdown outside `apps/web` is `territory` with a wider owner pool of yuezengwu,
 except for the root policy and agent-instruction files: `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `SECURITY.md`, and
 the Chinese mirrors of the last two. Those are pulled back into the gate, because agent-instruction files change what
 agents in this repository do and are behavior rather than documentation, and `CONTRIBUTING.md` is where this policy
-itself is written down. Four routine chore paths are `territory`: `pnpm-lock.yaml`, `.editorconfig`, `.gitignore`, and
-`LICENSE`. `packages/server/drizzle/` carries a defensive `gate` pin so irreversible migrations stay mutually reviewed.
-Everything else is gated: the packages, `apps/cli`, `.github`, `scripts`, `e2e`, root build and quality-gate
-configuration, and any directory added in the future.
+itself is written down. Three routine chore paths are `territory`: `.editorconfig`, `.gitignore`, and `LICENSE`. The
+dependency manifests are `exempt`: `package.json` at any depth and `pnpm-lock.yaml` name no owners, so a dependabot bump
+no longer auto-requests a reviewer. The auto-request is GitHub's and reads only `.github/CODEOWNERS`, which cannot tell
+one author from another, so the same exemption lets a human-authored manifest change merge without approval; that is the
+price of the behaviour and the reason the exemption stops at the manifests. `packages/server/drizzle/` carries a
+defensive `gate` pin so irreversible migrations stay mutually reviewed. Everything else is gated: the packages,
+`apps/cli`, `.github`, `scripts`, `e2e`, the rest of the root build and quality-gate configuration, and any directory
+added in the future.
 
 Two rules apply on top of the per-file result. When the pull request author has no write access to the repository, as
 an outside contributor, from a fork, or as a bot including dependabot, the pull request additionally needs an approval

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -57,9 +57,12 @@ npm 发布、绕开受保护流程创建 production tag，以及回退到 token 
 `apps/web` 之外的 Markdown 为 territory，owner 范围更宽，包括 yuezengwu、bestony、Gandy2025 和 liuchao-001，
 但根目录的策略与 agent 指令文件除外：`AGENTS.md`、`CLAUDE.md`、`CONTRIBUTING.md`、`SECURITY.md` 以及后两者的中文镜像。
 这些文件被拉回 gate，因为 agent 指令文件会改变本仓库中 agent 的行为，属于行为而非文档，而 `CONTRIBUTING.md` 正是本策略
-自身的载体。四个例行杂务路径为 territory：`pnpm-lock.yaml`、`.editorconfig`、`.gitignore` 和 `LICENSE`。
-`packages/server/drizzle/` 带有一个防御性的 gate pin，使不可逆的 migration 始终经过交叉评审。其余一切都受 gate 约束：
-各 package、`apps/cli`、`.github`、`scripts`、`e2e`、根目录的构建与质量门禁配置，以及未来新增的任何目录。
+自身的载体。三个例行杂务路径为 territory：`.editorconfig`、`.gitignore` 和 `LICENSE`。依赖清单为 exempt：任意层级的
+`package.json` 与 `pnpm-lock.yaml` 都不列出 owner，因此 dependabot 的版本升级不会再自动请求 reviewer。自动请求由
+GitHub 发起，只读取 `.github/CODEOWNERS`，无法区分作者，所以同一份豁免也让人工提交的依赖清单改动无需批准即可合并；
+这是该行为的代价，也是豁免范围仅限于依赖清单的原因。`packages/server/drizzle/` 带有一个防御性的 gate pin，使不可逆的
+migration 始终经过交叉评审。其余一切都受 gate 约束：各 package、`apps/cli`、`.github`、`scripts`、`e2e`、根目录其余的
+构建与质量门禁配置，以及未来新增的任何目录。
 
 在逐文件结果之上还有两条规则。当 Pull Request 作者对仓库没有写权限时——外部贡献者、来自 fork，或包括 dependabot 在内的
 bot——无论改动了哪些文件，该 Pull Request 都还需要 `.github/CODEOWNERS` 中列出的任意一位 owner 的批准；`apps/web`


### PR DESCRIPTION
## What

Makes the dependency manifests ownerless in `.github/CODEOWNERS`, so a dependency bump auto-requests no reviewer:

- `package.json` — new, depth-agnostic, `exempt`
- `/pnpm-lock.yaml` — `territory` → `exempt`, owners removed

`.github/ownership-modes.json` declares both `exempt`, which `check-ownership-policy.mjs` requires for an ownerless rule, and both `CONTRIBUTING` files are updated to match.

## Why

GitHub auto-requests a review from the owners of every file a pull request touches. `/pnpm-lock.yaml` was owned and every workspace `package.json` fell through to the `*` gate, so both bestony and yuezengwu landed on the reviewer list of every dependabot bump. Ownerless is the only lever that reaches this: the auto-request runs off `CODEOWNERS` alone and cannot tell dependabot from any other author.

`package.json` is depth-agnostic on purpose. Dependabot resolves `directory: /` through `pnpm-workspace.yaml`, so one update rewrites the workspace manifests, not only the root one — a root-anchored `/package.json` would have covered none of the manifests in the most recent production-group bump.

## Rule placement

Both edges of the block's position are load-bearing:

- **Below `*.md`** — a manifest inside a directory whose name ends in `.md` would otherwise be *reached* by `*.md` and *named* by this rule. The gate resolves that disagreement by falling back to gate mode over an ownerless rule, which produces a red check that no approval can clear. Verified: with the block above `*.md`, `packages/notes.md/package.json` splits `reach=*.md` / `names=package.json`; below it, both resolve to `package.json`.
- **Above the `/.github/` and `/packages/server/drizzle/` pins** — a manifest ever added beneath either keeps the pin's gate rather than escaping through the new rule. Verified: `.github/package.json` → `/.github/`, `packages/server/drizzle/package.json` → the drizzle pin.

## Validation

- `pnpm check` — exit 0. Resolution table: `package.json` wins 6 files, `/pnpm-lock.yaml` wins 1, both pins unchanged at 19 and 77.
- `node --test --test-concurrency=1 scripts/__tests__/*.test.mjs` — 311/311 pass.
- `node scripts/check-doc-mirrors.mjs --base main --head HEAD` — passes; both `CONTRIBUTING` files change together.
- Replayed the real file list of a recent dependabot PR through the matcher: all seven manifests plus the lockfile resolve to ownerless rules.

## What this does not do

- **The `ownership-gate` check still goes red on dependabot pull requests.** `pull-request.mjs` hard-codes every bot to no write access, and `decideExternalAuthor` then requires an approval from one owner named anywhere in `CODEOWNERS`, whatever files the PR touches. That rule is deliberately untouched here. The approval count is unchanged from today; what changes is that nobody is auto-notified, so someone has to go look. This was the requested scope — stop the reviewer request, not open a green lane.
- **The github-actions ecosystem is unaffected.** Those dependabot PRs touch `.github/workflows/*.yml`, which the `/.github/` pin gates, and `checkPinShape` forces that pin to stay `gate` with owners. Weekly reviewer pings are roughly halved, not removed.

## Review-worthy consequence

The auto-request is author-blind, so the same exemption that silences dependabot also lets a **human-authored** manifest change merge with no approval. Two spots are worth a decision, and neither is addressed here:

- Root `package.json` holds the `pnpm check` and `test` command strings that `ci.yml` runs, so the definition of "green CI" is now editable without review — including removing `check-ownership-policy.mjs` from the chain. Its `prepare` hook also runs during `pnpm install` in the publish job that holds `id-token: write`.
- `apps/cli/package.json` `scripts` and `files` flow into the published npm tarball. `prepare-cli-release.mjs` validates `name`/`private`/`license`/`repository`/`bin` but not `scripts` or `files`, and `cli-pack-smoke.mjs` installs with `--ignore-scripts`, so an injected `postinstall` would be neither executed nor detected before publish.

Narrowing the CODEOWNERS pattern to exclude those two files would re-request reviewers on most dependabot PRs and defeat the change. The mitigation that does not conflict is to harden the release scripts — allowlist `scripts` keys and assert `files` in `prepare-cli-release.mjs`, and `--ignore-scripts` on the publish job's install. Those files stay gated, so they remain reviewed. Happy to open that as a follow-up.
