### PR TITLE
fix(onboarding): keep optional cleanup out of setup commands

### DIFF
--- a/apps/web/src/onboarding-v2/setup-memory-adapter.test.ts
+++ b/apps/web/src/onboarding-v2/setup-memory-adapter.test.ts
@@ -51,6 +51,8 @@ describe("createMemorySetupAdapter", () => {
     expect(issued.bootstrapCommand).toContain('"$HOME/.local/bin/opentag" connect');
     expect(issued.bootstrapCommand).toContain("--server https://opentag.invalid -- memory-");
     expect(issued.bootstrapCommand).not.toContain("opentag.ai");
+    expect(issued.bootstrapCommand).not.toMatch(/(?:^|[\s;|&])rm\s+-f(?:\s|$)/);
+    expect(issued.bootstrapCommand).not.toContain("|");
   });
 
   it.each([

--- a/apps/web/src/onboarding-v2/setup-memory-adapter.ts
+++ b/apps/web/src/onboarding-v2/setup-memory-adapter.ts
@@ -661,7 +661,7 @@ export function createMemorySetupAdapter(seed: MemorySetupSeed): MemorySetupAdap
         // pointing a copy-pasted fixture at a real installer or control plane.
         bootstrapCommand:
           'opentag_installer="$(mktemp)" && curl -fsSL https://download.opentag.invalid/releases/prod/install.sh' +
-          ' -o "$opentag_installer" && sh "$opentag_installer" && rm -f "$opentag_installer"' +
+          ' -o "$opentag_installer" && sh "$opentag_installer"' +
           ` && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag" connect` +
           ` --server https://opentag.invalid -- memory-${connectCodeId}`,
         connectCodeId,

--- a/packages/server/src/__tests__/computer-connect-command.test.ts
+++ b/packages/server/src/__tests__/computer-connect-command.test.ts
@@ -1,0 +1,388 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildComputerConnectCommand } from "../services/computers/machine-auth-service.js";
+
+const DOWNLOAD_BASE_URL = "https://download.opentag.invalid/releases";
+const CODE = "otcc_testcode";
+const CHANNELS = [
+  { environment: "prod" as const, binName: "opentag", publicUrl: "https://opentag.invalid" },
+  { environment: "staging" as const, binName: "opentag-staging", publicUrl: "https://staging.opentag.invalid" },
+];
+
+const sandboxes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(sandboxes.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("buildComputerConnectCommand", () => {
+  it.each(CHANNELS)("chains mktemp, curl -fsSL to a file, sh, then $binName connect for $environment", (channel) => {
+    const command = releasedCommand(channel);
+    const installerUrl = releasedInstallerUrl(channel.environment);
+    expect(command).toBe(
+      `opentag_installer="$(mktemp)" && curl -fsSL ${installerUrl} -o "$opentag_installer"` +
+        ` && sh "$opentag_installer"` +
+        ` && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/${channel.binName}" connect` +
+        ` --server ${channel.publicUrl} -- ${CODE}`,
+    );
+    expect(command).not.toMatch(/(?:^|[\s;|&])rm(?:\s|$)/);
+    expect(command).not.toMatch(/\btrap\b/);
+    expect(command).not.toContain("|");
+  });
+
+  it("keeps the dev variant on the local install script", () => {
+    const command = buildComputerConnectCommand({
+      code: CODE,
+      downloadBaseUrl: DOWNLOAD_BASE_URL,
+      environment: "dev",
+      publicUrl: "http://127.0.0.1:8000",
+    });
+    expect(command).toBe(
+      `./scripts/dev-install.sh && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag-dev" connect --server http://127.0.0.1:8000 -- ${CODE}`,
+    );
+    expect(command).not.toContain("mktemp");
+    expect(command).not.toContain("curl");
+    expect(command).not.toMatch(/(?:^|[\s;|&])rm(?:\s|$)/);
+  });
+
+  it("quotes an unsafe connect code without changing the install chain", () => {
+    const command = buildComputerConnectCommand({
+      code: "a'; echo nope",
+      downloadBaseUrl: DOWNLOAD_BASE_URL,
+      environment: "prod",
+      publicUrl: "https://example.com/a b",
+    });
+    expect(command).toContain("'a'\\''; echo nope'");
+    expect(command.startsWith('opentag_installer="$(mktemp)" && curl -fsSL ')).toBe(true);
+    expect(command).not.toMatch(/(?:^|[\s;|&])rm(?:\s|$)/);
+  });
+
+  it("admits the generated command to a synthetic rm -f preflight that rejects the previous deletion chain", () => {
+    // Synthetic fixture only: not a real target Agent, Cursor, or Codex execution-tool policy.
+    const previousWithDeletion =
+      `opentag_installer="$(mktemp)" && curl -fsSL https://download.opentag.invalid/releases/prod/install.sh -o "$opentag_installer"` +
+      ` && sh "$opentag_installer" && rm -f "$opentag_installer"` +
+      ` && PATH="$HOME/.local/bin\${PATH:+:$PATH}" "$HOME/.local/bin/opentag" connect --server https://opentag.invalid -- ${CODE}`;
+    expect(syntheticRmDashFPreflightAdmits(previousWithDeletion)).toBe(false);
+    for (const channel of CHANNELS) {
+      expect(syntheticRmDashFPreflightAdmits(releasedCommand(channel))).toBe(true);
+    }
+  });
+});
+
+describe("generated Computer connect command shell execution", () => {
+  it.each(CHANNELS)(
+    "installs and connects with the new $binName for $environment, leaving the installer in TMPDIR",
+    async (channel) => {
+      const sandbox = await createSandbox({
+        binName: channel.binName,
+        installerUrl: releasedInstallerUrl(channel.environment),
+      });
+      const result = runGeneratedCommand(releasedCommand(channel), sandbox.env);
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      expect(await readEventLog(sandbox.eventLog)).toEqual([
+        "mktemp",
+        "curl",
+        "install",
+        `new-connect connect --server ${channel.publicUrl} -- ${CODE}`,
+      ]);
+      expect(await readdir(sandbox.tmp)).not.toEqual([]);
+    },
+  );
+
+  it.each(CHANNELS)("does not use the preexisting $binName when mktemp fails for $environment", async (channel) => {
+    const sandbox = await createSandbox({
+      binName: channel.binName,
+      installerUrl: releasedInstallerUrl(channel.environment),
+      mktempFail: true,
+    });
+    const result = runGeneratedCommand(releasedCommand(channel), sandbox.env);
+    expect(result.status).not.toBe(0);
+    expect(await readEventLog(sandbox.eventLog)).toEqual(["mktemp"]);
+  });
+
+  it.each(CHANNELS)("does not use the preexisting $binName when download fails for $environment", async (channel) => {
+    const sandbox = await createSandbox({
+      binName: channel.binName,
+      curlMode: "fail",
+      installerUrl: releasedInstallerUrl(channel.environment),
+    });
+    const result = runGeneratedCommand(releasedCommand(channel), sandbox.env);
+    expect(result.status).toBe(22);
+    expect(await readEventLog(sandbox.eventLog)).toEqual(["mktemp", "curl"]);
+  });
+
+  it.each(CHANNELS)(
+    "does not run a partial executable download or the preexisting $binName for $environment",
+    async (channel) => {
+      const sandbox = await createSandbox({
+        binName: channel.binName,
+        curlMode: "partial",
+        installerUrl: releasedInstallerUrl(channel.environment),
+      });
+      const result = runGeneratedCommand(releasedCommand(channel), sandbox.env);
+      expect(result.status).toBe(22);
+      expect(await readEventLog(sandbox.eventLog)).toEqual(["mktemp", "curl"]);
+    },
+  );
+
+  it.each(CHANNELS)(
+    "does not use the preexisting $binName when installation fails for $environment",
+    async (channel) => {
+      const sandbox = await createSandbox({
+        binName: channel.binName,
+        installFail: true,
+        installerUrl: releasedInstallerUrl(channel.environment),
+      });
+      const result = runGeneratedCommand(releasedCommand(channel), sandbox.env);
+      expect(result.status).not.toBe(0);
+      expect(await readEventLog(sandbox.eventLog)).toEqual(["mktemp", "curl", "install"]);
+    },
+  );
+
+  it.each(CHANNELS)("still connects for $environment when rm is unavailable", async (channel) => {
+    const sandbox = await createSandbox({
+      binName: channel.binName,
+      installerUrl: releasedInstallerUrl(channel.environment),
+      rm: "unavailable",
+    });
+    const result = runGeneratedCommand(releasedCommand(channel), sandbox.env);
+    expect(result.status, result.stderr).toBe(0);
+    expect(await readEventLog(sandbox.eventLog)).toEqual([
+      "mktemp",
+      "curl",
+      "install",
+      `new-connect connect --server ${channel.publicUrl} -- ${CODE}`,
+    ]);
+  });
+
+  it.each(CHANNELS)("still connects for $environment when rm fails", async (channel) => {
+    const sandbox = await createSandbox({
+      binName: channel.binName,
+      installerUrl: releasedInstallerUrl(channel.environment),
+      rm: "fail",
+    });
+    const result = runGeneratedCommand(releasedCommand(channel), sandbox.env);
+    expect(result.status, result.stderr).toBe(0);
+    expect(await readEventLog(sandbox.eventLog)).toEqual([
+      "mktemp",
+      "curl",
+      "install",
+      `new-connect connect --server ${channel.publicUrl} -- ${CODE}`,
+    ]);
+  });
+
+  it.each(CHANNELS)("propagates a nonzero $binName connect status for $environment", async (channel) => {
+    const sandbox = await createSandbox({
+      binName: channel.binName,
+      connectExit: 9,
+      installerUrl: releasedInstallerUrl(channel.environment),
+    });
+    const result = runGeneratedCommand(releasedCommand(channel), sandbox.env);
+    expect(result.status).toBe(9);
+    expect(await readEventLog(sandbox.eventLog)).toEqual([
+      "mktemp",
+      "curl",
+      "install",
+      `new-connect connect --server ${channel.publicUrl} -- ${CODE}`,
+    ]);
+  });
+});
+
+function releasedInstallerUrl(environment: "prod" | "staging"): string {
+  return `${DOWNLOAD_BASE_URL}/${environment}/install.sh`;
+}
+
+function releasedCommand(channel: (typeof CHANNELS)[number]): string {
+  return buildComputerConnectCommand({
+    code: CODE,
+    downloadBaseUrl: DOWNLOAD_BASE_URL,
+    environment: channel.environment,
+    publicUrl: channel.publicUrl,
+  });
+}
+
+/**
+ * Narrow stand-in for an execution-tool preflight that refuses explicit `rm -f`.
+ * This is not a real target Agent acceptance check.
+ */
+function syntheticRmDashFPreflightAdmits(command: string): boolean {
+  return !/(?:^|[\s;|&])rm\s+-f(?:\s|$)/.test(command);
+}
+
+function runGeneratedCommand(command: string, env: Record<string, string>) {
+  return spawnSync("/bin/sh", ["-c", command], {
+    cwd: env.HOME,
+    encoding: "utf8",
+    env,
+    timeout: 10_000,
+  });
+}
+
+async function createSandbox(input: {
+  binName: string;
+  installerUrl: string;
+  curlMode?: "success" | "fail" | "partial";
+  mktempFail?: boolean;
+  installFail?: boolean;
+  connectExit?: number;
+  rm?: "fail" | "unavailable";
+}): Promise<{ env: Record<string, string>; eventLog: string; tmp: string }> {
+  const root = await mkdtemp(join(tmpdir(), "opentag-connect-cmd-"));
+  sandboxes.push(root);
+  const home = join(root, "home");
+  const tmp = join(root, "tmp");
+  const stubBin = join(root, "stub-bin");
+  const tools = join(root, "tools");
+  const fixtures = join(root, "fixtures");
+  const eventLog = join(root, "events.log");
+  const localBin = join(home, ".local", "bin");
+  await Promise.all([mkdir(tmp), mkdir(stubBin), mkdir(tools), mkdir(fixtures), mkdir(localBin, { recursive: true })]);
+  await Promise.all(["sh", "mkdir", "cat", "chmod"].map(async (name) => symlink(resolveTool(name), join(tools, name))));
+  await writeExecutable(
+    join(stubBin, "mktemp"),
+    `#!/bin/sh
+printf '%s\\n' mktemp >> "$OPENTAG_TEST_EVENT_LOG"
+if [ "\${OPENTAG_TEST_MKTEMP_FAIL:-}" = "1" ]; then
+  exit 1
+fi
+file="\${TMPDIR%/}/opentag-installer-$$"
+i=0
+while [ -e "$file" ]; do
+  i=$((i + 1))
+  file="\${TMPDIR%/}/opentag-installer-$$.$i"
+done
+: > "$file"
+printf '%s\\n' "$file"
+`,
+  );
+  await writeExecutable(
+    join(stubBin, "curl"),
+    `#!/bin/sh
+printf '%s\\n' curl >> "$OPENTAG_TEST_EVENT_LOG"
+fs_sl=0
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -fsSL)
+      fs_sl=1
+      shift
+      ;;
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -*)
+      exit 2
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+if [ "$fs_sl" -ne 1 ] || [ -z "$out" ] || [ -z "$url" ]; then
+  exit 2
+fi
+if [ "$url" != "$OPENTAG_TEST_INSTALLER_URL" ]; then
+  printf '%s\\n' "unexpected-url $url" >> "$OPENTAG_TEST_EVENT_LOG"
+  exit 3
+fi
+mode="\${OPENTAG_TEST_CURL_MODE:-success}"
+if [ "$mode" = "fail" ]; then
+  exit 22
+fi
+if [ "$mode" = "partial" ]; then
+  cat "$OPENTAG_TEST_PARTIAL_INSTALLER" > "$out"
+  exit 22
+fi
+cat "$OPENTAG_TEST_INSTALLER" > "$out"
+exit 0
+`,
+  );
+  if (input.rm === "fail") {
+    await writeExecutable(
+      join(stubBin, "rm"),
+      `#!/bin/sh
+printf '%s\\n' "rm $*" >> "$OPENTAG_TEST_EVENT_LOG"
+exit 1
+`,
+    );
+  }
+  await writeFile(
+    join(fixtures, "installer.sh"),
+    `#!/bin/sh
+printf '%s\\n' install >> "$OPENTAG_TEST_EVENT_LOG"
+if [ "\${OPENTAG_TEST_INSTALL_FAIL:-}" = "1" ]; then
+  exit 1
+fi
+mkdir -p "$HOME/.local/bin"
+cat > "$HOME/.local/bin/$OPENTAG_TEST_BIN_NAME" <<'BIN'
+#!/bin/sh
+printf '%s\\n' "new-connect $*" >> "$OPENTAG_TEST_EVENT_LOG"
+exit "\${OPENTAG_TEST_CONNECT_EXIT:-0}"
+BIN
+chmod +x "$HOME/.local/bin/$OPENTAG_TEST_BIN_NAME"
+`,
+    { mode: 0o644 },
+  );
+  await writeFile(
+    join(fixtures, "partial-installer.sh"),
+    `#!/bin/sh
+printf '%s\\n' partial-installer >> "$OPENTAG_TEST_EVENT_LOG"
+exit 0
+`,
+    { mode: 0o755 },
+  );
+  await writeExecutable(
+    join(localBin, input.binName),
+    `#!/bin/sh
+printf '%s\\n' "old-connect $*" >> "$OPENTAG_TEST_EVENT_LOG"
+exit 0
+`,
+  );
+  const env: Record<string, string> = {
+    HOME: home,
+    OPENTAG_TEST_BIN_NAME: input.binName,
+    OPENTAG_TEST_CURL_MODE: input.curlMode ?? "success",
+    OPENTAG_TEST_EVENT_LOG: eventLog,
+    OPENTAG_TEST_INSTALLER: join(fixtures, "installer.sh"),
+    OPENTAG_TEST_INSTALLER_URL: input.installerUrl,
+    OPENTAG_TEST_PARTIAL_INSTALLER: join(fixtures, "partial-installer.sh"),
+    PATH: `${stubBin}:${tools}`,
+    TMPDIR: tmp,
+  };
+  if (input.mktempFail) env.OPENTAG_TEST_MKTEMP_FAIL = "1";
+  if (input.installFail) env.OPENTAG_TEST_INSTALL_FAIL = "1";
+  if (input.connectExit !== undefined) env.OPENTAG_TEST_CONNECT_EXIT = String(input.connectExit);
+  return { env, eventLog, tmp };
+}
+
+async function writeExecutable(path: string, body: string): Promise<void> {
+  await writeFile(path, body, { mode: 0o755 });
+  await chmod(path, 0o755);
+}
+
+function resolveTool(name: string): string {
+  for (const dir of ["/bin", "/usr/bin"]) {
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(`missing ${name} for the Computer connect command sandbox`);
+}
+
+async function readEventLog(eventLog: string): Promise<string[]> {
+  try {
+    const contents = await readFile(eventLog, "utf8");
+    return contents.trim() === "" ? [] : contents.trim().split("\n");
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  }
+}

--- a/packages/server/src/__tests__/integration/computers.test.ts
+++ b/packages/server/src/__tests__/integration/computers.test.ts
@@ -611,7 +611,7 @@ describe("Computer connection persistence", () => {
         expect(issued.headers["cache-control"]).toBe("no-store");
         const command = issued.json().bootstrapCommand as string;
         expect(command).toContain(
-          'opentag_installer="$(mktemp)" && curl -fsSL https://storage.googleapis.com/opentag-release/releases/staging/install.sh -o "$opentag_installer" && sh "$opentag_installer" && rm -f "$opentag_installer" && PATH="$HOME/.local/bin${PATH:+:$PATH}" "$HOME/.local/bin/opentag-staging" connect --server https://dev.example.com -- otcc_',
+          'opentag_installer="$(mktemp)" && curl -fsSL https://storage.googleapis.com/opentag-release/releases/staging/install.sh -o "$opentag_installer" && sh "$opentag_installer" && PATH="$HOME/.local/bin${PATH:+:$PATH}" "$HOME/.local/bin/opentag-staging" connect --server https://dev.example.com -- otcc_',
         );
         const code = command.split(" -- ").at(-1);
         if (!code) throw new Error("Computer connect command did not contain a code");

--- a/packages/server/src/__tests__/server-account-services.test.ts
+++ b/packages/server/src/__tests__/server-account-services.test.ts
@@ -590,7 +590,7 @@ describe("machine authentication and Computer services", () => {
       }),
     ).toBe(
       'opentag_installer="$(mktemp)" && curl -fsSL https://mirror.example/releases/staging/install.sh -o "$opentag_installer"' +
-        ' && sh "$opentag_installer" && rm -f "$opentag_installer"' +
+        ' && sh "$opentag_installer"' +
         ' && PATH="$HOME/.local/bin${PATH:+:$PATH}" "$HOME/.local/bin/opentag-staging" connect --server https://dev.example.com -- abc',
     );
     expect(

--- a/packages/server/src/services/computers/machine-auth-service.ts
+++ b/packages/server/src/services/computers/machine-auth-service.ts
@@ -606,8 +606,11 @@ export function buildComputerConnectCommand(options: {
    * download leaves behind, so `curl … | sh &&` would run whatever Client is already on disk and
    * report a download failure as an unrelated CLI usage error. Landing the installer in a file
    * first keeps every step in one `&&` chain, so the command stops at the step that actually broke.
+   * Some execution tools reject the entire submitted command if it contains explicit deletion.
+   * Leave this public installer in the OS temporary directory for independent cleanup, so deletion
+   * neither blocks setup at preflight nor becomes a prerequisite of connect or replaces its status.
    */
-  return `opentag_installer="$(mktemp)" && curl -fsSL ${shellArg(installerUrl)} -o "$opentag_installer" && sh "$opentag_installer" && rm -f "$opentag_installer" && ${connect}`;
+  return `opentag_installer="$(mktemp)" && curl -fsSL ${shellArg(installerUrl)} -o "$opentag_installer" && sh "$opentag_installer" && ${connect}`;
 }
 
 function shellArg(value: string): string {


### PR DESCRIPTION
## Summary

OpenTag's generated setup command included `rm -f` before `connect`. A coding Agent's execution tool could reject the entire command before installation started, and a cleanup failure in the shell could skip connection after a successful install.

Remove explicit deletion from the generated production/staging command and synchronize the Web memory adapter and API fixtures. The command still uses `mktemp && curl -fsSL ... -o file && sh file && connect`, so temporary-file, download and installation failures stop setup even when an older binary exists. Connection's exit status remains the final result. The public installer stays in the OS temporary directory for independent cleanup; immediate reclamation is not guaranteed. The dev command is unchanged.

Synced main `8cc14e38` in merge commit `3fac08f3`. The sole conflict was the Computer integration command fixture: retain main's `dl.opentag.build` download domain together with this PR's removal of explicit deletion.

Closes #567.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test` — passed; 3,569 unit/script tests on the merged tree.
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — 360 tests passed; all four coverage dimensions 100%.
- `pnpm --filter @opentag/server test:integration` — passed on synchronized head `3fac08f3` in GitHub CI: 18 files / 324 tests. The local attempt could not start because Docker exhausted container process resources; the CI run supplies current-head integration evidence. [Checks job](https://github.com/first-tree-ai/opentag/actions/runs/34302188655/job/102311255938).
- All technical CI checks on `3fac08f3` passed, including patch coverage and Node 22/24/26 compatibility. Ownership approval and the target-Agent acceptance below remain outstanding.
- New 21-case command suite executes the actual generator output in isolated shells for prod/staging: existing old binary, temporary-file failure, failed/partial download, installer failure, successful replacement, unavailable/failing deletion, and connection exit status. A narrowly modeled preflight rejects the previous `rm -f` command and admits the new command. This is explicitly synthetic policy coverage.

## UI validation

Authenticated Docker acceptance passed on synchronized Web/Server head `3fac08f3` for both prod and staging. Exercised actual built Web login, test Agent creation and Copy button with separate disposable accounts/PGlite databases. Clipboard visible text matched after whitespace normalization, and its shell suffix exactly matched the actual API command. Submitted each complete clipboard unchanged through the current Codex execution tool to `/bin/sh -lc` in separate Linux arm64 containers with real nonroot accounts and user-systemd managers. Existing host policy remained `danger-full-access` / `approval never`.

Both official published installers completed: prod `0.0.2` (`db870b63`), staging `0.0.3-staging.107.1` (`bc019e0c`). Both full commands exited 0 and reported **4/4 ready**: real Computer connection/daemon, Codex CLI `0.153.4`, Lark CLI `1.0.92`, and Slack CLI `4.7.0`. Independent runtime inspections also exited 0. With explicit user authorization, only the local Codex auth file was mounted read-only; its before/after digest and permissions were unchanged. No installer, CLI, provider executable or readiness fixture was used.

After one explicit Web refresh per channel, real daemon observations and both Web pages showed Computer online, Codex ready and messaging support ready. Clicking Continue succeeded for both channels and opened messaging setup. The test scope ended before messaging-account binding or message sending. Both task containers, Servers and browser tabs were cleaned up after evidence collection. No product source or existing Computer binding changed.

**Review boundary:** the requested Linux Docker acceptance is complete. The original macOS incident's exact Agent policy remains unverified; this run does not establish that policy's behavior. Reviewer approval remains outstanding. No layout, styling or breakpoint behavior changed.

## Breaking changes

None. Temporary public installer files may remain until the system's normal retention policy removes them. No tool policy, release, deployment or current computer binding is changed.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and comments cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] No canonical/mirrored documentation changes are required.
- [x] Authenticated Linux Docker copy/paste setup and real CLI/Web readiness acceptance completed for prod/staging.
- [ ] Original incident Agent policy behavior verified or Docker acceptance accepted by the reviewer as sufficient.

