### PR TITLE
refactor(web): flatten Messaging and Computer settings pages

### DIFF
--- a/apps/web/messages/agent-settings/en.json
+++ b/apps/web/messages/agent-settings/en.json
@@ -12,6 +12,7 @@
   "agent_settings_channel_detail_with_name": "{provider} · @{name}",
   "agent_settings_claude_code": "Claude Code",
   "agent_settings_codex": "Codex",
+  "agent_settings_computer_description": "The Computer this Agent runs on. It can work only while that Computer is online.",
   "agent_settings_computer_none_heading": "No Computer connected",
   "agent_settings_computer_none_status": "Not connected",
   "agent_settings_computer_none_summary": "No Computer connected",

--- a/apps/web/messages/agent-settings/zh.json
+++ b/apps/web/messages/agent-settings/zh.json
@@ -12,6 +12,7 @@
   "agent_settings_channel_detail_with_name": "消息渠道：{provider} · @{name}",
   "agent_settings_claude_code": "Claude Code",
   "agent_settings_codex": "Codex",
+  "agent_settings_computer_description": "此 Agent 运行所在的电脑。只有这台电脑在线时，它才能工作。",
   "agent_settings_computer_none_heading": "未连接计算机",
   "agent_settings_computer_none_status": "未连接",
   "agent_settings_computer_none_summary": "未连接计算机",

--- a/apps/web/messages/im/en.json
+++ b/apps/web/messages/im/en.json
@@ -58,6 +58,7 @@
   "im_mentions_only_description": "The Agent checks the conversation when someone @mentions it. Messages since its last reply are included for context.",
   "im_messaging_app": "Messaging app",
   "im_messaging_connect_description": "Connect {provider} or {alternateProvider} so teammates can send messages to this Agent.",
+  "im_messaging_page_description": "Where teammates reach this Agent, and which messages it answers.",
   "im_messaging_page_title": "Messaging",
   "im_no_messaging_app": "No messaging app connected",
   "im_permissions_required": "Permissions required",

--- a/apps/web/messages/im/zh.json
+++ b/apps/web/messages/im/zh.json
@@ -58,6 +58,7 @@
   "im_mentions_only_description": "当有人 @Agent 时，Agent 会检查对话，并包含自上次回复以来的消息作为上下文。",
   "im_messaging_app": "消息应用",
   "im_messaging_connect_description": "连接{provider}或 {alternateProvider}，让团队成员可以向此 Agent 发送消息。",
+  "im_messaging_page_description": "团队成员在哪里联系此 Agent，以及它会回应哪些消息。",
   "im_messaging_page_title": "消息",
   "im_no_messaging_app": "未连接消息应用",
   "im_permissions_required": "需要权限",

