### PR TITLE
fix(feishu): read a rich-text title and settle @ elements and empty paragraphs

### DIFF
--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -386,14 +386,14 @@ export function TaskDetailPage({
           aria-label={m.tasks_details()}
         >
           <TaskDetailFact label={m.tasks_agent_label()}>
-            <span className="inline-flex items-center gap-2">
+            <span className="flex min-w-0 items-center gap-2">
               <span
-                className="grid size-7 place-items-center rounded-full bg-kumo-brand text-xs font-medium text-kumo-inverse"
+                className="grid size-7 shrink-0 place-items-center rounded-full bg-kumo-brand text-xs font-medium text-kumo-inverse"
                 aria-hidden="true"
               >
                 {task.agent.displayName.charAt(0)}
               </span>
-              <strong>{task.agent.displayName}</strong>
+              <strong className="min-w-0 break-words">{task.agent.displayName}</strong>
             </span>
           </TaskDetailFact>
           <TaskDetailFact label={m.tasks_source_label()}>

--- a/packages/server/src/__tests__/feishu-adapter.test.ts
+++ b/packages/server/src/__tests__/feishu-adapter.test.ts
@@ -172,7 +172,7 @@ describe("Feishu adapter", () => {
       "[unsupported:text]",
       "[image]",
       "[file]",
-      "first\nsecond",
+      "Title\nfirst\nsecond",
       "[unsupported:sticker]",
     ]);
     expect(received[1]?.resources[0]).toMatchObject({ fileKey: "img_1", fileName: "image.png" });
@@ -221,7 +221,28 @@ describe("Feishu adapter", () => {
       { key: "@_user_1", id: { open_id: "ou_bot" }, name: "Atlas", mentioned_type: "app" },
     ];
     await dispatcher.invoke(post, { needCheck: false });
-    expect(received.map((message) => message.content)).toEqual(["@_user_1 please fix the docs\n\nbefore 5pm"]);
+    expect(received.map((message) => message.content)).toEqual(["@_user_1 please fix the docs\nbefore 5pm"]);
+  });
+
+  it("writes an @ element without a usable id by name rather than matching a mention without one", async () => {
+    const received: NormalizedMessage[] = [];
+    const dispatcher = createReliableFeishuDispatcher((message) => {
+      received.push(message);
+    });
+    const post = rawMessage("ev-post-at", "om-post-at", "9");
+    post.event.message.message_type = "post";
+    post.event.message.content = JSON.stringify({
+      title: "",
+      content: [
+        [
+          { tag: "at", user_name: "Someone" },
+          { tag: "text", text: " hi", style: [] },
+        ],
+      ],
+    });
+    (post.event.message as { mentions?: unknown }).mentions = [{ key: "@_user_1", id: {}, name: "Other" }];
+    await dispatcher.invoke(post, { needCheck: false });
+    expect(received.map((message) => message.content)).toEqual(["@Someone hi"]);
   });
 
   it("falls back to a rich-text message's markdown copy when the tagged paragraphs carry no text", async () => {

--- a/packages/server/src/services/im-bindings/feishu/adapter.ts
+++ b/packages/server/src/services/im-bindings/feishu/adapter.ts
@@ -257,44 +257,59 @@ function parseRawContent(message: RawFeishuMessageEvent["message"]): {
 type RawFeishuMention = NonNullable<RawFeishuMessageEvent["message"]["mentions"]>[number];
 
 /**
- * The plain text of a rich-text message, read from its documented shape: paragraphs of tagged
- * elements under `content`, at the top level or under a locale key. Feishu also sends the same
- * paragraphs as markdown under `content_v2`; that copy is read only when the tagged form has no
- * text, so a message is never repeated. Runs of one paragraph stay on one line, and an `@` element
- * becomes its mention key, the same placeholder a plain-text message carries.
+ * The plain text of a rich-text message, read from its documented shape: an optional title, then
+ * paragraphs of tagged elements under `content`, at the top level or under a locale key. Feishu
+ * also sends the same paragraphs as markdown under `content_v2`; that copy is read only when the
+ * tagged form has no text, so a message is never repeated. Runs of one paragraph stay on one line,
+ * and an `@` element becomes its mention key, the same placeholder a plain-text message carries.
  */
 function postText(content: Record<string, unknown>, mentions: readonly RawFeishuMention[] = []): string {
-  const tagged = paragraphsText(postParagraphs(content, "content"), mentions);
-  return tagged || paragraphsText(postParagraphs(content, "content_v2"), mentions);
+  const title = postField(content, "title");
+  const tagged = paragraphsText(postField(content, "content"), mentions);
+  const body = tagged || paragraphsText(postField(content, "content_v2"), mentions);
+  return [typeof title === "string" ? title.trim() : "", body].filter(Boolean).join("\n");
 }
 
-function postParagraphs(content: Record<string, unknown>, key: "content" | "content_v2"): unknown[] {
-  if (Array.isArray(content[key])) return content[key];
+/** A field of the post at the top level, or under the locale key the older shape wraps it in. */
+function postField(content: Record<string, unknown>, key: "title" | "content" | "content_v2"): unknown {
+  if (content[key] !== undefined) return content[key];
   for (const value of Object.values(content)) {
     if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
     const nested = (value as Record<string, unknown>)[key];
-    if (Array.isArray(nested)) return nested;
+    if (nested !== undefined) return nested;
   }
-  return [];
+  return undefined;
 }
 
-function paragraphsText(paragraphs: readonly unknown[], mentions: readonly RawFeishuMention[]): string {
+/**
+ * Paragraphs joined by line breaks. A paragraph whose elements render nothing, such as an image
+ * on its own line, is left out rather than shown as a blank line; an authored empty paragraph stays.
+ */
+function paragraphsText(paragraphs: unknown, mentions: readonly RawFeishuMention[]): string {
+  if (!Array.isArray(paragraphs)) return "";
   return paragraphs
     .map((paragraph) => (Array.isArray(paragraph) ? paragraph : [paragraph]))
-    .map((paragraph) => paragraph.map((element) => elementText(element, mentions)).join(""))
+    .map((paragraph) => ({ authored: paragraph.length === 0, text: elementsText(paragraph, mentions) }))
+    .filter(({ authored, text }) => authored || text !== "")
+    .map(({ text }) => text)
     .join("\n")
     .trim();
+}
+
+function elementsText(elements: readonly unknown[], mentions: readonly RawFeishuMention[]): string {
+  return elements.map((element) => elementText(element, mentions)).join("");
 }
 
 function elementText(element: unknown, mentions: readonly RawFeishuMention[]): string {
   if (typeof element !== "object" || element === null) return "";
   const { tag, text, user_id, user_name } = element as Record<string, unknown>;
-  if (tag === "at") {
-    const mention = mentions.find((candidate) => candidate.id.open_id === user_id || candidate.id.user_id === user_id);
-    if (mention) return mention.key;
-    return typeof user_name === "string" && user_name ? `@${user_name}` : "";
-  }
-  return typeof text === "string" ? text : "";
+  if (tag !== "at") return typeof text === "string" ? text : "";
+  const id = typeof user_id === "string" && user_id ? user_id : undefined;
+  const mention = id
+    ? mentions.find((candidate) => candidate.id.open_id === id || candidate.id.user_id === id)
+    : undefined;
+  if (mention) return mention.key;
+  return typeof user_name === "string" && user_name ? `@${user_name}` : "";
 }
 
 function rawReceiveToNormalized(raw: RawFeishuMessageEvent): NormalizedMessage {


### PR DESCRIPTION
## Summary

Follow-ups from the review of #492, which read a Feishu rich-text (`post`) message from its documented shape. Three of the four were raised there as non-blocking; the fourth is the layout case the reviewer asked to be checked.

- **A rich-text title is read as the first line.** The old walker and #492 both dropped `title`, yet it is authored content: a request whose ask sits in the heading reached the stored text, the Task title, and the Agent prompt without it.
- **An `@` element without a usable id is written by name.** The lookup could match a mention entry that had no id either (`undefined === undefined`) and write that entry's key, naming the wrong person and tokenising the wrong mention. The id must now be a non-empty string before any mention is consulted.
- **A paragraph that renders nothing is left out.** An image on its own line used to become a blank line in the text; it is skipped, while an authored empty paragraph still stays.
- **A long unbreakable Agent name wraps inside its details column** on the Task detail page instead of spilling across its neighbour in the five-column grid.

## Testing

- `pnpm check`, `pnpm typecheck`, `@opentag/server` and `@opentag/web` test suites on the rebased branch; the full gate including `pnpm build` and the e2e smoke suite passed on the same diff before the rebase.
- Adapter tests: the locale-wrapped `post` fixture now expects its title as the first line; runs of one paragraph stay on one line with the image-only paragraph dropped; an `@` element without an id next to a mention without an id renders by name.

## UI validation

- Desktop evidence: local stack at 1440px with a 60-character unbreakable Agent display name in the DEV example Task: the name wraps inside its 179px column, no details cell overflows (`scrollWidth` equals `clientWidth` for all five), Status stays in the fifth column.
- Mobile evidence: unchanged from #492 (stacked single column below 36rem).
- Widths checked (`320px` / `390px` / `768px` / `1440px`): 1440px for the new case; the other widths are unchanged from #492, where all four were checked.
- States verified: failed example with the long name.
- Keyboard/accessibility checks: no interactive change.
- New reusable block, theme value, or CSS exception: none.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
