### PR TITLE
feat(web): restore stable onboarding readiness primitive (F4)

### DIFF
--- a/apps/web/src/onboarding-v2/agent-setup-lab-page.test.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-lab-page.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * The Agent Setup lab page: the four production stage scenarios stay available, and the
+ * readiness scenarios render one persistent presentational list whose fixture copy is explicit.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { browserApi } from "../api.js";
+import { AgentSetupLabPage } from "./agent-setup-lab-page.js";
+import { deferred } from "./agent-setup-test-fixtures.js";
+import {
+  LONG_RUNTIME_LABEL_EN,
+  LONG_RUNTIME_LABEL_ZH,
+  READINESS_SCENARIO_LABELS,
+  READINESS_SCENARIOS,
+} from "./readiness-lab-fixtures.js";
+
+const COMPONENTS = ["computer", "runtime", "im-cli:feishu", "im-cli:slack"] as const;
+
+/** The production surface talks to browserApi; these endpoints are scripted like the page tests. */
+function mockBrowserApi(): void {
+  vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [] });
+  vi.spyOn(browserApi, "issueComputerConnectCode").mockImplementation(() => deferred<never>().promise);
+}
+
+/** The production surface reads computers through react-query, exactly like the page tests. */
+function renderLabPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentSetupLabPage />
+    </QueryClientProvider>,
+  );
+}
+
+function readinessRow(component: string): HTMLElement {
+  const element = document.querySelector(`[data-ui="readiness-list"] [data-component="${component}"]`);
+  if (!element) throw new Error(`Missing readiness row for ${component}`);
+  return element as HTMLElement;
+}
+
+function readinessList(): HTMLElement {
+  const element = document.querySelector('[data-ui="readiness-list"]');
+  if (!element) throw new Error("Missing readiness list");
+  return element as HTMLElement;
+}
+
+function slot(rowElement: HTMLElement, ui: string): HTMLElement {
+  const element = rowElement.querySelector(`[data-ui="${ui}"]`);
+  if (!element) throw new Error(`Missing ${ui} slot`);
+  return element as HTMLElement;
+}
+
+/** Opens the labelled combobox and picks the option by its visible label. */
+async function chooseOption(label: string, optionName: string): Promise<void> {
+  const trigger = screen.getByRole("combobox", { name: label });
+  fireEvent.click(trigger);
+  const option = await screen.findByRole("option", { name: optionName });
+  fireEvent.pointerMove(option, { pointerType: "mouse" });
+  fireEvent.pointerDown(option, { pointerType: "mouse" });
+  fireEvent.pointerUp(option, { pointerType: "mouse" });
+  fireEvent.click(option);
+  await waitFor(() => expect(trigger.textContent?.trim()).toContain(optionName));
+}
+
+beforeEach(() => mockBrowserApi());
+afterEach(() => vi.restoreAllMocks());
+
+describe("agent setup lab page", () => {
+  it("keeps the four production stage scenarios selectable beside the readiness fixtures", async () => {
+    renderLabPage();
+
+    // The default scenario still mounts the production surface.
+    expect(document.querySelector('[data-ui="agent-setup"]')).not.toBeNull();
+    expect(document.querySelector('[data-ui="readiness-lab"]')).toBeNull();
+
+    const trigger = screen.getByRole("combobox", { name: "Scenario" });
+    fireEvent.click(trigger);
+    const options = await screen.findAllByRole("option");
+    expect(options.map((option) => option.textContent?.trim() ?? "")).toEqual([
+      "Needs computer",
+      "Needs runtime",
+      "Needs messaging",
+      "Ready",
+      ...READINESS_SCENARIOS.map((scenario) => READINESS_SCENARIO_LABELS[scenario]),
+    ]);
+
+    // A production stage choice keeps the production surface and never opens the readiness lab.
+    fireEvent.pointerMove(screen.getByRole("option", { name: "Ready" }), { pointerType: "mouse" });
+    fireEvent.pointerDown(screen.getByRole("option", { name: "Ready" }), { pointerType: "mouse" });
+    fireEvent.pointerUp(screen.getByRole("option", { name: "Ready" }), { pointerType: "mouse" });
+    fireEvent.click(screen.getByRole("option", { name: "Ready" }));
+    await waitFor(() => expect(document.querySelector('[data-ui="agent-setup-ready"]')).not.toBeNull());
+    expect(document.querySelector('[data-ui="readiness-lab"]')).toBeNull();
+    expect(screen.getByRole("heading", { name: "Set up Reviewer" })).toBeTruthy();
+  });
+
+  it("renders the ready checklist with four rows and the exact ready copy", async () => {
+    renderLabPage();
+    await chooseOption("Scenario", "Checklist: ready");
+
+    expect(document.querySelector('[data-ui="agent-setup"]')).toBeNull();
+    expect(screen.getByRole("heading", { name: "Readiness checklist" })).toBeTruthy();
+    const list = readinessList();
+    expect(list.tagName).toBe("OL");
+    expect(list.getAttribute("aria-label")).toBe("Readiness results");
+
+    const items = list.querySelectorAll("li");
+    expect(items).toHaveLength(4);
+    expect([...items].map((item) => item.getAttribute("data-component"))).toEqual([...COMPONENTS]);
+    items.forEach((item, index) => {
+      expect(item.getAttribute("data-state")).toBe("passed");
+      expect(item.getAttribute("data-status")).toBe("ready");
+      expect(item.querySelector(".otv2-readiness__marker")?.textContent).toBe(String(index + 1));
+    });
+
+    // The runtime row carries the default Codex label; every row shows the exact caller copy.
+    const computer = readinessRow("computer");
+    expect(slot(computer, "readiness-title").textContent).toBe("ComputerComputer ready");
+    expect(slot(computer, "readiness-detail").textContent).toBe("Connected to Review Mac.");
+    const runtime = readinessRow("runtime");
+    expect(slot(runtime, "readiness-title").textContent).toBe("CodexCodex ready");
+    expect(slot(runtime, "readiness-detail").textContent).toContain("operator-supplied CLI");
+    const feishu = readinessRow("im-cli:feishu");
+    expect(slot(feishu, "readiness-title").textContent).toBe("Lark CLILark CLI ready");
+    expect(slot(feishu, "readiness-detail").textContent).toBe("Compatible Lark CLI artifact verified locally.");
+    const slack = readinessRow("im-cli:slack");
+    expect(slot(slack, "readiness-title").textContent).toBe("Slack CLISlack CLI ready");
+    expect(slot(slack, "readiness-detail").textContent).toBe("Compatible Slack CLI artifact verified locally.");
+  });
+
+  it("relabels the runtime row when Preview Runtime moves to Claude Code", async () => {
+    renderLabPage();
+    await chooseOption("Scenario", "Checklist: ready");
+    const runtimeRow = readinessRow("runtime");
+    const computerRow = readinessRow("computer");
+
+    const runtimeTrigger = screen.getByRole("combobox", { name: "Preview Runtime" });
+    expect(runtimeTrigger.textContent?.trim()).toBe("Codex");
+    fireEvent.click(runtimeTrigger);
+    const optionNames = await screen.findAllByRole("option");
+    expect(optionNames.map((option) => option.textContent?.trim() ?? "")).toEqual([
+      "Codex",
+      "Claude Code",
+      LONG_RUNTIME_LABEL_EN,
+    ]);
+    // Close the popover again before opening it fresh, or the selection lands on a closing option.
+    fireEvent.click(runtimeTrigger);
+    await waitFor(() => expect(screen.queryAllByRole("option")).toHaveLength(0));
+
+    await chooseOption("Preview Runtime", "Claude Code");
+    expect(readinessRow("runtime")).toBe(runtimeRow);
+    expect(readinessRow("computer")).toBe(computerRow);
+    expect(slot(readinessRow("runtime"), "readiness-title").textContent).toBe("Claude CodeClaude Code ready");
+    expect(slot(readinessRow("runtime"), "readiness-detail").textContent).toContain("operator-supplied CLI");
+    expect(slot(readinessRow("computer"), "readiness-title").textContent).toBe("ComputerComputer ready");
+  });
+
+  it("keeps one persistent list with the same row elements across every fixture scenario", async () => {
+    renderLabPage();
+    await chooseOption("Scenario", "Checklist: waiting");
+
+    const firstRows = new Map(COMPONENTS.map((component) => [component, readinessRow(component)]));
+    const firstList = readinessList();
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("waiting");
+    expect(readinessRow("runtime").getAttribute("data-state")).toBe("blocked");
+
+    for (const scenario of READINESS_SCENARIOS) {
+      await chooseOption("Scenario", READINESS_SCENARIO_LABELS[scenario]);
+      expect(readinessList()).toBe(firstList);
+      expect(screen.getByRole("heading", { name: "Readiness checklist" })).toBeTruthy();
+      for (const component of COMPONENTS) {
+        expect(readinessRow(component)).toBe(firstRows.get(component));
+      }
+      const items = readinessList().querySelectorAll("li");
+      items.forEach((item, index) => {
+        expect(item.querySelector(".otv2-readiness__marker")?.textContent).toBe(String(index + 1));
+      });
+    }
+
+    // The last scenario really replaced the rows' content, not just the attributes.
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("ready");
+    expect(readinessRow("runtime").getAttribute("data-state")).toBe("passed");
+    expect(slot(readinessRow("runtime"), "readiness-title").textContent).toBe("CodexCodex ready");
+  });
+
+  it("exposes the long English and Chinese fixture copy", async () => {
+    renderLabPage();
+
+    await chooseOption("Scenario", "Long English");
+    const runtimeDetail = slot(readinessRow("runtime"), "readiness-detail").textContent ?? "";
+    expect(runtimeDetail).toContain("Wait for a fresh reading");
+    expect(runtimeDetail).toContain("OpenTag does not install Runtime CLIs");
+    expect(runtimeDetail).toContain("example_runtime_diagnostic_");
+    expect(runtimeDetail).toContain("\n");
+    const feishuDetail = slot(readinessRow("im-cli:feishu"), "readiness-detail").textContent ?? "";
+    expect(feishuDetail).toContain("opentag provider-cli inspect --provider feishu");
+
+    await chooseOption("Scenario", "中文长文案");
+    const runtimeRow = readinessRow("runtime");
+    expect(slot(readinessRow("computer"), "readiness-title").textContent).toBe("电脑就绪");
+    // The sample sentences are Chinese; brand names still follow the app locale via the naming helper.
+    expect(slot(readinessRow("im-cli:feishu"), "readiness-title").textContent).toBe("Lark CLI需要安装");
+    expect(slot(runtimeRow, "readiness-title").textContent).toBe("Codex需要关注");
+    const zhRuntimeDetail = slot(runtimeRow, "readiness-detail").textContent ?? "";
+    expect(zhRuntimeDetail).toContain("因此本项尚未就绪");
+    expect(zhRuntimeDetail).toContain("OpenTag 不会自动安装 Runtime CLI");
+    const zhFeishuDetail = slot(readinessRow("im-cli:feishu"), "readiness-detail").textContent ?? "";
+    expect(zhFeishuDetail).toContain("opentag provider-cli inspect --provider feishu");
+    expect(zhFeishuDetail).toContain("这不等于正在安装");
+
+    // The deliberately long caller-supplied runtime label follows the fixture locale.
+    await chooseOption("Preview Runtime", LONG_RUNTIME_LABEL_ZH);
+    expect(readinessRow("runtime")).toBe(runtimeRow);
+    expect(slot(readinessRow("runtime"), "readiness-title").textContent).toBe(`${LONG_RUNTIME_LABEL_ZH}需要关注`);
+    expect(screen.getByRole("combobox", { name: "Preview Runtime" }).textContent?.trim()).toBe(LONG_RUNTIME_LABEL_ZH);
+  });
+
+  it("exposes the passed warning and the genuinely blank details", async () => {
+    renderLabPage();
+
+    await chooseOption("Scenario", "Passed with warning");
+    const warningRow = readinessRow("runtime");
+    expect(warningRow.getAttribute("data-state")).toBe("passed");
+    expect(warningRow.getAttribute("data-status")).toBe("ready");
+    expect(slot(warningRow, "readiness-title").textContent).toBe("CodexCodex ready");
+    expect(slot(warningRow, "readiness-detail").textContent).toContain("Non-blocking warning");
+    expect(readinessRow("computer").getAttribute("data-state")).toBe("passed");
+    expect(readinessRow("im-cli:slack").getAttribute("data-state")).toBe("passed");
+
+    await chooseOption("Scenario", "Blank details");
+    for (const component of COMPONENTS) {
+      const detail = slot(readinessRow(component), "readiness-detail");
+      expect(detail.textContent).toBe("");
+      expect(detail.getAttribute("aria-label")).not.toBe("");
+      expect(detail.getAttribute("aria-label")).not.toBeNull();
+      expect(readinessRow(component).querySelector('[data-ui="readiness-title"]')?.textContent).not.toBe("");
+    }
+    expect(readinessList().querySelectorAll('[data-ui="readiness-detail"]')).toHaveLength(4);
+  });
+
+  it("keeps stale reports blocked and messaging authorization out of preparation fixtures", async () => {
+    renderLabPage();
+    await chooseOption("Scenario", "Checklist: stale");
+    for (const component of COMPONENTS) {
+      expect(readinessRow(component).getAttribute("data-state")).toBe("blocked");
+      expect(readinessRow(component).getAttribute("data-status")).toBe("stale");
+    }
+    for (const scenario of READINESS_SCENARIOS) {
+      await chooseOption("Scenario", READINESS_SCENARIO_LABELS[scenario]);
+      expect(readinessList().textContent).not.toMatch(
+        /workspace authoriz|workspace token|credentials expire|opentag-runtime-(install|upgrade)|review\.invalid/i,
+      );
+    }
+  });
+});

