### PR TITLE
fix(web): keep first-connect preparation observable through transient failures

### DIFF
--- a/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.test.tsx
@@ -313,6 +313,7 @@ describe("AgentSetupPage stages", () => {
     expect(footer?.contains(continueButton)).toBe(true);
     expect(screen.getByRole("status").textContent).toBe("Complete the action above, then check again.");
     expect(continueButton.hasAttribute("disabled")).toBe(true);
+    expect(screen.queryByText("Checking Messaging support automatically. No action needed…")).toBeNull();
   });
 
   it("shows a real checking observation as checking and nothing else animates", async () => {
@@ -622,6 +623,7 @@ describe("preparation review regressions", () => {
       imCliReadiness: { feishu: "checking", slack: "ready" },
     });
     const reads = vi.spyOn(memory.adapter, "readSnapshot");
+    const refreshes = vi.spyOn(memory.adapter, "refreshPreparation");
     renderSetup(memory.adapter);
     await settle();
     expect(readinessRow("runtime").getAttribute("data-status")).toBe("install-required");
@@ -629,9 +631,17 @@ describe("preparation review regressions", () => {
     memory.controls.setImCliReadiness("feishu", "ready");
     await advance(POLL_MS);
     expect(readinessRow("messaging-support").getAttribute("data-status")).toBe("ready");
-    const settledReads = reads.mock.calls.length;
-    await advance(POLL_MS * 40);
-    expect(reads).toHaveBeenCalledTimes(settledReads);
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("install-required");
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+    const afterCliReady = reads.mock.calls.length;
+    await advance(POLL_MS * 3 + 10);
+    expect(reads.mock.calls.length).toBeGreaterThan(afterCliReady);
+    await advance(BOUNDED_POLL_WINDOW_MS);
+    const stopped = reads.mock.calls.length;
+    expect(stopped).toBeLessThanOrEqual(1 + BOUNDED_POLL_ATTEMPTS);
+    await advance(POLL_MS * 4);
+    expect(reads.mock.calls.length).toBe(stopped);
+    expect(refreshes).not.toHaveBeenCalled();
     expect(document.querySelector('[data-ui="agent-setup-messaging"]')).toBeNull();
   });
 
@@ -1470,35 +1480,131 @@ describe("AgentSetupPage preparation rows across stages", () => {
 });
 
 describe("AgentSetupPage preparation polling", () => {
-  it("never polls a settled Provider CLI install failure", async () => {
+  it("follows the real first-connect heartbeats: waiting, install at 30s, ready after t60", async () => {
     const memory = createMemorySetupAdapter({
       agent: setupAgent(),
-      imCliReadiness: { feishu: "install", slack: "ready" },
+      runtimeMissing: true,
+      imCliReadiness: {},
     });
     const reads = vi.spyOn(memory.adapter, "readSnapshot");
+    const refreshes = vi.spyOn(memory.adapter, "refreshPreparation");
+    renderSetup(memory.adapter);
+    await settle();
+    const t0 = Date.now();
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("waiting");
+    expect(readinessRow("messaging-support").getAttribute("data-status")).toBe("waiting");
+    expect(screen.getByRole("status").textContent).toBe("Checking Codex automatically. No action needed…");
+    expect(screen.queryByRole("button", { name: "Check again" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+
+    await advance(30_000 - (Date.now() - t0));
+    memory.controls.setRuntimeStatus("ready");
+    memory.controls.setImCliReadiness("feishu", "ready");
+    memory.controls.setImCliReadiness("slack", "install");
+    await advance(POLL_MS + 10);
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("ready");
+    expect(readinessRow("messaging-support").getAttribute("data-status")).toBe("install-required");
+    expect(rowTitle("messaging-support")).toContain("Installation required");
+    expect(screen.queryByText("Checking Messaging support automatically. No action needed…")).toBeNull();
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+    expect(refreshes).not.toHaveBeenCalled();
+
+    await advance(60_000 - (Date.now() - t0));
+    expect(readinessRow("messaging-support").getAttribute("data-status")).toBe("install-required");
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+    const readsAtT60 = reads.mock.calls.length;
+    expect(readsAtT60).toBeGreaterThan(1);
+
+    await advance(4_000);
+    expect(readinessRow("messaging-support").getAttribute("data-status")).toBe("install-required");
+    expect(reads.mock.calls.length).toBeGreaterThan(readsAtT60);
+    expect(refreshes).not.toHaveBeenCalled();
+
+    memory.controls.setImCliReadiness("slack", "ready");
+    await advance(POLL_MS + 10);
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+    expect(screen.getByRole("status").textContent).toBe("This computer is ready. Continue to connect messaging.");
+    expect(refreshes).not.toHaveBeenCalled();
+  });
+
+  it("converges a slow install that becomes ready near the end of the window", async () => {
+    const memory = createMemorySetupAdapter({
+      agent: setupAgent(),
+      imCliReadiness: { feishu: "ready", slack: "install" },
+    });
+    const refreshes = vi.spyOn(memory.adapter, "refreshPreparation");
+    renderSetup(memory.adapter);
+    await settle();
+    expect(readinessRow("messaging-support").getAttribute("data-status")).toBe("install-required");
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+
+    await advance(BOUNDED_POLL_WINDOW_MS - POLL_MS * 2);
+    memory.controls.setImCliReadiness("slack", "ready");
+    await advance(POLL_MS + 10);
+    await settle();
+
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+    expect(refreshes).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["Runtime install", { runtimeStatus: "install" as const }],
+    ["Runtime sign-in", { runtimeStatus: "sign-in" as const }],
+    ["Runtime unavailable", { runtimeStatus: "unavailable" as const }],
+    ["IM CLI install", { imCliReadiness: { feishu: "install" as const, slack: "ready" as const } }],
+    ["IM CLI unavailable", { imCliReadiness: { feishu: "unavailable" as const, slack: "ready" as const } }],
+  ] as const)("stops persistent %s within the bound and then offers Check again", async (_label, seed) => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent(), ...seed });
+    const reads = vi.spyOn(memory.adapter, "readSnapshot");
+    const refreshes = vi.spyOn(memory.adapter, "refreshPreparation");
     renderSetup(memory.adapter);
     await settle();
     expect(reads).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+    expect(refreshes).not.toHaveBeenCalled();
 
+    await advance(BOUNDED_POLL_WINDOW_MS + 10);
+    const stopped = reads.mock.calls.length;
+    expect(stopped).toBeGreaterThan(1);
+    expect(stopped).toBeLessThanOrEqual(1 + BOUNDED_POLL_ATTEMPTS);
     await advance(POLL_MS * 4);
-    expect(reads).toHaveBeenCalledTimes(1);
+    expect(reads).toHaveBeenCalledTimes(stopped);
+    expect(refreshes).not.toHaveBeenCalled();
+    expect(screen.getByRole("status").textContent).toBe("Automatic checking paused. Check again to retry.");
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
 
-    // The explicit Check again is still the way a manual-action failure moves forward.
     fireEvent.click(screen.getByRole("button", { name: "Check again" }));
     await settle();
-    expect(reads).toHaveBeenCalledTimes(2);
+    expect(refreshes).toHaveBeenCalledWith(SETUP_AGENT_ID);
+    expect(reads.mock.calls.length).toBe(stopped + 1);
+    await advance(POLL_MS + 10);
+    expect(reads.mock.calls.length).toBe(stopped + 2);
   });
 
-  it("never polls a settled Runtime install or sign-in failure", async () => {
-    for (const runtimeStatus of ["install", "sign-in"] as const) {
-      const memory = createMemorySetupAdapter({ agent: setupAgent(), runtimeStatus });
-      const reads = vi.spyOn(memory.adapter, "readSnapshot");
-      renderSetup(memory.adapter);
-      await settle();
-      expect(reads).toHaveBeenCalledTimes(1);
-      await advance(POLL_MS * 4);
-      expect(reads).toHaveBeenCalledTimes(1);
+  it("does not reset the bounded window when blocked local-prep states change", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent(), runtimeMissing: true });
+    const reads = vi.spyOn(memory.adapter, "readSnapshot");
+    const refreshes = vi.spyOn(memory.adapter, "refreshPreparation");
+    renderSetup(memory.adapter);
+    await settle();
+    const startedAt = Date.now();
+
+    for (const status of ["checking", "install", "sign-in", "unavailable", "checking"] as const) {
+      await advance(POLL_MS + 10);
+      memory.controls.setRuntimeStatus(status);
     }
+    await advance(BOUNDED_POLL_WINDOW_MS - (Date.now() - startedAt) + 10);
+    const stopped = reads.mock.calls.length;
+    expect(stopped).toBeGreaterThan(1);
+    expect(stopped).toBeLessThanOrEqual(1 + BOUNDED_POLL_ATTEMPTS);
+    await advance(BOUNDED_POLL_WINDOW_MS / 2);
+    expect(reads.mock.calls.length).toBe(stopped);
+    expect(refreshes).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
   });
 
   it("polls a checking Runtime report inside the finite budget and then stops", async () => {
@@ -1519,7 +1625,7 @@ describe("AgentSetupPage preparation polling", () => {
     expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
   });
 
-  it("clears an exhausted checking message when an outstanding poll finds a manual action", async () => {
+  it("keeps an exhausted window exhausted when a late read changes checking to install", async () => {
     const memory = createMemorySetupAdapter({ agent: setupAgent(), runtimeStatus: "checking" });
     const modelRead = memory.adapter.readSnapshot;
     const finalRead = deferred<AgentSetupSnapshot>();
@@ -1540,8 +1646,11 @@ describe("AgentSetupPage preparation polling", () => {
     finalRead.resolve(await modelRead(SETUP_AGENT_ID));
     await settle();
 
-    expect(screen.getByRole("status").textContent).toBe("Complete the action above, then check again.");
-    expect(screen.queryByText("Automatic checking paused. Check again to retry.")).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Automatic checking paused. Check again to retry.");
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("install-required");
+    expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+    await advance(POLL_MS * 4);
+    expect(screen.getByRole("status").textContent).toBe("Automatic checking paused. Check again to retry.");
   });
 
   it("polls while one blocking required CLI is transitional, even beside a settled row", async () => {
@@ -1562,6 +1671,71 @@ describe("AgentSetupPage preparation polling", () => {
     expect(stopped).toBeLessThanOrEqual(1 + BOUNDED_POLL_ATTEMPTS);
     await advance(POLL_MS * 4);
     expect(reads.mock.calls.length).toBe(stopped);
+  });
+
+  it("preserves the install-window deadline and fences a late stale reply", async () => {
+    const installing = createMemorySetupAdapter({ agent: setupAgent(), runtimeStatus: "install" });
+    const ready = createMemorySetupAdapter({ agent: setupAgent() });
+    const hung = deferred<AgentSetupSnapshot>();
+    let calls = 0;
+    const adapter = scriptedAdapter(async (agentId) => {
+      calls += 1;
+      if (calls === 1) return installing.adapter.readSnapshot(agentId);
+      if (calls === 2) return hung.promise;
+      return ready.adapter.readSnapshot(agentId);
+    });
+    renderSetup(adapter);
+    await settle();
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("install-required");
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+
+    await advance(POLL_MS + 10);
+    expect(calls).toBe(2);
+    await advance(AGENT_SETUP_READ_TIMEOUT_MS);
+    await settle();
+    await advance(POLL_MS + 10);
+    await settle();
+    expect(calls).toBeGreaterThanOrEqual(3);
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+    expect(adapter.refreshPreparation).not.toHaveBeenCalled();
+
+    hung.resolve(await installing.adapter.readSnapshot(SETUP_AGENT_ID));
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+    expect(readinessRow("runtime").getAttribute("data-status")).toBe("ready");
+  });
+
+  it("reads current ready on re-entry and opens a fresh window when still blocked", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent(), runtimeStatus: "install" });
+    const reads = vi.spyOn(memory.adapter, "readSnapshot");
+    const refreshes = vi.spyOn(memory.adapter, "refreshPreparation");
+    const blocked = renderSetup(memory.adapter);
+    await settle();
+    await advance(BOUNDED_POLL_WINDOW_MS + 10);
+    const exhausted = reads.mock.calls.length;
+    expect(exhausted).toBeGreaterThan(1);
+    expect(exhausted).toBeLessThanOrEqual(1 + BOUNDED_POLL_ATTEMPTS);
+    expect(screen.getByRole("status").textContent).toBe("Automatic checking paused. Check again to retry.");
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+    blocked.unmount();
+
+    const blockedAgain = renderSetup(memory.adapter);
+    await settle();
+    const remounted = reads.mock.calls.length;
+    expect(remounted).toBe(exhausted + 1);
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(true);
+    await advance(POLL_MS + 10);
+    expect(reads.mock.calls.length).toBe(remounted + 1);
+    blockedAgain.unmount();
+
+    memory.controls.setRuntimeStatus("ready");
+    renderSetup(memory.adapter);
+    await settle();
+    expect(screen.getByRole("button", { name: "Continue" }).hasAttribute("disabled")).toBe(false);
+    const readyReads = reads.mock.calls.length;
+    await advance(POLL_MS * 4);
+    expect(reads.mock.calls.length).toBe(readyReads);
+    expect(refreshes).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/onboarding-v2/agent-setup-page.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.tsx
@@ -52,14 +52,18 @@ export const SETUP_POLL_MS = 2_000;
 /** How many times to report readiness before the reader is offered an explicit retry. */
 const READY_REPORT_ATTEMPTS = 3;
 /**
- * The finite attempt cap for automatic local-preparation polls (a required IM CLI still waiting
- * or checking behind the gate, a Runtime report missing or still checking). An explicit Check
- * again or returning to the page restarts a fresh window. The cap never resets on an unchanged
- * snapshot, and Messaging/offline observation keeps its unbounded beat.
+ * The finite attempt cap for automatic local-preparation polls. Connected blocking snapshots
+ * (`needs-runtime` or `needs-provider-clis`) share one 90s / 45-attempt read window, including
+ * install, sign-in, and unavailable. Two default daemon heartbeats (30s) plus delivery margin must
+ * fit inside the bound — the page must not depend on a late request after expiry. The snapshot has
+ * no provenance that can tell a stale first install report from a lasting manual-action failure, so
+ * GET observation continues until ready or the bound is exhausted. An explicit Check again or a new
+ * mount restarts a fresh window. Changes among checking, waiting, install, sign-in, and unavailable
+ * never reset the same window. Messaging/offline observation keeps its unbounded beat.
  */
-export const BOUNDED_POLL_ATTEMPTS = 30;
-/** Wall-clock bound for the same window, so a hung or slow read cannot stretch automatic checking. */
-export const BOUNDED_POLL_WINDOW_MS = 60_000;
+export const BOUNDED_POLL_ATTEMPTS = 45;
+/** Three default heartbeat periods at the 2s GET cadence, so a hung or slow read cannot stretch automatic checking. */
+export const BOUNDED_POLL_WINDOW_MS = 90_000;
 
 function boundedWindowRemaining(startedAt: { current: number | undefined }): number {
   const started = startedAt.current ?? Date.now();
@@ -178,24 +182,25 @@ type SetupPollClass = "bounded" | "unbounded" | undefined;
 
 /**
  * How a snapshot the outside world is still moving should be watched. Messaging authorizing,
- * waiting-handoff, and an offline Computer keep the existing unbounded beat. Local preparation
- * polls inside a finite budget only while a leg is genuinely transitional: a required IM CLI
- * whose report is missing or still checking, or a Runtime report missing or still
- * checking. A settled manual-action failure (install, sign-in, unavailable) never polls on its
- * own — nothing on this page can install, sign in, or repair a CLI. Check again or returning
- * to this page retrieves a fresh snapshot after an operator acts.
+ * waiting-handoff, and an offline Computer keep the existing unbounded beat. Connected local
+ * preparation (`needs-runtime` or `needs-provider-clis`) always uses the finite read window —
+ * GET only, never `refreshPreparation` and never an automatic install. The rows stay truthful
+ * while that window is open; genuine waiting/checking copy is a separate visual decision.
  */
 function snapshotPollClass(snapshot: AgentSetupSnapshot): SetupPollClass {
   if (snapshot.messaging.kind === "authorizing" || snapshot.messaging.kind === "waiting-handoff") return "unbounded";
   if (snapshot.computer.kind === "bound" && snapshot.computer.connectionStatus === "offline") return "unbounded";
-  if (
-    (snapshot.stage === "needs-runtime" || snapshot.stage === "needs-provider-clis") &&
-    preparationIsTransitional(snapshot)
-  )
-    return "bounded";
+  if (snapshot.stage === "needs-runtime" || snapshot.stage === "needs-provider-clis") return "bounded";
   if (snapshot.runtime.kind === "waiting") return "bounded";
   if (snapshot.runtime.kind === "observed" && snapshot.runtime.status === "checking") return "bounded";
   return undefined;
+}
+
+/** Footer spinner and "checking automatically" copy follow a real waiting/checking observation. */
+function preparationShowsAutomaticChecking(snapshot: AgentSetupSnapshot): boolean {
+  if (snapshot.runtime.kind === "waiting") return true;
+  if (snapshot.runtime.kind === "observed" && snapshot.runtime.status === "checking") return true;
+  return preparationIsTransitional(snapshot);
 }
 
 /** A snapshot the outside world is still moving: read it again on a beat until it settles. */
@@ -511,10 +516,10 @@ function useAgentSetup(
     setPollExhausted(false);
     setPollRestartKey((value) => value + 1);
   }, []);
-  // Exhaustion describes only the bounded transitional state that consumed the window. Once the
-  // snapshot settles or moves to another polling class, a later transition deserves a fresh
-  // window and must not inherit the old "paused" message. Effect restarts of the same class keep
-  // the elapsed start so they cannot silently extend unchanged state.
+  // Exhaustion describes the bounded window that consumed its budget. Checking, waiting, install,
+  // sign-in, and unavailable share that class, so a late shift among them must not clear the
+  // paused retry. Leaving bounded observation (ready, messaging, offline) deserves a fresh window.
+  // Effect restarts of the same class keep the elapsed start so they cannot silently extend it.
   useEffect(() => {
     if (pollClass === "bounded") return;
     pollBudget.current = BOUNDED_POLL_ATTEMPTS;
@@ -948,11 +953,15 @@ function SetupStageNavigation({
 }) {
   if (!showingPreparation) return computerObservationFailed ? null : refreshAction;
   const pollClass = snapshotPollClass(snapshot);
+  const observingAutomatically = pollClass === "bounded" && !controller.pollExhausted;
+  const genuineChecking = preparationShowsAutomaticChecking(snapshot);
+  // Hide Check again only while a real waiting/checking observation is in flight. Settled
+  // install/sign-in/unavailable rows keep the immediate retry while background GETs continue.
   const preparationRefreshAction =
-    !computerObservationFailed && (pollClass !== "bounded" || controller.pollExhausted) ? refreshAction : undefined;
+    !computerObservationFailed && !(observingAutomatically && genuineChecking) ? refreshAction : undefined;
   return (
     <PreparationNavigation
-      checking={pollClass === "bounded" && !controller.pollExhausted}
+      checking={observingAutomatically && genuineChecking}
       onContinue={onContinue}
       pollExhausted={controller.pollExhausted}
       ready={ready}

--- a/apps/web/src/onboarding-v2/preparation-contract.test.tsx
+++ b/apps/web/src/onboarding-v2/preparation-contract.test.tsx
@@ -421,7 +421,7 @@ describe("F6 cross-layer gating, page level", () => {
     // The row never fabricates a checking state for an unavailable report.
     expect(rowTitle("messaging-support")).not.toContain("Checking");
     expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
-    // A manual Check again is the only page move: it re-reads; nothing installs anything.
+    // A manual Check again is the only page move that writes: it re-reads; nothing installs anything.
     const reads = vi.spyOn(memory.adapter, "readSnapshot");
     fireEvent.click(screen.getByRole("button", { name: "Check again" }));
     await settle();


### PR DESCRIPTION
## Summary

During a fresh Computer connection, the first daemon heartbeat can report a messaging CLI as `install` even after the foreground installer has completed. Setup previously stopped reading at that report, so the second heartbeat's `ready` state never enabled Continue.

Keep connected preparation blockers in one finite, read-only observation window, including install/sign-in/unavailable. Allow 90 seconds / 45 attempts so two default 30-second heartbeats and delivery margin fit. Blocked-state changes cannot replenish the window. Preserve immediate Check again and truthful diagnostics for manual-action failures; retain single-flight reads, timeouts, stale-response fencing, and explicit retry semantics. No Server/Client changes or GET-triggered preparation.

## Testing

- `pnpm check`, `pnpm build`, `pnpm typecheck`, `pnpm test`: passed (3,470 workspace tests and 330 root script tests).
- `pnpm --filter @opentag/client test:agent-runtime:coverage`: 378 tests, 100% required-scope coverage.
- `pnpm --filter @opentag/server test:integration`: 329 passed.
- Regressions cover first-heartbeat install followed by ready at t64, slow preparation near the deadline, persistent failures, explicit retry, unchanged budgets across blocked states, late replies, read timeouts, and re-entry after exhaustion.
- Real Linux arm64 installation against staging `acf7609b`, official CLI `0.0.4-staging.6.1`, and Codex `0.153.4`: new account, Agent, and empty client container. Candidate Web used real staging JSON with an additional 4-second setup-response transport delay. Local readiness: 09:07:47.960 UTC; first install heartbeat: 09:08:14 UTC; ready heartbeat: 09:08:44.534 UTC; Web received ready 62.26 seconds after its first online snapshot and enabled Continue automatically. Zero setup/refresh POSTs, reloads, or focus changes during convergence.
- Real persistent sign-in failure: remove only the task container's read-only auth mount; host credentials remain unchanged. The page retains actionable diagnostics and immediate Check again, stops issuing reads at the 90-second bound, and keeps Continue disabled. No passive refresh POSTs; one explicit click after exhaustion sends one POST (204) and starts a fresh observation window.

## UI validation

- Desktop/mobile screenshots and timestamped DOM/HTTP evidence retained in the task's local validation report.
- Widths checked: 320px / 390px / 768px / 1440px; no horizontal overflow; Continue enabled on ready.
- States verified: waiting, temporary installation required, automatic ready, persistent sign-in failure, exhausted observation, explicit retry, and re-entry.
- Accessibility: existing semantic buttons, status text, and disabled Continue gating are preserved and covered by component tests.
- No new reusable blocks, CSS, theme values, or translated strings.

## Breaking changes

None. Observations beyond the finite window still require an explicit retry or page return. This validation does not establish native macOS installation or messaging acceptance. No production deployment or merge is included.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [x] Required local checks pass.
- [x] No credentials, private data, or generated build output are included.
- [x] No canonical documentation or translation changes are needed.
