### PR TITLE
fix(web): show setup spinner only on the selected messaging app

### DIFF
--- a/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
@@ -61,6 +61,7 @@ function renderSetup(
   adapter: AgentSetupAdapter,
   props: {
     agentId?: string;
+    onExternalNavigation?: (url: string) => void;
     onOpenAgent?: () => void;
     onReady?: (agentId: string) => Promise<void> | void;
     reviewMode?: boolean;
@@ -73,6 +74,7 @@ function renderSetup(
       <AgentSetupPage
         adapter={adapter}
         agentId={props.agentId ?? SETUP_AGENT_ID}
+        onExternalNavigation={props.onExternalNavigation}
         onOpenAgent={props.onOpenAgent}
         onReady={props.onReady}
         reviewMode={props.reviewMode}
@@ -132,6 +134,51 @@ function continueFromPreparation(): void {
   const button = screen.getByRole("button", { name: "Continue" });
   expect(button.hasAttribute("disabled")).toBe(false);
   fireEvent.click(button);
+}
+
+function messagingChoices(): HTMLElement {
+  const list = document.querySelector('[data-ui="agent-setup-messaging-choices"]');
+  if (!list) throw new Error("Missing messaging choices");
+  return list as HTMLElement;
+}
+
+function messagingChoice(name: RegExp): HTMLElement {
+  return within(messagingChoices()).getByRole("button", { name });
+}
+
+/** Kumo Button loading renders a Loader with role=status and aria-label="Loading". */
+function choiceHasLoadingDom(button: HTMLElement): boolean {
+  return within(button).queryByRole("status", { name: "Loading" }) !== null;
+}
+
+function expectPendingMessagingChoice(selected: RegExp, idle: RegExp): void {
+  const selectedButton = messagingChoice(selected);
+  const idleButton = messagingChoice(idle);
+  expect(choiceHasLoadingDom(selectedButton)).toBe(true);
+  expect(choiceHasLoadingDom(idleButton)).toBe(false);
+  expect(selectedButton.hasAttribute("disabled")).toBe(true);
+  expect(idleButton.hasAttribute("disabled")).toBe(true);
+}
+
+function expectIdleMessagingChoices(): void {
+  const slack = messagingChoice(/Slack/);
+  const lark = messagingChoice(/Lark/);
+  expect(choiceHasLoadingDom(slack)).toBe(false);
+  expect(choiceHasLoadingDom(lark)).toBe(false);
+  expect(slack.hasAttribute("disabled")).toBe(false);
+  expect(lark.hasAttribute("disabled")).toBe(false);
+}
+
+async function renderMessagingStartChoice(
+  overrides: Partial<AgentSetupAdapter> = {},
+  props: Parameters<typeof renderSetup>[1] = {},
+): Promise<AgentSetupAdapter> {
+  const memory = createMemorySetupAdapter({ agent: setupAgent() });
+  const adapter = scriptedAdapter((agentId) => memory.adapter.readSnapshot(agentId), overrides);
+  renderSetup(adapter, props);
+  await settle();
+  continueFromPreparation();
+  return adapter;
 }
 
 async function currentBindingId(adapter: AgentSetupAdapter): Promise<string> {
@@ -1045,6 +1092,136 @@ describe("AgentSetupPage transitions", () => {
 
     expect(screen.getByText("network is down")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Prepare this computer" })).toBeTruthy();
+  });
+});
+
+describe("AgentSetupPage messaging choice loading", () => {
+  it("shows a spinner only on Slack while both choices stay disabled", async () => {
+    const gate = deferred<string>();
+    await renderMessagingStartChoice(
+      {
+        startSlackInstall: vi.fn(async () => gate.promise),
+      },
+      { onExternalNavigation: vi.fn() },
+    );
+
+    fireEvent.click(messagingChoice(/Slack/));
+    await settle();
+
+    expectPendingMessagingChoice(/Slack/, /Lark/);
+    gate.resolve("https://slack.com/oauth/v2/authorize?state=scripted");
+    await settle();
+  });
+
+  it("shows a spinner only on Lark while both choices stay disabled", async () => {
+    const gate = deferred<void>();
+    await renderMessagingStartChoice({
+      startFeishuAttempt: vi.fn(async () => gate.promise),
+    });
+
+    fireEvent.click(messagingChoice(/Lark/));
+    await settle();
+
+    expectPendingMessagingChoice(/Lark/, /Slack/);
+    gate.resolve();
+    await settle();
+  });
+
+  it("clears both spinners when a pending start resolves with the choices still visible", async () => {
+    const slackGate = deferred<string>();
+    const larkGate = deferred<void>();
+    const navigate = vi.fn();
+    const adapter = await renderMessagingStartChoice(
+      {
+        startSlackInstall: vi.fn(async () => slackGate.promise),
+        startFeishuAttempt: vi.fn(async () => larkGate.promise),
+      },
+      { onExternalNavigation: navigate },
+    );
+
+    fireEvent.click(messagingChoice(/Slack/));
+    await settle();
+    expectPendingMessagingChoice(/Slack/, /Lark/);
+    slackGate.resolve("https://slack.com/oauth/v2/authorize?state=scripted");
+    await settle();
+    expectIdleMessagingChoices();
+    expect(navigate).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(messagingChoice(/Lark/));
+    await settle();
+    expectPendingMessagingChoice(/Lark/, /Slack/);
+    larkGate.resolve();
+    await settle();
+    expectIdleMessagingChoices();
+    expect(adapter.startSlackInstall).toHaveBeenCalledTimes(1);
+    expect(adapter.startFeishuAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["Slack", "Lark"] as const)("clears a failed %s start before retrying the other provider", async (name) => {
+    const gates = { Slack: deferred<void>(), Lark: deferred<void>() };
+    const other = name === "Slack" ? "Lark" : "Slack";
+    const selectedPattern = new RegExp(name);
+    const otherPattern = new RegExp(other);
+    const adapter = await renderMessagingStartChoice(
+      {
+        startFeishuAttempt: vi.fn(async () => gates.Lark.promise),
+        startSlackInstall: vi.fn(async () => {
+          await gates.Slack.promise;
+          return "https://slack.com/oauth/v2/authorize?state=scripted";
+        }),
+      },
+      { onExternalNavigation: vi.fn() },
+    );
+
+    fireEvent.click(messagingChoice(selectedPattern));
+    await settle();
+    expectPendingMessagingChoice(selectedPattern, otherPattern);
+
+    gates[name].reject(new Error("refused"));
+    await settle();
+    expectIdleMessagingChoices();
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    fireEvent.click(messagingChoice(otherPattern));
+    await settle();
+    expectPendingMessagingChoice(otherPattern, selectedPattern);
+    expect(screen.queryByRole("alert")).toBeNull();
+    gates[other].resolve();
+    await settle();
+    expectIdleMessagingChoices();
+    expect(adapter.startSlackInstall).toHaveBeenCalledTimes(1);
+    expect(adapter.startFeishuAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["Slack", "Lark"] as const)("refuses same-event-loop duplicate clicks starting with %s", async (name) => {
+    const gates = { Slack: deferred<string>(), Lark: deferred<void>() };
+    const selectedPattern = new RegExp(name);
+    const otherPattern = name === "Slack" ? /Lark/ : /Slack/;
+    const adapter = await renderMessagingStartChoice(
+      {
+        startFeishuAttempt: vi.fn(async () => gates.Lark.promise),
+        startSlackInstall: vi.fn(async () => gates.Slack.promise),
+      },
+      { onExternalNavigation: vi.fn() },
+    );
+
+    const selected = messagingChoice(selectedPattern);
+    const other = messagingChoice(otherPattern);
+    // Batch the clicks before React can commit disabled buttons, exercising the synchronous guard.
+    act(() => {
+      fireEvent.click(selected);
+      fireEvent.click(selected);
+      fireEvent.click(other);
+    });
+    await settle();
+
+    expect(adapter.startFeishuAttempt).toHaveBeenCalledTimes(name === "Lark" ? 1 : 0);
+    expect(adapter.startSlackInstall).toHaveBeenCalledTimes(name === "Slack" ? 1 : 0);
+    expectPendingMessagingChoice(selectedPattern, otherPattern);
+    gates.Slack.resolve("https://slack.com/oauth/v2/authorize?state=scripted");
+    gates.Lark.resolve();
+    await settle();
+    expectIdleMessagingChoices();
   });
 });
 

--- a/apps/web/src/onboarding-v2/agent-setup-page.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.tsx
@@ -369,11 +369,11 @@ function useSetupActions(
   onExternalNavigation?: AgentSetupPageProps["onExternalNavigation"],
 ): {
   actionError: string | undefined;
-  busyKey: AgentSetupAction["kind"] | undefined;
+  busyKey: AgentSetupAction | undefined;
   act: (action: AgentSetupAction) => Promise<boolean>;
 } {
   const [actionError, setActionError] = useState<string>();
-  const [busyKey, setBusyKey] = useState<AgentSetupAction["kind"]>();
+  const [busyKey, setBusyKey] = useState<AgentSetupAction>();
   const busyRef = useRef(false);
   const actionRun = useRef(0);
 
@@ -389,7 +389,7 @@ function useSetupActions(
     async (action: AgentSetupAction): Promise<boolean> => {
       if (busyRef.current) return false;
       busyRef.current = true;
-      setBusyKey(action.kind);
+      setBusyKey(action);
       setActionError(undefined);
       // A poll started before the write could commit the state the write just made obsolete; the
       // hold keeps the on-screen snapshot frozen until the post-action read lifts it.
@@ -434,8 +434,8 @@ interface AgentSetupController {
   readonly refreshError: string | undefined;
   /** The last action's failure, in words that name what was being attempted. */
   readonly actionError: string | undefined;
-  /** Which action kind is in flight, so every action control can refuse a second submission. */
-  readonly busyKey: AgentSetupAction["kind"] | undefined;
+  /** The in-flight action identity, so loading can name the selected control while every action stays disabled. */
+  readonly busyKey: AgentSetupAction | undefined;
   /** Runs one snapshot-listed action to completion and re-reads. Resolves false when it failed. */
   readonly act: (action: AgentSetupAction) => Promise<boolean>;
   /** A silent re-read, for surfaces that finished their own work (a bind, a repair). */
@@ -965,7 +965,7 @@ function SetupRefreshButton({ controller }: { readonly controller: AgentSetupCon
     <Button
       className="otv2-step-footer__secondary-action"
       disabled={controller.busyKey !== undefined}
-      loading={controller.busyKey === "refresh"}
+      loading={controller.busyKey?.kind === "refresh"}
       onClick={() => {
         controller.resetPollBudget();
         void controller.act({ kind: "refresh" });
@@ -1309,7 +1309,7 @@ function MessagingStartChoice({
   onStart,
   snapshot,
 }: {
-  readonly busyKey: AgentSetupAction["kind"] | undefined;
+  readonly busyKey: AgentSetupAction | undefined;
   readonly onStart: (action: AgentSetupAction) => Promise<boolean>;
   readonly snapshot: AgentSetupSnapshot;
 }) {
@@ -1326,7 +1326,7 @@ function MessagingStartChoice({
             <Button
               className={CARD}
               disabled={busyKey !== undefined}
-              loading={busyKey === "start-messaging"}
+              loading={busyKey?.kind === "start-messaging" && busyKey.provider === action.provider}
               onClick={() => void onStart(action)}
               variant="ghost"
             >
@@ -1357,7 +1357,7 @@ function FeishuAuthorizing({
   onAct,
   snapshot,
 }: {
-  readonly busyKey: AgentSetupAction["kind"] | undefined;
+  readonly busyKey: AgentSetupAction | undefined;
   readonly messaging: Extract<AgentSetupSnapshot["messaging"], { kind: "authorizing"; provider: "feishu" }>;
   readonly onAct: (action: AgentSetupAction) => Promise<boolean>;
   readonly snapshot: AgentSetupSnapshot;
@@ -1381,7 +1381,7 @@ function FeishuAuthorizing({
         <div>
           <Button
             disabled={busyKey !== undefined}
-            loading={busyKey === "cancel-messaging-attempt"}
+            loading={busyKey?.kind === "cancel-messaging-attempt"}
             onClick={() => void onAct(cancel)}
             variant="ghost"
           >
@@ -1564,7 +1564,7 @@ function BlockedMessaging({
           {reauthorize ? (
             <Button
               disabled={busy}
-              loading={controller.busyKey === "reauthorize-messaging"}
+              loading={controller.busyKey?.kind === "reauthorize-messaging"}
               onClick={() => void controller.act(reauthorize)}
             >
               {messaging.code === "reauthorization-required" ? m.im_update_permissions() : m.im_reconnect()}
@@ -1573,7 +1573,7 @@ function BlockedMessaging({
           {replace ? (
             <Button
               disabled={busy}
-              loading={controller.busyKey === "replace-messaging"}
+              loading={controller.busyKey?.kind === "replace-messaging"}
               onClick={() => void controller.act(replace)}
               variant="secondary"
             >
@@ -1625,14 +1625,14 @@ function UnbindMessagingDialog({
   returnFocusRef,
 }: {
   readonly action: Extract<AgentSetupAction, { kind: "unbind-messaging" }>;
-  readonly busyKey: AgentSetupAction["kind"] | undefined;
+  readonly busyKey: AgentSetupAction | undefined;
   readonly error: string | undefined;
   readonly onAct: (action: AgentSetupAction) => Promise<boolean>;
   readonly onClose: () => void;
   readonly returnFocusRef: React.RefObject<HTMLButtonElement | null>;
 }) {
   const providerName = providerTitle(action.provider);
-  const busy = busyKey === "unbind-messaging";
+  const busy = busyKey?.kind === "unbind-messaging";
   return (
     <Dialog
       busy={busy}


### PR DESCRIPTION
## Summary

Clicking Slack or Lark during Agent setup previously showed a spinner on both choices because the pending state retained only `start-messaging`. Retain the complete pending action and match its provider when rendering loading, so only the selected app spins while both choices remain disabled.

The existing synchronous duplicate-action guard and success/error/stale-result cleanup remain in place. Add seven rendered interaction regressions covering both providers, successful cleanup, failure followed by a retry of the other provider, and rapid clicks before React commits disabled buttons.

Fixes #566.

## Testing

- `pnpm install` via worktree bootstrap (frozen lockfile).
- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test` passed. The full test command passed 330 script tests and 3,183 package tests, including 690 Web tests. Unchanged package tasks used valid Turbo cache entries.
- `pnpm --filter @opentag/web exec vitest run --maxWorkers=1 src/onboarding-v2/agent-setup-page.test.tsx`: 85 passed.
- `pnpm --filter @opentag/client test:agent-runtime:coverage`: passed with 100% statements, branches, functions, and lines.
- `pnpm --filter @opentag/server test:integration`: 18 files / 324 tests passed against isolated PostgreSQL containers.
- Regression proof: load the pre-fix page from base `42362fd0` into the new tests using a temporary Vite loader; all seven new cases fail because the unselected choice also has a Loading indicator.
- Guard proof: remove only the synchronous `busyRef` check in the temporary test loader; both rapid-click cases fail on duplicate adapter calls. The committed source was unchanged by these two checks.
- `git diff --check` passed.

## UI validation

- Desktop evidence: local Browser checks at 1440px using the production `AgentSetupPage` and real Kumo buttons over an in-memory adapter with manually resolved/rejected requests. The pre-fix page showed two Loading indicators for one Slack request; the fixed page shows only the selected provider's indicator. Screenshots are retained in the task's local validation report.
- Mobile evidence: the same pending, failure, retry, and success states were inspected at 320px and 390px; tablet inspected at 768px. Buttons remain within the available width.
- Widths checked: `320px`, `390px`, `768px`, `1440px`.
- States verified: each provider pending independently; other choice static and both disabled; both directions of failure-to-other-provider retry; both successful outcomes clear loading while choices remain visible.
- Keyboard/accessibility checks: Enter starts Slack once; disabled Lark cannot be activated; only the selected button exposes the real `role="status"`, `aria-label="Loading"` indicator. Rendered tests exercise same-batch duplicate clicks for both providers.
- New reusable block, theme value, or CSS exception: none.

## Breaking changes

None. Polling logic and provider naming are outside this change. Browser validation used synthetic local data and intercepted navigation; live production OAuth and messaging were not exercised.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no documentation or copy change).
