### PR TITLE
fix(client): grant runtimes access to Context Tree configuration

### DIFF
--- a/apps/cli/src/__tests__/context-tree.test.ts
+++ b/apps/cli/src/__tests__/context-tree.test.ts
@@ -178,29 +178,32 @@ describe("readContextTreeState", () => {
     });
   });
 
-  it("reports a recorded unavailable GitHub preparation as invalid", async () => {
-    const home = await temporaryDirectory("opentag-ct-state-preparation-");
-    await mkdir(join(home, "config"), { mode: 0o700, recursive: true });
-    await mkdir(join(home, "state"), { mode: 0o700, recursive: true });
-    await writeFile(
-      configFile(home),
-      JSON.stringify({ schemaVersion: 1, target: { kind: "github", repository: "acme/missing" } }),
-      "utf8",
-    );
-    await writeFile(
-      join(home, "state", "context-tree-preparation.json"),
-      JSON.stringify({
-        schemaVersion: 1,
-        target: "acme/missing",
-        status: "unavailable",
-        reason: "GITHUB_AUTH",
-        at: new Date().toISOString(),
-      }),
-      "utf8",
-    );
+  it.each(["GITHUB_AUTH", "SHIM_UNAVAILABLE", "PACKAGE_MISSING"])(
+    "reports recorded %s preparation instead of not cloned",
+    async (reason) => {
+      const home = await temporaryDirectory("opentag-ct-state-preparation-");
+      await mkdir(join(home, "config"), { mode: 0o700, recursive: true });
+      await mkdir(join(home, "state"), { mode: 0o700, recursive: true });
+      await writeFile(
+        configFile(home),
+        JSON.stringify({ schemaVersion: 1, target: { kind: "github", repository: "acme/missing" } }),
+        "utf8",
+      );
+      await writeFile(
+        join(home, "state", "context-tree-preparation.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          target: "acme/missing",
+          status: "unavailable",
+          reason,
+          at: new Date().toISOString(),
+        }),
+        "utf8",
+      );
 
-    await expect(
-      readContextTreeState({ home, contextTreePackage: await fakeCli({ list: listing([]) }) }),
-    ).resolves.toMatchObject({ target: "acme/missing", tree: "invalid", detail: "GITHUB_AUTH" });
-  });
+      await expect(
+        readContextTreeState({ home, contextTreePackage: await fakeCli({ list: listing([]) }) }),
+      ).resolves.toMatchObject({ target: "acme/missing", tree: "invalid", detail: reason });
+    },
+  );
 });

--- a/apps/cli/src/__tests__/context-tree.test.ts
+++ b/apps/cli/src/__tests__/context-tree.test.ts
@@ -77,6 +77,34 @@ describe("opentag context-tree connect", () => {
     expect(text()).toContain("team-context-tree");
   });
 
