### PR TITLE
fix(release): include Context Tree runtime in portable artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}"
           --binary "${{ steps.version.outputs.binary_name }}"
 
+      - name: Smoke staging portable app
+        run: >-
+          node scripts/portable/smoke-portable-app.mjs
+          --channel staging
+          --version "${{ steps.version.outputs.version }}"
+
       - name: Restore and prepare production identity
         run: |
           git checkout -- apps/cli/package.json apps/cli/src/build-info.ts
@@ -302,6 +308,12 @@ jobs:
             --name open-tag \
             --version 0.0.2 \
             --binary opentag
+
+      - name: Smoke production portable app
+        run: >-
+          node scripts/portable/smoke-portable-app.mjs
+          --channel prod
+          --version 0.0.2
 
   container-smoke:
     name: Container Smoke

--- a/docs/portable-release.md
+++ b/docs/portable-release.md
@@ -61,12 +61,15 @@ Each payload contains:
 VERSION                 Plain-text version
 INSTALL.json            Release metadata, platform, install mode, and app entry
 node/bin/node           Embedded Node.js runtime, checked against the official SHASUMS256.txt
-app/                    Bundled CLI, its package manifest, LICENSE, README, THIRD_PARTY_NOTICES
+app/                    Bundled CLI, its package manifest, LICENSE, README, THIRD_PARTY_NOTICES,
+                        dependency-closure.json, and the embedded node_modules/ dependency tree
 bin/<binName>           Artifact-local shim, used before the payload is activated
 ~~~
 
-The bundled CLI has no `node_modules`: `apps/cli` declares no runtime dependencies, and the build fails closed if that
-ever changes rather than shipping an artifact that only breaks when a user runs it.
+The bundled CLI's Context Tree integration resolves the installed `@first-tree-ai/context-tree` package at runtime —
+its `package.json` through `createRequire`, its bundled CLI, and its packaged skills and templates — so every payload
+embeds that package and its full production dependency closure as a physical `app/node_modules` tree.
+`app/dependency-closure.json` records the exact direct pins and every embedded package name and version.
 
 ## Automatic upgrades
 
@@ -145,8 +148,31 @@ node scripts/portable/verify-portable-artifact.mjs \
   --tarball .portable-release/staging/0.0.2-staging.1.1/open-tag-staging-0.0.2-staging.1.1-darwin-arm64.tar.gz
 ~~~
 
-The verifier checks the published checksum, the extracted layout, and the metadata, and additionally runs the artifact
-when it targets the host platform.
+The verifier checks the published checksum, the extracted layout, the metadata, and the embedded dependency graph
+(exact direct pins, the closure record, packaged assets, and the no-symlink/no-native layout). When the artifact
+targets the host platform it additionally executes it: the OpenTag CLI through its shim, and the embedded Context
+Tree CLI (`--version`, `--help`, `list`) against an isolated home. It also runs OpenTag's
+`context-tree connect` against a nonexistent managed name, verifying real runtime resolution without connecting a
+tree or persisting configuration.
+
+The portable builder ships `@first-tree-ai/context-tree` and every production dependency the frozen install resolves
+for it as a deterministic flat `app/node_modules` tree: one real directory per package, no symlinks, no nested
+`node_modules`, and no native addons. Packages are copied from the installed store only — nothing is fetched and no
+lifecycle script runs; Context Tree's own `postinstall` ships inside its published files but stays inert because
+OpenTag invokes the packaged CLI directly. The app manifest keeps only the truthful direct pins, and both the builder
+(before its identity smoke) and the artifact verifier (for every platform) run the same graph checks.
+
+**Fail-closed dependency shapes.** `apps/cli` may declare only `@first-tree-ai/context-tree`, pinned to an exact
+`x.y.z` version. Unknown or non-exact direct pins, non-empty optional or peer dependencies, `os`/`cpu`-constrained
+packages, lifecycle scripts on embedded packages other than Context Tree's own, symlinks inside published files,
+native addons, and same-name packages resolving to different installed roots all fail the build. These dependency
+shapes need explicit packaging support before they can ship.
+
+**CI gate.** Every `CLI Pack Smoke` run for staging and production assembles the real portable app from the freshly
+built release-channel CLI, verifies its embedded graph, and runs both the relocated Context Tree CLI and OpenTag's
+runtime resolution probe with a temporary `HOME` and a minimal environment (no `NODE_PATH`, `NODE_OPTIONS`, or host
+credentials; `scripts/portable/smoke-portable-app.mjs`). The gate needs no downloaded Node.js runtime,
+so a dependency regression fails ordinary CI rather than the release.
 
 The embedded Node.js version is pinned in `scripts/portable/node-version.txt` and must be an exact `vX.Y.Z`. Its tarball
 is checked against the official `SHASUMS256.txt` for that release before it becomes part of an artifact.

--- a/docs/zh-CN/portable-release.md
+++ b/docs/zh-CN/portable-release.md
@@ -1,7 +1,7 @@
 # OpenTag Portable 发布指南
 
 > Canonical source: [../portable-release.md](../portable-release.md)
-> Last synced with: 2026-09-02
+> Last synced with: 2026-09-03
 
 Portable release 是一份自包含的 OpenTag 安装包：每个平台一个 tarball，同时携带 bundle 后的 CLI **和它自己的
 Node.js runtime**，因此没有 Node.js、没有 npm、没有任何 package manager 的机器也能安装并运行 OpenTag。它发布到
@@ -59,12 +59,15 @@ shim，并能在之后每一次更新后继续生效。shim 会在 exec 内嵌 r
 VERSION                 纯文本 version
 INSTALL.json            release metadata、platform、install mode 与 app entry
 node/bin/node           内嵌 Node.js runtime，已对官方 SHASUMS256.txt 校验
-app/                    bundle 后的 CLI、其 package manifest、LICENSE、README、THIRD_PARTY_NOTICES
+app/                    bundle 后的 CLI、其 package manifest、LICENSE、README、THIRD_PARTY_NOTICES、
+                        dependency-closure.json 与内嵌的 node_modules/ 依赖树
 bin/<binName>           artifact 本地 shim，在 payload 激活之前使用
 ~~~
 
-bundle 后的 CLI 没有 `node_modules`：`apps/cli` 不声明任何 runtime dependency，一旦这一点发生变化，构建会 fail
-closed，而不是产出一个只在用户运行时才崩溃的 artifact。
+bundle 后的 CLI 的 Context Tree 集成会在运行时解析已安装的 `@first-tree-ai/context-tree` 包——通过 `createRequire`
+读取其 `package.json`、执行其 bundle 后的 CLI，并读取其自带的 skills 与 templates——因此每个 payload 都会内嵌该包
+及其完整的生产依赖闭包，作为物理的 `app/node_modules` 目录树。`app/dependency-closure.json`
+记录精确的 direct pin 与每个内嵌包的 name 与 version。
 
 ## 自动升级
 
@@ -135,7 +138,28 @@ node scripts/portable/verify-portable-artifact.mjs \
   --tarball .portable-release/staging/0.0.2-staging.1.1/open-tag-staging-0.0.2-staging.1.1-darwin-arm64.tar.gz
 ~~~
 
-verifier 会检查已发布的 checksum、解压后的结构与 metadata；当 artifact 目标平台就是宿主平台时，还会实际运行它。
+verifier 会检查已发布的 checksum、解压后的结构、metadata 与内嵌的依赖图（精确 direct pin、closure record、随包
+assets，以及无 symlink/无 native 的布局）。当 artifact 目标平台就是宿主平台时，还会实际运行它：通过 shim 运行
+OpenTag CLI，并在隔离 home 下运行内嵌的 Context Tree CLI（`--version`、`--help`、`list`）。
+它还会对不存在的 managed name 执行 OpenTag 的 `context-tree connect`，验证真实的 runtime 解析路径，
+但不连接 Tree、不持久化配置。
+
+portable builder 会内嵌 `@first-tree-ai/context-tree` 以及 frozen install 为它解析出的每个生产依赖，形成确定性的
+扁平 `app/node_modules` 目录树：每个包一个真实目录，无 symlink、无嵌套 `node_modules`、无 native addon。包内容
+只从已安装的 store 拷贝——绝不联网拉取，也绝不执行 lifecycle script；Context Tree 自带的 `postinstall` 会随发布
+内容一起携带但保持惰性，因为 OpenTag 直接调用打包好的 CLI。app manifest 只保留真实的 direct pin；builder（在
+identity smoke 之前）与 artifact verifier（对每个平台）都会运行同一套图校验。
+
+**Fail-closed 依赖形状。** `apps/cli` 只能声明 `@first-tree-ai/context-tree`，且必须是精确的 `x.y.z` pin。未知或
+非精确的 direct pin、非空的 optional/peer dependency、带 `os`/`cpu` 约束的包、内嵌包（Context Tree 自身除外）上
+的 lifecycle script、发布内容里的 symlink、native addon，以及同名包解析到不同的已安装根目录都会让构建失败。
+这些依赖形状必须先获得明确的打包支持才能发布。
+
+**CI gate。** staging 与 production 的每次 `CLI Pack Smoke` 都会用刚构建好的 release-channel CLI 组装真实的
+portable app、校验其内嵌依赖图，并在临时 `HOME` 与最小环境下运行迁移后的 Context Tree CLI 和 OpenTag 的
+runtime 解析探针（无 `NODE_PATH`、`NODE_OPTIONS` 或宿主凭证；`scripts/portable/smoke-portable-app.mjs`）。
+该 gate 不需要下载 Node.js runtime，因此依赖回归会直接在普通 CI
+失败，而不是拖到 release 阶段。
 
 内嵌 Node.js version 固定在 `scripts/portable/node-version.txt`，必须是精确的 `vX.Y.Z`。其 tarball 在成为 artifact
 的一部分之前，会先对该 release 的官方 `SHASUMS256.txt` 校验。

