### PR TITLE
test(web): follow the repair command's comment to its shell-safe form

### DIFF
--- a/apps/web/src/__tests__/agent-computers.test.tsx
+++ b/apps/web/src/__tests__/agent-computers.test.tsx
@@ -75,7 +75,9 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.getByRole("region", { name: "Reconnect Ada's Mac" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Reconnect Ada's Mac" })).toBeNull();
     expect(await screen.findByRole("button", { name: "Copy command" })).toBeTruthy();
-    expect(screen.getByText("# Run this command in the terminal on Ada's Mac")).toBeTruthy();
+    // The POSIX null command, with the apostrophe closed and reopened so the sentence cannot escape
+    // its quotes: a `#` comment is what an interactive shell rejects when the block is pasted.
+    expect(screen.getByText(": 'Run this command in the terminal on Ada'\\''s Mac'")).toBeTruthy();
     const repairRequests = vi
       .mocked(fetch)
       .mock.calls.filter(([path, init]) => path === "/api/v1/computer-connect-codes" && init?.method === "POST");


### PR DESCRIPTION
## What

`main` is red. `apps/web/src/__tests__/agent-computers.test.tsx` still expects the Computer repair block to open with:

```
# Run this command in the terminal on Ada's Mac
```

That `#` form is precisely what #500 removed. An interactive shell rejects a pasted comment line, so the block now opens with the POSIX null command, closing and reopening the apostrophe so the sentence cannot escape its quotes:

```
: 'Run this command in the terminal on Ada'\''s Mac'
```

`computer-connect.test.tsx` was updated to match — it carries the same string as a named constant with that reasoning. This one assertion was missed.

## Evidence

The failure is on `main` itself, not on any branch: `agent-computers.test.tsx > generates a command naming the assigned Computer without leaving the Agent` fails identically on a clean `origin/main` checkout at `5c8db374`, and main's own CI run for that SHA fails on **Node 22, Node 24, Node 26 and Checks** with this test.

With this change, on the same checkout: `pnpm check`, `pnpm typecheck` and `pnpm test` all exit `0`.

## Scope

One assertion in one test file. No product change — the rendered form is already correct and deliberate; only the expectation was stale.

## How it was found

It surfaced while merging current `main` into #498, which is unrelated to Computer connect. Filed separately rather than folded in, so the fix for a red `main` is not gated on that PR's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
