### PR TITLE
test(web): follow the inert command comment into the Agent computers test

### DIFF
--- a/apps/web/src/__tests__/agent-computers.test.tsx
+++ b/apps/web/src/__tests__/agent-computers.test.tsx
@@ -75,7 +75,9 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("region", { name: "Reconnect Ada's Mac" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Reconnect Ada's Mac" })).toBeNull();
     expect(await screen.findByRole("button", { name: "Copy command" })).toBeTruthy();
-    expect(screen.getByText("# Run this command in the terminal on Ada's Mac")).toBeTruthy();
+    // The comment is the POSIX null command, not a `#` line: zsh runs a pasted `#` and answers
+    // "command not found", so #500 made it inert. This is the rendered form.
+    expect(screen.getByText(": 'Run this command in the terminal on Ada'\\''s Mac'")).toBeTruthy();
     const repairRequests = vi
       .mocked(fetch)
       .mock.calls.filter(([path, init]) => path === "/api/v1/computer-connect-codes" && init?.method === "POST");


### PR DESCRIPTION
## `main` is red, and has been since #500 merged

`apps/web/src/__tests__/agent-computers.test.tsx` fails on pristine `origin/main` (`5c8db374`):

```
FAIL src/__tests__/agent-computers.test.tsx > generates a command naming the assigned Computer
Unable to find an element with the text: # Run this command in the terminal on Ada's Mac
```

I confirmed this on a detached checkout of `origin/main` with nothing of my own in it, after hitting it while rebasing an unrelated branch.

## Why

#500 deliberately replaced the `# …` comment in the connect command with the POSIX null command `: '…'` — and for a good reason, quoted from its own comment: zsh leaves `interactive_comments` off for interactive use, so a pasted `#` line runs and answers `command not found: #`, which reads as a failure on a command that actually works.

It updated the catalogues and `computer-connect.test.tsx`, which now asserts `: 'Run this command in the terminal on Ada'\''s Mac'`. It missed `agent-computers.test.tsx`, which renders the same block through the Agent computers surface and still expected the `#` form.

## The fix

One assertion, updated to the form the block renders. Nothing in the product changes.

I am **not** reverting or re-litigating #500's decision — the inert comment is right, and this is only the assertion it left behind.

## Testing at `ef51f075`

| Command | Result |
|---|---|
| `pnpm --filter @opentag/web test` | **58 files / 561 tests passed** |
| target file alone | 16/16 passed |

Prioritising this over my own #505, which is blocked behind the same red.