--- a/apps/web/src/onboarding-v2/agent-setup-lab-page.test.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-lab-page.test.tsx
@@ -62,6 +62,9 @@ async function chooseOption(label: string, optionName: string): Promise<void> {
   fireEvent.pointerUp(option, { pointerType: "mouse" });
   fireEvent.click(option);
   await waitFor(() => expect(trigger.textContent?.trim()).toContain(optionName));
+  // Kumo keeps the closing popup mounted during its exit transition. Wait for it to leave the
+  // accessible tree before another selector opens, or a slow runner can read both option sets.
+  await waitFor(() => expect(screen.queryAllByRole("option")).toHaveLength(0));
 }
 
 beforeEach(() => mockBrowserApi());

--- a/apps/web/src/onboarding-v2/agent-setup-lab-page.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-lab-page.tsx
@@ -1,8 +1,18 @@
 import type { AgentSummary } from "@opentag/shared/browser";
 import { useMemo, useState } from "react";
 import * as m from "../paraglide/messages.js";
-import { KumoSelectControl } from "../ui/design-system.js";
+import { KumoSelectControl, Text } from "../ui/design-system.js";
 import { AgentSetupPage } from "./agent-setup-page.js";
+import {
+  PREVIEW_RUNTIMES,
+  type PreviewRuntime,
+  READINESS_SCENARIO_LABELS,
+  READINESS_SCENARIOS,
+  type ReadinessScenario,
+  readinessRowsForScenario,
+  runtimeLabelFor,
+} from "./readiness-lab-fixtures.js";
+import { ReadinessList } from "./readiness-list.js";
 import { createMemorySetupAdapter, type MemorySetupSeed } from "./setup-memory-adapter.js";
 
 const LAB_AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
