### PR TITLE
fix(agents): keep list order stable by creation time

### DIFF
--- a/apps/web/src/features/agent-list-order.test.ts
+++ b/apps/web/src/features/agent-list-order.test.ts
@@ -37,11 +37,11 @@ import { agentDetailLink, agentSettingsLink, agentSettingsSectionLink, agentUsag
 import { agentSettingsSummary } from "./agents/agent-settings/sections.js";
 
 describe("Agent list order", () => {
-  it("takes the incoming priority order on the first render", () => {
+  it("takes the Server's creation order on the first render", () => {
     expect(orderAgentIds(["c", "a", "b"], [])).toEqual(["c", "a", "b"]);
   });
 
-  it("keeps the shown order when a status change would resort the list", () => {
+  it("keeps the shown order if background revalidation changes the incoming order", () => {
     expect(orderAgentIds(["c", "a", "b"], ["a", "b", "c"])).toEqual(["a", "b", "c"]);
   });
 
@@ -385,7 +385,6 @@ describe("Agent availability model and presentation", () => {
     expect(agentCardStatus({ ...base, evidenceConfirmed: true } as never)).toEqual({
       detail: undefined,
       label: "Ready for new work",
-      priority: 3,
       tone: "success",
     });
     expect(
@@ -397,7 +396,6 @@ describe("Agent availability model and presentation", () => {
     ).toEqual({
       detail: "Working now · started 8m ago",
       label: "Ready for new work",
-      priority: 3,
       tone: "success",
     });
     expect(agentCardStatus({ ...base, evidenceConfirmed: false } as never)).toMatchObject({
@@ -409,28 +407,28 @@ describe("Agent availability model and presentation", () => {
         evidenceConfirmed: true,
         availability: { ...base.availability, state: "not_connected" },
       } as never),
-    ).toEqual({ label: "Messaging not connected", priority: 2, tone: "neutral" });
+    ).toEqual({ label: "Messaging not connected", tone: "neutral" });
     expect(
       agentCardStatus({
         ...base,
         evidenceConfirmed: true,
         availability: { ...base.availability, state: "action_required", reason: "runtime_unavailable" },
       } as never),
-    ).toMatchObject({ label: "Codex unavailable", priority: 0, tone: "warning" });
+    ).toMatchObject({ label: "Codex unavailable", tone: "warning" });
     expect(
       agentCardStatus({
         ...base,
         evidenceConfirmed: true,
         availability: { ...base.availability, state: "action_required", reason: "im_error" },
       } as never),
-    ).toEqual({ label: "Messaging connection failed", priority: 0, tone: "warning" });
+    ).toEqual({ label: "Messaging connection failed", tone: "warning" });
     expect(
       agentCardStatus({
         ...base,
         evidenceConfirmed: true,
         availability: { ...base.availability, state: "setting_up", reason: "im_provisioning" },
       } as never),
-    ).toMatchObject({ label: "Setting up messaging", priority: 2, tone: "info" });
+    ).toMatchObject({ label: "Setting up messaging", tone: "info" });
     expect(titleCase("runtime_unavailable")).toBe("Runtime Unavailable");
     expect(platformLabel("darwin")).toBe("macOS");
     expect(platformLabel("win32")).toBe("Windows");

--- a/apps/web/src/features/agent-list-order.ts
+++ b/apps/web/src/features/agent-list-order.ts
@@ -1,12 +1,11 @@
 /**
  * Display order for the Agent list, held stable for as long as the list stays mounted.
  *
- * The list revalidates in the background every 30 seconds, and its status-first sort moves a
- * row the moment an Agent's availability changes. Because the whole row is a link, a row that
- * moves under the pointer opens a different Agent than the one that was pressed. Rows keep the
- * position they were first shown in, and an Agent that changes state turns amber where it
- * already is rather than jumping to the top unobserved. Agents added since the first render
- * join at the end, in the incoming order.
+ * The Server orders Agents by creation time ascending, then ID ascending. Status, activity,
+ * usage, and names do not affect that order. Because the whole row is a link, background
+ * revalidation must also preserve the positions already shown under the viewer's pointer.
+ * Surviving rows keep their relative order, and newly observed Agents join at the end in the
+ * Server's order. Remounting the list starts from the same canonical Server order.
  *
  * The result is stable under reapplication, so re-rendering with an unchanged list is a no-op.
  */

--- a/apps/web/src/features/agents/agent-presentation.ts
+++ b/apps/web/src/features/agents/agent-presentation.ts
@@ -20,25 +20,24 @@ import type { AgentSettingsSection } from "./agent-settings/sections.js";
 type AgentCardStatus = {
   detail?: string;
   label: string;
-  priority: number;
   tone: StatusTone;
 };
 
 export function agentCardStatus(agent: AgentListItem): AgentCardStatus {
   if (agent.status === "suspended" || agent.availability.state === "suspended") {
-    return { label: m.agents_card_status_paused(), priority: 4, tone: "neutral" };
+    return { label: m.agents_card_status_paused(), tone: "neutral" };
   }
   if (!agent.evidenceConfirmed || agent.availability.state === "unconfirmed") {
-    return { label: m.agents_card_status_unavailable(), priority: 1, tone: "neutral" };
+    return { label: m.agents_card_status_unavailable(), tone: "neutral" };
   }
   if (agent.availability.state === "ready") {
     return readyAgentCardStatus(agent);
   }
   if (agent.availability.state === "setting_up") {
-    return { label: m.agents_card_status_setting_up_messaging(), priority: 2, tone: "info" };
+    return { label: m.agents_card_status_setting_up_messaging(), tone: "info" };
   }
   if (agent.availability.state === "not_connected") {
-    return { label: m.agents_card_status_messaging_not_connected(), priority: 2, tone: "neutral" };
+    return { label: m.agents_card_status_messaging_not_connected(), tone: "neutral" };
   }
   return blockedAgentCardStatus(agent);
 }
@@ -50,50 +49,48 @@ function readyAgentCardStatus(agent: AgentListItem): AgentCardStatus {
         ? m.agents_card_activity_working({ elapsed: formatElapsedCompact(agent.activity.startedAt) })
         : undefined,
     label: m.agents_card_status_ready(),
-    priority: 3,
     tone: "success",
   };
 }
 
 function blockedAgentCardStatus(agent: AgentListItem): AgentCardStatus {
   if (agent.availability.reason === "computer_not_bound") {
-    return { label: m.agents_card_status_no_computer(), priority: 2, tone: "neutral" };
+    return { label: m.agents_card_status_no_computer(), tone: "neutral" };
   }
   if (agent.availability.reason === "computer_offline") {
-    return { label: m.agents_card_status_computer_offline(), priority: 0, tone: "warning" };
+    return { label: m.agents_card_status_computer_offline(), tone: "warning" };
   }
   if (agent.availability.reason === "runtime_unavailable") {
     return runtimeAgentCardStatus(agent);
   }
   if (agent.availability.reason === "im_reauthorization_required") {
-    return { label: m.agents_card_status_messaging_permissions_required(), priority: 0, tone: "warning" };
+    return { label: m.agents_card_status_messaging_permissions_required(), tone: "warning" };
   }
   if (agent.availability.reason === "im_disabled") {
-    return { label: m.agents_card_status_messaging_disconnected(), priority: 2, tone: "neutral" };
+    return { label: m.agents_card_status_messaging_disconnected(), tone: "neutral" };
   }
   if (agent.availability.reason === "handoff_unavailable") {
-    return { label: m.agents_card_status_cannot_receive_messages(), priority: 0, tone: "warning" };
+    return { label: m.agents_card_status_cannot_receive_messages(), tone: "warning" };
   }
-  return { label: m.agents_card_status_messaging_connection_failed(), priority: 0, tone: "warning" };
+  return { label: m.agents_card_status_messaging_connection_failed(), tone: "warning" };
 }
 
 function runtimeAgentCardStatus(agent: AgentListItem): AgentCardStatus {
   const { provider, status } = agent.availability.dependencies.runtime;
   const providerName = runtimeProviderName(provider);
   if (status === "checking") {
-    return { label: m.agents_card_status_runtime_checking({ providerName }), priority: 2, tone: "info" };
+    return { label: m.agents_card_status_runtime_checking({ providerName }), tone: "info" };
   }
   if (status === "install") {
-    return { label: m.agents_card_status_runtime_not_installed({ providerName }), priority: 0, tone: "warning" };
+    return { label: m.agents_card_status_runtime_not_installed({ providerName }), tone: "warning" };
   }
   if (status === "sign-in") {
     return {
       label: m.agents_card_status_runtime_sign_in_required({ providerName }),
-      priority: 0,
       tone: "warning",
     };
   }
-  return { label: m.agents_card_status_runtime_unavailable({ providerName }), priority: 0, tone: "warning" };
+  return { label: m.agents_card_status_runtime_unavailable({ providerName }), tone: "warning" };
 }
 
 /**

--- a/apps/web/src/features/agents/agents-page.test.tsx
+++ b/apps/web/src/features/agents/agents-page.test.tsx
@@ -1,0 +1,71 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { agentListItem, secondAgentListItem } from "../../__tests__/support/app-fixtures.js";
+import { renderInRouter } from "../../__tests__/support/router.js";
+import type { AgentListItem } from "./agent-model.js";
+import { AgentList } from "./agents-page.js";
+
+const readyAgent: AgentListItem = {
+  ...agentListItem,
+  evidenceConfirmed: true,
+  availability: {
+    state: "ready",
+    reason: null,
+    lastConfirmedAt: agentListItem.updatedAt,
+    dependencies: {
+      computer: { state: "ready", lastConfirmedAt: agentListItem.updatedAt },
+      runtime: { provider: "codex", status: "ready" },
+      channel: { state: "connected", provider: "feishu", botDisplayName: "Reviewer" },
+      handoff: { state: "ready", lastConfirmedAt: agentListItem.updatedAt },
+    },
+  },
+};
+
+function shownAgents() {
+  return screen.getAllByRole("link", { name: /^Open / }).map((link) => link.getAttribute("aria-label"));
+}
+
+describe("Agent list creation order", () => {
+  it("preserves Server order across status, name, usage, activity changes and remounts", async () => {
+    const newerAgent: AgentListItem = {
+      ...readyAgent,
+      ...secondAgentListItem,
+      createdAt: "2026-08-21T00:00:00.000Z",
+      availability: {
+        ...readyAgent.availability,
+        state: "not_connected",
+        reason: "im_not_connected",
+        dependencies: {
+          ...readyAgent.availability.dependencies,
+          channel: { state: "not_connected", provider: null, botDisplayName: null },
+          handoff: { state: "not_connected", lastConfirmedAt: null },
+        },
+      },
+    };
+    const { rerender } = await renderInRouter(<AgentList agents={[readyAgent, newerAgent]} />);
+    expect(shownAgents()).toEqual(["Open Reviewer", "Open Helper"]);
+    expect(screen.getByText("Messaging not connected")).toBeTruthy();
+    const originalRow = screen.getByRole("link", { name: "Open Reviewer" });
+
+    const updatedAgents: AgentListItem[] = [
+      { ...readyAgent, status: "suspended" },
+      {
+        ...newerAgent,
+        name: "aaa-helper",
+        displayName: "Renamed Helper",
+        updatedAt: "2026-08-22T00:00:00.000Z",
+        availability: readyAgent.availability,
+        activity: { state: "working", startedAt: new Date().toISOString() },
+        usage: { windowDays: 30, tasks: 100, failed: 0, tokens: 1_000_000 },
+      },
+    ];
+    rerender(<AgentList agents={updatedAgents} />);
+    expect(shownAgents()).toEqual(["Open Reviewer", "Open Renamed Helper"]);
+    expect(screen.getByRole("link", { name: "Open Reviewer" })).toBe(originalRow);
+    expect(screen.getByText("100 tasks")).toBeTruthy();
+
+    rerender(<AgentList agents={updatedAgents} key="reopened" />);
+    expect(shownAgents()).toEqual(["Open Reviewer", "Open Renamed Helper"]);
+    expect(screen.getByRole("link", { name: "Open Reviewer" })).not.toBe(originalRow);
+  });
+});

--- a/apps/web/src/features/agents/agents-page.tsx
+++ b/apps/web/src/features/agents/agents-page.tsx
@@ -51,17 +51,14 @@ export function AgentsContent({ agents }: { agents: AgentListItem[] }) {
 
 export function AgentList({ agents }: { agents: AgentListItem[] }) {
   const shownOrder = useRef<readonly string[]>([]);
-  const byPriority = [...agents].sort(
-    (left, right) => agentCardStatus(left).priority - agentCardStatus(right).priority,
-  );
   const byId = new Map(agents.map((agent) => [agent.id, agent]));
   /*
    * Written during render on purpose. `orderAgentIds` is stable under reapplication, so a
    * repeated render of the same list produces the same order; deferring it to an effect would
-   * show one frame of the resorted list before restoring the order the viewer is pointing at.
+   * show one frame of a changed order before restoring the order the viewer is pointing at.
    */
   const order = orderAgentIds(
-    byPriority.map((agent) => agent.id),
+    agents.map((agent) => agent.id),
     shownOrder.current,
   );
   shownOrder.current = order;

--- a/packages/server/src/services/agents/__tests__/agent-service.test.ts
+++ b/packages/server/src/services/agents/__tests__/agent-service.test.ts
@@ -215,6 +215,52 @@ async function createDelivery(
 }
 
 describe("AgentService", () => {
+  it("lists Agents by creation time and ID, preserving order through edits and appending new Agents", async () => {
+    const { bootstrap, computer, service } = await fixture();
+    const oldest = {
+      id: "33333333-3333-4333-8333-333333333333",
+      name: "zulu",
+      createdAt: new Date("2026-08-20T00:00:00.000Z"),
+    };
+    const tiedFirst = {
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "charlie",
+      createdAt: new Date("2026-08-21T00:00:00.000Z"),
+    };
+    const tiedSecond = {
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "bravo",
+      createdAt: tiedFirst.createdAt,
+    };
+    await unitDatabase.database.insert(agents).values(
+      [tiedSecond, tiedFirst, oldest].map((agent) => ({
+        ...agent,
+        displayName: agent.name,
+        createdByUserId: bootstrap.userId,
+        computerId: computer.id,
+        runtimeProvider: "codex" as const,
+        updatedAt: agent.createdAt,
+      })),
+    );
+    const expectedOrder = [oldest.id, tiedFirst.id, tiedSecond.id];
+    expect((await service.listForAccount(bootstrap.userId)).agents.map((agent) => agent.id)).toEqual(expectedOrder);
+
+    await unitDatabase.database
+      .update(agents)
+      .set({ name: "alpha", displayName: "Renamed Agent", status: "suspended", updatedAt: NOW })
+      .where(eq(agents.id, tiedSecond.id));
+    const freshService = new AgentService(unitDatabase.database, { now: () => NOW });
+    expect((await freshService.listForAccount(bootstrap.userId)).agents.map((agent) => agent.id)).toEqual(
+      expectedOrder,
+    );
+
+    const newest = await createAgent(service, bootstrap.userId, computer.id, "aaa-new-agent");
+    expect((await service.listForAccount(bootstrap.userId)).agents.map((agent) => agent.id)).toEqual([
+      ...expectedOrder,
+      newest.id,
+    ]);
+  });
+
   it("fails loudly when a stored Agent projection is internally inconsistent", async () => {
     const { bootstrap, computer, service } = await fixture();
     const created = await createAgent(service, bootstrap.userId, computer.id);

--- a/packages/server/src/services/agents/agent-service.ts
+++ b/packages/server/src/services/agents/agent-service.ts
@@ -584,7 +584,7 @@ export class AgentService {
       .innerJoin(creator, eq(creator.id, agents.createdByUserId))
       .leftJoin(computers, eq(computers.id, agents.computerId))
       .where(and(eq(agents.createdByUserId, callerUserId), ne(agents.status, "deleted")))
-      .orderBy(asc(agents.name), asc(agents.id));
+      .orderBy(asc(agents.createdAt), asc(agents.id));
     const summaries = rows.flatMap((row) => {
       if (!row.id) return [];
       if (!row.creatorDisplayName) throw new Error("Active Agent is missing its creator audit record");


### PR DESCRIPTION
## Summary

Agents with unfinished setup currently appear ahead of Ready Agents, and reopening the list can move rows as their status changes. Order the account's Agents by creation time ascending, with ID ascending as the tie-breaker, and remove the web list's status ranking.

Existing rows retain their positions during background refreshes, newly observed Agents append at the end, and reopening the list uses the same server order. Regression tests cover equal creation timestamps, edits, new Agents, status and usage changes, and component remounts.

## Testing

- Passed: `pnpm install --frozen-lockfile`, `pnpm check`, `pnpm build`, and `pnpm typecheck`.
- `pnpm test`: Shared (220 tests), Client (988), and Server (854) passed. CLI passed 429/431 tests; two daemon-wrapper tests read this machine's existing credentials and returned exit code 1 instead of 3. The same two failures reproduced against an `origin/main` CLI source snapshot (`dcae5e42`) with identical Client/Shared dependencies. Rerunning both files with an isolated, empty `OPENTAG_HOME` passed all 15 tests.
- Passed: `pnpm --filter @opentag/web test` (683 tests across 64 files), run separately after the CLI failure interrupted the aggregate run.
- Passed: `pnpm --filter @opentag/client test:agent-runtime:coverage` (360 tests; statements, branches, functions, and lines all 100%).
- `pnpm --filter @opentag/server test:integration`: 322/324 tests passed; one Session collaboration test and one setup-backfill test exceeded the default 5-second timeout during concurrent local validation. Rerunning both complete files with `--maxWorkers=1` passed all 20 tests without code or timeout changes.

The aggregate-test checklist remains unchecked because the unmodified `pnpm test` command encountered the local credential issue described above.

## UI validation

- Desktop/mobile evidence: component regression tests verify displayed row order, live updates, and reopening the list. No manual screenshots were captured.
- Widths checked: N/A for `320px`, `390px`, `768px`, and `1440px`; the change is to ordering only and uses the same list component at every width.
- States verified: Ready, messaging not connected, suspended, working, renamed, updated usage, initial render, background rerender, and remount.
- Keyboard/accessibility checks: the regression test verifies that an existing Agent's link keeps its DOM identity across updates; existing app-shell tests exercise the list links and Agent navigation.
- New reusable block, theme value, or CSS exception: none.

## Breaking changes

The Agent list API's default order changes from name ascending to creation time ascending. Its response schema is unchanged.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no documentation changes).
