### PR TITLE
fix(client): admit healthy initial Provider CLI Turns

### DIFF
--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -604,12 +604,15 @@ describe("AgentTurnRunner", () => {
     runner.start(liveOwner(delivery()));
     await runner.settled();
     expect(order).toEqual(["credentials", "plan", "runtime", "prompt", "plan-cleanup", "credential-cleanup"]);
-    expect(turnPlan.prepare).toHaveBeenCalledWith({
-      provider: "slack",
-      sessionId: "session-1",
-      runId: "turn-1",
-      configDir: "/tmp/slack-config",
-    });
+    expect(turnPlan.prepare).toHaveBeenCalledWith(
+      {
+        provider: "slack",
+        sessionId: "session-1",
+        runId: "turn-1",
+        configDir: "/tmp/slack-config",
+      },
+      expect.any(AbortSignal),
+    );
 
     const driftedEnsure = vi.fn();
     const drifted = new AgentTurnRunner({

--- a/packages/client/src/__tests__/provider-cli-initial-readiness.integration.test.ts
+++ b/packages/client/src/__tests__/provider-cli-initial-readiness.integration.test.ts
@@ -1,0 +1,508 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { DirectImMessageDeliveryRequest, SessionMessageDeliveryRequest } from "@opentag/shared";
+import { RUNTIME_PROVIDER_CLI_REQUIREMENT_OPERATION } from "@opentag/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.setConfig({ testTimeout: 30_000 });
+
+import {
+  AgentTurnRunner,
+  computeFileIdentity,
+  computeTargetFingerprint,
+  ImCredentialEnvironmentManager,
+  ProviderCliManager,
+  ProviderCliReconciler,
+  ProviderCliTurnPlanManager,
+  readProviderCliSelection,
+  readProviderCliTurnPlan,
+  writeProviderCliSelection,
+} from "../index.js";
+import { AdmissionController } from "../runtime/admission-controller.js";
+import type { SessionBindingStore } from "../runtime/session-binding-store.js";
+import { SessionMessageInbox } from "../runtime/session-message-inbox.js";
+import type { SessionRuntimeManager } from "../runtime/session-runtime-manager.js";
+import type { LiveTurnOwner, TurnCustodyOwner } from "../runtime/turn-custody-owner.js";
+import type { TurnReportOwner } from "../runtime/turn-report-owner.js";
+import { makeTempDir, writeFakeCli } from "./fixtures/provider-cli.js";
+import { providerCliTurnRunnerInvocation } from "./fixtures/provider-cli-turn-plan.js";
+
+const tempDirs: string[] = [];
+const closers: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(closers.splice(0).map((close) => close()));
+  await Promise.all(tempDirs.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+const quiet = { debug() {}, info() {}, warn() {}, error() {} };
+
+describe("provider CLI initial readiness", () => {
+  it.each(["feishu", "slack"] as const)(
+    "admits concurrent first %s Turns after the pending initial inspection",
+    async (provider) => {
+      const harness = await createHarness(provider);
+      harness.pauseNextInspection();
+      const refreshing = harness.emitRequirement();
+      await harness.inspectionEntered.promise;
+      const first = harness.owner();
+      const second = harness.owner();
+      harness.runner.start(first);
+      harness.runner.start(second);
+      await vi.waitFor(() => expect(harness.inspectCalls).toBeGreaterThanOrEqual(3));
+      expect(harness.modelStarts).toBe(0);
+      expect(harness.reports).toHaveLength(0);
+      harness.releaseInspection();
+      await refreshing;
+      await harness.runner.settled();
+      expect(harness.modelStarts).toBe(2);
+      expect(harness.reports).toHaveLength(2);
+      expect(harness.reports.every((report) => report.outcome === "completed")).toBe(true);
+      expect(harness.ensure).not.toHaveBeenCalled();
+
+      harness.runner.start(harness.owner(first.request.sessionId));
+      await harness.runner.settled();
+      expect(harness.reports.at(-1)?.outcome).toBe("completed");
+      expect(harness.modelStarts).toBe(3);
+    },
+  );
+
+  it.each(["feishu", "slack"] as const)(
+    "keeps concurrent %s Turns on the accepted selection during a reconnect inspection",
+    async (provider) => {
+      const harness = await createHarness(provider);
+      await harness.emitRequirement();
+      harness.pauseNextInspection();
+      const refreshing = harness.emitRequirement();
+      await harness.inspectionEntered.promise;
+      harness.runner.start(harness.owner());
+      harness.runner.start(harness.owner());
+      await vi.waitFor(() =>
+        expect(harness.reports.filter((report) => report.outcome === "completed")).toHaveLength(2),
+      );
+      expect(harness.modelStarts).toBe(2);
+      harness.releaseInspection();
+      await refreshing;
+      await harness.runner.settled();
+    },
+  );
+
+  it("refuses a Run that discovers a replacement and admits the next Run on the new selection", async () => {
+    const harness = await createHarness("slack");
+    await harness.emitRequirement();
+    const before = await readProviderCliSelection(harness.manager.layout, "slack");
+    expect(before).toBeTruthy();
+    if (!before) throw new Error("Expected an installed Slack selection");
+    await writeProviderCliSelection(harness.manager.layout, "slack", before.selection, before);
+
+    harness.runner.start(harness.owner());
+    await harness.runner.settled();
+    expect(harness.modelStarts).toBe(0);
+    expect(harness.reports[0]).toMatchObject({
+      outcome: "failed",
+      errorReason: "credential_unavailable",
+      executionEffects: "not_started",
+    });
+    expect(harness.logs.some((log) => log.fields.errorCode === "selection_invalid")).toBe(true);
+
+    harness.runner.start(harness.owner());
+    await harness.runner.settled();
+    expect(harness.modelStarts).toBe(1);
+    expect(harness.reports.at(-1)?.outcome).toBe("completed");
+  });
+
+  it("rejects first Turns when selection generation changes during the initial wait", async () => {
+    const harness = await createHarness("slack");
+    harness.pauseNextInspection();
+    const refreshing = harness.emitRequirement();
+    await harness.inspectionEntered.promise;
+    harness.runner.start(harness.owner());
+    harness.runner.start(harness.owner());
+    await vi.waitFor(() => expect(harness.inspectCalls).toBeGreaterThanOrEqual(3));
+    const before = await readProviderCliSelection(harness.manager.layout, "slack");
+    const replacement = join(dirname(harness.target), "slack-rotated");
+    await writeFile(replacement, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    const identity = await computeFileIdentity(replacement);
+    await writeProviderCliSelection(
+      harness.manager.layout,
+      "slack",
+      {
+        kind: "external",
+        executablePath: identity.path,
+        fingerprint: computeTargetFingerprint(identity, "4.7.0"),
+        trust: "catalog-verified",
+        version: "4.7.0",
+      },
+      before ?? undefined,
+    );
+    harness.releaseInspection();
+    await refreshing;
+    await harness.runner.settled();
+    expect(harness.modelStarts).toBe(0);
+    expect(harness.reports).toHaveLength(2);
+    expect(
+      harness.reports.every((report) => report.outcome === "failed" && report.errorReason === "credential_unavailable"),
+    ).toBe(true);
+    expect(harness.logs.every((log) => log.fields.errorCode === "selection_invalid")).toBe(true);
+  });
+
+  it("lets one timed-out waiter fail without blocking the other first Turn", async () => {
+    const harness = await createHarness("feishu");
+    harness.pauseNextInspection();
+    const refreshing = harness.emitRequirement();
+    await harness.inspectionEntered.promise;
+    const timedOut = harness.owner();
+    timedOut.request.deadlineAt = new Date(Date.now() - 1_000).toISOString();
+    harness.runner.start(timedOut);
+    harness.runner.start(harness.owner());
+    await vi.waitFor(() => expect(harness.inspectCalls).toBeGreaterThanOrEqual(2));
+    await vi.waitFor(() => expect(harness.reports.some((report) => report.errorReason === "turn_timeout")).toBe(true));
+    expect(harness.modelStarts).toBe(0);
+    harness.releaseInspection();
+    await refreshing;
+    await harness.runner.settled();
+    expect(harness.modelStarts).toBe(1);
+    expect(harness.reports.some((report) => report.outcome === "completed")).toBe(true);
+    expect(harness.reports.some((report) => report.errorReason === "turn_timeout")).toBe(true);
+  });
+
+  it("stops a waiting Turn before model execution when the runner closes", async () => {
+    const harness = await createHarness("slack");
+    harness.pauseNextInspection();
+    const refreshing = harness.emitRequirement();
+    await harness.inspectionEntered.promise;
+    harness.runner.start(harness.owner());
+    await vi.waitFor(() => expect(harness.inspectCalls).toBeGreaterThanOrEqual(2));
+    harness.runner.stop();
+    await harness.runner.settled();
+    expect(harness.modelStarts).toBe(0);
+    expect(harness.reports[0]).toMatchObject({
+      outcome: "cancelled",
+      errorReason: "client_shutdown",
+    });
+    harness.releaseInspection();
+    await refreshing;
+  });
+
+  it("does not publish a collaboration plan after the Run timeout fires during readiness", async () => {
+    const harness = await createHarness("feishu");
+    let fireTimeout: () => void = () => undefined;
+    const inbox = new SessionMessageInbox({
+      admission: new AdmissionController(),
+      credentialEnvironment: harness.credentials,
+      imCredentialGrantVersion: () => 2,
+      reconciler: {
+        checkSessionMessageDelivery: () => undefined,
+        clearActivity: () => true,
+        setActivity: () => undefined,
+        withAgentLock: async <T>(_agentId: string, task: () => Promise<T>) => task(),
+      },
+      runtimeManager: {
+        ensureRuntime: harness.ensureRuntime as never,
+        sessionKind: vi.fn(() => "visible" as const),
+      },
+      timeoutScheduler: {
+        schedule(_delay, task) {
+          fireTimeout = task;
+          return {
+            cancel() {
+              fireTimeout = () => undefined;
+            },
+          };
+        },
+      },
+      turnPlan: harness.plans,
+    });
+    closers.push(async () => {
+      inbox.stop();
+      await inbox.settled();
+    });
+    harness.pauseNextInspection();
+    const refreshing = harness.emitRequirement();
+    await harness.inspectionEntered.promise;
+    const request = collaborationDelivery();
+    expect((await inbox.accept(request)).status).toBe("accepted");
+    await vi.waitFor(() => expect(harness.inspectCalls).toBeGreaterThanOrEqual(2));
+    fireTimeout();
+    await inbox.settled();
+    expect(harness.modelStarts).toBe(0);
+    expect(
+      await readProviderCliTurnPlan(join(harness.plans.sessionDir(request.targetSessionId), "plan.json")),
+    ).toBeUndefined();
+    harness.releaseInspection();
+    await refreshing;
+    expect(
+      await readProviderCliTurnPlan(join(harness.plans.sessionDir(request.targetSessionId), "plan.json")),
+    ).toBeUndefined();
+  });
+});
+
+async function createHarness(provider: "feishu" | "slack") {
+  const accountHome = await makeTempDir("opentag-470-account-");
+  const openTagHome = await makeTempDir("opentag-470-home-");
+  tempDirs.push(accountHome, openTagHome);
+  await mkdir(openTagHome, { recursive: true, mode: 0o700 });
+  const bin = join(accountHome, "bin");
+  const target = await writeFakeCli(bin, provider, { version: provider === "slack" ? "4.7.0" : "1.0.92" });
+  const manager = new ProviderCliManager({
+    accountHome,
+    env: { PATH: bin },
+    fetcher: async () => {
+      throw new Error("Public network disabled in readiness regression");
+    },
+  });
+  const installed = await manager.ensure(provider, { mode: "auto" });
+  expect(installed.ok).toBe(true);
+  const ensure = vi.spyOn(manager, "ensure");
+  const inspectionEntered = deferred();
+  const release = deferred();
+  let pauseNextInspection = false;
+  let inspectCalls = 0;
+  const inspect = async (name: "feishu" | "slack") => {
+    inspectCalls += 1;
+    const actual = await manager.inspect(name);
+    if (pauseNextInspection) {
+      pauseNextInspection = false;
+      inspectionEntered.resolve();
+      await release.promise;
+    }
+    return actual;
+  };
+  const frames: Array<{ type: string; status?: string }> = [];
+  const listeners = new Set<(frame: Record<string, unknown>) => void | Promise<void>>();
+  const emit = async (frame: Record<string, unknown>) => {
+    await Promise.all([...listeners].map((listener) => listener(frame)));
+  };
+  const connection = {
+    subscribeBusinessFrames(listener: (frame: never) => void | Promise<void>) {
+      listeners.add(listener as (frame: Record<string, unknown>) => void | Promise<void>);
+      return () => listeners.delete(listener as (frame: Record<string, unknown>) => void | Promise<void>);
+    },
+    capabilityVersion: () => 1,
+    setImCliReadiness() {},
+    async send(frame: { type: string; requestId?: string; status?: string }) {
+      frames.push(frame);
+      if (frame.type === "im:credential") {
+        queueMicrotask(() => {
+          void emit({
+            type: "im:credential:result",
+            requestId: frame.requestId,
+            status: "succeeded",
+            credentialGeneration: 1,
+            grant:
+              provider === "slack"
+                ? { provider, botAccessToken: "synthetic-test-only" }
+                : { provider, appId: "A1", appSecret: "synthetic-test-only", teamBrand: "feishu" },
+            outboxContext:
+              provider === "slack"
+                ? { provider, sessionKind: "channel", channelId: "C1" }
+                : { provider, sessionKind: "channel", chatId: "C1" },
+          });
+        });
+      }
+    },
+  };
+  const reconciler = new ProviderCliReconciler({
+    connection,
+    manager: { layout: manager.layout, inspect, ensure: manager.ensure.bind(manager) },
+    validation: {
+      async run() {
+        throw new Error("No remote validation expected");
+      },
+      async cleanupAll() {},
+    },
+    logger: quiet,
+  });
+  const credentials = new ImCredentialEnvironmentManager({
+    connection,
+    home: openTagHome,
+    logger: quiet,
+    exchangeFeishuToken: async () => "synthetic-test-token",
+  });
+  const plans = new ProviderCliTurnPlanManager({
+    accountHome,
+    openTagHome,
+    readySelection: reconciler.readySelectionForRun.bind(reconciler),
+    runnerInvocation: providerCliTurnRunnerInvocation(),
+  });
+  const reports: Array<{
+    outcome?: string;
+    errorReason?: string;
+    executionEffects?: string;
+  }> = [];
+  const logs: Array<{ fields: { errorCode?: string }; message: string }> = [];
+  let modelStarts = 0;
+  const ensureRuntime = vi.fn(async (_sessionId: string, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    modelStarts += 1;
+    return {
+      async prompt(input: { runId: string }) {
+        return { runId: input.runId, status: "completed" as const, output: [] };
+      },
+      waitForIdle: async () => undefined,
+    };
+  });
+  const runner = new AgentTurnRunner({
+    bindingStore: { updateUnresolved: async () => undefined } as unknown as SessionBindingStore,
+    connection,
+    custody: { markReporting: async () => undefined, recordResult() {} } as unknown as TurnCustodyOwner,
+    reportOwner: {
+      create: (report: { outcome?: string; errorReason?: string; executionEffects?: string }) => {
+        reports.push(report);
+        return { ...report, type: "turn:report", requestId: randomUUID(), resultHash: "a".repeat(64) };
+      },
+      async submit() {},
+    } as unknown as TurnReportOwner,
+    runtimeManager: {
+      ensureRuntime,
+      cwd: () => accountHome,
+      sessionKind: () => "visible",
+      observe: () => () => undefined,
+    } as unknown as SessionRuntimeManager,
+    credentialEnvironment: credentials,
+    turnPlan: plans,
+    logger: {
+      ...quiet,
+      warn: (fields: { errorCode?: string }, message: string) => logs.push({ fields, message }),
+    } as never,
+  });
+  closers.push(async () => {
+    release.resolve();
+    runner.stop();
+    await runner.settled();
+    await credentials.close();
+    await reconciler.close();
+  });
+  const agentId = randomUUID();
+  const integrationId = randomUUID();
+  return {
+    credentials,
+    ensure,
+    ensureRuntime,
+    get inspectCalls() {
+      return inspectCalls;
+    },
+    inspectionEntered,
+    logs,
+    manager,
+    get modelStarts() {
+      return modelStarts;
+    },
+    owner(sessionId: string = randomUUID()): LiveTurnOwner {
+      return liveOwner(provider, sessionId, agentId);
+    },
+    pauseNextInspection() {
+      pauseNextInspection = true;
+    },
+    plans,
+    releaseInspection() {
+      release.resolve();
+    },
+    reports,
+    runner,
+    target,
+    emitRequirement() {
+      return emit({
+        type: "provider-cli:requirement",
+        operation: RUNTIME_PROVIDER_CLI_REQUIREMENT_OPERATION,
+        requestId: randomUUID(),
+        provider,
+        agentId,
+        integrationId,
+        credentialGeneration: 1,
+        expectedIdentity:
+          provider === "slack"
+            ? { provider, teamId: "T1", botUserId: "U1", botId: "B1" }
+            : { provider, appId: "A1", botOpenId: "B1", teamBrand: "feishu" },
+      });
+    },
+  };
+}
+
+function liveOwner(provider: "feishu" | "slack", sessionId: string, agentId: string): LiveTurnOwner {
+  const request: DirectImMessageDeliveryRequest = {
+    type: "im:deliver",
+    requestId: randomUUID(),
+    deliveryId: randomUUID(),
+    imMessageId: randomUUID(),
+    sessionId,
+    agentId,
+    placementGeneration: 1,
+    attention: "direct",
+    content: {
+      kind: "text",
+      text: "hello",
+      providerRef:
+        provider === "slack"
+          ? {
+              provider,
+              appId: "A1",
+              teamId: "T1",
+              botUserId: "U1",
+              channelId: "C1",
+              messageTs: "1710000000.000001",
+            }
+          : {
+              provider,
+              teamBrand: "feishu",
+              appId: "A1",
+              botOpenId: "B1",
+              chatId: "C1",
+              messageId: "M1",
+            },
+    },
+    runtime: {
+      revision: { agent: { sequence: 1, id: "agent-revision" }, session: { sequence: 1, id: "session-revision" } },
+      agentId,
+      provider: "codex",
+      instructions: { platform: "test", agent: "test" },
+      execution: { approvalPolicy: "never", networkAccess: true },
+      workspace: { workspaceId: agentId, mode: "empty_on_create", sharing: "agent" },
+    },
+  };
+  return {
+    inputHash: "a".repeat(64),
+    request,
+    reservation: {} as LiveTurnOwner["reservation"],
+    turnId: randomUUID(),
+  };
+}
+
+function collaborationDelivery(): SessionMessageDeliveryRequest {
+  const agentId = randomUUID();
+  return {
+    type: "session:message:deliver",
+    requestId: randomUUID(),
+    messageId: randomUUID(),
+    sourceSessionId: randomUUID(),
+    targetSessionId: randomUUID(),
+    agentId,
+    placementGeneration: 1,
+    runtime: {
+      revision: { agent: { sequence: 1, id: "a".repeat(64) }, session: { sequence: 1, id: "b".repeat(64) } },
+      agentId,
+      provider: "codex",
+      instructions: { platform: "platform", agent: "agent" },
+      execution: { approvalPolicy: "never", networkAccess: true },
+      workspace: { workspaceId: agentId, mode: "empty_on_create", sharing: "agent" },
+    },
+    content: { kind: "text", text: "callback" },
+  };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  let settled = false;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return {
+    promise,
+    resolve() {
+      if (settled) return;
+      settled = true;
+      resolve();
+    },
+  };
+}

--- a/packages/client/src/__tests__/provider-cli-reconciler.test.ts
+++ b/packages/client/src/__tests__/provider-cli-reconciler.test.ts
@@ -13,6 +13,7 @@ import {
   type ProviderCliReconcilerOptions,
   ProviderCliValidationRunner,
   type RuntimeBusinessFrame,
+  readProviderCliSelection,
   resolveProviderCliAccountLayout,
   writeProviderCliSelection,
 } from "../index.js";
@@ -142,6 +143,32 @@ async function externalReadyFixture() {
   };
 }
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve: () => resolve() };
+}
+
+function holdFirstInspect(result: () => ProviderCliInspection | Promise<ProviderCliInspection>) {
+  const gate = deferred();
+  let hold = true;
+  const inspect = vi.fn(async () => {
+    if (hold) {
+      hold = false;
+      await gate.promise;
+    }
+    return result();
+  });
+  return { inspect, release: () => gate.resolve() };
+}
+
+function isAbortFailure(error: unknown, reason?: unknown): boolean {
+  if (reason !== undefined && error === reason) return true;
+  return error instanceof Error && error.name === "AbortError";
+}
+
 function grantFrame(overrides: Record<string, unknown> = {}) {
   return {
     type: "provider-cli:validation:grant",
@@ -257,6 +284,323 @@ describe("provider CLI reconciler", () => {
       generation: selection.generation,
       path: identity.path,
     });
+    await reconciler.close();
+  });
+
+  it("does not treat a previously accepted then unavailable provider as initial confirmation", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    let failInspect = false;
+    let inspection = fixture.inspection;
+    const inspect = vi.fn(async () => {
+      if (failInspect) throw new Error("Synthetic inspection failure");
+      return inspection;
+    });
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure: vi.fn(), layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+    await runtime.emit(requirement);
+    const accepted = await reconciler.readySelectionForRun("slack");
+    expect(accepted).toMatchObject({ generation: fixture.selection.generation });
+
+    failInspect = true;
+    await runtime.emit({ ...requirement, requestId: "99999999-9999-4999-8999-999999999999" });
+    expect(runtime.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "provider-cli:artifact:status", status: "unavailable" }),
+      expect.anything(),
+    );
+
+    const replacement = join(dirname(fixture.inspection.selection.path), "slack-history");
+    await writeFile(replacement, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    const identity = await computeFileIdentity(replacement);
+    const fingerprint = computeTargetFingerprint(identity, "4.7.0");
+    const selection = await writeProviderCliSelection(
+      fixture.layout,
+      "slack",
+      {
+        kind: "external",
+        executablePath: identity.path,
+        fingerprint,
+        trust: "catalog-verified",
+        version: "4.7.0",
+      },
+      fixture.selection,
+    );
+    inspection = readyInspect({
+      fingerprint,
+      selection: {
+        kind: "external",
+        path: identity.path,
+        version: "4.7.0",
+        generation: selection.generation,
+        trust: "catalog-verified",
+      },
+    });
+    failInspect = false;
+
+    await expect(reconciler.readySelectionForRun("slack")).resolves.toBeUndefined();
+    await expect(reconciler.readySelectionForRun("slack")).resolves.toMatchObject({
+      generation: selection.generation,
+      path: identity.path,
+    });
+    expect(selection.generation).not.toBe(accepted?.generation);
+    await reconciler.close();
+  });
+
+  it("admits concurrent first Runs after the in-flight initial reconcile when identity is unchanged", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    const { inspect, release } = holdFirstInspect(() => fixture.inspection);
+    const ensure = vi.fn();
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure, layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+
+    const requirementJob = runtime.emit(requirement);
+    await vi.waitFor(() => expect(inspect).toHaveBeenCalledOnce());
+    const first = reconciler.readySelectionForRun("slack");
+    const second = reconciler.readySelectionForRun("slack");
+    await vi.waitFor(() => expect(inspect.mock.calls.length).toBeGreaterThanOrEqual(3));
+    expect(ensure).not.toHaveBeenCalled();
+    release();
+    await requirementJob;
+    await expect(first).resolves.toMatchObject({
+      generation: fixture.selection.generation,
+      path: fixture.inspection.selection.path,
+      version: fixture.inspection.selection.version,
+      fingerprint: fixture.inspection.fingerprint,
+    });
+    await expect(second).resolves.toMatchObject({
+      generation: fixture.selection.generation,
+      path: fixture.inspection.selection.path,
+    });
+    expect(ensure).not.toHaveBeenCalled();
+    await reconciler.close();
+  });
+
+  it("keeps one waiter's abort independent of another waiter's initial admission", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    const { inspect, release } = holdFirstInspect(() => fixture.inspection);
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure: vi.fn(), layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+
+    const requirementJob = runtime.emit(requirement);
+    await vi.waitFor(() => expect(inspect).toHaveBeenCalledOnce());
+    const cancelled = new AbortController();
+    const aborted = reconciler.readySelectionForRun("slack", cancelled.signal);
+    const surviving = reconciler.readySelectionForRun("slack");
+    await vi.waitFor(() => expect(inspect.mock.calls.length).toBeGreaterThanOrEqual(3));
+    cancelled.abort("turn_timeout");
+    await expect(aborted).rejects.toSatisfy((error) => isAbortFailure(error, "turn_timeout"));
+    release();
+    await requirementJob;
+    await expect(surviving).resolves.toMatchObject({ generation: fixture.selection.generation });
+    await reconciler.close();
+  });
+
+  it("rejects an initial Run when selection generation changes during the wait", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    const { inspect, release } = holdFirstInspect(async () => {
+      const record = await readProviderCliSelection(fixture.layout, "slack");
+      if (!record) return fixture.inspection;
+      return readyInspect({
+        fingerprint: record.selection.fingerprint,
+        selection: {
+          kind: "external",
+          path:
+            record.selection.kind === "external" ? record.selection.executablePath : fixture.inspection.selection.path,
+          version: record.selection.version,
+          generation: record.generation,
+          trust: "catalog-verified",
+        },
+      });
+    });
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure: vi.fn(), layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+
+    const requirementJob = runtime.emit(requirement);
+    await vi.waitFor(() => expect(inspect).toHaveBeenCalledOnce());
+    const waiting = reconciler.readySelectionForRun("slack");
+    await vi.waitFor(() => expect(inspect.mock.calls.length).toBeGreaterThanOrEqual(2));
+    const replacement = join(dirname(fixture.inspection.selection.path), "slack-rotated");
+    await writeFile(replacement, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    const identity = await computeFileIdentity(replacement);
+    const fingerprint = computeTargetFingerprint(identity, "4.7.0");
+    await writeProviderCliSelection(
+      fixture.layout,
+      "slack",
+      {
+        kind: "external",
+        executablePath: identity.path,
+        fingerprint,
+        trust: "catalog-verified",
+        version: "4.7.0",
+      },
+      fixture.selection,
+    );
+    release();
+    await requirementJob;
+    await expect(waiting).resolves.toBeUndefined();
+    await reconciler.close();
+  });
+
+  it("does not admit a waiting Run after close even if reconcile later succeeds", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    const { inspect, release } = holdFirstInspect(() => fixture.inspection);
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure: vi.fn(), layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+
+    const requirementJob = runtime.emit(requirement);
+    await vi.waitFor(() => expect(inspect).toHaveBeenCalledOnce());
+    const waiting = reconciler.readySelectionForRun("slack");
+    await vi.waitFor(() => expect(inspect.mock.calls.length).toBeGreaterThanOrEqual(2));
+    const closing = reconciler.close();
+    await expect(waiting).resolves.toBeUndefined();
+    release();
+    await Promise.all([requirementJob, closing]);
+  });
+
+  it("interrupts a pending initial readiness inspection when the caller aborts", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    const gate = deferred();
+    const entered = deferred();
+    const inspect = vi.fn(async () => {
+      entered.resolve();
+      await gate.promise;
+      return fixture.inspection;
+    });
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure: vi.fn(), layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+    const abort = new AbortController();
+    const caller = reconciler.readySelectionForRun("slack", abort.signal).then(
+      () => ({ outcome: "resolved" as const }),
+      (error: unknown) => ({ outcome: "rejected" as const, error }),
+    );
+    await entered.promise;
+    abort.abort("turn_timeout");
+    const result = await Promise.race([
+      caller,
+      new Promise<{ outcome: string }>((resolve) => {
+        setTimeout(() => resolve({ outcome: "still_waiting" }), 100);
+      }),
+    ]);
+    expect(result.outcome).toBe("rejected");
+    expect(isAbortFailure((result as { error?: unknown }).error, "turn_timeout")).toBe(true);
+    gate.resolve();
+    await caller;
+    await reconciler.close();
+  });
+
+  it("observes a failed status publication that also cancels its caller", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    const held = holdFirstInspect(() => fixture.inspection);
+    const abort = new AbortController();
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect: held.inspect, ensure: vi.fn(), layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+    const requirementJob = runtime.emit(requirement);
+    try {
+      await vi.waitFor(() => expect(held.inspect).toHaveBeenCalledOnce());
+      runtime.send.mockImplementationOnce(async () => {
+        abort.abort("turn_timeout");
+        throw new Error("Status transport closed");
+      });
+      await expect(reconciler.readySelectionForRun("slack", abort.signal)).rejects.toBe("turn_timeout");
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    } finally {
+      held.release();
+      await requirementJob;
+      await reconciler.close();
+    }
+  });
+
+  it("interrupts a pending final readiness recheck when the caller aborts", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    const finalHold = deferred();
+    const finalEntered = deferred();
+    let inspectCalls = 0;
+    const inspect = vi.fn(async () => {
+      inspectCalls += 1;
+      if (inspectCalls === 3) {
+        finalEntered.resolve();
+        await finalHold.promise;
+      }
+      return fixture.inspection;
+    });
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure: vi.fn(), layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+    const abort = new AbortController();
+    const caller = reconciler.readySelectionForRun("slack", abort.signal).then(
+      () => ({ outcome: "resolved" as const }),
+      (error: unknown) => ({ outcome: "rejected" as const, error }),
+    );
+    await finalEntered.promise;
+    abort.abort("turn_timeout");
+    const result = await Promise.race([
+      caller,
+      new Promise<{ outcome: string }>((resolve) => {
+        setTimeout(() => resolve({ outcome: "still_waiting" }), 100);
+      }),
+    ]);
+    expect(result.outcome).toBe("rejected");
+    finalHold.resolve();
+    await caller;
+    await reconciler.close();
+  });
+
+  it("fails closed when the live CLI is missing at the start of the wait", async () => {
+    const runtime = connection();
+    const fixture = await externalReadyFixture();
+    const gate = deferred();
+    let hold = true;
+    const inspect = vi.fn(async () => {
+      if (hold) {
+        hold = false;
+        await gate.promise;
+        return fixture.inspection;
+      }
+      return notReadyInspect("slack", "install", { code: "not_installed" });
+    });
+    const reconciler = new ProviderCliReconciler({
+      connection: runtime,
+      manager: { inspect, ensure: vi.fn(), layout: fixture.layout },
+      validation: { run: vi.fn(), cleanupAll: vi.fn() },
+    });
+
+    const requirementJob = runtime.emit(requirement);
+    await vi.waitFor(() => expect(inspect).toHaveBeenCalledOnce());
+    const waiting = reconciler.readySelectionForRun("slack");
+    await vi.waitFor(() => expect(inspect).toHaveBeenCalledTimes(2));
+    gate.resolve();
+    await requirementJob;
+    await expect(waiting).resolves.toBeUndefined();
     await reconciler.close();
   });
 

