### PR TITLE
test(portable): retain the installed-vs-source pin regression

### DIFF
--- a/scripts/__tests__/portable-runtime-dependencies.test.mjs
+++ b/scripts/__tests__/portable-runtime-dependencies.test.mjs
@@ -220,6 +220,23 @@ test("materializing the closure copies published content and never runs lifecycl
   assert.deepEqual(readdirSync(join(appDir, "node_modules")).sort(), ["@first-tree-ai", "commander"]);
 });
 
+test("the installed direct dependency must match the exact source pin", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const cliRoot = fixtureCliRoot(root);
+  const sourcePin = JSON.parse(readFileSync(join(cliRoot, "package.json"), "utf8")).dependencies[
+    "@first-tree-ai/context-tree"
+  ];
+  writeContextTreePackage(join(cliRoot, "node_modules"), { version: "0.0.1" });
+  assert.throws(
+    () => collectRuntimeDependencyClosure({ sourceManifestPath: join(cliRoot, "package.json") }),
+    (error) =>
+      error.message.includes(
+        `installed package @first-tree-ai/context-tree is version 0.0.1, but the source pins ${sourcePin}`,
+      ),
+  );
+});
+
 test("a declared dependency that is not installed fails closed", async (t) => {
   const root = await mkdtemp(join(tmpdir(), "opentag-portable-rdep-"));
   t.after(() => rm(root, { force: true, recursive: true }));


### PR DESCRIPTION
Follow-up to #552, which removed the regression test for the installed-vs-source pin check while bumping `@first-tree-ai/context-tree` to 0.1.11. @yuezengwu asked in review on that PR to retain the coverage.

The production guard it covered is still live — `collectRuntimeDependencyClosure` fails closed when an installed runtime dependency's version differs from the exact source pin (`scripts/portable/runtime-dependencies.mjs`). Without the test, nothing in CI proves that branch still throws.

This restores the test with one change to why it was dropped: the expected pin is now read from the fixture manifest instead of hard-coded, so the next context-tree bump does not force an edit here. The deliberately-wrong installed version is `0.0.1`, which no future pin will collide with.

## Validation

- `node --test scripts/__tests__/portable-runtime-dependencies.test.mjs` — 19/19 pass (was 18).
- `node --test scripts/__tests__/*.test.mjs` — 330/330 pass.
- `pnpm check` — exit 0.
- Mutation check: disabling the pin comparison in `runtime-dependencies.mjs` makes exactly this test fail (18 pass / 1 fail), confirming it observes the guard rather than passing vacuously.