@@ -26,6 +36,14 @@ const LAB_AGENT: AgentSummary = {
 const SCENARIOS = ["needs-computer", "needs-runtime", "needs-messaging", "ready"] as const;
 type LabScenario = (typeof SCENARIOS)[number];
 
+/** Every selectable lab scenario: the production stage seeds first, then the readiness fixtures. */
+const ALL_SCENARIOS = [...SCENARIOS, ...READINESS_SCENARIOS] as const;
+type LabScenarioOption = (typeof ALL_SCENARIOS)[number];
+
+function isReadinessScenario(scenario: LabScenarioOption): scenario is ReadinessScenario {
+  return (READINESS_SCENARIOS as readonly string[]).includes(scenario);
+}
+
 function scenarioSeed(scenario: LabScenario): MemorySetupSeed {
   if (scenario === "needs-computer") return { agent: { ...LAB_AGENT, computer: null } };
   if (scenario === "needs-runtime") return { agent: LAB_AGENT, runtimeStatus: "install" };
@@ -35,37 +53,98 @@ function scenarioSeed(scenario: LabScenario): MemorySetupSeed {
   return { agent: LAB_AGENT };
 }
 
-function scenarioLabel(scenario: LabScenario): string {
+function scenarioLabel(scenario: LabScenarioOption): string {
+  if (isReadinessScenario(scenario)) return READINESS_SCENARIO_LABELS[scenario];
   if (scenario === "needs-computer") return m.onboarding_v2_lab_needs_computer();
   if (scenario === "needs-runtime") return m.onboarding_v2_lab_needs_runtime();
   if (scenario === "needs-messaging") return m.onboarding_v2_lab_needs_messaging();
   return m.onboarding_v2_lab_ready();
 }
 
-/** The production presentation against Issue 437's in-memory Adapter, with only the seed state selectable. */
-export function AgentSetupLabPage() {
-  const [scenario, setScenario] = useState<LabScenario>("needs-computer");
+/** The four production scenarios drive the real Agent Setup surface over the in-memory Adapter. */
+function ProductionSetupView({ scenario }: { scenario: LabScenario }) {
   const memory = useMemo(() => createMemorySetupAdapter(scenarioSeed(scenario)), [scenario]);
+  return <AgentSetupPage adapter={memory.adapter} agentId={LAB_AGENT_ID} />;
+}
+
+/**
+ * A purely presentational preview of the readiness list: one persistent list under a fixed
+ * heading, and the Preview Runtime selector whose label the fixtures treat as caller copy. No
+ * setup state, adapter, timers, or stage calculations live here.
+ */
+function ReadinessLabView({
+  onRuntimeChange,
+  runtime,
+  scenario,
+}: {
+  onRuntimeChange: (runtime: PreviewRuntime) => void;
+  runtime: PreviewRuntime;
+  scenario: ReadinessScenario;
+}) {
+  const rows = readinessRowsForScenario(scenario, runtime);
+  return (
+    <div className="otv2-readiness-lab min-h-screen bg-kumo-canvas" data-ui="readiness-lab">
+      <div className="otv2-readiness-lab__inner">
+        <Text as="h1" size="lg" variant="heading">
+          Readiness checklist
+        </Text>
+        <p className="m-0 text-sm text-kumo-subtle">Static review fixtures only — no live checks.</p>
+        <div className="otv2-readiness-lab__controls">
+          <label className="otv2-readiness-lab__label" htmlFor="readiness-lab-runtime">
+            Preview Runtime
+          </label>
+          <KumoSelectControl
+            className="otv2-readiness-lab__select"
+            id="readiness-lab-runtime"
+            onChange={(event) => onRuntimeChange(event.target.value as PreviewRuntime)}
+            value={runtime}
+          >
+            {PREVIEW_RUNTIMES.map((candidate) => (
+              <option key={candidate} value={candidate}>
+                {runtimeLabelFor(candidate, scenario)}
+              </option>
+            ))}
+          </KumoSelectControl>
+        </div>
+        <ReadinessList label="Readiness results" rows={rows} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The lab against Issue 437's in-memory Adapter: the production stage seeds stay selectable, and
+ * the readiness scenarios render the same presentational list with explicit fixture copy.
+ */
+export function AgentSetupLabPage() {
+  const [scenario, setScenario] = useState<LabScenarioOption>("needs-computer");
+  const [runtime, setRuntime] = useState<PreviewRuntime>("codex");
   return (
     <div className="relative min-h-screen">
-      <AgentSetupPage adapter={memory.adapter} agentId={LAB_AGENT_ID} />
-      <aside className="fixed inset-x-4 bottom-4 z-10 mx-auto flex max-w-md items-center gap-3 rounded-lg bg-kumo-base p-3 shadow-lg ring ring-kumo-line">
+      <aside
+        className={`${isReadinessScenario(scenario) ? "otv2-readiness-lab__scenario" : "fixed inset-x-4 bottom-4"} z-10 mx-auto flex max-w-md items-center gap-3 rounded-lg bg-kumo-base p-3 shadow-lg ring ring-kumo-line`}
+      >
         <label className="text-sm font-medium text-kumo-strong" htmlFor="agent-setup-lab-scenario">
           {m.onboarding_v2_lab_scenario()}
         </label>
         <KumoSelectControl
           className="min-w-0 flex-1"
           id="agent-setup-lab-scenario"
-          onChange={(event) => setScenario(event.target.value as LabScenario)}
+          onChange={(event) => setScenario(event.target.value as LabScenarioOption)}
           value={scenario}
         >
-          {SCENARIOS.map((candidate) => (
+          {ALL_SCENARIOS.map((candidate) => (
             <option key={candidate} value={candidate}>
               {scenarioLabel(candidate)}
             </option>
           ))}
         </KumoSelectControl>
       </aside>
+      {isReadinessScenario(scenario) ? (
+        <ReadinessLabView onRuntimeChange={setRuntime} runtime={runtime} scenario={scenario} />
+      ) : (
+        <ProductionSetupView scenario={scenario} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/onboarding-v2/layout.test.ts
+++ b/apps/web/src/onboarding-v2/layout.test.ts
@@ -20,6 +20,22 @@ function declarationValue(selector: string, property: string): string {
   return value;
 }
 
+/** Reads a declaration from the rules inside a media query that names the given width limit. */
+function mediaDeclarationValue(limit: string, selector: string, property: string): string {
+  let value: string | undefined;
+  stylesheet.walkAtRules("media", (atRule) => {
+    if (!atRule.params.includes(limit)) return;
+    atRule.walkRules((rule) => {
+      if (!rule.selectors.includes(selector)) return;
+      rule.walkDecls(property, (declaration) => {
+        value = declaration.value;
+      });
+    });
+  });
+  if (!value) throw new Error(`Missing ${property} declaration for ${selector} within ${limit} media`);
+  return value;
+}
+
 describe("onboarding flow layout", () => {
   it("selects the Codex mark from the app theme instead of the operating-system theme", () => {
     expect(declarationValue(".otv2-codex-mark--light", "display")).toBe("block");
@@ -96,5 +112,83 @@ describe("onboarding flow layout", () => {
     expect(atWidth("640px", ".otv2-slot--outcome", "min-height")).toBe("71px");
     expect(atWidth("640px", ".otv2-field-error", "min-height")).toBe("34px");
     expect(atWidth("359px", ".otv2-slot--outcome", "min-height")).toBe("114px");
+  });
+
+  /*
+   * The readiness rows follow the same rule as the slots above: the reserved heights and the
+   * fixed marker are declarations the layout depends on, so they are guarded here rather than
+   * left to be deleted as decoration.
+   */
+  it("lays the readiness list out as a bordered column of padded rows", () => {
+    expect(declarationValue(".otv2-readiness", "display")).toBe("flex");
+    expect(declarationValue(".otv2-readiness", "flex-direction")).toBe("column");
+    expect(declarationValue(".otv2-readiness", "gap")).toBe("0.75rem");
+    expect(declarationValue(".otv2-readiness__line", "padding")).toBe("0.75rem");
+    expect(declarationValue(".otv2-readiness__line", "box-sizing")).toBe("border-box");
+  });
+
+  it("fixes the decorative readiness markers at 24px", () => {
+    expect(declarationValue(".otv2-readiness__marker", "width")).toBe("24px");
+    expect(declarationValue(".otv2-readiness__marker", "height")).toBe("24px");
+    expect(declarationValue(".otv2-readiness__marker", "flex-shrink")).toBe("0");
+  });
+
+  it("reserves fixed heights for the readiness title and detail slots and scrolls their overflow", () => {
+    expect(declarationValue(".otv2-readiness__title", "height")).toBe("2.75rem");
+    expect(declarationValue(".otv2-readiness__title", "line-height")).toBe("1.25rem");
+    expect(declarationValue(".otv2-readiness__detail", "height")).toBe("3.375rem");
+    expect(declarationValue(".otv2-readiness__detail", "line-height")).toBe("1.125rem");
+    // A fixed height only stays fixed when padding and borders are counted inside it.
+    expect(declarationValue(".otv2-readiness__title", "box-sizing")).toBe("border-box");
+    expect(declarationValue(".otv2-readiness__detail", "box-sizing")).toBe("border-box");
+    // Copy that does not fit scrolls inside its own slot; the slots are keyboard-focusable in
+    // the markup, and the visible focus answers the keyboard.
+    expect(declarationValue(".otv2-readiness__title", "overflow-y")).toBe("auto");
+    expect(declarationValue(".otv2-readiness__detail", "overflow-y")).toBe("auto");
+    expect(declarationValue(".otv2-readiness__detail:focus-visible", "outline")).toBe(
+      "2px solid var(--color-kumo-focus)",
+    );
+  });
+
+  it("wraps long readiness copy instead of widening the rows or clipping it", () => {
+    expect(declarationValue(".otv2-readiness__title", "white-space")).toBe("pre-wrap");
+    expect(declarationValue(".otv2-readiness__title", "overflow-wrap")).toBe("anywhere");
+    expect(declarationValue(".otv2-readiness__detail", "white-space")).toBe("pre-wrap");
+    expect(declarationValue(".otv2-readiness__detail", "overflow-wrap")).toBe("anywhere");
+    expect(declarationValue(".otv2-readiness__copy", "min-width")).toBe("0");
+  });
+
+  it("reserves the taller title and detail slots a narrow readiness layout needs", () => {
+    expect(mediaDeclarationValue("640px", ".otv2-readiness__title", "height")).toBe("3.75rem");
+    expect(mediaDeclarationValue("640px", ".otv2-readiness__detail", "height")).toBe("4.5rem");
+  });
+
+  it("lets lab select wrappers and their triggers shrink on narrow screens", () => {
+    expect(declarationValue(".otv2-readiness-lab__controls > div", "min-width")).toBe("0");
+    expect(declarationValue(".otv2-readiness-lab__scenario > div", "min-width")).toBe("0");
+    expect(declarationValue(".otv2-readiness-lab__select", "width")).toBe("100%");
+    expect(declarationValue('.otv2-readiness-lab__scenario [role="combobox"]', "width")).toBe("100%");
+  });
+
+  it("keeps readiness state emphasis on the marker, never in the row geometry", () => {
+    expect(declarationValue('.otv2-readiness__line[data-state="passed"] .otv2-readiness__marker', "background")).toBe(
+      "var(--brand-soft)",
+    );
+    expect(declarationValue('.otv2-readiness__line[data-state="passed"] .otv2-readiness__marker', "color")).toBe(
+      "var(--brand-ink)",
+    );
+    expect(declarationValue('.otv2-readiness__line[data-state="failed"] .otv2-readiness__marker', "background")).toBe(
+      "var(--color-kumo-recessed)",
+    );
+    expect(declarationValue('.otv2-readiness__line[data-state="blocked"] .otv2-readiness__marker', "background")).toBe(
+      "var(--color-kumo-recessed)",
+    );
+    // No rule keyed on a row state may change a fixed size.
+    stylesheet.walkRules((rule) => {
+      if (!rule.selectors.some((selector) => selector.includes('data-state="'))) return;
+      rule.walkDecls((declaration) => {
+        expect(declaration.prop).not.toMatch(/^(height|min-height|max-height|padding|border-width)$/);
+      });
+    });
   });
 });

--- a/apps/web/src/onboarding-v2/onboarding-v2.css
+++ b/apps/web/src/onboarding-v2/onboarding-v2.css
@@ -176,3 +176,191 @@
 .otv2-slack-install img {
   height: 40px;
 }
+
+/* Readiness rows --------------------------------------------------------- */
+
+/*
+ * The four readiness rows use fixed reservations: each slot keeps one
+ * height for every state it can hold, so no row grows, collapses, or shifts while the copy under
+ * it resolves. Text that does not fit scrolls inside its own slot; both slots are focusable in
+ * the markup and keep a visible focus ring, so a keyboard can read every line.
+ */
+.otv2-readiness {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: var(--color-kumo-base);
+  border: 1px solid var(--color-kumo-line);
+  border-radius: 0.75rem;
+}
+
+.otv2-readiness__line {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+}
+
+/* Decorative running number. The state never lives in the marker alone: the row always states it. */
+.otv2-readiness__marker {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-kumo-line);
+  border-radius: 50%;
+  font-size: 0.75rem;
+  line-height: 1;
+  color: var(--text-color-kumo-subtle);
+}
+
+.otv2-readiness__copy {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+/* A row's header: the caller's label with its status label underneath, in one fixed slot. */
+.otv2-readiness__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  height: 2.75rem;
+  box-sizing: border-box;
+  overflow-x: hidden;
+  overflow-y: auto;
+  line-height: 1.25rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.otv2-readiness__name {
+  color: var(--text-color-kumo-strong);
+  font-weight: 500;
+}
+
+.otv2-readiness__status {
+  color: var(--text-color-kumo-subtle);
+  font-size: 0.75rem;
+}
+
+/* The diagnostic region, mounted even when its copy is empty. */
+.otv2-readiness__detail {
+  height: 3.375rem;
+  box-sizing: border-box;
+  overflow-x: hidden;
+  overflow-y: auto;
+  line-height: 1.125rem;
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--text-color-kumo-subtle);
+}
+
+/* Both slots are scroll regions, so both answer a keyboard visit with the focus ring. */
+.otv2-readiness__title:focus-visible,
+.otv2-readiness__detail:focus-visible {
+  outline: 2px solid var(--color-kumo-focus);
+  outline-offset: 2px;
+}
+
+/*
+ * A row's outcome is told in text first; the marker only frames it. The emphasis stays on the
+ * marker, never on the row geometry, so a fixed-height row cannot change shape with its state.
+ */
+.otv2-readiness__line[data-state="passed"] .otv2-readiness__marker {
+  border-color: var(--brand-ink);
+  background: var(--brand-soft);
+  color: var(--brand-ink);
+}
+
+.otv2-readiness__line[data-state="failed"] .otv2-readiness__marker,
+.otv2-readiness__line[data-state="blocked"] .otv2-readiness__marker {
+  background: var(--color-kumo-recessed);
+  color: var(--text-color-kumo-strong);
+}
+
+/* Below 640px each slot reserves the extra lines its copy needs there. */
+@media (width <= 640px) {
+  .otv2-readiness__title {
+    height: 3.75rem;
+  }
+
+  .otv2-readiness__detail {
+    height: 4.5rem;
+  }
+}
+
+/* Readiness lab (internal preview) --------------------------------------- */
+
+/*
+ * The readiness lab replaces the production surface while a readiness scenario is selected. The
+ * preview is capped at 720px and centered. Its scenario toolbar stays in normal flow above the
+ * checklist so it cannot cover a diagnostic region. Everything here is lab-only and must not
+ * leak into the production surface.
+ */
+.otv2-readiness-lab {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  padding: 1.25rem 1rem;
+  min-width: 0;
+}
+
+.otv2-readiness-lab__inner {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(100%, 720px);
+  min-width: 0;
+}
+
+.otv2-readiness-lab__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+/* Kumo owns the select's outer grid; the flex child, not just its trigger, must shrink. */
+.otv2-readiness-lab__controls > div,
+.otv2-readiness-lab__scenario > div {
+  flex: 1;
+  min-width: 0;
+}
+
+.otv2-readiness-lab__scenario {
+  box-sizing: border-box;
+  width: calc(100% - 2rem);
+  max-width: 720px;
+  margin-top: 1rem;
+}
+
+.otv2-readiness-lab__scenario label {
+  flex-shrink: 0;
+}
+
+.otv2-readiness-lab__label {
+  flex-shrink: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-color-kumo-strong);
+}
+
+.otv2-readiness-lab__select,
+.otv2-readiness-lab__scenario [role="combobox"] {
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}

--- a/apps/web/src/onboarding-v2/readiness-lab-fixtures.ts
+++ b/apps/web/src/onboarding-v2/readiness-lab-fixtures.ts
@@ -1,0 +1,429 @@
+/**
+ * Review fixtures for the readiness lab: every row model is explicit, and every string is static
+ * copy written for the lab only. The lab never passes these rows through a setup adapter — it
+ * renders them straight into the presentational `ReadinessList`.
+ */
+
+import { messagingProviderLabel } from "../im/provider-label.js";
+import type { CheckRow, CheckState, ReadinessRows, ReadinessStatus } from "./readiness-list.js";
+
+export const READINESS_SCENARIOS = [
+  "readiness-waiting",
+  "readiness-checking",
+  "readiness-install-required",
+  "readiness-ready",
+  "readiness-needs-attention",
+  "readiness-stale",
+  "readiness-blank",
+  "readiness-long-en",
+  "readiness-long-zh",
+  "readiness-mixed",
+  "readiness-warning",
+] as const;
+
+export type ReadinessScenario = (typeof READINESS_SCENARIOS)[number];
+
+export const READINESS_SCENARIO_LABELS: Readonly<Record<ReadinessScenario, string>> = {
+  "readiness-waiting": "Checklist: waiting",
+  "readiness-checking": "Checklist: checking",
+  "readiness-install-required": "Checklist: install required",
+  "readiness-ready": "Checklist: ready",
+  "readiness-needs-attention": "Checklist: needs attention",
+  "readiness-stale": "Checklist: stale",
+  "readiness-blank": "Blank details",
+  "readiness-long-en": "Long English",
+  "readiness-long-zh": "中文长文案",
+  "readiness-mixed": "Mixed states",
+  "readiness-warning": "Passed with warning",
+};
+
+export const PREVIEW_RUNTIMES = ["codex", "claude-code", "long"] as const;
+export type PreviewRuntime = (typeof PREVIEW_RUNTIMES)[number];
+
+export const CODE_RUNTIME_LABEL = "Codex";
+export const CLAUDE_CODE_RUNTIME_LABEL = "Claude Code";
+export const LONG_RUNTIME_LABEL_EN =
+  "Codex with an unusually long custom runtime display name for this review workspace";
+export const LONG_RUNTIME_LABEL_ZH = "Codex——自定义运行时显示名称被故意设置得很长，用于预览窄屏换行与滚动（仅评审）";
+
+/** The runtime row label is always the caller's supplied runtime copy, never inferred here. */
+export function runtimeLabelFor(runtime: PreviewRuntime, scenario: ReadinessScenario): string {
+  if (runtime === "codex") return CODE_RUNTIME_LABEL;
+  if (runtime === "claude-code") return CLAUDE_CODE_RUNTIME_LABEL;
+  return scenario === "readiness-long-zh" ? LONG_RUNTIME_LABEL_ZH : LONG_RUNTIME_LABEL_EN;
+}
+
+function row(model: {
+  readonly label: string;
+  readonly detailLabel: string;
+  readonly state: CheckState;
+  readonly status: ReadinessStatus;
+  readonly statusLabel: string;
+  readonly detail: string;
+}): CheckRow {
+  return { ...model };
+}
+
+function computerRow(detail: string, state: CheckState, status: ReadinessStatus, statusLabel: string): CheckRow {
+  return row({
+    label: "Computer",
+    detailLabel: "Computer diagnostics",
+    detail,
+    state,
+    status,
+    statusLabel,
+  });
+}
+
+function runtimeRow(
+  runtimeLabel: string,
+  state: CheckState,
+  status: ReadinessStatus,
+  statusLabel: string,
+  detail: string,
+): CheckRow {
+  return row({ label: runtimeLabel, detailLabel: "Runtime diagnostics", detail, state, status, statusLabel });
+}
+
+function feishuRow(state: CheckState, status: ReadinessStatus, statusLabel: string, detail: string): CheckRow {
+  return row({
+    label: `${messagingProviderLabel("feishu")} CLI`,
+    detailLabel: `${messagingProviderLabel("feishu")} CLI diagnostics`,
+    detail,
+    state,
+    status,
+    statusLabel,
+  });
+}
+
+function slackRow(state: CheckState, status: ReadinessStatus, statusLabel: string, detail: string): CheckRow {
+  return row({
+    label: `${messagingProviderLabel("slack")} CLI`,
+    detailLabel: `${messagingProviderLabel("slack")} CLI diagnostics`,
+    detail,
+    state,
+    status,
+    statusLabel,
+  });
+}
+
+function waitingRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow("Waiting for the computer to finish connecting.", "pending", "waiting", "Waiting"),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "blocked",
+      "waiting",
+      "Waiting for Computer",
+      "Runtime checks wait for the computer to connect first.",
+    ),
+    feishu: feishuRow(
+      "blocked",
+      "waiting",
+      "Waiting for Computer",
+      `The ${messagingProviderLabel("feishu")} CLI check starts once the computer is connected.`,
+    ),
+    slack: slackRow(
+      "blocked",
+      "waiting",
+      "Waiting for Computer",
+      `The ${messagingProviderLabel("slack")} check waits behind the computer check.`,
+    ),
+  };
+}
+
+function checkingRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow("Checking the current Computer connection.", "pending", "checking", "Checking"),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "pending",
+      "checking",
+      "Checking",
+      "Checking the installed runtime version and its sign-in state.",
+    ),
+    feishu: feishuRow(
+      "pending",
+      "checking",
+      "Checking",
+      `Checking the ${messagingProviderLabel("feishu")} CLI executable and compatible version.`,
+    ),
+    slack: slackRow(
+      "pending",
+      "checking",
+      "Checking",
+      `Checking the ${messagingProviderLabel("slack")} CLI executable and compatible version.`,
+    ),
+  };
+}
+
+function installRequiredRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow("Connected to Review Mac.", "passed", "ready", "Ready"),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "failed",
+      "install-required",
+      "Install required",
+      "The selected Runtime CLI is missing. Install it manually, then check again; OpenTag does not install Runtime CLIs.",
+    ),
+    feishu: feishuRow(
+      "pending",
+      "install-required",
+      "Install required",
+      `The foreground preparation command must install the ${messagingProviderLabel("feishu")} CLI artifact, then the daemon can check it again.`,
+    ),
+    slack: slackRow(
+      "pending",
+      "install-required",
+      "Install required",
+      `The foreground preparation command must install the ${messagingProviderLabel("slack")} CLI artifact, then the daemon can check it again.`,
+    ),
+  };
+}
+
+function readyRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow("Connected to Review Mac.", "passed", "ready", "Computer ready"),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "passed",
+      "ready",
+      `${runtimeLabel} ready`,
+      "The operator-supplied CLI, required capabilities, and Runtime sign-in check passed.",
+    ),
+    feishu: feishuRow(
+      "passed",
+      "ready",
+      `${messagingProviderLabel("feishu")} CLI ready`,
+      `Compatible ${messagingProviderLabel("feishu")} CLI artifact verified locally.`,
+    ),
+    slack: slackRow(
+      "passed",
+      "ready",
+      `${messagingProviderLabel("slack")} CLI ready`,
+      `Compatible ${messagingProviderLabel("slack")} CLI artifact verified locally.`,
+    ),
+  };
+}
+
+function needsAttentionRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow("Connected to Review Mac.", "passed", "ready", "Ready"),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "failed",
+      "needs-attention",
+      "Needs attention",
+      "version_incompatible: the selected Runtime CLI lacks a required capability. Update it manually, then recheck.",
+    ),
+    feishu: feishuRow(
+      "failed",
+      "needs-attention",
+      "Needs attention",
+      `integrity_failed: the selected ${messagingProviderLabel("feishu")} CLI artifact did not pass verification. Use the reported idempotent repair action.`,
+    ),
+    slack: slackRow(
+      "failed",
+      "needs-attention",
+      "Needs attention",
+      `executable_unavailable: the ${messagingProviderLabel("slack")} CLI executable cannot be launched. Repair the artifact and inspect it again.`,
+    ),
+  };
+}
+
+function staleRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow(
+      "The current connection report expired. Refresh to obtain fresh evidence for this exact Computer.",
+      "blocked",
+      "stale",
+      "Stale",
+    ),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "blocked",
+      "stale",
+      "Stale",
+      "The Runtime report expired. The previous ready result is no longer current; request a fresh check.",
+    ),
+    feishu: feishuRow(
+      "blocked",
+      "stale",
+      "Stale",
+      `The ${messagingProviderLabel("feishu")} CLI artifact report expired. Request a fresh local inspection.`,
+    ),
+    slack: slackRow(
+      "blocked",
+      "stale",
+      "Stale",
+      `The ${messagingProviderLabel("slack")} CLI artifact report expired. Request a fresh local inspection.`,
+    ),
+  };
+}
+
+function blankRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow("", "pending", "waiting", "Waiting"),
+    runtime: runtimeRow(runtimeLabel, "pending", "checking", "Checking", ""),
+    feishu: feishuRow("pending", "install-required", "Install required", ""),
+    slack: slackRow("pending", "waiting", "Waiting", ""),
+  };
+}
+
+function longEnRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow(
+      "Review fixture: the exact bound Computer is online on its current connection. The remaining rows are independent observations; connection alone does not prove any CLI ready.",
+      "passed",
+      "ready",
+      "Ready",
+    ),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "pending",
+      "checking",
+      "Checking",
+      "Review fixture: a real checking observation is in progress for the selected operator-supplied Runtime CLI. Its executable, compatible version, required capabilities, and Runtime sign-in are checked independently of messaging setup.\nWait for a fresh reading. If the check reports a missing or incompatible CLI, install or update that Runtime manually and request another check. OpenTag does not install Runtime CLIs.\nFictional diagnostic identifier for wrapping: example_runtime_diagnostic_abcdefghijklmnopqrstuvwxyz_0123456789_abcdefghijklmnopqrstuvwxyz_0123456789_abcdefghijklmnopqrstuvwxyz\nThis is static review copy, not a live progress report or an executable repair instruction.",
+    ),
+    feishu: feishuRow(
+      "failed",
+      "install-required",
+      "Install required",
+      `Review fixture: the ${messagingProviderLabel("feishu")} CLI artifact requires installation. This does not mean installation is currently running. Use the foreground command's reported idempotent repair action, then inspect the artifact again.\nVerification command: opentag provider-cli inspect --provider feishu\nFictional diagnostic identifier: example_artifact_diagnostic_abcdefghijklmnopqrstuvwxyz_0123456789_abcdefghijklmnopqrstuvwxyz_0123456789\nA local artifact check does not select or connect a messaging integration.`,
+    ),
+    slack: slackRow(
+      "pending",
+      "waiting",
+      "Waiting",
+      `Review fixture: no ${messagingProviderLabel("slack")} CLI artifact observation has arrived from this Computer connection. Absence of a report is waiting, not checking. Wait for the daemon's fresh local artifact inspection or request a recheck; do not reuse a consumed Computer connect code.\nVerification command: opentag provider-cli inspect --provider slack`,
+    ),
+  };
+}
+
+const ZH_COMPUTER_DETAIL =
+  "评审示例：当前智能体明确绑定的 Review Mac 已在线。Computer 连接与各个 CLI 的本机检查是独立事实；仅连接成功不能代表其余项目已就绪。";
+const ZH_RUNTIME_DETAIL =
+  "评审示例：version_incompatible，第一步所选 Runtime CLI 不具备所需能力，因此本项尚未就绪。请由操作者手动安装或更新所选 Runtime，再重新检查。OpenTag 不会自动安装 Runtime CLI。\n本项检查操作者预装的确切可执行文件、兼容版本、所需能力及 Runtime 登录状态。修复后需要收到新的检查报告，不能继续沿用先前的就绪结果。\n用于测试换行的虚构诊断编号：example_runtime_diagnostic_abcdefghijklmnopqrstuvwxyz_0123456789_abcdefghijklmnopqrstuvwxyz_0123456789_abcdefghijklmnopqrstuvwxyz\n这些文字仅用于评审固定槽位和滚动，不是实时安装进度。";
+function zhFeishuDetail(): string {
+  return `评审示例：${messagingProviderLabel("feishu")} CLI 本机文件需要安装，这不等于正在安装。使用前台准备命令返回的幂等修复动作，完成后重新检查本机文件。\n验证命令：opentag provider-cli inspect --provider feishu\n用于窄屏换行的虚构诊断编号：example_artifact_diagnostic_abcdefghijklmnopqrstuvwxyz_0123456789_abcdefghijklmnopqrstuvwxyz_0123456789\n本机 CLI 文件的准备不选择或连接消息应用。`;
+}
+
+function zhSlackDetail(): string {
+  return `评审示例：尚未收到当前 Computer 连接的 ${messagingProviderLabel("slack")} CLI 本机检查报告。没有报告应当显示等待，而不是伪装成检查中。请等待新的 daemon 检查结果，或重新检查；不要重用已消费的一次性 Computer 连接码。\n验证命令：opentag provider-cli inspect --provider slack`;
+}
+
+function longZhRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: row({
+      label: "电脑",
+      detailLabel: "电脑诊断",
+      detail: ZH_COMPUTER_DETAIL,
+      state: "passed",
+      status: "ready",
+      statusLabel: "就绪",
+    }),
+    runtime: row({
+      label: runtimeLabel,
+      detailLabel: "运行时诊断",
+      detail: ZH_RUNTIME_DETAIL,
+      state: "failed",
+      status: "needs-attention",
+      statusLabel: "需要关注",
+    }),
+    feishu: row({
+      label: `${messagingProviderLabel("feishu")} CLI`,
+      detailLabel: `${messagingProviderLabel("feishu")} CLI 诊断`,
+      detail: zhFeishuDetail(),
+      state: "failed",
+      status: "install-required",
+      statusLabel: "需要安装",
+    }),
+    slack: row({
+      label: `${messagingProviderLabel("slack")} CLI`,
+      detailLabel: `${messagingProviderLabel("slack")} CLI 诊断`,
+      detail: zhSlackDetail(),
+      state: "pending",
+      status: "waiting",
+      statusLabel: "等待中",
+    }),
+  };
+}
+
+function mixedRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow("Connected to Review Mac.", "passed", "ready", "Ready"),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "pending",
+      "checking",
+      "Checking",
+      "Checking the runtime version before the sign-in step.",
+    ),
+    feishu: feishuRow(
+      "failed",
+      "needs-attention",
+      "Needs attention",
+      `integrity_failed: the ${messagingProviderLabel("feishu")} CLI artifact requires repair and a fresh inspection.`,
+    ),
+    slack: slackRow(
+      "blocked",
+      "stale",
+      "Blocked",
+      `The ${messagingProviderLabel("slack")} CLI artifact report expired; waiting for a fresh inspection.`,
+    ),
+  };
+}
+
+function warningRows(runtimeLabel: string): ReadinessRows {
+  return {
+    computer: computerRow("Connected to Review Mac.", "passed", "ready", "Ready"),
+    runtime: runtimeRow(
+      runtimeLabel,
+      "passed",
+      "ready",
+      `${runtimeLabel} ready`,
+      "Non-blocking warning: a newer version is available, but this installed Runtime satisfies all required capabilities. This observation remains ready.",
+    ),
+    feishu: feishuRow(
+      "passed",
+      "ready",
+      `${messagingProviderLabel("feishu")} CLI ready`,
+      `Compatible ${messagingProviderLabel("feishu")} CLI artifact verified locally.`,
+    ),
+    slack: slackRow(
+      "passed",
+      "ready",
+      `${messagingProviderLabel("slack")} CLI ready`,
+      "Non-blocking warning: global_path_not_configured. The verified managed launcher works, so the CLI remains ready.",
+    ),
+  };
+}
+
+export function readinessRowsForScenario(scenario: ReadinessScenario, runtime: PreviewRuntime): ReadinessRows {
+  const runtimeLabel = runtimeLabelFor(runtime, scenario);
+  switch (scenario) {
+    case "readiness-waiting":
+      return waitingRows(runtimeLabel);
+    case "readiness-checking":
+      return checkingRows(runtimeLabel);
+    case "readiness-install-required":
+      return installRequiredRows(runtimeLabel);
+    case "readiness-ready":
+      return readyRows(runtimeLabel);
+    case "readiness-needs-attention":
+      return needsAttentionRows(runtimeLabel);
+    case "readiness-stale":
+      return staleRows(runtimeLabel);
+    case "readiness-blank":
+      return blankRows(runtimeLabel);
+    case "readiness-long-en":
+      return longEnRows(runtimeLabel);
+    case "readiness-long-zh":
+      return longZhRows(runtimeLabel);
+    case "readiness-mixed":
+      return mixedRows(runtimeLabel);
+    case "readiness-warning":
+      return warningRows(runtimeLabel);
+  }
+}

