### PR TITLE
fix: integrate Context Tree without project instruction writes

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -51,7 +51,7 @@
     "test": "vitest run --maxWorkers=1"
   },
   "dependencies": {
-    "@first-tree-ai/context-tree": "0.1.8"
+    "@first-tree-ai/context-tree": "0.1.10"
   },
   "devDependencies": {
     "@opentag/client": "workspace:*",

--- a/apps/cli/src/__tests__/context-tree.test.ts
+++ b/apps/cli/src/__tests__/context-tree.test.ts
@@ -33,6 +33,7 @@ async function fakeCli(responses: Readonly<Record<string, unknown>>): Promise<Co
   await writeFile(
     cliPath,
     `const table = ${JSON.stringify(responses)};
+if (!process.argv.includes("--json")) { process.stdout.write("Human-readable text"); process.exit(0); }
 const entry = table[process.argv[2]];
 if (entry === undefined) { process.stdout.write(JSON.stringify({ error: { code: "UNKNOWN", message: "" }, ok: false })); process.exit(1); }
 process.stdout.write(JSON.stringify(entry.payload));

--- a/apps/cli/src/core/context-tree/connect.ts
+++ b/apps/cli/src/core/context-tree/connect.ts
@@ -48,12 +48,12 @@ async function validateTarget(
 ): Promise<{ message: string } | undefined> {
   if (target.kind === "github") return undefined;
   if (target.kind === "path") {
-    const { failureCode } = await runContextTreeCli(assets, ["verify", "--tree-path", target.path]);
+    const { failureCode } = await runContextTreeCli(assets, ["verify", "--tree-path", target.path, "--json"]);
     return failureCode === undefined
       ? undefined
       : { message: `${target.path} is not a usable Context Tree (${failureCode}).` };
   }
-  const { payload, failureCode } = await runContextTreeCli(assets, ["list"]);
+  const { payload, failureCode } = await runContextTreeCli(assets, ["list", "--json"]);
   if (failureCode !== undefined) return { message: `Could not list managed Context Trees (${failureCode}).` };
   const trees = (payload as { trees?: readonly { name?: unknown }[] }).trees ?? [];
   return trees.some((entry) => entry.name === target.name)

--- a/apps/cli/src/core/context-tree/state.ts
+++ b/apps/cli/src/core/context-tree/state.ts
@@ -34,11 +34,11 @@ export async function readContextTreeState(deps: ContextTreeCommandDeps = {}): P
   if (!assets) return { configPath, target, tree: "unknown", detail: "the Context Tree package is missing" };
 
   if (configured.kind === "path") {
-    const { failureCode } = await runContextTreeCli(assets, ["verify", "--tree-path", configured.path]);
+    const { failureCode } = await runContextTreeCli(assets, ["verify", "--tree-path", configured.path, "--json"]);
     if (failureCode === undefined) return { configPath, target, tree: "valid" };
     return { configPath, target, tree: "invalid", detail: failureCode };
   }
-  const { payload, failureCode } = await runContextTreeCli(assets, ["list"]);
+  const { payload, failureCode } = await runContextTreeCli(assets, ["list", "--json"]);
   if (failureCode !== undefined) return { configPath, target, tree: "unknown", detail: failureCode };
   const trees = (payload as { trees?: readonly { name?: unknown; tree?: { repository?: unknown } }[] }).trees ?? [];
   if (configured.kind === "managed") {

--- a/docs/design/context-tree-integration.md
+++ b/docs/design/context-tree-integration.md
@@ -45,8 +45,8 @@ whenever `npm_config_global` was set — which npm also sets for the dependencie
 install, so `npm i -g open-tag` would have written six skill directories into the user's personal
 `~/.claude` and `~/.codex` as an invisible side effect. `@first-tree-ai/context-tree` now also
 requires that it is the install *target* rather than a nested copy, so being a dependency has no
-side effects. That guard first ships in **0.1.8**, which is the pinned version; **do not relax the
-pin below it.** `scripts/cli-pack-smoke.mjs` holds the line empirically: for the production
+side effects. That guard first ships in **0.1.8**. The coordinated CLI and client pins target
+**0.1.10**, which removes project instruction writes; do not lower those pins. `scripts/cli-pack-smoke.mjs` holds the line empirically: for the production
 identity it installs the packed CLI globally under an isolated `HOME`, asserts no `.claude` or
 `.codex` appears, and then runs the nested `postinstall` with `npm_config_global=true` to prove the
 dependency guard is what kept it inert rather than a script that merely failed to run.
@@ -95,7 +95,7 @@ workspace once per recorded target, cached in memory:
 
 ```text
 cwd = await workspace.cwd(agentId)
-connect <target> --project-path <cwd>     # clones on first use when the kind is github
+connect <target> --project-path <cwd> --json  # clones on first use when the kind is github
 install --host claude --project <cwd>     # -> <cwd>/.claude/skills/context-tree-*
 install --host codex                      # -> $CODEX_HOME/skills/context-tree-*
 ```
@@ -110,8 +110,7 @@ tree shared across Agents.
 
 The path always comes from `AgentWorkspaceManager.cwd(agentId)`, which refuses to return a path
 until the workspace layout state is schema-v3 `complete`. That ordering is load-bearing: it is
-what keeps the connection from writing into a workspace still mid-migration, where an unproven
-root `AGENTS.md` would make the transition fail closed.
+what keeps preparation from installing skills into a workspace still mid-migration.
 
 Preparation runs in `SessionRuntimeManager` at Provider Runtime start, not in workspace
 preparation. `verifyAgent` delegates to `prepareAgent` and the preflight calls it on every Turn
@@ -196,10 +195,10 @@ Two consequences to hold in view:
   `effectiveSnapshotHash` therefore does not fully determine future Session behaviour. V1 accepts
   this because the workspace is OpenTag's own private per-Agent directory and Claude Code already
   runs there with bypassed permissions.
-- `context-tree connect` writes a marker-delimited pointer into `<workspace>/AGENTS.md` and
-  symlinks `CLAUDE.md` to it. With project settings loaded, that block becomes the Session's
-  ambient notice of the tree path — OpenTag-controlled text, but a second instruction channel
-  alongside the managed prompt. Suppressing it needs a `--no-pointer` flag upstream.
+- Context Tree leaves workspace `AGENTS.md` unchanged. When it is a regular file and no
+  `CLAUDE.md` entry exists, connection best-effort creates a `CLAUDE.md → AGENTS.md` symlink.
+  OpenTag supplies memory instructions through its managed prompt. Existing instruction
+  content, including legacy pointer blocks, is preserved.
 
 ### Codex
 
@@ -312,9 +311,7 @@ which is why the failure reader honours both shapes.
 Both delivery mechanisms were confirmed against the real CLIs before the surrounding work landed:
 
 - Claude Code under `--print --input-format stream-json --setting-sources project` discovers
-  `<workspace>/.claude/skills/context-tree-*`; under `--setting-sources ""` it does not. The same
-  contrast holds for the workspace `AGENTS.md` pointer, which is inert without project settings
-  and ambient with them.
+  `<workspace>/.claude/skills/context-tree-*`; under `--setting-sources ""` it does not.
 - Codex discovers `~/.codex/skills/context-tree-*` with `plugins` and `hooks` disabled. Its
   `skip_host_skill_discovery` feature is separate from both.
 
@@ -359,7 +356,6 @@ the dependency from the published bundle.
   `commands/`, and `CLAUDE.md`) on every `prepareAgent`, so project settings contribute only
   OpenTag-written content.
 - Server-propagated target, so a Computer inherits it when it connects.
-- Suppressing the workspace `AGENTS.md` pointer with an upstream `--no-pointer` flag.
 - Project-scoped trees, so several Agents share a tree without sharing all Computer memory.
 - Windows support, which needs Provider lifecycle, path, lock, and isolated-home CI coverage
   first. The shim is POSIX and reports `shim_unavailable` elsewhere.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.5.1"
   },
   "devDependencies": {
-    "@first-tree-ai/context-tree": "0.1.8",
+    "@first-tree-ai/context-tree": "0.1.10",
     "@types/semver": "^7.8.0",
     "@types/ws": "^8.18.1",
     "vitest": "^4.1.11"

--- a/packages/client/src/__tests__/context-tree.integration.test.ts
+++ b/packages/client/src/__tests__/context-tree.integration.test.ts
@@ -58,7 +58,9 @@ async function isolatedAccount(prefix: string): Promise<{
   );
   const environment: NodeJS.ProcessEnv = { HOME: accountHome, PATH: process.env.PATH };
   const seed = await temporaryDirectory(`${prefix}-seed-`);
-  const { treePath } = (await runCli(["create", "--project-path", seed], environment)) as { treePath: string };
+  const { treePath } = (await runCli(["create", "--project-path", seed, "--json"], environment)) as {
+    treePath: string;
+  };
 
   previousHome = process.env.HOME;
   homeWasSet = true;
@@ -105,6 +107,12 @@ describe("Context Tree end-to-end", () => {
     // Sharing one tree across Agents is the point of the feature, so both must land on it.
     await expect(manager.ensureAgent(workspaceB)).resolves.toEqual(first);
 
+    for (const workspace of [workspaceA, workspaceB]) {
+      for (const file of ["AGENTS.md", "CLAUDE.md"]) {
+        await expect(readFile(join(workspace, file))).rejects.toMatchObject({ code: "ENOENT" });
+      }
+    }
+
     // Each workspace carries the skills Claude Code discovers under `--setting-sources project`.
     for (const workspace of [workspaceA, workspaceB]) {
       await expect(
@@ -116,7 +124,7 @@ describe("Context Tree end-to-end", () => {
     ).resolves.toContain("context-tree");
 
     // Exactly what a Session does: run the bare command name with the shim directory on PATH.
-    const { stdout } = await execFileAsync("context-tree", ["resolve", "--project-path", workspaceA], {
+    const { stdout } = await execFileAsync("context-tree", ["resolve", "--project-path", workspaceA, "--json"], {
       encoding: "utf8",
       env: { HOME: accountHome, PATH: `${manager.binDirectory()}${delimiter}${process.env.PATH ?? ""}` },
     });
@@ -197,7 +205,7 @@ describe("Context Tree end-to-end", () => {
 
     // Agent B, in a different workspace, reads it from the shared tree.
     const read = (await runCli(
-      ["read", "members/researcher-agent/memory.md", "--tree-path", treePath],
+      ["read", "members/researcher-agent/memory.md", "--tree-path", treePath, "--json"],
       environment,
     )) as { node: { body: string } };
     expect(read.node.body).toContain("Prefer the repository formatter");

--- a/packages/client/src/__tests__/context-tree.test.ts
+++ b/packages/client/src/__tests__/context-tree.test.ts
@@ -34,14 +34,14 @@ const installReply = {
   ],
   schemaVersion: 1,
   skipped: [],
-  version: "0.1.8",
+  version: "0.1.10",
 };
 const skippedInstallReply = (reason: unknown) =>
   ({
     installed: [],
     schemaVersion: 1,
     skipped: [{ host: "codex", reason }],
-    version: "0.1.8",
+    version: "0.1.10",
   }) as unknown;
 
 /** Record a Computer's Context Tree target, the way `opentag context-tree connect` does. */
@@ -141,7 +141,7 @@ describe("ContextTreeManager", () => {
     await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "ready", treePath: "/srv/trees/team" });
     // `connect` already returns the resolved tree, so no separate `resolve` round-trip is needed.
     expect(calls).toEqual([
-      ["connect", "team-context-tree", "--project-path", cwd],
+      ["connect", "team-context-tree", "--project-path", cwd, "--json"],
       ["install", "--host", "claude", "--project", cwd],
       ["install", "--host", "codex"],
     ]);
@@ -177,14 +177,14 @@ describe("ContextTreeManager", () => {
       "/home/user/.codex does not exist; install codex first.",
     ],
     [skippedInstallReply(""), "CODEX_NOT_INSTALLED"],
-    [{ installed: [], schemaVersion: 1, skipped: [], version: "0.1.8" }, "CODEX_NOT_INSTALLED"],
+    [{ installed: [], schemaVersion: 1, skipped: [], version: "0.1.10" }, "CODEX_NOT_INSTALLED"],
   ])("reports an unavailable Codex host install for %j", async (installPayload, reason) => {
     const { execFile, calls } = recording({ connect: treeReply("/srv/t"), install: installPayload });
     const { cwd, manager } = await computer({ execFile, target: managed });
 
     await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unavailable", reason });
     // The tree itself connected before the install, so connect must still have run.
-    expect(calls[0]).toEqual(["connect", "team-context-tree", "--project-path", cwd]);
+    expect(calls[0]).toEqual(["connect", "team-context-tree", "--project-path", cwd, "--json"]);
   });
 
   it("activates a target recorded after start, and follows every target change", async () => {
@@ -224,7 +224,7 @@ describe("ContextTreeManager", () => {
     const { cwd, manager } = await computer({ execFile, target });
 
     await expect(manager.ensureAgent(cwd)).resolves.toMatchObject({ status: "ready" });
-    expect(calls[0]).toEqual([...expected, "--project-path", cwd]);
+    expect(calls[0]).toEqual([...expected, "--project-path", cwd, "--json"]);
   });
 
   it.each([

--- a/packages/client/src/runtime/context-tree.ts
+++ b/packages/client/src/runtime/context-tree.ts
@@ -106,7 +106,7 @@ export function codexInstallSkipReason(payload: unknown): string | undefined {
 
 /** `connect` arguments for one target kind, mirroring the CLI's own argument shape. */
 function connectArguments(target: ContextTreeConfig["target"], projectPath: string): readonly string[] {
-  const project = ["--project-path", projectPath];
+  const project = ["--project-path", projectPath, "--json"];
   if (target.kind === "managed") return ["connect", target.name, ...project];
   if (target.kind === "github") return ["connect", target.repository, ...project];
   return ["connect", "--tree-path", target.path, ...project];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -984,7 +984,7 @@ packages:
     resolution: {integrity: sha512-g89ag4BCcD9YP5wBZXixzoLnuf5j89p/sXFcfpCiv2pdEkYYukBEoK3heVzqsp0EAtszVDc2BBZG0KZqeAShIA==}
 
   '@first-tree-ai/context-tree@0.1.10':
-    resolution: {integrity: sha512-zpf1Z+m3KKApeJQDNXAd6kK0gK0fe+0h1Z5beYnQXLlBoDZdkzpbAITEj19pPaKKjd5hJGuRmKK0zfgOlU5ymQ==}
+    resolution: {integrity: sha512-35+QaHOKSqIL01t9rtNA/NqHkUM/Ze8w7wExt7ZdYrX6wArRYXEq4N6kcPHqvB8OqX2p2fjzT3kAx9fmYWZJaw==}
     engines: {node: '>=22.13.0'}
     hasBin: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
   apps/cli:
     dependencies:
       '@first-tree-ai/context-tree':
-        specifier: 0.1.8
-        version: 0.1.8
+        specifier: 0.1.10
+        version: 0.1.10
     devDependencies:
       '@opentag/client':
         specifier: workspace:*
@@ -189,8 +189,8 @@ importers:
         version: 4.5.4
     devDependencies:
       '@first-tree-ai/context-tree':
-        specifier: 0.1.8
-        version: 0.1.8
+        specifier: 0.1.10
+        version: 0.1.10
       '@types/semver':
         specifier: ^7.8.0
         version: 7.8.0
@@ -983,8 +983,8 @@ packages:
   '@fastify/websocket@11.3.0':
     resolution: {integrity: sha512-g89ag4BCcD9YP5wBZXixzoLnuf5j89p/sXFcfpCiv2pdEkYYukBEoK3heVzqsp0EAtszVDc2BBZG0KZqeAShIA==}
 
-  '@first-tree-ai/context-tree@0.1.8':
-    resolution: {integrity: sha512-etLK47svtL6vOgxfK7M7q8s9tSJJEovgr/FIeRNUPFGVX+rltab8xAaXluDMSSoHZ+XQRF+5a0fLj8IDCxWyKA==}
+  '@first-tree-ai/context-tree@0.1.10':
+    resolution: {integrity: sha512-zpf1Z+m3KKApeJQDNXAd6kK0gK0fe+0h1Z5beYnQXLlBoDZdkzpbAITEj19pPaKKjd5hJGuRmKK0zfgOlU5ymQ==}
     engines: {node: '>=22.13.0'}
     hasBin: true
 
@@ -5339,7 +5339,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@first-tree-ai/context-tree@0.1.8':
+  '@first-tree-ai/context-tree@0.1.10':
     dependencies:
       commander: 15.0.0
       mdast-util-from-markdown: 2.0.3

--- a/scripts/__tests__/portable-runtime-dependencies.test.mjs
+++ b/scripts/__tests__/portable-runtime-dependencies.test.mjs
@@ -57,7 +57,7 @@ function fakeCliEntry(version, binName) {
 
 function writeContextTreePackage(
   nodeModulesDir,
-  { assets = true, dependencies = { commander: "^15.0.0" }, extra = {}, version = "0.1.8" } = {},
+  { assets = true, dependencies = { commander: "^15.0.0" }, extra = {}, version = "0.1.10" } = {},
 ) {
   const packageDir = join(nodeModulesDir, "@first-tree-ai", "context-tree");
   writeJson(join(packageDir, "package.json"), {
@@ -96,7 +96,7 @@ function fixtureCliRoot(root, { version = "0.0.2" } = {}) {
     license: "Apache-2.0",
     description: "portable fixture CLI",
     bin: { opentag: "./dist/cli/index.mjs" },
-    dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+    dependencies: { "@first-tree-ai/context-tree": "0.1.10" },
   });
   writeText(join(cliRoot, "dist", "cli", "index.mjs"), fakeCliEntry(version, "opentag"));
   writeText(join(cliRoot, "dist", "index.mjs"), "export {};\n");
@@ -134,15 +134,15 @@ function assembleFixtureApp(root) {
     name: "open-tag",
     version: "0.0.2",
     type: "module",
-    dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+    dependencies: { "@first-tree-ai/context-tree": "0.1.10" },
   });
   writeDependencyClosureFile(appDir, closure);
   return appDir;
 }
 
 test("the portable runtime dependency contract accepts only the supported exact pin", () => {
-  assert.deepEqual(readPortableDirectDependencyPins({ dependencies: { "@first-tree-ai/context-tree": "0.1.8" } }), [
-    { name: "@first-tree-ai/context-tree", version: "0.1.8" },
+  assert.deepEqual(readPortableDirectDependencyPins({ dependencies: { "@first-tree-ai/context-tree": "0.1.10" } }), [
+    { name: "@first-tree-ai/context-tree", version: "0.1.10" },
   ]);
   assert.deepEqual(readPortableDirectDependencyPins({}), []);
   assert.deepEqual(readPortableDirectDependencyPins({ dependencies: {} }), []);
@@ -151,7 +151,7 @@ test("the portable runtime dependency contract accepts only the supported exact 
     /unsupported runtime dependency/,
   );
   assert.throws(
-    () => readPortableDirectDependencyPins({ dependencies: { "@first-tree-ai/context-tree": "^0.1.8" } }),
+    () => readPortableDirectDependencyPins({ dependencies: { "@first-tree-ai/context-tree": "^0.1.10" } }),
     /exact x\.y\.z/,
   );
   assert.throws(
@@ -161,7 +161,7 @@ test("the portable runtime dependency contract accepts only the supported exact 
   assert.throws(
     () =>
       readPortableDirectDependencyPins({
-        dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+        dependencies: { "@first-tree-ai/context-tree": "0.1.10" },
         optionalDependencies: { bufferutil: "^4.0.0" },
       }),
     /non-empty optionalDependencies/,
@@ -169,7 +169,7 @@ test("the portable runtime dependency contract accepts only the supported exact 
   assert.throws(
     () =>
       readPortableDirectDependencyPins({
-        dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+        dependencies: { "@first-tree-ai/context-tree": "0.1.10" },
         peerDependencies: { react: "^19.0.0" },
       }),
     /non-empty peerDependencies/,
@@ -179,7 +179,7 @@ test("the portable runtime dependency contract accepts only the supported exact 
 test("the checked-in apps/cli manifest is accepted under the portable shipping contract", () => {
   const cliManifest = JSON.parse(readFileSync(join(repoRoot, "apps", "cli", "package.json"), "utf8"));
   assert.deepEqual(readPortableDirectDependencyPins(cliManifest), [
-    { name: "@first-tree-ai/context-tree", version: "0.1.8" },
+    { name: "@first-tree-ai/context-tree", version: "0.1.10" },
   ]);
 });
 
@@ -196,7 +196,7 @@ test("materializing the closure copies published content and never runs lifecycl
     nodeModulesDir: join(appDir, "node_modules"),
     sourceManifestPath: join(cliRoot, "package.json"),
   });
-  assert.deepEqual(closure.direct, [{ name: "@first-tree-ai/context-tree", version: "0.1.8" }]);
+  assert.deepEqual(closure.direct, [{ name: "@first-tree-ai/context-tree", version: "0.1.10" }]);
   assert.deepEqual(
     closure.packages.map((entry) => entry.name),
     ["@first-tree-ai/context-tree", "commander"],
@@ -227,7 +227,7 @@ test("the installed direct dependency must match the exact source pin", async (t
   writeContextTreePackage(join(cliRoot, "node_modules"), { version: "0.1.9" });
   assert.throws(
     () => collectRuntimeDependencyClosure({ sourceManifestPath: join(cliRoot, "package.json") }),
-    /installed package @first-tree-ai\/context-tree is version 0\.1\.9, but the source pins 0\.1\.8/,
+    /installed package @first-tree-ai\/context-tree is version 0\.1\.9, but the source pins 0\.1\.10/,
   );
 });
 
@@ -372,7 +372,7 @@ test("the graph verifier rejects extra, missing, and unreferenced packages", asy
   const withDroppedLink = assembleFixtureApp(join(root, "dropped"));
   writeJson(join(withDroppedLink, "node_modules", "@first-tree-ai", "context-tree", "package.json"), {
     name: "@first-tree-ai/context-tree",
-    version: "0.1.8",
+    version: "0.1.10",
     dependencies: {},
   });
   assert.throws(() => verifyPortableDependencyGraph(withDroppedLink), /unreferenced dependency package/);
@@ -458,7 +458,7 @@ test("dependency-free apps keep the legacy shape and verify clean", () => {
       name: "open-tag",
       version: "0.0.2",
       type: "module",
-      dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+      dependencies: { "@first-tree-ai/context-tree": "0.1.10" },
     });
     assert.throws(() => verifyPortableDependencyGraph(appDir), /missing dependency-closure\.json/);
   } finally {
@@ -478,7 +478,7 @@ test("createAppTemplate assembles a verified app from an offline fixture", async
   t.after(() => rm(template.root, { force: true, recursive: true }));
   const appPackage = JSON.parse(readFileSync(join(template.appDir, "package.json"), "utf8"));
   assert.equal(appPackage.name, "open-tag");
-  assert.deepEqual(appPackage.dependencies, { "@first-tree-ai/context-tree": "0.1.8" });
+  assert.deepEqual(appPackage.dependencies, { "@first-tree-ai/context-tree": "0.1.10" });
   assert.equal(
     existsSync(join(template.appDir, "node_modules", "@first-tree-ai", "context-tree", "dist", "cli", "index.mjs")),
     true,
@@ -525,13 +525,13 @@ test("the real frozen install closure assembles, verifies, and runs the embedded
   });
   assert.equal(closure.direct.length, 1);
   assert.equal(closure.packages[0].name, "@first-tree-ai/context-tree");
-  assert.equal(closure.packages[0].version, "0.1.8");
+  assert.equal(closure.packages[0].version, "0.1.10");
   assert.ok(closure.packages.length >= 20, `real closure is unexpectedly small: ${closure.packages.length}`);
   writeJson(join(appDir, "package.json"), {
     name: "open-tag",
     version: "0.0.2",
     type: "module",
-    dependencies: { "@first-tree-ai/context-tree": "0.1.8" },
+    dependencies: { "@first-tree-ai/context-tree": "0.1.10" },
   });
   writeDependencyClosureFile(appDir, closure);
   writeText(join(appDir, "cli", "index.mjs"), "export {};\n");

--- a/scripts/portable/runtime-dependencies.mjs
+++ b/scripts/portable/runtime-dependencies.mjs
@@ -583,7 +583,7 @@ export function runContextTreeRuntimeProbe({ appDir, nodePath, homeDir, probeOpe
   }
   let listing;
   try {
-    listing = JSON.parse(runNode(nodePath, [cliPath, "list"], cleanEnv).stdout.trim());
+    listing = JSON.parse(runNode(nodePath, [cliPath, "list", "--json"], cleanEnv).stdout.trim());
   } catch {
     fail("embedded Context Tree list did not emit its JSON payload");
   }


### PR DESCRIPTION
## Summary

Context Tree create/connect no longer modifies project AGENTS.md. Upgrade both exact Context Tree pins to 0.1.10 and add explicit `--json` to parsed connect, verify, list, resolve, and read calls and portable probes. OpenTag continues delivering memory instructions through its managed prompt. Update integration documentation and regression tests to verify connection resolution without project instruction files.

Uses the published Context Tree 0.1.10 release containing https://github.com/first-tree-ai/context-tree/pull/15. Both exact pins remain aligned. The lockfile now uses npm's published artifact integrity, and a frozen install resolves both consumers to that release.

## Testing

- Passed after release: frozen lockfile installation against npm 0.1.10 and `pnpm check`.
- Passed: `pnpm check`, `pnpm build`, `pnpm typecheck`, and all configured pre-push gates.
- Passed: 39 affected client tests, 65 affected CLI tests, and 39 portable build/runtime-dependency tests, including assembly and execution of the published npm 0.1.10 package. All 143 affected tests were rerun against the released artifact.
- Passed: `pnpm --filter @opentag/server test:integration` (320 tests).
- `pnpm test` reached unrelated failures in `daemon-ensure-service.test.ts:98` and `daemon-service-commands.test.ts:57`: the Commander wrappers produced exit code 0 where the tests expect 3. Both failures reproduced in an isolated rerun. The full-suite run is not green.
- Passed on rerun: `pnpm --filter @opentag/client test:agent-runtime:coverage` (359 tests; 100% statements, branches, functions, and lines). An initial Claude readiness assertion failed under concurrent load and passed in isolation and on the complete rerun.

## Breaking changes

Context Tree create/connect results no longer contain `pointer`. Existing instruction content, including old pointer blocks, is preserved. No cleanup migration is performed.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.

