### PR TITLE
feat: define agent-managed Home layout in runtime prompts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -223,9 +223,17 @@ files (`0600`). Directories and files are created only when their owner needs th
 daemon; runtime recovery records and workspaces appear on the first relevant reconcile.
 
 OpenTag does not maintain control files inside an Agent work area. Platform and Agent instructions are injected through
-the selected Provider's native system-prompt surface. A new work-area root is the Provider cwd. For an existing
-schema-v1/v2 local Workspace layout, one compatibility transition preserves `files/` as the cwd instead of moving user files. It
-removes only legacy instruction files whose OpenTag provenance can be established from the old state; a user-authored or
+the selected Provider's native system-prompt surface. A new work-area root is the Provider cwd. That cwd is the Agent
+Home: one persistent directory shared across this Agent's Sessions on this Computer. The managed prompt describes
+agent-managed `source-repos/<unique-repo-key>/` bare clones (identity from the user or task, not platform bindings),
+`worktrees/<unique-task-key>/` for source access and code work (one checkout per concurrent code task), and
+`files/<unique-task-key>/` for non-repository artifacts created only when needed. OpenTag does not declare repositories,
+create those directories, or garbage-collect them. Context Tree remains the separately configured shared tree; from a
+task subdirectory, Context Tree project commands pass `--project-path` for that Home instead of creating or reconnecting
+a tree because cwd changed.
+
+For an existing schema-v1/v2 local Workspace layout, one compatibility transition preserves `files/` as the cwd instead of
+moving user files. It removes only legacy instruction files whose OpenTag provenance can be established from the old state; a user-authored or
 changed conflict is preserved and fails closed. The transition state is written before cleanup so an interrupted attempt
 is idempotent. After it completes, the Client uses workspace state only to preserve layout and identity and no longer
 inspects or manages local Workspace entries. Schema v3 is also a downgrade fence: older v1/v2 Clients reject it instead

--- a/DEVELOPMENT.zh-CN.md
+++ b/DEVELOPMENT.zh-CN.md
@@ -1,7 +1,7 @@
 # OpenTag 开发指南
 
 > Canonical source: [DEVELOPMENT.md](./DEVELOPMENT.md)
-> Last synced with: 2026-09-01
+> Last synced with: 2026-09-07
 
 ## 前置要求
 
@@ -217,7 +217,14 @@ ${OPENTAG_HOME}/
 runtime recovery record 和 Workspace 在首次相关 reconcile 时才出现。
 
 OpenTag 不会在 Agent work area 内维护控制文件。Platform 与 Agent instructions 通过所选 Provider 的原生系统
-提示词接口注入。新 work area 直接以根目录作为 Provider cwd。既有 schema v1/v2 本地 Workspace layout 会执行一次兼容
+提示词接口注入。新 work area 直接以根目录作为 Provider cwd。该 cwd 即 Agent Home：同一 Computer 上该 Agent 的各
+Session 共享一个持久目录。托管 prompt 约定由 Agent 自行管理 `source-repos/<unique-repo-key>/` 裸克隆（仓库身份来自
+用户或任务，而非平台绑定）、用 `worktrees/<unique-task-key>/` 做源码访问与代码工作（并发代码任务各自使用独立
+checkout）、以及仅在需要时创建的 `files/<unique-task-key>/` 非仓库产物。OpenTag 不声明仓库、不自动创建这些目录、
+也不做回收。Context Tree 仍是另行配置的共享树；从任务子目录运行 Context Tree 项目命令时传入该 Home 的
+`--project-path`，不要因为任务 cwd 变化而新建或重连一棵树。
+
+既有 schema v1/v2 本地 Workspace layout 会执行一次兼容
 过渡：继续以 `files/` 为 cwd，而不搬动用户文件；只删除可由旧 state 证明 provenance 的 OpenTag legacy
 instruction file。用户创建或已修改的冲突文件会原样保留并 fail closed。清理前先持久化 transition state，
 因此中断后可幂等重试。过渡完成后，Client 只用 workspace state 保持 layout 与 identity，不再检查或管理