+  it("requires reconnecting an old-only configuration and reads the new target afterward", async () => {
+    const home = await temporaryDirectory("opentag-ct-upgrade-");
+    const oldFile = join(home, "config", "context-tree.json");
+    const oldConfig = JSON.stringify({ schemaVersion: 1, target: { kind: "managed", name: "old-tree" } });
+    await mkdir(join(home, "config"), { recursive: true });
+    await writeFile(oldFile, oldConfig);
+    const contextTreePackage = await fakeCli({ list: listing(["new-tree"]) });
+
+    await expect(readContextTreeState({ home, contextTreePackage })).resolves.toEqual({
+      configPath: configFile(home),
+      tree: "unknown",
+    });
+    await expect(readFile(configFile(home))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      runContextTreeConnect({ ...capture().deps, home, contextTreePackage, target: "new-tree" }),
+    ).resolves.toEqual({ exitCode: 0 });
+    expect(JSON.parse(await readFile(configFile(home), "utf8"))).toEqual({
+      schemaVersion: 1,
+      target: { kind: "managed", name: "new-tree" },
+    });
+    await expect(readContextTreeState({ home, contextTreePackage })).resolves.toEqual({
+      configPath: configFile(home),
+      target: "new-tree",
+      tree: "valid",
+    });
+    await expect(readFile(oldFile, "utf8")).resolves.toBe(oldConfig);
+  });
+
   it("accepts a GitHub target without network work, and says who clones it", async () => {
     const home = await temporaryDirectory("opentag-ct-github-");
     const { deps, text } = capture();

--- a/apps/cli/src/__tests__/context-tree.test.ts
+++ b/apps/cli/src/__tests__/context-tree.test.ts
@@ -53,7 +53,7 @@ function capture(): { deps: { stdout: (chunk: string) => void; stderr: (chunk: s
 const listing = (names: readonly string[]) => ({
   payload: { schemaVersion: 1, trees: names.map((name) => ({ name, tree: { kind: "local", path: `/t/${name}` } })) },
 });
-const configFile = (home: string) => join(home, "config", "context-tree.json");
+const configFile = (home: string) => join(home, "config", "context-tree", "config.json");
 const invalid = { findings: [{ code: "MISSING_ROOT" }], ok: false };
 
 describe("opentag context-tree connect", () => {
@@ -159,7 +159,7 @@ describe("readContextTreeState", () => {
   ])("reports %s", async (_label, target, responses, expected) => {
     const home = await temporaryDirectory("opentag-ct-state-");
     if (target !== undefined) {
-      await mkdir(join(home, "config"), { mode: 0o700, recursive: true });
+      await mkdir(join(home, "config", "context-tree"), { mode: 0o700, recursive: true });
       await writeFile(configFile(home), JSON.stringify({ schemaVersion: 1, target }), "utf8");
     }
 
@@ -170,7 +170,7 @@ describe("readContextTreeState", () => {
 
   it("treats unreadable configuration as unknown rather than failing", async () => {
     const home = await temporaryDirectory("opentag-ct-state-bad-");
-    await mkdir(join(home, "config"), { mode: 0o700, recursive: true });
+    await mkdir(join(home, "config", "context-tree"), { mode: 0o700, recursive: true });
     await writeFile(configFile(home), "{ not json", "utf8");
 
     await expect(readContextTreeState({ home, contextTreePackage: await fakeCli({}) })).resolves.toMatchObject({
@@ -182,7 +182,7 @@ describe("readContextTreeState", () => {
     "reports recorded %s preparation instead of not cloned",
     async (reason) => {
       const home = await temporaryDirectory("opentag-ct-state-preparation-");
-      await mkdir(join(home, "config"), { mode: 0o700, recursive: true });
+      await mkdir(join(home, "config", "context-tree"), { mode: 0o700, recursive: true });
       await mkdir(join(home, "state"), { mode: 0o700, recursive: true });
       await writeFile(
         configFile(home),

--- a/apps/cli/src/__tests__/doctor.test.ts
+++ b/apps/cli/src/__tests__/doctor.test.ts
@@ -695,9 +695,9 @@ describe("doctor report and exit contract", () => {
   it("never lets a Context Tree fault change the doctor exit code", async () => {
     const home = await createHome();
     const cases = [
-      { configPath: resolve(home, "config", "context-tree.json"), tree: "unknown" as const },
+      { configPath: resolve(home, "config", "context-tree", "config.json"), tree: "unknown" as const },
       {
-        configPath: resolve(home, "config", "context-tree.json"),
+        configPath: resolve(home, "config", "context-tree", "config.json"),
         target: "team-context-tree",
         tree: "invalid" as const,
         detail: "DIRTY_TREE",
@@ -720,7 +720,7 @@ describe("doctor report and exit contract", () => {
     const home = await createHome();
     const result = await runHealthyDoctor(home, {
       inspectContextTreeState: vi.fn().mockResolvedValue({
-        configPath: resolve(home, "config", "context-tree.json"),
+        configPath: resolve(home, "config", "context-tree", "config.json"),
         tree: "unknown" as const,
       }),
     });
@@ -735,7 +735,7 @@ describe("doctor report and exit contract", () => {
     const home = await createHome();
     const result = await runHealthyDoctor(home, {
       inspectContextTreeState: vi.fn().mockResolvedValue({
-        configPath: resolve(home, "config", "context-tree.json"),
+        configPath: resolve(home, "config", "context-tree", "config.json"),
         target: "acme/shared-context",
         tree: "not-cloned" as const,
       }),
@@ -802,7 +802,7 @@ async function runHealthyDoctor(home: string, overrides: Partial<DoctorOptions> 
 
 function configuredContextTree(home: string) {
   return {
-    configPath: resolve(home, "config", "context-tree.json"),
+    configPath: resolve(home, "config", "context-tree", "config.json"),
     target: "team-context-tree",
     tree: "valid" as const,
   };

--- a/apps/cli/src/core/context-tree/shared.ts
+++ b/apps/cli/src/core/context-tree/shared.ts
@@ -38,7 +38,7 @@ export function resolveContextTreeAssets(deps: ContextTreeCommandDeps = {}): Con
 }
 
 export function contextTreeConfigPath(home: string): string {
-  return join(home, "config", "context-tree.json");
+  return join(home, "config", "context-tree", "config.json");
 }
 
 export async function readContextTreeConfig(home: string): Promise<ContextTreeConfig | undefined> {

--- a/docs/design/context-tree-integration.md
+++ b/docs/design/context-tree-integration.md
@@ -157,11 +157,16 @@ What this costs, stated rather than left implicit:
 
 ### The CLI shim
 
-`<OPENTAG_HOME>/context-tree/bin/context-tree` is a generated `0700` shim that execs the installed
+`<OPENTAG_HOME>/context-tree/bin/context-tree` is a generated `0700` shim that execs the bundled
 CLI with the same Node.js runtime OpenTag itself uses, so a Session cannot resolve a different one
 from the user's shell configuration. That directory is prepended to the Provider `PATH` during
 Client composition, unconditionally — it is a stable OpenTag-owned path, and a directory that does
 not exist yet is inert on `PATH`.
+
+The shim is prepared before checking Computer configuration, so an unconfigured Computer can run
+the bundled command without creating or connecting a tree. Preparation failures retain the existing
+unavailable statuses. Managed instructions identify command availability failures as runtime setup
+problems; a global install is unnecessary.
 
 The package's own `node_modules/.bin/context-tree` is not used for this: npm populates
 `<consumer>/node_modules/.bin` but pnpm's virtual store does not, so the location is not portable
@@ -171,6 +176,12 @@ resolve whatever `node` the Session's `PATH` happens to find.
 It is prepended at composition rather than through per-Session workspace environment because a
 Session-level `PATH` would replace the value the factory composes, including the discovered
 executable directory that lets `codex` and `claude` resolve at all.
+
+Visible Sessions supply their tool directory through workspace `pathPrepend`. Every Provider factory
+prepends it after composing its environment, preserving the Context Tree and executable directories.
+Internal Sessions retain Context Tree without adding visible-Session tools.
+
+Rollout requires restarting the daemon and affected Sessions after release; no migration is needed.
 
 OpenTag's own invocations never rely on the shim: they exec the resolved CLI path directly, so a
 broken or shadowed shim cannot change what OpenTag executes.

--- a/docs/design/context-tree-integration.md
+++ b/docs/design/context-tree-integration.md
@@ -74,7 +74,7 @@ There is deliberately no `inspect` subcommand. `opentag doctor` already owns dia
 the injectable-inspector seam, and two surfaces over one piece of state means every future reason
 code has to be rendered twice.
 
-The target is recorded machine-locally in `<OPENTAG_HOME>/config/context-tree.json`, mode
+The target is recorded machine-locally in `<OPENTAG_HOME>/config/context-tree/config.json`, mode
 `0600`, credential-free. The Server is not involved. The three target kinds mirror
 `context-tree connect`'s own argument shape, so OpenTag passes the target through rather than
 reinterpreting it.
@@ -238,10 +238,12 @@ a managed `CODEX_HOME`. That option was dropped because it changes provider arti
 invalidating existing bindings, and forces a visible one-time `codex login` in the managed home.
 Writing one owned, reversible skill directory is the smaller intrusion.
 
-OpenTag creates the Computer config directory before granting access. Linux grants that directory,
-allowing initial file creation, atomic replacement, and changes to sibling configuration files.
-macOS retains the Context Tree config-file grant. If directory creation fails, OpenTag logs the
-failure and starts the provider without that grant, preserving workspace, Slack, and tree grants.
+OpenTag creates the Context Tree config leaf — `<OPENTAG_HOME>/config/context-tree/` — before
+granting access, on both platforms. The grant is that leaf directory, which contains exactly one
+file, so it carries no more authority on Linux than the macOS file grant and never touches
+`<OPENTAG_HOME>/config`, where the Computer's identity and machine credential live. If directory
+creation fails, OpenTag logs the failure and starts the provider without that grant, preserving
+workspace, Slack, and tree grants.
 
 Codex runs `workspace-write`, so a shared tree outside the workspace would be read-only to it.
 The resolved tree path is appended to `writableRoots`, composing with the Slack config root rather
@@ -385,20 +387,3 @@ the dependency from the published bundle.
 - Windows support, which needs Provider lifecycle, path, lock, and isolated-home CI coverage
   first. The shim is POSIX and reports `shim_unavailable` elsewhere.
 - Any Provider beyond Codex and Claude Code.
-
-### Linux configuration-grant smoke verification (2026-09-08)
-
-An offline smoke run used Codex CLI 0.114.0 (Linux aarch64), Node 24 in Docker,
-and the built OpenTag CLI with Context Tree 0.1.11. The container used
-`--network none --security-opt seccomp=unconfined`; Codex itself actively enforced
-`sandbox linux --full-auto` with
-`sandbox_workspace_write.writable_roots=["/computer/config"]`, cwd `/workspace`.
-Codex's `sandbox_workspace_write.network_access=true` allowed Node's local subprocess
-machinery; Docker still disabled external networking. With Codex network access disabled,
-Node subprocess creation returned `EPERM`, so that configuration did not complete the smoke.
-
-After creating two real local trees outside the sandbox, the sandboxed OpenTag command
-created an absent `/computer/config/context-tree.json` with
-`context-tree connect --tree-path <first-tree>`, then replaced it with the second target.
-A write to `/computer/unrelated` failed with `Permission denied`, confirming filesystem
-enforcement outside the granted directory. This was not an unsandboxed container run.

--- a/docs/design/context-tree-integration.md
+++ b/docs/design/context-tree-integration.md
@@ -79,6 +79,10 @@ The target is recorded machine-locally in `<OPENTAG_HOME>/config/context-tree.js
 `context-tree connect`'s own argument shape, so OpenTag passes the target through rather than
 reinterpreting it.
 
+Visible and internal Agents can change this Computer-wide configuration directly. Schema validation
+still applies when reading it, but direct edits bypass command-level target validation. Later
+Provider Runtime starts consume the changed target.
+
 `connect` validates without side effects: `list` for a managed name, `verify` for an exact path.
 It deliberately does not connect a throwaway project directory to test a target, because that
 would leave a stale record in the CLI's connection store and write instruction files into it.
@@ -120,7 +124,7 @@ admission, so work placed there would run per Turn.
 The CLI replaces its connection store atomically but without a cross-process lock, so concurrent
 read-modify-write can lose unrelated records. OpenTag serializes its own invocations behind one
 in-process mutex. Concurrent starts for the same workspace join one in-flight preparation.
-Session start races that work against a 5-second budget: if preparation is still running, the
+Session start races the full pipeline, including shim preparation and configuration reads, against a 5-second budget: if preparation is still running, the
 Session receives `PREPARING` and starts without durable memory while the serialized work continues
 in the background. A completed success is cached per workspace and target. A failure is held in a
 one-minute cooldown, limiting an unreachable target to one attempt per minute per workspace while
@@ -162,6 +166,12 @@ CLI with the same Node.js runtime OpenTag itself uses, so a Session cannot resol
 from the user's shell configuration. That directory is prepended to the Provider `PATH` during
 Client composition, unconditionally — it is a stable OpenTag-owned path, and a directory that does
 not exist yet is inert on `PATH`.
+
+Shim preparation is shared across workspaces and cached after success for the manager's lifetime;
+restart the daemon to refresh it. Failed preparation retries after the one-minute cooldown.
+Configured package and shim failures replace the durable preparation record and use the workspace
+cooldown. Without a target they remain unavailable statuses without creating a preparation record;
+they are distinct from ordinary unconfigured state.
 
 The shim is prepared before checking Computer configuration, so an unconfigured Computer can run
 the bundled command without creating or connecting a tree. Preparation failures retain the existing
@@ -227,6 +237,11 @@ This mutates user configuration, which an earlier revision of this document reje
 a managed `CODEX_HOME`. That option was dropped because it changes provider artifact identity,
 invalidating existing bindings, and forces a visible one-time `codex login` in the managed home.
 Writing one owned, reversible skill directory is the smaller intrusion.
+
+OpenTag creates the Computer config directory before granting access. Linux grants that directory,
+allowing initial file creation, atomic replacement, and changes to sibling configuration files.
+macOS retains the Context Tree config-file grant. If directory creation fails, OpenTag logs the
+failure and starts the provider without that grant, preserving workspace, Slack, and tree grants.
 
 Codex runs `workspace-write`, so a shared tree outside the workspace would be read-only to it.
 The resolved tree path is appended to `writableRoots`, composing with the Slack config root rather
@@ -370,3 +385,20 @@ the dependency from the published bundle.
 - Windows support, which needs Provider lifecycle, path, lock, and isolated-home CI coverage
   first. The shim is POSIX and reports `shim_unavailable` elsewhere.
 - Any Provider beyond Codex and Claude Code.
+
+### Linux configuration-grant smoke verification (2026-09-08)
+
+An offline smoke run used Codex CLI 0.114.0 (Linux aarch64), Node 24 in Docker,
+and the built OpenTag CLI with Context Tree 0.1.11. The container used
+`--network none --security-opt seccomp=unconfined`; Codex itself actively enforced
+`sandbox linux --full-auto` with
+`sandbox_workspace_write.writable_roots=["/computer/config"]`, cwd `/workspace`.
+Codex's `sandbox_workspace_write.network_access=true` allowed Node's local subprocess
+machinery; Docker still disabled external networking. With Codex network access disabled,
+Node subprocess creation returned `EPERM`, so that configuration did not complete the smoke.
+
+After creating two real local trees outside the sandbox, the sandboxed OpenTag command
+created an absent `/computer/config/context-tree.json` with
+`context-tree connect --tree-path <first-tree>`, then replaced it with the second target.
+A write to `/computer/unrelated` failed with `Permission denied`, confirming filesystem
+enforcement outside the granted directory. This was not an unsandboxed container run.

--- a/docs/design/context-tree-integration.md
+++ b/docs/design/context-tree-integration.md
@@ -79,6 +79,14 @@ The target is recorded machine-locally in `<OPENTAG_HOME>/config/context-tree/co
 `context-tree connect`'s own argument shape, so OpenTag passes the target through rather than
 reinterpreting it.
 
+**Upgrade requires reconnecting.** Existing `<OPENTAG_HOME>/config/context-tree.json` files are
+ignored, so previously configured installations report unconfigured until reconnected. Run
+`opentag context-tree connect <managed-name>`, `opentag context-tree connect OWNER/REPO`, or
+`opentag context-tree connect --tree-path <path>` using the previous target. Restart the daemon
+and affected Sessions to pick up the Runtime changes, then verify the connection with
+`opentag doctor`. The old configuration and existing tree data remain on disk; there is no
+fallback or automatic migration.
+
 Visible and internal Agents can change this Computer-wide configuration directly. Schema validation
 still applies when reading it, but direct edits bypass command-level target validation. Later
 Provider Runtime starts consume the changed target.
@@ -191,7 +199,8 @@ Visible Sessions supply their tool directory through workspace `pathPrepend`. Ev
 prepends it after composing its environment, preserving the Context Tree and executable directories.
 Internal Sessions retain Context Tree without adding visible-Session tools.
 
-Rollout requires restarting the daemon and affected Sessions after release; no migration is needed.
+Rollout requires reconnecting existing installations and restarting the daemon and affected Sessions
+as described in the upgrade instructions above.
 
 OpenTag's own invocations never rely on the shim: they exec the resolved CLI path directly, so a
 broken or shadowed shim cannot change what OpenTag executes.

--- a/packages/client/src/__tests__/agent-home-context.integration.test.ts
+++ b/packages/client/src/__tests__/agent-home-context.integration.test.ts
@@ -63,7 +63,7 @@ describe("shared Agent Home and Context Tree", () => {
     expect(treePath.startsWith(`${fixture.accountHome}/`)).toBe(true);
 
     const layout = resolveOpenTagHomeLayout(openTagHome);
-    await mkdir(layout.config, { recursive: true });
+    await mkdir(layout.contextTreeConfigDir, { recursive: true });
     await writeFile(
       layout.contextTreeConfigFile,
       `${JSON.stringify({ schemaVersion: 1, target: { kind: "path", path: treePath } })}\n`,

--- a/packages/client/src/__tests__/agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/agent-runtime-exhaustive.test.ts
@@ -1,4 +1,6 @@
+import { delimiter } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { composeRuntimeEnvironment } from "../agent-runtime/environment.js";
 
 // Real child-process lifecycle cases need headroom under parallel CI load.
 vi.setConfig({ testTimeout: 30_000 });
@@ -793,3 +795,15 @@ function deferred<T = void>(): { promise: Promise<T>; resolve: (value?: T) => vo
     reject: (error) => rejectValue?.(error),
   };
 }
+
+it("composes workspace overrides before prepending tools and handles absent or already leading paths", () => {
+  expect(composeRuntimeEnvironment({ PATH: "/base", KEEP: "yes" }, { PATH: "/workspace" }, "/tools")).toEqual({
+    PATH: `/tools${delimiter}/workspace`,
+    KEEP: "yes",
+  });
+  expect(composeRuntimeEnvironment({}, undefined, "/tools")).toEqual({ PATH: "/tools" });
+  expect(composeRuntimeEnvironment({ PATH: "/tools" }, undefined, "/tools")).toEqual({ PATH: "/tools" });
+  expect(composeRuntimeEnvironment({ PATH: `/tools${delimiter}/base` }, undefined, "/tools")).toEqual({
+    PATH: `/tools${delimiter}/base`,
+  });
+});

--- a/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/claude-code-agent-runtime-exhaustive.test.ts
@@ -1,6 +1,7 @@
+import { spawn } from "node:child_process";
 import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getRuntimeConfigurationOptions } from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -925,3 +926,31 @@ async function temporaryDirectory(prefix: string): Promise<string> {
   directories.push(directory);
   return directory;
 }
+
+it.each(["visible", "internal"])(
+  "preserves bundled Context Tree in the actual %s process environment",
+  async (kind) => {
+    const paths: Array<string | undefined> = [];
+    const basePath = `/opentag/context-tree/bin${delimiter}/provider/bin${delimiter}/usr/bin`;
+    const runtime = await new ClaudeCodeAgentRuntimeFactory({
+      createSessionId: () => SESSION_ID,
+      process: {
+        env: { PATH: basePath },
+        spawnProcess: (_command, _args, options) => {
+          paths.push(options.env?.PATH);
+          return spawn(process.execPath, [fixture], { ...options, stdio: "pipe" });
+        },
+      },
+    }).create({
+      ...createRequest(() => undefined),
+      workspace: {
+        cwd: process.cwd(),
+        environment: { OPENTAG_HOME: "/opentag" },
+        ...(kind === "visible" ? { pathPrepend: "/session/tools" } : {}),
+      },
+    });
+    await runtime.prompt({ runId: "path-check", input: input("hello") });
+    await runtime.close();
+    expect(paths).toEqual([kind === "visible" ? `/session/tools${delimiter}${basePath}` : basePath]);
+  },
+);

--- a/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/codex-agent-runtime-exhaustive.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -1833,3 +1833,31 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reje
   if (!resolveValue || !rejectValue) throw new Error("could not create deferred promise");
   return { promise, resolve: resolveValue, reject: rejectValue };
 }
+
+it.each(["visible", "internal"])(
+  "preserves bundled Context Tree in the actual %s process environment",
+  async (kind) => {
+    const paths: Array<string | undefined> = [];
+    const basePath = `/opentag/context-tree/bin${delimiter}/provider/bin${delimiter}/usr/bin`;
+    const runtime = await new CodexAgentRuntimeFactory({
+      clientVersion: "0.0.1-test",
+      process: {
+        env: { PATH: basePath },
+        spawnProcess: (_command, _args, options) => {
+          paths.push(options.env?.PATH);
+          return spawn(process.execPath, [fixture], { ...options, stdio: "pipe" });
+        },
+      },
+    }).create({
+      ...createRequest(() => undefined),
+      workspace: {
+        cwd: process.cwd(),
+        environment: { OPENTAG_HOME: "/opentag" },
+        ...(kind === "visible" ? { pathPrepend: "/session/tools" } : {}),
+      },
+    });
+    await runtime.prompt({ runId: "path-check", input: input("hello") });
+    await runtime.close();
+    expect(paths).toEqual([kind === "visible" ? `/session/tools${delimiter}${basePath}` : basePath]);
+  },
+);

--- a/packages/client/src/__tests__/context-tree.integration.test.ts
+++ b/packages/client/src/__tests__/context-tree.integration.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { promisify } from "node:util";
@@ -95,6 +95,23 @@ async function recordMemberMemory(worktreePath: string, slug: string, memory: st
 }
 
 describe("Context Tree end-to-end", () => {
+  it("provides the bundled command before configuration without connecting or creating a tree", async () => {
+    const home = await temporaryDirectory("opentag-ct-unconfigured-");
+    const cwd = await temporaryDirectory("opentag-ct-unconfigured-agent-");
+    const manager = new ContextTreeManager({ home });
+    await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unconfigured" });
+    const { stdout } = await execFileAsync("/bin/sh", ["-c", "context-tree --version"], {
+      cwd,
+      env: { HOME: home, PATH: manager.binDirectory() },
+    });
+    expect(stdout.trim()).not.toBe("");
+    expect(await readdir(cwd)).toEqual([]);
+    await expect(readFile(resolveOpenTagHomeLayout(home).contextTreeConfigFile)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(await readdir(home)).toEqual(["context-tree"]);
+  });
+
   it("connects two Agent workspaces on one Computer to the same shared tree", async () => {
     const { accountHome, treePath, manager } = await isolatedAccount("opentag-ct-share");
     // The CLI installs Codex skills only for a host that is present. Simulate an installed Codex.

--- a/packages/client/src/__tests__/context-tree.integration.test.ts
+++ b/packages/client/src/__tests__/context-tree.integration.test.ts
@@ -68,7 +68,7 @@ async function isolatedAccount(prefix: string): Promise<{
 
   const openTagHome = await temporaryDirectory(`${prefix}-home-`);
   const layout = resolveOpenTagHomeLayout(openTagHome);
-  await mkdir(layout.config, { mode: 0o700, recursive: true });
+  await mkdir(layout.contextTreeConfigDir, { mode: 0o700, recursive: true });
   await writeFile(
     layout.contextTreeConfigFile,
     `${JSON.stringify({ schemaVersion: 1, target: { kind: "path", path: treePath } })}\n`,

--- a/packages/client/src/__tests__/context-tree.test.ts
+++ b/packages/client/src/__tests__/context-tree.test.ts
@@ -350,7 +350,7 @@ describe("ContextTreeManager", () => {
         { status: "unavailable", reason: "PREPARING" },
         { status: "unavailable", reason: "PREPARING" },
       ]);
-      expect(writes).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(writes).toHaveBeenCalledTimes(1));
       release();
       await vi.waitFor(async () => {
         await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unconfigured" });

--- a/packages/client/src/__tests__/context-tree.test.ts
+++ b/packages/client/src/__tests__/context-tree.test.ts
@@ -48,7 +48,7 @@ const skippedInstallReply = (reason: unknown) =>
 /** Record a Computer's Context Tree target, the way `opentag context-tree connect` does. */
 async function writeTarget(home: string, target: unknown): Promise<void> {
   const layout = resolveOpenTagHomeLayout(home);
-  await mkdir(layout.config, { mode: 0o700, recursive: true });
+  await mkdir(layout.contextTreeConfigDir, { mode: 0o700, recursive: true });
   await writeFile(layout.contextTreeConfigFile, `${JSON.stringify({ schemaVersion: 1, target })}\n`, "utf8");
 }
 

--- a/packages/client/src/__tests__/context-tree.test.ts
+++ b/packages/client/src/__tests__/context-tree.test.ts
@@ -308,7 +308,7 @@ describe("ContextTreeManager", () => {
     });
 
     // A recorded target that has since been corrupted on disk.
-    const corrupt = await computer({ packaged: false, target: managed });
+    const corrupt = await computer({ target: managed });
     await writeFile(resolveOpenTagHomeLayout(corrupt.home).contextTreeConfigFile, "{ not json", "utf8");
     await expect(corrupt.manager.readConfig()).resolves.toBeUndefined();
     await expect(corrupt.manager.ensureAgent(corrupt.cwd)).resolves.toEqual({ status: "unconfigured" });

--- a/packages/client/src/__tests__/context-tree.test.ts
+++ b/packages/client/src/__tests__/context-tree.test.ts
@@ -9,6 +9,7 @@ import {
   contextTreeFailureCode,
   resolveContextTreePackage,
 } from "../runtime/context-tree.js";
+import * as durableFile from "../storage/durable-file.js";
 import { resolveOpenTagHomeLayout } from "../storage/home-layout.js";
 
 const directories: string[] = [];
@@ -298,6 +299,103 @@ describe("ContextTreeManager", () => {
       },
       { interval: 5, timeout: 1_000 },
     );
+  });
+
+  it("shares successful shim preparation across concurrent and repeated starts", async () => {
+    const { home, manager, cwd } = await computer();
+    const writes = vi.spyOn(durableFile, "writeDurableFile");
+    await Promise.all([manager.ensureAgent(cwd), manager.ensureAgent(`${cwd}-other`)]);
+    const shim = join(resolveOpenTagHomeLayout(home).contextTreeBin, "context-tree");
+    const before = await stat(shim);
+    await manager.ensureAgent(cwd);
+    expect((await stat(shim)).ino).toBe(before.ino);
+    expect((await stat(shim)).mtimeMs).toBe(before.mtimeMs);
+    expect(writes).toHaveBeenCalledTimes(1);
+    writes.mockRestore();
+  });
+
+  it("bounds stalled shim preparation and shares its background work", async () => {
+    const { manager, cwd } = await computer({ sessionStartBudgetMs: 10 });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const original = durableFile.writeDurableFile;
+    const writes = vi.spyOn(durableFile, "writeDurableFile").mockImplementation(async (...args) => {
+      await gate;
+      return original(...args);
+    });
+    try {
+      expect(await Promise.all([manager.ensureAgent(cwd), manager.ensureAgent(`${cwd}-other`)])).toEqual([
+        { status: "unavailable", reason: "PREPARING" },
+        { status: "unavailable", reason: "PREPARING" },
+      ]);
+      expect(writes).toHaveBeenCalledTimes(1);
+      release();
+      await vi.waitFor(async () => {
+        await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unconfigured" });
+      });
+    } finally {
+      release();
+      writes.mockRestore();
+    }
+  });
+
+  it("bounds stalled configuration reads", async () => {
+    const { manager, cwd } = await computer({ sessionStartBudgetMs: 10 });
+    let release!: (value: undefined) => void;
+    vi.spyOn(manager, "readConfig").mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unavailable", reason: "PREPARING" });
+    release(undefined);
+  });
+
+  it.each([
+    { packaged: false as const, reason: "PACKAGE_MISSING" },
+    { platform: "win32" as const, reason: "SHIM_UNAVAILABLE" },
+  ])("replaces stale records for configured $reason", async (options) => {
+    const { home, manager, cwd } = await computer({ ...options, target: managed });
+    const file = resolveOpenTagHomeLayout(home).contextTreePreparationFile;
+    await mkdir(join(file, ".."), { recursive: true });
+    await writeFile(
+      file,
+      JSON.stringify({
+        schemaVersion: 1,
+        target: "old",
+        status: "unavailable",
+        reason: "OLD",
+        at: new Date().toISOString(),
+      }),
+    );
+    await manager.ensureAgent(cwd);
+    expect(JSON.parse(await readFile(file, "utf8"))).toMatchObject({ reason: options.reason, target: managed.name });
+    const recorded = await stat(file);
+    await manager.ensureAgent(cwd);
+    expect((await stat(file)).mtimeMs).toBe(recorded.mtimeMs);
+
+    const unconfigured = await computer(options);
+    await expect(unconfigured.manager.ensureAgent(unconfigured.cwd)).resolves.toEqual({
+      status: "unavailable",
+      reason: options.reason,
+    });
+    await expect(stat(resolveOpenTagHomeLayout(unconfigured.home).contextTreePreparationFile)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("retries failed shim preparation after cooldown and recovers", async () => {
+    const { home, manager, cwd } = await computer({ failureCooldownMs: 30 });
+    const bin = resolveOpenTagHomeLayout(home).contextTreeBin;
+    await mkdir(join(bin, ".."), { recursive: true });
+    await writeFile(bin, "blocked");
+    await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unavailable", reason: "SHIM_UNAVAILABLE" });
+    await rm(bin);
+    await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unavailable", reason: "SHIM_UNAVAILABLE" });
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unconfigured" });
   });
 
   it("degrades on a platform with no shim, and on unreadable configuration", async () => {

--- a/packages/client/src/__tests__/context-tree.test.ts
+++ b/packages/client/src/__tests__/context-tree.test.ts
@@ -129,6 +129,26 @@ describe("ContextTreeManager", () => {
     await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unconfigured" });
   });
 
+  it("ignores the old configuration and activates a reconnected target while the old file remains", async () => {
+    const { execFile, calls } = recording({ connect: treeReply("/srv/trees/new"), install: installReply });
+    const { home, cwd, manager } = await computer({ execFile });
+    const oldFile = join(home, "config", "context-tree.json");
+    const oldConfig = JSON.stringify({ schemaVersion: 1, target: managed });
+    await mkdir(join(home, "config"), { recursive: true });
+    await writeFile(oldFile, oldConfig);
+
+    await expect(manager.readConfig()).resolves.toBeUndefined();
+    await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "unconfigured" });
+    expect(calls).toEqual([]);
+
+    const target = { kind: "path", path: "/srv/trees/new" };
+    await writeTarget(home, target);
+    await expect(manager.readConfig()).resolves.toMatchObject({ target });
+    await expect(manager.ensureAgent(cwd)).resolves.toEqual({ status: "ready", treePath: target.path });
+    expect(calls[0]).toEqual(["connect", "--tree-path", target.path, "--project-path", cwd, "--json"]);
+    await expect(readFile(oldFile, "utf8")).resolves.toBe(oldConfig);
+  });
+
   it("reports a missing package without running anything", async () => {
     const { cwd, manager } = await computer({ target: managed, packaged: false });
 

--- a/packages/client/src/__tests__/home-layout.test.ts
+++ b/packages/client/src/__tests__/home-layout.test.ts
@@ -21,7 +21,8 @@ describe("OpenTag Home layout", () => {
     expect(resolveOpenTagHomeLayout(home)).toEqual({
       config: join(root, "config"),
       contextTreeBin: join(root, "context-tree", "bin"),
-      contextTreeConfigFile: join(root, "config", "context-tree.json"),
+      contextTreeConfigDir: join(root, "config", "context-tree"),
+      contextTreeConfigFile: join(root, "config", "context-tree", "config.json"),
       contextTreePreparationFile: join(root, "state", "context-tree-preparation.json"),
       daemonState: join(root, "state", "daemon"),
       data: join(root, "data"),

--- a/packages/client/src/__tests__/pi-agent-runtime-exhaustive.test.ts
+++ b/packages/client/src/__tests__/pi-agent-runtime-exhaustive.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeEvent, CreateAgentRuntimeRequest } from "../agent-runtime/types.js";
@@ -922,3 +922,31 @@ interface PackageManifest {
   readonly optionalDependencies?: Record<string, string>;
   readonly peerDependencies?: Record<string, string>;
 }
+
+it.each(["visible", "internal"])(
+  "preserves bundled Context Tree in the actual %s process environment",
+  async (kind) => {
+    const paths: Array<string | undefined> = [];
+    const basePath = `/opentag/context-tree/bin${delimiter}/provider/bin${delimiter}/usr/bin`;
+    const runtime = await new PiAgentRuntimeFactory({
+      createSessionId: () => SESSION_ID,
+      process: {
+        env: { PATH: basePath },
+        spawnProcess: (_command, _args, options) => {
+          paths.push(options.env?.PATH);
+          return spawn(process.execPath, [fixture], { ...options, stdio: "pipe" });
+        },
+      },
+    }).create({
+      ...request(() => undefined),
+      workspace: {
+        cwd: process.cwd(),
+        environment: { OPENTAG_HOME: "/opentag" },
+        ...(kind === "visible" ? { pathPrepend: "/session/tools" } : {}),
+      },
+    });
+    await runtime.prompt({ runId: "path-check", input: input("hello") });
+    await runtime.close();
+    expect(paths).toEqual([kind === "visible" ? `/session/tools${delimiter}${basePath}` : basePath]);
+  },
+);

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { delimiter, resolve } from "node:path";
+import { resolve } from "node:path";
 import {
   computeRuntimeSnapshotHashes,
   type EffectiveRuntimeSnapshot,
@@ -233,7 +233,6 @@ describe("SessionRuntimeManager", () => {
     const manager = new SessionRuntimeManager({
       bindingStore: store,
       home,
-      inheritedPath: `/tmp/ambient-slack${delimiter}/usr/bin`,
       providers: await providerRegistry(factory),
       providerCliLaunchPath: (sessionId) => resolve(home, "plans", sessionId),
       providerEnvironmentPath: () => "/tmp/provider-env.sh",
@@ -248,16 +247,13 @@ describe("SessionRuntimeManager", () => {
     await manager.ensureRuntime("session-1");
     const created = factory.created[0];
     if (!created) throw new Error("visible runtime was not created");
-    const path = created.workspace.environment?.PATH ?? "";
-    expect(path.startsWith(`${launchDir}${delimiter}`)).toBe(true);
-    expect(path).toContain("/tmp/ambient-slack");
-    expect(path.indexOf(launchDir)).toBeLessThan(path.indexOf("/tmp/ambient-slack"));
+    expect(created.workspace.pathPrepend).toBe(launchDir);
+    expect(created.workspace.environment).not.toHaveProperty("PATH");
 
     const internalFactory = new FakeFactory();
     const internalManager = new SessionRuntimeManager({
       bindingStore: store,
       home,
-      inheritedPath: `/tmp/ambient-slack${delimiter}/usr/bin`,
       providers: await providerRegistry(internalFactory),
       providerCliLaunchPath: () => launchDir,
       providerEnvironmentPath: () => "/tmp/provider-env.sh",
@@ -277,53 +273,10 @@ describe("SessionRuntimeManager", () => {
     ).resolves.toMatchObject({ status: "ready" });
     await internalManager.ensureRuntime("session-internal");
     expect(internalFactory.created[0]?.workspace.environment).not.toHaveProperty("PATH");
-
-    const exactFactory = new FakeFactory();
-    const exactManager = new SessionRuntimeManager({
-      bindingStore: store,
-      home,
-      inheritedPath: launchDir,
-      providers: await providerRegistry(exactFactory),
-      providerCliLaunchPath: () => launchDir,
-      providerEnvironmentPath: () => "/tmp/provider-env.sh",
-      workspace,
-    });
-    const exactRequest = { ...reconcile(computerId, snapshot(1)), sessionId: "session-exact-path" };
-    await expect(
-      new SessionReconciler({
-        installationId: computerId,
-        preparation: exactManager,
-        localPolicy: exactManager,
-      }).reconcile(exactRequest),
-    ).resolves.toMatchObject({ status: "ready" });
-    await exactManager.ensureRuntime(exactRequest.sessionId);
-    expect(exactFactory.created[0]?.workspace.environment?.PATH).toBe(launchDir);
-
-    const isolatedFactory = new FakeFactory();
-    const isolatedManager = new SessionRuntimeManager({
-      bindingStore: store,
-      home,
-      inheritedPath: "",
-      providers: await providerRegistry(isolatedFactory),
-      providerCliLaunchPath: () => launchDir,
-      providerEnvironmentPath: () => "/tmp/provider-env.sh",
-      workspace,
-    });
-    const isolatedRequest = { ...reconcile(computerId, snapshot(1)), sessionId: "session-isolated-path" };
-    await expect(
-      new SessionReconciler({
-        installationId: computerId,
-        preparation: isolatedManager,
-        localPolicy: isolatedManager,
-      }).reconcile(isolatedRequest),
-    ).resolves.toMatchObject({ status: "ready" });
-    await isolatedManager.ensureRuntime(isolatedRequest.sessionId);
-    expect(isolatedFactory.created[0]?.workspace.environment?.PATH).toBe(launchDir);
+    expect(internalFactory.created[0]?.workspace.pathPrepend).toBeUndefined();
 
     await manager.close();
     await internalManager.close();
-    await exactManager.close();
-    await isolatedManager.close();
   });
 
   it("prepares Context Tree once per Agent workspace and names the tree as a writable root", async () => {

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -97,10 +97,10 @@ describe("SessionRuntimeManager", () => {
     });
     expect(factory.created[0]?.workspace.writableRoots).toEqual([
       factory.created[0]?.workspace.cwd,
-      ...(configFailure ? [] : [resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json")]),
+      ...(configFailure ? [] : [resolve(home, "config/context-tree")]),
     ]);
     expect((await stat(resolve(home, "config"))).isDirectory()).toBe(!configFailure);
-    await expect(stat(resolve(home, "config/context-tree.json"))).rejects.toMatchObject({
+    await expect(stat(resolve(home, "config/context-tree", "config.json"))).rejects.toMatchObject({
       code: configFailure ? "ENOTDIR" : "ENOENT",
     });
     expect(factory.created[0]?.hostedTools).toBeUndefined();
@@ -157,7 +157,7 @@ describe("SessionRuntimeManager", () => {
     expect(factory.created[0]?.workspace.writableRoots).toEqual([
       factory.created[0]?.workspace.cwd,
       slackLeaf,
-      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
+      resolve(home, "config/context-tree"),
     ]);
     expect(factory.created[0]?.workspace.writableRoots).not.toContain(parentCredentials);
     expect(factory.created[0]?.workspace.environment).toMatchObject({
@@ -194,7 +194,7 @@ describe("SessionRuntimeManager", () => {
     expect(internalResolved).toEqual([]);
     expect(internalFactory.created[0]?.workspace.writableRoots).toEqual([
       internalFactory.created[0]?.workspace.cwd,
-      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
+      resolve(home, "config/context-tree"),
     ]);
     expect(internalFactory.created[0]?.workspace.environment).not.toHaveProperty("OPENTAG_PROVIDER_ENV_FILE");
 
@@ -218,7 +218,7 @@ describe("SessionRuntimeManager", () => {
     await feishuManager.ensureRuntime(feishuRequest.sessionId);
     expect(feishuFactory.created[0]?.workspace.writableRoots).toEqual([
       feishuFactory.created[0]?.workspace.cwd,
-      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
+      resolve(home, "config/context-tree"),
     ]);
 
     await manager.close();
@@ -314,11 +314,7 @@ describe("SessionRuntimeManager", () => {
     const cwd = await workspace.cwd(request.agentId);
     expect(contextTree.ensureAgent).toHaveBeenCalledWith(cwd);
     // Codex is workspace-write, so the shared tree is unreachable unless it is named here.
-    expect(created?.workspace.writableRoots).toEqual([
-      cwd,
-      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
-      treePath,
-    ]);
+    expect(created?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree"), treePath]);
     expect(created?.systemPrompt).toContain(`Context Tree: ${treePath}`);
     expect(created?.systemPrompt).toContain("members/<your Agent slug>/");
     await manager.close();
@@ -354,10 +350,7 @@ describe("SessionRuntimeManager", () => {
 
     const created = factory.created[0];
     const cwd = await workspace.cwd(request.agentId);
-    expect(created?.workspace.writableRoots).toEqual([
-      cwd,
-      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
-    ]);
+    expect(created?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree")]);
     expect(created?.systemPrompt).toContain("Context Tree unavailable (DIRTY_TREE)");
     expect(created?.systemPrompt).toContain("Do not assume earlier decisions were recorded");
     await manager.close();
@@ -427,14 +420,8 @@ describe("SessionRuntimeManager", () => {
     expect(factory.created).toHaveLength(2);
     expect(factory.created[0]?.workspace.cwd).toBe(cwd);
     expect(factory.created[1]?.workspace.cwd).toBe(cwd);
-    expect(factory.created[0]?.workspace.writableRoots).toEqual([
-      cwd,
-      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
-    ]);
-    expect(factory.created[1]?.workspace.writableRoots).toEqual([
-      cwd,
-      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
-    ]);
+    expect(factory.created[0]?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree")]);
+    expect(factory.created[1]?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree")]);
     expect(factory.created[0]?.systemPrompt).toContain(`Your Agent Home is ${cwd}.`);
     expect(factory.created[1]?.systemPrompt).toContain(`Your Agent Home is ${cwd}.`);
     expect(factory.created[0]?.systemPrompt).toContain("source-repos/<unique-repo-key>/");
@@ -495,7 +482,7 @@ describe("SessionRuntimeManager", () => {
     await manager.ensureRuntime("session-1");
     expect(factory.created[0]?.workspace.writableRoots).toEqual([
       factory.created[0]?.workspace.cwd,
-      resolve(process.env.OPENTAG_HOME as string, process.platform === "linux" ? "config" : "config/context-tree.json"),
+      resolve(process.env.OPENTAG_HOME as string, "config/context-tree"),
     ]);
     expect((await stat(resolve(process.env.OPENTAG_HOME as string, "config"))).isDirectory()).toBe(true);
     await manager.ensureRuntime("session-1", new AbortController().signal);

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import {
@@ -52,9 +52,10 @@ afterEach(async () => {
 });
 
 describe("SessionRuntimeManager", () => {
-  it("materializes a runtime-managed proof for internal Sessions without exposing IM credentials", async () => {
+  it.each([false, true])("starts internal Sessions with configuration directory failure=%s", async (configFailure) => {
     const home = await mkdtemp(resolve(tmpdir(), "opentag-internal-runtime-"));
     homes.push(home);
+    if (configFailure) await writeFile(resolve(home, "config"), "blocked");
     const store = new SessionBindingStore({ home, providerArtifactIdentity: () => "a".repeat(64) });
     const workspace = new AgentWorkspaceManager({ home, bindingStore: store });
     const factory = new FakeFactory();
@@ -96,10 +97,12 @@ describe("SessionRuntimeManager", () => {
     });
     expect(factory.created[0]?.workspace.writableRoots).toEqual([
       factory.created[0]?.workspace.cwd,
-      resolve(home, "config/context-tree.json"),
+      ...(configFailure ? [] : [resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json")]),
     ]);
-    expect((await stat(resolve(home, "config"))).isDirectory()).toBe(true);
-    await expect(stat(resolve(home, "config/context-tree.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await stat(resolve(home, "config"))).isDirectory()).toBe(!configFailure);
+    await expect(stat(resolve(home, "config/context-tree.json"))).rejects.toMatchObject({
+      code: configFailure ? "ENOTDIR" : "ENOENT",
+    });
     expect(factory.created[0]?.hostedTools).toBeUndefined();
     expect(factory.created[0]?.systemPrompt).toContain("opentag-dev session send");
     expect(factory.created[0]?.systemPrompt).toContain(
@@ -154,7 +157,7 @@ describe("SessionRuntimeManager", () => {
     expect(factory.created[0]?.workspace.writableRoots).toEqual([
       factory.created[0]?.workspace.cwd,
       slackLeaf,
-      resolve(home, "config/context-tree.json"),
+      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
     ]);
     expect(factory.created[0]?.workspace.writableRoots).not.toContain(parentCredentials);
     expect(factory.created[0]?.workspace.environment).toMatchObject({
@@ -191,7 +194,7 @@ describe("SessionRuntimeManager", () => {
     expect(internalResolved).toEqual([]);
     expect(internalFactory.created[0]?.workspace.writableRoots).toEqual([
       internalFactory.created[0]?.workspace.cwd,
-      resolve(home, "config/context-tree.json"),
+      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
     ]);
     expect(internalFactory.created[0]?.workspace.environment).not.toHaveProperty("OPENTAG_PROVIDER_ENV_FILE");
 
@@ -215,7 +218,7 @@ describe("SessionRuntimeManager", () => {
     await feishuManager.ensureRuntime(feishuRequest.sessionId);
     expect(feishuFactory.created[0]?.workspace.writableRoots).toEqual([
       feishuFactory.created[0]?.workspace.cwd,
-      resolve(home, "config/context-tree.json"),
+      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
     ]);
 
     await manager.close();
@@ -311,7 +314,11 @@ describe("SessionRuntimeManager", () => {
     const cwd = await workspace.cwd(request.agentId);
     expect(contextTree.ensureAgent).toHaveBeenCalledWith(cwd);
     // Codex is workspace-write, so the shared tree is unreachable unless it is named here.
-    expect(created?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree.json"), treePath]);
+    expect(created?.workspace.writableRoots).toEqual([
+      cwd,
+      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
+      treePath,
+    ]);
     expect(created?.systemPrompt).toContain(`Context Tree: ${treePath}`);
     expect(created?.systemPrompt).toContain("members/<your Agent slug>/");
     await manager.close();
@@ -347,7 +354,10 @@ describe("SessionRuntimeManager", () => {
 
     const created = factory.created[0];
     const cwd = await workspace.cwd(request.agentId);
-    expect(created?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree.json")]);
+    expect(created?.workspace.writableRoots).toEqual([
+      cwd,
+      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
+    ]);
     expect(created?.systemPrompt).toContain("Context Tree unavailable (DIRTY_TREE)");
     expect(created?.systemPrompt).toContain("Do not assume earlier decisions were recorded");
     await manager.close();
@@ -417,8 +427,14 @@ describe("SessionRuntimeManager", () => {
     expect(factory.created).toHaveLength(2);
     expect(factory.created[0]?.workspace.cwd).toBe(cwd);
     expect(factory.created[1]?.workspace.cwd).toBe(cwd);
-    expect(factory.created[0]?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree.json")]);
-    expect(factory.created[1]?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree.json")]);
+    expect(factory.created[0]?.workspace.writableRoots).toEqual([
+      cwd,
+      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
+    ]);
+    expect(factory.created[1]?.workspace.writableRoots).toEqual([
+      cwd,
+      resolve(home, process.platform === "linux" ? "config" : "config/context-tree.json"),
+    ]);
     expect(factory.created[0]?.systemPrompt).toContain(`Your Agent Home is ${cwd}.`);
     expect(factory.created[1]?.systemPrompt).toContain(`Your Agent Home is ${cwd}.`);
     expect(factory.created[0]?.systemPrompt).toContain("source-repos/<unique-repo-key>/");
@@ -479,7 +495,7 @@ describe("SessionRuntimeManager", () => {
     await manager.ensureRuntime("session-1");
     expect(factory.created[0]?.workspace.writableRoots).toEqual([
       factory.created[0]?.workspace.cwd,
-      resolve(process.env.OPENTAG_HOME as string, "config/context-tree.json"),
+      resolve(process.env.OPENTAG_HOME as string, process.platform === "linux" ? "config" : "config/context-tree.json"),
     ]);
     expect((await stat(resolve(process.env.OPENTAG_HOME as string, "config"))).isDirectory()).toBe(true);
     await manager.ensureRuntime("session-1", new AbortController().signal);

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, resolve } from "node:path";
 import {
@@ -7,7 +7,7 @@ import {
   type EffectiveRuntimeSnapshot,
   type SessionReconcileRequest,
 } from "@opentag/shared";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentAbortRequest,
   AgentInteractionResponse,
@@ -41,7 +41,15 @@ class SessionRuntimeManager extends ProductionSessionRuntimeManager {
 }
 
 const homes: string[] = [];
-afterEach(async () => Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true }))));
+beforeEach(async () => {
+  const home = await mkdtemp(resolve(tmpdir(), "opentag-runtime-env-"));
+  homes.push(home);
+  vi.stubEnv("OPENTAG_HOME", home);
+});
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
 
 describe("SessionRuntimeManager", () => {
   it("materializes a runtime-managed proof for internal Sessions without exposing IM credentials", async () => {
@@ -86,7 +94,12 @@ describe("SessionRuntimeManager", () => {
       OPENTAG_HOME: home,
       OPENTAG_SESSION_PROOF_FILE: "/tmp/session-proof.json",
     });
-    expect(factory.created[0]?.workspace.writableRoots).toEqual([factory.created[0]?.workspace.cwd]);
+    expect(factory.created[0]?.workspace.writableRoots).toEqual([
+      factory.created[0]?.workspace.cwd,
+      resolve(home, "config/context-tree.json"),
+    ]);
+    expect((await stat(resolve(home, "config"))).isDirectory()).toBe(true);
+    await expect(stat(resolve(home, "config/context-tree.json"))).rejects.toMatchObject({ code: "ENOENT" });
     expect(factory.created[0]?.hostedTools).toBeUndefined();
     expect(factory.created[0]?.systemPrompt).toContain("opentag-dev session send");
     expect(factory.created[0]?.systemPrompt).toContain(
@@ -138,7 +151,11 @@ describe("SessionRuntimeManager", () => {
     await expect(reconciler.reconcile(visible)).resolves.toMatchObject({ status: "ready" });
     await manager.ensureRuntime(visible.sessionId);
     expect(resolved).toEqual([visible.sessionId]);
-    expect(factory.created[0]?.workspace.writableRoots).toEqual([factory.created[0]?.workspace.cwd, slackLeaf]);
+    expect(factory.created[0]?.workspace.writableRoots).toEqual([
+      factory.created[0]?.workspace.cwd,
+      slackLeaf,
+      resolve(home, "config/context-tree.json"),
+    ]);
     expect(factory.created[0]?.workspace.writableRoots).not.toContain(parentCredentials);
     expect(factory.created[0]?.workspace.environment).toMatchObject({
       OPENTAG_PROVIDER_ENV_FILE: "/tmp/provider-env.sh",
@@ -172,7 +189,10 @@ describe("SessionRuntimeManager", () => {
     ).resolves.toMatchObject({ status: "ready" });
     await internalManager.ensureRuntime(internalRequest.sessionId);
     expect(internalResolved).toEqual([]);
-    expect(internalFactory.created[0]?.workspace.writableRoots).toEqual([internalFactory.created[0]?.workspace.cwd]);
+    expect(internalFactory.created[0]?.workspace.writableRoots).toEqual([
+      internalFactory.created[0]?.workspace.cwd,
+      resolve(home, "config/context-tree.json"),
+    ]);
     expect(internalFactory.created[0]?.workspace.environment).not.toHaveProperty("OPENTAG_PROVIDER_ENV_FILE");
 
     const feishuFactory = new FakeFactory();
@@ -193,7 +213,10 @@ describe("SessionRuntimeManager", () => {
       }).reconcile(feishuRequest),
     ).resolves.toMatchObject({ status: "ready" });
     await feishuManager.ensureRuntime(feishuRequest.sessionId);
-    expect(feishuFactory.created[0]?.workspace.writableRoots).toEqual([feishuFactory.created[0]?.workspace.cwd]);
+    expect(feishuFactory.created[0]?.workspace.writableRoots).toEqual([
+      feishuFactory.created[0]?.workspace.cwd,
+      resolve(home, "config/context-tree.json"),
+    ]);
 
     await manager.close();
     await internalManager.close();
@@ -335,7 +358,7 @@ describe("SessionRuntimeManager", () => {
     const cwd = await workspace.cwd(request.agentId);
     expect(contextTree.ensureAgent).toHaveBeenCalledWith(cwd);
     // Codex is workspace-write, so the shared tree is unreachable unless it is named here.
-    expect(created?.workspace.writableRoots).toEqual([cwd, treePath]);
+    expect(created?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree.json"), treePath]);
     expect(created?.systemPrompt).toContain(`Context Tree: ${treePath}`);
     expect(created?.systemPrompt).toContain("members/<your Agent slug>/");
     await manager.close();
@@ -371,7 +394,7 @@ describe("SessionRuntimeManager", () => {
 
     const created = factory.created[0];
     const cwd = await workspace.cwd(request.agentId);
-    expect(created?.workspace.writableRoots).toEqual([cwd]);
+    expect(created?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree.json")]);
     expect(created?.systemPrompt).toContain("Context Tree unavailable (DIRTY_TREE)");
     expect(created?.systemPrompt).toContain("Do not assume earlier decisions were recorded");
     await manager.close();
@@ -441,8 +464,8 @@ describe("SessionRuntimeManager", () => {
     expect(factory.created).toHaveLength(2);
     expect(factory.created[0]?.workspace.cwd).toBe(cwd);
     expect(factory.created[1]?.workspace.cwd).toBe(cwd);
-    expect(factory.created[0]?.workspace.writableRoots).toEqual([cwd]);
-    expect(factory.created[1]?.workspace.writableRoots).toEqual([cwd]);
+    expect(factory.created[0]?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree.json")]);
+    expect(factory.created[1]?.workspace.writableRoots).toEqual([cwd, resolve(home, "config/context-tree.json")]);
     expect(factory.created[0]?.systemPrompt).toContain(`Your Agent Home is ${cwd}.`);
     expect(factory.created[1]?.systemPrompt).toContain(`Your Agent Home is ${cwd}.`);
     expect(factory.created[0]?.systemPrompt).toContain("source-repos/<unique-repo-key>/");
@@ -501,6 +524,11 @@ describe("SessionRuntimeManager", () => {
     await expect(reconciler.reconcile(first)).resolves.toMatchObject({ status: "ready" });
     expect(manager.sessionKind(first.sessionId)).toBe("visible");
     await manager.ensureRuntime("session-1");
+    expect(factory.created[0]?.workspace.writableRoots).toEqual([
+      factory.created[0]?.workspace.cwd,
+      resolve(process.env.OPENTAG_HOME as string, "config/context-tree.json"),
+    ]);
+    expect((await stat(resolve(process.env.OPENTAG_HOME as string, "config"))).isDirectory()).toBe(true);
     await manager.ensureRuntime("session-1", new AbortController().signal);
     expect(manager.runtime("session-1")).toBe(factory.runtimes[0]);
     expect(factory.created).toHaveLength(1);

--- a/packages/client/src/agent-runtime/environment.ts
+++ b/packages/client/src/agent-runtime/environment.ts
@@ -1,0 +1,15 @@
+import { delimiter } from "node:path";
+
+/** Compose all environment layers before giving Session tools first place on PATH. */
+export function composeRuntimeEnvironment(
+  environment: NodeJS.ProcessEnv,
+  workspaceEnvironment?: Readonly<Record<string, string>>,
+  pathPrepend?: string,
+): NodeJS.ProcessEnv {
+  const composed = { ...environment, ...workspaceEnvironment };
+  const current = composed.PATH;
+  if (pathPrepend && current !== pathPrepend && !current?.startsWith(`${pathPrepend}${delimiter}`)) {
+    composed.PATH = current ? `${pathPrepend}${delimiter}${current}` : pathPrepend;
+  }
+  return composed;
+}

--- a/packages/client/src/agent-runtime/types.ts
+++ b/packages/client/src/agent-runtime/types.ts
@@ -127,6 +127,8 @@ export interface AgentRunResult {
 }
 
 export interface AgentRuntimeWorkspace {
+  /** Directory prepended after the Provider and workspace environments are composed. */
+  readonly pathPrepend?: string;
   readonly cwd: string;
   readonly environment?: Readonly<Record<string, string>>;
   readonly writableRoots?: readonly string[];

--- a/packages/client/src/providers/claude-code/agent-runtime.ts
+++ b/packages/client/src/providers/claude-code/agent-runtime.ts
@@ -4,6 +4,7 @@ import { isAbsolute } from "node:path";
 import { promisify } from "node:util";
 import { getRuntimeConfigurationOptions } from "@opentag/shared";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
+import { composeRuntimeEnvironment } from "../../agent-runtime/environment.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
 import { classifiedProviderProbeIssue } from "../../agent-runtime/probe-failure.js";
 import {
@@ -603,6 +604,7 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
     cwd: string,
     args: readonly string[],
     environment?: Readonly<Record<string, string>>,
+    pathPrepend?: string,
   ) => ClaudeCodeProcessClient;
   readonly #probeRunner: (signal?: AbortSignal) => Promise<{
     readonly credential: boolean;
@@ -618,12 +620,12 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
     const prefix = options.process?.args ?? [];
     this.#createProcess =
       options.createProcess ??
-      ((cwd, args, workspaceEnvironment) =>
+      ((cwd, args, workspaceEnvironment, pathPrepend) =>
         new ClaudeCodeProcess({
           command,
           args: [...prefix, ...args],
           cwd,
-          env: { ...environment, ...workspaceEnvironment },
+          env: composeRuntimeEnvironment(environment, workspaceEnvironment, pathPrepend),
           maxLineBytes: options.process?.maxLineBytes,
           maxStderrBytes: options.process?.maxStderrBytes,
           spawnProcess: options.process?.spawnProcess,
@@ -688,7 +690,13 @@ export class ClaudeCodeAgentRuntimeFactory implements AgentRuntimeFactory {
       return new ClaudeCodeAgentRuntime({
         binding,
         configuration: request.configuration,
-        createProcess: (args) => this.#createProcess(request.workspace.cwd, args, request.workspace.environment),
+        createProcess: (args) =>
+          this.#createProcess(
+            request.workspace.cwd,
+            args,
+            request.workspace.environment,
+            request.workspace.pathPrepend,
+          ),
         emptyNativeToolAllowList: isEmptyNativeToolAllowList(request.policy),
         eventSink: request.eventSink,
         hostedTools: request.hostedTools,

--- a/packages/client/src/providers/codex/agent-runtime.ts
+++ b/packages/client/src/providers/codex/agent-runtime.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
 import { getRuntimeConfigurationOptions, hashTuple } from "@opentag/shared";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
+import { composeRuntimeEnvironment } from "../../agent-runtime/environment.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
 import {
   classifiedProviderProbeIssue,
@@ -725,6 +726,7 @@ export class CodexAgentRuntimeFactory implements AgentRuntimeFactory {
   readonly #createClient: (
     cwd: string,
     environment?: Readonly<Record<string, string>>,
+    pathPrepend?: string,
   ) => InteractiveCodexAppServerClient;
   readonly #probeRunner: (signal?: AbortSignal) => Promise<{
     readonly appServer: boolean;
@@ -740,13 +742,14 @@ export class CodexAgentRuntimeFactory implements AgentRuntimeFactory {
     const createDefaultClient = (
       cwd: string,
       workspaceEnvironment?: Readonly<Record<string, string>>,
+      pathPrepend?: string,
       expectedCodexHome = options.process?.expectedCodexHome,
     ) =>
       new CodexAppServerProcess({
         command,
         args: options.process?.args ?? [...CODEX_AGENT_RUNTIME_APP_SERVER_ARGS],
         cwd,
-        env: { ...environment, ...workspaceEnvironment },
+        env: composeRuntimeEnvironment(environment, workspaceEnvironment, pathPrepend),
         expectedCodexHome,
         maxLineBytes: options.process?.maxLineBytes,
         requestTimeoutMs: options.process?.requestTimeoutMs,
@@ -756,7 +759,7 @@ export class CodexAgentRuntimeFactory implements AgentRuntimeFactory {
     const createProbeClient =
       options.createClient ??
       ((cwd: string, probeEnvironment?: Readonly<Record<string, string>>) =>
-        createDefaultClient(cwd, probeEnvironment, probeEnvironment?.CODEX_HOME));
+        createDefaultClient(cwd, probeEnvironment, undefined, probeEnvironment?.CODEX_HOME));
     this.#probeRunner =
       options.probeRunner ??
       (async (signal) => {
@@ -943,7 +946,11 @@ export class CodexAgentRuntimeFactory implements AgentRuntimeFactory {
         "Codex binding hosted tools cannot change during exact resume",
       );
     }
-    const client = this.#createClient(request.workspace.cwd, request.workspace.environment);
+    const client = this.#createClient(
+      request.workspace.cwd,
+      request.workspace.environment,
+      request.workspace.pathPrepend,
+    );
     try {
       if (request.hostedTools && typeof client.setDynamicToolHandler !== "function") {
         throw new AgentRuntimeError(

--- a/packages/client/src/providers/pi/agent-runtime.ts
+++ b/packages/client/src/providers/pi/agent-runtime.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { isAbsolute } from "node:path";
 import { promisify } from "node:util";
 import { BaseAgentRuntime } from "../../agent-runtime/base-agent-runtime.js";
+import { composeRuntimeEnvironment } from "../../agent-runtime/environment.js";
 import { AgentProviderError, AgentRuntimeError } from "../../agent-runtime/errors.js";
 import {
   AGENT_RUNTIME_CONTRACT_VERSION,
@@ -628,6 +629,7 @@ export class PiAgentRuntimeFactory implements AgentRuntimeFactory {
     cwd: string,
     args: readonly string[],
     environment?: Readonly<Record<string, string>>,
+    pathPrepend?: string,
   ) => PiRpcClient;
   readonly #probeRunner: (signal?: AbortSignal) => Promise<{
     readonly credential: boolean;
@@ -648,12 +650,12 @@ export class PiAgentRuntimeFactory implements AgentRuntimeFactory {
     this.#sessionDirectory = sessionDirectory;
     this.#createClient =
       options.createClient ??
-      ((cwd, args, workspaceEnvironment) =>
+      ((cwd, args, workspaceEnvironment, pathPrepend) =>
         new PiRpcProcess({
           command,
           args: [...prefix, ...args],
           cwd,
-          env: { ...environment, ...workspaceEnvironment },
+          env: composeRuntimeEnvironment(environment, workspaceEnvironment, pathPrepend),
           maxLineBytes: options.process?.maxLineBytes,
           maxStderrBytes: options.process?.maxStderrBytes,
           requestTimeoutMs: options.process?.requestTimeoutMs,
@@ -712,7 +714,8 @@ export class PiAgentRuntimeFactory implements AgentRuntimeFactory {
       return new PiAgentRuntime({
         binding,
         configuration: request.configuration,
-        createClient: (args) => this.#createClient(request.workspace.cwd, args, request.workspace.environment),
+        createClient: (args) =>
+          this.#createClient(request.workspace.cwd, args, request.workspace.environment, request.workspace.pathPrepend),
         eventSink: request.eventSink,
         policy: request.policy,
         resume: mode === "resume",

--- a/packages/client/src/runtime/client-runtime-composition.ts
+++ b/packages/client/src/runtime/client-runtime-composition.ts
@@ -623,7 +623,6 @@ export async function createClientRuntime(
     providers,
     providerEnvironmentPath: (sessionId) => credentialEnvironment.pathForSession(sessionId),
     providerCliLaunchPath: (sessionId) => providerCliTurnPlans.sessionDir(sessionId),
-    inheritedPath: sourceEnvironment.PATH,
     slackConfigWritableRoot: (sessionId) => credentialEnvironment.activeSlackConfigDirForSession(sessionId),
     proofManager,
     workspace,

--- a/packages/client/src/runtime/context-tree.ts
+++ b/packages/client/src/runtime/context-tree.ts
@@ -200,6 +200,8 @@ export class ContextTreeManager {
   readonly #cooldown = new Map<string, { target: string; status: ContextTreeStatus; until: number }>();
   readonly #inFlight = new Map<string, { target: string; promise: Promise<ContextTreeStatus> }>();
   readonly #observedTarget = new Map<string, string>();
+  #shimPreparation: Promise<boolean> | undefined;
+  #shimRetryAt = 0;
   #pending: Promise<unknown> = Promise.resolve();
 
   constructor(options: ContextTreeManagerOptions) {
@@ -231,18 +233,22 @@ export class ContextTreeManager {
    * connection from writing into a workspace still mid-migration.
    */
   async ensureAgent(cwd: string): Promise<ContextTreeStatus> {
-    if (!this.#package) return { status: "unavailable", reason: "PACKAGE_MISSING" };
-    const shim = await this.#writeShim().catch((error: unknown) => {
-      this.#logger.warn({ err: describe(error) }, "Context Tree shim could not be created");
-      return false;
-    });
-    if (!shim) return { status: "unavailable", reason: "SHIM_UNAVAILABLE" };
+    return this.#withinSessionStartBudget(this.#prepareAgent(cwd));
+  }
+
+  async #prepareAgent(cwd: string): Promise<ContextTreeStatus> {
+    const executableFailure = !this.#package
+      ? "PACKAGE_MISSING"
+      : (await this.#prepareShim())
+        ? undefined
+        : "SHIM_UNAVAILABLE";
 
     // Read the configuration before consulting the cache. `opentag context-tree connect` only
     // writes the file, so a Computer configured after this daemon started must still activate,
     // and an entry recorded under another target must never be served for this one.
     const config = await this.readConfig();
-    if (!config) return { status: "unconfigured" };
+    if (!config)
+      return executableFailure ? { status: "unavailable", reason: executableFailure } : { status: "unconfigured" };
     const target = formatContextTreeTarget(config.target);
     if (this.#observedTarget.get(cwd) !== target) {
       this.#observedTarget.set(cwd, target);
@@ -254,7 +260,7 @@ export class ContextTreeManager {
     const cooling = this.#cooldown.get(cwd);
     if (cooling?.target === target && cooling.until > Date.now()) return cooling.status;
     if (cooling) this.#cooldown.delete(cwd);
-    return this.#withinSessionStartBudget(this.#joinPreparation(cwd, config, target));
+    return this.#joinPreparation(cwd, config, target, executableFailure);
   }
 
   async readConfig(): Promise<ContextTreeConfig | undefined> {
@@ -322,6 +328,22 @@ export class ContextTreeManager {
    * The shim pins the same Node.js runtime OpenTag uses, so a Session cannot resolve a different
    * one from the user's shell configuration.
    */
+  #prepareShim(): Promise<boolean> {
+    if (this.#shimPreparation && Date.now() < this.#shimRetryAt) return this.#shimPreparation;
+    if (this.#shimPreparation && this.#shimRetryAt === 0) return this.#shimPreparation;
+    this.#shimRetryAt = 0;
+    this.#shimPreparation = this.#writeShim()
+      .catch((error: unknown) => {
+        this.#logger.warn({ err: describe(error) }, "Context Tree shim could not be created");
+        return false;
+      })
+      .then((success) => {
+        if (!success) this.#shimRetryAt = Date.now() + this.#failureCooldownMs;
+        return success;
+      });
+    return this.#shimPreparation;
+  }
+
   async #writeShim(): Promise<boolean> {
     if (!this.#package) return false;
     if (this.#platform === "win32") {
@@ -348,12 +370,19 @@ export class ContextTreeManager {
     return { status: "unavailable", reason };
   }
 
-  #joinPreparation(cwd: string, config: ContextTreeConfig, target: string): Promise<ContextTreeStatus> {
+  #joinPreparation(
+    cwd: string,
+    config: ContextTreeConfig,
+    target: string,
+    executableFailure?: string,
+  ): Promise<ContextTreeStatus> {
     const current = this.#inFlight.get(cwd);
     if (current?.target === target) return current.promise;
     // The CLI's connection store has no cross-process lock, so background work remains serialized
     // even though Session callers stop waiting after their short budget.
-    const prepared = this.#serialize(() => this.#ensureAgentOnce(cwd, config)).catch((error: unknown) => {
+    const prepared = this.#serialize(async () =>
+      executableFailure ? this.#unavailable(executableFailure, config) : this.#ensureAgentOnce(cwd, config),
+    ).catch((error: unknown) => {
       this.#logger.error({ err: describe(error) }, "Context Tree preparation raised an unexpected failure");
       return { status: "unavailable", reason: "CLI_FAILED" } as const;
     });

--- a/packages/client/src/runtime/context-tree.ts
+++ b/packages/client/src/runtime/context-tree.ts
@@ -231,6 +231,13 @@ export class ContextTreeManager {
    * connection from writing into a workspace still mid-migration.
    */
   async ensureAgent(cwd: string): Promise<ContextTreeStatus> {
+    if (!this.#package) return { status: "unavailable", reason: "PACKAGE_MISSING" };
+    const shim = await this.#writeShim().catch((error: unknown) => {
+      this.#logger.warn({ err: describe(error) }, "Context Tree shim could not be created");
+      return false;
+    });
+    if (!shim) return { status: "unavailable", reason: "SHIM_UNAVAILABLE" };
+
     // Read the configuration before consulting the cache. `opentag context-tree connect` only
     // writes the file, so a Computer configured after this daemon started must still activate,
     // and an entry recorded under another target must never be served for this one.
@@ -266,11 +273,6 @@ export class ContextTreeManager {
     // The CLI never reads `CODEX_HOME`; `install --host codex` targets `<HOME>/.codex/skills`.
     // An unsupported home is diagnosed before any CLI work, so nothing can land in the wrong place.
     if (!this.#codexHomeIsDefaultNamed) return this.#unavailable("CODEX_HOME_UNSUPPORTED", config);
-    const shim = await this.#writeShim().catch((error: unknown) => {
-      this.#logger.warn({ err: describe(error) }, "Context Tree shim could not be created");
-      return false;
-    });
-    if (!shim) return this.#unavailable("SHIM_UNAVAILABLE", config);
 
     try {
       // `connect` is idempotent for an identical connection and already returns the resolved

--- a/packages/client/src/runtime/managed-instructions.ts
+++ b/packages/client/src/runtime/managed-instructions.ts
@@ -62,6 +62,7 @@ function renderAgentHome(agentHome?: string): readonly string[] {
     "- `worktrees/<unique-task-key>/` — agent-managed checkouts for source access and code work. Concurrent code tasks each use a distinct worktree (and a distinct branch when editing). Keep later operations for the same task in its own worktree. No two code tasks edit one checkout.",
     "- `files/<unique-task-key>/` — non-repository task artifacts, created only when needed.",
     "",
+    "OpenTag provides the bundled `context-tree` command. If it cannot run, report a runtime setup problem; do not install it globally.",
     'Context Tree stays the separately configured shared tree managed by its matching CLI and skills. When running Context Tree project commands from a task subdirectory, pass `--project-path "<Agent Home>"` to use the connected Home; do not create or reconnect a tree just because the task cwd changed. Follow the matching skill write protocol. Do not invent an independent Git policy for Tree writes.',
     "",
   ];

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -1,5 +1,4 @@
 import { mkdir } from "node:fs/promises";
-import { delimiter } from "node:path";
 import type {
   EffectiveRuntimeSnapshot,
   InputRejectReason,
@@ -64,8 +63,6 @@ export interface SessionRuntimeManagerOptions {
   readonly slackConfigWritableRoot?: (sessionId: string) => string | undefined;
   /** Absolute Session launch-bin directory prepended to the Agent Runtime PATH. Visible only. */
   readonly providerCliLaunchPath?: (sessionId: string) => string | undefined;
-  /** Inherited PATH after the launch bin. Tests may override; production uses process.env.PATH. */
-  readonly inheritedPath?: string;
   readonly workspace: AgentWorkspaceManager;
 }
 
@@ -81,7 +78,6 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   readonly #proofManager: Pick<SessionCliProofManager, "cleanup" | "materialize">;
   readonly #slackConfigWritableRoot?: SessionRuntimeManagerOptions["slackConfigWritableRoot"];
   readonly #providerCliLaunchPath?: SessionRuntimeManagerOptions["providerCliLaunchPath"];
-  readonly #inheritedPath: string | undefined;
   readonly #workspace: AgentWorkspaceManager;
   readonly #sessions = new Map<string, ManagedSessionRuntime>();
   readonly #prepares = new Set<Promise<SessionPreparationResult>>();
@@ -101,7 +97,6 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
     this.#providerEnvironmentPath = options.providerEnvironmentPath;
     this.#slackConfigWritableRoot = options.slackConfigWritableRoot;
     this.#providerCliLaunchPath = options.providerCliLaunchPath;
-    this.#inheritedPath = options.inheritedPath ?? process.env.PATH;
     this.#proofManager =
       options.proofManager ??
       ({
@@ -280,13 +275,13 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
       }),
       workspace: {
         cwd: managed.cwd,
+        ...visibleProviderCliPath(managed, this.#providerCliLaunchPath),
         environment: {
           ...(this.#home ? { OPENTAG_HOME: this.#home } : {}),
           ...(managed.proofPath ? { OPENTAG_SESSION_PROOF_FILE: managed.proofPath } : {}),
           ...(managed.sessionKind === "visible"
             ? {
                 OPENTAG_PROVIDER_ENV_FILE: this.#providerEnvironmentPath(managed.binding.sessionId),
-                ...visibleProviderCliPath(managed.binding.sessionId, this.#providerCliLaunchPath, this.#inheritedPath),
               }
             : {}),
         },
@@ -456,21 +451,6 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   }
 }
 
-function visibleProviderCliPath(
-  sessionId: string,
-  resolveLaunchPath: ((sessionId: string) => string | undefined) | undefined,
-  inheritedPath: string | undefined,
-  pathDelimiter = delimiter,
-): { PATH: string } | Record<string, never> {
-  const launchPath = resolveLaunchPath?.(sessionId);
-  if (!launchPath) return {};
-  if (!inheritedPath) return { PATH: launchPath };
-  if (inheritedPath === launchPath || inheritedPath.startsWith(`${launchPath}${pathDelimiter}`)) {
-    return { PATH: inheritedPath };
-  }
-  return { PATH: `${launchPath}${pathDelimiter}${inheritedPath}` };
-}
-
 /**
  * Resolve Context Tree for one Agent Workspace into the two things a Provider Runtime needs.
  *
@@ -518,4 +498,11 @@ async function waitForStart(start: Promise<AgentRuntime>, signal?: AbortSignal):
   } finally {
     signal.removeEventListener("abort", onAbort);
   }
+}
+
+function visibleProviderCliPath(
+  managed: ManagedSessionRuntime,
+  resolveLaunchPath: ((sessionId: string) => string | undefined) | undefined,
+): { pathPrepend?: string } {
+  return managed.sessionKind === "visible" ? { pathPrepend: resolveLaunchPath?.(managed.binding.sessionId) } : {};
 }

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -513,7 +513,7 @@ async function prepareConfigurationRoots(layout: ReturnType<typeof resolveOpenTa
     return [layout.contextTreeConfigDir];
   } catch (error) {
     logger.warn(
-      { code: error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined },
+      { code: (error as NodeJS.ErrnoException).code },
       "Context Tree configuration directory could not be created",
     );
     return [];

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -261,7 +261,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
     // never throws, so a failure only changes what the prompt reports.
     const contextTree = await prepareContextTree(this.#contextTree, managed.cwd);
     const homeLayout = resolveOpenTagHomeLayout(this.#home);
-    await mkdir(homeLayout.config, { mode: 0o700, recursive: true });
+    const configurationRoots = await prepareConfigurationRoots(homeLayout);
     const common = {
       eventSink,
       systemPrompt: renderManagedSystemPrompt(managed.snapshot, {
@@ -292,7 +292,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
             managed.binding.sessionId,
             this.#slackConfigWritableRoot,
           ),
-          homeLayout.contextTreeConfigFile,
+          ...configurationRoots,
           ...contextTree.writableRoots,
         ],
       },
@@ -505,4 +505,17 @@ function visibleProviderCliPath(
   resolveLaunchPath: ((sessionId: string) => string | undefined) | undefined,
 ): { pathPrepend?: string } {
   return managed.sessionKind === "visible" ? { pathPrepend: resolveLaunchPath?.(managed.binding.sessionId) } : {};
+}
+
+async function prepareConfigurationRoots(layout: ReturnType<typeof resolveOpenTagHomeLayout>): Promise<string[]> {
+  try {
+    await mkdir(layout.config, { mode: 0o700, recursive: true });
+    return [process.platform === "linux" ? layout.config : layout.contextTreeConfigFile];
+  } catch (error) {
+    logger.warn(
+      { err: error instanceof Error ? error.name : "unknown" },
+      "Computer configuration directory could not be created",
+    );
+    return [];
+  }
 }

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -509,12 +509,12 @@ function visibleProviderCliPath(
 
 async function prepareConfigurationRoots(layout: ReturnType<typeof resolveOpenTagHomeLayout>): Promise<string[]> {
   try {
-    await mkdir(layout.config, { mode: 0o700, recursive: true });
-    return [process.platform === "linux" ? layout.config : layout.contextTreeConfigFile];
+    await mkdir(layout.contextTreeConfigDir, { mode: 0o700, recursive: true });
+    return [layout.contextTreeConfigDir];
   } catch (error) {
     logger.warn(
-      { err: error instanceof Error ? error.name : "unknown" },
-      "Computer configuration directory could not be created",
+      { code: error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined },
+      "Context Tree configuration directory could not be created",
     );
     return [];
   }

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises";
 import { delimiter } from "node:path";
 import type {
   EffectiveRuntimeSnapshot,
@@ -7,6 +8,7 @@ import type {
 } from "@opentag/shared";
 import type { AgentRuntime, AgentRuntimeEventSink } from "../agent-runtime/types.js";
 import { createLogger } from "../observability/logger.js";
+import { resolveOpenTagHomeLayout } from "../storage/home-layout.js";
 import type { AgentRuntimeProviderRegistry } from "./agent-runtime-provider-registry.js";
 import type { AgentWorkspaceManager } from "./agent-workspace.js";
 import type { ContextTreeManager, ContextTreeStatus } from "./context-tree.js";
@@ -74,7 +76,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   readonly #contextTree?: SessionRuntimeManagerOptions["contextTree"];
   readonly #ensureProviderReady: SessionRuntimeManagerOptions["ensureProviderReady"];
   readonly #providers: AgentRuntimeProviderRegistry;
-  readonly #home: string;
+  readonly #home: string | undefined;
   readonly #providerEnvironmentPath: SessionRuntimeManagerOptions["providerEnvironmentPath"];
   readonly #proofManager: Pick<SessionCliProofManager, "cleanup" | "materialize">;
   readonly #slackConfigWritableRoot?: SessionRuntimeManagerOptions["slackConfigWritableRoot"];
@@ -95,7 +97,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
     if (options.contextTree) this.#contextTree = options.contextTree;
     this.#ensureProviderReady = options.ensureProviderReady;
     this.#providers = options.providers;
-    this.#home = options.home ?? "";
+    this.#home = options.home;
     this.#providerEnvironmentPath = options.providerEnvironmentPath;
     this.#slackConfigWritableRoot = options.slackConfigWritableRoot;
     this.#providerCliLaunchPath = options.providerCliLaunchPath;
@@ -263,6 +265,8 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
     // caches per workspace, revalidates that entry against the Computer's recorded target, and
     // never throws, so a failure only changes what the prompt reports.
     const contextTree = await prepareContextTree(this.#contextTree, managed.cwd);
+    const homeLayout = resolveOpenTagHomeLayout(this.#home);
+    await mkdir(homeLayout.config, { mode: 0o700, recursive: true });
     const common = {
       eventSink,
       systemPrompt: renderManagedSystemPrompt(managed.snapshot, {
@@ -293,6 +297,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
             managed.binding.sessionId,
             this.#slackConfigWritableRoot,
           ),
+          homeLayout.contextTreeConfigFile,
           ...contextTree.writableRoots,
         ],
       },

--- a/packages/client/src/storage/home-layout.ts
+++ b/packages/client/src/storage/home-layout.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 export interface OpenTagHomeLayout {
   config: string;
   contextTreeBin: string;
+  contextTreeConfigDir: string;
   contextTreeConfigFile: string;
   contextTreePreparationFile: string;
   daemonState: string;
@@ -33,7 +34,8 @@ export function resolveOpenTagHomeLayout(home = resolveOpenTagHome()): OpenTagHo
     config,
     // Holds the shim the Context Tree skills invoke by name; OpenTag's own calls bypass it.
     contextTreeBin: join(resolvedHome, "context-tree", "bin"),
-    contextTreeConfigFile: join(config, "context-tree.json"),
+    contextTreeConfigDir: join(config, "context-tree"),
+    contextTreeConfigFile: join(config, "context-tree", "config.json"),
     contextTreePreparationFile: join(state, "context-tree-preparation.json"),
     daemonState: join(state, "daemon"),
     data,


### PR DESCRIPTION
## Summary

Agents can run `opentag context-tree connect` before Context Tree is configured. Every provider runtime receives the dedicated `<OPENTAG_HOME>/config/context-tree/` writable directory, created before provider startup. The configuration now lives at `config/context-tree/config.json`. The directory grant supports file creation on Linux while keeping Computer identity and credential files outside the grant.

Both visible and internal Sessions can change this Computer-wide target, including through direct configuration edits. Later provider runtime starts consume the selected target. Workspace, Slack, and connected-tree grants are preserved. Claude Code already runs with unrestricted filesystem access; this PR does not add isolation for it.

Session PATH composition preserves the Context Tree shim and provider executable directories. Shim preparation is shared, bounded by the Session start budget, and retried after failures; preparation failures remain diagnosable. The stalled-preparation test waits for the shared write instead of assuming filesystem preparation completes within 10 ms.

## Breaking changes

Existing `<OPENTAG_HOME>/config/context-tree.json` files are ignored. There is no automatic migration or read fallback. Previously configured Computers must reconnect using their previous target:

- `opentag context-tree connect <managed-name>`
- `opentag context-tree connect OWNER/REPO`
- `opentag context-tree connect --tree-path <path>`

Restart the daemon and affected Sessions, then verify with `opentag doctor`. The old configuration and existing tree data remain on disk. When both configuration files exist, the new path wins. The schema and connection command syntax are unchanged.

## Testing

- CI passed on reviewed head `0dacb63515f5c1a78ec853d5d2b22df3b45613a3`, including Checks, patch coverage, and Node 22/24/26 compatibility: https://github.com/first-tree-ai/opentag/actions/runs/34302866500.
- Independent review validation on that head passed check, build, typecheck, 1,004 Client tests, 434 CLI tests, and the 368-test Agent Runtime coverage gate at 100% across all four metrics.
- The earlier real Linux Codex sandbox probe established that the exact-file grant could not create the configuration; this motivated granting an existing directory. The final implementation grants only the dedicated Context Tree configuration directory on both platforms. That earlier probe is not a fresh sandbox run of the final layout.
- Runtime and CLI tests cover an old-only configuration and new-path precedence when both files exist. Independent upgrade validation confirmed manual reconnect writes the new configuration with private permissions and leaves legacy bytes untouched.
- Review follow-up: all 41 tests in `packages/client/src/__tests__/context-tree.test.ts` passed locally after fixing the timing-sensitive assertion; `pnpm check` passed. CI must run again for the follow-up commit.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] Check, build, typecheck, and tests passed for the reviewed head as recorded above.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical documentation describes the directory grant and breaking upgrade; no Chinese mirror exists for this design document.