--- a/apps/web/src/__tests__/agent-computers.test.tsx
+++ b/apps/web/src/__tests__/agent-computers.test.tsx
@@ -70,8 +70,12 @@ describe("OpenTag Web App Shell", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Need to reinstall? Generate a repair command." }));
 
-    expect(screen.getByRole("heading", { name: "Reconnect Ada's Mac" })).toBeTruthy();
+    // The disclosure is one labelled region rather than a heading repeating the name the command
+    // block already carries.
+    expect(screen.getByRole("region", { name: "Reconnect Ada's Mac" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Reconnect Ada's Mac" })).toBeNull();
     expect(await screen.findByRole("button", { name: "Copy command" })).toBeTruthy();
+    expect(screen.getByText("# Run this command in the terminal on Ada's Mac")).toBeTruthy();
     const repairRequests = vi
       .mocked(fetch)
       .mock.calls.filter(([path, init]) => path === "/api/v1/computer-connect-codes" && init?.method === "POST");

--- a/apps/web/src/features/agents/agent-settings/agent-computer-settings.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-computer-settings.tsx
@@ -17,18 +17,19 @@ import { AgentSettingsPageHeader } from "./settings-layout.js";
 function AgentComputerBinding({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChanged: () => void }) {
   return (
     <div className="grid gap-6">
-      <AgentSettingsPageHeader id="computer-heading" title={m.agents_status_computer()} />
-      <section
-        aria-labelledby="computer-heading"
-        className="grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
-      >
+      <AgentSettingsPageHeader
+        description={m.agent_settings_computer_description()}
+        id="computer-heading"
+        title={m.agents_status_computer()}
+      />
+      <section aria-labelledby="computer-heading" className="grid gap-4">
         <header className="flex flex-wrap items-start justify-between gap-3">
           <Text as="h2" variant="heading">
             {m.agent_settings_computer_none_heading()}
           </Text>
           <StatusIndicator label={m.agent_settings_computer_none_status()} tone="warning" />
         </header>
-        <div className="grid gap-4 rounded-md bg-kumo-recessed p-4">
+        <div className="grid gap-4">
           <p>{computerRecoveryMessage(agent)}</p>
           <AgentComputerChoice agentId={agent.id} onBound={onAgentChanged} />
         </div>
@@ -60,11 +61,12 @@ export function AgentComputerSettings({
   if (!agent.computer) return <AgentComputerBinding agent={agent} onAgentChanged={onAgentChanged} />;
   return (
     <div className="grid gap-6">
-      <AgentSettingsPageHeader id="computer-heading" title={m.agents_status_computer()} />
-      <section
-        aria-labelledby="computer-device-heading"
-        className="grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
-      >
+      <AgentSettingsPageHeader
+        description={m.agent_settings_computer_description()}
+        id="computer-heading"
+        title={m.agents_status_computer()}
+      />
+      <section aria-labelledby="computer-device-heading" className="grid gap-4">
         <header className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3" data-ui="computer-identity">
           <span aria-hidden="true" className="grid size-8 shrink-0 place-items-center rounded-md bg-kumo-tint">
             <Icon name="laptop" />
@@ -83,27 +85,25 @@ export function AgentComputerSettings({
           <StatusIndicator className="justify-self-end" label={computerStatus} tone={computerTone} />
         </header>
         {ready ? null : (
-          <div className="rounded-md bg-kumo-recessed p-4">
-            <div className="grid gap-3">
-              {computerState.lastConfirmedAt ? (
-                <p>
-                  {m.agent_settings_last_seen({
-                    relative: formatRelativeTime(computerState.lastConfirmedAt),
-                    date: formatDateTime(computerState.lastConfirmedAt),
-                  })}
-                </p>
-              ) : null}
-              <p>{computerRecoveryMessage(agent)}</p>
-              {/* Re-enrolment only answers an unreachable Computer; a missing Provider needs the
-                  Provider installed, so offering it there would send an operator down a dead path. */}
-              {computerState.state === "action_required" ? (
-                <AgentComputerRepair
-                  computer={agent.computer}
-                  key={agent.computer.computerId}
-                  onAgentChanged={onAgentChanged}
-                />
-              ) : null}
-            </div>
+          <div className="grid gap-3">
+            {computerState.lastConfirmedAt ? (
+              <p>
+                {m.agent_settings_last_seen({
+                  relative: formatRelativeTime(computerState.lastConfirmedAt),
+                  date: formatDateTime(computerState.lastConfirmedAt),
+                })}
+              </p>
+            ) : null}
+            <p>{computerRecoveryMessage(agent)}</p>
+            {/* Re-enrolment only answers an unreachable Computer; a missing Provider needs the
+                Provider installed, so offering it there would send an operator down a dead path. */}
+            {computerState.state === "action_required" ? (
+              <AgentComputerRepair
+                computer={agent.computer}
+                key={agent.computer.computerId}
+                onAgentChanged={onAgentChanged}
+              />
+            ) : null}
           </div>
         )}
       </section>
@@ -121,9 +121,12 @@ function AgentComputerRepair({
   const [reconnecting, setReconnecting] = useState(false);
   return (
     <>
+      {/* The negative inset cancels the control's own padding: a borderless button reads as part of
+          the prose above it only when its text starts on the same left edge. */}
       <Button
         aria-controls="agent-computer-reconnect"
         aria-expanded={reconnecting}
+        className="-mx-2 text-kumo-link"
         size="compact"
         variant="inline"
         onClick={() => setReconnecting((value) => !value)}
@@ -131,10 +134,17 @@ function AgentComputerRepair({
         {reconnecting ? m.agent_settings_computer_repair_hide() : m.agent_settings_computer_repair_show()}
       </Button>
       {reconnecting ? (
-        <div className="grid gap-3" id="agent-computer-reconnect">
-          <Text as="h2" variant="heading">
-            {m.computer_connect_repair_title({ computerName: computer.displayName })}
-          </Text>
+        /*
+         * Everything the disclosure adds -- the command, how long it lasts, what happens once it
+         * runs -- sits on one surface, so it reads as the single thing the button opened rather
+         * than as loose paragraphs after it. The name it used to repeat as a heading is the
+         * region's label instead: the command block below already names the machine.
+         */
+        <section
+          aria-label={m.computer_connect_repair_title({ computerName: computer.displayName })}
+          className="grid gap-3 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
+          id="agent-computer-reconnect"
+        >
           <ComputerConnect
             intent={{
               mode: "repair",
@@ -143,7 +153,7 @@ function AgentComputerRepair({
             onConnected={onAgentChanged}
           />
           <p className="text-sm text-kumo-subtle">{m.agent_settings_reconnecting_description()}</p>
-        </div>
+        </section>
       ) : null}
     </>
   );

--- a/apps/web/src/features/agents/agent-settings/im-tab.tsx
+++ b/apps/web/src/features/agents/agent-settings/im-tab.tsx
@@ -102,6 +102,7 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
         <Text as="h1" ref={messagingHeadingRef} size="lg" tabIndex={-1} variant="heading">
           {m.im_messaging_page_title()}
         </Text>
+        <p className="text-sm text-kumo-subtle">{m.im_messaging_page_description()}</p>
       </header>
       <FeishuSetup
         agentId={agent.id}
@@ -136,10 +137,7 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
                 <AsyncState state={state}>
                   {(binding) => (
                     <div className="grid gap-6">
-                      <section
-                        className="grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
-                        aria-labelledby="messaging-app-heading"
-                      >
+                      <section className="grid gap-4" aria-labelledby="messaging-app-heading">
                         <Text as="h2" id="messaging-app-heading" variant="heading">
                           {m.im_messaging_app()}
                         </Text>
@@ -241,10 +239,7 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
                       </section>
 
                       {binding ? (
-                        <section
-                          className="grid gap-4 rounded-lg bg-kumo-base p-4 ring ring-kumo-line"
-                          aria-labelledby="trigger-rules-heading"
-                        >
+                        <section className="grid gap-4" aria-labelledby="trigger-rules-heading">
                           <div className="grid gap-2">
                             <Text
                               as="h2"


### PR DESCRIPTION
## Why

On the Agent Settings sub-pages, Messaging and Computer each wrapped their content in a card, while
Instructions is a plain title / description / setting. Two different page shapes for the same kind of
page, and the card added nothing: there is one group inside it.

The Computer page's repair disclosure had two further problems. Its toggle is a borderless button, so
its own padding pushed the label 8px right of the prose it follows and it read as misaligned. And what
the toggle opened -- a heading repeating the Computer's name, the command, its expiry, the waiting
status, and a closing note -- was a run of loose paragraphs with nothing saying they were one thing.

## What

- Messaging and Computer now open as title, description, setting, like Instructions. Both pages gain a
  page description; the section headings inside them stay, the card chrome around them does not.
- The repair toggle is coloured and inset by its own padding, so its label starts on the same left edge
  as the text above it.
- Everything the toggle discloses sits on one surface. The `Reconnect <name>` heading is gone from
  view: the command block underneath already names the machine, and the name is now the disclosed
  region's accessible label rather than a line repeating it.

## Verification

`pnpm --filter @opentag/web test`, `pnpm exec biome check`, and the complexity ratchet, all locally.
The change is visual, so it wants an exact-head QA pass on the running app: Agent Settings ->
Messaging, and -> Computer with the Computer offline, opening and closing the repair command.