--- a/apps/web/src/onboarding-v2/readiness-list.test.tsx
+++ b/apps/web/src/onboarding-v2/readiness-list.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * The readiness rows primitive: a fixed set of rows that show exactly the state and copy they are
+ * handed, keep their DOM identity across rerenders, and keep their slots mounted even when empty.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  type CheckRow,
+  type CheckState,
+  ReadinessList,
+  type ReadinessRows,
+  type ReadinessStatus,
+} from "./readiness-list.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const COMPUTER = "computer";
+const RUNTIME = "runtime";
+const FEISHU = "im-cli:feishu";
+const SLACK = "im-cli:slack";
+const ORDER = [COMPUTER, RUNTIME, FEISHU, SLACK] as const;
+
+const CHECK_STATES: readonly CheckState[] = ["pending", "passed", "failed", "blocked"];
+const READINESS_STATUSES: readonly ReadinessStatus[] = [
+  "waiting",
+  "checking",
+  "install-required",
+  "ready",
+  "needs-attention",
+  "stale",
+];
+
+const LONG_EN_DETAIL =
+  "The runtime answered, but the version it reports is older than this workspace expects, so the " +
+  "check needs a repair command before onboarding can continue past this step.";
+const ZH_TITLE = "这是一段很长很长的中文行标题，用来确认换行和滚动都不会改变这一行的结构";
+const ZH_DETAIL =
+  "第一行：安装命令已经打印在上一步。\n第二行：安装完成之后重新运行检查。\n第三行：这是一段很长的中文诊断文字，用来确认诊断槽位保持固定。";
+
+function checkRow(overrides: Partial<CheckRow> = {}): CheckRow {
+  return {
+    state: "pending",
+    status: "waiting",
+    label: "Computer",
+    statusLabel: "Waiting",
+    detail: "",
+    detailLabel: "Computer diagnostics",
+    ...overrides,
+  };
+}
+
+/** Four fixed rows whose detail is blank by default, so "mounted even when empty" is the norm. */
+function readinessRows(
+  computer: Partial<CheckRow> = {},
+  runtime: Partial<CheckRow> = {},
+  feishu: Partial<CheckRow> = {},
+  slack: Partial<CheckRow> = {},
+): ReadinessRows {
+  return {
+    computer: checkRow(computer),
+    runtime: checkRow(runtime),
+    feishu: checkRow(feishu),
+    slack: checkRow(slack),
+  };
+}
+
+function row(component: string): HTMLElement {
+  const element = document.querySelector(`[data-ui="readiness-list"] [data-component="${component}"]`);
+  if (!element) throw new Error(`Missing readiness row for ${component}`);
+  return element as HTMLElement;
+}
+
+describe("readiness list", () => {
+  it("renders one labelled semantic list with the four rows in the fixed order", () => {
+    render(<ReadinessList label="Readiness check" rows={readinessRows()} />);
+
+    const list = screen.getByRole("list", { name: "Readiness check" });
+    expect(list.tagName).toBe("OL");
+    expect(list.getAttribute("data-ui")).toBe("readiness-list");
+
+    const items = within(list).getAllByRole("listitem");
+    expect(items).toHaveLength(4);
+    expect(items.map((item) => item.getAttribute("data-component"))).toEqual([...ORDER]);
+    items.forEach((item, index) => {
+      const marker = item.querySelector(".otv2-readiness__marker");
+      expect(marker?.getAttribute("aria-hidden")).toBe("true");
+      expect(marker?.textContent).toBe(String(index + 1));
+    });
+  });
+
+  it("passes every state and readiness status through as row attributes", () => {
+    const view = render(<ReadinessList label="Readiness" rows={readinessRows()} />);
+    let previousRows: HTMLElement[] = [];
+    for (const state of CHECK_STATES) {
+      for (const status of READINESS_STATUSES) {
+        const rows = readinessRows({ state, status }, { state, status }, { state, status }, { state, status });
+        view.rerender(<ReadinessList label="Readiness" rows={rows} />);
+        const items = [...ORDER].map((component) => row(component));
+        expect(items.map((item) => item.getAttribute("data-state"))).toEqual(Array(4).fill(state));
+        expect(items.map((item) => item.getAttribute("data-status"))).toEqual(Array(4).fill(status));
+        items.forEach((item, index) => {
+          expect(item.querySelector(".otv2-readiness__marker")?.textContent).toBe(String(index + 1));
+        });
+        if (previousRows.length > 0) {
+          items.forEach((item, index) => {
+            expect(item).toBe(previousRows[index]);
+          });
+        }
+        previousRows = items;
+      }
+    }
+  });
+
+  it("shows exactly the copy the caller supplies, including Codex and Claude Code labels", () => {
+    render(
+      <ReadinessList
+        label="Readiness"
+        rows={readinessRows(
+          { label: "Codex computer", statusLabel: "Ready", detail: "Connected", detailLabel: "Computer diagnostics" },
+          {
+            label: "Claude Code runtime",
+            statusLabel: "Checking",
+            detail: "Contacting the runtime",
+            detailLabel: "Runtime diagnostics",
+          },
+          { label: "Feishu CLI", statusLabel: "Install required", detail: "", detailLabel: "Feishu diagnostics" },
+          { label: "Slack CLI", statusLabel: "Needs attention", detail: "Reconnect", detailLabel: "Slack diagnostics" },
+        )}
+      />,
+    );
+
+    expect(within(row(COMPUTER)).getByText("Codex computer")).toBeTruthy();
+    expect(within(row(COMPUTER)).getByText("Ready")).toBeTruthy();
+    expect(within(row(RUNTIME)).getByText("Claude Code runtime")).toBeTruthy();
+    expect(within(row(RUNTIME)).getByText("Checking")).toBeTruthy();
+    expect(within(row(FEISHU)).getByText("Feishu CLI")).toBeTruthy();
+    expect(within(row(FEISHU)).getByText("Install required")).toBeTruthy();
+    expect(within(row(SLACK)).getByText("Slack CLI")).toBeTruthy();
+    expect(within(row(SLACK)).getByText("Needs attention")).toBeTruthy();
+  });
+
+  it("keeps product and provider naming out of the primitive itself", () => {
+    const source = readFileSync(resolve(here, "readiness-list.tsx"), "utf8");
+    expect(source).not.toMatch(/Codex|Claude/i);
+    expect(source).not.toMatch(/lark/i);
+  });
+
+  it("always mounts the title and detail slots, even when the detail copy is blank", () => {
+    const labels = ["Codex computer", "Claude Code runtime", "Feishu CLI", "Slack CLI"];
+    const statusLabels = ["Ready", "Checking", "Install required", "Needs attention"];
+    const detailLabels = ["Computer diagnostics", "Runtime diagnostics", "Feishu diagnostics", "Slack diagnostics"];
+    render(
+      <ReadinessList
+        label="Readiness"
+        rows={readinessRows(
+          { label: labels[0], statusLabel: statusLabels[0], detail: "", detailLabel: detailLabels[0] },
+          { label: labels[1], statusLabel: statusLabels[1], detail: "", detailLabel: detailLabels[1] },
+          { label: labels[2], statusLabel: statusLabels[2], detail: "", detailLabel: detailLabels[2] },
+          { label: labels[3], statusLabel: statusLabels[3], detail: "", detailLabel: detailLabels[3] },
+        )}
+      />,
+    );
+
+    [...ORDER].forEach((component, index) => {
+      const item = row(component);
+      const title = item.querySelector('[data-ui="readiness-title"]');
+      const detail = item.querySelector('[data-ui="readiness-detail"]');
+
+      expect(title).not.toBeNull();
+      expect(detail).not.toBeNull();
+      expect(title?.textContent).toContain(labels[index]);
+      expect(title?.textContent).toContain(statusLabels[index]);
+      expect(detail?.textContent).toBe("");
+      expect(detail?.getAttribute("aria-label")).toBe(detailLabels[index]);
+      // The slots are the scroll regions, so both stay keyboard-reachable...
+      expect((title as HTMLElement).tabIndex).toBe(0);
+      expect((detail as HTMLElement).tabIndex).toBe(0);
+    });
+  });
+
+  it("rerenders blank, long English, and long Chinese copy into the same row and slot elements", () => {
+    const view = render(<ReadinessList label="Readiness" rows={readinessRows()} />);
+    const firstRows = [...ORDER].map((component) => row(component));
+    const firstDetails = firstRows.map((item) => item.querySelector('[data-ui="readiness-detail"]'));
+
+    view.rerender(
+      <ReadinessList
+        label="Readiness"
+        rows={readinessRows(
+          {
+            state: "passed",
+            status: "ready",
+            label: "Codex computer",
+            statusLabel: "Ready",
+            detail: LONG_EN_DETAIL,
+            detailLabel: "Computer diagnostics",
+          },
+          {
+            state: "failed",
+            status: "needs-attention",
+            label: "Claude Code runtime",
+            statusLabel: "Needs attention",
+            detail: "Install the supported runtime version, then check again.",
+            detailLabel: "Runtime diagnostics",
+          },
+          {
+            state: "pending",
+            status: "install-required",
+            label: "Feishu CLI",
+            statusLabel: "Install required",
+            detail: "Run the printed command and check again.",
+            detailLabel: "Feishu diagnostics",
+          },
+          {
+            state: "blocked",
+            status: "stale",
+            label: "Slack CLI",
+            statusLabel: "Stale",
+            detail: "The install link expired; ask for a fresh one.",
+            detailLabel: "Slack diagnostics",
+          },
+        )}
+      />,
+    );
+
+    const enRows = [...ORDER].map((component) => row(component));
+    enRows.forEach((item, index) => {
+      expect(item).toBe(firstRows[index]);
+    });
+    expect(within(row(COMPUTER)).getByText(LONG_EN_DETAIL)).toBeTruthy();
+
+    view.rerender(
+      <ReadinessList
+        label="就绪检查"
+        rows={readinessRows(
+          {
+            state: "passed",
+            status: "needs-attention",
+            label: "电脑",
+            statusLabel: "需要关注",
+            detail: ZH_DETAIL,
+            detailLabel: "电脑诊断",
+          },
+          {
+            state: "passed",
+            status: "ready",
+            label: "运行时",
+            statusLabel: "就绪",
+            detail: "",
+            detailLabel: "运行时诊断",
+          },
+          {
+            state: "failed",
+            status: "install-required",
+            label: ZH_TITLE,
+            statusLabel: "需要安装",
+            detail: "",
+            detailLabel: "命令行诊断",
+          },
+          {
+            state: "blocked",
+            status: "stale",
+            label: "Slack 命令行",
+            statusLabel: "已过期",
+            detail: "",
+            detailLabel: "Slack 诊断",
+          },
+        )}
+      />,
+    );
+
+    const zhRows = [...ORDER].map((component) => row(component));
+    zhRows.forEach((item, index) => {
+      expect(item).toBe(firstRows[index]);
+      expect(item.querySelector('[data-ui="readiness-detail"]')).toBe(firstDetails[index]);
+    });
+    expect(screen.getByRole("list", { name: "就绪检查" })).toBeTruthy();
+    expect(within(row(FEISHU)).getByText(ZH_TITLE)).toBeTruthy();
+    const zhDetail = row(COMPUTER).querySelector('[data-ui="readiness-detail"]');
+    expect(zhDetail?.textContent).toContain("第一行");
+    expect(zhDetail?.textContent).toContain("\n");
+    expect(row(SLACK).querySelector('[data-ui="readiness-detail"]')?.textContent).toBe("");
+    zhRows.forEach((item, index) => {
+      expect(item.querySelector(".otv2-readiness__marker")?.textContent).toBe(String(index + 1));
+    });
+  });
+
+  it("keeps a passed row passed when a needs-attention warning arrives", () => {
+    const view = render(
+      <ReadinessList
+        label="Readiness"
+        rows={readinessRows(
+          {},
+          {
+            state: "passed",
+            status: "ready",
+            label: "Claude Code runtime",
+            statusLabel: "Ready",
+            detail: "Up to date",
+            detailLabel: "Runtime diagnostics",
+          },
+        )}
+      />,
+    );
+    const runtimeRow = row(RUNTIME);
+    expect(runtimeRow.getAttribute("data-state")).toBe("passed");
+    expect(runtimeRow.getAttribute("data-status")).toBe("ready");
+
+    view.rerender(
+      <ReadinessList
+        label="Readiness"
+        rows={readinessRows(
+          {},
+          {
+            state: "passed",
+            status: "needs-attention",
+            label: "Claude Code runtime",
+            statusLabel: "Needs attention",
+            detail: "A newer runtime version is recommended.",
+            detailLabel: "Runtime diagnostics",
+          },
+        )}
+      />,
+    );
+
+    expect(row(RUNTIME)).toBe(runtimeRow);
+    expect(row(RUNTIME).getAttribute("data-state")).toBe("passed");
+    expect(row(RUNTIME).getAttribute("data-status")).toBe("needs-attention");
+    expect(within(row(RUNTIME)).getByText("Needs attention")).toBeTruthy();
+    expect(within(row(RUNTIME)).getByText("A newer runtime version is recommended.")).toBeTruthy();
+  });
+
+  it("renders HTML-looking diagnostics as text, never as markup", () => {
+    const detail = '<b>bold</b> install <script>alert("install")</script> me';
+    render(
+      <ReadinessList
+        label="Readiness"
+        rows={readinessRows(
+          {},
+          {},
+          { label: "Feishu CLI", statusLabel: "Install required", detail, detailLabel: "Feishu diagnostics" },
+          {},
+        )}
+      />,
+    );
+
+    const feishuDetail = row(FEISHU).querySelector('[data-ui="readiness-detail"]');
+    expect(feishuDetail?.textContent).toBe(detail);
+    expect(document.querySelectorAll("b, script")).toHaveLength(0);
+  });
+});

