### PR TITLE
test(web): take the clock out of the assertions that raced it

### DIFF
--- a/apps/web/src/__tests__/account.test.tsx
+++ b/apps/web/src/__tests__/account.test.tsx
@@ -118,7 +118,16 @@ describe("OpenTag Web App Shell", () => {
   });
 
   it("lets no new save race an in-flight refresh retry", async () => {
-    installApi({ meFailuresAfterProfileUpdate: 1, meDelayMsAfterProfileUpdate: 40 });
+    /*
+     * The refresh is held open by a promise this test resolves, not by a wall-clock delay. The
+     * assertions below describe what is true *while* it is in flight, so the window has to last
+     * exactly as long as they take -- which a fixed 40ms could not guarantee on a loaded machine.
+     */
+    let releaseRefresh = () => undefined as void;
+    const refreshInFlight = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    installApi({ meFailuresAfterProfileUpdate: 1, meHoldAfterProfileUpdate: refreshInFlight });
     window.history.replaceState({}, "", "/account");
     render(<App />);
 
@@ -140,6 +149,7 @@ describe("OpenTag Web App Shell", () => {
     expect(displayName.disabled).toBe(true);
     fireEvent.click(screen.getByRole("button", { name: "Refreshing…" }));
     fireEvent.submit(form);
+    releaseRefresh();
 
     expect(await screen.findByText("Account profile saved.")).toBeTruthy();
     expect(

--- a/apps/web/src/__tests__/account.test.tsx
+++ b/apps/web/src/__tests__/account.test.tsx
@@ -123,7 +123,7 @@ describe("OpenTag Web App Shell", () => {
      * assertions below describe what is true *while* it is in flight, so the window has to last
      * exactly as long as they take -- which a fixed 40ms could not guarantee on a loaded machine.
      */
-    let releaseRefresh = () => undefined as void;
+    let releaseRefresh!: () => void;
     const refreshInFlight = new Promise<void>((resolve) => {
       releaseRefresh = resolve;
     });

--- a/apps/web/src/__tests__/app-shell.test.tsx
+++ b/apps/web/src/__tests__/app-shell.test.tsx
@@ -1,10 +1,11 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app.js";
 import { agentId, installApi, resetWebAppState } from "./support/app-fixtures.js";
 
 describe("OpenTag Web App Shell", () => {
   beforeEach(resetWebAppState);
+  afterEach(() => vi.useRealTimers());
 
   it("keeps the Account Agents page local and opens Agent navigation only after selection", async () => {
     installApi();
@@ -139,10 +140,16 @@ describe("OpenTag Web App Shell", () => {
   });
 
   it("shows elapsed time without exposing conversation content for a working Agent", async () => {
+    /*
+     * The clock is pinned because the assertion is about a rounded interval: with a live clock the
+     * fixture's "8 minutes ago" becomes "9m ago" the moment 30 seconds pass between building it and
+     * rendering it, which is a wait this test never asked for and cannot control on a loaded machine.
+     */
+    vi.setSystemTime(new Date("2026-09-02T12:00:00.000Z"));
     installApi({
       agentActivity: {
         state: "working",
-        startedAt: new Date(Date.now() - 8 * 60_000).toISOString(),
+        startedAt: new Date("2026-09-02T11:52:00.000Z").toISOString(),
       },
       bound: true,
       handoffReady: true,

--- a/apps/web/src/__tests__/support/app-fixtures.tsx
+++ b/apps/web/src/__tests__/support/app-fixtures.tsx
@@ -332,7 +332,13 @@ export function installApi(
     internalToolsOffered?: boolean;
     provider?: "feishu" | "slack";
     runtimeProvider?: "codex" | "claude-code";
-    meDelayMsAfterProfileUpdate?: number;
+    /*
+     * Holds the post-save `/api/v1/me` refresh in flight until the test resolves it. This used to be
+     * a wall-clock delay, which made the assertions a race: on a loaded machine the delay could
+     * expire before the test reached them, and the refresh it was meant to catch mid-flight had
+     * already finished. A promise the test controls removes the clock from the question entirely.
+     */
+    meHoldAfterProfileUpdate?: Promise<unknown>;
     meFailuresAfterProfileUpdate?: number;
     /** Answers the `/me` refresh a profile save starts, so a test can hold it across a sign-out. */
     meAfterProfileUpdate?: () => Promise<Response> | Response;
@@ -445,15 +451,17 @@ export function installApi(
       if (loggedOut && options.meAfterLogout) return options.meAfterLogout();
       if (options.unauthenticated) return json({ error: { message: "Sign in required" } }, 401);
       if (profileUpdated && options.meAfterProfileUpdate) return options.meAfterProfileUpdate();
-      if (profileUpdated && options.meDelayMsAfterProfileUpdate) {
-        await new Promise((resolve) => setTimeout(resolve, options.meDelayMsAfterProfileUpdate));
-      }
       if (profileUpdated && meFailuresRemaining > 0) {
         meFailuresRemaining -= 1;
         return json(
           { error: { code: "SERVICE_UNAVAILABLE", category: "transient", message: "Account state unavailable" } },
           503,
         );
+      }
+      // After the seeded failures, so the refresh a test holds open is the retry rather than the
+      // first attempt the retry exists to follow.
+      if (profileUpdated && options.meHoldAfterProfileUpdate) {
+        await options.meHoldAfterProfileUpdate;
       }
       return json({
         user: { id: userId, email: "ada@example.com", displayName: currentDisplayName },

--- a/apps/web/src/features/agent-list-order.test.ts
+++ b/apps/web/src/features/agent-list-order.test.ts
@@ -5,7 +5,7 @@ import type {
   ImBindingHandoffStatus,
   ImBindingSummary,
 } from "@opentag/shared/browser";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatCompactNumber, formatElapsedCompact, formatRelativeTime, initials } from "../i18n/format.js";
 import { orderAgentIds } from "./agent-list-order.js";
 import {
@@ -61,6 +61,15 @@ describe("Agent list order", () => {
 });
 
 describe("Agent availability model and presentation", () => {
+  /*
+   * These assertions compare an interval against the clock -- "8m ago", "2m", "1 minute ago" -- so a
+   * live clock makes each one a race it cannot win: a full minute of real delay between building the
+   * fixture and reading the string turns 8m into 9m. Pinning removes the dependency rather than
+   * widening a tolerance around it.
+   */
+  beforeEach(() => vi.setSystemTime(new Date("2026-09-02T12:00:00.000Z")));
+  afterEach(() => vi.useRealTimers());
+
   const boundComputerId = "22222222-2222-4222-8222-222222222222";
   const agent = {
     id: "11111111-1111-4111-8111-111111111111",


### PR DESCRIPTION
Addresses #325 in part. Please read the scope section — this does **not** fix every failure that issue records, and I do not think it can.

## The issue's file no longer exists

#325 is written about `apps/web/src/__tests__/app.test.tsx`. That file was deleted by #388, which split the app suite by bounded context, so its tests now live in `account.test.tsx`, `agent-home.test.tsx`, `app-shell.test.tsx`, `agent-tasks.test.tsx` and `agent-usage.test.tsx`. The named failures in the issue's table map onto those files. The phenomenon is real; only the filename is stale.

## What actually couples a test to the clock — two places, both fixed

**1. A 40 ms window that had to outlast the assertions** (`account.test.tsx`, the test #306 names)

The test holds a `/api/v1/me` refresh in flight and asserts what is true *while* it is in flight: the field is disabled, a second retry does not start, a submit cannot slip a competing write past it. The fixture kept it in flight with `setTimeout(..., 40)`. Under contention those 40 ms can expire before the assertions run, the refresh completes, and the state they describe is gone.

It is now held by a promise the test resolves, so the window lasts exactly as long as the assertions take, on any machine.

One detail worth naming: the hold had to move **after** the seeded failures in the fixture. Applied before them it held the *first* refresh — the one that must fail fast to produce "Account not refreshed" — and the test hung on its own gate. That the deferred made this ordering visible is an argument for it over a sleep.

**2. Assertions compared against a live clock** (`app-shell.test.tsx`, `agent-list-order.test.ts`)

Fixtures built `Date.now() - 8 * 60_000` and asserted `"started 8m ago"`. I measured the tolerance rather than guessing: at **59 seconds** of real delay between building the fixture and reading the string it still reads `8m`; at **60** it reads `9m` and the test fails. Same for `"2m"`, `"1 minute ago"` and friends.

The clock is now pinned, which removes the dependency rather than widening a tolerance around it.

## What this does not fix, and why I am not attempting it

#325 records that **every failure was a `waitFor` timeout**. Most of those are not clock coupling — they are a machine too busy to render inside the default one-second budget. Nothing in this PR changes that, and the two remedies that would are both ruled out by the issue itself: raising timeouts, and retries.

So this closes the part of #325 that is a test defect. The remainder is a capacity problem, and the honest options are to run the suite with fewer competing workers, or to accept that a machine at load 25+ cannot be trusted as a measuring instrument. I would rather say that than claim the flake is fixed.

## Verification

Each change was mutation-checked rather than assumed:

- Replacing `await options.meHoldAfterProfileUpdate` with `void` — so the refresh completes immediately — fails the in-flight assertions. The gate is load-bearing.
- Moving the pinned `startedAt` from 8 to 9 minutes fails with `Unable to find … "started 8m ago"`, confirming the assertion is sensitive to exactly the drift that was previously uncontrolled.

| Command | Result |
|---|---|
| `pnpm --filter @opentag/web test` | **58 files / 560 tests passed** |
| `pnpm --filter @opentag/web typecheck` | exit 0 |
| `pnpm check` | exit 0 (ratchet passed, no new baselines) |
| `node scripts/unit-coverage.mjs --project web` | exit 0 (web 91.77%) |

Run at load ~6. No live QA proposed: test-only change, no product code touched.