--- a/packages/client/src/__tests__/provider-cli-turn-plan-manager.test.ts
+++ b/packages/client/src/__tests__/provider-cli-turn-plan-manager.test.ts
@@ -1,6 +1,6 @@
 import { chmod, lstat, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deriveProviderCliHomeNamespace,
   deriveProviderCliSessionKey,
@@ -12,6 +12,7 @@ import {
   resolveProviderCliAccountLayout,
   writeProviderCliSelection,
 } from "../index.js";
+import * as turnPlanStorage from "../runtime/provider-cli/turn-plan.js";
 import { makeTempDir } from "./fixtures/provider-cli.js";
 import {
   installTurnTarget,
@@ -262,6 +263,109 @@ describe("ProviderCliTurnPlanManager prepare", () => {
     await expect(manager.prepare({ provider: "feishu", sessionId: "s-1", runId: "run-1" })).rejects.toMatchObject({
       code: "selection_invalid",
     });
+  });
+
+  it("does not publish a plan when the caller aborts while waiting for readiness", async () => {
+    const base = await makeTurnPlanHarness();
+    tempDirs.push(base.accountHome, base.openTagHome);
+    const target = await installTurnTarget(join(base.accountHome, "bin"));
+    const record = await writeExternalTurnSelection(base.layout, "feishu", target);
+    const ready = {
+      fingerprint: record.selection.fingerprint,
+      generation: record.generation,
+      path: target,
+      version: record.selection.version,
+    };
+    let settleReady!: (value: typeof ready) => void;
+    const readySelection = vi.fn((_provider: "feishu" | "slack", signal?: AbortSignal) => {
+      return new Promise<typeof ready>((resolve, reject) => {
+        const onAbort = () => {
+          signal?.removeEventListener("abort", onAbort);
+          reject(signal?.reason ?? new DOMException("This operation was aborted", "AbortError"));
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+        settleReady = (value) => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve(value);
+        };
+      });
+    });
+    const manager = new ProviderCliTurnPlanManager({
+      accountHome: base.accountHome,
+      openTagHome: base.openTagHome,
+      readySelection,
+      runnerInvocation: providerCliTurnRunnerInvocation(),
+    });
+    const abort = new AbortController();
+    const preparing = manager.prepare(
+      { provider: "feishu", sessionId: "s-abort-wait", runId: "run-abort-wait" },
+      abort.signal,
+    );
+    await vi.waitFor(() => expect(readySelection).toHaveBeenCalledOnce());
+    expect(readySelection).toHaveBeenCalledWith("feishu", abort.signal);
+    abort.abort("turn_timeout");
+    await expect(preparing).rejects.toSatisfy(
+      (error) => error === "turn_timeout" || (error instanceof Error && error.name === "AbortError"),
+    );
+    settleReady(ready);
+    await Promise.resolve();
+    await expect(
+      readProviderCliTurnPlan(join(manager.sessionDir("s-abort-wait"), "plan.json")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("discards this Run's plan when abort races exclusive publication", async () => {
+    const base = await makeTurnPlanHarness();
+    tempDirs.push(base.accountHome, base.openTagHome);
+    const target = await installTurnTarget(join(base.accountHome, "bin"));
+    const record = await writeExternalTurnSelection(base.layout, "feishu", target);
+    const abort = new AbortController();
+    const manager = new ProviderCliTurnPlanManager({
+      accountHome: base.accountHome,
+      openTagHome: base.openTagHome,
+      readySelection: async () => ({
+        fingerprint: record.selection.fingerprint,
+        generation: record.generation,
+        path: target,
+        version: record.selection.version,
+      }),
+      runnerInvocation: providerCliTurnRunnerInvocation(),
+    });
+    let didPublish!: () => void;
+    const published = new Promise<void>((resolve) => {
+      didPublish = resolve;
+    });
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const publish = turnPlanStorage.publishProviderCliTurnPlanExclusive;
+    const publishing = vi
+      .spyOn(turnPlanStorage, "publishProviderCliTurnPlanExclusive")
+      .mockImplementationOnce(async (path, plan) => {
+        const result = await publish(path, plan);
+        expect(await readProviderCliTurnPlan(path)).toMatchObject({ runId: "run-late-publish" });
+        didPublish();
+        await released;
+        return result;
+      });
+    try {
+      const first = manager.prepare(
+        { provider: "feishu", sessionId: "s-late-publish", runId: "run-late-publish" },
+        abort.signal,
+      );
+      const rejected = expect(first).rejects.toBe("turn_timeout");
+      await published;
+      abort.abort("turn_timeout");
+      const next = manager.prepare({ provider: "feishu", sessionId: "s-late-publish", runId: "run-next" });
+      release();
+      await rejected;
+      const prepared = await next;
+      expect(await readProviderCliTurnPlan(prepared.planPath)).toMatchObject({ runId: "run-next" });
+    } finally {
+      release();
+      publishing.mockRestore();
+    }
   });
 
   it("rejects empty, oversized, or control-character identities", async () => {

--- a/packages/client/src/__tests__/session-message-inbox.test.ts
+++ b/packages/client/src/__tests__/session-message-inbox.test.ts
@@ -867,6 +867,7 @@ describe("SessionMessageInbox", () => {
     expect(order).toEqual(["prepare", "plan", "runtime", "prompt", "plan-cleanup", "cleanup"]);
     expect(turnPlan.prepare).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "feishu", runId: expect.stringMatching(/^session-message-/) }),
+      expect.any(AbortSignal),
     );
     visible.stop();
 
@@ -886,6 +887,113 @@ describe("SessionMessageInbox", () => {
     await internal.settled();
     expect(internalPlan.prepare).not.toHaveBeenCalled();
     internal.stop();
+  });
+
+  it("bounds visible plan preparation with the Run timeout and does not start the model", async () => {
+    let fireTimeout: () => void = () => undefined;
+    const timeoutScheduler: RuntimeRetryScheduler = {
+      schedule(_delay, task) {
+        fireTimeout = task;
+        return {
+          cancel() {
+            fireTimeout = () => undefined;
+          },
+        };
+      },
+    };
+    const turnPlan = {
+      prepare: vi.fn((_input: unknown, signal?: AbortSignal) => {
+        return new Promise((_resolve, reject) => {
+          const onAbort = () => {
+            reject(signal?.reason ?? new Error("aborted"));
+          };
+          signal?.addEventListener("abort", onAbort, { once: true });
+        });
+      }),
+      cleanup: vi.fn(async () => undefined),
+    };
+    const ensureRuntime = vi.fn();
+    const inbox = new SessionMessageInbox({
+      admission: new AdmissionController(),
+      credentialEnvironment: {
+        prepare: vi.fn(async () => ({
+          path: "/tmp/provider-env.sh",
+          provider: "feishu" as const,
+          outboxContext: {
+            provider: "feishu" as const,
+            sessionKind: "channel" as const,
+            chatId: "oc-visible",
+          },
+        })),
+        cleanup: vi.fn(async () => undefined),
+      },
+      imCredentialGrantVersion: () => 2,
+      reconciler: inboxReconciler(),
+      runtimeManager: {
+        ensureRuntime: ensureRuntime as never,
+        sessionKind: vi.fn(() => "visible" as const),
+      },
+      timeoutScheduler,
+      turnPlan,
+    });
+    expect((await inbox.accept(delivery())).status).toBe("accepted");
+    await vi.waitFor(() => expect(turnPlan.prepare).toHaveBeenCalledOnce());
+    expect(turnPlan.prepare).toHaveBeenCalledWith(expect.any(Object), expect.any(AbortSignal));
+    fireTimeout();
+    await inbox.settled();
+    expect(ensureRuntime).not.toHaveBeenCalled();
+    expect(turnPlan.cleanup).not.toHaveBeenCalled();
+    inbox.stop();
+  });
+
+  it("does not start the model when the Run signal aborts after plan prepare", async () => {
+    let fireTimeout: () => void = () => undefined;
+    const timeoutScheduler: RuntimeRetryScheduler = {
+      schedule(_delay, task) {
+        fireTimeout = task;
+        return {
+          cancel() {
+            fireTimeout = () => undefined;
+          },
+        };
+      },
+    };
+    const turnPlan = {
+      prepare: vi.fn(async () => {
+        fireTimeout();
+        return { sessionDir: "/tmp/plans" };
+      }),
+      cleanup: vi.fn(async () => undefined),
+    };
+    const ensureRuntime = vi.fn();
+    const inbox = new SessionMessageInbox({
+      admission: new AdmissionController(),
+      credentialEnvironment: {
+        prepare: vi.fn(async () => ({
+          path: "/tmp/provider-env.sh",
+          provider: "feishu" as const,
+          outboxContext: {
+            provider: "feishu" as const,
+            sessionKind: "channel" as const,
+            chatId: "oc-visible",
+          },
+        })),
+        cleanup: vi.fn(async () => undefined),
+      },
+      imCredentialGrantVersion: () => 2,
+      reconciler: inboxReconciler(),
+      runtimeManager: {
+        ensureRuntime: ensureRuntime as never,
+        sessionKind: vi.fn(() => "visible" as const),
+      },
+      timeoutScheduler,
+      turnPlan,
+    });
+    expect((await inbox.accept(delivery())).status).toBe("accepted");
+    await inbox.settled();
+    expect(turnPlan.prepare).toHaveBeenCalledOnce();
+    expect(ensureRuntime).not.toHaveBeenCalled();
+    inbox.stop();
   });
 
   it("rejects a visible callback before ACK under grant v1 and accepts the same message after v2 is restored", async () => {

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -42,7 +42,7 @@ export interface AgentTurnRunnerOptions {
   readonly credentialEnvironment: Pick<ImCredentialEnvironmentManager, "cleanup" | "prepare">;
   readonly turnPlan?: {
     cleanup(input: ProviderCliTurnPlanPrepareInput): Promise<void>;
-    prepare(input: ProviderCliTurnPlanPrepareInput): Promise<unknown>;
+    prepare(input: ProviderCliTurnPlanPrepareInput, signal?: AbortSignal): Promise<unknown>;
   };
 }
 
@@ -221,8 +221,9 @@ export class AgentTurnRunner {
           runId: owner.turnId,
           ...(credentials.slackConfigDir ? { configDir: credentials.slackConfigDir } : {}),
         };
-        await this.#turnPlan.prepare(turnPlanInput);
+        await this.#turnPlan.prepare(turnPlanInput, signal);
       }
+      signal.throwIfAborted();
       const runtime = await this.#runtimeManager.ensureRuntime(owner.request.sessionId, signal);
       turn.runtime = runtime;
       const cwd = this.#runtimeManager.cwd(owner.request.sessionId);

--- a/packages/client/src/runtime/provider-cli/reconciler.ts
+++ b/packages/client/src/runtime/provider-cli/reconciler.ts
@@ -96,11 +96,13 @@ export class ProviderCliReconciler {
   readonly #inspectionJobs = new Map<ProviderCliProvider, Promise<ImCliReadinessStatus>>();
   readonly #logger: Pick<ClientLogger, "info" | "warn">;
   readonly #providerJobs = new Map<string, Promise<ProviderCliArtifactStatusFrame["status"]>>();
+  readonly #acceptedOnce = new Set<ProviderCliProvider>();
   readonly #readySelection = new Map<ProviderCliProvider, ProviderCliReadySelection>();
   readonly #signal?: AbortSignal;
   readonly #sleep: (ms: number) => Promise<void>;
   readonly #unsubscribe: () => void;
   readonly #validation: ProviderCliReconcilerOptions["validation"];
+  readonly #waiterAbort = new AbortController();
   #closePromise?: Promise<void>;
   #closed = false;
 
@@ -129,6 +131,7 @@ export class ProviderCliReconciler {
 
   async #performClose(): Promise<void> {
     this.#closed = true;
+    this.#waiterAbort.abort();
     this.#unsubscribe();
     this.#imCliPublished.clear();
     this.#abortAll();
@@ -145,12 +148,86 @@ export class ProviderCliReconciler {
   }
 
   /**
-   * Return the exact selection already accepted by daemon readiness. A local
-   * selection drift first republishes artifact checking, repairs if possible,
-   * and only then exposes the new selection to a visible Run.
+   * Return the exact selection already accepted by daemon readiness.
+   *
+   * An already-accepted selection that still matches the live CLI is admitted
+   * immediately. A never-accepted, already-healthy live CLI joins the in-flight
+   * provider reconcile and is admitted only when path, fingerprint, version, and
+   * generation stay identical across the wait. A provider that was accepted once
+   * and later failed or rotated is not treated as a fresh cold start. Caller
+   * cancellation interrupts inspect, reconcile wait, and publication wait without
+   * cancelling shared work or another waiter.
    */
-  async readySelectionForRun(provider: ProviderCliProvider): Promise<ProviderCliReadySelection | undefined> {
-    if (this.#closed || this.#signal?.aborted) return undefined;
+  async readySelectionForRun(
+    provider: ProviderCliProvider,
+    signal?: AbortSignal,
+  ): Promise<ProviderCliReadySelection | undefined> {
+    try {
+      return await this.#selectReadyForRun(provider, signal);
+    } catch (error) {
+      this.#throwIfReadinessAborted(signal);
+      if (this.#closed || this.#waiterAbort.signal.aborted) return undefined;
+      throw error;
+    }
+  }
+
+  async #selectReadyForRun(
+    provider: ProviderCliProvider,
+    signal?: AbortSignal,
+  ): Promise<ProviderCliReadySelection | undefined> {
+    this.#throwIfReadinessAborted(signal);
+    if (this.#closed) return undefined;
+    const live = await this.#awaitReadiness(this.#inspectLiveSelection(provider), signal);
+    this.#throwIfReadinessAborted(signal);
+    if (this.#closed) return undefined;
+    const accepted = this.#readySelection.get(provider);
+    if (accepted && live && selectionsMatch(accepted, live)) return { ...live };
+
+    // Never-accepted + already-healthy is initial confirmation. An accepted,
+    // failed, or rotated selection must not reset to never-initialized.
+    const initialConfirmation = accepted === undefined && live !== undefined && !this.#acceptedOnce.has(provider);
+
+    await this.#awaitReadiness(this.#publishCurrentProvider(provider, "checking"), signal);
+    const status = await this.#awaitReadiness(this.#reconcileProvider(provider), signal);
+    this.#throwIfReadinessAborted(signal);
+    if (this.#closed) return undefined;
+    await this.#awaitReadiness(this.#publishCurrentProvider(provider, status), signal);
+    if (!initialConfirmation || !live) return undefined;
+    return this.#admitUnchangedInitialSelection(provider, live, signal);
+  }
+
+  async #admitUnchangedInitialSelection(
+    provider: ProviderCliProvider,
+    live: ProviderCliReadySelection,
+    signal?: AbortSignal,
+  ): Promise<ProviderCliReadySelection | undefined> {
+    const acceptedAfter = this.#readySelection.get(provider);
+    if (!acceptedAfter || !selectionsMatch(acceptedAfter, live)) return undefined;
+    const liveAfter = await this.#awaitReadiness(this.#inspectLiveSelection(provider), signal);
+    this.#throwIfReadinessAborted(signal);
+    if (this.#closed) return undefined;
+    if (!liveAfter || !selectionsMatch(acceptedAfter, liveAfter) || !selectionsMatch(live, liveAfter)) {
+      return undefined;
+    }
+    return { ...liveAfter };
+  }
+
+  #throwIfReadinessAborted(signal?: AbortSignal): void {
+    signal?.throwIfAborted();
+    this.#signal?.throwIfAborted();
+  }
+
+  #readinessSignals(signal?: AbortSignal): AbortSignal[] {
+    return [this.#signal, this.#waiterAbort.signal, signal].filter(
+      (candidate): candidate is AbortSignal => candidate !== undefined,
+    );
+  }
+
+  async #awaitReadiness<T>(work: Promise<T>, signal?: AbortSignal): Promise<T> {
+    return joinSharedWork(work, this.#readinessSignals(signal));
+  }
+
+  async #inspectLiveSelection(provider: ProviderCliProvider): Promise<ProviderCliReadySelection | undefined> {
     const inspection = await this.#manager.inspect(provider).catch((error: unknown) => {
       logger.debug(
         { code: "ready_inspection_failed", provider, error: String(error) },
@@ -158,17 +235,7 @@ export class ProviderCliReconciler {
       );
       return undefined;
     });
-    const live = inspection ? await readySelectionFromInspect(this.#manager.layout, provider, inspection) : undefined;
-    const accepted = this.#readySelection.get(provider);
-    if (accepted && live && selectionsMatch(accepted, live)) return { ...live };
-
-    await this.#publishCurrentProvider(provider, "checking");
-    const status = await this.#reconcileProvider(provider);
-    await this.#publishCurrentProvider(provider, status);
-    // Do not admit the Run that discovered drift. The checking/ready transition
-    // feeds the Server's handoff and diagnostics view (it no longer gates the Turn
-    // grant); a normal delivery retry then obtains a grant and uses the new selection.
-    return undefined;
+    return inspection ? readySelectionFromInspect(this.#manager.layout, provider, inspection) : undefined;
   }
 
   async #handleFrame(frame: RuntimeBusinessFrame): Promise<void> {
@@ -330,6 +397,7 @@ export class ProviderCliReconciler {
           return "unavailable";
         }
         this.#readySelection.set(provider, ready);
+        this.#acceptedOnce.add(provider);
         return "ready";
       }
       this.#readySelection.delete(provider);
@@ -606,6 +674,48 @@ function selectionsMatch(left: ProviderCliReadySelection, right: ProviderCliRead
     left.path === right.path &&
     left.version === right.version
   );
+}
+
+/**
+ * Wait for shared work without cancelling it. One waiter's abort only stops that
+ * waiter; the underlying job keeps running for everyone else.
+ */
+function joinSharedWork<T>(work: Promise<T>, signals: readonly AbortSignal[]): Promise<T> {
+  if (signals.length === 0) return work;
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      for (const signal of signals) signal.removeEventListener("abort", onAbort);
+    };
+    const finishOk = (value: T): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const finishErr = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = (): void => {
+      for (const signal of signals) {
+        if (!signal.aborted) continue;
+        try {
+          signal.throwIfAborted();
+        } catch (error) {
+          finishErr(error);
+          return;
+        }
+      }
+      finishErr(new DOMException("This operation was aborted", "AbortError"));
+    };
+    for (const signal of signals) signal.addEventListener("abort", onAbort, { once: true });
+    // Starting work may synchronously abort a caller; still observe its rejection.
+    void work.then(finishOk, finishErr);
+    if (signals.some((signal) => signal.aborted)) onAbort();
+  });
 }
 
 function expectedIdentitiesMatch(

--- a/packages/client/src/runtime/provider-cli/turn-plan-manager.ts
+++ b/packages/client/src/runtime/provider-cli/turn-plan-manager.ts
@@ -47,7 +47,10 @@ export interface ProviderCliTurnPlanManagerDeps {
   /** Absolute argv that starts the current daemon Node and loads the runner module. */
   readonly runnerInvocation: readonly string[];
   /** Production readiness fence. Omit only in isolated storage tests. */
-  readonly readySelection?: (provider: ProviderCliProvider) => Promise<ProviderCliReadySelection | undefined>;
+  readonly readySelection?: (
+    provider: ProviderCliProvider,
+    signal?: AbortSignal,
+  ) => Promise<ProviderCliReadySelection | undefined>;
   readonly platform?: NodeJS.Platform;
   readonly sleep?: (ms: number) => Promise<void>;
 }
@@ -113,7 +116,8 @@ export class ProviderCliTurnPlanManager {
    * same Session is rejected; the same Run is idempotent even if selection later
    * changes.
    */
-  async prepare(input: ProviderCliTurnPlanPrepareInput): Promise<ProviderCliPreparedTurnPlan> {
+  async prepare(input: ProviderCliTurnPlanPrepareInput, signal?: AbortSignal): Promise<ProviderCliPreparedTurnPlan> {
+    signal?.throwIfAborted();
     const sessionId = assertIdentity("sessionId", input.sessionId);
     const runId = assertIdentity("runId", input.runId);
     assertProviderCliTurnPlanConfigDir(input.provider, input.configDir);
@@ -121,7 +125,9 @@ export class ProviderCliTurnPlanManager {
     const sessionDir = providerCliPlanSessionDir(this.#layout, this.#homeNamespace, sessionKey);
     assertPlanWithinRoot(this.#layout.plans, sessionDir);
     await ensurePrivateDirectory(this.#layout.root, sessionDir);
-    return await this.#withSessionLock(sessionDir, () => this.#prepareLocked(input, sessionId, runId, sessionDir));
+    return await this.#withSessionLock(sessionDir, () =>
+      this.#prepareLocked(input, sessionId, runId, sessionDir, signal),
+    );
   }
 
   /**
@@ -210,10 +216,12 @@ export class ProviderCliTurnPlanManager {
     sessionId: string,
     runId: string,
     sessionDir: string,
+    signal?: AbortSignal,
   ): Promise<ProviderCliPreparedTurnPlan> {
+    signal?.throwIfAborted();
     const existing = await this.#readExistingPlan(sessionDir);
     if (existing) return this.#reuseExistingPlan(input, sessionId, runId, sessionDir, existing);
-    return this.#publishNewPlan(input, sessionId, runId, sessionDir);
+    return this.#publishNewPlan(input, sessionId, runId, sessionDir, signal);
   }
 
   async #reuseExistingPlan(
@@ -242,8 +250,11 @@ export class ProviderCliTurnPlanManager {
     sessionId: string,
     runId: string,
     sessionDir: string,
+    signal?: AbortSignal,
   ): Promise<ProviderCliPreparedTurnPlan> {
-    const expected = await this.#deps.readySelection?.(input.provider);
+    signal?.throwIfAborted();
+    const expected = await this.#deps.readySelection?.(input.provider, signal);
+    signal?.throwIfAborted();
     if (this.#deps.readySelection && !expected) {
       throw new ProviderCliTurnPlanError(
         "selection_invalid",
@@ -252,13 +263,35 @@ export class ProviderCliTurnPlanManager {
     }
     const record = await this.#readSelection(input.provider);
     const plan = await this.#planFromSelection(input, sessionId, runId, record, expected);
+    signal?.throwIfAborted();
     await this.#writeLauncher(sessionDir, plan);
-    const published = await publishProviderCliTurnPlanExclusive(providerCliTurnPlanPath(sessionDir), plan);
+    signal?.throwIfAborted();
+    let published: "created" | "exists";
+    try {
+      published = await publishProviderCliTurnPlanExclusive(providerCliTurnPlanPath(sessionDir), plan);
+    } finally {
+      if (signal?.aborted) await this.#discardMatchingPlan(input, sessionDir);
+    }
+    signal?.throwIfAborted();
     if (published === "created") return this.#prepared(plan, sessionDir);
 
     const raced = await this.#readExistingPlan(sessionDir);
     if (!raced) throw new ProviderCliTurnPlanError("plan_invalid", "Provider CLI Turn plan publish raced");
     return this.#reuseExistingPlan(input, sessionId, runId, sessionDir, raced);
+  }
+
+  async #discardMatchingPlan(input: ProviderCliTurnPlanPrepareInput, sessionDir: string): Promise<void> {
+    const existing = await this.#readExistingPlan(sessionDir);
+    if (!existing) return;
+    if (
+      existing.homeNamespace !== this.#homeNamespace ||
+      existing.sessionId !== input.sessionId ||
+      existing.runId !== input.runId ||
+      existing.provider !== input.provider
+    ) {
+      return;
+    }
+    await rm(providerCliTurnPlanPath(sessionDir), { force: true });
   }
 
   async #readSelection(provider: ProviderCliProvider): Promise<ProviderCliSelectionRecord> {

--- a/packages/client/src/runtime/session-message-inbox.ts
+++ b/packages/client/src/runtime/session-message-inbox.ts
@@ -49,7 +49,7 @@ export interface SessionMessageInboxOptions {
   credentialEnvironment: Pick<ImCredentialEnvironmentManager, "cleanup" | "prepare">;
   turnPlan?: {
     cleanup(input: ProviderCliTurnPlanPrepareInput): Promise<void>;
-    prepare(input: ProviderCliTurnPlanPrepareInput): Promise<unknown>;
+    prepare(input: ProviderCliTurnPlanPrepareInput, signal?: AbortSignal): Promise<unknown>;
   };
   imCredentialGrantVersion(): number | undefined;
   logger?: Pick<ClientLogger, "warn">;
@@ -295,6 +295,18 @@ export class SessionMessageInbox {
     let credentialPrepared = false;
     let turnPlanInput: ProviderCliTurnPlanPrepareInput | undefined;
     let phase = "runtime";
+    const timeout = new AbortController();
+    let timer: { cancel(): void } | undefined;
+    let runSignal: AbortSignal | undefined;
+    const ensureRunSignal = (): AbortSignal => {
+      if (runSignal) return runSignal;
+      timer = this.#timeoutScheduler.schedule(
+        next.request.runtime.budget?.maxDurationMs ?? RUNTIME_DEFAULT_MAX_DURATION_MS,
+        () => timeout.abort(new Error("Session message Run timed out")),
+      );
+      runSignal = AbortSignal.any([this.#abort.signal, timeout.signal]);
+      return runSignal;
+    };
     try {
       if (current) current = await this.#transition(current, "running");
       await this.#reconciler.withAgentLock(next.request.agentId, async () => {
@@ -318,34 +330,28 @@ export class SessionMessageInbox {
           throw new Error("The credential grant did not include visible Session outbox context");
         }
         outboxContext = prepared.outboxContext;
-        turnPlanInput = await this.#prepareTurnPlan(sessionId, runId, prepared);
+        turnPlanInput = await this.#prepareTurnPlan(sessionId, runId, prepared, ensureRunSignal());
       }
       phase = "runtime";
-      const runtime = await this.#runtimeManager.ensureRuntime(sessionId, this.#abort.signal);
+      const runtimeSignal = sessionKind === "visible" ? ensureRunSignal() : this.#abort.signal;
+      runtimeSignal.throwIfAborted();
+      const runtime = await this.#runtimeManager.ensureRuntime(sessionId, runtimeSignal);
       await runtime.waitForIdle();
       phase = "prompt";
-      const timeout = new AbortController();
-      const timer = this.#timeoutScheduler.schedule(
-        next.request.runtime.budget?.maxDurationMs ?? RUNTIME_DEFAULT_MAX_DURATION_MS,
-        () => timeout.abort(new Error("Session message Run timed out")),
-      );
-      try {
-        const result = await runtime.prompt({
-          runId,
-          input: buildSessionMessageInput(
-            next.request,
-            this.#cliCommand,
-            sessionKind === "visible"
-              ? { sessionKind, outboxContext: requireOutboxContext(outboxContext) }
-              : { sessionKind },
-          ),
-          signal: AbortSignal.any([this.#abort.signal, timeout.signal]),
-        });
-        if (result.status !== "completed") {
-          throw new Error(result.error?.message ?? `Session message Run ended with status ${result.status}`);
-        }
-      } finally {
-        timer.cancel();
+      ensureRunSignal().throwIfAborted();
+      const result = await runtime.prompt({
+        runId,
+        input: buildSessionMessageInput(
+          next.request,
+          this.#cliCommand,
+          sessionKind === "visible"
+            ? { sessionKind, outboxContext: requireOutboxContext(outboxContext) }
+            : { sessionKind },
+        ),
+        signal: ensureRunSignal(),
+      });
+      if (result.status !== "completed") {
+        throw new Error(result.error?.message ?? `Session message Run ended with status ${result.status}`);
       }
       if (current && !this.#abort.signal.aborted) {
         await this.#transition(current, "succeeded");
@@ -354,6 +360,7 @@ export class SessionMessageInbox {
     } catch (error) {
       if (current) await this.#handleFailure(current, next.hash, phase, error);
     } finally {
+      timer?.cancel();
       await this.#cleanupTurnPlan(turnPlanInput);
       if (credentialPrepared) await this.#credentialEnvironment.cleanup(sessionId).catch(() => undefined);
       await this.#reconciler.withAgentLock(next.request.agentId, async () => {
@@ -387,6 +394,7 @@ export class SessionMessageInbox {
     sessionId: string,
     runId: string,
     prepared: PreparedImCredentialEnvironment,
+    signal: AbortSignal,
   ): Promise<ProviderCliTurnPlanPrepareInput | undefined> {
     if (!this.#turnPlan) return undefined;
     const input: ProviderCliTurnPlanPrepareInput = {
@@ -395,7 +403,7 @@ export class SessionMessageInbox {
       runId,
       ...(prepared.slackConfigDir ? { configDir: prepared.slackConfigDir } : {}),
     };
-    await this.#turnPlan.prepare(input);
+    await this.#turnPlan.prepare(input, signal);
     return input;
   }
 


### PR DESCRIPTION
## Summary

A healthy first Feishu or Slack Turn could receive credentials, wait for the Client's initial Provider CLI inspection to complete, and still fail with `selection_invalid` before model startup. Waiting initial Turns now join the provider reconciliation and can proceed when the exact selection remains healthy and unchanged.

Initial confirmation checks path, fingerprint, version and selection generation before and after waiting. Previously accepted providers retain their history after failed inspections so recovery or rotation still rejects the Turn that discovers the change. Per-Turn cancellation reaches readiness reads and preparation, and a cancelled waiter leaves shared reconciliation available to other Sessions.

Fixes #470.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` passed on the final implementation (3,548 tests including repository script tests).
- `pnpm --filter @opentag/client test:agent-runtime:coverage` passed: 360 tests; 100% statements, branches, functions and lines.
- `pnpm --filter @opentag/server test:integration` passed: 324 tests against disposable PostgreSQL. Server and Shared source are unchanged.
- Independent real Client-component probes passed 12 healthy Feishu/Slack cold-start and reconnect Turns, plus per-caller timeout isolation, historical selection invalidation and cancelled inspection cases. They use local executable fixtures, synthetic grants and a stub model boundary.
- A status-send cancellation race reproduced an unhandled Promise rejection before the fix; its regression now passes. Publication cancellation is tested after the real plan write while another Run waits for the same Session lock.

Deployed first-message behavior with real provider accounts remains unverified. The existing Server grant behavior and permanent provider-failure policy are unchanged.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no documentation or translation changes).