--- a/packages/client/src/__tests__/managed-instructions.test.ts
+++ b/packages/client/src/__tests__/managed-instructions.test.ts
@@ -1,0 +1,88 @@
+import type { EffectiveRuntimeSnapshot } from "@opentag/shared";
+import { describe, expect, it } from "vitest";
+import { type ManagedSessionContext, renderManagedSystemPrompt } from "../runtime/managed-instructions.js";
+
+const snapshot: EffectiveRuntimeSnapshot = {
+  revision: {
+    agent: { sequence: 1, id: "agent-revision-1" },
+    session: { sequence: 1, id: "session-revision-1" },
+  },
+  agentId: "agent-1",
+  provider: "codex",
+  model: "model-1",
+  instructions: { platform: "platform", agent: "agent" },
+  execution: { approvalPolicy: "never", networkAccess: true },
+  workspace: { workspaceId: "workspace-1", mode: "empty_on_create", sharing: "agent" },
+};
+
+const session: ManagedSessionContext = {
+  sessionId: "session-1",
+  sessionKind: "visible",
+  cliCommand: "opentag-dev",
+  sessionCliAvailable: true,
+};
+
+describe("renderManagedSystemPrompt Agent Home", () => {
+  it("describes one persistent Home with prompt-only source-repos, worktrees, and files conventions", () => {
+    const prompt = renderManagedSystemPrompt(snapshot, { ...session, agentHome: "/tmp/agent-home" });
+
+    expect(prompt).toContain("## Agent Home");
+    expect(prompt).toContain("Your Agent Home is /tmp/agent-home.");
+    expect(prompt).toContain("shared across this Agent's Sessions on this Computer");
+    expect(prompt).toContain("Files survive tasks");
+    expect(prompt).toContain("absolute paths");
+    expect(prompt).toContain("from Agent Home, not the task cwd");
+    expect(prompt).toContain("prompt conventions, not platform-managed resources or automatic cleanup policies");
+    expect(prompt).toContain("source-repos/<unique-repo-key>/");
+    expect(prompt).toContain("not from platform bindings");
+    expect(prompt).toContain("verify it belongs to the intended repository");
+    expect(prompt).toContain("Preserve existing files");
+    expect(prompt).toContain("Do not clone into the Home root");
+    expect(prompt).toContain("worktrees/<unique-task-key>/");
+    expect(prompt).toContain("distinct worktree");
+    expect(prompt).toContain("Keep later operations for the same task in its own worktree");
+    expect(prompt).toContain("No two code tasks edit one checkout");
+    expect(prompt).toContain("files/<unique-task-key>/");
+    expect(prompt).toContain("created only when needed");
+    expect(prompt).toContain('--project-path "<Agent Home>"');
+    expect(prompt).toContain("do not create or reconnect a tree just because the task cwd changed");
+    expect(prompt).toContain("matching skill write protocol");
+    expect(prompt).not.toContain("sandbox");
+    expect(prompt).not.toContain("manifest");
+    expect(prompt).not.toMatch(/\bGC\b/);
+    expect(prompt).not.toContain("migration");
+  });
+
+  it("still describes Agent Home conventions when the concrete path is omitted", () => {
+    const prompt = renderManagedSystemPrompt(snapshot, session);
+    expect(prompt).toContain("## Agent Home");
+    expect(prompt).toContain("source-repos/<unique-repo-key>/");
+    expect(prompt).toContain('--project-path "<Agent Home>"');
+    expect(prompt).not.toContain("Your Agent Home is");
+  });
+
+  it("keeps missing Context Tree wording unchanged", () => {
+    const unconfigured = renderManagedSystemPrompt(snapshot, {
+      ...session,
+      agentHome: "/tmp/agent-home",
+      contextTree: { status: "unconfigured" },
+    });
+    expect(unconfigured).toContain("Context Tree: not configured on this Computer (opentag-dev context-tree connect).");
+    expect(unconfigured).toContain("do not attempt to create a tree yourself");
+
+    const unavailable = renderManagedSystemPrompt(snapshot, {
+      ...session,
+      contextTree: { status: "unavailable", reason: "DIRTY_TREE" },
+    });
+    expect(unavailable).toContain("Context Tree unavailable (DIRTY_TREE)");
+    expect(unavailable).toContain("Do not assume earlier decisions were recorded");
+    expect(unavailable).toContain("do not attempt to repair the tree yourself");
+  });
+
+  it("omits Agent Home when no Session context is supplied", () => {
+    const prompt = renderManagedSystemPrompt(snapshot);
+    expect(prompt).not.toContain("## Agent Home");
+    expect(prompt).toContain("## Platform\n\nplatform");
+    expect(prompt).toContain("## Agent\n\nagent");
+  });
+});

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, resolve } from "node:path";
 import {
@@ -407,6 +407,47 @@ describe("SessionRuntimeManager", () => {
     expect(factory.created[0]?.systemPrompt).toContain("preparation is continuing in the background");
     expect(factory.created[0]?.systemPrompt).toContain("not active for this Session");
     expect(factory.created[0]?.systemPrompt).not.toContain("repair the tree");
+    await manager.close();
+  });
+
+  it("wires the same Agent Home into every Session prompt without creating source-repos, worktrees, or files", async () => {
+    const home = await mkdtemp(resolve(tmpdir(), "opentag-agent-home-prompt-"));
+    homes.push(home);
+    const store = new SessionBindingStore({ home, providerArtifactIdentity: () => "a".repeat(64) });
+    const workspace = new AgentWorkspaceManager({ home, bindingStore: store });
+    const factory = new FakeFactory();
+    const manager = new SessionRuntimeManager({
+      bindingStore: store,
+      home,
+      providers: await providerRegistry(factory),
+      providerEnvironmentPath: () => "/tmp/provider-env.sh",
+      workspace,
+    });
+    const computerId = randomUUID();
+    const reconciler = new SessionReconciler({
+      installationId: computerId,
+      preparation: manager,
+      localPolicy: manager,
+    });
+    const first = reconcile(computerId, snapshot(1));
+    const second = { ...reconcile(computerId, snapshot(1)), requestId: randomUUID(), sessionId: "session-2" };
+
+    await expect(reconciler.reconcile(first)).resolves.toMatchObject({ status: "ready" });
+    await manager.ensureRuntime(first.sessionId);
+    await expect(reconciler.reconcile(second)).resolves.toMatchObject({ status: "ready" });
+    await manager.ensureRuntime(second.sessionId);
+
+    const cwd = await workspace.cwd("agent-1");
+    expect(factory.created).toHaveLength(2);
+    expect(factory.created[0]?.workspace.cwd).toBe(cwd);
+    expect(factory.created[1]?.workspace.cwd).toBe(cwd);
+    expect(factory.created[0]?.workspace.writableRoots).toEqual([cwd]);
+    expect(factory.created[1]?.workspace.writableRoots).toEqual([cwd]);
+    expect(factory.created[0]?.systemPrompt).toContain(`Your Agent Home is ${cwd}.`);
+    expect(factory.created[1]?.systemPrompt).toContain(`Your Agent Home is ${cwd}.`);
+    expect(factory.created[0]?.systemPrompt).toContain("source-repos/<unique-repo-key>/");
+    expect(factory.created[1]?.systemPrompt).toContain("worktrees/<unique-task-key>/");
+    await expect(readdir(cwd)).resolves.toEqual([]);
     await manager.close();
   });
 

--- a/packages/client/src/runtime/managed-instructions.ts
+++ b/packages/client/src/runtime/managed-instructions.ts
@@ -8,6 +8,7 @@ export interface ManagedSessionContext {
   cliCommand: string;
   sessionCliAvailable: boolean;
   contextTree?: ContextTreeStatus;
+  agentHome?: string;
 }
 
 /**
@@ -46,9 +47,30 @@ function renderContextTree(status: ContextTreeStatus, cliCommand: string): reado
   ];
 }
 
+function renderAgentHome(agentHome?: string): readonly string[] {
+  const location = agentHome
+    ? `Your Agent Home is ${agentHome}. One persistent Home is shared across this Agent's Sessions on this Computer.`
+    : "One persistent Home is shared across this Agent's Sessions on this Computer.";
+  return [
+    "## Agent Home",
+    "",
+    location,
+    "Files survive tasks. Use absolute paths; resolve the directories below from Agent Home, not the task cwd.",
+    "",
+    "These directories are prompt conventions, not platform-managed resources or automatic cleanup policies. Create them only as needed:",
+    "- `source-repos/<unique-repo-key>/` — agent-managed bare source clones. Repository identity comes from the user or task, not from platform bindings. Before reusing an existing clone, verify it belongs to the intended repository. Preserve existing files. Do not clone into the Home root.",
+    "- `worktrees/<unique-task-key>/` — agent-managed checkouts for source access and code work. Concurrent code tasks each use a distinct worktree (and a distinct branch when editing). Keep later operations for the same task in its own worktree. No two code tasks edit one checkout.",
+    "- `files/<unique-task-key>/` — non-repository task artifacts, created only when needed.",
+    "",
+    'Context Tree stays the separately configured shared tree managed by its matching CLI and skills. When running Context Tree project commands from a task subdirectory, pass `--project-path "<Agent Home>"` to use the connected Home; do not create or reconnect a tree just because the task cwd changed. Follow the matching skill write protocol. Do not invent an independent Git policy for Tree writes.',
+    "",
+  ];
+}
+
 export function renderManagedSystemPrompt(snapshot: EffectiveRuntimeSnapshot, context?: ManagedSessionContext): string {
   const session = context
     ? [
+        ...renderAgentHome(context.agentHome),
         "## Session",
         "",
         `Current Session: ${context.sessionId}`,

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -271,6 +271,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
         ...(managed.creatorSessionId ? { creatorSessionId: managed.creatorSessionId } : {}),
         cliCommand: this.#cliCommand,
         sessionCliAvailable: Boolean(managed.proofPath),
+        agentHome: managed.cwd,
         ...contextTree.promptContext,
       }),
       workspace: {


### PR DESCRIPTION
## Summary

Refs #221 and #213.

- Following [First Tree's Agent Home/worktree instructions](https://github.com/agent-team-foundation/first-tree/blob/2e0c4c26d8f09ef7115e45a96695c612124356aa/packages/client/src/runtime/templates/agent-briefing.ejs#L108), describe persistent shared Home, Agent-managed `source-repos/`, independent task `worktrees/`, and on-demand `files/` in the managed prompt.
- Pass the resolved Home into the prompt and anchor Context Tree project commands to that Home when working in a task subdirectory. Keep Provider cwd, writable roots, and missing-memory behavior unchanged.
- Add prompt/runtime regression tests and synchronize English/Chinese development docs. No repository model, automatic directory creation, GC, migration, or new instruction files.

## Testing

- Passed: frozen install; `pnpm check`; `pnpm build`; `pnpm typecheck`; pre-commit and all pre-push hooks.
- Passed: 145 focused client tests; Agent Runtime coverage suite **360 tests, 100% statements/branches/functions/lines**; Server integration **324 tests**.
- Passed: full `pnpm test` (Shared 220, Client 987, Server 853, CLI 431, Web 665 tests, plus root script checks).
- Focused-local acceptance rerun at `1de1b883`: two Sessions share a Home across manager reconstruction; two task worktrees keep concurrent edits separate; each task writes to and reads from the same Context Tree 0.1.10 using `--project-path` for the Home. Real filesystem/Git/packaged CLI, isolated test account, preserved user instructions, final Tree valid and clean. No live model-provider E2E; prompt conventions are not an enforced sandbox.

## Breaking changes

None. `ManagedSessionContext.agentHome` is optional; existing cwd and filesystem policy remain unchanged.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
