### PR TITLE
fix(e2e): gate the e2e stack on the real Postgres server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,9 @@ jobs:
             --env POSTGRES_PASSWORD=opentag \
             postgres:17-alpine
           for _ in $(seq 1 30); do
-            if docker exec opentag-postgres-ci pg_isready --username opentag --dbname opentag; then
+            # Probe over TCP: the image's temporary initialization server listens on the Unix socket
+            # only, so a socket probe reports ready before the real server exists.
+            if docker exec opentag-postgres-ci pg_isready --host 127.0.0.1 --username opentag --dbname opentag; then
               exit 0
             fi
             sleep 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,9 @@ services:
     volumes:
       - opentag-postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U opentag -d opentag"]
+      # Probe over TCP: the image's temporary initialization server listens on the Unix socket only,
+      # so a socket probe reports ready before the real server exists.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U opentag -d opentag"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/e2e/scripts/stack-server.mjs
+++ b/e2e/scripts/stack-server.mjs
@@ -36,6 +36,11 @@ function connectionTarget(url) {
   };
 }
 
+// The postgres image runs a temporary server during first-time initialization so it can apply the
+// init scripts, then shuts it down and starts the real one. That temporary server listens on the Unix
+// socket only, so every statement here goes over TCP inside the container, which only the real server
+// answers. A socket connection cannot tell the two apart and lands in the handover as
+// `FATAL: the database system is shutting down`.
 async function psql(url, sql) {
   const { database, password, username } = connectionTarget(url);
   const { stdout } = await execFileAsync(
@@ -50,6 +55,8 @@ async function psql(url, sql) {
       `PGPASSWORD=${password}`,
       "postgres",
       "psql",
+      "-h",
+      "127.0.0.1",
       "-U",
       username,
       "-d",
@@ -68,6 +75,7 @@ async function run(command, args, options = {}) {
   return execFileAsync(command, args, { cwd: repositoryRoot, ...options });
 }
 
+// Gates on the real server: `select 1` cannot succeed over TCP while initialization is still running.
 async function waitForDatabase() {
   const deadline = Date.now() + 60_000;
   let lastError;

--- a/scripts/e2e/doctor-docker.mjs
+++ b/scripts/e2e/doctor-docker.mjs
@@ -152,7 +152,9 @@ async function main() {
     "--env",
     "POSTGRES_PASSWORD=opentag",
     "--health-cmd",
-    "pg_isready -U opentag -d opentag",
+    // Probe over TCP: the image's temporary initialization server listens on the Unix socket only,
+    // so a socket probe reports ready before the real server exists.
+    "pg_isready -h 127.0.0.1 -U opentag -d opentag",
     "--health-interval",
     "1s",
     "--health-timeout",


### PR DESCRIPTION
Closes #502.

## Summary

`Browser Smoke` was going red at the e2e bootstrap, before any test ran, on changes that could not have
caused it — most recently on 2026-09-04, and at least five times in the two days after the issue was filed:

```
[WebServer] psql: error: ... FATAL:  the database system is shutting down
Error: Process from config.webServer was not able to start. Exit code: 1
```

The `postgres` image runs a temporary server during first-time initialization so it can apply the init
scripts, then shuts it down and starts the real one. That temporary server listens on the Unix socket
only. `stack-server.mjs` gated on a single `select 1` over that socket, so the gate could be satisfied by
the temporary server, and the `drop database` / `create database` that follow then landed in the handover.

Measured on `postgres:17` with initialization slowed to 8s so the window is observable, probing both
transports from inside the container:

```
t=4s   socket=1     tcp=connection refused      <- temporary init server
t=11s  socket=1     tcp=connection refused
t=12s  socket=FATAL tcp=1                       <- handover: this is the CI failure
t=13s  socket=1     tcp=1                       <- real server
```

So the fix is to gate on the transport only the real server answers: every `psql` in the bootstrap path
(`stack-server.mjs`) now connects over TCP inside the container, and `waitForDatabase()` cannot return
while initialization is still going. No retry and no sleep — the signal itself now distinguishes the two
servers. `e2e/tests/fixtures.ts` still uses the socket and is deliberately left alone here: it runs only
after Playwright's `webServer` gate, so it cannot race initialization. It is tracked in #533 with the
mechanical check that would keep the rule from being re-broken.

The same socket-only probe was written in three more places with the same blind spot, so they get the
same one-flag correction: the compose `healthcheck`, the Container Smoke wait loop in CI, and the Docker
doctor's `--health-cmd`.

## Testing

- Replayed the old and new gate against a `postgres:17` container with initialization slowed to 8s, asking
  after the gate returns which server accepted it (`show listen_addresses` is empty on the init server and
  `*` on the real one):
  - old gate: `(empty => INIT SERVER)` on both runs, and one run reproduced the handover failure;
  - new gate: `*` on both runs, with 71 and 97 consecutive `drop`/`create` cycles across the whole
    initialization window and no failure.
- `pg_isready` over the socket reports ready at t=1s (init server) and over TCP at t≈9s (real server),
  which is the signal the other three call sites relied on.
- `pnpm check`, `pnpm build`, `pnpm typecheck` pass. `pnpm test` reported two failures in
  `packages/client` (`claude-code-agent-runtime-exhaustive`, `pi-agent-runtime-exhaustive`); both are
  process-spawning tests hitting the 5s per-test budget on a machine at load average ~10, and both pass
  on a re-run with headroom. Nothing in this change is reachable from `packages/client`.
- `pnpm test:e2e:smoke` locally with the compose volume removed first, so the run went through the
  first-time initialization path this changes: 8 passed.

## Breaking changes

None. Local development is unaffected: a container with an existing data volume never runs the
initialization server, so the TCP probe succeeds immediately.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [ ] Tests and documentation cover the changed behavior — the change *is* the e2e/CI readiness gate, so
      it has no unit-test surface; it is covered by the `pnpm test:e2e:smoke` run and the controlled
      old-vs-new replay under Testing.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass — see the note on two
      load-sensitive `packages/client` timeouts under Testing.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
