### PR TITLE
docs: bound the walkthrough alt text to what the README claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ plan you already pay for, with its work area in plain files on your own machine.
 </div>
 
 <p align="center">
-  <img src="docs/assets/opentag-walkthrough.gif" alt="OpenTag in four steps: bring your own subscription, an AI worker in your team chat, shared knowledge kept on your own machine, and connecting the rest of your stack." width="100%">
+  <img src="docs/assets/opentag-walkthrough.gif" alt="OpenTag in four steps: bring your own subscription, an AI worker in your team chat, shared knowledge kept on your own machine, and reaching the tools already set up on that machine." width="100%">
 </p>
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 > 权威来源：[README.md](./README.md)　·　同步日期：2026-09-02
 
 <p align="center">
-  <img src="docs/assets/opentag-walkthrough.gif" alt="OpenTag 的四个步骤：自带订阅、团队群里的 AI worker、留在你自己机器上的共享知识，以及连接你的其余工具。" width="100%">
+  <img src="docs/assets/opentag-walkthrough.gif" alt="OpenTag 的四个步骤：自带订阅、团队群里的 AI worker、留在你自己机器上的共享知识，以及使用那台机器上已有的工具。" width="100%">
 </p>
 
 ---


### PR DESCRIPTION
## Summary

Follow-up to #513, offered there. One clause per README, nothing else.

The hero animation's alt text ends "connecting the rest of your stack" (EN) and "连接你的其余工具" (zh-CN). Both READMEs bound that claim about thirty lines below the image: a tool that is installed, signed in, and visible to the provider runtime on that Computer can be used from the thread, and *"OpenTag does not discover or expose tools"*. A sighted reader gets the bounded version. A screen-reader user gets the alt text and nothing else, so the wider claim is the only one that reaches them.

This restores the narrower wording on that one clause:

- EN: `and connecting the rest of your stack.` → `and reaching the tools already set up on that machine.`
- zh-CN: `以及连接你的其余工具。` → `以及使用那台机器上已有的工具。`

## What this is not

**This does not touch the animation or reopen #513.** That the marketing walkthrough may run ahead of shipped capability is the owner's call and it stands. This is only about the two prose lines, which are bounded elsewhere on the same page in the repo's own words.

Both alt texts still say "four steps". They should: that is the intent of the asset. The recording currently plays only two of them ([details in #513](https://github.com/first-tree-ai/opentag/pull/513#issuecomment-5520225893)), which a re-record fixes — not an alt-text edit, since describing two steps would bake the truncation in.

## Interaction with #518

#518 (draft) rewrites both READMEs and **deletes the bulleted statement that bounds this claim**, while leaving the `<img>` line untouched. If that lands first, this clause becomes the only description of tool reach in the README rather than the narrower of two. The two changes touch adjacent lines, so whichever merges second will want a look; this one is two lines and trivial to re-apply either way.

## Testing

Documentation only. Both READMEs still resolve every relative link, anchor, and image.

## Breaking changes

None.
