### PR TITLE
fix(server): scope setup CLI prewarm to pending agents

### DIFF
--- a/packages/server/src/__tests__/provider-cli-reconcile-owner.test.ts
+++ b/packages/server/src/__tests__/provider-cli-reconcile-owner.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
   RUNTIME_CAPABILITY,
+  RUNTIME_CLIENT_CAPABILITY_TTL_MS,
   RUNTIME_PROVIDER_CLI_ARTIFACT_TTL_MS,
   RUNTIME_PROVIDER_CLI_CREDENTIAL_TTL_MS,
   RUNTIME_PROVIDER_CLI_REQUIREMENT_OPERATION,
@@ -18,8 +19,11 @@ function socket(): WebSocket & { send: ReturnType<typeof vi.fn> } {
   } as unknown as WebSocket & { send: ReturnType<typeof vi.fn> };
 }
 
-async function registered(registry: ConnectionRegistry, options: { capabilities?: boolean; prewarm?: boolean } = {}) {
-  const computerId = randomUUID();
+async function registered(
+  registry: ConnectionRegistry,
+  options: { capabilities?: boolean; prewarm?: boolean; computerId?: string } = {},
+) {
+  const computerId = options.computerId ?? randomUUID();
   const instanceId = randomUUID();
   const installationId = randomUUID();
   const runtimeSocket = socket();
@@ -849,9 +853,10 @@ describe("ProviderCliReconcileOwner", () => {
   it("authorizes a one-time inspection of both official CLIs during first setup", async () => {
     const registry = new ConnectionRegistry();
     const shouldPrewarmOfficialProviderClis = vi.fn(async () => true);
+    const issueIntegrationCliValidationGrant = vi.fn();
     const owner = new ProviderCliReconcileOwner(registry, {
       listActiveProviderCliRequirements: vi.fn(async () => []),
-      issueIntegrationCliValidationGrant: vi.fn(),
+      issueIntegrationCliValidationGrant,
       shouldPrewarmOfficialProviderClis,
     });
     const connection = await registered(registry);
@@ -864,6 +869,8 @@ describe("ProviderCliReconcileOwner", () => {
     });
     expect(JSON.stringify(connection.socket.send.mock.calls[0]?.[0])).not.toContain("xoxb");
     expect(JSON.stringify(connection.socket.send.mock.calls[0]?.[0])).not.toContain("appSecret");
+    // An Agent without messaging setup gets inspection only: no requirement or validation grant.
+    expect(issueIntegrationCliValidationGrant).not.toHaveBeenCalled();
   });
 
   it("does not keep requesting unselected CLI inspection after setup is complete", async () => {
@@ -913,5 +920,194 @@ describe("ProviderCliReconcileOwner", () => {
       agentId,
       integrationId,
     });
+  });
+
+  it.each(["missing", "expired"])("repeats inspection on reconnect with %s observations", async (state) => {
+    const registry = new ConnectionRegistry();
+    const shouldPrewarmOfficialProviderClis = vi.fn(async () => true);
+    const issueIntegrationCliValidationGrant = vi.fn();
+    const owner = new ProviderCliReconcileOwner(registry, {
+      listActiveProviderCliRequirements: vi.fn(async () => []),
+      issueIntegrationCliValidationGrant,
+      shouldPrewarmOfficialProviderClis,
+    });
+    const first = await registered(registry);
+    await owner.onComputerRegistered(first);
+    expect(first.socket.send).toHaveBeenCalledTimes(1);
+    const firstFrame = JSON.parse(first.socket.send.mock.calls[0]?.[0] as string) as { requestId: string };
+
+    if (state === "expired") {
+      const observedAt = Date.now() - RUNTIME_CLIENT_CAPABILITY_TTL_MS - 1;
+      expect(
+        registry.touch(first.computerId, first.instanceId, first.socket, observedAt, undefined, undefined, [
+          { provider: "feishu", status: "ready" },
+          { provider: "slack", status: "ready" },
+        ]),
+      ).toBe(true);
+      expect(registry.imCliReadiness(first.computerId, observedAt)).toHaveLength(2);
+    }
+    expect(registry.imCliReadiness(first.computerId)).toEqual([]);
+
+    // A reconnect whose fresh registration has no observations is eligible again: exactly one new
+    // inspection goes out, and only to the current instance.
+    const second = await registered(registry, { computerId: first.computerId });
+    await owner.onComputerRegistered(second);
+
+    expect(shouldPrewarmOfficialProviderClis).toHaveBeenCalledTimes(2);
+    expect(first.socket.send).toHaveBeenCalledTimes(1);
+    expect(second.socket.send).toHaveBeenCalledTimes(1);
+    const secondFrame = JSON.parse(second.socket.send.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(secondFrame).toMatchObject({ type: "provider-cli:prewarm", providers: ["feishu", "slack"] });
+    expect(secondFrame.requestId).not.toBe(firstFrame.requestId);
+    expect(issueIntegrationCliValidationGrant).not.toHaveBeenCalled();
+  });
+
+  it("sends prewarm only to the exact eligible Computer", async () => {
+    const registry = new ConnectionRegistry();
+    const target = await registered(registry);
+    const other = await registered(registry);
+    const shouldPrewarmOfficialProviderClis = vi.fn(async (computerId: string) => computerId === target.computerId);
+    const owner = new ProviderCliReconcileOwner(registry, {
+      listActiveProviderCliRequirements: vi.fn(async () => []),
+      issueIntegrationCliValidationGrant: vi.fn(),
+      shouldPrewarmOfficialProviderClis,
+    });
+
+    await Promise.all([owner.onComputerRegistered(target), owner.onComputerRegistered(other)]);
+
+    expect(shouldPrewarmOfficialProviderClis).toHaveBeenCalledWith(target.computerId);
+    expect(shouldPrewarmOfficialProviderClis).toHaveBeenCalledWith(other.computerId);
+    expect(target.socket.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(target.socket.send.mock.calls[0]?.[0] as string)).toMatchObject({
+      type: "provider-cli:prewarm",
+      providers: ["feishu", "slack"],
+    });
+    expect(other.socket.send).not.toHaveBeenCalled();
+  });
+
+  it("drops a stale eligibility result after another instance registers", async () => {
+    const registry = new ConnectionRegistry();
+    let resolveFirst!: (eligible: boolean) => void;
+    const firstEligibility = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const shouldPrewarmOfficialProviderClis = vi.fn(async () => true).mockReturnValueOnce(firstEligibility);
+    const owner = new ProviderCliReconcileOwner(registry, {
+      listActiveProviderCliRequirements: vi.fn(async () => []),
+      issueIntegrationCliValidationGrant: vi.fn(),
+      shouldPrewarmOfficialProviderClis,
+    });
+    const first = await registered(registry);
+    const pending = owner.onComputerRegistered(first);
+    await vi.waitFor(() => expect(shouldPrewarmOfficialProviderClis).toHaveBeenCalledTimes(1));
+    const second = await registered(registry, { computerId: first.computerId });
+    await owner.onComputerRegistered(second);
+    resolveFirst(true);
+    await pending;
+
+    expect(first.socket.send).not.toHaveBeenCalled();
+    expect(second.socket.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(second.socket.send.mock.calls[0]?.[0] as string)).toMatchObject({
+      type: "provider-cli:prewarm",
+      providers: ["feishu", "slack"],
+    });
+  });
+
+  it("converges only the selected Provider once a messaging binding exists", async () => {
+    const registry = new ConnectionRegistry();
+    const agentId = randomUUID();
+    const integrationId = randomUUID();
+    // Slack is bound and active; feishu was never selected, so no first-setup prewarm is due.
+    const owner = new ProviderCliReconcileOwner(registry, {
+      listActiveProviderCliRequirements: vi.fn(async () => [
+        { agentId, integrationId, provider: "slack" as const, credentialGeneration: 2, expectedIdentity: identity },
+      ]),
+      issueIntegrationCliValidationGrant: vi.fn(async () => ({
+        expectedIdentity: identity,
+        grant: { provider: "slack" as const, botAccessToken: "xoxb-secret" },
+      })),
+      shouldPrewarmOfficialProviderClis: vi.fn(async () => false),
+    });
+    const connection = await registered(registry);
+    await owner.onComputerRegistered(connection);
+
+    const dispatched = connection.socket.send.mock.calls.map(
+      (call) => JSON.parse(call[0] as string) as Record<string, unknown>,
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]).toMatchObject({
+      type: "provider-cli:requirement",
+      provider: "slack",
+      agentId,
+      integrationId,
+    });
+
+    // The selected Provider converges through artifact and grant; the unselected one never gains
+    // a requirement, a prewarm, or a grant.
+    await owner.businessOptions().handle(
+      {
+        type: "provider-cli:artifact:status",
+        requestId: dispatched[0]?.requestId as string,
+        provider: "slack",
+        agentId,
+        integrationId,
+        credentialGeneration: 2,
+        status: "ready",
+      },
+      contextOf(connection),
+    );
+    const frames = connection.socket.send.mock.calls.map(
+      (call) => JSON.parse(call[0] as string) as Record<string, unknown>,
+    );
+    expect(frames.map((frame) => frame.type)).toEqual(["provider-cli:requirement", "provider-cli:validation:grant"]);
+    expect(frames.every((frame) => frame.provider === "slack")).toBe(true);
+  });
+
+  it("skips the setup prewarm when no eligibility predicate is wired", async () => {
+    const registry = new ConnectionRegistry();
+    const agentId = randomUUID();
+    const integrationId = randomUUID();
+    const owner = new ProviderCliReconcileOwner(registry, {
+      listActiveProviderCliRequirements: vi.fn(async () => [
+        { agentId, integrationId, provider: "slack" as const, credentialGeneration: 1, expectedIdentity: identity },
+      ]),
+      issueIntegrationCliValidationGrant: vi.fn(),
+    });
+    const connection = await registered(registry);
+    await owner.onComputerRegistered(connection);
+
+    // The missing predicate fails safe to "no prewarm"; active-binding reconcile continues.
+    expect(connection.socket.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(connection.socket.send.mock.calls[0]?.[0] as string)).toMatchObject({
+      type: "provider-cli:requirement",
+      provider: "slack",
+      agentId,
+      integrationId,
+    });
+  });
+
+  it("keeps active-Integration reconcile running when the prewarm send fails", async () => {
+    const registry = new ConnectionRegistry();
+    const agentId = randomUUID();
+    const integrationId = randomUUID();
+    const owner = new ProviderCliReconcileOwner(registry, {
+      listActiveProviderCliRequirements: vi.fn(async () => [
+        { agentId, integrationId, provider: "slack" as const, credentialGeneration: 1, expectedIdentity: identity },
+      ]),
+      issueIntegrationCliValidationGrant: vi.fn(),
+      shouldPrewarmOfficialProviderClis: vi.fn(async () => true),
+    });
+    const connection = await registered(registry);
+    connection.socket.send.mockImplementationOnce((_data: string, cb?: (error?: Error) => void) =>
+      cb?.(new Error("socket closed")),
+    );
+    await owner.onComputerRegistered(connection);
+
+    // The failed prewarm is dropped and the bound requirement is still dispatched.
+    const frames = connection.socket.send.mock.calls.map(
+      (call) => JSON.parse(call[0] as string) as Record<string, unknown>,
+    );
+    expect(frames.map((frame) => frame.type)).toEqual(["provider-cli:prewarm", "provider-cli:requirement"]);
+    expect(frames[1]).toMatchObject({ provider: "slack", agentId, integrationId });
   });
 });

--- a/packages/server/src/__tests__/server-account-services.test.ts
+++ b/packages/server/src/__tests__/server-account-services.test.ts
@@ -14,6 +14,7 @@ import {
   computerConnectCodes,
   computerCredentials,
   computers,
+  imBindings,
   users,
 } from "../db/schema/index.js";
 import {
@@ -661,8 +662,9 @@ describe("machine authentication and Computer services", () => {
       { getActiveUserById: vi.fn() },
       { now: () => NOW, presenceTimeoutMs: 1000 },
     );
-    expect(await service.accountInFirstSetup(exchange.computerId)).toBe(true);
-    expect(await service.accountInFirstSetup(randomUUID())).toBe(false);
+    // No Agent is bound yet, and a missing Computer is never eligible.
+    expect(await service.hasActiveAgentWithoutMessagingSetup(exchange.computerId)).toBe(false);
+    expect(await service.hasActiveAgentWithoutMessagingSetup(randomUUID())).toBe(false);
     const frame = {
       type: "computer:register" as const,
       requestId: randomUUID(),
@@ -697,6 +699,7 @@ describe("machine authentication and Computer services", () => {
         runtimeProvider: "codex",
       },
     ]);
+    expect(await service.hasActiveAgentWithoutMessagingSetup(exchange.computerId)).toBe(true);
     expect(await service.heartbeat(exchange, frame.instanceId)).toBe(true);
     expect(await service.heartbeat(exchange, randomUUID())).toBe(false);
     expect(await service.disconnect(exchange.computerId, frame.instanceId)).toBe(true);
@@ -715,7 +718,9 @@ describe("machine authentication and Computer services", () => {
       imCliReadiness: expect.any(Array),
     });
     await unit.database.update(users).set({ setupCompletedAt: NOW }).where(eq(users.id, value.bootstrap.userId));
-    expect(await service.accountInFirstSetup(exchange.computerId)).toBe(false);
+    // Account completion says nothing about this Computer's Agents: eligibility only ends with a
+    // current messaging binding, not with setup_completed_at.
+    expect(await service.hasActiveAgentWithoutMessagingSetup(exchange.computerId)).toBe(true);
     await expect(service.assertActiveCredential(exchange)).resolves.toBeUndefined();
     await unit.database
       .update(computerCredentials)
@@ -723,6 +728,149 @@ describe("machine authentication and Computer services", () => {
       .where(eq(computerCredentials.id, exchange.credentialId));
     await expect(service.assertActiveCredential(exchange)).rejects.toMatchObject({ code: "COMPUTER_NOT_REGISTERED" });
     await expect(service.register(exchange, frame)).rejects.toMatchObject({ code: "COMPUTER_NOT_REGISTERED" });
+  });
+
+  it("keeps a Computer eligible when its Account completed setup before the Computer connected", async () => {
+    const value = await machineFixture();
+    // The Account finished onboarding before this Computer ever registered, so the retired
+    // setup_completed_at gate would have skipped prewarm even though nothing is prepared here.
+    await unit.database.update(users).set({ setupCompletedAt: NOW }).where(eq(users.id, value.bootstrap.userId));
+    const exchange = await value.machine.exchangeConnectCode(exchangeInput(value.issued.code));
+    const service = new ComputerService(unit.database, { getActiveUserById: vi.fn() }, { now: () => NOW });
+
+    // A missing Computer and a Computer without Agents are not eligible.
+    expect(await service.hasActiveAgentWithoutMessagingSetup(randomUUID())).toBe(false);
+    expect(await service.hasActiveAgentWithoutMessagingSetup(exchange.computerId)).toBe(false);
+
+    await unit.database.insert(agents).values({
+      createdByUserId: value.bootstrap.userId,
+      computerId: exchange.computerId,
+      name: "late-computer",
+      displayName: "Late Computer",
+      runtimeProvider: "codex",
+    });
+
+    expect(await service.hasActiveAgentWithoutMessagingSetup(exchange.computerId)).toBe(true);
+  });
+
+  it("scopes prewarm eligibility to active Agents bound to the exact Computer", async () => {
+    const value = await machineFixture();
+    const service = new ComputerService(unit.database, { getActiveUserById: vi.fn() }, { now: () => NOW });
+    const target = await value.machine.exchangeConnectCode(exchangeInput(value.issued.code));
+    const secondIssued = await value.machine.issueForAccount(value.bootstrap.userId, {});
+    const other = await value.machine.exchangeConnectCode(exchangeInput(secondIssued.code));
+
+    // Unbound, suspended, and deleted Agents never qualify, and an active Agent bound to another
+    // Computer does not leak eligibility into the target Computer.
+    await unit.database.insert(agents).values([
+      { createdByUserId: value.bootstrap.userId, name: "unbound", displayName: "Unbound", runtimeProvider: "codex" },
+      {
+        createdByUserId: value.bootstrap.userId,
+        computerId: target.computerId,
+        name: "suspended",
+        displayName: "Suspended",
+        runtimeProvider: "codex",
+        status: "suspended",
+      },
+      {
+        createdByUserId: value.bootstrap.userId,
+        computerId: target.computerId,
+        name: "deleted",
+        displayName: "Deleted",
+        runtimeProvider: "codex",
+        status: "deleted",
+      },
+      {
+        createdByUserId: value.bootstrap.userId,
+        computerId: other.computerId,
+        name: "elsewhere",
+        displayName: "Elsewhere",
+        runtimeProvider: "codex",
+      },
+    ]);
+    expect(await service.hasActiveAgentWithoutMessagingSetup(target.computerId)).toBe(false);
+    expect(await service.hasActiveAgentWithoutMessagingSetup(other.computerId)).toBe(true);
+
+    // A second Agent with a current messaging binding does not hide the Agent still waiting for
+    // its first setup on the same Computer.
+    const pending = randomUUID();
+    const connected = randomUUID();
+    await unit.database.insert(agents).values([
+      {
+        id: pending,
+        createdByUserId: value.bootstrap.userId,
+        computerId: target.computerId,
+        name: "pending",
+        displayName: "Pending",
+        runtimeProvider: "codex",
+      },
+      {
+        id: connected,
+        createdByUserId: value.bootstrap.userId,
+        computerId: target.computerId,
+        name: "connected",
+        displayName: "Connected",
+        runtimeProvider: "codex",
+      },
+    ]);
+    await unit.database.insert(imBindings).values({
+      agentId: connected,
+      provider: "feishu",
+      status: "active",
+      externalAppId: "cli_target",
+      externalBotId: "ou_target",
+      credentialSchemaVersion: 1,
+      credentialGeneration: 1,
+      activatedAt: NOW,
+      encryptedCredential: "encrypted",
+    });
+    expect(await service.hasActiveAgentWithoutMessagingSetup(target.computerId)).toBe(true);
+
+    // Suspending the pending Agent leaves no eligible Agent on the target Computer.
+    await unit.database.update(agents).set({ status: "suspended" }).where(eq(agents.id, pending));
+    expect(await service.hasActiveAgentWithoutMessagingSetup(target.computerId)).toBe(false);
+  });
+
+  it("treats every non-disabled binding status as a current messaging setup and disabled rows as history", async () => {
+    const value = await machineFixture();
+    const service = new ComputerService(unit.database, { getActiveUserById: vi.fn() }, { now: () => NOW });
+    const target = await value.machine.exchangeConnectCode(exchangeInput(value.issued.code));
+    const agentId = randomUUID();
+    await unit.database.insert(agents).values({
+      id: agentId,
+      createdByUserId: value.bootstrap.userId,
+      computerId: target.computerId,
+      name: "agent",
+      displayName: "Agent",
+      runtimeProvider: "codex",
+    });
+    expect(await service.hasActiveAgentWithoutMessagingSetup(target.computerId)).toBe(true);
+
+    for (const status of ["provisioning", "active", "reauthorization_required", "error"] as const) {
+      await unit.database.insert(imBindings).values(
+        status === "active" || status === "reauthorization_required"
+          ? {
+              agentId,
+              provider: "feishu" as const,
+              status,
+              externalAppId: "cli_current",
+              externalBotId: "ou_current",
+              credentialSchemaVersion: 1,
+              credentialGeneration: 1,
+              activatedAt: NOW,
+              encryptedCredential: "encrypted",
+            }
+          : { agentId, provider: "feishu" as const, status },
+      );
+      // Messaging setup has started or completed, in any current state: no first-setup prewarm.
+      expect(await service.hasActiveAgentWithoutMessagingSetup(target.computerId)).toBe(false);
+      await unit.database.delete(imBindings).where(eq(imBindings.agentId, agentId));
+      expect(await service.hasActiveAgentWithoutMessagingSetup(target.computerId)).toBe(true);
+    }
+
+    // A disabled binding is history: the Agent may start a fresh setup and stays eligible.
+    await unit.database.insert(imBindings).values({ agentId, provider: "feishu", status: "disabled", disabledAt: NOW });
+    expect(await service.hasActiveAgentWithoutMessagingSetup(target.computerId)).toBe(true);
   });
 
   it("projects readiness for online and offline Computers", async () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -292,7 +292,8 @@ export async function startServer(): Promise<void> {
     providerCliReconcileOwner = new ProviderCliReconcileOwner(registry, {
       listActiveProviderCliRequirements: (computerId) => imBindingService.listActiveProviderCliRequirements(computerId),
       issueIntegrationCliValidationGrant: (input) => imBindingService.issueIntegrationCliValidationGrant(input),
-      shouldPrewarmOfficialProviderClis: (computerId) => computerService.accountInFirstSetup(computerId),
+      shouldPrewarmOfficialProviderClis: (computerId) =>
+        computerService.hasActiveAgentWithoutMessagingSetup(computerId),
     });
     const agentRuntimeTestOwner = new AgentRuntimeTestOwner(registry);
     const sessionCollaborationService = new SessionCollaborationService({

--- a/packages/server/src/runtime/provider-cli-reconcile-owner.ts
+++ b/packages/server/src/runtime/provider-cli-reconcile-owner.ts
@@ -45,6 +45,11 @@ export interface ProviderCliReconcileBindingSource {
     provider: ImCliProvider;
   }): Promise<IntegrationCliValidationGrantMaterial | undefined>;
   listActiveProviderCliRequirements(computerId: string): Promise<readonly ProviderCliRequirementSnapshot[]>;
+  /**
+   * First-setup eligibility for the exact Computer: true while at least one active bound Agent has
+   * no current messaging setup. Evaluated once per (re)registration; a missing or rejected
+   * predicate fails safe to "no prewarm" and never affects active-binding reconcile.
+   */
   shouldPrewarmOfficialProviderClis?(computerId: string): Promise<boolean>;
 }
 
@@ -180,6 +185,13 @@ export class ProviderCliReconcileOwner {
     }
   }
 
+  /**
+   * Sends one inspect-both prewarm for an eligible (re)registration. The frame only asks the
+   * daemon to inspect and report both official Provider CLIs; the foreground targeted connect
+   * remains the first-setup installer. Active-binding requirements stay separate: a sibling Agent
+   * still awaiting messaging setup may qualify this Computer for inspection, but never creates
+   * continuing requirements for an unselected Provider.
+   */
   async #dispatchSetupPrewarm(input: {
     computerId: string;
     installationId: string;

--- a/packages/server/src/services/computers/computer-service.ts
+++ b/packages/server/src/services/computers/computer-service.ts
@@ -1,7 +1,7 @@
 import type { ComputerRegisterFrame, ListAccountComputersResponse, MeResponse } from "@opentag/shared";
-import { and, asc, eq, isNull, ne } from "drizzle-orm";
+import { and, asc, eq, isNull, ne, notExists } from "drizzle-orm";
 import type { DatabaseClient, DatabaseTransaction } from "../../db/client.js";
-import { agents, computerCredentials, computers, users } from "../../db/schema/index.js";
+import { agents, computerCredentials, computers, imBindings } from "../../db/schema/index.js";
 import { AuthServiceError } from "../auth/index.js";
 import type { ComputerAuthContext } from "./machine-auth-service.js";
 import { rejectUnsupportedClientVersion } from "./machine-auth-service.js";
@@ -34,14 +34,31 @@ export class ComputerService {
     this.#providerReadiness = options.providerReadiness;
   }
 
-  async accountInFirstSetup(computerId: string): Promise<boolean> {
+  /**
+   * First-setup Provider CLI prewarm eligibility for one exact Computer: at least one active Agent
+   * bound to this Computer has no current messaging setup. Every im_bindings row whose status is
+   * not "disabled" - provisioning, active, reauthorization_required, or error - is a current
+   * messaging setup, while a disabled row is history and never gates a fresh setup. The Account's
+   * setup_completed_at says nothing about this Computer's Agents, so it is not consulted here.
+   */
+  async hasActiveAgentWithoutMessagingSetup(computerId: string): Promise<boolean> {
     const [row] = await this.#database
-      .select({ setupCompletedAt: users.setupCompletedAt })
-      .from(computers)
-      .innerJoin(users, eq(users.id, computers.ownerAccountId))
-      .where(eq(computers.id, computerId))
+      .select({ id: agents.id })
+      .from(agents)
+      .where(
+        and(
+          eq(agents.computerId, computerId),
+          eq(agents.status, "active"),
+          notExists(
+            this.#database
+              .select({ id: imBindings.id })
+              .from(imBindings)
+              .where(and(eq(imBindings.agentId, agents.id), ne(imBindings.status, "disabled"))),
+          ),
+        ),
+      )
       .limit(1);
-    return row !== undefined && row.setupCompletedAt === null;
+    return row !== undefined;
   }
 
   async listAccountComputers(


### PR DESCRIPTION
## Summary

- Replace account-level setup completion as the Provider CLI prewarm eligibility signal with the exact Computer's active Agents that have no current messaging setup.
- Keep registration/reconnect prewarm as a capability-negotiated, connection-instance-fenced inspection of both official Provider CLIs. Historical disabled bindings permit a fresh setup; current provisioning, active, reauthorization-required and error bindings do not create a new dual-Provider setup requirement.
- Preserve foreground targeted `connect` as the first-setup installer and active binding reconciliation as selected-Provider-only. No F1 stage/schema dependency, CLI or Web change, migration, or new persistent state.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- Server targeted suites: `server-account-services.test.ts` and `provider-cli-reconcile-owner.test.ts` — 62 tests passed.
- Client `provider-cli-reconciler.test.ts` — 22 tests passed, including inspect/report without install or credential validation.
- `pnpm test` — 8/8 tasks passed.
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — 351 tests passed.
- `pnpm --filter @opentag/server test:integration` — 18 files / 313 tests passed using repository-owned PostgreSQL Testcontainers.
- `git diff --check`

Regression coverage includes Account completion before Computer connection, exact-Computer and multi-Agent isolation, all current binding statuses versus disabled history, missing/expired observations on reconnect, stale-instance eligibility results, selected-Provider-only convergence, and capability/predicate/send failure safety.

Evidence scope is test-only: deterministic Computer/Agent/binding regression tests and repository-required checks. This PR does not claim full Web onboarding or real Provider E2E validation.

### CI evidence for 89b5528

- All applicable automated CI checks passed, including patch coverage of 14/14 changed lines (100%). The separate non-author Code Owner approval gate is still pending.
- The first Checks attempt failed in the unchanged Client test `provider-cli-turn-runner.test.ts` / `forwards SIGTERM and SIGINT to the target` (missing `got SIGINT`). Its fixture announces readiness before installing signal handlers, a possible timing race. A targeted local rerun passed 14/14; one bounded same-head CI job rerun also passed. No Client source was changed and the original failure remains disclosed: https://github.com/first-tree-ai/opentag/actions/runs/33712869901.
- Main advanced again with documentation-only commit 01bb5f97 after this tested head. Latest-main alignment and renewed verification are required before merge; no approval is assumed to transfer to a changed head.

## Breaking changes

None. Existing capability negotiation, prewarm frame shape, and older Client fail-safe behavior are unchanged.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no documentation changes).
