### PR TITLE
fix(web): center button content consistently

### DIFF
--- a/apps/web/messages/onboarding-v2/en.json
+++ b/apps/web/messages/onboarding-v2/en.json
@@ -190,7 +190,7 @@
   "onboarding_v2_runtime_codex_title": "Codex",
   "onboarding_v2_setup_computer_rebind": "{computerName} belongs to another Account. Choose a Computer owned by this Account for {name}.",
   "onboarding_v2_setup_load_failed": "We couldn't read your agent's setup.",
-  "onboarding_v2_setup_messaging_auth_failed": "The {provider} authorization didn't complete. Disconnect this incomplete connection, then start again.",
+  "onboarding_v2_setup_messaging_auth_failed": "{provider} authorization didn't complete. Disconnect {provider}, then reconnect it.",
   "onboarding_v2_setup_messaging_computer_attention": "Repair the {provider} connection in the coding agent on this computer, then check again.",
   "onboarding_v2_setup_messaging_confirming_computer": "Confirming the computer can connect to {provider}…",
   "onboarding_v2_setup_messaging_needs_attention": "Needs attention",

--- a/apps/web/messages/onboarding-v2/zh.json
+++ b/apps/web/messages/onboarding-v2/zh.json
@@ -190,7 +190,7 @@
   "onboarding_v2_runtime_codex_title": "Codex",
   "onboarding_v2_setup_computer_rebind": "{computerName} 属于其他 Account。请为 {name} 选择一台属于当前 Account 的 Computer。",
   "onboarding_v2_setup_load_failed": "无法读取你的 Agent 的设置状态。",
-  "onboarding_v2_setup_messaging_auth_failed": "{provider} 授权未完成。请先断开这条未完成的连接，再重新开始。",
+  "onboarding_v2_setup_messaging_auth_failed": "{provider} 授权未完成。请断开 {provider}，然后重新连接。",
   "onboarding_v2_setup_messaging_computer_attention": "使用这台电脑上的编码 Agent 修复 {provider} 连接，然后重新检查。",
   "onboarding_v2_setup_messaging_confirming_computer": "正在确认这台电脑可以连接到 {provider}…",
   "onboarding_v2_setup_messaging_needs_attention": "需要处理",

--- a/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
@@ -822,11 +822,7 @@ describe("AgentSetupPage transitions", () => {
     await settle();
 
     expect(cancel).toHaveBeenCalledWith(attemptId);
-    expect(
-      screen.getByText(
-        "The Lark authorization didn't complete. Disconnect this incomplete connection, then start again.",
-      ),
-    ).toBeTruthy();
+    expect(screen.getByText("Lark authorization didn't complete. Disconnect Lark, then reconnect it.")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Disconnect Lark" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Your Slack workspace/ })).toBeNull();
   });

--- a/apps/web/src/onboarding-v2/agent-setup-page.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.tsx
@@ -106,7 +106,7 @@ const SECTION_HEADER = "flex flex-col gap-1";
 const HINT = "text-sm text-kumo-subtle m-0";
 const CHOICE_GRID = "otv2-choices--grid grid gap-3 m-0 p-0 list-none";
 const CARD =
-  "otv2-choice flex w-full items-center gap-4 rounded-xl bg-kumo-base p-4 ring ring-kumo-line cursor-pointer";
+  "otv2-choice flex w-full items-center justify-start gap-4 rounded-xl bg-kumo-base p-4 ring ring-kumo-line cursor-pointer";
 
 export type AgentSetupPreviewView = "checks" | "complete" | "computer" | "messaging";
 

--- a/apps/web/src/onboarding-v2/steps.tsx
+++ b/apps/web/src/onboarding-v2/steps.tsx
@@ -23,7 +23,7 @@ const HINT = "text-sm text-kumo-subtle m-0";
 const CHOICES = "flex flex-col gap-3 m-0 p-0 list-none";
 const CHOICE_GRID = "otv2-choices--grid grid gap-3 m-0 p-0 list-none";
 const CARD =
-  "otv2-choice flex w-full items-center gap-4 rounded-xl bg-kumo-base p-4 ring ring-kumo-line cursor-pointer";
+  "otv2-choice flex w-full items-center justify-start gap-4 rounded-xl bg-kumo-base p-4 ring ring-kumo-line cursor-pointer";
 
 export function StepRail({ steps }: { steps: FlowState["steps"] }) {
   return (

--- a/apps/web/src/ui/design-system.test.tsx
+++ b/apps/web/src/ui/design-system.test.tsx
@@ -30,6 +30,14 @@ describe("Kumo semantic adapter", () => {
     expect(screen.getByRole("button", { name: "Disconnect" }).className).toContain("text-kumo-danger");
   });
 
+  it("centers button content by default while preserving explicit alignment", () => {
+    expect(buttonClassName({ className: "min-w-28" }).split(" ")).toContain("justify-center");
+
+    const leftAligned = buttonClassName({ className: "w-full justify-start" }).split(" ");
+    expect(leftAligned).toContain("justify-start");
+    expect(leftAligned).not.toContain("justify-center");
+  });
+
   it("overrides Kumo's lightened emphasis mix with accessible button surfaces", () => {
     render(
       <>

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -168,6 +168,7 @@ export function buttonClassName({
 } = {}): string {
   return classes(
     buttonVariants({ variant: kumoButtonVariant(variant), size: size === "compact" ? "sm" : "base" }),
+    "justify-center",
     variant === "primary" &&
       "[--kumo-button-emphasis-bg:var(--opentag-button-primary-bg)] [--kumo-button-emphasis-gradient-end:var(--opentag-button-primary-gradient-end)] [--kumo-button-emphasis-gradient-start:var(--opentag-button-primary-gradient-start)] [--kumo-button-emphasis-ring:var(--opentag-button-primary-ring)]",
     variant === "danger" &&


### PR DESCRIPTION
## Summary

- center content in the shared web Button adapter so fixed-width and full-width actions render correctly
- preserve intentional left alignment for onboarding choice cards
- shorten the incomplete messaging authorization guidance in English and Chinese

## Verification

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @opentag/web test` (63 files, 674 tests)
- focused web tests (2 files, 91 tests)
- manual browser review of onboarding choices, preparation Continue action, and messaging recovery actions