--- a/scripts/__tests__/portable-build.test.mjs
+++ b/scripts/__tests__/portable-build.test.mjs
@@ -10,7 +10,6 @@ import {
   APP_ENTRY,
   artifactDownloadUrl,
   artifactFileName,
-  assertBundledCliHasNoRuntimeDependencies,
   buildPortableReleaseMetadata,
   DEFAULT_DOWNLOAD_BASE_URL,
   getPortableChannelConfig,
@@ -136,7 +135,7 @@ test("normalizers fail closed on inexact release inputs", () => {
   assert.throws(() => normalizeGeneratedAt(""), /requires a timestamp value/);
 });
 
-test("the portable app manifest exposes exactly one channel binary and no runtime dependencies", () => {
+test("the portable app manifest exposes exactly one channel binary and only supported runtime dependencies", () => {
   const sourcePackage = {
     description: "OpenTag command-line interface",
     engines: { node: "^24.0.0" },
@@ -149,14 +148,20 @@ test("the portable app manifest exposes exactly one channel binary and no runtim
   assert.deepEqual(appPackage.bin, { opentag: "./cli/index.mjs" });
   assert.equal(appPackage.dependencies, undefined);
 
-  assertBundledCliHasNoRuntimeDependencies(sourcePackage);
+  const withDependency = portableAppPackageJson({
+    channelConfig: CHANNEL_CONFIG.prod,
+    sourcePackage: { ...sourcePackage, dependencies: { "@first-tree-ai/context-tree": "0.1.8" } },
+    version: "1.2.3",
+  });
+  assert.deepEqual(withDependency.dependencies, { "@first-tree-ai/context-tree": "0.1.8" });
   assert.throws(
-    () => assertBundledCliHasNoRuntimeDependencies({ dependencies: { commander: "^13.1.0" } }),
-    /ships without node_modules/,
-  );
-  assert.throws(
-    () => assertBundledCliHasNoRuntimeDependencies({ optionalDependencies: { bufferutil: "^4.0.0" } }),
-    /ships without node_modules/,
+    () =>
+      portableAppPackageJson({
+        channelConfig: CHANNEL_CONFIG.prod,
+        sourcePackage: { ...sourcePackage, dependencies: { commander: "^13.1.0" } },
+        version: "1.2.3",
+      }),
+    /unsupported runtime dependency/,
   );
 });
 

--- a/scripts/__tests__/portable-runtime-dependencies.test.mjs
+++ b/scripts/__tests__/portable-runtime-dependencies.test.mjs
@@ -1,0 +1,542 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createAppTemplate, getPortableChannelConfig } from "../portable/build-portable.mjs";
+import {
+  CONTEXT_TREE_SKILL_DIRECTORIES,
+  CONTEXT_TREE_TEMPLATE_FILES,
+  collectRuntimeDependencyClosure,
+  DEPENDENCY_CLOSURE_FILE,
+  materializeRuntimeDependencyClosure,
+  readPortableDirectDependencyPins,
+  runContextTreeRuntimeProbe,
+  verifyPortableDependencyGraph,
+  writeDependencyClosureFile,
+} from "../portable/runtime-dependencies.mjs";
+
+const scriptsDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(scriptsDir, "..");
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeText(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function fakeCliEntry(version, binName) {
+  return [
+    `if (process.argv[2] === "--version") {`,
+    `  console.log(${JSON.stringify(version)});`,
+    "  process.exit(0);",
+    "}",
+    `if (process.argv[2] === "--help") {`,
+    `  console.log("Usage: ${binName} [command]");`,
+    "  process.exit(0);",
+    "}",
+    "process.exit(3);",
+    "",
+  ].join("\n");
+}
+
+function writeContextTreePackage(
+  nodeModulesDir,
+  { assets = true, dependencies = { commander: "^15.0.0" }, extra = {}, version = "0.1.8" } = {},
+) {
+  const packageDir = join(nodeModulesDir, "@first-tree-ai", "context-tree");
+  writeJson(join(packageDir, "package.json"), {
+    name: "@first-tree-ai/context-tree",
+    version,
+    type: "module",
+    scripts: { postinstall: "node ./scripts/postinstall.mjs" },
+    dependencies,
+    ...extra,
+  });
+  writeText(join(packageDir, "dist", "cli", "index.mjs"), "export const cli = true;\n");
+  writeText(
+    join(packageDir, "scripts", "postinstall.mjs"),
+    'import { writeFileSync } from "node:fs";\nwriteFileSync(new URL("./postinstall-ran.marker", import.meta.url), "ran");\n',
+  );
+  writeText(join(packageDir, "LICENSE"), "Apache-2.0 fixture license\n");
+  if (assets) {
+    for (const skill of CONTEXT_TREE_SKILL_DIRECTORIES) {
+      writeText(join(packageDir, "skills", skill, "SKILL.md"), `# ${skill}\n`);
+    }
+    for (const template of CONTEXT_TREE_TEMPLATE_FILES) {
+      writeText(join(packageDir, "templates", template), `template ${template}\n`);
+    }
+  }
+  return packageDir;
+}
+
+/** An offline `apps/cli` stand-in whose dist entry answers the identity smoke correctly. */
+function fixtureCliRoot(root, { version = "0.0.2" } = {}) {
+  const cliRoot = join(root, "cli");
+  writeJson(join(cliRoot, "package.json"), {
+    name: "open-tag",
+    version,
+    private: true,
+    type: "module",
+    license: "Apache-2.0",
+    description: "portable fixture CLI",
+    bin: { opentag: "./dist/cli/index.mjs" },
+    dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+  });
+  writeText(join(cliRoot, "dist", "cli", "index.mjs"), fakeCliEntry(version, "opentag"));
+  writeText(join(cliRoot, "dist", "index.mjs"), "export {};\n");
+  writeText(join(cliRoot, "LICENSE"), "fixture license\n");
+  writeText(join(cliRoot, "README.md"), "fixture readme\n");
+  writeText(join(cliRoot, "THIRD_PARTY_NOTICES"), "fixture notices\n");
+  return cliRoot;
+}
+
+function writeChildPackage(nodeModulesDir, name, { dependencies = {}, extra = {}, version = "1.0.0" } = {}) {
+  const packageDir = join(nodeModulesDir, ...name.split("/"));
+  writeJson(join(packageDir, "package.json"), { name, version, dependencies, ...extra });
+  writeText(join(packageDir, "index.js"), `module.exports = ${JSON.stringify(name)};\n`);
+  return packageDir;
+}
+
+/** A complete offline CLI root with the supported direct dependency and one transitive child. */
+function fixtureTree(root) {
+  const cliRoot = fixtureCliRoot(root);
+  const nodeModulesDir = join(cliRoot, "node_modules");
+  writeContextTreePackage(nodeModulesDir);
+  writeChildPackage(nodeModulesDir, "commander", { version: "15.0.0" });
+  return cliRoot;
+}
+
+/** Assembles a verifiable offline app: manifest, materialized node_modules, and closure record. */
+function assembleFixtureApp(root) {
+  const cliRoot = fixtureTree(root);
+  const appDir = join(root, "app");
+  const closure = materializeRuntimeDependencyClosure({
+    nodeModulesDir: join(appDir, "node_modules"),
+    sourceManifestPath: join(cliRoot, "package.json"),
+  });
+  writeJson(join(appDir, "package.json"), {
+    name: "open-tag",
+    version: "0.0.2",
+    type: "module",
+    dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+  });
+  writeDependencyClosureFile(appDir, closure);
+  return appDir;
+}
+
+test("the portable runtime dependency contract accepts only the supported exact pin", () => {
+  assert.deepEqual(readPortableDirectDependencyPins({ dependencies: { "@first-tree-ai/context-tree": "0.1.8" } }), [
+    { name: "@first-tree-ai/context-tree", version: "0.1.8" },
+  ]);
+  assert.deepEqual(readPortableDirectDependencyPins({}), []);
+  assert.deepEqual(readPortableDirectDependencyPins({ dependencies: {} }), []);
+  assert.throws(
+    () => readPortableDirectDependencyPins({ dependencies: { commander: "^15.0.0" } }),
+    /unsupported runtime dependency/,
+  );
+  assert.throws(
+    () => readPortableDirectDependencyPins({ dependencies: { "@first-tree-ai/context-tree": "^0.1.8" } }),
+    /exact x\.y\.z/,
+  );
+  assert.throws(
+    () => readPortableDirectDependencyPins({ dependencies: { "@first-tree-ai/context-tree": "workspace:*" } }),
+    /exact x\.y\.z/,
+  );
+  assert.throws(
+    () =>
+      readPortableDirectDependencyPins({
+        dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+        optionalDependencies: { bufferutil: "^4.0.0" },
+      }),
+    /non-empty optionalDependencies/,
+  );
+  assert.throws(
+    () =>
+      readPortableDirectDependencyPins({
+        dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+        peerDependencies: { react: "^19.0.0" },
+      }),
+    /non-empty peerDependencies/,
+  );
+});
+
+test("the checked-in apps/cli manifest is accepted under the portable shipping contract", () => {
+  const cliManifest = JSON.parse(readFileSync(join(repoRoot, "apps", "cli", "package.json"), "utf8"));
+  assert.deepEqual(readPortableDirectDependencyPins(cliManifest), [
+    { name: "@first-tree-ai/context-tree", version: "0.1.8" },
+  ]);
+});
+
+test("materializing the closure copies published content and never runs lifecycle scripts", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureTree(root);
+  const treePackageDir = join(cliRoot, "node_modules", "@first-tree-ai", "context-tree");
+  // pnpm-style bin droppings inside the installed package must never be copied.
+  writeText(join(treePackageDir, "node_modules", ".bin", "context-tree"), "ignored\n");
+
+  const appDir = join(root, "app");
+  const closure = materializeRuntimeDependencyClosure({
+    nodeModulesDir: join(appDir, "node_modules"),
+    sourceManifestPath: join(cliRoot, "package.json"),
+  });
+  assert.deepEqual(closure.direct, [{ name: "@first-tree-ai/context-tree", version: "0.1.8" }]);
+  assert.deepEqual(
+    closure.packages.map((entry) => entry.name),
+    ["@first-tree-ai/context-tree", "commander"],
+  );
+
+  const embeddedRoot = join(appDir, "node_modules", "@first-tree-ai", "context-tree");
+  assert.equal(readFileSync(join(embeddedRoot, "LICENSE"), "utf8"), "Apache-2.0 fixture license\n");
+  assert.equal(readFileSync(join(embeddedRoot, "dist", "cli", "index.mjs"), "utf8"), "export const cli = true;\n");
+  assert.equal(
+    readFileSync(join(embeddedRoot, "skills", "context-tree-read", "SKILL.md"), "utf8"),
+    "# context-tree-read\n",
+  );
+  assert.equal(existsSync(join(embeddedRoot, "scripts", "postinstall.mjs")), true);
+  assert.equal(
+    existsSync(join(embeddedRoot, "scripts", "postinstall-ran.marker")),
+    false,
+    "lifecycle scripts must never execute",
+  );
+  assert.equal(existsSync(join(embeddedRoot, "node_modules")), false, "a package's own node_modules must not ship");
+  assert.equal(existsSync(join(appDir, "node_modules", "commander", "index.js")), true);
+  assert.deepEqual(readdirSync(join(appDir, "node_modules")).sort(), ["@first-tree-ai", "commander"]);
+});
+
+test("the installed direct dependency must match the exact source pin", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureCliRoot(root);
+  writeContextTreePackage(join(cliRoot, "node_modules"), { version: "0.1.9" });
+  assert.throws(
+    () => collectRuntimeDependencyClosure({ sourceManifestPath: join(cliRoot, "package.json") }),
+    /installed package @first-tree-ai\/context-tree is version 0\.1\.9, but the source pins 0\.1\.8/,
+  );
+});
+
+test("a declared dependency that is not installed fails closed", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureCliRoot(root);
+  writeContextTreePackage(join(cliRoot, "node_modules"));
+  assert.throws(
+    () => collectRuntimeDependencyClosure({ sourceManifestPath: join(cliRoot, "package.json") }),
+    /could not be resolved from/,
+  );
+});
+
+test("same-name packages from different installed roots fail closed", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureCliRoot(root);
+  const nodeModulesDir = join(cliRoot, "node_modules");
+  writeContextTreePackage(nodeModulesDir, { dependencies: { a: "^1.0.0", b: "^1.0.0" } });
+  for (const [name, xVersion] of [
+    ["a", "1.0.0"],
+    ["b", "2.0.0"],
+  ]) {
+    writeChildPackage(nodeModulesDir, name, { dependencies: { x: "^1.0.0" } });
+    writeJson(join(nodeModulesDir, name, "node_modules", "x", "package.json"), {
+      name: "x",
+      version: xVersion,
+      dependencies: {},
+    });
+    writeText(join(nodeModulesDir, name, "node_modules", "x", "index.js"), `module.exports = "x@${xVersion}";\n`);
+  }
+  assert.throws(
+    () => collectRuntimeDependencyClosure({ sourceManifestPath: join(cliRoot, "package.json") }),
+    /cannot ship both versions/,
+  );
+});
+
+test("dependency cycles deduplicate against the visited graph", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureCliRoot(root);
+  const nodeModulesDir = join(cliRoot, "node_modules");
+  writeContextTreePackage(nodeModulesDir, { dependencies: { commander: "^15.0.0" } });
+  writeChildPackage(nodeModulesDir, "commander", {
+    dependencies: { "@first-tree-ai/context-tree": "^0.1.0" },
+    version: "15.0.0",
+  });
+  const closure = collectRuntimeDependencyClosure({ sourceManifestPath: join(cliRoot, "package.json") });
+  assert.deepEqual(
+    closure.packages.map((entry) => entry.name),
+    ["@first-tree-ai/context-tree", "commander"],
+  );
+});
+
+test("embedded metadata that the portable layout cannot express is rejected", async () => {
+  const rejections = [
+    [{ optionalDependencies: { fsevents: "^2.3.3" } }, /non-empty optionalDependencies/],
+    [{ peerDependencies: { react: "^19.0.0" } }, /non-empty peerDependencies/],
+    [{ os: ["linux"] }, /declares os/],
+    [{ scripts: { postinstall: "node x" } }, /lifecycle scripts/],
+    [{ dependencies: [] }, /dependencies must be an object/],
+    [{ dependencies: { x: null } }, /invalid dependency specifier/],
+    [{ bundleDependencies: ["hidden"] }, /non-empty bundleDependencies/],
+  ];
+  for (const [extra, pattern] of rejections) {
+    const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+    try {
+      const cliRoot = fixtureCliRoot(root);
+      const nodeModulesDir = join(cliRoot, "node_modules");
+      writeContextTreePackage(nodeModulesDir);
+      writeChildPackage(nodeModulesDir, "commander", { extra, version: "15.0.0" });
+      assert.throws(
+        () => collectRuntimeDependencyClosure({ sourceManifestPath: join(cliRoot, "package.json") }),
+        pattern,
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  }
+});
+
+test("optional-only peer metadata (empty peers) stays shippable", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureCliRoot(root);
+  const nodeModulesDir = join(cliRoot, "node_modules");
+  writeContextTreePackage(nodeModulesDir);
+  writeChildPackage(nodeModulesDir, "commander", {
+    extra: { peerDependenciesMeta: { "supports-color": { optional: true } } },
+    version: "15.0.0",
+  });
+  const closure = collectRuntimeDependencyClosure({ sourceManifestPath: join(cliRoot, "package.json") });
+  assert.equal(closure.packages.length, 2);
+});
+
+test("published symlinks and native addons fail closed during materialization", async () => {
+  for (const variant of ["symlink", "native"]) {
+    const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+    try {
+      const cliRoot = fixtureTree(root);
+      const commanderDir = join(cliRoot, "node_modules", "commander");
+      if (variant === "symlink") {
+        symlinkSync(join(root, "outside-target"), join(commanderDir, "tool"));
+      } else {
+        writeText(join(commanderDir, "binding.node"), "\u0000binary");
+      }
+      assert.throws(
+        () =>
+          materializeRuntimeDependencyClosure({
+            nodeModulesDir: join(root, "app", "node_modules"),
+            sourceManifestPath: join(cliRoot, "package.json"),
+          }),
+        variant === "symlink" ? /symbolic link/ : /native addon/,
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  }
+});
+
+test("the graph verifier accepts a complete offline app", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const appDir = assembleFixtureApp(root);
+  assert.equal(verifyPortableDependencyGraph(appDir).packageCount, 2);
+  assert.equal(existsSync(join(appDir, DEPENDENCY_CLOSURE_FILE)), true);
+});
+
+test("the graph verifier rejects extra, missing, and unreferenced packages", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+
+  const withExtra = assembleFixtureApp(join(root, "extra"));
+  writeChildPackage(join(withExtra, "node_modules"), "lodash", { version: "4.0.0" });
+  assert.throws(() => verifyPortableDependencyGraph(withExtra), /unreferenced dependency package/);
+
+  const withMissing = assembleFixtureApp(join(root, "missing"));
+  rmSync(join(withMissing, "node_modules", "commander"), { force: true, recursive: true });
+  assert.throws(() => verifyPortableDependencyGraph(withMissing), /missing dependency package commander/);
+
+  const withDroppedLink = assembleFixtureApp(join(root, "dropped"));
+  writeJson(join(withDroppedLink, "node_modules", "@first-tree-ai", "context-tree", "package.json"), {
+    name: "@first-tree-ai/context-tree",
+    version: "0.1.8",
+    dependencies: {},
+  });
+  assert.throws(() => verifyPortableDependencyGraph(withDroppedLink), /unreferenced dependency package/);
+});
+
+test("the graph verifier rejects direct pin drift and deleted Context Tree assets", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+
+  const drifted = assembleFixtureApp(join(root, "drifted"));
+  writeJson(join(drifted, "package.json"), {
+    name: "open-tag",
+    version: "0.0.2",
+    type: "module",
+    dependencies: { "@first-tree-ai/context-tree": "0.1.9" },
+  });
+  assert.throws(() => verifyPortableDependencyGraph(drifted), /do not match the recorded direct pins/);
+
+  const withDeletedAsset = assembleFixtureApp(join(root, "assets"));
+  rmSync(join(withDeletedAsset, "node_modules", "@first-tree-ai", "context-tree", "skills", "context-tree-read"), {
+    force: true,
+    recursive: true,
+  });
+  assert.throws(() => verifyPortableDependencyGraph(withDeletedAsset), /missing packaged asset/);
+});
+
+test("the resolver cannot borrow packages from outside the frozen install", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureCliRoot(join(root, "isolated"));
+  writeContextTreePackage(join(root, "node_modules"), { dependencies: {} });
+  const sourceManifestPath = join(cliRoot, "package.json");
+  assert.throws(() => collectRuntimeDependencyClosure({ sourceManifestPath }), /could not be resolved from/);
+  mkdirSync(join(cliRoot, "node_modules", "@first-tree-ai"), { recursive: true });
+  symlinkSync(
+    join(root, "node_modules", "@first-tree-ai", "context-tree"),
+    join(cliRoot, "node_modules", "@first-tree-ai", "context-tree"),
+  );
+  assert.throws(() => collectRuntimeDependencyClosure({ sourceManifestPath }), /outside the frozen install root/);
+});
+
+test("the verifier rejects nested dependencies, symlinked roots, and inconsistent records", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const nested = assembleFixtureApp(join(root, "nested"));
+  mkdirSync(join(nested, "node_modules", "commander", "node_modules"));
+  assert.throws(() => verifyPortableDependencyGraph(nested), /nested node_modules/);
+
+  const linked = assembleFixtureApp(join(root, "linked"));
+  const linkedModules = join(linked, "node_modules");
+  rmSync(linkedModules, { force: true, recursive: true });
+  symlinkSync(join(nested, "node_modules"), linkedModules);
+  assert.throws(() => verifyPortableDependencyGraph(linked), /missing its node_modules/);
+
+  const duplicate = assembleFixtureApp(join(root, "duplicate"));
+  const duplicatePath = join(duplicate, DEPENDENCY_CLOSURE_FILE);
+  const duplicateRecord = JSON.parse(readFileSync(duplicatePath, "utf8"));
+  duplicateRecord.packages.push(duplicateRecord.packages[0]);
+  writeJson(duplicatePath, duplicateRecord);
+  assert.throws(() => verifyPortableDependencyGraph(duplicate), /duplicate package/);
+
+  const drift = assembleFixtureApp(join(root, "drift"));
+  const driftPath = join(drift, DEPENDENCY_CLOSURE_FILE);
+  const driftRecord = JSON.parse(readFileSync(driftPath, "utf8"));
+  driftRecord.packages[0].version = "0.1.9";
+  writeJson(driftPath, driftRecord);
+  writeJson(join(drift, "node_modules", "@first-tree-ai", "context-tree", "package.json"), {
+    name: "@first-tree-ai/context-tree",
+    version: "0.1.9",
+    dependencies: { commander: "^15.0.0" },
+  });
+  assert.throws(() => verifyPortableDependencyGraph(drift), /does not match the direct pin/);
+});
+
+test("dependency-free apps keep the legacy shape and verify clean", () => {
+  const root = mkdtempSync(join(tmpdir(), "opentag-portable-rdep-"));
+  try {
+    const appDir = join(root, "app");
+    mkdirSync(appDir, { recursive: true });
+    writeJson(join(appDir, "package.json"), { name: "open-tag", version: "0.0.2", type: "module" });
+    assert.equal(verifyPortableDependencyGraph(appDir).packageCount, 0);
+    writeJson(join(appDir, "package.json"), {
+      name: "open-tag",
+      version: "0.0.2",
+      type: "module",
+      dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+    });
+    assert.throws(() => verifyPortableDependencyGraph(appDir), /missing dependency-closure\.json/);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("createAppTemplate assembles a verified app from an offline fixture", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureTree(root);
+  const template = await createAppTemplate({
+    channelConfig: getPortableChannelConfig("prod"),
+    cliRoot,
+    version: "0.0.2",
+  });
+  t.after(() => rm(template.root, { force: true, recursive: true }));
+  const appPackage = JSON.parse(readFileSync(join(template.appDir, "package.json"), "utf8"));
+  assert.equal(appPackage.name, "open-tag");
+  assert.deepEqual(appPackage.dependencies, { "@first-tree-ai/context-tree": "0.1.8" });
+  assert.equal(
+    existsSync(join(template.appDir, "node_modules", "@first-tree-ai", "context-tree", "dist", "cli", "index.mjs")),
+    true,
+  );
+  assert.equal(existsSync(join(template.appDir, DEPENDENCY_CLOSURE_FILE)), true);
+  assert.ok(!template.appDir.startsWith(repoRoot), "the template must live outside the build checkout");
+  verifyPortableDependencyGraph(template.appDir);
+});
+
+test("a failed template assembly cleans up its temporary tree", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureTree(root);
+  writeJson(join(cliRoot, "package.json"), {
+    ...JSON.parse(readFileSync(join(cliRoot, "package.json"), "utf8")),
+    version: "9.9.9",
+  });
+  writeText(join(cliRoot, "dist", "cli", "index.mjs"), fakeCliEntry("9.9.9", "opentag"));
+  const before = readdirSync(root).sort();
+  await assert.rejects(
+    createAppTemplate({
+      channelConfig: getPortableChannelConfig("prod"),
+      cliRoot,
+      version: "0.0.2",
+      temporaryParent: root,
+    }),
+    /reports version 9\.9\.9, expected 0\.0\.2/,
+  );
+  assert.deepEqual(readdirSync(root).sort(), before, "a failed assembly must remove its temporary app tree");
+});
+
+test("the real frozen install closure assembles, verifies, and runs the embedded Context Tree CLI", {
+  skip:
+    !existsSync(join(repoRoot, "apps", "cli", "node_modules", "@first-tree-ai", "context-tree", "package.json")) &&
+    "apps/cli frozen install is not present",
+}, async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const appDir = join(root, "app");
+  const sourceManifestPath = join(repoRoot, "apps", "cli", "package.json");
+  const closure = materializeRuntimeDependencyClosure({
+    nodeModulesDir: join(appDir, "node_modules"),
+    sourceManifestPath,
+  });
+  assert.equal(closure.direct.length, 1);
+  assert.equal(closure.packages[0].name, "@first-tree-ai/context-tree");
+  assert.equal(closure.packages[0].version, "0.1.8");
+  assert.ok(closure.packages.length >= 20, `real closure is unexpectedly small: ${closure.packages.length}`);
+  writeJson(join(appDir, "package.json"), {
+    name: "open-tag",
+    version: "0.0.2",
+    type: "module",
+    dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+  });
+  writeDependencyClosureFile(appDir, closure);
+  writeText(join(appDir, "cli", "index.mjs"), "export {};\n");
+  assert.equal(verifyPortableDependencyGraph(appDir).packageCount, closure.packages.length);
+  const homeDir = join(root, "context-tree-home");
+  runContextTreeRuntimeProbe({ appDir, homeDir, nodePath: process.execPath });
+  assert.deepEqual(readdirSync(homeDir), [], "the probe must leave its isolated home untouched");
+});

