### PR TITLE
fix(web): refine Agent navigation hierarchy and alignment

### DIFF
--- a/apps/web/src/__tests__/app-shell.test.tsx
+++ b/apps/web/src/__tests__/app-shell.test.tsx
@@ -83,9 +83,7 @@ describe("OpenTag Web App Shell", () => {
     const switcher = await screen.findByRole("button", { name: "Switch Agent, current Agent Reviewer" });
     expect(switcher.closest('[data-sidebar="header"]')).toBeTruthy();
     const workspaceNavigation = screen.getByRole("navigation", { name: "Agent" });
-    expect(workspaceNavigation.closest('[data-sidebar="content"]')?.className).toContain(
-      "md:[&_[data-sidebar=viewport]]:pt-0",
-    );
+    expect(workspaceNavigation.closest('[data-sidebar="content"]')).toBeTruthy();
     expect(
       within(workspaceNavigation)
         .getAllByRole("link")

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -162,7 +162,7 @@ body {
   flex-shrink: 0;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem;
+  padding: 0.75rem 0.375rem;
 }
 
 .app-global-navigation > :first-child {
@@ -288,7 +288,7 @@ body {
 
   .app-account-trigger {
     min-height: 2.75rem;
-    padding-inline: 0.375rem;
+    padding-inline: 0.75rem;
   }
 
   .app-agent-navigation {
@@ -357,7 +357,7 @@ body {
     gap: 0;
   }
 
-  .app-home-link[data-compact="true"] > svg {
+  .app-home-link[data-compact="true"] .app-home-icon > svg {
     width: 1.375rem;
     height: 1.375rem;
   }
@@ -365,6 +365,11 @@ body {
   .app-account-trigger[data-compact="true"] > div {
     gap: 0;
     translate: none;
+  }
+
+  .app-account-trigger[data-compact="true"] .app-account-icon {
+    width: 2rem;
+    height: 2rem;
   }
 
   .app-account-trigger[data-compact="true"] .app-account-avatar {

--- a/apps/web/src/features/shell/account-menu.tsx
+++ b/apps/web/src/features/shell/account-menu.tsx
@@ -48,10 +48,10 @@ export function AccountMenu({
       <Sidebar.MenuButton
         ref={triggerRef}
         aria-label={m.shell_account_menu()}
-        className="app-account-trigger justify-start"
+        className="app-account-trigger justify-start [&>div]:translate-none"
         data-compact={placement === "dock" ? "true" : undefined}
         icon={
-          <span className="flex w-8 shrink-0 items-center justify-center" aria-hidden="true">
+          <span className="app-account-icon grid size-6 shrink-0 place-items-center" aria-hidden="true">
             <span className="app-account-avatar grid size-6 place-items-center rounded-full bg-kumo-tint text-xs font-medium">
               {initials(me.user.displayName)}
             </span>

--- a/apps/web/src/features/shell/agent-shell.tsx
+++ b/apps/web/src/features/shell/agent-shell.tsx
@@ -43,14 +43,14 @@ export default function AgentNavigation({ agentId, pathname }: { agentId: string
   ] as const;
   return (
     <>
-      <Sidebar.Header className="h-16 border-b-0 px-3">
+      <Sidebar.Header className="h-16 border-b-0 px-1.5">
         <Sidebar.Menu className="min-w-0 flex-1">
           <Sidebar.MenuItem>
             <AgentSwitcher agent={agent} agents={agents} pathname={pathname} agentId={agentId} />
           </Sidebar.MenuItem>
         </Sidebar.Menu>
       </Sidebar.Header>
-      <Sidebar.Content className="md:[&_[data-sidebar=viewport]]:pt-0">
+      <Sidebar.Content className="[&_[data-sidebar=viewport]]:px-1.5 [&_[data-sidebar=viewport]]:pt-0">
         <nav aria-label={m.shell_agent()}>
           <Sidebar.Group className="pt-1">
             <Sidebar.Menu className="gap-1">
@@ -61,9 +61,13 @@ export default function AgentNavigation({ agentId, pathname }: { agentId: string
                     key={item.section}
                     active={active}
                     aria-current={active ? "page" : undefined}
-                    className="min-h-11 rounded-lg px-3 data-[active]:bg-(--brand-soft) focus-visible:ring-2 focus-visible:ring-kumo-focus"
+                    className="min-h-11 rounded-lg px-3 font-normal data-[active]:bg-(--brand-soft) data-[active]:font-medium focus-visible:ring-2 focus-visible:ring-kumo-focus [&>div]:translate-none"
                     href={router.buildLocation(item.link).href}
-                    icon={<Icon className="size-4.5" name={item.icon} />}
+                    icon={
+                      <span className="grid size-6 shrink-0 place-items-center text-kumo-subtle" aria-hidden="true">
+                        <Icon className="size-4" name={item.icon} />
+                      </span>
+                    }
                   >
                     {item.label}
                   </Sidebar.MenuButton>
@@ -108,10 +112,10 @@ function AgentSwitcher({
             aria-label={
               agent ? m.shell_switch_agent_current({ currentAgent: agent.displayName }) : m.shell_switch_agent()
             }
-            className="min-h-11 rounded-lg px-2 hover:bg-kumo-fill-hover"
+            className="min-h-11 rounded-lg px-3 hover:bg-kumo-fill-hover focus-visible:ring-2 focus-visible:ring-kumo-focus [&>div]:translate-none"
             icon={
               <span
-                className="grid size-8 shrink-0 place-items-center rounded-full bg-kumo-tint text-sm font-semibold group-data-[state=collapsed]/sidebar:size-4 group-data-[state=collapsed]/sidebar:text-xs"
+                className="grid size-6 shrink-0 place-items-center rounded-full bg-kumo-tint text-xs font-semibold"
                 aria-hidden="true"
               >
                 {agent ? initials(agent.displayName) : "A"}

--- a/apps/web/src/features/shell/app-shell.tsx
+++ b/apps/web/src/features/shell/app-shell.tsx
@@ -84,7 +84,7 @@ function WorkspaceShell() {
               </Suspense>
             )}
           </div>
-          <Sidebar.Footer className="app-account-navigation h-14 px-3">
+          <Sidebar.Footer className="app-account-navigation h-14 px-1.5">
             <Sidebar.Menu className="min-w-0 flex-1">
               <Sidebar.MenuItem>
                 <AccountMenu placement={agentId ? "sidebar" : "dock"} />
@@ -135,7 +135,9 @@ function GlobalHome({ compact, active }: { compact: boolean; active: boolean }) 
           aria-current={active ? "page" : undefined}
           data-compact={compact ? "true" : undefined}
         >
-          <Icon className="size-5" name="home" />
+          <span className="app-home-icon grid size-6 shrink-0 place-items-center" aria-hidden="true">
+            <Icon className="size-5" name="home" />
+          </span>
           <span className="app-nav-label">{m.shell_all_agents()}</span>
         </Link>
       }

--- a/apps/web/src/ui/kumo-contract.test.ts
+++ b/apps/web/src/ui/kumo-contract.test.ts
@@ -212,7 +212,7 @@ describe("Kumo integration contract", () => {
     const shell = ["app-shell.tsx", "agent-shell.tsx", "shell-main.tsx", "account-menu.tsx"]
       .map((file) => readFileSync(resolve(root, "features/shell", file), "utf8"))
       .join("\n");
-    expect(shell).toContain('<Sidebar.Header className="h-16 border-b-0 px-3">');
+    expect(shell).toMatch(/<Sidebar\.Header(?:\s|>)/);
     expect(shell).toMatch(/<Sidebar\.Content(?:\s|>)/);
     expect(shell).toContain('<Sidebar.Menu className="gap-1">');
     expect(shell).toContain("<Sidebar.MenuButton");
@@ -220,7 +220,6 @@ describe("Kumo integration contract", () => {
     expect(shell).toContain("<DropdownMenu.LinkItem");
     expect(shell).toContain("<DropdownMenu.Separator />");
     expect(shell).toContain('aria-current={candidate.id === agentId ? "true" : undefined}');
-    expect(shell).toContain('className="flex w-8 shrink-0 items-center justify-center"');
     expect(shell).not.toContain("accountMenuRef");
     expect(shell).not.toContain("<Sidebar.Rail />");
     expect(shell).toContain('collapsible={isMobile ? "icon" : "none"}');


### PR DESCRIPTION
## Summary

The Agent switcher used a larger avatar and a different text inset from its page links, making the sidebar feel misaligned and visually heavy. Align All Agents, the Agent name, page navigation and Account to one 24px icon column. Use a 24px Agent avatar, quieter 16px page icons, regular inactive labels and a medium-weight current page.

Keep the floating frame, 64 × 128px Workspace dock, 44px expanded navigation targets and all Account destinations, including Internal tools. Grouping uses spacing without tree indentation or new dividers. Neutralize Kumo's internal horizontal translation and retain a visible keyboard focus ring on the switcher. Sidebar contract tests now check the compound structure instead of exact spacing utilities.

## Testing

- Passed: `pnpm install`, `pnpm check`, `pnpm build`, `pnpm typecheck` and Git hooks.
- Unit suites verified: Web **802**, CLI **434**, Client **1,093**, Server **907**, Shared **227** tests.
- Agent Runtime coverage: **378 tests**, **100%** statements, branches, functions and lines via `pnpm --filter @opentag/client test:agent-runtime:coverage`.
- PostgreSQL integration: **330 tests** verified using the complete one-worker suite plus a successful retry of the single suite whose Docker container failed to bind its host port.
- Browser E2E: `navigation-polish.spec.ts` **5 passed**, complete serial `app.spec.ts` **13 passed**.
- Pre-commit code review and local visual acceptance completed.

Local execution notes: the root `pnpm test` run encountered an existing CLI assumption about empty credentials and process-probe/Context Tree timeouts under concurrent load. CLI passed with an isolated temporary `OPENTAG_HOME`; the timed-out runtime and Context Tree tests passed separately. The initial `pnpm --filter @opentag/server test:integration` run hit timing limits; reran all tests with `pnpm --filter @opentag/server exec vitest run src/__tests__/integration --maxWorkers=1 --testTimeout=30000`, then retried the one Docker startup failure successfully with default test timeouts. No unrelated product code or test assertions were changed to resolve these environment failures. The canonical CI run remains pending.

## UI validation

- Desktop evidence: inspected the running application and generated Agent navigation, switcher, Workspace dock and Account menu screenshots. Label starts align, expanded rows are 44px high, and the switcher-to-page gap is 14px. Screenshots remain local test artifacts.
- Mobile evidence: inspected the 320px Account menu screenshot; touch E2E verified Account and Agent switcher menus at 320px and 390px.
- Widths checked: 320px, 390px, 768px and 1440px.
- States verified: current/inactive pages, section-preserving Agent switching, long names, stable content during Workspace/Agent transitions, dirty-settings navigation, reduced motion and all Account destinations.
- Keyboard/accessibility checks: menu navigation and Escape, focus restoration, visible switcher focus, mobile focus containment, automated accessibility and overflow checks.
- New reusable block, theme value, or CSS exception: no new block or theme value; existing shell CSS and icon wrappers align navigation columns while preserving compact-dock centering.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [ ] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass. (`check`, `build` and `typecheck` passed locally; package suites are verified separately as described above; canonical CI `pnpm test` is pending.)
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