--- a/apps/web/src/onboarding-v2/readiness-list.tsx
+++ b/apps/web/src/onboarding-v2/readiness-list.tsx
@@ -1,0 +1,91 @@
+/**
+ * The readiness rows: four fixed lines that show exactly the state and copy they are handed.
+ *
+ * Every string arrives already translated and every state already decided, so this primitive never
+ * derives a readiness from the values it receives and never invents product or provider copy of
+ * its own. It is display only: keep the four rows, their reserved slot heights, and their DOM
+ * identity steady while the copy beneath them resolves. Styling lives in the scoped
+ * `.otv2-readiness*` rules in `onboarding-v2.css`.
+ */
+
+export type CheckState = "pending" | "passed" | "failed" | "blocked";
+
+export type ReadinessStatus = "waiting" | "checking" | "install-required" | "ready" | "needs-attention" | "stale";
+
+export interface CheckRow {
+  /** The row's own outcome. Styling and tests read it; nothing here derives it from the copy. */
+  readonly state: CheckState;
+  /** The caller's readiness reading. Published and displayed exactly as given. */
+  readonly status: ReadinessStatus;
+  readonly label: string;
+  readonly statusLabel: string;
+  readonly detail: string;
+  /** Accessible label for the diagnostic region, which stays mounted even when empty. */
+  readonly detailLabel: string;
+}
+
+export type ReadinessRows = Readonly<{
+  computer: CheckRow;
+  runtime: CheckRow;
+  feishu: CheckRow;
+  slack: CheckRow;
+}>;
+
+const READINESS_ORDER: ReadonlyArray<{ key: keyof ReadinessRows; component: string }> = [
+  { key: "computer", component: "computer" },
+  { key: "runtime", component: "runtime" },
+  { key: "feishu", component: "im-cli:feishu" },
+  { key: "slack", component: "im-cli:slack" },
+];
+
+/**
+ * One readiness row. `position` becomes a decorative 1..4 marker, `component` a stable identity
+ * the list also uses as the row key, so a row never moves or remounts as its copy changes.
+ *
+ * The title and detail slots are fixed-height scroll regions: both are always mounted and
+ * keyboard-focusable, and the detail slot carries its own accessible label.
+ */
+export function CheckLine({ check, position, component }: { check: CheckRow; position: number; component: string }) {
+  return (
+    <li className="otv2-readiness__line" data-component={component} data-state={check.state} data-status={check.status}>
+      <span aria-hidden="true" className="otv2-readiness__marker">
+        {position}
+      </span>
+      <div className="otv2-readiness__copy">
+        <div
+          className="otv2-readiness__title"
+          data-ui="readiness-title"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: The title slot is a fixed-height scroll region; keyboard users must be able to focus and scroll it.
+          tabIndex={0}
+        >
+          <span className="otv2-readiness__name">{check.label}</span>
+          <span className="otv2-readiness__status">{check.statusLabel}</span>
+        </div>
+        <section
+          aria-label={check.detailLabel}
+          className="otv2-readiness__detail"
+          data-ui="readiness-detail"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: The detail slot is a fixed-height scroll region; keyboard users must be able to focus and scroll it.
+          tabIndex={0}
+        >
+          {check.detail}
+        </section>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The four readiness rows — computer, runtime, feishu, slack — in that fixed order inside one
+ * labelled list. The rows are read from the caller's named `rows`, so four lines always render
+ * even when some copy is blank.
+ */
+export function ReadinessList({ rows, label }: { rows: ReadinessRows; label: string }) {
+  return (
+    <ol aria-label={label} className="otv2-readiness" data-ui="readiness-list">
+      {READINESS_ORDER.map(({ key, component }, index) => (
+        <CheckLine check={rows[key]} component={component} key={component} position={index + 1} />
+      ))}
+    </ol>
+  );
+}


### PR DESCRIPTION
## Summary

- Restore the historical `ce432c93` readiness-row UI intent as a standalone, presentational `ReadinessList` / `CheckLine` primitive. It always renders Computer, selected Runtime, and the two messaging CLI artifact rows with fixed markers and title/detail slots.
- Accept caller-decided state, readiness status, and translated copy; expose stable `data-ui`, `data-component`, `data-state`, and `data-status` hooks. The primitive has no imports, API reads, timers, readiness inference, or stage transitions.
- Add eleven review-only scenarios to `/internal/agent-setup`, including blank details, six readiness statuses, long English/Chinese diagnostics, mixed states, and a non-blocking warning. Runtime labels cover Codex, Claude Code, and deliberately long caller copy.
- Keep existing production scenarios selectable. No changes to the production setup page, IM CLI status component, setup adapters, Paraglide catalogues/generated files, shared schemas, Server, CLI, or persistence. Production integration remains separate F5 work.

## Testing

All mandatory local gates passed against the committed content tree `652c74349fea9e4dfc9e63e0b042e9a91530593a` at candidate `167889709a07a5c79fd4fbb31e18d022816ca54c`, based on `01bb5f97df0e7f6b1c468b6a0fece1867e20f472`:

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (Web: 60 files / 580 tests; unchanged packages reused matching Turbo cache entries)
- `pnpm --filter @opentag/client test:agent-runtime:coverage` (24 files / 351 tests; all configured coverage metrics 100%)
- `pnpm --filter @opentag/server test:integration` (18 files / 313 tests, repository-owned Testcontainers)
- `git diff --check`

The new focused suites exercise all state/status combinations, row and slot identity, literal/escaped copy, arbitrary Runtime labels, persistent empty slots, stable CSS reservations, and the review scenarios. Existing brand-naming and Kumo source contracts pass unchanged.

Local gate logs: `/tmp/opentag-onboarding-qa-20260903.uirwNX/f4-validation/gates-jZLLjs/`. The final working-tree content was unchanged between these gates and the commit (tree SHA above). The seven lab tests also passed ten consecutive runs with `CI=true`.

## UI validation

- Desktop evidence: real Chromium preview at 1440px, screenshots of ready, mixed, long English, and long Chinese scenarios; fixed row/marker/title/detail bounds across every state and Runtime label. Screenshots are retained with the task rather than added to product source.
- Mobile evidence: the same captures at 320px; the long Runtime select wrapper now shrinks without widening the document. The readiness-only scenario toolbar is in normal flow and does not cover the checklist.
- Widths checked: 320px / 390px / 768px / 1440px.
- States verified: 11 scenarios × 3 Runtime choices × 4 widths = 132 layout/DOM-identity cases. Waiting, checking, install-required, ready, needs-attention, stale, blank details, mixed states, long EN/ZH, and ready-with-warning are covered.
- Keyboard/accessibility checks: fixed-height title and diagnostic regions remain focusable and scroll with End; all four viewport keyboard checks passed, eight Axe scans found zero violations, and no browser page errors occurred. HTML-looking diagnostics render as text.
- New reusable block, theme value, or CSS exception: one local readiness list/row primitive; only scoped `otv2-readiness*` CSS is added. Existing Kumo theme tokens and Text/select components are reused. The two documented `noNoninteractiveTabindex` exceptions make fixed-height scroll regions keyboard reachable; no new theme tokens or weakened guards.
- Exact-commit browser evidence: `/tmp/opentag-onboarding-qa-20260903.uirwNX/f4-browser/qa-y8qroR/` (136 records: 132 layout cases plus four keyboard cases, 10 PNGs, and `results.json`; no page errors or accessibility violations).
- Reproduce: build/start the Web app, open `/internal/agent-setup`, choose a `Checklist:`/long-copy/blank/warning scenario, then change `Preview Runtime`. These are explicitly labelled static fixtures, not live readiness evidence.

Validation tier: focused-local. This verifies the F4 presentational UI, not end-to-end onboarding, Runtime installation, IM authorization, or a new production readiness projection.

## CI follow-up

The initial head exposed a lab-test synchronization race on Node 22/24: the outgoing Scenario popup was still accessible when the test enumerated Runtime options. Commit `16788970` waits for the closing popup to leave the accessible tree; it does not weaken the expected Runtime options or change production code. All local gates and the full browser matrix were repeated on the corrected content.

Separately, the initial Browser Smoke job failed during the existing PostgreSQL setup, before any browser test executed. No CI/database workaround was added. The updated head receives a fresh complete CI run; merge remains gated on the actual remote checks.

## Breaking changes

None. This is independently mergeable F4 UI groundwork; F1/F2/F3/F5 behavior is intentionally not included.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no public docs or message catalogues changed; lab-only EN/ZH copy fixtures are included).
