### PR TITLE
feat(release): serve portable installs from dl.opentag.build

### DIFF
--- a/apps/cli/src/__tests__/manual-upgrade.test.ts
+++ b/apps/cli/src/__tests__/manual-upgrade.test.ts
@@ -269,7 +269,7 @@ describe("manual upgrade", () => {
     const home = await tempHome();
     const installed: string[] = [];
     const fetchFn = (async (url: string | URL | Request) => {
-      expect(String(url)).toBe("https://storage.googleapis.com/opentag-release/releases/staging/latest.json");
+      expect(String(url)).toBe("https://dl.opentag.build/releases/staging/latest.json");
       return jsonResponse({ channel: "staging", version: "0.0.3-staging.1.1" });
     }) as typeof fetch;
     const result = await runUpgrade({

--- a/apps/cli/src/core/update/portable-installer.ts
+++ b/apps/cli/src/core/update/portable-installer.ts
@@ -14,7 +14,7 @@ import type { ChannelName } from "@opentag/shared";
  * commit point. A version directory is never rewritten in place.
  */
 
-export const DEFAULT_DOWNLOAD_BASE_URL = "https://storage.googleapis.com/opentag-release/releases";
+export const DEFAULT_DOWNLOAD_BASE_URL = "https://dl.opentag.build/releases";
 const PORTABLE_APP_ENTRY = "app/cli/index.mjs";
 const MANIFEST_SCHEMA_VERSION = 1;
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -96,7 +96,7 @@ server container.
 | `OPENTAG_JWT_SECRET` | At least 32 random characters, unique to Staging and distinct from `BETTER_AUTH_SECRET`; signs Slack OAuth state only |
 | `OPENTAG_ENCRYPTION_KEY` | Base64 32-byte key, unique to Staging |
 | `OPENTAG_AUTO_MIGRATE` | `true` so each rollout applies pending migrations |
-| `OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` | Optional; defaults to `https://storage.googleapis.com/opentag-release/releases` |
+| `OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` | Optional; defaults to `https://dl.opentag.build/releases` |
 | `OPENTAG_CHANNEL_TARGET_POLL_INTERVAL_MS` | Optional; defaults to `300000` |
 
 The two optional variables control how the Server learns the exact channel latest target it advertises to connected

--- a/docs/portable-release.md
+++ b/docs/portable-release.md
@@ -18,7 +18,7 @@ identity rewrite, and the same version coordinate as the npm package it accompan
 ## Installing
 
 ~~~bash
-curl -fsSL https://storage.googleapis.com/opentag-release/releases/prod/install.sh | sh
+curl -fsSL https://dl.opentag.build/releases/prod/install.sh | sh
 ~~~
 
 The installer resolves the channel's `latest.json`, downloads the tarball for the detected platform, verifies its
@@ -116,8 +116,10 @@ Current version, target, updater state, and the last attempt with its failure re
 <prefix>/<channel>/<version>/<package>-<version>-<platform>.tar.gz
 ~~~
 
-Default coordinates are the `opentag-release` bucket under the `releases` prefix, served from
-`https://storage.googleapis.com/opentag-release/releases`.
+Default coordinates are the `opentag-release` bucket under the `releases` prefix. The bucket is exposed publicly
+through the `dl.opentag.build` custom domain, so the default download base URL is `https://dl.opentag.build/releases`.
+The storage coordinates and the public host are independent settings: the upload path only ever builds `gs://` URIs
+from the bucket and prefix, and the download base URL is never derived from the bucket name.
 
 Everything under a version prefix is immutable and written with a create-only precondition
 (`--if-generation-match=0`) plus a `--content-md5` digest, so Cloud Storage rejects both a silent overwrite and a
@@ -247,7 +249,7 @@ Required repository variables:
 | `OPENTAG_PORTABLE_GCS_BUCKET` | Bucket name (default `opentag-release`) |
 | `OPENTAG_PORTABLE_GCS_PREFIX` | Object prefix before the channel segment (default `releases`) |
 | `OPENTAG_PORTABLE_GCS_PROJECT` | Project used for `gcloud` calls |
-| `OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` | Public base URL (default `https://storage.googleapis.com/opentag-release/releases`) |
+| `OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` | Public base URL (default `https://dl.opentag.build/releases`) |
 | `OPENTAG_PORTABLE_PLATFORMS` | Optional platform filter for the build |
 
 Publishing uses workload identity federation, so no service-account key is stored in the repository. The service
@@ -261,8 +263,12 @@ elsewhere.
 The workload identity provider must carry an attribute condition that pins it to this repository. Without one, any
 GitHub Actions workflow anywhere can mint a token for the pool and impersonate the release service account.
 
-The bucket must serve the release prefix publicly at the download base URL. Until it does, uploads still succeed but
-the public verification gate fails and the channel pointers are deliberately left untouched.
+The download base URL must serve the release prefix publicly, byte for byte, from the objects the upload just wrote.
+Because that host is a custom domain in front of the bucket rather than the bucket's own endpoint, a failure here can
+come from either side: the bucket's public access, or the domain mapping. The domain must also honor the object
+`Cache-Control` headers the upload sets, since the channel pointers are published as `no-cache` and are re-read
+immediately afterwards. Until all of that holds, uploads still succeed but the public verification gate fails and the
+channel pointers are deliberately left untouched.
 
 ## Operational notes
 

--- a/docs/zh-CN/deploying.md
+++ b/docs/zh-CN/deploying.md
@@ -1,7 +1,7 @@
 # OpenTag 部署指南
 
 > Canonical source: [../deploying.md](../deploying.md)
-> Last synced with: 2026-09-02
+> Last synced with: 2026-09-07
 
 OpenTag 的 Staging 环境运行在 [CapRover](https://caprover.com/) 上。每个合入 `main` 且通过 CI 的 revision，都会用
 `Docker` workflow 已经发布到 GHCR 的容器镜像自动部署。CapRover 主机上不构建任何内容，也不上传源码 tarball；一次部署
@@ -89,7 +89,7 @@ service，不会配置 CapRover 的 server container。
 | `OPENTAG_JWT_SECRET` | 至少 32 个随机字符，Staging 专用，且与 `BETTER_AUTH_SECRET` 不同；仅用于签名 Slack OAuth state |
 | `OPENTAG_ENCRYPTION_KEY` | Base64 编码的 32 字节 key，Staging 专用 |
 | `OPENTAG_AUTO_MIGRATE` | `true`，使每次上线都应用待执行的 migration |
-| `OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` | 可选；默认 `https://storage.googleapis.com/opentag-release/releases` |
+| `OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` | 可选；默认 `https://dl.opentag.build/releases` |
 | `OPENTAG_CHANNEL_TARGET_POLL_INTERVAL_MS` | 可选；默认 `300000` |
 
 这两个可选变量控制 Server 如何获知它向已连接 Client 广播的 channel 精确最新目标（用于自动升级）：它轮询下载

--- a/docs/zh-CN/portable-release.md
+++ b/docs/zh-CN/portable-release.md
@@ -1,7 +1,7 @@
 # OpenTag Portable 发布指南
 
 > Canonical source: [../portable-release.md](../portable-release.md)
-> Last synced with: 2026-09-03
+> Last synced with: 2026-09-07
 
 Portable release 是一份自包含的 OpenTag 安装包：每个平台一个 tarball，同时携带 bundle 后的 CLI **和它自己的
 Node.js runtime**，因此没有 Node.js、没有 npm、没有任何 package manager 的机器也能安装并运行 OpenTag。它发布到
@@ -18,7 +18,7 @@ identity 改写和相同的 version coordinate，coordinate 的推导方式见 [
 ## 安装
 
 ~~~bash
-curl -fsSL https://storage.googleapis.com/opentag-release/releases/prod/install.sh | sh
+curl -fsSL https://dl.opentag.build/releases/prod/install.sh | sh
 ~~~
 
 installer 会解析 channel 的 `latest.json`，下载所检测平台对应的 tarball，校验其已发布的 SHA-256，解压，运行一次新
@@ -107,8 +107,9 @@ daemon 的 updater 遵循严格的契约：
 <prefix>/<channel>/<version>/<package>-<version>-<platform>.tar.gz
 ~~~
 
-默认 coordinate 是 `opentag-release` bucket 的 `releases` prefix，通过
-`https://storage.googleapis.com/opentag-release/releases` 对外提供。
+默认 coordinate 是 `opentag-release` bucket 的 `releases` prefix。该 bucket 通过 `dl.opentag.build` 自定义域名对外
+提供，因此默认的 download base URL 是 `https://dl.opentag.build/releases`。storage coordinate 与公网 host 是两个
+相互独立的设置：上传路径只会用 bucket 与 prefix 拼出 `gs://` URI，而 download base URL 从不由 bucket 名推导。
 
 version prefix 下的一切都是不可变的，写入时带 create-only precondition（`--if-generation-match=0`）以及
 `--content-md5` digest，因此 Cloud Storage 会同时拒绝静默覆盖和损坏的上传。只有 `latest.json` 与 `install.sh` 可变；
@@ -228,7 +229,7 @@ preflight，使不可变 prefix 冲突在 release 仍可重试时就失败；随
 | `OPENTAG_PORTABLE_GCS_BUCKET` | bucket 名称（默认 `opentag-release`） |
 | `OPENTAG_PORTABLE_GCS_PREFIX` | channel 段之前的 object prefix（默认 `releases`） |
 | `OPENTAG_PORTABLE_GCS_PROJECT` | 执行 `gcloud` 调用所用的 project |
-| `OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` | 公网 base URL（默认 `https://storage.googleapis.com/opentag-release/releases`） |
+| `OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` | 公网 base URL（默认 `https://dl.opentag.build/releases`） |
 | `OPENTAG_PORTABLE_PLATFORMS` | 可选的构建平台过滤 |
 
 发布使用 workload identity federation，因此仓库中不保存任何 service-account key。该 service account 需要 bucket 上的
@@ -240,8 +241,10 @@ preflight，使不可变 prefix 冲突在 release 仍可重试时就失败；随
 workload identity provider 必须带上把它固定到本仓库的 attribute condition。若不设置，任何地方的 GitHub Actions
 workflow 都能为该 pool 换取 token 并冒充这个 release service account。
 
-bucket 必须在 download base URL 上公开提供 release prefix。在此之前，上传仍会成功，但公网校验闸门会失败，channel
-指针会被刻意保持原样。
+download base URL 必须逐字节地公开提供刚刚上传的那些 object。由于该 host 是 bucket 前面的自定义域名、而不是 bucket
+自身的 endpoint，这里失败可能来自两侧中的任意一侧：bucket 的公开访问权限，或域名映射。该域名还必须遵守上传时设置的
+object `Cache-Control` 头，因为 channel 指针以 `no-cache` 发布并会在紧随其后被重新读取。在这些条件全部满足之前，
+上传仍会成功，但公网校验闸门会失败，channel 指针会被刻意保持原样。
 
 ## 运维说明
 

--- a/packages/server/src/__tests__/account-api.test.ts
+++ b/packages/server/src/__tests__/account-api.test.ts
@@ -173,7 +173,7 @@ function appWith(
     computerService: service.computerService as unknown as ComputerService,
     accountSetupService: service.accountSetupService as unknown as AccountSetupService,
     computerConnectCode: {
-      downloadBaseUrl: "https://storage.googleapis.com/opentag-release/releases",
+      downloadBaseUrl: "https://dl.opentag.build/releases",
       environment: "dev",
       publicUrl: "https://opentag.example",
     },

--- a/packages/server/src/__tests__/config.test.ts
+++ b/packages/server/src/__tests__/config.test.ts
@@ -80,7 +80,7 @@ describe("parseServerConfig", () => {
 
   it("defaults the channel target coordinates to the public release endpoint", () => {
     expect(parseServerConfig(required).channelTarget).toEqual({
-      downloadBaseUrl: "https://storage.googleapis.com/opentag-release/releases",
+      downloadBaseUrl: "https://dl.opentag.build/releases",
       pollIntervalMs: 300_000,
     });
     expect(

--- a/packages/server/src/__tests__/integration/computers.test.ts
+++ b/packages/server/src/__tests__/integration/computers.test.ts
@@ -446,7 +446,7 @@ describe("Computer connection persistence", () => {
       const app = createApp({
         authService: value.auth,
         computerConnectCode: {
-          downloadBaseUrl: "https://storage.googleapis.com/opentag-release/releases",
+          downloadBaseUrl: "https://dl.opentag.build/releases",
           environment: "staging",
           publicUrl: "https://dev.example.com",
         },
@@ -511,7 +511,7 @@ describe("Computer connection persistence", () => {
       const app = createApp({
         authService: value.auth,
         computerConnectCode: {
-          downloadBaseUrl: "https://storage.googleapis.com/opentag-release/releases",
+          downloadBaseUrl: "https://dl.opentag.build/releases",
           environment: "staging",
           publicUrl: "https://dev.example.com",
         },
@@ -594,7 +594,7 @@ describe("Computer connection persistence", () => {
       const app = createApp({
         authService: value.auth,
         computerConnectCode: {
-          downloadBaseUrl: "https://storage.googleapis.com/opentag-release/releases",
+          downloadBaseUrl: "https://dl.opentag.build/releases",
           environment: "staging",
           publicUrl: "https://dev.example.com",
         },
@@ -611,7 +611,7 @@ describe("Computer connection persistence", () => {
         expect(issued.headers["cache-control"]).toBe("no-store");
         const command = issued.json().bootstrapCommand as string;
         expect(command).toContain(
-          'opentag_installer="$(mktemp)" && curl -fsSL https://storage.googleapis.com/opentag-release/releases/staging/install.sh -o "$opentag_installer" && sh "$opentag_installer" && rm -f "$opentag_installer" && PATH="$HOME/.local/bin${PATH:+:$PATH}" "$HOME/.local/bin/opentag-staging" connect --server https://dev.example.com -- otcc_',
+          'opentag_installer="$(mktemp)" && curl -fsSL https://dl.opentag.build/releases/staging/install.sh -o "$opentag_installer" && sh "$opentag_installer" && rm -f "$opentag_installer" && PATH="$HOME/.local/bin${PATH:+:$PATH}" "$HOME/.local/bin/opentag-staging" connect --server https://dev.example.com -- otcc_',
         );
         const code = command.split(" -- ").at(-1);
         if (!code) throw new Error("Computer connect command did not contain a code");
@@ -647,7 +647,7 @@ describe("Computer connection persistence", () => {
       const app = createApp({
         authService: value.auth,
         computerConnectCode: {
-          downloadBaseUrl: "https://storage.googleapis.com/opentag-release/releases",
+          downloadBaseUrl: "https://dl.opentag.build/releases",
           environment: "staging",
           publicUrl: "https://dev.example.com",
         },
@@ -866,7 +866,7 @@ describe("Connect code redemption status", () => {
       const app = createApp({
         authService: value.auth,
         computerConnectCode: {
-          downloadBaseUrl: "https://storage.googleapis.com/opentag-release/releases",
+          downloadBaseUrl: "https://dl.opentag.build/releases",
           environment: "staging",
           publicUrl: "https://dev.example.com",
         },

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -123,9 +123,7 @@ const ServerEnvironmentSchema = z
      * This is the same authority the portable installer consumes; release tooling keeps the npm
      * dist-tag at the same coordinate, so one target serves both install modes.
      */
-    OPENTAG_PORTABLE_DOWNLOAD_BASE_URL: DownloadBaseUrlSchema.default(
-      "https://storage.googleapis.com/opentag-release/releases",
-    ),
+    OPENTAG_PORTABLE_DOWNLOAD_BASE_URL: DownloadBaseUrlSchema.default("https://dl.opentag.build/releases"),
     OPENTAG_CHANNEL_TARGET_POLL_INTERVAL_MS: z.coerce.number().int().min(1_000).max(3_600_000).default(300_000),
     OPENTAG_PORT: z.coerce.number().int().min(1).max(65_535).default(8000),
     OPENTAG_PUBLIC_URL: PublicUrlSchema,

--- a/scripts/__tests__/portable-build.test.mjs
+++ b/scripts/__tests__/portable-build.test.mjs
@@ -63,7 +63,7 @@ test("artifact names and download URLs stay derivable from the release coordinat
       fileName: "open-tag-1.2.3-linux-x64.tar.gz",
       version: "1.2.3",
     }),
-    "https://storage.googleapis.com/opentag-release/releases/prod/1.2.3/open-tag-1.2.3-linux-x64.tar.gz",
+    "https://dl.opentag.build/releases/prod/1.2.3/open-tag-1.2.3-linux-x64.tar.gz",
   );
   assert.equal(
     manifestDownloadUrl({
@@ -71,23 +71,17 @@ test("artifact names and download URLs stay derivable from the release coordinat
       downloadBaseUrl: DEFAULT_DOWNLOAD_BASE_URL,
       version: "0.0.2-staging.4.1",
     }),
-    "https://storage.googleapis.com/opentag-release/releases/staging/0.0.2-staging.4.1/manifest.json",
+    "https://dl.opentag.build/releases/staging/0.0.2-staging.4.1/manifest.json",
   );
 });
 
 test("download base URLs reject inputs that would publish to the wrong prefix", () => {
-  assert.equal(
-    normalizeDownloadBaseUrl("https://storage.googleapis.com/opentag-release/releases//"),
-    "https://storage.googleapis.com/opentag-release/releases",
-  );
+  assert.equal(normalizeDownloadBaseUrl("https://dl.opentag.build/releases//"), "https://dl.opentag.build/releases");
   assert.throws(
-    () => normalizeDownloadBaseUrl("https://storage.googleapis.com/opentag-release/releases/prod"),
+    () => normalizeDownloadBaseUrl("https://dl.opentag.build/releases/prod"),
     /must not include the channel segment/,
   );
-  assert.throws(
-    () => normalizeDownloadBaseUrl("http://storage.googleapis.com/opentag-release/releases"),
-    /must use https/,
-  );
+  assert.throws(() => normalizeDownloadBaseUrl("http://dl.opentag.build/releases"), /must use https/);
   assert.throws(() => normalizeDownloadBaseUrl(""), /is required/);
   // Local endpoints stay usable so an installer can be exercised without a public bucket.
   assert.equal(normalizeDownloadBaseUrl("http://127.0.0.1:8799"), "http://127.0.0.1:8799");
@@ -98,7 +92,7 @@ test("release metadata pins the version manifest the channel pointer resolves to
     {
       platform: "linux-x64",
       fileName: "open-tag-1.2.3-linux-x64.tar.gz",
-      url: "https://storage.googleapis.com/opentag-release/releases/prod/1.2.3/open-tag-1.2.3-linux-x64.tar.gz",
+      url: "https://dl.opentag.build/releases/prod/1.2.3/open-tag-1.2.3-linux-x64.tar.gz",
       sha256: "a".repeat(64),
       size: 42,
     },
@@ -120,7 +114,7 @@ test("release metadata pins the version manifest the channel pointer resolves to
   assert.equal(manifest.generatedAt, "2026-08-25T00:00:00.000Z");
   assert.deepEqual(manifest.assets, assets);
   assert.equal(manifest.manifestUrl, undefined);
-  assert.equal(latest.manifestUrl, "https://storage.googleapis.com/opentag-release/releases/prod/1.2.3/manifest.json");
+  assert.equal(latest.manifestUrl, "https://dl.opentag.build/releases/prod/1.2.3/manifest.json");
 });
 
 test("normalizers fail closed on inexact release inputs", () => {
@@ -201,15 +195,11 @@ test("the artifact shim runs the embedded runtime through relative paths only", 
 
 test("rendered installers pin the channel and base URL they were released with", async () => {
   const template = await readFile(join(portableDir, "install.sh"), "utf8");
-  const rendered = renderInstallerForChannel(
-    "staging",
-    "https://storage.googleapis.com/opentag-release/releases",
-    template,
-  );
+  const rendered = renderInstallerForChannel("staging", "https://dl.opentag.build/releases", template);
   assert.match(rendered, /PORTABLE_CHANNEL="\$\{OPENTAG_PORTABLE_CHANNEL:-staging\}"/);
   assert.match(
     rendered,
-    /DOWNLOAD_BASE_URL="\$\{OPENTAG_PORTABLE_DOWNLOAD_BASE_URL:-https:\/\/storage\.googleapis\.com\/opentag-release\/releases\}"/,
+    /DOWNLOAD_BASE_URL="\$\{OPENTAG_PORTABLE_DOWNLOAD_BASE_URL:-https:\/\/dl\.opentag\.build\/releases\}"/,
   );
   assert.throws(
     () => renderInstallerForChannel("dev", DEFAULT_DOWNLOAD_BASE_URL, template),
@@ -404,7 +394,10 @@ test("shell helpers import release modules without tripping their CLI entry poin
   assert.equal(result.stderr, "");
 });
 
-test("the release scripts default to the OpenTag Cloud Storage coordinates", async () => {
+// The Cloud Storage coordinates and the public download host are independent: the bucket and prefix
+// only ever build gs:// URIs, while the base URL is a custom domain served in front of them. They are
+// pinned in one place so a cutover of either one cannot silently drift the other.
+test("the release scripts default to the OpenTag storage coordinates and download host", async () => {
   const upload = await readFile(join(portableDir, "upload-gcs.sh"), "utf8");
   assert.match(upload, /DEFAULT_BUCKET="opentag-release"/);
   assert.match(upload, /DEFAULT_PREFIX="releases"/);
@@ -412,9 +405,18 @@ test("the release scripts default to the OpenTag Cloud Storage coordinates", asy
   for (const name of ["build-release.sh", "release-gcs.sh"]) {
     const source = await readFile(join(portableDir, name), "utf8");
     await access(join(portableDir, name), constants.X_OK);
-    assert.match(source, /DEFAULT_DOWNLOAD_BASE_URL="https:\/\/storage\.googleapis\.com\/opentag-release\/releases"/);
+    assert.match(source, /DEFAULT_DOWNLOAD_BASE_URL="https:\/\/dl\.opentag\.build\/releases"/);
   }
-  assert.equal(DEFAULT_DOWNLOAD_BASE_URL, "https://storage.googleapis.com/opentag-release/releases");
+
+  // The installer template ships its own fallback, and a local `sh install.sh` run resolves against it
+  // whenever the rendered per-channel copy is not what the user fetched. Nothing else pins this literal.
+  const installer = await readFile(join(portableDir, "install.sh"), "utf8");
+  assert.match(
+    installer,
+    /DOWNLOAD_BASE_URL="\$\{OPENTAG_PORTABLE_DOWNLOAD_BASE_URL:-https:\/\/dl\.opentag\.build\/releases\}"/,
+  );
+
+  assert.equal(DEFAULT_DOWNLOAD_BASE_URL, "https://dl.opentag.build/releases");
 });
 
 test("forwarded option arrays survive the bash 3.2 that ships with macOS", async () => {

--- a/scripts/portable/build-portable.mjs
+++ b/scripts/portable/build-portable.mjs
@@ -47,7 +47,7 @@ export const PORTABLE_PLATFORMS = ["darwin-arm64", "darwin-x64", "linux-arm64", 
 export const PORTABLE_CHANNELS = ["prod", "staging"];
 export const MANIFEST_SCHEMA_VERSION = 1;
 export const APP_ENTRY = "app/cli/index.mjs";
-export const DEFAULT_DOWNLOAD_BASE_URL = "https://storage.googleapis.com/opentag-release/releases";
+export const DEFAULT_DOWNLOAD_BASE_URL = "https://dl.opentag.build/releases";
 export const NODE_VERSION_FILE = join(SCRIPT_DIR, "node-version.txt");
 export const INSTALLER_TEMPLATE_FILE = join(SCRIPT_DIR, "install.sh");
 

--- a/scripts/portable/build-release.sh
+++ b/scripts/portable/build-release.sh
@@ -13,7 +13,7 @@ NODE_VERSION_FILE="$SCRIPT_DIR/node-version.txt"
 
 DEFAULT_PLATFORMS=("darwin-arm64" "darwin-x64" "linux-arm64" "linux-x64")
 DEFAULT_OUT_DIR=".portable-release"
-DEFAULT_DOWNLOAD_BASE_URL="https://storage.googleapis.com/opentag-release/releases"
+DEFAULT_DOWNLOAD_BASE_URL="https://dl.opentag.build/releases"
 
 CHANNEL=""
 VERSION=""

--- a/scripts/portable/install.sh
+++ b/scripts/portable/install.sh
@@ -9,7 +9,7 @@ set -eu
 # pinned to the channel they belong to.
 
 PORTABLE_CHANNEL="${OPENTAG_PORTABLE_CHANNEL:-prod}"
-DOWNLOAD_BASE_URL="${OPENTAG_PORTABLE_DOWNLOAD_BASE_URL:-https://storage.googleapis.com/opentag-release/releases}"
+DOWNLOAD_BASE_URL="${OPENTAG_PORTABLE_DOWNLOAD_BASE_URL:-https://dl.opentag.build/releases}"
 DEFAULT_PREFIX="${HOME}/.local/share/opentag/${PORTABLE_CHANNEL}"
 DEFAULT_BIN_DIR="${HOME}/.local/bin"
 PATH_MODE="auto"

--- a/scripts/portable/release-gcs.sh
+++ b/scripts/portable/release-gcs.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-DEFAULT_DOWNLOAD_BASE_URL="https://storage.googleapis.com/opentag-release/releases"
+DEFAULT_DOWNLOAD_BASE_URL="https://dl.opentag.build/releases"
 
 CHANNEL=""
 VERSION=""


### PR DESCRIPTION
## What

Points the public portable-release download base URL at the newly bound `dl.opentag.build` custom domain.

| | |
|---|---|
| Old | `https://storage.googleapis.com/opentag-release/releases` |
| New | `https://dl.opentag.build/releases` |

The domain was verified to serve the same objects 1:1 before this change — `staging/install.sh` returns an identical `etag` and `x-goog-meta-sha256` on both hosts, and `staging/latest.json` plus a versioned `manifest.json` resolve on the new host. `prod/install.sh` 404s on both, so there is no regression there.

## What does *not* change

Only the public HTTP base URL moves. The Cloud Storage coordinates stay put: `upload-gcs.sh` still writes to the `opentag-release` bucket under the `releases` prefix, and those literals plus their ratchet assertions are deliberately untouched.

This is safe because nothing derives the public host from the bucket name. `$BUCKET` only ever appears inside `gs://` URIs, and both validators (`normalizeDownloadBaseUrl`, `validate_download_base_url`) check protocol and a trailing channel segment, never host identity. `upload-gcs.sh` needs no edit at all — `derive_download_base_url` recovers the base URL from the built `latest.json`, so the upload side follows the build automatically.

## Changes

- The five in-repo defaults: `build-portable.mjs`, `build-release.sh`, `release-gcs.sh`, `install.sh`, and the CLI's `portable-installer.ts`.
- The server-side Zod default in `packages/server/src/config.ts`, which drives both the channel-target poller and the `install.sh` URL baked into every Computer connect command.
- Test assertions that pin those defaults, plus pass-through fixtures, kept consistent.
- Docs (EN + zh-CN mirrors, sync dates refreshed).

### New test coverage

`scripts/portable/install.sh`'s `DOWNLOAD_BASE_URL` fallback was pinned by **no test at all** — it was the one default that could have silently kept the old host with `pnpm check` and `pnpm test` both green. It is now covered by the same ratchet that pins the bucket and prefix. Verified by regressing the literal and confirming the test fails.

## Operational notes

- **The CI repository variable has been repointed.** `vars.OPENTAG_PORTABLE_DOWNLOAD_BASE_URL` was explicitly set to the old URL and overrides every in-repo default in all four publish steps. Without that update this PR would have been completely inert for real releases, and silently so, since build and upload read the same variable and would have agreed with each other.
- **The cutover completes at the next release, not at merge.** The published per-channel `install.sh` is a *rendered* copy with the base URL baked in, and `latest.json` / `manifest.json` embed absolute asset URLs. Until a release is published, the new domain still serves artifacts pointing at the old host.
- **Both hosts must stay live.** Version prefixes are immutable (create-only), so every already-published `manifest.json` points at the old host permanently. Pinned installs (`--version <old>`) and rollbacks will keep using it. This is an additive cutover; the old host cannot be decommissioned.
- No ordering of (merge) × (variable update) × (next release) breaks an install or a self-update. Installers resolve the tarball from the manifest's absolute `asset.url` and validate only the scheme, so mixed-host states install correctly.
- Worth re-validating on the new domain before the first publish: it must honor the object `Cache-Control` headers, since channel pointers are written `no-cache` and re-read immediately by the post-publish verification.

## Testing

All green locally:

- `pnpm check`
- `pnpm typecheck`
- `pnpm test` (263 test files)
- `pnpm build`
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — 100% statements/branches/functions/lines
- `pnpm --filter @opentag/server test:integration` — 18 files, 324 tests (this suite owns the `bootstrapCommand` assertion in `computers.test.ts`, which `pnpm check`/`pnpm test` do not cover)

No migration is added, so the `CURRENT_MIGRATION_COUNT` ratchet does not apply.
