### PR TITLE
fix(web): rebalance computer summary spacing

### DIFF
--- a/apps/web/src/onboarding-v2/agent-setup-page.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.tsx
@@ -1005,27 +1005,29 @@ function PreparationSummarySection({ snapshot }: { readonly snapshot: AgentSetup
   const { computer } = snapshot;
   if (computer.kind === "not-bound") return null;
   return (
-    <section className={SECTION} data-ui="agent-setup-preparation">
+    <section className="otv2-preparation flex flex-col" data-ui="agent-setup-preparation">
       <header className={SECTION_HEADER}>
         <Text as="h1" size="lg" variant="heading">
           {m.onboarding_v2_prep_title()}
         </Text>
         <p className={HINT}>{m.onboarding_v2_prep_intro()}</p>
       </header>
-      <ComputerSummary
-        metadata={platformLabel(computer.platform)}
-        status={m.onboarding_v2_connect_online()}
-        title={computer.displayName}
-        tone="success"
-      />
-      <ol
-        aria-label={m.onboarding_v2_prep_title()}
-        className="otv2-readiness otv2-readiness--compact"
-        data-ui="readiness-list"
-      >
-        <CheckLine check={rows.runtime} component="runtime" position={1} scrollable={false} />
-        <CheckLine check={rows.messaging} component="messaging-support" position={2} scrollable={false} />
-      </ol>
+      <div className="otv2-preparation__checks">
+        <ComputerSummary
+          metadata={platformLabel(computer.platform)}
+          status={m.onboarding_v2_connect_online()}
+          title={computer.displayName}
+          tone="success"
+        />
+        <ol
+          aria-label={m.onboarding_v2_prep_title()}
+          className="otv2-readiness otv2-readiness--compact"
+          data-ui="readiness-list"
+        >
+          <CheckLine check={rows.runtime} component="runtime" position={1} scrollable={false} />
+          <CheckLine check={rows.messaging} component="messaging-support" position={2} scrollable={false} />
+        </ol>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/onboarding-v2/layout.test.ts
+++ b/apps/web/src/onboarding-v2/layout.test.ts
@@ -114,6 +114,16 @@ describe("onboarding flow layout", () => {
     expect(atWidth("359px", ".otv2-slot--outcome", "min-height")).toBe("114px");
   });
 
+  it("groups the compact Computer context with the Step 2 checklist", () => {
+    expect(declarationValue(".otv2-preparation", "gap")).toBe("1.25rem");
+    expect(declarationValue(".otv2-preparation__checks", "display")).toBe("flex");
+    expect(declarationValue(".otv2-preparation__checks", "flex-direction")).toBe("column");
+    expect(declarationValue(".otv2-preparation__checks", "gap")).toBe("0.75rem");
+    expect(declarationValue(".otv2-preparation__checks > .otv2-computer-summary", "height")).toBe("40px");
+    expect(declarationValue(".otv2-preparation__checks > .otv2-computer-summary", "padding-block")).toBe("0.25rem");
+    expect(mediaDeclarationValue("640px", ".otv2-preparation", "gap")).toBe("1rem");
+  });
+
   /*
    * The readiness rows follow the same rule as the slots above: the reserved heights and the
    * fixed marker are declarations the layout depends on, so they are guarded here rather than

--- a/apps/web/src/onboarding-v2/onboarding-v2.css
+++ b/apps/web/src/onboarding-v2/onboarding-v2.css
@@ -135,6 +135,27 @@
   height: 56px;
 }
 
+/*
+ * Step 2 reads as one progression: heading, the Computer being checked, then its checks. Keep the
+ * heading's section-level breathing room, but bind the Computer more closely to the checklist it
+ * qualifies. The smaller row reservation removes empty space without changing the shared summary
+ * in connect and repair states.
+ */
+.otv2-preparation {
+  gap: 1.25rem;
+}
+
+.otv2-preparation__checks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.otv2-preparation__checks > .otv2-computer-summary {
+  height: 40px;
+  padding-block: 0.25rem;
+}
+
 /* Cards sit side by side wherever two tracks fit, and stack when they do not. */
 .otv2-choices--grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -164,6 +185,10 @@
 @media (width <= 640px) {
   .otv2-computer-summary {
     height: 72px;
+  }
+
+  .otv2-preparation {
+    gap: 1rem;
   }
 
   .otv2-slot--outcome {

--- a/e2e/tests/app.spec.ts
+++ b/e2e/tests/app.spec.ts
@@ -66,8 +66,23 @@ test("Agent Setup Lab exposes recoverable core states through its real controls"
   await page.getByRole("option", { name: "Preparation · Runtime report missing" }).click();
   await closeLab.click();
   await expect(page.getByRole("heading", { name: "Prepare this computer" })).toBeVisible();
+  const preparation = page.locator('[data-ui="agent-setup-preparation"]');
+  const preparationHeader = preparation.locator(":scope > header");
+  const computerSummary = preparation.locator('[data-ui="agent-setup-computer-summary"]');
   const readiness = page.locator('[data-ui="readiness-list"].otv2-readiness--compact');
   const readinessRows = readiness.locator(":scope > li");
+  await expect(computerSummary).toHaveCSS("height", "40px");
+  const [headerBox, computerBox, readinessBox] = await Promise.all([
+    preparationHeader.boundingBox(),
+    computerSummary.boundingBox(),
+    readiness.boundingBox(),
+  ]);
+  expect(headerBox).not.toBeNull();
+  expect(computerBox).not.toBeNull();
+  expect(readinessBox).not.toBeNull();
+  if (!headerBox || !computerBox || !readinessBox) throw new Error("Preparation layout did not produce boxes");
+  expect(Math.round(computerBox.y - (headerBox.y + headerBox.height))).toBe(16);
+  expect(Math.round(readinessBox.y - (computerBox.y + computerBox.height))).toBe(12);
   await expect(readinessRows).toHaveCount(2);
   await expect(readinessRows.nth(0)).toContainText("Codex");
   await expect(readinessRows.nth(0)).toContainText(


### PR DESCRIPTION
## Summary
- group the Computer context with the Step 2 readiness checklist
- use asymmetric vertical rhythm: 20px section gap on desktop, 16px on narrow screens, and 12px from Computer to checks
- compact only the preparation Computer row from 56px to 40px without changing connect or repair states
- lock the geometry with layout and browser assertions

## Validation
- independent code review: passed with no findings
- pnpm check
- pnpm typecheck
- pnpm build
- full Web suite: 62 files, 666 tests passed
- focused setup component/layout suite: 91 tests passed
- Agent Setup browser journeys: 2 passed
- manual desktop and 390px visual walkthrough; no page overflow