### PR TITLE
test(web): realign the offline Computer assertion with the shipped copy

### DIFF
--- a/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
@@ -131,7 +131,7 @@ describe("AgentSetupPage stages", () => {
 
     expect(
       screen.getByText(
-        "Review Mac is offline. Start OpenTag on that Computer; this page will continue when it reconnects.",
+        "Review Mac is offline. Run opentag daemon start in a terminal on that Computer; this page will continue when it reconnects.",
       ),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();


### PR DESCRIPTION
## Summary

`main` is red since #469 merged: its `agent-setup-page.test.tsx` still expects the offline Computer message that #482 replaced with the command that brings the Computer back ("Run opentag daemon start in a terminal on that Computer"). This realigns the one assertion with the shipped copy; no product change.

## Testing

- `pnpm --filter @opentag/web exec vitest run src/onboarding-v2/agent-setup-page.test.tsx` — 33 passed (after `pnpm --filter @opentag/shared build` and `pnpm --filter @opentag/web paraglide` on `main`).

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. — the affected file passes locally; CI is the full run.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable. — none affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
