### PR TITLE
chore: upgrade context tree to 0.1.12

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -51,7 +51,7 @@
     "test": "vitest run --maxWorkers=1"
   },
   "dependencies": {
-    "@first-tree-ai/context-tree": "0.1.11"
+    "@first-tree-ai/context-tree": "0.1.12"
   },
   "devDependencies": {
     "@opentag/client": "workspace:*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,7 +29,7 @@
     "zod": "^4.5.1"
   },
   "devDependencies": {
-    "@first-tree-ai/context-tree": "0.1.11",
+    "@first-tree-ai/context-tree": "0.1.12",
     "@types/semver": "^7.8.0",
     "@types/ws": "^8.18.1",
     "vitest": "^4.1.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
   apps/cli:
     dependencies:
       '@first-tree-ai/context-tree':
-        specifier: 0.1.11
-        version: 0.1.11
+        specifier: 0.1.12
+        version: 0.1.12
     devDependencies:
       '@opentag/client':
         specifier: workspace:*
@@ -189,8 +189,8 @@ importers:
         version: 4.5.4
     devDependencies:
       '@first-tree-ai/context-tree':
-        specifier: 0.1.11
-        version: 0.1.11
+        specifier: 0.1.12
+        version: 0.1.12
       '@types/semver':
         specifier: ^7.8.0
         version: 7.8.0
@@ -983,8 +983,8 @@ packages:
   '@fastify/websocket@11.3.0':
     resolution: {integrity: sha512-g89ag4BCcD9YP5wBZXixzoLnuf5j89p/sXFcfpCiv2pdEkYYukBEoK3heVzqsp0EAtszVDc2BBZG0KZqeAShIA==}
 
-  '@first-tree-ai/context-tree@0.1.11':
-    resolution: {integrity: sha512-VLlnDqQS3ysYicQnuT8AVYH0toezbs8jw/K1t1uPAvC2QxbtaLriP0cNiHYA7C+pTtHvdDv9iTt+FssYKa7fHQ==}
+  '@first-tree-ai/context-tree@0.1.12':
+    resolution: {integrity: sha512-kJ3fNpkCqgDNzjcMPAmrCUJ6iZQBpvXnvU3WAZ5ahvz3Zk+h6ZeyKilE3yrmBfozRYz6yxKp//y59/65Qo7cDQ==}
     engines: {node: '>=22.13.0'}
     hasBin: true
 
@@ -5339,7 +5339,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@first-tree-ai/context-tree@0.1.11':
+  '@first-tree-ai/context-tree@0.1.12':
     dependencies:
       commander: 15.0.0
       mdast-util-from-markdown: 2.0.3

--- a/scripts/__tests__/portable-runtime-dependencies.test.mjs
+++ b/scripts/__tests__/portable-runtime-dependencies.test.mjs
@@ -179,7 +179,7 @@ test("the portable runtime dependency contract accepts only the supported exact 
 test("the checked-in apps/cli manifest is accepted under the portable shipping contract", () => {
   const cliManifest = JSON.parse(readFileSync(join(repoRoot, "apps", "cli", "package.json"), "utf8"));
   assert.deepEqual(readPortableDirectDependencyPins(cliManifest), [
-    { name: "@first-tree-ai/context-tree", version: "0.1.11" },
+    { name: "@first-tree-ai/context-tree", version: "0.1.12" },
   ]);
 });
 
@@ -531,13 +531,13 @@ test("the real frozen install closure assembles, verifies, and runs the embedded
   });
   assert.equal(closure.direct.length, 1);
   assert.equal(closure.packages[0].name, "@first-tree-ai/context-tree");
-  assert.equal(closure.packages[0].version, "0.1.11");
+  assert.equal(closure.packages[0].version, "0.1.12");
   assert.ok(closure.packages.length >= 20, `real closure is unexpectedly small: ${closure.packages.length}`);
   writeJson(join(appDir, "package.json"), {
     name: "open-tag",
     version: "0.0.2",
     type: "module",
-    dependencies: { "@first-tree-ai/context-tree": "0.1.11" },
+    dependencies: { "@first-tree-ai/context-tree": "0.1.12" },
   });
   writeDependencyClosureFile(appDir, closure);
   writeText(join(appDir, "cli", "index.mjs"), "export {};\n");


### PR DESCRIPTION
Upgrade the bundled Context Tree dependency from 0.1.11 to 0.1.12 for the CLI and client runtime. The portable-release dependency contracts now assert the upgraded version.

Validation:

- `pnpm check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/client exec vitest run src/__tests__/context-tree.integration.test.ts src/__tests__/context-tree.test.ts` (47 tests)
- `pnpm test` (fails in two unrelated CLI daemon-wrapper tests: expected exit code 3, received 0 after the local `opentag-dev` service restarts)