--- a/scripts/portable/build-portable.mjs
+++ b/scripts/portable/build-portable.mjs
@@ -31,6 +31,12 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
 import { CHANNEL_CONFIG } from "../channel-config.mjs";
 import { parseStableVersion, parseStagingVersion } from "../release-versions.mjs";
+import {
+  materializeRuntimeDependencyClosure,
+  readPortableDirectDependencyPins,
+  verifyPortableDependencyGraph,
+  writeDependencyClosureFile,
+} from "./runtime-dependencies.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..", "..");
@@ -141,25 +147,8 @@ export function normalizeGeneratedAt(value) {
   return date.toISOString();
 }
 
-/**
- * The portable app ships the bundled CLI verbatim, with no `node_modules` beside it. A runtime
- * dependency would therefore resolve to nothing at all on an installed machine, so it must fail the
- * build instead of producing an artifact that only breaks once a user runs it.
- */
-export function assertBundledCliHasNoRuntimeDependencies(sourcePackage) {
-  for (const field of ["dependencies", "optionalDependencies", "peerDependencies"]) {
-    const names = Object.keys(sourcePackage[field] ?? {});
-    if (names.length > 0) {
-      fail(
-        `apps/cli declares ${field} (${names.join(", ")}), but the portable app ships without node_modules. ` +
-          "Bundle the dependency into the CLI build, or extend the portable builder to install and ship it.",
-      );
-    }
-  }
-}
-
 export function portableAppPackageJson({ channelConfig, version, sourcePackage }) {
-  return {
+  const manifest = {
     name: channelConfig.packageName,
     version,
     type: "module",
@@ -169,6 +158,13 @@ export function portableAppPackageJson({ channelConfig, version, sourcePackage }
     engines: sourcePackage.engines,
     bin: { [channelConfig.binName]: "./cli/index.mjs" },
   };
+  const dependencyPins = readPortableDirectDependencyPins(sourcePackage);
+  if (dependencyPins.length > 0) {
+    manifest.dependencies = Object.fromEntries(
+      dependencyPins.map(({ name, version: pinnedVersion }) => [name, pinnedVersion]),
+    );
+  }
+  return manifest;
 }
 
 export function buildPortableMetadata({ channel, channelConfig, version, gitSha, nodeVersion, generatedAt }) {
@@ -387,24 +383,44 @@ export function assertBuiltCliIdentity({ appDir, channelConfig, version }) {
  * Assembles the channel- and version-specific app tree once, so every platform artifact ships
  * byte-identical application code and only differs in its embedded Node.js runtime.
  */
-async function createAppTemplate({ channelConfig, version }) {
-  const root = await mkdtemp(join(tmpdir(), "opentag-portable-app-"));
-  const appDir = join(root, "app");
-  const sourcePackage = readJson(join(CLI_ROOT, "package.json"));
-  assertBundledCliHasNoRuntimeDependencies(sourcePackage);
+export async function createAppTemplate({ channelConfig, version, cliRoot = CLI_ROOT, temporaryParent = tmpdir() }) {
+  const root = await mkdtemp(join(temporaryParent, "opentag-portable-app-"));
+  try {
+    const appDir = join(root, "app");
+    const sourceManifestPath = join(cliRoot, "package.json");
+    const sourcePackage = readJson(sourceManifestPath);
+    const dependencyPins = readPortableDirectDependencyPins(sourcePackage);
 
-  // The runtime only loads ESM chunks; declaration files, source maps, and build info would triple
-  // the download for bytes no installed CLI ever reads.
-  cpSync(join(CLI_ROOT, "dist"), appDir, {
-    recursive: true,
-    filter: (source) => lstatSync(source).isDirectory() || source.endsWith(".mjs"),
-  });
-  cpSync(join(CLI_ROOT, "LICENSE"), join(appDir, "LICENSE"));
-  cpSync(join(CLI_ROOT, "README.md"), join(appDir, "README.md"));
-  cpSync(join(CLI_ROOT, "THIRD_PARTY_NOTICES"), join(appDir, "THIRD_PARTY_NOTICES"));
-  writeJson(join(appDir, "package.json"), portableAppPackageJson({ channelConfig, sourcePackage, version }));
-  assertBuiltCliIdentity({ appDir, channelConfig, version });
-  return { appDir, root };
+    // The runtime only loads ESM chunks; declaration files, source maps, and build info would
+    // triple the download for bytes no installed CLI ever reads.
+    cpSync(join(cliRoot, "dist"), appDir, {
+      recursive: true,
+      filter: (source) => lstatSync(source).isDirectory() || source.endsWith(".mjs"),
+    });
+    cpSync(join(cliRoot, "LICENSE"), join(appDir, "LICENSE"));
+    cpSync(join(cliRoot, "README.md"), join(appDir, "README.md"));
+    cpSync(join(cliRoot, "THIRD_PARTY_NOTICES"), join(appDir, "THIRD_PARTY_NOTICES"));
+    writeJson(join(appDir, "package.json"), portableAppPackageJson({ channelConfig, sourcePackage, version }));
+
+    // Materialize the runtime dependency closure from the frozen install into the app's own
+    // node_modules, and record the closed graph beside the app manifest.
+    if (dependencyPins.length > 0) {
+      const closure = materializeRuntimeDependencyClosure({
+        nodeModulesDir: join(appDir, "node_modules"),
+        sourceManifestPath,
+      });
+      writeDependencyClosureFile(appDir, closure);
+    }
+    // The shared verifier runs before the identity smoke, so an app whose embedded pieces cannot
+    // resolve or are incomplete never reaches the point of claiming a runnable identity.
+    verifyPortableDependencyGraph(appDir);
+    assertBuiltCliIdentity({ appDir, channelConfig, version });
+    return { appDir, root };
+  } catch (error) {
+    // A failed assembly must not leak its temporary app tree.
+    await rm(root, { force: true, recursive: true });
+    throw error;
+  }
 }
 
 async function downloadText(url) {

--- a/scripts/portable/runtime-dependencies.mjs
+++ b/scripts/portable/runtime-dependencies.mjs
@@ -1,0 +1,607 @@
+/**
+ * Assembles and verifies the production dependency closure embedded in a portable app.
+ *
+ * The portable app ships the bundled CLI next to a physical `node_modules` tree so the runtime can
+ * keep resolving `@first-tree-ai/context-tree` (its `package.json` through `createRequire`, its
+ * bundled CLI, and its packaged skills and templates) on machines that have no package manager.
+ * The closure is copied from the frozen pnpm install only - no fetch, no install, no lifecycle
+ * scripts - and the flat output layout stays deterministic and closed: one real directory per
+ * package, no symlinks, no native addons, and never two versions of the same package name.
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+const EXACT_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const PACKAGE_NAME_PATTERN = /^(@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/i;
+const LIFECYCLE_SCRIPT_NAMES = ["preinstall", "install", "postinstall"];
+
+/** The only runtime dependency the portable app may embed, mirroring the apps/cli dependency. */
+const SUPPORTED_DIRECT_DEPENDENCY = "@first-tree-ai/context-tree";
+
+export const DEPENDENCY_CLOSURE_FILE = "dependency-closure.json";
+export const DEPENDENCY_CLOSURE_SCHEMA_VERSION = 1;
+/** Packaged skill directories that the Context Tree CLI installs for agent hosts. */
+export const CONTEXT_TREE_SKILL_DIRECTORIES = Object.freeze([
+  "context-tree-connect",
+  "context-tree-create",
+  "context-tree-publish",
+  "context-tree-read",
+  "context-tree-setup",
+  "context-tree-write",
+]);
+/** Templates, relative to `templates/`, that the Context Tree CLI scaffolds tree roots from. */
+export const CONTEXT_TREE_TEMPLATE_FILES = Object.freeze(["AGENTS.md", "root-node.md", "validate-context-tree.yml"]);
+/** The packaged CLI entry, relative to the installed package root. */
+const CONTEXT_TREE_CLI_RELATIVE_PATH = "dist/cli/index.mjs";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRegularFile(path) {
+  return existsSync(path) && lstatSync(path).isFile();
+}
+
+function readJsonFile(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function byString(left, right) {
+  return left.localeCompare(right);
+}
+
+function byEntryName(left, right) {
+  return left.name.localeCompare(right.name);
+}
+
+function validatePackageName(name) {
+  if (typeof name !== "string" || !PACKAGE_NAME_PATTERN.test(name)) {
+    fail(`invalid package name: ${JSON.stringify(name)}`);
+  }
+}
+
+/**
+ * The top manifest of the portable source (and later of the shipped app) may only declare the
+ * supported Context Tree dependency, pinned to an exact stable version. Anything else would need a
+ * dependency shape the flat portable layout cannot express, so it fails closed here.
+ */
+export function readPortableDirectDependencyPins(packageManifest) {
+  if (!isRecord(packageManifest)) {
+    fail("package manifest must be an object");
+  }
+  const dependencies = packageManifest.dependencies;
+  if (dependencies !== undefined && dependencies !== null && !isRecord(dependencies)) {
+    fail("package manifest dependencies must be an object");
+  }
+  const names = Object.keys(dependencies ?? {});
+  const unknown = names.filter((name) => name !== SUPPORTED_DIRECT_DEPENDENCY);
+  if (unknown.length > 0) {
+    fail(
+      `unsupported runtime dependency "${unknown.join('", "')}": the portable app only embeds ${SUPPORTED_DIRECT_DEPENDENCY}`,
+    );
+  }
+  for (const name of names) {
+    const pin = dependencies[name];
+    if (typeof pin !== "string" || !EXACT_VERSION_PATTERN.test(pin)) {
+      fail(`runtime dependency ${name} must be pinned to an exact x.y.z version, got ${JSON.stringify(pin)}`);
+    }
+  }
+  for (const field of ["optionalDependencies", "peerDependencies"]) {
+    const value = packageManifest[field];
+    if (value !== undefined && value !== null && (!isRecord(value) || Object.keys(value).length > 0)) {
+      fail(`package manifest declares non-empty ${field}; the portable app cannot express it`);
+    }
+  }
+  return names.sort().map((name) => ({ name, version: dependencies[name] }));
+}
+
+/** The exact `node_modules` directories Node walks when loading from `fromPath`. */
+function nodeModulesLookupPaths(fromPath) {
+  const paths = [];
+  let directory = resolve(dirname(fromPath));
+  for (;;) {
+    paths.push(join(directory, "node_modules"));
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return paths;
+}
+
+function findInstallRoot(manifestPath) {
+  for (const candidate of nodeModulesLookupPaths(manifestPath)) {
+    const directory = dirname(candidate);
+    if (existsSync(join(directory, "pnpm-lock.yaml"))) return realpathSync(directory);
+  }
+  return realpathSync(dirname(manifestPath));
+}
+
+function isInside(directory, path) {
+  const suffix = relative(directory, path);
+  return !isAbsolute(suffix) && suffix !== ".." && !suffix.startsWith("../");
+}
+
+/**
+ * Resolves one installed package the way Node would load it from the referring manifest, and
+ * canonicalizes its root. Only candidates inside the referring package's own install tree count:
+ * machine-global paths (which `require.resolve.paths` appends last) must never answer for a
+ * package the portable app would then fail to find on an installed machine.
+ */
+export function resolveInstalledDependencyPackage(
+  fromManifestPath,
+  name,
+  installRoot = findInstallRoot(fromManifestPath),
+) {
+  fromManifestPath = realpathSync(fromManifestPath);
+  validatePackageName(name);
+  const lookupPaths = createRequire(fromManifestPath).resolve.paths(name) ?? [];
+  const installPaths = new Set(nodeModulesLookupPaths(fromManifestPath));
+  for (const nodeModulesDir of lookupPaths) {
+    if (!installPaths.has(nodeModulesDir) || !isInside(installRoot, nodeModulesDir)) continue;
+    const candidateRoot = join(nodeModulesDir, ...name.split("/"));
+    if (!isRegularFile(join(candidateRoot, "package.json"))) continue;
+    const root = realpathSync(candidateRoot);
+    if (!isInside(installRoot, root)) {
+      fail(`installed package ${name} resolves outside the frozen install root: ${root}`);
+    }
+    const manifest = readJsonFile(join(root, "package.json"));
+    if (!isRecord(manifest) || manifest.name !== name) {
+      fail(`installed package ${name} at ${root} does not carry its own name; reinstall and retry`);
+    }
+    return { name, root, manifest, manifestPath: join(root, "package.json") };
+  }
+  fail(
+    `installed package ${name} could not be resolved from ${fromManifestPath}; ` +
+      'run "pnpm install --frozen-lockfile" and rebuild apps/cli',
+  );
+}
+
+function assertEmptyObjectField(manifest, field, what) {
+  const value = manifest[field];
+  if (value === undefined || value === null) return;
+  if (!isRecord(value) || Object.keys(value).length > 0) {
+    fail(`embedded package ${what} declares non-empty ${field}; the portable app cannot express it yet`);
+  }
+}
+
+function assertNoPlatformConstraints(manifest, what) {
+  for (const field of ["os", "cpu"]) {
+    const value = manifest[field];
+    if (value !== undefined && (!Array.isArray(value) || value.length > 0)) {
+      fail(`embedded package ${what} declares ${field} constraints; platform-specific packages are not yet supported`);
+    }
+  }
+}
+
+function assertNoLifecycleScripts(manifest, what, allowLifecycleScripts) {
+  if (allowLifecycleScripts) return;
+  const names = LIFECYCLE_SCRIPT_NAMES.filter((name) => typeof manifest.scripts?.[name] === "string");
+  if (names.length > 0) {
+    fail(
+      `embedded package ${what} declares lifecycle scripts (${names.join(", ")}); ` +
+        "the portable app never runs install scripts",
+    );
+  }
+}
+
+/**
+ * Every embedded package must stay platform-neutral and inert. Optional-only peer metadata (an
+ * empty `peerDependencies` plus a `peerDependenciesMeta` note, as in `debug`) is accepted: it
+ * installs nothing and the package works without the peer.
+ */
+function validateEmbeddedPackageManifest(manifest, what, allowLifecycleScripts) {
+  if (!isRecord(manifest) || typeof manifest.name !== "string" || typeof manifest.version !== "string") {
+    fail(`embedded package ${what} has an invalid package manifest`);
+  }
+  validatePackageName(manifest.name);
+  if (!EXACT_VERSION_PATTERN.test(manifest.version)) {
+    fail(`embedded package ${what} must have an exact stable version`);
+  }
+  if (manifest.dependencies !== undefined && !isRecord(manifest.dependencies)) {
+    fail(`embedded package ${what} dependencies must be an object`);
+  }
+  for (const [name, specifier] of Object.entries(manifest.dependencies ?? {})) {
+    validatePackageName(name);
+    if (typeof specifier !== "string" || specifier.length === 0) {
+      fail(`embedded package ${what} has an invalid dependency specifier for ${name}`);
+    }
+  }
+  assertEmptyObjectField(manifest, "optionalDependencies", what);
+  assertEmptyObjectField(manifest, "peerDependencies", what);
+  assertEmptyObjectField(manifest, "bundledDependencies", what);
+  assertEmptyObjectField(manifest, "bundleDependencies", what);
+  const peerMeta = manifest.peerDependenciesMeta;
+  if (peerMeta !== undefined && peerMeta !== null && !isRecord(peerMeta)) {
+    fail(`embedded package ${what} has invalid peerDependenciesMeta`);
+  }
+  assertNoPlatformConstraints(manifest, what);
+  assertNoLifecycleScripts(manifest, what, allowLifecycleScripts);
+}
+
+/**
+ * Walks the installed dependency graph from the source manifest and records one canonical root per
+ * package name. Same-name packages from different installed roots cannot be expressed in the flat
+ * layout, so they fail closed instead of silently shipping one version for both referrers.
+ */
+export function collectRuntimeDependencyClosure({ sourceManifestPath }) {
+  const direct = readPortableDirectDependencyPins(readJsonFile(sourceManifestPath));
+  const installRoot = findInstallRoot(sourceManifestPath);
+  const byName = new Map();
+  const queue = direct.map((pin) => ({ from: sourceManifestPath, name: pin.name, pin }));
+  while (queue.length > 0) {
+    const job = queue.shift();
+    const resolved = resolveInstalledDependencyPackage(job.from, job.name, installRoot);
+    const recorded = byName.get(job.name);
+    if (recorded !== undefined) {
+      if (recorded.root !== resolved.root) {
+        fail(
+          `dependency ${job.name} resolves to ${resolved.root}, but the closure already embeds it from ` +
+            `${recorded.root}; the flat portable layout cannot ship both versions`,
+        );
+      }
+      continue;
+    }
+    const allowLifecycleScripts = direct.some((pin) => pin.name === job.name);
+    validateEmbeddedPackageManifest(
+      resolved.manifest,
+      `${job.name}@${resolved.manifest.version}`,
+      allowLifecycleScripts,
+    );
+    if (job.pin !== undefined && resolved.manifest.version !== job.pin.version) {
+      fail(
+        `installed package ${job.name} is version ${resolved.manifest.version}, but the source pins ` +
+          `${job.pin.version}; run "pnpm install --frozen-lockfile" and rebuild`,
+      );
+    }
+    byName.set(job.name, { name: job.name, root: resolved.root, version: resolved.manifest.version });
+    for (const child of Object.keys(resolved.manifest.dependencies ?? {}).sort()) {
+      queue.push({ from: resolved.manifestPath, name: child });
+    }
+  }
+  const packages = [...byName.values()]
+    .sort((left, right) => byString(left.name, right.name))
+    .map(({ name, root, version }) => ({ name, root, version }));
+  return { direct, packages };
+}
+
+/**
+ * Every published file of one installed package, in deterministic pre-order. The package's own
+ * nested `node_modules` (pnpm bin droppings) is never published content; a symlink inside the
+ * package would export a host link, and a native addon cannot run on every platform, so both fail
+ * closed instead.
+ */
+function publishedPackageFiles(packageEntry, relativeDirectory = "", shipped = false) {
+  const files = [];
+  const sourceDirectory = join(packageEntry.root, relativeDirectory);
+  const entries = readdirSync(sourceDirectory, { withFileTypes: true }).sort(byEntryName);
+  for (const entry of entries) {
+    if (skipInstalledNodeModules(entry, packageEntry.name, shipped)) continue;
+    const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name;
+    if (entry.isSymbolicLink()) {
+      fail(`package ${packageEntry.name} publishes a symbolic link (${relativePath}); refusing to export host links`);
+    }
+    if (entry.isDirectory()) {
+      files.push(...publishedPackageFiles(packageEntry, relativePath, shipped));
+      continue;
+    }
+    if (!entry.isFile()) {
+      fail(`package ${packageEntry.name} publishes a non-regular entry (${relativePath})`);
+    }
+    if (entry.name.endsWith(".node")) {
+      fail(
+        `package ${packageEntry.name} publishes a native addon (${relativePath}); native modules are not yet supported`,
+      );
+    }
+    files.push(relativePath);
+  }
+  return files;
+}
+
+function skipInstalledNodeModules(entry, name, shipped) {
+  if (entry.name !== "node_modules") return false;
+  if (shipped) fail(`package ${name} ships a nested node_modules directory`);
+  return true;
+}
+
+/**
+ * Copies the collected closure into a fresh flat `node_modules` directory. The destination must
+ * not exist: every `node_modules` directory in the output is assembler-owned.
+ */
+export function materializeRuntimeDependencyClosure({ sourceManifestPath, nodeModulesDir }) {
+  const closure = collectRuntimeDependencyClosure({ sourceManifestPath });
+  if (existsSync(nodeModulesDir)) {
+    fail(`refusing to reuse an existing node_modules directory: ${nodeModulesDir}`);
+  }
+  if (closure.packages.length === 0) return closure;
+  mkdirSync(nodeModulesDir, { recursive: true });
+  for (const packageEntry of closure.packages) {
+    const destinationRoot = join(nodeModulesDir, ...packageEntry.name.split("/"));
+    mkdirSync(destinationRoot, { recursive: true });
+    for (const relativePath of publishedPackageFiles(packageEntry)) {
+      const destination = join(destinationRoot, relativePath);
+      mkdirSync(dirname(destination), { recursive: true });
+      copyFileSync(join(packageEntry.root, relativePath), destination);
+      chmodSync(destination, 0o644);
+    }
+  }
+  return closure;
+}
+
+/**
+ * Writes the persisted record of the embedded graph next to the app manifest. `direct` keeps the
+ * truthful exact pins and `packages` names every embedded package, both sorted by name.
+ */
+export function writeDependencyClosureFile(appDir, closure) {
+  const record = {
+    schemaVersion: DEPENDENCY_CLOSURE_SCHEMA_VERSION,
+    direct: closure.direct.map(({ name, version }) => ({ name, version })),
+    packages: closure.packages.map(({ name, version }) => ({ name, version })),
+  };
+  writeFileSync(join(appDir, DEPENDENCY_CLOSURE_FILE), `${JSON.stringify(record, null, 2)}\n`);
+}
+
+function parseDependencyRecords(value, field) {
+  if (!Array.isArray(value)) fail(`${DEPENDENCY_CLOSURE_FILE} ${field} must be an array`);
+  const names = new Set();
+  return value.map((entry) => {
+    if (!isRecord(entry) || typeof entry.name !== "string" || typeof entry.version !== "string") {
+      fail(`${DEPENDENCY_CLOSURE_FILE} ${field} entries must carry name and version`);
+    }
+    validatePackageName(entry.name);
+    if (names.has(entry.name)) fail(`${DEPENDENCY_CLOSURE_FILE} ${field} has duplicate package ${entry.name}`);
+    names.add(entry.name);
+    if (!EXACT_VERSION_PATTERN.test(entry.version)) {
+      fail(`${DEPENDENCY_CLOSURE_FILE} ${field} version must be exact: ${entry.version}`);
+    }
+    return { name: entry.name, version: entry.version };
+  });
+}
+
+function readDependencyClosureRecord(appDir) {
+  const filePath = join(appDir, DEPENDENCY_CLOSURE_FILE);
+  if (!isRegularFile(filePath)) fail(`portable app is missing ${DEPENDENCY_CLOSURE_FILE} or it is not a regular file`);
+  const record = readJsonFile(filePath);
+  if (!isRecord(record) || record.schemaVersion !== DEPENDENCY_CLOSURE_SCHEMA_VERSION) {
+    fail(`${DEPENDENCY_CLOSURE_FILE} must carry schemaVersion ${DEPENDENCY_CLOSURE_SCHEMA_VERSION}`);
+  }
+  const direct = parseDependencyRecords(record.direct, "direct").sort((left, right) => byString(left.name, right.name));
+  const packages = parseDependencyRecords(record.packages, "packages").sort((left, right) =>
+    byString(left.name, right.name),
+  );
+  return { direct, packages };
+}
+
+/**
+ * Top-level package names in a flat `node_modules` tree. Scoped packages live under their scope
+ * directory; anything that is not a real directory fails closed, because every `node_modules`
+ * directory in the output is assembler-owned.
+ */
+function listPhysicalPackageNames(nodeModulesDir) {
+  const names = [];
+  for (const entry of readdirSync(nodeModulesDir, { withFileTypes: true }).sort(byEntryName)) {
+    if (entry.isSymbolicLink() || !entry.isDirectory()) {
+      fail(`unexpected entry in the portable app node_modules: ${entry.name}`);
+    }
+    if (entry.name.startsWith("@")) {
+      names.push(...listScopedPackageNames(nodeModulesDir, entry.name));
+    } else {
+      names.push(entry.name);
+    }
+  }
+  return names.sort(byString);
+}
+
+function listScopedPackageNames(nodeModulesDir, scope) {
+  const children = readdirSync(join(nodeModulesDir, scope), { withFileTypes: true }).sort(byEntryName);
+  if (children.length === 0) fail(`unexpected empty scope in portable app node_modules: ${scope}`);
+  return children.map((child) => {
+    if (child.isSymbolicLink() || !child.isDirectory()) {
+      fail(`unexpected entry in ${scope}: ${child.name}`);
+    }
+    return `${scope}/${child.name}`;
+  });
+}
+
+/**
+ * Verifies one assembled app's embedded dependency graph against its persisted closure record and
+ * its shipped package manifests. Dependency-free apps keep the historic shape (no `node_modules`,
+ * no closure file); apps that embed dependencies must be complete, closed, and inert.
+ */
+export function verifyPortableDependencyGraph(appDir) {
+  const manifestPath = join(appDir, "package.json");
+  if (!isRegularFile(manifestPath)) fail(`portable app is missing its regular package manifest: ${manifestPath}`);
+  const directPins = readPortableDirectDependencyPins(readJsonFile(manifestPath));
+  const nodeModulesDir = join(appDir, "node_modules");
+  if (directPins.length === 0) {
+    if (existsSync(nodeModulesDir)) {
+      fail(`portable app ships node_modules without declaring runtime dependencies: ${nodeModulesDir}`);
+    }
+    if (existsSync(join(appDir, DEPENDENCY_CLOSURE_FILE))) {
+      fail(`portable app ships ${DEPENDENCY_CLOSURE_FILE} without declaring runtime dependencies`);
+    }
+    return { packageCount: 0 };
+  }
+  const closure = readDependencyClosureRecord(appDir);
+  if (JSON.stringify(closure.direct) !== JSON.stringify(directPins)) {
+    fail("app package manifest dependencies do not match the recorded direct pins");
+  }
+  for (const pin of directPins) {
+    if (!closure.packages.some((entry) => entry.name === pin.name && entry.version === pin.version)) {
+      fail(`recorded dependency package ${pin.name} does not match the direct pin ${pin.version}`);
+    }
+  }
+  if (!existsSync(nodeModulesDir) || !lstatSync(nodeModulesDir).isDirectory()) {
+    fail(`portable app is missing its node_modules directory: ${nodeModulesDir}`);
+  }
+  verifyPhysicalPackages({ closure, directPins, nodeModulesDir });
+  verifyShippedGraph({ closure, directPins, nodeModulesDir });
+  assertContextTreeAssets(nodeModulesDir, directPins);
+  return { packageCount: closure.packages.length };
+}
+
+function verifyPhysicalPackages({ closure, directPins, nodeModulesDir }) {
+  const physicalNames = listPhysicalPackageNames(nodeModulesDir);
+  const shippedNames = new Set(closure.packages.map((entry) => entry.name));
+  for (const entry of closure.packages) {
+    if (!physicalNames.includes(entry.name)) fail(`portable app is missing dependency package ${entry.name}`);
+  }
+  const extras = physicalNames.filter((name) => !shippedNames.has(name));
+  if (extras.length > 0) fail(`portable app ships unreferenced dependency package(s): ${extras.join(", ")}`);
+  for (const entry of closure.packages) {
+    const packageDir = join(nodeModulesDir, ...entry.name.split("/"));
+    publishedPackageFiles({ name: entry.name, root: packageDir }, "", true);
+    const shippedManifest = readJsonFile(join(packageDir, "package.json"));
+    const allowLifecycleScripts = directPins.some((pin) => pin.name === entry.name);
+    validateEmbeddedPackageManifest(shippedManifest, `${entry.name}@${entry.version}`, allowLifecycleScripts);
+    if (shippedManifest.name !== entry.name || shippedManifest.version !== entry.version) {
+      fail(`dependency package ${entry.name}@${entry.version} does not match its shipped manifest`);
+    }
+  }
+}
+
+/** Re-walks the graph declared by the shipped manifests so a deleted or unreferenced package cannot ship. */
+function verifyShippedGraph({ closure, directPins, nodeModulesDir }) {
+  const shippedNames = new Set(closure.packages.map((entry) => entry.name));
+  const reachable = new Set();
+  const queue = directPins.map((pin) => pin.name);
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (reachable.has(name)) continue;
+    reachable.add(name);
+    const manifest = readJsonFile(join(nodeModulesDir, ...name.split("/"), "package.json"));
+    for (const dependency of Object.keys(manifest.dependencies ?? {}).sort()) {
+      if (!shippedNames.has(dependency)) {
+        fail(`dependency ${dependency} of ${name} is not part of the portable closure`);
+      }
+      queue.push(dependency);
+    }
+  }
+  const unreferenced = [...shippedNames].filter((name) => !reachable.has(name)).sort(byString);
+  if (unreferenced.length > 0) {
+    fail(`portable app ships unreferenced dependency package(s): ${unreferenced.join(", ")}`);
+  }
+}
+
+/** The packaged Context Tree files the runtime and its CLI need must all be present. */
+function assertContextTreeAssets(nodeModulesDir, directPins) {
+  if (!directPins.some((pin) => pin.name === SUPPORTED_DIRECT_DEPENDENCY)) return;
+  const packageDir = join(nodeModulesDir, ...SUPPORTED_DIRECT_DEPENDENCY.split("/"));
+  const assets = [
+    CONTEXT_TREE_CLI_RELATIVE_PATH,
+    ...CONTEXT_TREE_SKILL_DIRECTORIES.map((skill) => `skills/${skill}/SKILL.md`),
+    ...CONTEXT_TREE_TEMPLATE_FILES.map((template) => `templates/${template}`),
+  ];
+  for (const asset of assets) {
+    if (!isRegularFile(join(packageDir, asset))) {
+      fail(`Context Tree package is missing packaged asset ${asset}; reinstall the frozen dependencies and rebuild`);
+    }
+  }
+}
+
+function runNode(nodePath, args, env, expectedStatus = 0) {
+  const result = spawnSync(nodePath, args, {
+    encoding: "utf8",
+    env,
+    cwd: env.HOME,
+    timeout: 30_000,
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) fail(`${nodePath} failed to start: ${result.error.message}`);
+  if (result.status !== expectedStatus) {
+    fail(`${nodePath} ${args.join(" ")} exited ${result.status}\n${result.stdout}\n${result.stderr}`);
+  }
+  return result;
+}
+
+const DETACHED_RESOLUTION_SCRIPT = [
+  'const { createRequire } = require("node:module");',
+  'const { dirname, resolve } = require("node:path");',
+  'const resolved = createRequire(resolve(process.argv[1])).resolve("@first-tree-ai/context-tree/package.json");',
+  "console.log(dirname(resolved));",
+].join("\n");
+
+/**
+ * Exercises the embedded Context Tree CLI exactly as an installed user would, from a relocated app
+ * with an isolated `HOME` and no `NODE_PATH`. Only safe commands run (`--version`, `--help`,
+ * `list`); resolution must come from the app's own `node_modules`, never from the build checkout.
+ */
+export function runContextTreeRuntimeProbe({ appDir, nodePath, homeDir, probeOpenTag = false }) {
+  if (!existsSync(join(appDir, DEPENDENCY_CLOSURE_FILE))) return;
+  const closure = readDependencyClosureRecord(appDir);
+  const pinned = closure.direct.find((pin) => pin.name === SUPPORTED_DIRECT_DEPENDENCY);
+  if (!pinned) return;
+  const packageDir = join(appDir, "node_modules", ...SUPPORTED_DIRECT_DEPENDENCY.split("/"));
+  const cliPath = join(packageDir, CONTEXT_TREE_CLI_RELATIVE_PATH);
+  if (!isRegularFile(cliPath)) fail(`Context Tree CLI is missing from the app: ${cliPath}`);
+  const cleanEnv = {
+    HOME: homeDir,
+    PATH: `${dirname(nodePath)}:/usr/bin:/bin`,
+    LANG: "C",
+    TERM: "dumb",
+    OPENTAG_HOME: join(homeDir, "opentag"),
+    CODEX_HOME: join(homeDir, ".codex"),
+    CLAUDE_CONFIG_DIR: join(homeDir, ".claude"),
+    XDG_CONFIG_HOME: join(homeDir, ".config"),
+    XDG_CACHE_HOME: join(homeDir, ".cache"),
+  };
+  mkdirSync(homeDir, { recursive: true, mode: 0o700 });
+
+  const entryPath = join(appDir, "cli", "index.mjs");
+  if (!isRegularFile(entryPath)) fail(`app entry is missing; cannot probe detached resolution: ${entryPath}`);
+  const resolved = runNode(nodePath, ["-e", DETACHED_RESOLUTION_SCRIPT, entryPath], cleanEnv).stdout.trim();
+  if (realpathSync(resolved) !== realpathSync(packageDir)) {
+    fail(
+      `Context Tree resolved from ${resolved} instead of the relocated app package at ${packageDir}; ` +
+        "NODE_PATH or a build checkout must not answer for the app",
+    );
+  }
+
+  const reportedVersion = runNode(nodePath, [cliPath, "--version"], cleanEnv).stdout.trim();
+  if (reportedVersion !== pinned.version) {
+    fail(`embedded Context Tree reports version ${reportedVersion}, expected ${pinned.version}`);
+  }
+  const helpOutput = runNode(nodePath, [cliPath, "--help"], cleanEnv).stdout;
+  if (!helpOutput.includes("Usage: context-tree")) {
+    fail("embedded Context Tree help does not identify the context-tree CLI");
+  }
+  let listing;
+  try {
+    listing = JSON.parse(runNode(nodePath, [cliPath, "list"], cleanEnv).stdout.trim());
+  } catch {
+    fail("embedded Context Tree list did not emit its JSON payload");
+  }
+  if (
+    !isRecord(listing) ||
+    listing.schemaVersion !== 1 ||
+    !Array.isArray(listing.trees) ||
+    listing.trees.length !== 0
+  ) {
+    fail("embedded Context Tree list did not report the expected empty tree listing");
+  }
+  if (probeOpenTag) {
+    const target = "otqa-portable-nonexistent";
+    const result = runNode(nodePath, [entryPath, "context-tree", "connect", target], cleanEnv, 1);
+    if (!result.stderr.includes(`No managed Context Tree named "${target}" exists`)) {
+      fail(`OpenTag could not use its embedded Context Tree runtime: ${result.stdout}\n${result.stderr}`);
+    }
+  }
+  const leftovers = readdirSync(homeDir).filter((name) => name !== "." && name !== "..");
+  if (leftovers.length > 0) fail(`embedded Context Tree wrote into its isolated home: ${leftovers.join(", ")}`);
+}

--- a/scripts/portable/smoke-portable-app.mjs
+++ b/scripts/portable/smoke-portable-app.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+/**
+ * Assembles a real portable app from the already-built release-channel CLI and exercises it end to
+ * end without any network. The embedded dependency graph is materialized from the frozen install,
+ * verified, and the relocated Context Tree CLI is run with an isolated home and no NODE_PATH. This
+ * is the portable gate behind the CLI Pack Smoke CI job for staging and production.
+ */
+
+import { rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createAppTemplate, getPortableChannelConfig, validateChannelVersion } from "./build-portable.mjs";
+import { runContextTreeRuntimeProbe, verifyPortableDependencyGraph } from "./runtime-dependencies.mjs";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function printHelp() {
+  console.log("Usage: node scripts/portable/smoke-portable-app.mjs --channel staging|prod --version <version>");
+}
+
+export function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) fail(`${arg} requires a value`);
+      index += 1;
+      return value;
+    };
+    if (arg === "--channel") options.channel = next();
+    else if (arg === "--version") options.version = next();
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else fail(`unknown argument: ${arg}`);
+  }
+  if (!options.channel) fail("--channel is required");
+  if (!options.version) fail("--version is required");
+  return options;
+}
+
+export async function smokePortableApp({ channel, version }) {
+  const channelConfig = getPortableChannelConfig(channel);
+  validateChannelVersion(channel, version);
+  const template = await createAppTemplate({ channelConfig, version });
+  try {
+    const summary = verifyPortableDependencyGraph(template.appDir);
+    runContextTreeRuntimeProbe({
+      appDir: template.appDir,
+      homeDir: join(template.root, "context-tree-home"),
+      nodePath: process.execPath,
+      probeOpenTag: true,
+    });
+    console.log(
+      `[portable smoke] ${channel} ${version}: ${summary.packageCount} dependency package(s) embedded; ` +
+        "Context Tree runs from the relocated app",
+    );
+  } finally {
+    await rm(template.root, { force: true, recursive: true });
+  }
+}
+
+const isProcessEntry =
+  process.argv[1] !== undefined && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isProcessEntry) {
+  smokePortableApp(parseArgs(process.argv.slice(2))).catch((error) => {
+    console.error(`[portable smoke] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/portable/verify-portable-artifact.mjs
+++ b/scripts/portable/verify-portable-artifact.mjs
@@ -13,6 +13,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:f
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { APP_ENTRY, hostPlatform, MANIFEST_SCHEMA_VERSION, parsePlatform } from "./build-portable.mjs";
+import { runContextTreeRuntimeProbe, verifyPortableDependencyGraph } from "./runtime-dependencies.mjs";
 
 function fail(message) {
   throw new Error(message);
@@ -103,27 +104,41 @@ function verify(options) {
     const appPackage = readJson(join(artifactDir, "app", "package.json"));
     if (appPackage.name !== manifest.packageName) fail("app/package.json name does not match the manifest");
     if (appPackage.version !== manifest.version) fail("app/package.json version does not match the manifest");
-    for (const field of ["dependencies", "optionalDependencies", "peerDependencies"]) {
-      if (Object.keys(appPackage[field] ?? {}).length > 0) {
-        fail(`app/package.json declares ${field}, but the portable artifact ships without node_modules`);
-      }
-    }
+
+    // The embedded dependency graph must be closed and complete for every platform: the payload
+    // layout is platform-independent, so a broken graph fails the artifact everywhere.
+    verifyPortableDependencyGraph(join(artifactDir, "app"));
 
     if (options.platform !== hostPlatform()) {
       console.log(`[portable verify] ${options.platform} structure verified; skipping the runtime check on this host`);
       return;
     }
 
-    const versionOutput = run(join(artifactDir, "bin", manifest.binName), ["--version"], {
-      env: { ...process.env, OPENTAG_HOME: join(root, "home") },
-    }).stdout;
-    if (!versionOutput.includes(manifest.version)) {
-      fail(`expected --version output to include ${manifest.version}, got ${versionOutput.trim()}`);
-    }
-    console.log(`[portable verify] ${options.platform} verified and runnable (${manifest.version})`);
+    verifyHostRuntime({ artifactDir, manifest, platform: options.platform, root });
   } finally {
     rmSync(root, { force: true, recursive: true });
   }
+}
+
+/**
+ * Host-stage runtime checks execute the artifact's own binaries with isolated homes, so a payload
+ * that only passes structural checks still fails verification on the platform it runs on. The
+ * embedded Context Tree CLI is exercised through the artifact's own Node.js runtime.
+ */
+function verifyHostRuntime({ artifactDir, manifest, platform, root }) {
+  const versionOutput = run(join(artifactDir, "bin", manifest.binName), ["--version"], {
+    env: { ...process.env, OPENTAG_HOME: join(root, "home") },
+  }).stdout;
+  if (!versionOutput.includes(manifest.version)) {
+    fail(`expected --version output to include ${manifest.version}, got ${versionOutput.trim()}`);
+  }
+  runContextTreeRuntimeProbe({
+    probeOpenTag: true,
+    appDir: join(artifactDir, "app"),
+    homeDir: join(root, "context-tree-home"),
+    nodePath: join(artifactDir, "node", "bin", "node"),
+  });
+  console.log(`[portable verify] ${platform} verified and runnable (${manifest.version})`);
 }
 
 try {


### PR DESCRIPTION
## Summary

Fix the portable packaging failure in [npm Publish run 33740499085](https://github.com/first-tree-ai/opentag/actions/runs/33740499085/job/100601025424), which rejects the CLI's declared `@first-tree-ai/context-tree@0.1.8` dependency under the old no-node_modules contract.

- Materialize the frozen production dependency closure into a physical `app/node_modules` tree, preserving the package manifest, CLI, skills, templates, and licenses. Record exact package names/versions in `app/dependency-closure.json`; never fetch dependencies or run lifecycle scripts during assembly.
- Share strict graph/asset verification between the builder and artifact verifier. Reject missing or unreferenced packages, inconsistent pins/records, unsupported dependency shapes, escaping source resolution, nested node_modules, symlinks, and native addons.
- Add staging and production portable-app checks to CLI Pack Smoke. Run the relocated Context Tree CLI and OpenTag's real Context Tree resolution path in a clean temporary environment, without operator credentials or configuration writes.
- Synchronize the English/Chinese portable release documentation and add focused regressions.

## Testing

Head: `99f7c2fc13a9a4820272d3a2110c55f8bae49826`, based on main `21ac2485ffb72673812557292d3fafee94922ca9` at the start of validation.

During validation, main advanced to `217697e19a42052d4a8ef7f4b14b2594669b6385` with separate Web onboarding changes (#521). There is no changed-file overlap with this packaging fix. This PR retains the exact locally validated head; PR CI must verify its merge result against main.

Repository validation after updating to main:

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 330 script tests; Shared 218, Server 773, Client 950, CLI 431, Web 651.
- [x] `pnpm --filter @opentag/server test:integration` — 314 tests.
- [x] `pnpm --filter @opentag/client test:agent-runtime:coverage` — 357 tests; statements, branches, functions, and lines all 100%.

All six gates ran serially with `CI=1 TURBO_FORCE=true`. The source fingerprint was unchanged throughout validation.

Packaging acceptance already performed on the unchanged packaging/CLI source before the main update:

- 39 focused tests passed, including the actual frozen dependency closure.
- Staging and production portable-app smoke passed.
- Real four-platform staging artifacts built with official embedded Node v24.19.0 and passed structural/dependency verification.
- macOS ARM64 and a read-only, network-none Linux ARM64 Docker consumer passed actual OpenTag/Context Tree invocation outside the checkout.
- Repeated four-platform builds produced identical tarball hashes and manifest bytes.
- Five corrupted payloads were rejected: missing Context Tree CLI, missing skill, incorrect package version, external symlink, and native addon.

The main update changes only unrelated Server/Web code; packaging/CLI inputs are unchanged. The local artifacts use synthetic release coordinates and are not published onboarding evidence. x64 artifacts received structural verification only; x64 runtime execution was not available locally.

## Breaking changes

None. Existing CLI behavior, dependency pin, lockfile, installer, publication workflow, and release safety gates are preserved. This PR does not publish a release or update a channel pointer. W3 onboarding still requires the normally published staging installer after merge and successful main CI/release.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
