### PR TITLE
fix(web): recover setup polling after stalled reads

### DIFF
--- a/apps/web/src/__tests__/api.test.ts
+++ b/apps/web/src/__tests__/api.test.ts
@@ -7,7 +7,7 @@ import {
   type TaskSummary,
 } from "@opentag/shared/browser";
 import { describe, expect, it, vi } from "vitest";
-import { ApiError, BrowserApi } from "../api.js";
+import { AGENT_SETUP_READ_TIMEOUT_MS, ApiError, BrowserApi } from "../api.js";
 import { DiagnosticReporter } from "../observability/diagnostics.js";
 
 const userId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
@@ -36,6 +36,27 @@ function setDocumentCookie(value: string): void {
 
 function jsonResponse(value: unknown): Response {
   return new Response(JSON.stringify(value), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+function hangingJsonResponse(status = 200): Response {
+  return new Response(new ReadableStream(), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const SETUP_AGENT_ID = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
+
+async function expectAgentSetupDeadline(fetchImpl: typeof fetch): Promise<void> {
+  vi.useFakeTimers();
+  try {
+    const pending = new BrowserApi(fetchImpl).agentSetup(SETUP_AGENT_ID);
+    const assertion = expect(pending).rejects.toMatchObject({ name: "AbortError", code: "cancelled" });
+    await vi.advanceTimersByTimeAsync(AGENT_SETUP_READ_TIMEOUT_MS);
+    await assertion;
+  } finally {
+    vi.useRealTimers();
+  }
 }
 
 describe("BrowserApi", () => {
@@ -571,6 +592,21 @@ describe("BrowserApi", () => {
       routeTemplate: "/api/v1/agents/:id/setup",
       message: "The server returned an invalid response",
     });
+  });
+
+  it("times out agentSetup when fetch never settles, even if abort is ignored", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(() => new Promise(() => undefined));
+    await expectAgentSetupDeadline(fetchImpl);
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  it("times out agentSetup when the success body never settles", async () => {
+    await expectAgentSetupDeadline(vi.fn<typeof fetch>(async () => hangingJsonResponse()));
+  });
+
+  it("times out agentSetup when a non-OK diagnostic body never settles", async () => {
+    await expectAgentSetupDeadline(vi.fn<typeof fetch>(async () => hangingJsonResponse(500)));
   });
 
   it("records schema issue paths and codes without response detail", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -121,6 +121,39 @@ export class CancelledRequestError extends Error {
   }
 }
 
+/** Covers one Agent setup snapshot read: fetch, body, and diagnostic clones. */
+export const AGENT_SETUP_READ_TIMEOUT_MS = 10_000;
+
+/**
+ * Bounds `run` in elapsed time even when the AbortSignal is ignored. Fetch cancellation is
+ * best-effort; the deadline itself always rejects, including while a response body is hanging.
+ */
+export async function withDeadline<T>(timeoutMs: number, run: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const timeoutError = (): CancelledRequestError => {
+    const cause = new Error("The operation timed out.");
+    cause.name = "TimeoutError";
+    return new CancelledRequestError(cause);
+  };
+  const operation = Promise.resolve().then(() => run(controller.signal));
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      const error = timeoutError();
+      controller.abort(error);
+      reject(error);
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    if (timedOut) void operation.catch(() => undefined);
+  }
+}
+
 export class ApiError extends Error {
   constructor(
     readonly status: number,
@@ -208,9 +241,12 @@ export class BrowserApi {
   /**
    * The canonical setup state of one exact Agent. Stage, blockers, and permitted actions all
    * arrive derived by the Server; callers render them rather than re-deriving them locally.
+   * The deadline covers fetch and every body read; it does not depend on the transport honoring abort.
    */
   agentSetup(agentId: string): Promise<AgentSetupSnapshot> {
-    return this.request(agentSetupPath(agentId), AgentSetupSnapshotSchema);
+    return withDeadline(AGENT_SETUP_READ_TIMEOUT_MS, (signal) =>
+      this.request(agentSetupPath(agentId), AgentSetupSnapshotSchema, { signal }),
+    );
   }
 
   /** Starts a fresh Computer-owned preparation for this exact bound Agent. */

--- a/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
@@ -11,8 +11,8 @@ import type { AgentSetupSnapshot } from "@opentag/shared/browser";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiError, browserApi } from "../api.js";
-import { AgentSetupPage } from "./agent-setup-page.js";
+import { AGENT_SETUP_READ_TIMEOUT_MS, ApiError, BrowserApi, browserApi } from "../api.js";
+import { AgentSetupPage, BOUNDED_POLL_ATTEMPTS, BOUNDED_POLL_WINDOW_MS, SETUP_POLL_MS } from "./agent-setup-page.js";
 import {
   deferred,
   SETUP_AGENT_ID,
@@ -22,11 +22,11 @@ import {
   setupAgent,
 } from "./agent-setup-test-fixtures.js";
 import { AgentSetupSurface } from "./page.js";
-import type { AgentSetupAdapter } from "./setup-adapter.js";
+import { type AgentSetupAdapter, createHttpSetupAdapter } from "./setup-adapter.js";
 import type { MemorySetupSeed } from "./setup-memory-adapter.js";
 import { createMemorySetupAdapter } from "./setup-memory-adapter.js";
 
-const POLL_MS = 2_000;
+const POLL_MS = SETUP_POLL_MS;
 
 /** Flushes the promise queue: reads, writes, and QR rendering all settle without a clock. */
 async function settle(rounds = 6): Promise<void> {
@@ -519,7 +519,7 @@ describe("preparation review regressions", () => {
     expect(adapter.readSnapshot).toHaveBeenCalledTimes(2);
   });
 
-  it("queues one return refresh behind an existing automatic poll", async () => {
+  it("retires a hung automatic poll on focus and coalesces the recovery read", async () => {
     const memory = createMemorySetupAdapter({ agent: setupAgent(), imCliReadiness: {} });
     const snapshot = await memory.adapter.readSnapshot(SETUP_AGENT_ID);
     const pending = deferred<AgentSetupSnapshot>();
@@ -536,10 +536,12 @@ describe("preparation review regressions", () => {
       document.dispatchEvent(new Event("visibilitychange"));
     });
     await settle();
-    expect(adapter.readSnapshot).toHaveBeenCalledTimes(2);
-    pending.resolve(snapshot);
+    expect(adapter.readSnapshot).toHaveBeenCalledTimes(3);
+    pending.resolve({ ...snapshot, agent: { ...snapshot.agent, displayName: "Stale Reviewer" } });
     await settle();
     expect(adapter.readSnapshot).toHaveBeenCalledTimes(3);
+    expect(screen.queryByText("Stale Reviewer")).toBeNull();
+    expect(screen.getByRole("heading", { name: "Prepare this computer" })).toBeTruthy();
   });
 
   it("continues observing required CLI work after a Runtime failure", async () => {
@@ -679,12 +681,13 @@ describe("AgentSetupPage transitions", () => {
     await settle();
     expect(reads).toHaveBeenCalledTimes(1);
 
-    // The documented budget: 30 polls at the 2s interval, then the timer stops on its own.
-    await advance(POLL_MS * 31 + 10);
-    expect(reads.mock.calls.length).toBe(31);
+    await advance(BOUNDED_POLL_WINDOW_MS + 10);
+    const stopped = reads.mock.calls.length;
+    expect(stopped).toBeGreaterThan(1);
+    expect(stopped).toBeLessThanOrEqual(1 + BOUNDED_POLL_ATTEMPTS);
 
     await advance(POLL_MS * 4);
-    expect(reads.mock.calls.length).toBe(31);
+    expect(reads.mock.calls.length).toBe(stopped);
   });
 
   it("reopens the bounded observation window on an explicit Check again", async () => {
@@ -694,15 +697,16 @@ describe("AgentSetupPage transitions", () => {
     await settle();
     expect(reads.mock.calls.length).toBe(1);
 
-    await advance(POLL_MS * 31 + 10);
-    expect(reads.mock.calls.length).toBe(31);
+    await advance(BOUNDED_POLL_WINDOW_MS + 10);
+    const stopped = reads.mock.calls.length;
+    expect(stopped).toBeGreaterThan(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Check again" }));
     await settle();
-    expect(reads.mock.calls.length).toBe(32);
+    expect(reads.mock.calls.length).toBe(stopped + 1);
 
     await advance(POLL_MS + 10);
-    expect(reads.mock.calls.length).toBe(33);
+    expect(reads.mock.calls.length).toBe(stopped + 2);
   });
 
   it("does not overlap automatic reads when a bounded poll is slow", async () => {
@@ -1277,31 +1281,38 @@ describe("AgentSetupPage preparation polling", () => {
     await settle();
     expect(reads).toHaveBeenCalledTimes(1);
 
-    await advance(POLL_MS * 31 + 10);
-    expect(reads).toHaveBeenCalledTimes(31);
+    await advance(BOUNDED_POLL_WINDOW_MS + 10);
+    const stopped = reads.mock.calls.length;
+    expect(stopped).toBeGreaterThan(1);
+    expect(stopped).toBeLessThanOrEqual(1 + BOUNDED_POLL_ATTEMPTS);
 
     await advance(POLL_MS * 4);
-    expect(reads).toHaveBeenCalledTimes(31);
+    expect(reads).toHaveBeenCalledTimes(stopped);
     expect(screen.getByRole("status").textContent).toBe("Automatic checking paused. Check again to retry.");
     expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
   });
 
-  it("clears an exhausted checking message when the final poll finds a manual action", async () => {
+  it("clears an exhausted checking message when an outstanding poll finds a manual action", async () => {
     const memory = createMemorySetupAdapter({ agent: setupAgent(), runtimeStatus: "checking" });
     const modelRead = memory.adapter.readSnapshot;
-    let reads = 0;
+    const finalRead = deferred<AgentSetupSnapshot>();
+    let deferReads = false;
     vi.spyOn(memory.adapter, "readSnapshot").mockImplementation(async (agentId) => {
-      reads += 1;
-      if (reads === 31) memory.controls.setRuntimeStatus("install");
+      if (deferReads) return finalRead.promise;
       return modelRead(agentId);
     });
     renderSetup(memory.adapter);
     await settle();
 
-    await advance(POLL_MS * 31 + 10);
+    await advance(BOUNDED_POLL_WINDOW_MS - POLL_MS * 2);
+    deferReads = true;
+    await advance(POLL_MS * 2 + 10);
+    expect(screen.getByRole("status").textContent).toBe("Automatic checking paused. Check again to retry.");
+
+    memory.controls.setRuntimeStatus("install");
+    finalRead.resolve(await modelRead(SETUP_AGENT_ID));
     await settle();
 
-    expect(reads).toBe(31);
     expect(screen.getByRole("status").textContent).toBe("Complete the action above, then check again.");
     expect(screen.queryByText("Automatic checking paused. Check again to retry.")).toBeNull();
   });
@@ -1319,9 +1330,287 @@ describe("AgentSetupPage preparation polling", () => {
     await advance(POLL_MS * 3 + 10);
     expect(reads.mock.calls.length).toBeGreaterThan(1);
 
-    // The budget still ends the window on an unchanged snapshot.
-    await advance(POLL_MS * 28);
-    expect(reads.mock.calls.length).toBe(31);
+    await advance(BOUNDED_POLL_WINDOW_MS);
+    const stopped = reads.mock.calls.length;
+    expect(stopped).toBeLessThanOrEqual(1 + BOUNDED_POLL_ATTEMPTS);
+    await advance(POLL_MS * 4);
+    expect(reads.mock.calls.length).toBe(stopped);
+  });
+});
+
+describe("AgentSetupPage hung-read recovery", () => {
+  it("offers a localized retry when the initial read times out", async () => {
+    const ready = createMemorySetupAdapter({ agent: setupAgent() });
+    let calls = 0;
+    const adapter = scriptedAdapter((agentId) => {
+      calls += 1;
+      return calls === 1 ? new Promise(() => undefined) : ready.adapter.readSnapshot(agentId);
+    });
+    renderSetup(adapter);
+    await settle();
+    await advance(AGENT_SETUP_READ_TIMEOUT_MS);
+    expect(screen.getByRole("alert").textContent).toBe("We couldn't read your agent's setup.");
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("stops at the deadline when slow reads leave no request in flight at expiry", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent(), runtimeStatus: "checking" });
+    const modelRead = memory.adapter.readSnapshot;
+    let calls = 0;
+    vi.spyOn(memory.adapter, "readSnapshot").mockImplementation(async (agentId) => {
+      calls += 1;
+      if (calls > 1) await new Promise((resolve) => setTimeout(resolve, 800));
+      return modelRead(agentId);
+    });
+    renderSetup(memory.adapter);
+    await settle();
+    await advance(BOUNDED_POLL_WINDOW_MS + 10);
+    expect(screen.getByRole("status").textContent).toBe("Automatic checking paused. Check again to retry.");
+    const callsAtPause = calls;
+    expect(callsAtPause).toBeGreaterThan(1);
+    expect(callsAtPause).toBeLessThan(BOUNDED_POLL_ATTEMPTS);
+    await advance(BOUNDED_POLL_WINDOW_MS);
+    expect(calls).toBe(callsAtPause);
+  });
+
+  it("enables Continue after a hung checking read times out and a later read is ready", async () => {
+    const checking = createMemorySetupAdapter({
+      agent: setupAgent(),
+      imCliReadiness: { feishu: "checking", slack: "checking" },
+    });
+    const ready = createMemorySetupAdapter({ agent: setupAgent() });
+    const hung = deferred<AgentSetupSnapshot>();
+    let calls = 0;
+    const adapter = scriptedAdapter(async (agentId) => {
+      calls += 1;
+      if (calls === 1) return checking.adapter.readSnapshot(agentId);
+      if (calls === 2) return hung.promise;
+      return ready.adapter.readSnapshot(agentId);
+    });
+    renderSetup(adapter);
+    await settle();
+    expect(readinessRow("messaging-support").getAttribute("data-status")).toBe("checking");
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+
+    await advance(POLL_MS + 10);
+    expect(calls).toBe(2);
+
+    await advance(AGENT_SETUP_READ_TIMEOUT_MS);
+    await settle();
+    await advance(POLL_MS + 10);
+    await settle();
+
+    expect(calls).toBeGreaterThanOrEqual(3);
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+    hung.resolve(await checking.adapter.readSnapshot(SETUP_AGENT_ID));
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("pauses automatic checking when hung reads exhaust the wall-clock window", async () => {
+    const checking = createMemorySetupAdapter({
+      agent: setupAgent(),
+      imCliReadiness: { feishu: "checking", slack: "checking" },
+    });
+    const snapshot = await checking.adapter.readSnapshot(SETUP_AGENT_ID);
+    let calls = 0;
+    const adapter = scriptedAdapter(async () => {
+      calls += 1;
+      if (calls === 1) return snapshot;
+      return new Promise(() => undefined);
+    });
+    renderSetup(adapter);
+    await settle();
+
+    await advance(BOUNDED_POLL_WINDOW_MS + 10);
+    await settle();
+    expect(screen.getByRole("status").textContent).toBe("Automatic checking paused. Check again to retry.");
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+    const callsAtPause = calls;
+    await advance(BOUNDED_POLL_WINDOW_MS);
+    expect(calls).toBe(callsAtPause);
+  });
+
+  it("resumes from the paused retry after hung reads once Check again sees a ready snapshot", async () => {
+    const checking = createMemorySetupAdapter({
+      agent: setupAgent(),
+      imCliReadiness: { feishu: "checking", slack: "checking" },
+    });
+    const ready = createMemorySetupAdapter({ agent: setupAgent() });
+    let hang = true;
+    let calls = 0;
+    const adapter = scriptedAdapter(async (agentId) => {
+      calls += 1;
+      if (hang && calls > 1) return new Promise(() => undefined);
+      if (hang) return checking.adapter.readSnapshot(agentId);
+      return ready.adapter.readSnapshot(agentId);
+    });
+    renderSetup(adapter);
+    await settle();
+    await advance(BOUNDED_POLL_WINDOW_MS + 10);
+    await settle();
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+
+    hang = false;
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("recovers on focus while a checking read is hung and fences the late stale reply", async () => {
+    const checking = createMemorySetupAdapter({
+      agent: setupAgent(),
+      imCliReadiness: { feishu: "checking", slack: "checking" },
+    });
+    const ready = createMemorySetupAdapter({ agent: setupAgent() });
+    const hung = deferred<AgentSetupSnapshot>();
+    let calls = 0;
+    const adapter = scriptedAdapter(async (agentId) => {
+      calls += 1;
+      if (calls === 1) return checking.adapter.readSnapshot(agentId);
+      if (calls === 2) return hung.promise;
+      return ready.adapter.readSnapshot(agentId);
+    });
+    renderSetup(adapter);
+    await settle();
+    await advance(POLL_MS + 10);
+    expect(calls).toBe(2);
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("pageshow"));
+    });
+    await settle();
+    expect(calls).toBe(3);
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+
+    const stale = await checking.adapter.readSnapshot(SETUP_AGENT_ID);
+    hung.resolve({ ...stale, agent: { ...stale.agent, displayName: "Stale Reviewer" } });
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+    expect(screen.queryByText("Stale Reviewer")).toBeNull();
+  });
+
+  it("recovers unbounded offline polling after a single hung read", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent(), computerOnline: false });
+    const hung = deferred<AgentSetupSnapshot>();
+    const modelRead = memory.adapter.readSnapshot;
+    let calls = 0;
+    vi.spyOn(memory.adapter, "readSnapshot").mockImplementation((agentId) => {
+      calls += 1;
+      if (calls === 2) return hung.promise;
+      return modelRead(agentId);
+    });
+    renderSetup(memory.adapter);
+    await settle();
+    await advance(POLL_MS + 10);
+    expect(calls).toBe(2);
+
+    await advance(AGENT_SETUP_READ_TIMEOUT_MS);
+    await settle();
+    await advance(POLL_MS + 10);
+    expect(calls).toBe(3);
+    expect(screen.getByText("Offline")).toBeTruthy();
+  });
+
+  it("does not apply a late error after a hung read has been superseded", async () => {
+    const checking = createMemorySetupAdapter({
+      agent: setupAgent(),
+      imCliReadiness: { feishu: "checking", slack: "checking" },
+    });
+    const ready = createMemorySetupAdapter({ agent: setupAgent() });
+    const hung = deferred<AgentSetupSnapshot>();
+    let calls = 0;
+    const adapter = scriptedAdapter(async (agentId) => {
+      calls += 1;
+      if (calls === 1) return checking.adapter.readSnapshot(agentId);
+      if (calls === 2) return hung.promise;
+      return ready.adapter.readSnapshot(agentId);
+    });
+    renderSetup(adapter);
+    await settle();
+    await advance(POLL_MS + 10);
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+    hung.reject(new Error("late network failure"));
+    await settle();
+    expect(screen.queryByText("late network failure")).toBeNull();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("releases a hung read on unmount without applying it later", async () => {
+    const checking = createMemorySetupAdapter({
+      agent: setupAgent(),
+      imCliReadiness: { feishu: "checking", slack: "checking" },
+    });
+    const hung = deferred<AgentSetupSnapshot>();
+    let calls = 0;
+    const adapter = scriptedAdapter(async (agentId) => {
+      calls += 1;
+      if (calls === 1) return checking.adapter.readSnapshot(agentId);
+      return hung.promise;
+    });
+    const view = renderSetup(adapter);
+    await settle();
+    await advance(POLL_MS + 10);
+    view.unmount();
+    hung.resolve(await checking.adapter.readSnapshot(SETUP_AGENT_ID));
+    await settle();
+    await advance(AGENT_SETUP_READ_TIMEOUT_MS);
+    await settle();
+    expect(calls).toBe(2);
+  });
+
+  it("converges an isolated HTTP-backed first installation through a hung messaging check", async () => {
+    const offline = await createMemorySetupAdapter({
+      agent: setupAgent(),
+      computerOnline: false,
+      runtimeMissing: true,
+      imCliReadiness: {},
+    }).adapter.readSnapshot(SETUP_AGENT_ID);
+    const checking = await createMemorySetupAdapter({
+      agent: setupAgent(),
+      imCliReadiness: { feishu: "checking", slack: "checking" },
+    }).adapter.readSnapshot(SETUP_AGENT_ID);
+    const ready = await createMemorySetupAdapter({ agent: setupAgent() }).adapter.readSnapshot(SETUP_AGENT_ID);
+    let phase: "offline" | "checking" | "hung" | "ready" = "offline";
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const path = String(input);
+      if (!path.endsWith("/setup")) throw new Error(`unexpected request: ${path}`);
+      if (phase === "hung") return new Promise(() => undefined);
+      const snapshot = phase === "offline" ? offline : phase === "checking" ? checking : ready;
+      return new Response(JSON.stringify(snapshot), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const adapter = createHttpSetupAdapter(new BrowserApi(fetchImpl));
+    renderSetup(adapter);
+    await settle();
+    expect(screen.getByText("Offline")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+
+    phase = "checking";
+    await advance(POLL_MS + 10);
+    await settle();
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("ready");
+    expect(readinessRow("messaging-support").getAttribute("data-status")).toBe("checking");
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+
+    phase = "hung";
+    await advance(POLL_MS + 10);
+    await advance(AGENT_SETUP_READ_TIMEOUT_MS);
+    await settle();
+    phase = "ready";
+    await advance(POLL_MS + 10);
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
   });
 });
 

--- a/apps/web/src/onboarding-v2/agent-setup-page.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.tsx
@@ -21,7 +21,7 @@ import type {
   ProviderCliHandoffProgress,
 } from "@opentag/shared/browser";
 import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { ApiError } from "../api.js";
+import { AGENT_SETUP_READ_TIMEOUT_MS, ApiError, CancelledRequestError, withDeadline } from "../api.js";
 import { AgentComputerChoice, type AgentComputerInventoryAdapter } from "../features/agents/agent-computer-choice.js";
 import { platformLabel } from "../features/agents/agent-presentation.js";
 import {
@@ -47,34 +47,46 @@ import { type AgentSetupAdapter, createHttpSetupAdapter } from "./setup-adapter.
 import { CardCopy, DoneStep, StepRail } from "./steps.js";
 
 /** The snapshot doubles as the observation channel while the outside world is expected to move it. */
-const SETUP_POLL_MS = 2_000;
+export const SETUP_POLL_MS = 2_000;
 /** How many times to report readiness before the reader is offered an explicit retry. */
 const READY_REPORT_ATTEMPTS = 3;
 /**
- * The finite budget for automatic local-preparation polls (a required IM CLI still waiting or
- * checking behind the gate, a Runtime report missing or still checking): 30 polls at 2s is
- * roughly a one-minute observation window. Exhaustion stops the timer; an explicit Check again
- * restarts a fresh window. The budget never resets on an unchanged snapshot, and
- * Messaging/offline observation keeps its unbounded beat.
+ * The finite attempt cap for automatic local-preparation polls (a required IM CLI still waiting
+ * or checking behind the gate, a Runtime report missing or still checking). An explicit Check
+ * again or returning to the page restarts a fresh window. The cap never resets on an unchanged
+ * snapshot, and Messaging/offline observation keeps its unbounded beat.
  */
-const BOUNDED_POLL_ATTEMPTS = 30;
+export const BOUNDED_POLL_ATTEMPTS = 30;
+/** Wall-clock bound for the same window, so a hung or slow read cannot stretch automatic checking. */
+export const BOUNDED_POLL_WINDOW_MS = 60_000;
+
+function boundedWindowRemaining(startedAt: { current: number | undefined }): number {
+  const started = startedAt.current ?? Date.now();
+  startedAt.current = started;
+  return BOUNDED_POLL_WINDOW_MS - (Date.now() - started);
+}
 
 /**
  * Arms one automatic-read observation window. The window is single-flight across effect
  * restarts: an automatic read an earlier window started is awaited before a new one begins, and
- * a manual refresh deliberately supersedes its reply through the request lifecycle instead.
+ * a manual refresh, focus recovery, timeout, or unmount retires it. Bounded observation expires
+ * in elapsed time even while a read is still outstanding.
  */
 function armAutomaticPollWindow(
   pollClass: Exclude<SetupPollClass, undefined>,
   budget: { current: number },
+  windowStartedAt: { current: number | undefined },
   inFlight: { current: Promise<boolean> | undefined },
   read: () => Promise<boolean>,
   onExhausted?: () => void,
 ): () => void {
   let cancelled = false;
   let timer: number | undefined;
+  let expiryTimer: number | undefined;
+  const exhaustAttempts = (): boolean => pollClass === "bounded" && budget.current <= 0;
   const poll = async (): Promise<void> => {
-    if (pollClass === "bounded" && budget.current <= 0) {
+    if (cancelled) return;
+    if (exhaustAttempts()) {
       onExhausted?.();
       return;
     }
@@ -87,17 +99,34 @@ function armAutomaticPollWindow(
     await turn;
     if (inFlight.current === turn) inFlight.current = undefined;
     if (cancelled) return;
-    if (pollClass === "bounded" && budget.current <= 0) {
+    if (exhaustAttempts()) {
       onExhausted?.();
       return;
     }
     timer = window.setTimeout(() => void poll(), SETUP_POLL_MS);
   };
-  if (pollClass === "bounded" && budget.current <= 0) onExhausted?.();
-  else timer = window.setTimeout(() => void poll(), SETUP_POLL_MS);
+  if (exhaustAttempts() || (pollClass === "bounded" && boundedWindowRemaining(windowStartedAt) <= 0)) {
+    onExhausted?.();
+    return () => {
+      cancelled = true;
+    };
+  }
+  if (pollClass === "bounded") {
+    expiryTimer = window.setTimeout(
+      () => {
+        if (cancelled) return;
+        cancelled = true;
+        window.clearTimeout(timer);
+        onExhausted?.();
+      },
+      Math.max(0, boundedWindowRemaining(windowStartedAt)),
+    );
+  }
+  timer = window.setTimeout(() => void poll(), SETUP_POLL_MS);
   return () => {
     cancelled = true;
     window.clearTimeout(timer);
+    window.clearTimeout(expiryTimer);
   };
 }
 
@@ -174,6 +203,7 @@ export function setupSnapshotIsTransitional(snapshot: AgentSetupSnapshot): boole
 }
 
 function setupReadError(cause: unknown): string {
+  if (cause instanceof CancelledRequestError) return m.onboarding_v2_setup_load_failed();
   return cause instanceof Error && cause.message ? cause.message : m.onboarding_v2_setup_load_failed();
 }
 
@@ -340,13 +370,16 @@ function useSnapshotReader(
   const read = useCallback(async (): Promise<boolean> => {
     const ticket = lifecycle.next();
     try {
-      const snapshot = await adapter.readSnapshot(agentId);
+      const snapshot = await withDeadline(AGENT_SETUP_READ_TIMEOUT_MS, () => adapter.readSnapshot(agentId));
       if (!lifecycle.isCurrent(ticket)) return false;
       setRefreshError(undefined);
       setPhase({ kind: "ready", snapshot });
       return true;
     } catch (cause) {
       if (!lifecycle.isCurrent(ticket)) return false;
+      // A timed-out automatic re-read must settle so polling and focus can continue; the last-good
+      // snapshot stays until a later read or the bounded window offers Check again.
+      if (cause instanceof CancelledRequestError && phaseRef.current.kind === "ready") return false;
       failRead(cause);
       return false;
     }
@@ -458,34 +491,46 @@ function useAgentSetup(
   const snapshot = reader.phase.kind === "ready" ? reader.phase.snapshot : undefined;
   const pollClass = snapshot === undefined ? undefined : snapshotPollClass(snapshot);
   const pollBudget = useRef(BOUNDED_POLL_ATTEMPTS);
+  const pollWindowStartedAt = useRef<number | undefined>(undefined);
   /**
-   * The one automatic read the mounted controller allows at a time. A manual refresh deliberately
-   * supersedes a pending automatic read through the request lifecycle, but a new poll effect must
-   * never start a second automatic read while an earlier one is still in flight.
+   * The one automatic read the mounted controller allows at a time. Timeout, unmount, Check again,
+   * and focus recovery retire it so a hung adapter cannot own the window indefinitely. A new poll
+   * effect never starts a second automatic read while an earlier one is still in flight.
    */
   const autoPollInFlight = useRef<Promise<boolean> | undefined>(undefined);
   const [pollExhausted, setPollExhausted] = useState(false);
   // A stateful restart signal: an explicit Check again must reopen a bounded observation window
   // even when the busyKey updates around the refresh are collapsed into one render.
   const [pollRestartKey, setPollRestartKey] = useState(0);
-  /** An explicit Check again opens a fresh bounded observation window. */
+  /** An explicit Check again or return to the page opens a fresh bounded observation window. */
   const resetPollBudget = useCallback(() => {
     pollBudget.current = BOUNDED_POLL_ATTEMPTS;
+    pollWindowStartedAt.current = Date.now();
+    autoPollInFlight.current = undefined;
     setPollExhausted(false);
     setPollRestartKey((value) => value + 1);
   }, []);
   // Exhaustion describes only the bounded transitional state that consumed the window. Once the
   // snapshot settles or moves to another polling class, a later transition deserves a fresh
-  // window and must not inherit the old "paused" message.
+  // window and must not inherit the old "paused" message. Effect restarts of the same class keep
+  // the elapsed start so they cannot silently extend unchanged state.
   useEffect(() => {
     if (pollClass === "bounded") return;
     pollBudget.current = BOUNDED_POLL_ATTEMPTS;
+    pollWindowStartedAt.current = undefined;
     setPollExhausted(false);
   }, [pollClass]);
+  useEffect(() => {
+    return () => {
+      autoPollInFlight.current = undefined;
+    };
+  }, []);
   // biome-ignore lint/correctness/useExhaustiveDependencies: pollRestartKey explicitly restarts the observation window.
   useEffect(() => {
     if (pollClass === undefined || actions.busyKey !== undefined) return;
-    return armAutomaticPollWindow(pollClass, pollBudget, autoPollInFlight, reader.read, () => setPollExhausted(true));
+    return armAutomaticPollWindow(pollClass, pollBudget, pollWindowStartedAt, autoPollInFlight, reader.read, () =>
+      setPollExhausted(true),
+    );
   }, [pollClass, actions.busyKey, pollRestartKey, reader.read]);
 
   /*
@@ -493,9 +538,10 @@ function useAgentSetup(
    * daemon reconnect, a Runtime report, a handoff) may have moved it while the reader was away.
    * The refresh rides the same request lifecycle as every other read — a reply superseded by a
    * newer read or by an action is discarded, a transient failure over a good snapshot keeps the
-   * last-good snapshot on screen, and the automatic poll window never overlaps itself — and it
-   * is skipped while an action is in flight and when no snapshot is on screen yet (loading,
-   * load-failed, and unavailable keep their own manual flows).
+   * last-good snapshot on screen — and it is skipped while an action is in flight and when no
+   * snapshot is on screen yet (loading, load-failed, and unavailable keep their own manual flows).
+   * A hung automatic read is retired rather than queued behind: focus burst coalescing still
+   * collapses to one recovery read.
    */
   useEffect(() => {
     if (actions.busyKey !== undefined || reader.phase.kind !== "ready") return;
@@ -504,15 +550,11 @@ function useAgentSetup(
     const refreshOnReturn = (): void => {
       if (document.visibilityState !== "visible" || returnRead !== undefined) return;
       resetPollBudget();
-      const pending = autoPollInFlight.current;
-      // A return queues one fresh read behind an existing poll, never another concurrent one.
-      const turn =
-        pending === undefined
-          ? reader.read()
-          : pending.then(() => (cancelled || document.visibilityState !== "visible" ? false : reader.read()));
+      const turn = reader.read();
       returnRead = turn;
       autoPollInFlight.current = turn;
       void turn.then(() => {
+        if (cancelled) return;
         if (returnRead === turn) returnRead = undefined;
         if (autoPollInFlight.current === turn) autoPollInFlight.current = undefined;
       });


### PR DESCRIPTION
## Summary

When an Agent setup snapshot read never settles, Web previously stopped polling while still claiming automatic checking was progressing and keeping Continue disabled. Setup reads now have a 10-second deadline covering fetch and response-body consumption, including diagnostic error bodies, and abort the transport on timeout. The page also bounds custom adapter reads and rejects stale results through its existing request lifecycle.

Automatic preparation observation stops after 60 seconds, even when reads are slow or hung, and exposes the existing Check again action. Focus, visibility, and pageshow recovery supersede pending automatic reads without waiting indefinitely. A later ready snapshot enables Continue without a page reload.

Fixes #563. The original production network cause was not captured; this addresses the independently reproduced hung-read failure mechanism. Messaging option loading (#566) is outside this change.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` passed; the Web suite has 696 passing tests.
- `pnpm --filter @opentag/client test:agent-runtime:coverage` passed: 360 tests and 100% of enforced coverage metrics.
- `pnpm --filter @opentag/server test:integration` passed: 324 tests against disposable PostgreSQL.
- Regression coverage includes hangs in fetch, success body, and non-OK diagnostic body; initial-read retry; hung checking to ready; focus burst coalescing; stale success/error fencing; offline polling; window expiry between slow reads; and paused-state recovery.
- Independent built-Web/Chromium validation used a loopback HTTP service that sends an unfinished JSON body. On the base build, no further read occurred after more than two virtual minutes. With this change, the browser aborted the stalled response and the next snapshot enabled Continue. A scripted Computer offline → runtime checking → messaging checking → hung body → ready sequence also converged without reload.
- Production first-install acceptance remains pending user simulation after deployment. The isolated browser sequence uses fixture snapshots and does not establish real installer/daemon or production messaging behavior.

## UI validation

- Desktop evidence: local Chromium screenshots of paused and ready states at 1440px; no page errors.
- Mobile evidence: local Chromium screenshots of the same states at 320px and 390px.
- Widths checked: 320px / 390px / 768px / 1440px, all without horizontal overflow.
- States verified: automatic recovery to ready, repeated hangs to paused + Check again, explicit retry to enabled Continue.
- Keyboard/accessibility checks: focus and Enter on Continue advance to the messaging screen.
- New reusable block, theme value, or CSS exception: none; existing localized recovery copy and controls are reused.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no document or translation changes).
