### PR TITLE
fix(web): keep live status fresh and share resource queries

### DIFF
--- a/apps/web/messages/common/en.json
+++ b/apps/web/messages/common/en.json
@@ -68,6 +68,7 @@
   "common_try_again": "Try again",
   "common_unknown": "Unknown",
   "common_update": "Update",
+  "common_update_failed_last_available": "Update failed. Showing last available data.",
   "common_view": "View",
   "common_yes": "Yes"
 }

--- a/apps/web/messages/common/zh.json
+++ b/apps/web/messages/common/zh.json
@@ -68,6 +68,7 @@
   "common_try_again": "再试一次",
   "common_unknown": "未知",
   "common_update": "更新",
+  "common_update_failed_last_available": "更新失败，正在显示上次可用的数据。",
   "common_view": "查看",
   "common_yes": "是"
 }

--- a/apps/web/src/__tests__/agent-home.test.tsx
+++ b/apps/web/src/__tests__/agent-home.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app.js";
 import { agentId, installApi, json, memberUserId, resetWebAppState } from "./support/app-fixtures.js";
@@ -129,21 +129,16 @@ describe("OpenTag Web App Shell", () => {
     fireEvent.click(screen.getByRole("link", { name: "View Usage" }));
 
     expect(await screen.findByRole("heading", { level: 1, name: "Usage" })).toBeTruthy();
-    expect(agentReads).toBe(1);
+    expect(agentReads).toBe(0);
     const agentNavigation = await screen.findByRole("navigation", { name: "Agent" });
     expect(within(agentNavigation).getByRole("link", { name: "Usage" }).getAttribute("aria-current")).toBe("page");
   });
 
   it("keeps Agent context visible while opening Settings", async () => {
     let agentReads = 0;
-    let releaseAgentRead = () => {};
-    const pendingAgentRead = new Promise<void>((resolve) => {
-      releaseAgentRead = resolve;
-    });
     installApi({
       agentRead: () => {
         agentReads += 1;
-        return agentReads === 1 ? undefined : pendingAgentRead;
       },
       bound: true,
     });
@@ -155,18 +150,15 @@ describe("OpenTag Web App Shell", () => {
 
     expect(await screen.findByRole("heading", { name: "Agent settings" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "All Agents" }).getAttribute("href")).toBe("/agents");
-    await waitFor(() => expect(agentReads).toBe(2));
+    expect(agentReads).toBe(0);
     expect(screen.queryByLabelText("Loading current server state")).toBeNull();
-    await act(async () => releaseAgentRead());
   });
 
   it.each([403, 404])("replaces a cached Agent with a terminal detail response (%d)", async (status) => {
-    let agentReads = 0;
+    let gone = false;
     installApi({
-      agentRead: () => {
-        agentReads += 1;
-      },
-      agentReadStatus: () => (agentReads > 1 ? status : undefined),
+      agentListStatus: () => (gone ? status : undefined),
+      agentReadStatus: () => (gone ? status : undefined),
       bound: true,
     });
     window.history.replaceState({}, "", `/agents/${agentId}`);
@@ -175,7 +167,8 @@ describe("OpenTag Web App Shell", () => {
     expect(await screen.findByRole("heading", { name: "Reviewer" })).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: "Settings" }));
     expect(await screen.findByRole("heading", { name: "Agent settings" })).toBeTruthy();
-    await waitFor(() => expect(agentReads).toBe(2));
+    gone = true;
+    fireEvent(window, new Event("focus"));
     expect((await screen.findByRole("alert")).textContent).toContain("Agent unavailable");
     expect(screen.queryByRole("heading", { name: "Reviewer" })).toBeNull();
   });

--- a/apps/web/src/__tests__/agent-messaging.test.tsx
+++ b/apps/web/src/__tests__/agent-messaging.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app.js";
-import { agentId, installApi, json, resetWebAppState } from "./support/app-fixtures.js";
+import { agentId, computerId, installApi, json, resetWebAppState } from "./support/app-fixtures.js";
 import { withLocaleAsync } from "./support/with-locale.js";
 
 describe("OpenTag Web App Shell", () => {
@@ -195,20 +195,31 @@ describe("OpenTag Web App Shell", () => {
     expect(screen.queryByRole("heading", { name: "No messaging channel" })).toBeNull();
   });
 
-  it("does not overlap focus refreshes while an Agent read is still pending", async () => {
-    let agentReads = 0;
+  it("does not overlap focus refreshes while a Computer read is still pending", async () => {
+    let computerReads = 0;
     let computerStatus: "online" | "offline" = "online";
-    let releaseAgentRead = () => {};
-    const pendingAgentRead = new Promise<void>((resolve) => {
-      releaseAgentRead = resolve;
+    let releaseComputerRead = () => {};
+    const pendingComputerRead = new Promise<void>((resolve) => {
+      releaseComputerRead = resolve;
     });
     installApi({
-      agentRead: () => {
-        agentReads += 1;
-        return agentReads === 1 ? undefined : pendingAgentRead;
-      },
       bound: true,
       computerStatus: () => computerStatus,
+      computers: async () => {
+        computerReads += 1;
+        if (computerReads > 1) await pendingComputerRead;
+        return [
+          {
+            id: computerId,
+            displayName: "Ada's Mac",
+            platform: "darwin",
+            connectionStatus: computerStatus,
+            providerReadiness: [{ provider: "codex", status: "ready", observedAt: "2026-08-20T00:00:00.000Z" }],
+            connectedAt: "2026-08-20T00:00:00.000Z",
+            lastSeenAt: "2026-08-20T00:00:00.000Z",
+          },
+        ];
+      },
     });
     window.history.replaceState({}, "", `/agents/${agentId}`);
     render(<App />);
@@ -217,22 +228,26 @@ describe("OpenTag Web App Shell", () => {
     computerStatus = "offline";
     fireEvent(window, new Event("focus"));
     fireEvent(window, new Event("focus"));
-    await waitFor(() => expect(agentReads).toBe(2));
-    expect(agentReads).toBe(2);
+    await waitFor(() => expect(computerReads).toBe(2));
+    expect(computerReads).toBe(2);
 
-    releaseAgentRead();
+    releaseComputerRead();
     expect(await screen.findByText("Offline")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Open computer setup" })).toBeTruthy();
   });
 
   it("invalidates a stale Agent detail after a background not-found response", async () => {
-    let agentReadStatus: number | undefined;
-    installApi({ agentReadStatus: () => agentReadStatus, bound: true });
+    let gone = false;
+    installApi({
+      agentListStatus: () => (gone ? 404 : undefined),
+      agentReadStatus: () => (gone ? 404 : undefined),
+      bound: true,
+    });
     window.history.replaceState({}, "", `/agents/${agentId}`);
     render(<App />);
     expect((await screen.findAllByText("Ready")).length).toBeGreaterThan(0);
 
-    agentReadStatus = 404;
+    gone = true;
     fireEvent(window, new Event("focus"));
     expect((await screen.findByRole("alert")).textContent).toContain("Agent unavailable");
     expect(within(screen.getByRole("main")).queryByText("Ready")).toBeNull();
@@ -281,7 +296,7 @@ describe("OpenTag Web App Shell", () => {
         vi
           .mocked(fetch)
           .mock.calls.filter(
-            ([input, init]) => String(input) === `/api/v1/agents/${agentId}` && (init?.method ?? "GET") === "GET",
+            ([input, init]) => String(input) === "/api/v1/agents" && (init?.method ?? "GET") === "GET",
           ),
       ).toHaveLength(2),
     );

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -13,7 +13,14 @@ import { formatCompactNumber, formatDay, formatNumber, formatPercent } from "../
 import * as m from "../paraglide/messages.js";
 import { queryKeys } from "../query/keys.js";
 import { liveResourceQueryOptions } from "../query/live.js";
-import { terminalResourceObservedAt } from "../query/session-cache.js";
+import {
+  observedAfter,
+  type ResourceObservation,
+  refusalOutranks,
+  resourceSuccessObservation,
+  type TerminalResourceObservation,
+  terminalResourceObservation,
+} from "../query/session-cache.js";
 import {
   Banner,
   ChartPalette,
@@ -160,29 +167,40 @@ function useAgentUsage(
   const queryClient = useQueryClient();
   const usageKey = queryKeys.agents.usage(agentId, windowDays);
   const canUseListSummary = Boolean(compact && windowDays === AGENT_USAGE_WINDOW_DAYS && accountId);
+  const listKey = queryKeys.agents.list(accountId ?? "");
   const listQuery = useAgentListQuery(accountId ?? "", canUseListSummary);
   const listed = listQuery.data?.agents.find((agent) => agent.id === agentId);
+  /*
+   * The summary is the last list answer the Server gave, held apart from the refresh state: a
+   * transient re-read failure adds a notice but must not pull totals the reader is already
+   * looking at. Only a terminal refusal of the list itself withdraws them, and the summary is
+   * never written into the full-usage cache.
+   */
+  const listRefused = terminalResourceObservation(queryClient, listKey) !== undefined;
   const listSummary =
-    canUseListSummary && listed && isConfirmedQuerySuccess(listQuery)
+    canUseListSummary && listed && !listRefused
       ? ({
           windowDays: AGENT_USAGE_WINDOW_DAYS,
           tasks: listed.usage.tasks,
           tokens: listed.usage.tokens,
         } satisfies UsageTotals)
       : undefined;
+  // A degraded list source asks the full read to stand in behind the retained summary.
+  const listRefreshFailed = Boolean(canUseListSummary && listed && !isConfirmedQuerySuccess(listQuery));
   const waitingForList = canUseListSummary && !listQuery.isFetched;
-  const cachedUsage = queryClient.getQueryState<AgentUsageDetail>(usageKey);
-  const usageSuccessAt = cachedUsage?.data !== undefined ? cachedUsage.dataUpdatedAt : 0;
-  const usageRefusalAt = terminalResourceObservedAt(queryClient, usageKey);
-  const listStamp = listQuery.isSuccess ? listQuery.dataUpdatedAt : 0;
-  const usageAuthoritative = usageSuccessAt > listStamp || usageRefusalAt > listStamp;
-  // Keyed by Agent and window. The home 30-day totals reuse the list summary when that read is the
-  // newest authorized source; a newer full read or refusal wins. A summary is never written into the
-  // detail cache.
+  const usageSuccess = resourceSuccessObservation(queryClient, usageKey);
+  const usageRefusal = terminalResourceObservation(queryClient, usageKey);
+  const listSuccess = resourceSuccessObservation(queryClient, listKey);
+  /*
+   * Keyed by Agent and window. The home 30-day totals reuse the list summary when that read is
+   * the newest authorized source; a newer full read or refusal wins. Observation order — never
+   * the wall clock — decides which read is newer, so same-millisecond answers still order.
+   */
+  const usageAuthoritative = observedAfter(usageSuccess, listSuccess) || refusalOutranks(usageRefusal, listSuccess);
   const query = useQuery({
     queryKey: usageKey,
     queryFn: () => browserApi.agentUsage(agentId, windowDays),
-    enabled: !waitingForList && (!listSummary || usageAuthoritative),
+    enabled: !waitingForList && (!listSummary || usageAuthoritative || listRefreshFailed),
     ...liveResourceQueryOptions,
   });
   const persistedError = usePersistedSettledError(usageKey, {
@@ -198,13 +216,13 @@ function useAgentUsage(
     retry,
     state: presentUsageState({
       detail: query.data,
-      detailUpdatedAt: query.dataUpdatedAt,
       listError: listQuery.isError ? usageError(listQuery.error) : undefined,
+      listSuccess,
       listSummary,
-      listUpdatedAt: listQuery.dataUpdatedAt,
-      persistedAt: usageRefusalAt,
       persistedError,
       queryError: query.isError ? usageError(query.error) : undefined,
+      usageRefusal,
+      usageSuccess,
     }),
   };
 }
@@ -225,33 +243,36 @@ function fallbackUsageState(detail: AgentUsageDetail | undefined, error: Error |
 
 function presentUsageState({
   detail,
-  detailUpdatedAt,
   listError,
+  listSuccess,
   listSummary,
-  listUpdatedAt,
-  persistedAt,
   persistedError,
   queryError,
+  usageRefusal,
+  usageSuccess,
 }: {
   detail?: AgentUsageDetail;
-  detailUpdatedAt: number;
   listError?: Error;
+  listSuccess?: ResourceObservation;
   listSummary?: UsageTotals;
-  listUpdatedAt: number;
-  persistedAt: number;
   persistedError: Error | null;
   queryError?: Error;
+  usageRefusal?: TerminalResourceObservation;
+  usageSuccess?: ResourceObservation;
 }): UsageState {
-  const refusalAt = persistedError && isTerminalResourceError(persistedError) ? persistedAt : 0;
-  const usageSuccessAt = detail ? detailUpdatedAt : 0;
-  const listAt = listSummary ? listUpdatedAt : 0;
-  if (refusalAt > listAt && refusalAt > usageSuccessAt) {
-    return { kind: "error", error: persistedError ?? queryError ?? new Error(m.usage_error_fallback()) };
+  // A terminal refusal stands until a read the Server answered settles strictly after it. A manual
+  // write, or an older answer that shares the refusal's millisecond, must not resurrect the data
+  // the refusal withdrew.
+  if (refusalOutranks(usageRefusal, listSuccess) && refusalOutranks(usageRefusal, usageSuccess)) {
+    return {
+      kind: "error",
+      error: usageRefusal?.error ?? persistedError ?? queryError ?? new Error(m.usage_error_fallback()),
+    };
   }
-  if (detail && usageSuccessAt >= listAt && usageSuccessAt >= refusalAt) {
+  if (detail && !observedAfter(listSuccess, usageSuccess) && !refusalOutranks(usageRefusal, usageSuccess)) {
     return readyUsage(detail, detail, usageRefreshError(persistedError ?? queryError));
   }
-  if (listSummary && listAt >= refusalAt) {
+  if (listSummary && !refusalOutranks(usageRefusal, listSuccess)) {
     return readyUsage(listSummary, undefined, usageRefreshError(listError));
   }
   return fallbackUsageState(detail, persistedError ?? queryError);

--- a/apps/web/src/features/agent-usage.tsx
+++ b/apps/web/src/features/agent-usage.tsx
@@ -4,7 +4,7 @@ import {
   type AgentUsageDetail,
   type AgentUsageWindowDays,
 } from "@opentag/shared/browser";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { type ComponentProps, lazy, Suspense, useCallback, useState } from "react";
 import { browserApi } from "../api.js";
@@ -12,6 +12,8 @@ import { PageHeader } from "../components/kumo/page-header/page-header.js";
 import { formatCompactNumber, formatDay, formatNumber, formatPercent } from "../i18n/format.js";
 import * as m from "../paraglide/messages.js";
 import { queryKeys } from "../query/keys.js";
+import { liveResourceQueryOptions } from "../query/live.js";
+import { terminalResourceObservedAt } from "../query/session-cache.js";
 import {
   Banner,
   ChartPalette,
@@ -25,7 +27,13 @@ import {
   Text,
   TimeseriesChart,
 } from "../ui/design-system.js";
-import { isTerminalResourceError } from "./resource/resource-state.js";
+import { useAgentListQuery } from "./agents/agent-queries.js";
+import {
+  isConfirmedQuerySuccess,
+  isTerminalResourceError,
+  ResourceRefreshNotice,
+  usePersistedSettledError,
+} from "./resource/resource-state.js";
 
 const LazyTimeseriesChart = lazy(async () => {
   const { echarts } = await import("./agent-usage-echarts.js");
@@ -36,10 +44,21 @@ const LazyTimeseriesChart = lazy(async () => {
   };
 });
 
+type UsageTotals = {
+  readonly windowDays: AgentUsageWindowDays;
+  readonly tasks: number;
+  readonly tokens: number;
+};
+
 type UsageState =
   | { readonly kind: "loading" }
   | { readonly kind: "error"; readonly error: Error }
-  | { readonly kind: "ready"; readonly value: AgentUsageDetail };
+  | {
+      readonly kind: "ready";
+      readonly value: UsageTotals;
+      readonly detail?: AgentUsageDetail;
+      readonly refreshError?: Error;
+    };
 
 /** The Agent home answers "how much has this Agent used recently", so it offers the shortest windows. */
 const AGENT_HOME_USAGE_WINDOW_OPTIONS = [1, 7, AGENT_USAGE_WINDOW_DAYS] as const;
@@ -60,9 +79,9 @@ export function usageXAxisTickLabel(value: number, endedAt: string, windowDays: 
   return distanceFromEnd >= 0 && distanceFromEnd < endLabelBuffer ? "" : formatDay(timestamp);
 }
 
-export function AgentUsageOverview({ agentId }: { agentId: string }) {
+export function AgentUsageOverview({ accountId, agentId }: { accountId?: string; agentId: string }) {
   const [windowDays, setWindowDays] = useState<AgentUsageWindowDays>(AGENT_USAGE_WINDOW_DAYS);
-  const { retry, state } = useAgentUsage(agentId, windowDays);
+  const { retry, state } = useAgentUsage(agentId, windowDays, { accountId, compact: true });
   return (
     <LayerCard
       render={<section />}
@@ -136,24 +155,106 @@ export function AgentUsageTab({ agentId }: { agentId: string }) {
 function useAgentUsage(
   agentId: string,
   windowDays: AgentUsageWindowDays,
+  { accountId, compact = false }: { accountId?: string; compact?: boolean } = {},
 ): { readonly retry: () => void; readonly state: UsageState } {
-  // Keyed by Agent and window, so the overview on an Agent's page and the tab on its usage page ask
-  // for the same 30 days once between them rather than each on its own.
+  const queryClient = useQueryClient();
+  const usageKey = queryKeys.agents.usage(agentId, windowDays);
+  const canUseListSummary = Boolean(compact && windowDays === AGENT_USAGE_WINDOW_DAYS && accountId);
+  const listQuery = useAgentListQuery(accountId ?? "", canUseListSummary);
+  const listed = listQuery.data?.agents.find((agent) => agent.id === agentId);
+  const listSummary =
+    canUseListSummary && listed && isConfirmedQuerySuccess(listQuery)
+      ? ({
+          windowDays: AGENT_USAGE_WINDOW_DAYS,
+          tasks: listed.usage.tasks,
+          tokens: listed.usage.tokens,
+        } satisfies UsageTotals)
+      : undefined;
+  const waitingForList = canUseListSummary && !listQuery.isFetched;
+  const cachedUsage = queryClient.getQueryState<AgentUsageDetail>(usageKey);
+  const usageSuccessAt = cachedUsage?.data !== undefined ? cachedUsage.dataUpdatedAt : 0;
+  const usageRefusalAt = terminalResourceObservedAt(queryClient, usageKey);
+  const listStamp = listQuery.isSuccess ? listQuery.dataUpdatedAt : 0;
+  const usageAuthoritative = usageSuccessAt > listStamp || usageRefusalAt > listStamp;
+  // Keyed by Agent and window. The home 30-day totals reuse the list summary when that read is the
+  // newest authorized source; a newer full read or refusal wins. A summary is never written into the
+  // detail cache.
   const query = useQuery({
-    queryKey: queryKeys.agents.usage(agentId, windowDays),
+    queryKey: usageKey,
     queryFn: () => browserApi.agentUsage(agentId, windowDays),
+    enabled: !waitingForList && (!listSummary || usageAuthoritative),
+    ...liveResourceQueryOptions,
   });
-  const retry = useCallback(() => void query.refetch(), [query]);
-  const error = query.isError ? usageError(query.error) : undefined;
-  const state: UsageState =
-    error && (!query.data || isTerminalResourceError(error))
-      ? { kind: "error", error }
-      : query.data
-        ? { kind: "ready", value: query.data }
-        : error
-          ? { kind: "error", error }
-          : { kind: "loading" };
-  return { retry, state };
+  const persistedError = usePersistedSettledError(usageKey, {
+    error: query.error ? usageError(query.error) : null,
+    isError: query.isError,
+    isSuccess: query.isSuccess,
+  });
+  const retry = useCallback(() => {
+    if (usageAuthoritative || !listSummary) void query.refetch();
+    else void listQuery.refetch();
+  }, [listQuery, listSummary, query, usageAuthoritative]);
+  return {
+    retry,
+    state: presentUsageState({
+      detail: query.data,
+      detailUpdatedAt: query.dataUpdatedAt,
+      listError: listQuery.isError ? usageError(listQuery.error) : undefined,
+      listSummary,
+      listUpdatedAt: listQuery.dataUpdatedAt,
+      persistedAt: usageRefusalAt,
+      persistedError,
+      queryError: query.isError ? usageError(query.error) : undefined,
+    }),
+  };
+}
+
+function usageRefreshError(error: Error | null | undefined): Error | undefined {
+  return error && !isTerminalResourceError(error) ? error : undefined;
+}
+
+function readyUsage(value: UsageTotals, detail?: AgentUsageDetail, refreshError?: Error): UsageState {
+  return { kind: "ready", value, detail, refreshError };
+}
+
+function fallbackUsageState(detail: AgentUsageDetail | undefined, error: Error | null | undefined): UsageState {
+  if (error && (!detail || isTerminalResourceError(error))) return { kind: "error", error };
+  if (detail) return readyUsage(detail, detail, usageRefreshError(error));
+  return error ? { kind: "error", error } : { kind: "loading" };
+}
+
+function presentUsageState({
+  detail,
+  detailUpdatedAt,
+  listError,
+  listSummary,
+  listUpdatedAt,
+  persistedAt,
+  persistedError,
+  queryError,
+}: {
+  detail?: AgentUsageDetail;
+  detailUpdatedAt: number;
+  listError?: Error;
+  listSummary?: UsageTotals;
+  listUpdatedAt: number;
+  persistedAt: number;
+  persistedError: Error | null;
+  queryError?: Error;
+}): UsageState {
+  const refusalAt = persistedError && isTerminalResourceError(persistedError) ? persistedAt : 0;
+  const usageSuccessAt = detail ? detailUpdatedAt : 0;
+  const listAt = listSummary ? listUpdatedAt : 0;
+  if (refusalAt > listAt && refusalAt > usageSuccessAt) {
+    return { kind: "error", error: persistedError ?? queryError ?? new Error(m.usage_error_fallback()) };
+  }
+  if (detail && usageSuccessAt >= listAt && usageSuccessAt >= refusalAt) {
+    return readyUsage(detail, detail, usageRefreshError(persistedError ?? queryError));
+  }
+  if (listSummary && listAt >= refusalAt) {
+    return readyUsage(listSummary, undefined, usageRefreshError(listError));
+  }
+  return fallbackUsageState(detail, persistedError ?? queryError);
 }
 
 function usageError(cause: unknown): Error {
@@ -195,7 +296,18 @@ function UsageSummaryState({
       />
     );
   }
-  return compact ? <UsageMetrics usage={state.value} compact /> : <AgentUsageDetailContent usage={state.value} />;
+  return (
+    <>
+      {state.refreshError ? <ResourceRefreshNotice error={state.refreshError} onRetry={onRetry} /> : null}
+      {compact ? (
+        <UsageMetrics usage={state.value} compact />
+      ) : state.detail ? (
+        <AgentUsageDetailContent usage={state.detail} />
+      ) : (
+        <UsageMetrics usage={state.value} />
+      )}
+    </>
+  );
 }
 
 function UsageLoading() {
@@ -230,7 +342,7 @@ function UsageMetricSkeleton() {
   );
 }
 
-function UsageMetrics({ compact = false, usage }: { compact?: boolean; usage: AgentUsageDetail }) {
+function UsageMetrics({ compact = false, usage }: { compact?: boolean; usage: UsageTotals }) {
   return (
     <dl
       className="grid grid-cols-2 divide-x divide-kumo-line"

--- a/apps/web/src/features/agents/agent-computer-choice.tsx
+++ b/apps/web/src/features/agents/agent-computer-choice.tsx
@@ -1,7 +1,9 @@
 import type { AccountComputerSummary } from "@opentag/shared/browser";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { browserApi } from "../../api.js";
 import * as m from "../../paraglide/messages.js";
+import { queryKeys } from "../../query/keys.js";
 import { Banner, Button, Text } from "../../ui/design-system.js";
 import { ComputerConnect, type ComputerConnectAdapter } from "../computer-connect/computer-connect.js";
 import { platformLabel } from "./agent-presentation.js";
@@ -22,7 +24,7 @@ interface MemoryInventoryState {
 }
 
 function useComputerInventory(inventoryAdapter: AgentComputerInventoryAdapter | undefined) {
-  const computersQuery = useComputersQuery(false, inventoryAdapter === undefined);
+  const computersQuery = useComputersQuery(false, inventoryAdapter === undefined, { refetchOnMount: "always" });
   const [memoryInventory, setMemoryInventory] = useState<MemoryInventoryState>({
     computers: undefined,
     error: false,
@@ -98,6 +100,7 @@ export function AgentComputerChoice({
    */
   onBound: () => void;
 }) {
+  const queryClient = useQueryClient();
   const inventory = useComputerInventory(inventoryAdapter);
   const [binding, setBinding] = useState(false);
   const [error, setError] = useState<string>();
@@ -141,6 +144,9 @@ export function AgentComputerChoice({
          * and asking the surface around this to re-read reports that rather than asserting a choice
          * from an inventory that has since changed.
          */
+        if (!inventoryAdapter) {
+          void queryClient.invalidateQueries({ queryKey: queryKeys.computers() });
+        }
         onBound();
       } catch (cause) {
         if (generation.current !== mine) return;
@@ -149,7 +155,7 @@ export function AgentComputerChoice({
         if (generation.current === mine) setBinding(false);
       }
     },
-    [agentId, inventoryAdapter, onBound],
+    [agentId, inventoryAdapter, onBound, queryClient],
   );
 
   // A different Agent answers for itself: the previous one's target and failure are not its result,

--- a/apps/web/src/features/agents/agent-detail-page.tsx
+++ b/apps/web/src/features/agents/agent-detail-page.tsx
@@ -21,7 +21,8 @@ import { useAgentDetailView } from "./agent-queries.js";
 import { agentDetailLink, agentSettingsLink } from "./agent-routes.js";
 
 export function AgentDetailPage({ agentId }: { agentId: string }) {
-  const state = useAgentDetailView(agentId, { watched: true });
+  const { me } = useAccount();
+  const state = useAgentDetailView(agentId, { watched: true, accountId: me.user.id });
   return (
     <AsyncState state={state}>
       {(agent) => (
@@ -34,7 +35,7 @@ export function AgentDetailPage({ agentId }: { agentId: string }) {
              * dependency belongs beside the work it is stopping rather than in a banner above it.
              */}
             <div className="grid gap-6 @min-[48rem]/content:grid-cols-2">
-              <AgentUsageOverview agentId={agent.id} />
+              <AgentUsageOverview accountId={me.user.id} agentId={agent.id} />
               <AgentStatusCard agent={agent} />
             </div>
             <AgentTasksSection agentId={agent.id} />

--- a/apps/web/src/features/agents/agent-model.ts
+++ b/apps/web/src/features/agents/agent-model.ts
@@ -50,6 +50,12 @@ export type AgentListItem = AgentListApiItem & {
   evidenceConfirmed: boolean;
 };
 
+/** List rows already carry identity, lifecycle and activity; usage is list-only and is dropped. */
+export function agentDetailFromListItem(item: AgentListApiItem): AgentDetail {
+  const { usage: _usage, ...detail } = item;
+  return detail;
+}
+
 export type DetailEvidence<T> = { kind: "ready"; value: T | undefined } | { kind: "unconfirmed" };
 
 export type AgentDetailView = AgentDetail & {

--- a/apps/web/src/features/agents/agent-queries.test.tsx
+++ b/apps/web/src/features/agents/agent-queries.test.tsx
@@ -1,11 +1,13 @@
 import type { AccountComputerSummary, AgentDetail } from "@opentag/shared/browser";
+import { useQueryClient } from "@tanstack/react-query";
 import { act, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderInRouter } from "../../__tests__/support/router.js";
 import { ApiError, browserApi } from "../../api.js";
+import { queryKeys } from "../../query/keys.js";
 import type { AgentDetailView } from "./agent-model.js";
 import { projectAgentAvailability } from "./agent-model.js";
-import { useAgentDetailView, useAgentListView } from "./agent-queries.js";
+import { useAgentDetailView, useAgentIdentityList, useAgentListView } from "./agent-queries.js";
 
 const accountId = "0b9c8d7e-6f50-4a1b-8c2d-3e4f50617283";
 const agentId = "3f1d3a2c-1f2e-4a1b-9c3d-5e6f70819a2b";
@@ -72,6 +74,11 @@ function DetailProbe({ initialAgent }: { initialAgent?: AgentDetailView }) {
   );
 }
 
+const agentListItem = {
+  ...agentDetail,
+  usage: { windowDays: 30 as const, tasks: 32, failed: 0, tokens: 428_000 },
+};
+
 function ListProbe() {
   const state = useAgentListView(accountId);
   return (
@@ -86,6 +93,29 @@ function ListProbe() {
       </span>
     </div>
   );
+}
+
+function IdentityProbe() {
+  const state = useAgentIdentityList(accountId);
+  return <span data-testid="identity">{state.kind}</span>;
+}
+
+function DetailWithAccountProbe() {
+  const state = useAgentDetailView(agentId, { watched: true, accountId });
+  return (
+    <div>
+      <span data-testid="kind">{state.kind}</span>
+      <span data-testid="value">
+        {state.kind === "ready" ? state.value.displayName : state.kind === "error" ? state.error.message : ""}
+      </span>
+    </div>
+  );
+}
+
+let capturedClient: ReturnType<typeof useQueryClient>;
+function CaptureClient() {
+  capturedClient = useQueryClient();
+  return null;
 }
 
 afterEach(() => vi.restoreAllMocks());
@@ -218,4 +248,100 @@ describe("Agent views read from the cache", () => {
       expect(screen.getByTestId("value").textContent).toBe(`Agents refused (${status})`);
     },
   );
+
+  it("lets the name-only switcher read the Agent list without Computer or messaging evidence", async () => {
+    const list = vi.spyOn(browserApi, "agents").mockResolvedValue({
+      agents: [
+        agentListItem,
+        { ...agentListItem, id: "22222222-2222-4222-8222-222222222222" },
+        { ...agentListItem, id: "33333333-3333-4333-8333-333333333333" },
+      ],
+    });
+    const computers = vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [computer] });
+    const binding = vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
+    const handoff = vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
+
+    await renderInRouter(<IdentityProbe />);
+    await waitFor(() => expect(screen.getByTestId("identity").textContent).toBe("ready"));
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(computers).not.toHaveBeenCalled();
+    expect(binding).not.toHaveBeenCalled();
+    expect(handoff).not.toHaveBeenCalled();
+  });
+
+  it("reuses a successful list row for the selected Agent instead of GET /agents/:id", async () => {
+    stubEvidence();
+    const list = vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [agentListItem] });
+    const detail = vi.spyOn(browserApi, "agent");
+
+    await renderInRouter(<DetailWithAccountProbe />);
+    await waitFor(() => expect(screen.getByTestId("kind").textContent).toBe("ready"));
+    expect(screen.getByTestId("value").textContent).toBe("Reviewer");
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(detail).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a list refusal as this Agent's authorization and recovers by id", async () => {
+    stubEvidence();
+    vi.spyOn(browserApi, "agents").mockRejectedValue(new ApiError(403, "Agents refused"));
+    const detail = vi.spyOn(browserApi, "agent").mockResolvedValue(agentDetail);
+
+    await renderInRouter(<DetailWithAccountProbe />);
+    await waitFor(() => expect(screen.getByTestId("kind").textContent).toBe("ready"));
+    expect(screen.getByTestId("value").textContent).toBe("Reviewer");
+    expect(detail).toHaveBeenCalledWith(agentId);
+  });
+
+  it("does not let an older list row overrule a newer per-Agent refusal", async () => {
+    stubEvidence();
+    const listResult = { agents: [agentListItem] };
+    vi.spyOn(browserApi, "agents").mockResolvedValue(listResult);
+    vi.spyOn(browserApi, "agent").mockRejectedValue(new ApiError(403, "Agent access removed"));
+    const view = await renderInRouter(<CaptureClient />);
+    capturedClient.setQueryData(queryKeys.agents.list(accountId), listResult, { updatedAt: Date.now() - 1_000 });
+    await capturedClient
+      .fetchQuery({ queryKey: queryKeys.agents.detail(agentId), queryFn: () => browserApi.agent(agentId) })
+      .catch(() => undefined);
+    view.rerender(
+      <>
+        <CaptureClient />
+        <DetailWithAccountProbe />
+      </>,
+    );
+    await waitFor(() => expect(screen.getByTestId("kind").textContent).toBe("error"));
+    expect(screen.getByTestId("value").textContent).toBe("Agent access removed");
+  });
+
+  it("keeps a newer per-Agent refusal across a transient failure and remount until authorized recovery", async () => {
+    stubEvidence();
+    const listResult = { agents: [agentListItem] };
+    vi.spyOn(browserApi, "agents").mockResolvedValue(listResult);
+    const detail = vi
+      .spyOn(browserApi, "agent")
+      .mockRejectedValueOnce(new ApiError(403, "Agent access removed"))
+      .mockRejectedValueOnce(new ApiError(503, "Temporary outage"))
+      .mockResolvedValue(agentDetail);
+    const view = await renderInRouter(<CaptureClient />);
+    capturedClient.setQueryData(queryKeys.agents.list(accountId), listResult, { updatedAt: Date.now() - 1_000 });
+    await capturedClient
+      .fetchQuery({ queryKey: queryKeys.agents.detail(agentId), queryFn: () => browserApi.agent(agentId) })
+      .catch(() => undefined);
+    await capturedClient
+      .fetchQuery({ queryKey: queryKeys.agents.detail(agentId), queryFn: () => browserApi.agent(agentId) })
+      .catch(() => undefined);
+    view.rerender(
+      <>
+        <CaptureClient />
+        <DetailWithAccountProbe />
+      </>,
+    );
+    await waitFor(() => expect(screen.getByTestId("kind").textContent).toBe("error"));
+    expect(screen.getByTestId("value").textContent).toBe("Agent access removed");
+    await act(async () => {
+      await capturedClient.refetchQueries({ queryKey: queryKeys.agents.detail(agentId) });
+    });
+    await waitFor(() => expect(screen.getByTestId("kind").textContent).toBe("ready"));
+    expect(screen.getByTestId("value").textContent).toBe("Reviewer");
+    expect(detail).toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/agents/agent-queries.ts
+++ b/apps/web/src/features/agents/agent-queries.ts
@@ -1,72 +1,108 @@
-import type { ImBindingHandoffStatus, ImBindingSummary } from "@opentag/shared/browser";
-import { useQueries, useQuery } from "@tanstack/react-query";
-import { useRef } from "react";
+import type {
+  AccountComputerSummary,
+  AgentDetail,
+  AgentListItem as AgentListApiItem,
+  ImBindingHandoffStatus,
+  ImBindingSummary,
+} from "@opentag/shared/browser";
+import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { browserApi } from "../../api.js";
 import { queryKeys } from "../../query/keys.js";
+import { liveResourceQueryOptions } from "../../query/live.js";
+import { terminalResourceObservedAt } from "../../query/session-cache.js";
 import type { LoadState } from "../resource/resource-state.js";
-import { isTerminalResourceError, toResourceState } from "../resource/resource-state.js";
+import {
+  isConfirmedQuerySuccess,
+  isTerminalResourceError,
+  toResourceState,
+  usePersistedSettledError,
+} from "../resource/resource-state.js";
 import type { AgentDetailView, AgentListItem } from "./agent-model.js";
-import { markAgentDetailUnconfirmed, markAgentListUnconfirmed, projectAgentAvailability } from "./agent-model.js";
+import {
+  agentDetailFromListItem,
+  markAgentDetailUnconfirmed,
+  markAgentListUnconfirmed,
+  projectAgentAvailability,
+} from "./agent-model.js";
 
-/**
- * What a page that waits for an Agent to recover asks for: re-read on an interval, and again when
- * the Account comes back to the tab. The query client leaves both off by default, because most
- * reads here answer a question the Account asked once.
- */
-const WATCHED = { refetchInterval: 30_000, refetchOnWindowFocus: true } as const;
+export function readAgentList() {
+  return browserApi.agents();
+}
+
+export function readAgent(agentId: string) {
+  return browserApi.agent(agentId);
+}
+
+export function readComputers() {
+  return browserApi.computers();
+}
 
 /*
  * These two endpoints answer 204 for an Agent that has none, which the API layer resolves as
  * `undefined`. A query may not resolve `undefined` — it is how the cache says "nothing read yet" —
  * so absence becomes `null` here, at the only place that has to know the difference.
  */
-const readImBinding = (agentId: string): Promise<ImBindingSummary | null> =>
+export const readImBinding = (agentId: string): Promise<ImBindingSummary | null> =>
   browserApi.imBinding(agentId).then((binding) => binding ?? null);
 
-const readImBindingHandoff = (agentId: string): Promise<ImBindingHandoffStatus | null> =>
+export const readImBindingHandoff = (agentId: string): Promise<ImBindingHandoffStatus | null> =>
   browserApi.imBindingHandoff(agentId).then((handoff) => handoff ?? null);
 
-/** The part of a query this remembers. Taking a plain object keeps the reads it accepts explicit. */
-interface SettlingQuery {
-  error: Error | null;
-  isError: boolean;
-  isSuccess: boolean;
+/** The Account's Computers. One cache entry, so every surface that needs them shares one read. */
+export function useComputersQuery(
+  watched = false,
+  enabled = true,
+  options: { refetchOnMount?: boolean | "always" } = {},
+) {
+  return useQuery({
+    queryKey: queryKeys.computers(),
+    queryFn: readComputers,
+    enabled,
+    ...(watched ? liveResourceQueryOptions : { staleTime: liveResourceQueryOptions.staleTime }),
+    ...(options.refetchOnMount !== undefined ? { refetchOnMount: options.refetchOnMount } : {}),
+  });
+}
+
+export function useAgentListQuery(accountId: string, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.agents.list(accountId),
+    queryFn: readAgentList,
+    enabled: enabled && accountId.length > 0,
+    ...liveResourceQueryOptions,
+  });
 }
 
 /**
- * The last answer the Server actually gave, held across the re-read that follows it.
- *
- * The cache clears `error` the moment a fetch starts on a query that has never held data, so
- * `isError` describes only the attempt in flight. A terminal response is not an attempt that failed
- * but an answer — the Agent is gone or forbidden — and forgetting it on every interval and every
- * focus is what let route state put a deleted Agent back on screen between re-reads. Only a success
- * retires it, and the resource it was recorded for keys it so a different Agent never inherits it.
+ * Names and ids only. The switcher must not subscribe to Computer, binding or handoff evidence for
+ * every Agent — those reads belong to surfaces that actually display availability.
  */
-function useSettledError(key: string, query: SettlingQuery): Error | null {
-  const settled = useRef<{ key: string; error: Error | null }>({ key, error: null });
-  if (settled.current.key !== key) settled.current = { key, error: null };
-  if (query.isSuccess) settled.current.error = null;
-  else if (query.isError) {
-    const error = query.error ?? new Error("The request failed");
-    const held = settled.current.error;
-    /*
-     * Losing contact is not news about the Agent. A 404 followed by a dropped connection still
-     * means the Agent is gone, so a transient failure may replace another transient failure or
-     * nothing at all, never a terminal answer — only a success says the Agent is readable again.
-     * A second terminal answer does replace the first: it is the Server's current one.
-     */
-    if (!held || !isTerminalResourceError(held) || isTerminalResourceError(error)) settled.current.error = error;
-  }
-  return settled.current.error;
+export function useAgentIdentityList(
+  accountId: string,
+): LoadState<{ agents: readonly { id: string; displayName: string }[] }> {
+  const agentsQuery = useAgentListQuery(accountId);
+  const agentsError = usePersistedSettledError(queryKeys.agents.list(accountId), agentsQuery);
+  if (agentsError && isTerminalResourceError(agentsError)) return { kind: "error", error: agentsError };
+  if (!agentsQuery.isFetched) return { kind: "loading" };
+  if (!agentsQuery.data) return { kind: "error", error: agentsError ?? new Error("The request failed") };
+  return toResourceState(
+    { data: { agents: agentsQuery.data.agents }, error: agentsError, isError: agentsError !== null },
+    (value) => value,
+  );
 }
 
-/** The Account's Computers. One cache entry, so every surface that needs them shares one read. */
-export function useComputersQuery(watched = false, enabled = true) {
+export function useImBindingQuery(agentId: string, watched = true) {
   return useQuery({
-    queryKey: queryKeys.computers(),
-    queryFn: () => browserApi.computers(),
-    enabled,
-    ...(watched ? WATCHED : {}),
+    queryKey: queryKeys.agents.imBinding(agentId),
+    queryFn: () => readImBinding(agentId),
+    ...(watched ? liveResourceQueryOptions : { staleTime: liveResourceQueryOptions.staleTime }),
+  });
+}
+
+export function useImBindingHandoffQuery(agentId: string, watched = true) {
+  return useQuery({
+    queryKey: queryKeys.agents.imBindingHandoff(agentId),
+    queryFn: () => readImBindingHandoff(agentId),
+    ...(watched ? liveResourceQueryOptions : { staleTime: liveResourceQueryOptions.staleTime }),
   });
 }
 
@@ -79,20 +115,16 @@ export function useComputersQuery(watched = false, enabled = true) {
  * kind of partial outage that makes this expensive.
  */
 export function useAgentListView(accountId: string): LoadState<{ agents: AgentListItem[] }> {
-  const agentsQuery = useQuery({
-    queryKey: queryKeys.agents.list(accountId),
-    queryFn: () => browserApi.agents(),
-    ...WATCHED,
-  });
+  const agentsQuery = useAgentListQuery(accountId);
   const computersQuery = useComputersQuery(true);
   const agents = agentsQuery.data?.agents ?? [];
-  const evidenceOffered = computersQuery.isSuccess;
+  const evidenceOffered = isConfirmedQuerySuccess(computersQuery);
   const bindings = useQueries({
     queries: agents.map((agent) => ({
       queryKey: queryKeys.agents.imBinding(agent.id),
       queryFn: () => readImBinding(agent.id),
       enabled: evidenceOffered,
-      ...WATCHED,
+      ...liveResourceQueryOptions,
     })),
   });
   const handoffs = useQueries({
@@ -100,11 +132,11 @@ export function useAgentListView(accountId: string): LoadState<{ agents: AgentLi
       queryKey: queryKeys.agents.imBindingHandoff(agent.id),
       queryFn: () => readImBindingHandoff(agent.id),
       enabled: evidenceOffered,
-      ...WATCHED,
+      ...liveResourceQueryOptions,
     })),
   });
 
-  const agentsError = useSettledError(accountId, agentsQuery);
+  const agentsError = usePersistedSettledError(queryKeys.agents.list(accountId), agentsQuery);
 
   // A terminal response is an answer about the list itself, so it outranks the reads still settling
   // beside it as well as any rows the cache still holds.
@@ -115,11 +147,13 @@ export function useAgentListView(accountId: string): LoadState<{ agents: AgentLi
   // failed Computer read leaves them disabled and never fetched, which would hold the page forever.
   if (evidenceOffered && [...bindings, ...handoffs].some((query) => !query.isFetched)) return { kind: "loading" };
 
-  const computers = computersQuery.data?.computers ?? [];
+  const computers = evidenceOffered ? (computersQuery.data?.computers ?? []) : [];
   const view = {
     agents: agents.map((agent, index) => {
       const binding = bindings[index];
       const handoff = handoffs[index];
+      const bindingConfirmed = Boolean(binding && isConfirmedQuerySuccess(binding));
+      const handoffConfirmed = Boolean(handoff && isConfirmedQuerySuccess(handoff));
       return {
         ...agent,
         availability: projectAgentAvailability(
@@ -127,10 +161,10 @@ export function useAgentListView(accountId: string): LoadState<{ agents: AgentLi
           evidenceOffered
             ? computers.find((computer) => computer.computerId === agent.computer?.computerId)
             : undefined,
-          binding?.isSuccess ? (binding.data ?? undefined) : undefined,
-          handoff?.isSuccess ? (handoff.data ?? undefined) : undefined,
-          binding?.isSuccess ?? false,
-          handoff?.isSuccess ?? false,
+          bindingConfirmed ? (binding?.data ?? undefined) : undefined,
+          handoffConfirmed ? (handoff?.data ?? undefined) : undefined,
+          bindingConfirmed,
+          handoffConfirmed,
         ),
         evidenceConfirmed: true,
       };
@@ -144,72 +178,201 @@ export function useAgentListView(accountId: string): LoadState<{ agents: AgentLi
  * has anything to show; the Computer, binding and handoff reads each contribute evidence and are
  * independent of one another, as they were when this was three settled promises.
  *
+ * When `accountId` is provided, a successful list row for this Agent is reused instead of repeating
+ * GET /agents/:id. A list failure is not an answer about this Agent: per-ID confirmation stays
+ * available, and a later list error cannot un-read a successful per-ID recovery.
+ *
  * `initialAgent` is an Agent carried in history state by the link that opened this page, so a page
  * reached from one that already had it does not flash a loading state.
  */
 export function useAgentDetailView(
   agentId: string,
-  { watched = false, initialAgent }: { watched?: boolean; initialAgent?: AgentDetailView } = {},
+  {
+    watched = false,
+    initialAgent,
+    accountId,
+  }: { watched?: boolean; initialAgent?: AgentDetailView; accountId?: string } = {},
 ): LoadState<AgentDetailView> {
-  const watch = watched ? WATCHED : {};
+  const queryClient = useQueryClient();
+  const watch = watched ? liveResourceQueryOptions : { staleTime: liveResourceQueryOptions.staleTime };
+  const listQuery = useAgentListQuery(accountId ?? "", Boolean(accountId));
+  const listed = listQuery.data?.agents.find((agent) => agent.id === agentId);
+  const listStamp = listQuery.isSuccess ? listQuery.dataUpdatedAt : 0;
+  const detailKey = queryKeys.agents.detail(agentId);
+  const cachedDetail = queryClient.getQueryState(detailKey);
+  const detailSuccessAt = cachedDetail?.data !== undefined ? cachedDetail.dataUpdatedAt : 0;
+  const detailRefusalAt = terminalResourceObservedAt(queryClient, detailKey);
+  const listedUsable = Boolean(
+    listed && isConfirmedQuerySuccess(listQuery) && listStamp >= detailRefusalAt && listStamp >= detailSuccessAt,
+  );
+  const listSettled = !accountId || listQuery.isFetched;
   const agentQuery = useQuery({
-    queryKey: queryKeys.agents.detail(agentId),
-    queryFn: () => browserApi.agent(agentId),
+    queryKey: detailKey,
+    queryFn: () => readAgent(agentId),
+    enabled: listSettled && !listedUsable,
     ...watch,
   });
   const computersQuery = useComputersQuery(watched);
-  const bindingQuery = useQuery({
-    queryKey: queryKeys.agents.imBinding(agentId),
-    queryFn: () => readImBinding(agentId),
-    ...watch,
-  });
-  const handoffQuery = useQuery({
-    queryKey: queryKeys.agents.imBindingHandoff(agentId),
-    queryFn: () => readImBindingHandoff(agentId),
-    ...watch,
-  });
+  const bindingQuery = useImBindingQuery(agentId, watched);
+  const handoffQuery = useImBindingHandoffQuery(agentId, watched);
+  const listError = usePersistedSettledError(queryKeys.agents.list(accountId ?? ""), listQuery);
+  const detailError = usePersistedSettledError(detailKey, agentQuery);
 
   /*
    * Waiting on the first read of each, not on whether one is in flight now. A re-read must not put
    * the page back into loading: doing so unmounts what the page is showing, and anything below that
    * reads the same evidence would be remounted into re-reading it, which never settles.
    */
-  const settling =
-    !agentQuery.isFetched || !computersQuery.isFetched || !bindingQuery.isFetched || !handoffQuery.isFetched;
-  const agentError = useSettledError(agentId, agentQuery);
-  if (agentError && isTerminalResourceError(agentError)) {
-    // A terminal primary response wins even while the evidence reads are still settling, and it
-    // keeps winning while the next re-read is in flight. Route state must not keep a deleted or
-    // forbidden Agent visible during either window.
-    return { kind: "error", error: agentError };
-  }
-  if (settling) return initialAgent ? { kind: "ready", value: initialAgent } : { kind: "loading" };
-  if (!agentQuery.data) {
-    // Route state is only a non-terminal fallback. A deleted or forbidden Agent must never remain
-    // visible just because navigation carried the last object that was rendered.
-    if (initialAgent) {
-      return { kind: "ready", value: markAgentDetailUnconfirmed(initialAgent) };
-    }
-    return { kind: "error", error: agentError ?? new Error("The request failed") };
-  }
+  const evidenceSettling = !computersQuery.isFetched || !bindingQuery.isFetched || !handoffQuery.isFetched;
+  const bindingConfirmed = isConfirmedQuerySuccess(bindingQuery);
+  const handoffConfirmed = isConfirmedQuerySuccess(handoffQuery);
+  const computersConfirmed = isConfirmedQuerySuccess(computersQuery);
+  return presentAgentDetailView({
+    agentData: agentQuery.data,
+    agentFetched: agentQuery.isFetched,
+    binding: bindingConfirmed ? (bindingQuery.data ?? undefined) : undefined,
+    bindingConfirmed,
+    computers: computersConfirmed ? computersQuery.data?.computers : undefined,
+    computersConfirmed,
+    detailError,
+    detailRefusalAt,
+    detailSuccessAt,
+    evidenceSettling,
+    handoff: handoffConfirmed ? (handoffQuery.data ?? undefined) : undefined,
+    handoffConfirmed,
+    initialAgent,
+    listError,
+    listSettled,
+    listStamp,
+    listed,
+    listedUsable,
+  });
+}
 
-  const agent = agentQuery.data;
-  const binding = bindingQuery.isSuccess ? (bindingQuery.data ?? undefined) : undefined;
-  const view: AgentDetailView = {
+function detailDisplayError(
+  listedUsable: boolean,
+  listError: Error | null,
+  detailError: Error | null,
+  listed: AgentListApiItem | undefined,
+): Error | null {
+  if (listedUsable) return listError && !isTerminalResourceError(listError) ? listError : null;
+  if (detailError) return detailError;
+  return listed && listError && !isTerminalResourceError(listError) ? listError : null;
+}
+
+function isNewerDetailRefusal(
+  detailError: Error | null,
+  detailRefusalAt: number,
+  listStamp: number,
+  detailSuccessAt: number,
+): detailError is Error {
+  return Boolean(
+    detailError &&
+      isTerminalResourceError(detailError) &&
+      detailRefusalAt > listStamp &&
+      detailRefusalAt > detailSuccessAt,
+  );
+}
+
+function resolveAgentProjection(
+  listedUsable: boolean,
+  listed: AgentListApiItem | undefined,
+  agentData: AgentDetail | undefined,
+): AgentDetail | undefined {
+  if (listedUsable && listed) return agentDetailFromListItem(listed);
+  return agentData ?? (listed ? agentDetailFromListItem(listed) : undefined);
+}
+
+function assembleAgentDetailView(
+  agent: AgentDetail,
+  computersConfirmed: boolean,
+  computers: readonly AccountComputerSummary[] | undefined,
+  bindingConfirmed: boolean,
+  binding: ImBindingSummary | undefined,
+  handoffConfirmed: boolean,
+  handoff: ImBindingHandoffStatus | undefined,
+): AgentDetailView {
+  return {
     ...agent,
-    messaging: bindingQuery.isSuccess ? { kind: "ready", value: binding } : { kind: "unconfirmed" },
+    messaging: bindingConfirmed ? { kind: "ready", value: binding } : { kind: "unconfirmed" },
     availability: projectAgentAvailability(
       agent,
-      // Evidence counts only while the read that carries it is confirmed, as it does on the list. A
-      // Computer the cache still holds after a failed re-read is not evidence of anything.
-      computersQuery.isSuccess
-        ? computersQuery.data.computers.find((computer) => computer.computerId === agent.computer?.computerId)
+      computersConfirmed
+        ? computers?.find((computer) => computer.computerId === agent.computer?.computerId)
         : undefined,
       binding,
-      handoffQuery.isSuccess ? (handoffQuery.data ?? undefined) : undefined,
-      bindingQuery.isSuccess,
-      handoffQuery.isSuccess,
+      handoff,
+      bindingConfirmed,
+      handoffConfirmed,
     ),
   };
-  return toResourceState({ data: view, error: agentError, isError: agentError !== null }, markAgentDetailUnconfirmed);
+}
+
+function presentAgentDetailView({
+  agentData,
+  agentFetched,
+  binding,
+  bindingConfirmed,
+  computers,
+  computersConfirmed,
+  detailError,
+  detailRefusalAt,
+  detailSuccessAt,
+  evidenceSettling,
+  handoff,
+  handoffConfirmed,
+  initialAgent,
+  listError,
+  listSettled,
+  listStamp,
+  listed,
+  listedUsable,
+}: {
+  agentData?: AgentDetail;
+  agentFetched: boolean;
+  binding?: ImBindingSummary;
+  bindingConfirmed: boolean;
+  computers?: readonly AccountComputerSummary[];
+  computersConfirmed: boolean;
+  detailError: Error | null;
+  detailRefusalAt: number;
+  detailSuccessAt: number;
+  evidenceSettling: boolean;
+  handoff?: ImBindingHandoffStatus;
+  handoffConfirmed: boolean;
+  initialAgent?: AgentDetailView;
+  listError: Error | null;
+  listSettled: boolean;
+  listStamp: number;
+  listed?: AgentListApiItem;
+  listedUsable: boolean;
+}): LoadState<AgentDetailView> {
+  if (isNewerDetailRefusal(detailError, detailRefusalAt, listStamp, detailSuccessAt)) {
+    return { kind: "error", error: detailError };
+  }
+  if (!listSettled || evidenceSettling || (!listedUsable && !agentFetched && !listed)) {
+    return initialAgent ? { kind: "ready", value: initialAgent } : { kind: "loading" };
+  }
+  const agent = resolveAgentProjection(listedUsable, listed, agentData);
+  if (!agent) {
+    if (initialAgent) return { kind: "ready", value: markAgentDetailUnconfirmed(initialAgent) };
+    return { kind: "error", error: detailError ?? new Error("The request failed") };
+  }
+  const displayError = detailDisplayError(listedUsable, listError, detailError, listed);
+  return toResourceState(
+    {
+      data: assembleAgentDetailView(
+        agent,
+        computersConfirmed,
+        computers,
+        bindingConfirmed,
+        binding,
+        handoffConfirmed,
+        handoff,
+      ),
+      error: displayError,
+      isError: displayError !== null,
+    },
+    markAgentDetailUnconfirmed,
+  );
 }

--- a/apps/web/src/features/agents/agent-queries.ts
+++ b/apps/web/src/features/agents/agent-queries.ts
@@ -9,7 +9,14 @@ import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { browserApi } from "../../api.js";
 import { queryKeys } from "../../query/keys.js";
 import { liveResourceQueryOptions } from "../../query/live.js";
-import { terminalResourceObservedAt } from "../../query/session-cache.js";
+import {
+  observedAfter,
+  type ResourceObservation,
+  refusalOutranks,
+  resourceSuccessObservation,
+  type TerminalResourceObservation,
+  terminalResourceObservation,
+} from "../../query/session-cache.js";
 import type { LoadState } from "../resource/resource-state.js";
 import {
   isConfirmedQuerySuccess,
@@ -197,13 +204,20 @@ export function useAgentDetailView(
   const watch = watched ? liveResourceQueryOptions : { staleTime: liveResourceQueryOptions.staleTime };
   const listQuery = useAgentListQuery(accountId ?? "", Boolean(accountId));
   const listed = listQuery.data?.agents.find((agent) => agent.id === agentId);
-  const listStamp = listQuery.isSuccess ? listQuery.dataUpdatedAt : 0;
   const detailKey = queryKeys.agents.detail(agentId);
-  const cachedDetail = queryClient.getQueryState(detailKey);
-  const detailSuccessAt = cachedDetail?.data !== undefined ? cachedDetail.dataUpdatedAt : 0;
-  const detailRefusalAt = terminalResourceObservedAt(queryClient, detailKey);
+  /*
+   * Observation order — never the wall clock — arbitrates between the shared list row and the
+   * per-Agent read: two answers that settle in the same millisecond, or under a clock that moved
+   * backwards, still order by which the cache observed later.
+   */
+  const listSuccess = resourceSuccessObservation(queryClient, queryKeys.agents.list(accountId ?? ""));
+  const detailSuccess = resourceSuccessObservation(queryClient, detailKey);
+  const detailRefusal = terminalResourceObservation(queryClient, detailKey);
   const listedUsable = Boolean(
-    listed && isConfirmedQuerySuccess(listQuery) && listStamp >= detailRefusalAt && listStamp >= detailSuccessAt,
+    listed &&
+      isConfirmedQuerySuccess(listQuery) &&
+      !refusalOutranks(detailRefusal, listSuccess) &&
+      !observedAfter(detailSuccess, listSuccess),
   );
   const listSettled = !accountId || listQuery.isFetched;
   const agentQuery = useQuery({
@@ -235,15 +249,15 @@ export function useAgentDetailView(
     computers: computersConfirmed ? computersQuery.data?.computers : undefined,
     computersConfirmed,
     detailError,
-    detailRefusalAt,
-    detailSuccessAt,
+    detailRefusal,
+    detailSuccess,
     evidenceSettling,
     handoff: handoffConfirmed ? (handoffQuery.data ?? undefined) : undefined,
     handoffConfirmed,
     initialAgent,
     listError,
     listSettled,
-    listStamp,
+    listSuccess,
     listed,
     listedUsable,
   });
@@ -262,15 +276,15 @@ function detailDisplayError(
 
 function isNewerDetailRefusal(
   detailError: Error | null,
-  detailRefusalAt: number,
-  listStamp: number,
-  detailSuccessAt: number,
+  detailRefusal: TerminalResourceObservation | undefined,
+  listSuccess: ResourceObservation | undefined,
+  detailSuccess: ResourceObservation | undefined,
 ): detailError is Error {
   return Boolean(
     detailError &&
       isTerminalResourceError(detailError) &&
-      detailRefusalAt > listStamp &&
-      detailRefusalAt > detailSuccessAt,
+      refusalOutranks(detailRefusal, listSuccess) &&
+      refusalOutranks(detailRefusal, detailSuccess),
   );
 }
 
@@ -316,15 +330,15 @@ function presentAgentDetailView({
   computers,
   computersConfirmed,
   detailError,
-  detailRefusalAt,
-  detailSuccessAt,
+  detailRefusal,
+  detailSuccess,
   evidenceSettling,
   handoff,
   handoffConfirmed,
   initialAgent,
   listError,
   listSettled,
-  listStamp,
+  listSuccess,
   listed,
   listedUsable,
 }: {
@@ -335,19 +349,19 @@ function presentAgentDetailView({
   computers?: readonly AccountComputerSummary[];
   computersConfirmed: boolean;
   detailError: Error | null;
-  detailRefusalAt: number;
-  detailSuccessAt: number;
+  detailRefusal?: TerminalResourceObservation;
+  detailSuccess?: ResourceObservation;
   evidenceSettling: boolean;
   handoff?: ImBindingHandoffStatus;
   handoffConfirmed: boolean;
   initialAgent?: AgentDetailView;
   listError: Error | null;
   listSettled: boolean;
-  listStamp: number;
+  listSuccess?: ResourceObservation;
   listed?: AgentListApiItem;
   listedUsable: boolean;
 }): LoadState<AgentDetailView> {
-  if (isNewerDetailRefusal(detailError, detailRefusalAt, listStamp, detailSuccessAt)) {
+  if (isNewerDetailRefusal(detailError, detailRefusal, listSuccess, detailSuccess)) {
     return { kind: "error", error: detailError };
   }
   if (!listSettled || evidenceSettling || (!listedUsable && !agentFetched && !listed)) {

--- a/apps/web/src/features/agents/agent-settings/agent-manage-settings.test.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-manage-settings.test.tsx
@@ -220,4 +220,45 @@ describe("Agent lifecycle actions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Pause Agent" }));
     expect((await screen.findByRole("alert")).textContent).toBe("Couldn’t pause this Agent. Try again.");
   });
+
+  it("does not make an unchanged peer list row newer than that peer's detail", async () => {
+    stubEvidence();
+    const peerId = "22222222-2222-4222-8222-222222222222";
+    const peer = { ...listItem, id: peerId, displayName: "Peer" };
+    vi.spyOn(browserApi, "agents").mockResolvedValue({ agents: [listItem, peer] });
+    vi.spyOn(browserApi, "agent").mockResolvedValue({ ...agentDetail, id: peerId, displayName: "Updated peer" });
+    vi.spyOn(browserApi, "deleteAgent").mockResolvedValue(undefined);
+    let client!: ReturnType<typeof useQueryClient>;
+    function Capture() {
+      client = useQueryClient();
+      return null;
+    }
+    function PeerNameProbe() {
+      const state = useAgentDetailView(peerId, { accountId });
+      return <output data-testid="peer-name">{state.kind === "ready" ? state.value.displayName : state.kind}</output>;
+    }
+    const view = await renderInRouter(<Capture />);
+    client.setQueryData(
+      queryKeys.agents.list(accountId),
+      { agents: [listItem, peer] },
+      { updatedAt: Date.now() - 1_000 },
+    );
+    client.setQueryData(
+      queryKeys.agents.detail(peerId),
+      { ...agentDetail, id: peerId, displayName: "Updated peer" },
+      { updatedAt: Date.now() - 500 },
+    );
+    view.rerender(
+      <>
+        <Capture />
+        <AgentListProbe />
+        <PeerNameProbe />
+        <AgentManageSettings agent={agentView} initialConfig={config} onAgentChanged={() => undefined} />
+      </>,
+    );
+    await waitFor(() => expect(screen.getByTestId("peer-name").textContent).toBe("Updated peer"));
+    await confirmDelete();
+    await waitFor(() => expect(screen.getByTestId("agent-list").textContent).toBe("Peer"));
+    expect(screen.getByTestId("peer-name").textContent).toBe("Updated peer");
+  });
 });

--- a/apps/web/src/features/agents/agent-settings/agent-manage-settings.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-manage-settings.tsx
@@ -1,9 +1,10 @@
-import type { AgentAdminConfig, ListAgentsResponse } from "@opentag/shared/browser";
+import type { AgentAdminConfig } from "@opentag/shared/browser";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { browserApi } from "../../../api.js";
 import * as m from "../../../paraglide/messages.js";
+import { evictAgentFromLists } from "../../../query/agent-sync.js";
 import { queryKeys } from "../../../query/keys.js";
 import {
   Banner,
@@ -81,10 +82,9 @@ export function AgentManageSettings({
       // stale data after a transient list failure.
       await queryClient.cancelQueries({ queryKey: queryKeys.agents.listRoot() });
       await queryClient.cancelQueries({ queryKey: queryKeys.agents.all(config.id) });
-      queryClient.setQueriesData<ListAgentsResponse>({ queryKey: queryKeys.agents.listRoot() }, (current) =>
-        current ? { ...current, agents: current.agents.filter((item) => item.id !== config.id) } : current,
-      );
+      evictAgentFromLists(queryClient, config.id);
       queryClient.removeQueries({ queryKey: queryKeys.agents.all(config.id) });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.computers() });
       void navigate({ to: "/agents" });
     } catch {
       setConfirmationError(m.agent_settings_delete_failed());

--- a/apps/web/src/features/agents/agent-settings/agent-settings-page.tsx
+++ b/apps/web/src/features/agents/agent-settings/agent-settings-page.tsx
@@ -2,10 +2,12 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { browserApi } from "../../../api.js";
 import * as m from "../../../paraglide/messages.js";
+import { syncAgentQueries } from "../../../query/agent-sync.js";
 import { queryKeys } from "../../../query/keys.js";
 import { Icon, Loader, Text } from "../../../ui/design-system.js";
 import { NotFoundPage } from "../../not-found.js";
 import { AsyncState, toResourceState } from "../../resource/resource-state.js";
+import { useAccount } from "../../session/session-context.js";
 import type { AgentDetailView } from "../agent-model.js";
 import { useAgentDetailView } from "../agent-queries.js";
 import { agentDetailLink, agentSettingsLink, agentSettingsSectionLink } from "../agent-routes.js";
@@ -19,12 +21,13 @@ import { agentSettingsGroups, agentSettingsSections, agentSettingsSummary } from
 import { AgentSettingsPageHeader } from "./settings-layout.js";
 
 export function AgentSettingsPage({ agentId, section }: { agentId: string; section?: string }) {
+  const { me } = useAccount();
   const routeState = useRouterState({ select: (state) => state.location.state });
   const initialAgent = routeState.agent?.id === agentId ? routeState.agent : undefined;
   const queryClient = useQueryClient();
   // Failure exits land here, so the page has to observe recovery on its own; it is where an
   // operator waits while a Computer reconnects or a Provider finishes installing.
-  const state = useAgentDetailView(agentId, { watched: true, initialAgent });
+  const state = useAgentDetailView(agentId, { watched: true, initialAgent, accountId: me.user.id });
   const selected = section as AgentSettingsSection | undefined;
   if (selected && !agentSettingsSections.some((item) => item.key === selected)) return <NotFoundPage />;
   return (
@@ -49,7 +52,7 @@ export function AgentSettingsPage({ agentId, section }: { agentId: string; secti
                   agent={agent}
                   section={selected}
                   // A write can change the Agent and its config together, so both are dropped.
-                  onAgentChanged={() => void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all(agentId) })}
+                  onAgentChanged={() => void syncAgentQueries(queryClient, agentId)}
                 />
               </div>
             </div>

--- a/apps/web/src/features/agents/agent-settings/im-tab.tsx
+++ b/apps/web/src/features/agents/agent-settings/im-tab.tsx
@@ -1,5 +1,4 @@
 import type { AgentSummary, ImBindingSummary } from "@opentag/shared/browser";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { type Ref, useEffect, useRef, useState } from "react";
 import { browserApi } from "../../../api.js";
 import { spaceScriptBoundary } from "../../../i18n/format.js";
@@ -7,19 +6,18 @@ import { FeishuSetup } from "../../../im/feishu-setup.js";
 import { messagingProviderLabel } from "../../../im/provider-label.js";
 import { SlackConfiguration } from "../../../im/slack-configuration.js";
 import * as m from "../../../paraglide/messages.js";
-import { queryKeys } from "../../../query/keys.js";
 import { Banner, Button, Dialog, StatusIndicator, Text } from "../../../ui/design-system.js";
 import { ProviderIcon } from "../../../ui/provider-icon.js";
 import { AsyncState, toResourceState } from "../../resource/resource-state.js";
 import type { AgentDetailView } from "../agent-model.js";
 import { messagingConnectionLabel, messagingConnectionTone } from "../agent-presentation.js";
+import { useImBindingQuery } from "../agent-queries.js";
 
 type Confirmation =
   | { bindingId: string; kind: "disable_binding"; provider: ImBindingSummary["provider"] }
   | { kind: "every_message" };
 
 export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAgentChanged: () => void }) {
-  const queryClient = useQueryClient();
   const [error, setError] = useState<string>();
   const [successMessage, setSuccessMessage] = useState<string>();
   const [confirmation, setConfirmation] = useState<Confirmation>();
@@ -32,13 +30,7 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
   const activeFeishuTriggerRef = useRef<HTMLElement | null>(null);
   const messagingHeadingRef = useRef<HTMLHeadingElement>(null);
   const triggerRulesHeadingRef = useRef<HTMLHeadingElement>(null);
-  const reload = () => void queryClient.invalidateQueries({ queryKey: queryKeys.agents.imBinding(agent.id) });
-  const state = toResourceState(
-    useQuery({
-      queryKey: queryKeys.agents.imBinding(agent.id),
-      queryFn: () => browserApi.imBinding(agent.id).then((binding) => binding ?? null),
-    }),
-  );
+  const state = toResourceState(useImBindingQuery(agent.id));
 
   useEffect(() => {
     if (confirmation || !restoreFocusTarget) return;
@@ -57,7 +49,6 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
       setConfirmationError(undefined);
       const config = await browserApi.agentConfig(agent.id);
       await browserApi.updateAgent(agent.id, { expectedRevision: config.revision, receiveMode });
-      reload();
       setRestoreFocusTarget("trigger_rules");
       setConfirmation(undefined);
       onAgentChanged();
@@ -78,7 +69,6 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
       setSuccessMessage(undefined);
       setConfirmationError(undefined);
       await browserApi.disableImBinding(bindingId);
-      reload();
       setRestoreFocusTarget("messaging");
       setConfirmation(undefined);
       onAgentChanged();
@@ -110,7 +100,6 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
         returnFocusRef={activeFeishuTriggerRef}
         onSuccess={() => {
           setSuccessMessage(m.im_feishu_connected({ provider: messagingProviderLabel("feishu") }));
-          reload();
           onAgentChanged();
         }}
       >
@@ -118,7 +107,6 @@ export function ImTab({ agent, onAgentChanged }: { agent: AgentDetailView; onAge
           <SlackConfiguration
             agentId={agent.id}
             onSuccess={() => {
-              reload();
               onAgentChanged();
             }}
           >

--- a/apps/web/src/features/agents/computers-page.tsx
+++ b/apps/web/src/features/agents/computers-page.tsx
@@ -1,10 +1,17 @@
 import type { AccountComputerSummary } from "@opentag/shared/browser";
 import { useState } from "react";
 import * as m from "../../paraglide/messages.js";
+import { queryKeys } from "../../query/keys.js";
 import { Button, StatusIndicator, Text } from "../../ui/design-system.js";
 import { ComputerConnect } from "../computer-connect/computer-connect.js";
 import { Page } from "../layout/page.js";
-import { AsyncState, toResourceState } from "../resource/resource-state.js";
+import {
+  AsyncState,
+  isTerminalResourceError,
+  ResourceRefreshNotice,
+  toResourceState,
+  usePersistedSettledError,
+} from "../resource/resource-state.js";
 import { useComputersQuery } from "./agent-queries.js";
 
 /**
@@ -16,11 +23,29 @@ export function ComputersPage() {
   // The one Computers entry every surface reads, watched because this page is where an operator
   // waits for a Computer to come back.
   const query = useComputersQuery(true);
-  const state = toResourceState(query);
+  const persistedError = usePersistedSettledError(queryKeys.computers(), {
+    error: query.error instanceof Error ? query.error : query.error ? new Error(String(query.error)) : null,
+    isError: query.isError,
+    isSuccess: query.isSuccess,
+  });
+  const terminalError = persistedError && isTerminalResourceError(persistedError) ? persistedError : null;
+  const refreshError =
+    !terminalError && query.data && query.isError && persistedError && !isTerminalResourceError(persistedError)
+      ? persistedError
+      : null;
+  const state = toResourceState(
+    {
+      data: query.data,
+      error: terminalError ?? (query.data ? null : persistedError),
+      isError: terminalError !== null || (Boolean(persistedError) && !query.data),
+    },
+    (value) => value,
+  );
   const [connecting, setConnecting] = useState(false);
 
   return (
     <Page title={m.agents_computers_title()} description={m.agents_computers_description()}>
+      {refreshError ? <ResourceRefreshNotice error={refreshError} onRetry={() => void query.refetch()} /> : null}
       <AsyncState state={state}>
         {(value) => (
           <div className="grid gap-6">

--- a/apps/web/src/features/computer-connect/computer-connect.test.tsx
+++ b/apps/web/src/features/computer-connect/computer-connect.test.tsx
@@ -1,11 +1,19 @@
 import type { AccountComputerSummary as Computer, ComputerConnectCodeStatus } from "@opentag/shared/browser";
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { StrictMode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render as renderPlain, screen } from "@testing-library/react";
+import { type ReactNode, StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { analytics } from "../../analytics/analytics.js";
 import type { GtagCommand } from "../../analytics/gtag.js";
 import { browserApi } from "../../api.js";
+import { createQueryClient } from "../../query/client.js";
 import { ComputerConnect } from "./computer-connect.js";
+
+function render(ui: ReactNode) {
+  const client = createQueryClient();
+  const view = renderPlain(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+  return Object.assign(view, { disposeQueryClient: () => client.clear() });
+}
 
 const NOW = "2026-08-20T00:00:00.000Z";
 const CONNECT_CODE_ID = "7a1c9e52-9a8b-4c7d-8e1f-2a3b4c5d6e7f";
@@ -503,12 +511,16 @@ describe("ComputerConnect", () => {
 
     const view = render(<ComputerConnect intent={{ mode: "create" }} />);
     await flushAsync();
+    const statusCalls = vi.mocked(browserApi.computerConnectCodeStatus).mock.calls.length;
     view.unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    expect(vi.mocked(browserApi.computerConnectCodeStatus).mock.calls.length).toBe(statusCalls);
     poll.resolve(redeemed());
     await flushAsync();
-
     expect(computers).not.toHaveBeenCalled();
-    expect(vi.getTimerCount()).toBe(0);
+    view.disposeQueryClient();
   });
 
   it("ignores a late issuance response after unmount", async () => {
@@ -519,8 +531,7 @@ describe("ComputerConnect", () => {
     view.unmount();
     issued.resolve({ connectCodeId: CONNECT_CODE_ID, bootstrapCommand: COMMAND, expiresIn: 900, issuedAt: NOW });
     await flushAsync();
-
     expect(browserApi.computerConnectCodeStatus).not.toHaveBeenCalled();
-    expect(vi.getTimerCount()).toBe(0);
+    view.disposeQueryClient();
   });
 });

--- a/apps/web/src/features/computer-connect/computer-connect.tsx
+++ b/apps/web/src/features/computer-connect/computer-connect.tsx
@@ -1,10 +1,13 @@
 import type { AccountComputerSummary, ComputerConnectCodeStatus } from "@opentag/shared/browser";
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type QueryClient, QueryClientContext } from "@tanstack/react-query";
+import { type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { analytics } from "../../analytics/analytics.js";
 import { ANALYTICS_EVENT } from "../../analytics/events.js";
 import { reportComputerConnected } from "../../analytics/milestones.js";
 import { browserApi } from "../../api.js";
 import * as m from "../../paraglide/messages.js";
+import { queryKeys } from "../../query/keys.js";
+import { fetchSharedResource } from "../../query/session-cache.js";
 import { CommandBlock, formatRemaining, readConnectCodeVerdict, useRemaining } from "../../setup/index.js";
 import { Button, Loader, StatusIndicator } from "../../ui/design-system.js";
 
@@ -197,14 +200,44 @@ export function ComputerConnect({ adapter, intent, onConnected }: ComputerConnec
   );
 }
 
-const browserAdapter: ComputerConnectAdapter = {
-  issue: (intent) =>
-    browserApi.issueComputerConnectCode(
-      intent.mode === "repair" ? { mode: "repair", targetComputerId: intent.target.computerId } : { mode: "create" },
-    ),
-  status: (connectCodeId) => browserApi.computerConnectCodeStatus(connectCodeId),
-  computers: () => browserApi.computers(),
-};
+function readComputerConnectStatus(
+  connectCodeId: string,
+  api: ComputerConnectBrowserApi,
+  queryClient?: QueryClient,
+): Promise<ComputerConnectCodeStatus> {
+  if (!queryClient) return api.computerConnectCodeStatus(connectCodeId);
+  return fetchSharedResource(queryClient, {
+    queryKey: queryKeys.computerConnectCode(connectCodeId),
+    queryFn: () => api.computerConnectCodeStatus(connectCodeId),
+    staleTime: 0,
+  });
+}
+
+function readComputerInventory(
+  api: ComputerConnectBrowserApi,
+  queryClient?: QueryClient,
+): Promise<{ readonly computers: readonly AccountComputerSummary[] }> {
+  if (!queryClient) return api.computers();
+  return fetchSharedResource(queryClient, {
+    queryKey: queryKeys.computers(),
+    queryFn: () => api.computers(),
+    staleTime: 0,
+  });
+}
+
+function createBrowserComputerConnectAdapter(
+  api: ComputerConnectBrowserApi = browserApi,
+  queryClient?: QueryClient,
+): ComputerConnectAdapter {
+  return {
+    issue: (intent) =>
+      api.issueComputerConnectCode(
+        intent.mode === "repair" ? { mode: "repair", targetComputerId: intent.target.computerId } : { mode: "create" },
+      ),
+    status: (connectCodeId) => readComputerConnectStatus(connectCodeId, api, queryClient),
+    computers: () => readComputerInventory(api, queryClient),
+  };
+}
 
 type ComputerConnectBrowserApi = Pick<
   typeof browserApi,
@@ -222,6 +255,7 @@ type ComputerConnectBrowserApi = Pick<
 export function createAgentTargetedComputerConnectAdapter(
   agentId: string,
   api: ComputerConnectBrowserApi = browserApi,
+  queryClient?: QueryClient,
 ): ComputerConnectAdapter {
   return {
     issue: (intent) =>
@@ -234,8 +268,8 @@ export function createAgentTargetedComputerConnectAdapter(
             }
           : { mode: "create", targetAgentId: agentId },
       ),
-    status: (connectCodeId) => api.computerConnectCodeStatus(connectCodeId),
-    computers: () => api.computers(),
+    status: (connectCodeId) => readComputerConnectStatus(connectCodeId, api, queryClient),
+    computers: () => readComputerInventory(api, queryClient),
   };
 }
 
@@ -244,16 +278,27 @@ export function createAgentTargetedComputerConnectAdapter(
  * The adapter is intentionally the only varying dependency: production and Review Lab both drive
  * the same state machine, including stale-work retirement and exact repair-target validation.
  */
+function useOptionalQueryClient(): QueryClient | undefined {
+  return useContext(QueryClientContext);
+}
+
 export function ComputerConnectLifecycleRoot({
-  adapter = browserAdapter,
+  adapter,
   children,
   intent,
   onConnected,
 }: ComputerConnectLifecycleProps) {
+  const queryClient = useOptionalQueryClient();
+  const defaultAdapter = useMemo(() => createBrowserComputerConnectAdapter(browserApi, queryClient), [queryClient]);
   const targetComputerId = intent.mode === "repair" ? intent.target.computerId : undefined;
   const attemptKey = `${intent.mode}:${targetComputerId ?? ""}`;
   return (
-    <ComputerConnectAttempt adapter={adapter} key={attemptKey} intent={intent} onConnected={onConnected}>
+    <ComputerConnectAttempt
+      adapter={adapter ?? defaultAdapter}
+      key={attemptKey}
+      intent={intent}
+      onConnected={onConnected}
+    >
       {children}
     </ComputerConnectAttempt>
   );

--- a/apps/web/src/features/resource/resource-state.tsx
+++ b/apps/web/src/features/resource/resource-state.tsx
@@ -1,12 +1,81 @@
+import type { QueryKey } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { ApiError } from "../../api.js";
 import * as m from "../../paraglide/messages.js";
-import { Loader } from "../../ui/design-system.js";
+import { terminalResourceError } from "../../query/session-cache.js";
+import { Banner, Button, Loader } from "../../ui/design-system.js";
 
 export type LoadState<T> = { kind: "loading" } | { kind: "error"; error: Error } | { kind: "ready"; value: T };
 
 export function isTerminalResourceError(error: Error): boolean {
   return error instanceof ApiError && [401, 403, 404, 410].includes(error.status);
+}
+
+/** A paused or offline observer is not a fresh confirmation of the value it still holds. */
+export function isConfirmedQuerySuccess(query: { isSuccess: boolean; fetchStatus: string }): boolean {
+  return query.isSuccess && query.fetchStatus !== "paused";
+}
+
+/** The part of a query this remembers. Taking a plain object keeps the reads it accepts explicit. */
+export interface SettlingQuery {
+  error: Error | null;
+  isError: boolean;
+  isSuccess: boolean;
+}
+
+/**
+ * The last answer the Server actually gave, held on the QueryClient so remounts, in-flight refreshes,
+ * and later transient failures cannot resurrect a 401/403/404/410. Only a later successful read
+ * retires it. Transient failures are not stored here: they describe the attempt, not the resource.
+ */
+export function usePersistedSettledError(queryKey: QueryKey, query: SettlingQuery): Error | null {
+  const queryClient = useQueryClient();
+  const held = terminalResourceError(queryClient, queryKey);
+  if (held) return held;
+  if (query.isSuccess) return null;
+  return query.isError ? (query.error ?? new Error(m.common_request_failed())) : null;
+}
+
+export function ResourceRefreshNotice({ error, onRetry }: { error: Error; onRetry: () => void }) {
+  return (
+    <Banner
+      action={<Banner.Action onClick={onRetry}>{m.common_try_again()}</Banner.Action>}
+      data-ui="resource-refresh-failed"
+      description={error.message}
+      role="status"
+      title={m.common_update_failed_last_available()}
+      variant="alert"
+    />
+  );
+}
+
+export function liveRefreshErrors(
+  query: SettlingQuery & { data?: unknown; isFetchNextPageError?: boolean },
+  persistedError: Error | null,
+): { terminalError: Error | null; refreshError: Error | null; loadMoreError: Error | null } {
+  const terminalError = persistedError && isTerminalResourceError(persistedError) ? persistedError : null;
+  const current = query.error ?? persistedError;
+  const loadMoreError = query.isFetchNextPageError && !terminalError ? current : null;
+  const refreshError =
+    !terminalError && query.data !== undefined && query.isError && !query.isFetchNextPageError ? current : null;
+  return { terminalError, refreshError, loadMoreError };
+}
+
+export function ResourceRefreshStatus({ error, onRetry }: { error: Error; onRetry: () => void }) {
+  return (
+    <p
+      className="flex flex-wrap items-center gap-3 text-sm text-kumo-subtle"
+      data-ui="resource-refresh-failed"
+      role="status"
+    >
+      <span>{m.common_update_failed_last_available()}</span>
+      <Button size="compact" type="button" variant="secondary" onClick={onRetry}>
+        {m.common_try_again()}
+      </Button>
+      <span className="text-kumo-danger">{error.message}</span>
+    </p>
+  );
 }
 
 export function AsyncState<T>({

--- a/apps/web/src/features/shell/agent-shell.tsx
+++ b/apps/web/src/features/shell/agent-shell.tsx
@@ -4,8 +4,7 @@ import { initials } from "../../i18n/format.js";
 import { useInternalNavigationVisibility } from "../../internal/navigation-visibility.js";
 import * as m from "../../paraglide/messages.js";
 import { DropdownMenu, Icon, Sidebar } from "../../ui/design-system.js";
-import type { AgentListItem } from "../agents/agent-model.js";
-import { useAgentListView } from "../agents/agent-queries.js";
+import { useAgentIdentityList } from "../agents/agent-queries.js";
 import {
   agentDetailLink,
   agentIntegrationsLink,
@@ -19,7 +18,7 @@ import { MenuItemIcon } from "./menu-item-icon.js";
 export default function AgentNavigation({ agentId, pathname }: { agentId: string; pathname: string }) {
   const { me } = useAccount();
   const router = useRouter();
-  const state = useAgentListView(me.user.id);
+  const state = useAgentIdentityList(me.user.id);
   const agents = state.kind === "ready" ? state.value.agents : [];
   const agent = agents.find((candidate) => candidate.id === agentId);
   const internal = useInternalNavigationVisibility();
@@ -96,8 +95,8 @@ function AgentSwitcher({
   pathname,
   agentId,
 }: {
-  agent?: AgentListItem;
-  agents: AgentListItem[];
+  agent?: { id: string; displayName: string };
+  agents: readonly { id: string; displayName: string }[];
   pathname: string;
   agentId: string;
 }) {

--- a/apps/web/src/features/tasks-page.test.tsx
+++ b/apps/web/src/features/tasks-page.test.tsx
@@ -699,7 +699,7 @@ describe("Tasks view", () => {
     vi.mocked(browserApi.tasks)
       .mockResolvedValueOnce({ tasks: [task], nextCursor: "retry" })
       .mockRejectedValueOnce(new Error("Agent append failed"));
-    view.rerender(<AgentTasksSection agentId={agentId} />);
+    view.rerender(<AgentTasksSection agentId="55555555-5555-4555-8555-555555555555" />);
     expect(await screen.findByRole("link", { name: task.title })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Load more" }));
     expect(await screen.findByText("Could not load more Tasks.")).toBeTruthy();

--- a/apps/web/src/features/tasks-page.tsx
+++ b/apps/web/src/features/tasks-page.tsx
@@ -15,6 +15,7 @@ import { compareText, foldCase, formatDateTime, formatRelativeTime, initials } f
 import { messagingProviderLabel } from "../im/provider-label.js";
 import * as m from "../paraglide/messages.js";
 import { queryKeys } from "../query/keys.js";
+import { liveResourceQueryOptions } from "../query/live.js";
 import {
   Button,
   buttonClassName,
@@ -30,7 +31,12 @@ import {
 } from "../ui/design-system.js";
 import { ProviderIcon } from "../ui/provider-icon.js";
 import { agentTaskDetailLink, agentTasksLink } from "./agents/agent-routes.js";
-import { isTerminalResourceError } from "./resource/resource-state.js";
+import {
+  liveRefreshErrors,
+  ResourceRefreshNotice,
+  ResourceRefreshStatus,
+  usePersistedSettledError,
+} from "./resource/resource-state.js";
 import { useRememberedState } from "./shell/shell-memory.js";
 import { TaskMessageBody } from "./task-message-body.js";
 import { TaskOutgoingReplies } from "./task-outgoing-replies.js";
@@ -56,23 +62,33 @@ export function TasksPage({ agentId, showExamples = false }: { agentId?: string;
    * Pages accumulate in the cache, so a failed append leaves the rows already on screen alone and
    * stays retryable — the behavior the hand-rolled append kept its own error state for.
    */
+  const listKey = taskListQueryKey(agentId, showExamples);
   const tasksQuery = useInfiniteQuery({
-    queryKey: taskListQueryKey(agentId, showExamples),
+    queryKey: listKey,
     queryFn: ({ pageParam }) => readTasks({ agentId, cursor: pageParam, showExamples }),
     initialPageParam: undefined as string | undefined,
     // The API reports the end of the list as null; the cache reads undefined as "no page after this".
     getNextPageParam: (page) => page.nextCursor ?? undefined,
+    ...liveResourceQueryOptions,
   });
   const loaded = useMemo(() => tasksQuery.data?.pages.flatMap((page) => page.tasks) ?? [], [tasksQuery.data]);
   const taskError = asError(tasksQuery.error);
+  const persistedError = usePersistedSettledError(listKey, {
+    error: tasksQuery.error ? taskError : null,
+    isError: tasksQuery.isError,
+    isSuccess: tasksQuery.isSuccess,
+  });
   /*
    * Which page failed does not change what a terminal status means. The Server resolves the Task
    * scope before it parses a cursor — an unusable cursor is a 400 — so a 401, 403, 404 or 410 on an
    * append says the same thing it says on the first read, and the rows already in hand are exactly
    * what must stop being shown.
    */
-  const terminalTasksError = tasksQuery.isError && isTerminalResourceError(taskError) ? taskError : null;
-  const loadMoreError = tasksQuery.isFetchNextPageError && !terminalTasksError ? taskError : null;
+  const {
+    terminalError: terminalTasksError,
+    loadMoreError,
+    refreshError,
+  } = liveRefreshErrors({ ...tasksQuery, error: taskError }, persistedError);
 
   const agents = useMemo(
     () =>
@@ -180,6 +196,7 @@ export function TasksPage({ agentId, showExamples = false }: { agentId?: string;
           {m.tasks_development_examples()}
         </Text>
       ) : null}
+      {refreshError ? <ResourceRefreshNotice error={refreshError} onRetry={() => void tasksQuery.refetch()} /> : null}
 
       {!terminalTasksError && tasksQuery.isPending ? (
         <TaskNotice loading heading={m.tasks_loading_tasks()} detail={m.tasks_loading_tasks_detail()} />
@@ -212,11 +229,11 @@ export function TasksPage({ agentId, showExamples = false }: { agentId?: string;
           {tasksQuery.hasNextPage ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button
-                disabled={tasksQuery.isFetchingNextPage}
+                disabled={tasksQuery.isFetching}
                 loading={tasksQuery.isFetchingNextPage}
                 type="button"
                 variant="secondary"
-                onClick={() => void tasksQuery.fetchNextPage()}
+                onClick={() => void tasksQuery.fetchNextPage({ cancelRefetch: false })}
               >
                 {tasksQuery.isFetchingNextPage
                   ? m.tasks_loading_more()
@@ -251,18 +268,28 @@ export function AgentTasksSection({ agentId }: { agentId: string }) {
    * belongs to the entry that started it, and the pages it accumulated are still there on the way
    * back — which is what the generation counter here had to imitate by hand.
    */
+  const listKey = queryKeys.tasks.byAgent(agentId);
   const tasksQuery = useInfiniteQuery({
-    queryKey: queryKeys.tasks.byAgent(agentId),
+    queryKey: listKey,
     queryFn: ({ pageParam }) => readTasks({ agentId, cursor: pageParam }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (page) => page.nextCursor ?? undefined,
+    ...liveResourceQueryOptions,
   });
   const tasks = useMemo(() => tasksQuery.data?.pages.flatMap((page) => page.tasks) ?? [], [tasksQuery.data]);
   const taskError = asError(tasksQuery.error);
+  const persistedError = usePersistedSettledError(listKey, {
+    error: tasksQuery.error ? taskError : null,
+    isError: tasksQuery.isError,
+    isSuccess: tasksQuery.isSuccess,
+  });
   // The same rule the Account list follows: a refusal withdraws the rows it refused, whichever
   // page asked for them. Only a transient append failure keeps them, reported beside its control.
-  const terminalTasksError = tasksQuery.isError && isTerminalResourceError(taskError) ? taskError : null;
-  const loadMoreError = tasksQuery.isFetchNextPageError && !terminalTasksError ? taskError : null;
+  const {
+    terminalError: terminalTasksError,
+    loadMoreError,
+    refreshError,
+  } = liveRefreshErrors({ ...tasksQuery, error: taskError }, persistedError);
   const unavailable = terminalTasksError !== null || (tasksQuery.isError && !tasksQuery.data);
 
   return (
@@ -289,6 +316,7 @@ export function AgentTasksSection({ agentId }: { agentId: string }) {
           {m.tasks_temporarily_unavailable()}
         </p>
       ) : null}
+      {refreshError ? <ResourceRefreshStatus error={refreshError} onRetry={() => void tasksQuery.refetch()} /> : null}
       {!unavailable && tasksQuery.data && tasks.length === 0 ? (
         <p className="text-sm text-kumo-subtle" role="status">
           {m.tasks_no_tasks_yet_detail()}
@@ -300,10 +328,10 @@ export function AgentTasksSection({ agentId }: { agentId: string }) {
           {tasksQuery.hasNextPage ? (
             <div className="flex flex-wrap items-center gap-3">
               <Button
-                disabled={tasksQuery.isFetchingNextPage}
+                disabled={tasksQuery.isFetching}
                 type="button"
                 variant="secondary"
-                onClick={() => void tasksQuery.fetchNextPage()}
+                onClick={() => void tasksQuery.fetchNextPage({ cancelRefetch: false })}
               >
                 {tasksQuery.isFetchingNextPage
                   ? m.tasks_loading_more()
@@ -337,20 +365,30 @@ export function TaskDetailPage({
    * The Task itself, its internal Sessions and its collaboration messages come from the first page
    * only, exactly as the hand-rolled append kept them; each further page contributes Turns.
    */
+  const detailKey = taskDetailQueryKey(taskId, showExamples);
   const taskQuery = useInfiniteQuery({
-    queryKey: taskDetailQueryKey(taskId, showExamples),
+    queryKey: detailKey,
     queryFn: ({ pageParam }) => readTaskDetail(taskId as string, agentId, pageParam, showExamples),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (page) => page.nextCursor ?? undefined,
     enabled: taskId !== undefined,
+    ...liveResourceQueryOptions,
   });
   const first = taskQuery.data?.pages[0];
   const turns = useMemo(() => taskQuery.data?.pages.flatMap((page) => page.turns) ?? [], [taskQuery.data]);
   const taskError = asError(taskQuery.error);
+  const persistedError = usePersistedSettledError(detailKey, {
+    error: taskQuery.error ? taskError : null,
+    isError: taskQuery.isError,
+    isSuccess: taskQuery.isSuccess,
+  });
   // `TaskService.get` resolves the Task before it parses a cursor, so a terminal status on a Turn
   // append is about the Task, not the page boundary. It withdraws the conversation with it.
-  const terminalTaskError = taskQuery.isError && isTerminalResourceError(taskError) ? taskError : null;
-  const loadMoreError = taskQuery.isFetchNextPageError && !terminalTaskError ? taskError : null;
+  const {
+    terminalError: terminalTaskError,
+    loadMoreError,
+    refreshError,
+  } = liveRefreshErrors({ ...taskQuery, error: taskError }, persistedError);
 
   if (terminalTaskError) {
     return <TaskUnavailable agentId={agentId} error={terminalTaskError} showExamples={showExamples} />;
@@ -419,6 +457,8 @@ export function TaskDetailPage({
         </dl>
       </header>
 
+      {refreshError ? <ResourceRefreshNotice error={refreshError} onRetry={() => void taskQuery.refetch()} /> : null}
+
       <section className="grid gap-5" aria-labelledby="task-activity-title" data-ui="task-thread">
         <Text as="h2" id="task-activity-title" variant="heading">
           {m.tasks_activity()}
@@ -438,8 +478,8 @@ export function TaskDetailPage({
           loading={taskQuery.isFetchingNextPage}
           type="button"
           variant="secondary"
-          disabled={taskQuery.isFetchingNextPage}
-          onClick={() => void taskQuery.fetchNextPage()}
+          disabled={taskQuery.isFetching}
+          onClick={() => void taskQuery.fetchNextPage({ cancelRefetch: false })}
         >
           {m.tasks_load_earlier_activity()}
         </Button>

--- a/apps/web/src/im/feishu-setup.test.tsx
+++ b/apps/web/src/im/feishu-setup.test.tsx
@@ -1,7 +1,9 @@
 import type { FeishuSetupAttempt, FeishuSetupIntent } from "@opentag/shared/browser";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApiError, browserApi } from "../api.js";
+import { createQueryClient } from "../query/client.js";
 import { FeishuSetup } from "./feishu-setup.js";
 
 const agentId = "1a63a21e-f6c7-4474-91ea-4dabf0566a24";
@@ -30,23 +32,25 @@ function Harness({
   presentation?: "dialog" | "inline";
 }) {
   return (
-    <FeishuSetup agentId={agentId} onSuccess={onSuccess} presentation={presentation}>
-      {(setup) => (
-        <>
-          <button type="button" onClick={() => void setup.start("create")}>
-            Create
-          </button>
-          <button type="button" onClick={() => void setup.start("reauthorize")}>
-            Reauthorize
-          </button>
-          <button type="button" onClick={() => void setup.start("replace")}>
-            Replace
-          </button>
-          {setup.loading ? <span>Loading setup</span> : null}
-          {setup.feedback}
-        </>
-      )}
-    </FeishuSetup>
+    <QueryClientProvider client={createQueryClient()}>
+      <FeishuSetup agentId={agentId} onSuccess={onSuccess} presentation={presentation}>
+        {(setup) => (
+          <>
+            <button type="button" onClick={() => void setup.start("create")}>
+              Create
+            </button>
+            <button type="button" onClick={() => void setup.start("reauthorize")}>
+              Reauthorize
+            </button>
+            <button type="button" onClick={() => void setup.start("replace")}>
+              Replace
+            </button>
+            {setup.loading ? <span>Loading setup</span> : null}
+            {setup.feedback}
+          </>
+        )}
+      </FeishuSetup>
+    </QueryClientProvider>
   );
 }
 

--- a/apps/web/src/im/feishu-setup.tsx
+++ b/apps/web/src/im/feishu-setup.tsx
@@ -1,20 +1,21 @@
 import type { FeishuSetupAttempt, FeishuSetupIntent } from "@opentag/shared/browser";
+import { useQueryClient } from "@tanstack/react-query";
 import { toString as qrToString } from "qrcode";
 import { type ReactNode, type RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, browserApi } from "../api.js";
 import { formatDateTime } from "../i18n/format.js";
 import * as m from "../paraglide/messages.js";
+import { queryKeys } from "../query/keys.js";
+import { fetchSharedResource } from "../query/session-cache.js";
 import { Banner, Button, buttonClassName, Dialog, Loader } from "../ui/design-system.js";
 import { messagingProviderLabel } from "./provider-label.js";
 
 const ACTIVE_STATES: readonly FeishuSetupAttempt["state"][] = ["awaiting_user", "validating"];
 const RETRYABLE_STATES: readonly FeishuSetupAttempt["state"][] = ["expired", "failed", "canceled"];
 /*
- * This stays outside the query cache on purpose, for the same reason the Computer setup beside it
- * does: it drives one authorization to completion rather than reading a resource. Nothing else reads
- * an attempt, so there is no sharing to gain, and the lifecycle it does keep — which error came from
- * starting versus from polling, and which attempt a late response belongs to — is the substance of
- * the flow rather than incidental bookkeeping.
+ * The 1.5s cadence, cancellation and generation fencing stay local. Only the GET is shared by
+ * attempt id so two surfaces watching the same attempt do not double the in-flight read. Setup still
+ * observes the attempt through its snapshot and does not add this GET.
  */
 const POLL_INTERVAL_MS = 1_500;
 export interface FeishuSetupControl {
@@ -70,6 +71,7 @@ function FeishuSetupLifecycle({
   presentation = "inline",
   returnFocusRef,
 }: FeishuSetupProps) {
+  const queryClient = useQueryClient();
   const [attempt, setAttempt] = useState<FeishuSetupAttempt>();
   const [error, setError] = useState<FeishuSetupError>();
   const [loading, setLoading] = useState(false);
@@ -171,7 +173,11 @@ function FeishuSetupLifecycle({
 
     const poll = async () => {
       try {
-        const next = await browserApi.feishuSetupAttempt(activeAttemptId);
+        const next = await fetchSharedResource(queryClient, {
+          queryKey: queryKeys.feishuSetupAttempt(activeAttemptId),
+          queryFn: () => browserApi.feishuSetupAttempt(activeAttemptId),
+          staleTime: 0,
+        });
         if (!active || lifecycleRef.current !== lifecycle) return;
         attemptRef.current = next;
         setAttempt(next);
@@ -208,7 +214,7 @@ function FeishuSetupLifecycle({
       active = false;
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [activeAttemptId, presentation]);
+  }, [activeAttemptId, presentation, queryClient]);
 
   async function cancelActiveAttempt() {
     const current = attemptRef.current;

--- a/apps/web/src/onboarding-v2/agent-setup-page.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.tsx
@@ -37,6 +37,7 @@ import { messagingProviderAlternateBrand, messagingProviderLabel } from "../im/p
 import { slackConfigurationMessage } from "../im/slack-configuration.js";
 import * as m from "../paraglide/messages.js";
 import { syncAgentQueries } from "../query/agent-sync.js";
+import { queryKeys } from "../query/keys.js";
 import { QrCode, WAITING_LINE } from "../setup/index.js";
 import { Banner, Button, Dialog, Icon, Loader, StatusIndicator, type StatusTone, Text } from "../ui/design-system.js";
 import { ProviderIcon } from "../ui/provider-icon.js";
@@ -670,6 +671,7 @@ export function AgentSetupPage({
       refreshSignal={refreshSignal}
       reviewMode={reviewMode}
       slackOAuthError={slackOAuthError}
+      syncAgentCachesOnReady={adapter === undefined}
     />
   );
 }
@@ -686,7 +688,17 @@ function AgentSetupPageContent({
   refreshSignal,
   reviewMode = false,
   slackOAuthError,
-}: Omit<AgentSetupPageProps, "adapter"> & { readonly adapter: AgentSetupAdapter }) {
+  syncAgentCachesOnReady = false,
+}: Omit<AgentSetupPageProps, "adapter"> & {
+  readonly adapter: AgentSetupAdapter;
+  /**
+   * Whether observing a completed messaging binding synchronizes the shared Agent caches. Only
+   * the production adapter does; Lab and in-memory adapters keep their isolation from the real
+   * QueryClient.
+   */
+  readonly syncAgentCachesOnReady?: boolean;
+}) {
+  const queryClient = useQueryClient();
   const controller = useAgentSetup(agentId, adapter, onExternalNavigation);
   const previousRefreshSignal = useRef(refreshSignal);
   const [oauthError] = useState(() => (slackOAuthError ? slackSetupErrorMessage(slackOAuthError) : undefined));
@@ -696,6 +708,29 @@ function AgentSetupPageContent({
   // The stages between a connected Computer and a usable Agent, which is where a reader who never
   // holds a conversation actually stops. Reported per stage, not per re-read.
   useAgentSetupStageReport(agentId, snapshot?.stage);
+
+  /*
+   * A completed authorization/handoff changes the Agent's messaging evidence, so the shared
+   * Agent, binding, and handoff caches synchronize exactly once per completion: when a ready
+   * binding is first observed under a binding identity and credential generation this mounted
+   * page has not synced yet. That covers the already-ready first snapshot on return from OAuth,
+   * a completion the poll observes, and a reauthorization that completes between two reads
+   * without the transitional state ever being shown — while repeated snapshots of the same
+   * completion (the 2s beat, focus returns) never sync twice. Syncing at the completion
+   * boundary, rather than on navigation away, is what lets a reader who returns home inside the
+   * 30s freshness window re-read instead of trusting the binding cached before Setup. The Setup
+   * snapshot read itself is not one of the synced keys.
+   */
+  const syncedCompletion = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (!syncAgentCachesOnReady) return;
+    const messaging = snapshot?.messaging;
+    if (messaging?.kind !== "ready") return;
+    const completion = `${messaging.provider}:${messaging.bindingId}:${messaging.credentialGeneration}`;
+    if (syncedCompletion.current === completion) return;
+    syncedCompletion.current = completion;
+    void syncAgentQueries(queryClient, agentId);
+  }, [syncAgentCachesOnReady, snapshot, queryClient, agentId]);
 
   useEffect(() => {
     if (previousRefreshSignal.current === refreshSignal) return;
@@ -1092,14 +1127,26 @@ function ComputerSetupSection({
     [agentId, queryClient],
   );
   const computerConnectAdapter = computerAdapter?.connect ?? serverComputerConnectAdapter;
-  const afterBind = () => {
-    if (!computerAdapter) void syncAgentQueries(queryClient, agentId);
-    onChanged();
+  /*
+   * A bind or repair moves the Computer state a snapshot GET begun before it may still be
+   * answering through the shared cache. Retire that in-flight read at the completion boundary, so
+   * the controller's next read starts after the write — the same operation boundary the messaging
+   * writes get from the adapter itself — then sync the shared caches as before. Lab adapters keep
+   * their own transport and their own isolation, so none of this touches them.
+   */
+  const afterComputerCompletion = (computers: boolean) => {
+    if (computerAdapter) {
+      onChanged();
+      return;
+    }
+    void (async () => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.agentSetup(agentId) });
+      void syncAgentQueries(queryClient, agentId, { computers });
+      onChanged();
+    })();
   };
-  const afterRepair = () => {
-    if (!computerAdapter) void syncAgentQueries(queryClient, agentId, { computers: true });
-    onChanged();
-  };
+  const afterBind = () => afterComputerCompletion(false);
+  const afterRepair = () => afterComputerCompletion(true);
   if (computer.kind === "not-bound") {
     return (
       <NotBoundComputerSection

--- a/apps/web/src/onboarding-v2/agent-setup-page.tsx
+++ b/apps/web/src/onboarding-v2/agent-setup-page.tsx
@@ -20,9 +20,10 @@ import type {
   ImProvider,
   ProviderCliHandoffProgress,
 } from "@opentag/shared/browser";
+import { useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useAgentSetupStageReport } from "../analytics/milestones.js";
-import { AGENT_SETUP_READ_TIMEOUT_MS, ApiError, CancelledRequestError, withDeadline } from "../api.js";
+import { AGENT_SETUP_READ_TIMEOUT_MS, ApiError, browserApi, CancelledRequestError, withDeadline } from "../api.js";
 import { AgentComputerChoice, type AgentComputerInventoryAdapter } from "../features/agents/agent-computer-choice.js";
 import { platformLabel } from "../features/agents/agent-presentation.js";
 import {
@@ -35,6 +36,7 @@ import { formatDateTime, spaceScriptBoundary } from "../i18n/format.js";
 import { messagingProviderAlternateBrand, messagingProviderLabel } from "../im/provider-label.js";
 import { slackConfigurationMessage } from "../im/slack-configuration.js";
 import * as m from "../paraglide/messages.js";
+import { syncAgentQueries } from "../query/agent-sync.js";
 import { QrCode, WAITING_LINE } from "../setup/index.js";
 import { Banner, Button, Dialog, Icon, Loader, StatusIndicator, type StatusTone, Text } from "../ui/design-system.js";
 import { ProviderIcon } from "../ui/provider-icon.js";
@@ -647,7 +649,11 @@ export function AgentSetupPage({
   reviewMode = false,
   slackOAuthError,
 }: AgentSetupPageProps) {
-  const resolvedAdapter = useMemo(() => adapter ?? createHttpSetupAdapter(), [adapter]);
+  const queryClient = useQueryClient();
+  const resolvedAdapter = useMemo(
+    () => adapter ?? createHttpSetupAdapter(browserApi, queryClient),
+    [adapter, queryClient],
+  );
   // Keyed on the exact target: a different Agent's setup is a different task, and remounting is
   // what retires everything the previous one still had in flight.
   return (
@@ -1080,8 +1086,20 @@ function ComputerSetupSection({
   readonly snapshot: AgentSetupSnapshot;
 }) {
   const { computer } = snapshot;
-  const serverComputerConnectAdapter = useMemo(() => createAgentTargetedComputerConnectAdapter(agentId), [agentId]);
+  const queryClient = useQueryClient();
+  const serverComputerConnectAdapter = useMemo(
+    () => createAgentTargetedComputerConnectAdapter(agentId, browserApi, queryClient),
+    [agentId, queryClient],
+  );
   const computerConnectAdapter = computerAdapter?.connect ?? serverComputerConnectAdapter;
+  const afterBind = () => {
+    if (!computerAdapter) void syncAgentQueries(queryClient, agentId);
+    onChanged();
+  };
+  const afterRepair = () => {
+    if (!computerAdapter) void syncAgentQueries(queryClient, agentId, { computers: true });
+    onChanged();
+  };
   if (computer.kind === "not-bound") {
     return (
       <NotBoundComputerSection
@@ -1089,7 +1107,7 @@ function ComputerSetupSection({
         computerConnectAdapter={computerConnectAdapter}
         inventoryAdapter={computerAdapter?.inventory}
         name={snapshot.agent.displayName}
-        onChanged={onChanged}
+        onChanged={afterBind}
         snapshot={snapshot}
       />
     );
@@ -1117,7 +1135,7 @@ function ComputerSetupSection({
               adapter={computerConnectAdapter}
               agentId={agentId}
               inventoryAdapter={computerAdapter?.inventory}
-              onBound={onChanged}
+              onBound={afterBind}
             />
           ) : null}
         </div>
@@ -1144,7 +1162,7 @@ function ComputerSetupSection({
     <BoundComputerSection
       computer={computer}
       computerConnectAdapter={computerConnectAdapter}
-      onChanged={onChanged}
+      onChanged={afterRepair}
       snapshot={snapshot}
     />
   );

--- a/apps/web/src/onboarding-v2/page.tsx
+++ b/apps/web/src/onboarding-v2/page.tsx
@@ -1,4 +1,5 @@
 import type { CreateAgentRequest } from "@opentag/shared/browser";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { analytics } from "../analytics/analytics.js";
@@ -6,6 +7,7 @@ import { ANALYTICS_EVENT, activationStep } from "../analytics/events.js";
 import { ApiError, browserApi } from "../api.js";
 import { agentDetailLink } from "../features/agents/agent-routes.js";
 import * as m from "../paraglide/messages.js";
+import { syncAgentQueries } from "../query/agent-sync.js";
 import { Banner, Button, Icon } from "../ui/design-system.js";
 import { AgentSetupPage, type AgentSetupPageProps, type AgentSetupPreviewView } from "./agent-setup-page.js";
 import { type AgentDraft, draftIsSubmittable, emptyDraft, type FlowState } from "./flow.js";
@@ -184,6 +186,7 @@ function AgentCreatePage({
   onAgentAvailable?: (agentId: string) => Promise<void> | void;
   onBackToAgents?: () => void;
 }) {
+  const queryClient = useQueryClient();
   const [draft, setDraft] = useState<AgentDraft>(() => {
     const initial = emptyDraft(existingAgentNames);
     return creationPreviewInitialView === "agent" ? { ...initial, destination: "local" } : initial;
@@ -244,6 +247,7 @@ function AgentCreatePage({
       try {
         const created = creationPreview ? await creationPreview(request) : await browserApi.createAgent(request);
         report.created(request.runtimeProvider);
+        if (!creationPreview) void syncAgentQueries(queryClient, created.id);
         await Promise.resolve(onAgentAvailable?.(created.id));
       } catch (cause) {
         report.refused(cause);
@@ -254,7 +258,7 @@ function AgentCreatePage({
         setSubmitting(false);
       }
     },
-    [creationPreview, onAgentAvailable],
+    [creationPreview, onAgentAvailable, queryClient],
   );
 
   return (

--- a/apps/web/src/onboarding-v2/setup-adapter.ts
+++ b/apps/web/src/onboarding-v2/setup-adapter.ts
@@ -21,7 +21,11 @@ import type {
   StartSlackOAuthResponse,
   UnbindAgentMessagingRequest,
 } from "@opentag/shared/browser";
+import type { QueryClient } from "@tanstack/react-query";
 import { browserApi } from "../api.js";
+import { syncAgentQueries } from "../query/agent-sync.js";
+import { queryKeys } from "../query/keys.js";
+import { fetchSharedResource } from "../query/session-cache.js";
 
 export interface AgentSetupAdapter {
   /** The canonical setup state of one exact Agent — the only read this surface makes. */
@@ -64,9 +68,19 @@ interface AgentSetupBrowserApi {
 }
 
 /** The production adapter: every call is the matching BrowserApi request, nothing more. */
-export function createHttpSetupAdapter(api: AgentSetupBrowserApi = browserApi): AgentSetupAdapter {
+export function createHttpSetupAdapter(
+  api: AgentSetupBrowserApi = browserApi,
+  queryClient?: QueryClient,
+): AgentSetupAdapter {
   return {
-    readSnapshot: (agentId) => api.agentSetup(agentId),
+    readSnapshot: (agentId) =>
+      queryClient
+        ? fetchSharedResource(queryClient, {
+            queryKey: queryKeys.agentSetup(agentId),
+            queryFn: () => api.agentSetup(agentId),
+            staleTime: 0,
+          })
+        : api.agentSetup(agentId),
     refreshPreparation: (agentId) => api.refreshAgentSetup(agentId),
     startFeishuAttempt: async (agentId, intent, expectedMessaging) => {
       await api.createFeishuSetupAttempt(agentId, intent, expectedMessaging);
@@ -84,6 +98,7 @@ export function createHttpSetupAdapter(api: AgentSetupBrowserApi = browserApi): 
     },
     unbindMessaging: async (agentId, provider, bindingId) => {
       await api.unbindAgentMessaging(agentId, { provider, bindingId });
+      if (queryClient) void syncAgentQueries(queryClient, agentId);
     },
   };
 }

--- a/apps/web/src/onboarding-v2/setup-adapter.ts
+++ b/apps/web/src/onboarding-v2/setup-adapter.ts
@@ -72,6 +72,21 @@ export function createHttpSetupAdapter(
   api: AgentSetupBrowserApi = browserApi,
   queryClient?: QueryClient,
 ): AgentSetupAdapter {
+  /*
+   * A write moves the resource an earlier snapshot described, so a snapshot GET begun before the
+   * write must not answer the read that follows it: the shared cache would otherwise hand the
+   * post-write read the pre-write request's promise. Retiring in-flight snapshot reads at the
+   * operation boundary makes the controller's next read a request that starts after the write,
+   * whether the write succeeded or the reader still needs the state the failure left behind.
+   * Reads begun within the same operation still share one in-flight GET, and nothing here
+   * invalidates — the page decides when the next read happens.
+   */
+  const retireSnapshotReads = async (agentId?: string): Promise<void> => {
+    if (!queryClient) return;
+    await queryClient.cancelQueries({
+      queryKey: agentId === undefined ? queryKeys.agentSetupRoot() : queryKeys.agentSetup(agentId),
+    });
+  };
   return {
     readSnapshot: (agentId) =>
       queryClient
@@ -81,23 +96,46 @@ export function createHttpSetupAdapter(
             staleTime: 0,
           })
         : api.agentSetup(agentId),
-    refreshPreparation: (agentId) => api.refreshAgentSetup(agentId),
+    refreshPreparation: async (agentId) => {
+      try {
+        await api.refreshAgentSetup(agentId);
+      } finally {
+        await retireSnapshotReads(agentId);
+      }
+    },
     startFeishuAttempt: async (agentId, intent, expectedMessaging) => {
-      await api.createFeishuSetupAttempt(agentId, intent, expectedMessaging);
+      try {
+        await api.createFeishuSetupAttempt(agentId, intent, expectedMessaging);
+      } finally {
+        await retireSnapshotReads(agentId);
+      }
     },
     cancelFeishuAttempt: async (attemptId) => {
-      await api.cancelFeishuSetupAttempt(attemptId);
+      try {
+        await api.cancelFeishuSetupAttempt(attemptId);
+      } finally {
+        // Attempts are keyed globally, so this seam never names an Agent; retire any setup read.
+        await retireSnapshotReads();
+      }
     },
     startSlackInstall: async (agentId, intent, expectedMessaging) => {
-      const started = await api.startSlackOAuth(agentId, {
-        intent,
-        returnSurface: "agent-setup",
-        expectedMessaging,
-      });
-      return started.authorizationUrl;
+      try {
+        const started = await api.startSlackOAuth(agentId, {
+          intent,
+          returnSurface: "agent-setup",
+          expectedMessaging,
+        });
+        return started.authorizationUrl;
+      } finally {
+        await retireSnapshotReads(agentId);
+      }
     },
     unbindMessaging: async (agentId, provider, bindingId) => {
-      await api.unbindAgentMessaging(agentId, { provider, bindingId });
+      try {
+        await api.unbindAgentMessaging(agentId, { provider, bindingId });
+      } finally {
+        await retireSnapshotReads(agentId);
+      }
       if (queryClient) void syncAgentQueries(queryClient, agentId);
     },
   };

--- a/apps/web/src/onboarding-v2/setup-completion-sync.test.tsx
+++ b/apps/web/src/onboarding-v2/setup-completion-sync.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * The completion boundary of Setup messaging: when a ready binding is observed, the shared Agent,
+ * binding, and handoff caches synchronize exactly once per completion, so a reader who returns
+ * home inside the 30s freshness window re-reads instead of trusting what was cached before Setup.
+ *
+ * The page drives the sync only on the production adapter; Lab and in-memory adapters keep their
+ * isolation from the real QueryClient.
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import { act, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderInRouter } from "../__tests__/support/router.js";
+import { browserApi } from "../api.js";
+import { useImBindingQuery } from "../features/agents/agent-queries.js";
+import { queryKeys } from "../query/keys.js";
+import { AgentSetupPage, SETUP_POLL_MS } from "./agent-setup-page.js";
+import { SETUP_AGENT_ID, setupAgent } from "./agent-setup-test-fixtures.js";
+import type { AgentSetupAdapter } from "./setup-adapter.js";
+import { createMemorySetupAdapter } from "./setup-memory-adapter.js";
+
+let client: ReturnType<typeof useQueryClient>;
+function Capture() {
+  client = useQueryClient();
+  return null;
+}
+
+/** The home binding consumer: reads the shared IM binding cache for the exact Agent. */
+function BindingProbe() {
+  const query = useImBindingQuery(SETUP_AGENT_ID);
+  return (
+    <output data-testid="binding">{query.isPending ? "loading" : query.data ? "connected" : "not connected"}</output>
+  );
+}
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < 20; index += 1) await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(10);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  client?.clear();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("Setup completion sync", () => {
+  it("synchronizes the Agent caches when authorization completes, before the reader returns home", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent() });
+    let connected = false;
+    const bindingRead = vi
+      .spyOn(browserApi, "imBinding")
+      .mockImplementation(async () => (connected ? { id: "bound-now", provider: "feishu" } : undefined) as never);
+    vi.spyOn(browserApi, "agentSetup").mockImplementation((id) => memory.adapter.readSnapshot(id));
+
+    const view = await renderInRouter(
+      <>
+        <Capture />
+        <BindingProbe />
+      </>,
+    );
+    await settle();
+    expect(screen.getByTestId("binding").textContent).toBe("not connected");
+
+    await memory.adapter.startFeishuAttempt(SETUP_AGENT_ID, "create", { kind: "unbound" });
+    const open = vi.fn();
+    view.rerender(
+      <>
+        <Capture />
+        <AgentSetupPage agentId={SETUP_AGENT_ID} onOpenAgent={open} />
+      </>,
+    );
+    await settle();
+    expect(screen.getByText("Waiting for you to scan…")).toBeTruthy();
+
+    memory.controls.scanFeishuCode();
+    memory.controls.completeHandoff();
+    connected = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SETUP_POLL_MS + 10);
+    });
+    await settle();
+    expect(memory.inspect().snapshot.stage).toBe("ready");
+
+    // The completion synced before any navigation: the binding cached as absent is already stale.
+    fireEvent.click(screen.getByRole("button", { name: "Open agent" }));
+    expect(open).toHaveBeenCalledTimes(1);
+    view.rerender(
+      <>
+        <Capture />
+        <BindingProbe />
+      </>,
+    );
+    await settle();
+    expect(screen.getByTestId("binding").textContent).toBe("connected");
+    expect(bindingRead).toHaveBeenCalledTimes(2);
+  });
+
+  it("syncs an already-ready first snapshot once, and not again for repeated snapshots of it", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent() });
+    await memory.adapter.startFeishuAttempt(SETUP_AGENT_ID, "create", { kind: "unbound" });
+    memory.controls.scanFeishuCode();
+    memory.controls.completeHandoff();
+    vi.spyOn(browserApi, "agentSetup").mockImplementation((id) => memory.adapter.readSnapshot(id));
+
+    const view = await renderInRouter(<Capture />);
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    view.rerender(
+      <>
+        <Capture />
+        <AgentSetupPage agentId={SETUP_AGENT_ID} />
+      </>,
+    );
+    await settle();
+
+    // One sync for the completion the return from authorization arrived at: the list root and the
+    // Agent's own prefix, nothing more.
+    expect(invalidate.mock.calls.map(([input]) => input?.queryKey)).toEqual([
+      queryKeys.agents.listRoot(),
+      queryKeys.agents.all(SETUP_AGENT_ID),
+    ]);
+
+    // Repeated reads of the same ready snapshot — focus returns inside the polling beat — never sync again.
+    for (let index = 0; index < 3; index += 1) {
+      act(() => window.dispatchEvent(new Event("focus")));
+      await settle();
+    }
+    expect(invalidate).toHaveBeenCalledTimes(2);
+  });
+
+  it("syncs again when a reauthorization completes on the same mounted page", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent() });
+    await memory.adapter.startFeishuAttempt(SETUP_AGENT_ID, "create", { kind: "unbound" });
+    memory.controls.scanFeishuCode();
+    memory.controls.completeHandoff();
+    vi.spyOn(browserApi, "agentSetup").mockImplementation((id) => memory.adapter.readSnapshot(id));
+
+    const view = await renderInRouter(<Capture />);
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    view.rerender(
+      <>
+        <Capture />
+        <AgentSetupPage agentId={SETUP_AGENT_ID} />
+      </>,
+    );
+    await settle();
+    expect(invalidate).toHaveBeenCalledTimes(2);
+
+    const prior = memory.inspect().snapshot.messaging;
+    if (prior.kind !== "ready") throw new Error("Expected ready messaging");
+    // Another authorization cycle can complete between two reads of the same mounted page, without
+    // the transitional state ever being shown.
+    await memory.adapter.startFeishuAttempt(SETUP_AGENT_ID, "reauthorize", {
+      kind: "bound",
+      provider: "feishu",
+      bindingId: prior.bindingId,
+      credentialGeneration: prior.credentialGeneration,
+    });
+    memory.controls.scanFeishuCode();
+    act(() => window.dispatchEvent(new Event("focus")));
+    await settle();
+
+    const current = memory.inspect().snapshot.messaging;
+    expect(current.kind).toBe("ready");
+    expect(current.kind === "ready" && current.credentialGeneration).toBe(prior.credentialGeneration + 1);
+    expect(invalidate).toHaveBeenCalledTimes(4);
+
+    // The second completion synced once: further snapshots of it do not repeat the sync.
+    act(() => window.dispatchEvent(new Event("focus")));
+    await settle();
+    expect(invalidate).toHaveBeenCalledTimes(4);
+  });
+
+  it("syncs the completed messaging evidence even when the Computer is offline and the stage is not ready", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent() });
+    let connected = false;
+    const bindingRead = vi
+      .spyOn(browserApi, "imBinding")
+      .mockImplementation(async () => (connected ? { id: "bound-now", provider: "feishu" } : undefined) as never);
+    vi.spyOn(browserApi, "agentSetup").mockImplementation((id) => memory.adapter.readSnapshot(id));
+
+    const view = await renderInRouter(
+      <>
+        <Capture />
+        <BindingProbe />
+      </>,
+    );
+    await settle();
+    expect(screen.getByTestId("binding").textContent).toBe("not connected");
+
+    await memory.adapter.startFeishuAttempt(SETUP_AGENT_ID, "create", { kind: "unbound" });
+    view.rerender(
+      <>
+        <Capture />
+        <AgentSetupPage agentId={SETUP_AGENT_ID} />
+      </>,
+    );
+    await settle();
+
+    memory.controls.scanFeishuCode();
+    memory.controls.completeHandoff();
+    connected = true;
+    memory.controls.setComputerOnline(false);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SETUP_POLL_MS + 10);
+    });
+    await settle();
+    expect(memory.inspect().snapshot.messaging.kind).toBe("ready");
+    expect(memory.inspect().snapshot.stage).not.toBe("ready");
+
+    view.rerender(
+      <>
+        <Capture />
+        <BindingProbe />
+      </>,
+    );
+    await settle();
+    expect(screen.getByTestId("binding").textContent).toBe("connected");
+    expect(bindingRead).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the shared caches alone on a custom adapter, preserving Lab isolation", async () => {
+    const memory = createMemorySetupAdapter({ agent: setupAgent() });
+    await memory.adapter.startFeishuAttempt(SETUP_AGENT_ID, "create", { kind: "unbound" });
+    memory.controls.scanFeishuCode();
+    memory.controls.completeHandoff();
+    const adapter: AgentSetupAdapter = memory.adapter;
+
+    const view = await renderInRouter(<Capture />);
+    await settle();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    view.rerender(
+      <>
+        <Capture />
+        <AgentSetupPage adapter={adapter} agentId={SETUP_AGENT_ID} />
+      </>,
+    );
+    await settle();
+    expect(screen.getByText(/is ready\./)).toBeTruthy();
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/onboarding-v2/setup-computer-sync.test.tsx
+++ b/apps/web/src/onboarding-v2/setup-computer-sync.test.tsx
@@ -1,0 +1,85 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { renderInRouter } from "../__tests__/support/router.js";
+import { browserApi } from "../api.js";
+import { useAgentDetailView } from "../features/agents/agent-queries.js";
+import { queryKeys } from "../query/keys.js";
+import { AgentSetupPage } from "./agent-setup-page.js";
+import {
+  SETUP_AGENT_ID,
+  SETUP_COMPUTER_ID,
+  SETUP_NOW,
+  SETUP_USER_ID,
+  setupAgent,
+} from "./agent-setup-test-fixtures.js";
+import { createMemorySetupAdapter } from "./setup-memory-adapter.js";
+
+let client: ReturnType<typeof useQueryClient>;
+function Capture() {
+  client = useQueryClient();
+  return null;
+}
+function HomeComputerProbe() {
+  const state = useAgentDetailView(SETUP_AGENT_ID, { accountId: SETUP_USER_ID });
+  return <output>{state.kind === "ready" ? (state.value.computer?.computerId ?? "no computer") : state.kind}</output>;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+it("binding a Computer in setup makes the next home view read the updated Agent binding", async () => {
+  let bound = false;
+  const waiting = createMemorySetupAdapter({ agent: setupAgent({ computer: null }) });
+  const connected = createMemorySetupAdapter({ agent: setupAgent() });
+  vi.spyOn(browserApi, "agentSetup").mockImplementation((id) => (bound ? connected : waiting).adapter.readSnapshot(id));
+  vi.spyOn(browserApi, "computers").mockImplementation(async () => ({
+    computers: [
+      {
+        computerId: SETUP_COMPUTER_ID,
+        displayName: "Review Mac",
+        platform: "darwin",
+        connectionStatus: "online",
+        providerReadiness: [{ provider: "codex", status: "ready", observedAt: SETUP_NOW }],
+        connectedAt: SETUP_NOW,
+        lastSeenAt: SETUP_NOW,
+        observedAt: SETUP_NOW,
+        createdAt: SETUP_NOW,
+        agentIds: bound ? [SETUP_AGENT_ID] : [],
+      },
+    ],
+  }));
+  const bind = vi.spyOn(browserApi, "rebindAgentComputer").mockImplementation(async () => {
+    bound = true;
+    return {} as never;
+  });
+  vi.spyOn(browserApi, "refreshAgentSetup").mockResolvedValue(undefined);
+  vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
+  vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
+  const list = () => ({
+    agents: [
+      {
+        ...setupAgent(bound ? {} : { computer: null }),
+        activity: { state: "idle" as const },
+        usage: { windowDays: 30 as const, tasks: 0, failed: 0, tokens: 0 },
+      },
+    ],
+  });
+  vi.spyOn(browserApi, "agents").mockImplementation(async () => list());
+  const view = await renderInRouter(<Capture />);
+  client.setQueryData(queryKeys.agents.list(SETUP_USER_ID), list());
+  view.rerender(
+    <>
+      <Capture />
+      <AgentSetupPage agentId={SETUP_AGENT_ID} />
+    </>,
+  );
+  await waitFor(() => expect(bind).toHaveBeenCalledWith(SETUP_AGENT_ID, SETUP_COMPUTER_ID));
+  await waitFor(() => expect(vi.mocked(browserApi.agentSetup).mock.calls.length).toBeGreaterThanOrEqual(2));
+  view.rerender(
+    <>
+      <Capture />
+      <HomeComputerProbe />
+    </>,
+  );
+  expect(await screen.findByText(SETUP_COMPUTER_ID)).toBeTruthy();
+});

--- a/apps/web/src/onboarding-v2/setup-operation-boundary.test.tsx
+++ b/apps/web/src/onboarding-v2/setup-operation-boundary.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * The operation boundary of the shared Setup read transport.
+ *
+ * The default HTTP adapter reads the canonical snapshot through the shared QueryClient so
+ * concurrent readers share one in-flight GET. A write moves the state an earlier snapshot
+ * described, so a GET begun before the write must never answer the read that follows it: the
+ * adapter retires in-flight snapshot reads at every operation boundary, and the controller's
+ * post-write read starts its own request after the write.
+ */
+
+import type { AgentSetupSnapshot } from "@opentag/shared/browser";
+import { useQueryClient } from "@tanstack/react-query";
+import { act, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { renderInRouter } from "../__tests__/support/router.js";
+import { ApiError, browserApi } from "../api.js";
+import { createQueryClient } from "../query/client.js";
+import { queryKeys } from "../query/keys.js";
+import { AgentSetupPage, SETUP_POLL_MS } from "./agent-setup-page.js";
+import { deferred, SETUP_AGENT_ID, setupAgent } from "./agent-setup-test-fixtures.js";
+import { createHttpSetupAdapter } from "./setup-adapter.js";
+import { createMemorySetupAdapter } from "./setup-memory-adapter.js";
+
+let client: ReturnType<typeof useQueryClient>;
+function Capture() {
+  client = useQueryClient();
+  return null;
+}
+
+/** Flushes the promise queue and the short timers the controller schedules around a beat. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < 20; index += 1) await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(10);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  client?.clear();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+it("starts the post-write read after an authorization write instead of adopting the pre-write focus read", async () => {
+  const memory = createMemorySetupAdapter({ agent: setupAgent() });
+  const before = await memory.adapter.readSnapshot(SETUP_AGENT_ID);
+  const preWrite = deferred<AgentSetupSnapshot>();
+  const get = vi
+    .spyOn(browserApi, "agentSetup")
+    .mockResolvedValueOnce(before)
+    .mockImplementationOnce(() => preWrite.promise)
+    .mockImplementation((id) => memory.adapter.readSnapshot(id));
+  const post = vi.spyOn(browserApi, "createFeishuSetupAttempt").mockImplementation(async (id, intent, expected) => {
+    if (!intent || !expected) throw new Error("The start action always names its intent and expected messaging");
+    await memory.adapter.startFeishuAttempt(id, intent, expected);
+    return {} as never;
+  });
+
+  const view = await renderInRouter(<Capture />);
+  view.rerender(
+    <>
+      <Capture />
+      <AgentSetupPage agentId={SETUP_AGENT_ID} />
+    </>,
+  );
+  await settle();
+  fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  await settle();
+  expect(screen.getByRole("button", { name: /Lark/ })).toBeTruthy();
+
+  // The window returning to view starts a slow snapshot GET that is still in flight when the write lands.
+  act(() => window.dispatchEvent(new Event("focus")));
+  await settle();
+  expect(get).toHaveBeenCalledTimes(2);
+
+  fireEvent.click(screen.getByRole("button", { name: /Lark/ }));
+  await settle();
+  expect(post).toHaveBeenCalledTimes(1);
+  // The read that follows the write is its own request, begun after the write — not the pre-write GET.
+  expect(get).toHaveBeenCalledTimes(3);
+  expect(screen.queryByText("Waiting for you to scan…")).not.toBeNull();
+
+  // The retired pre-write answer lands late and must not bury the authorizing snapshot or the beat.
+  preWrite.resolve(before);
+  await settle();
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(SETUP_POLL_MS * 3);
+  });
+  expect(screen.queryByText("Waiting for you to scan…")).not.toBeNull();
+  expect(get.mock.calls.length).toBeGreaterThan(3);
+});
+
+it("starts the post-write read after a cancel instead of republishing the pre-write poll read", async () => {
+  const memory = createMemorySetupAdapter({ agent: setupAgent() });
+  await memory.adapter.startFeishuAttempt(SETUP_AGENT_ID, "create", { kind: "unbound" });
+  const authorizing = await memory.adapter.readSnapshot(SETUP_AGENT_ID);
+  const preWrite = deferred<AgentSetupSnapshot>();
+  const get = vi
+    .spyOn(browserApi, "agentSetup")
+    .mockResolvedValueOnce(authorizing)
+    .mockImplementationOnce(() => preWrite.promise)
+    .mockImplementation((id) => memory.adapter.readSnapshot(id));
+  const cancel = vi.spyOn(browserApi, "cancelFeishuSetupAttempt").mockImplementation(async (attemptId) => {
+    await memory.adapter.cancelFeishuAttempt(attemptId);
+    return {} as never;
+  });
+
+  const view = await renderInRouter(<Capture />);
+  view.rerender(
+    <>
+      <Capture />
+      <AgentSetupPage agentId={SETUP_AGENT_ID} />
+    </>,
+  );
+  await settle();
+  expect(screen.getByText("Waiting for you to scan…")).toBeTruthy();
+
+  // The 2s beat starts a slow snapshot GET that is still in flight when the cancel lands.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(SETUP_POLL_MS);
+  });
+  expect(get).toHaveBeenCalledTimes(2);
+
+  fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+  await settle();
+  expect(cancel).toHaveBeenCalledTimes(1);
+  expect(get).toHaveBeenCalledTimes(3);
+  expect(screen.queryByText("Waiting for you to scan…")).toBeNull();
+
+  // The retired pre-cancel answer must not bring the QR back once it lands.
+  preWrite.resolve(authorizing);
+  await settle();
+  expect(screen.queryByText("Waiting for you to scan…")).toBeNull();
+});
+
+it("shares one in-flight read within an operation and retires it at the write boundary", async () => {
+  const queryClient = createQueryClient();
+  const memory = createMemorySetupAdapter({ agent: setupAgent() });
+  const slow = deferred<AgentSetupSnapshot>();
+  const get = vi
+    .spyOn(browserApi, "agentSetup")
+    .mockImplementationOnce(() => slow.promise)
+    .mockImplementation((id) => memory.adapter.readSnapshot(id));
+  const refresh = vi.spyOn(browserApi, "refreshAgentSetup").mockResolvedValue(undefined);
+  const adapter = createHttpSetupAdapter(browserApi, queryClient);
+
+  // Ordinary reuse: two readers of the same key share the GET that is already in the air.
+  const first = adapter.readSnapshot(SETUP_AGENT_ID);
+  const firstShared = adapter.readSnapshot(SETUP_AGENT_ID);
+  expect(get).toHaveBeenCalledTimes(1);
+
+  // The operation boundary: an explicit refresh retires the pre-write read, so the controller's
+  // next read starts its own GET after the write.
+  await adapter.refreshPreparation(SETUP_AGENT_ID);
+  expect(refresh).toHaveBeenCalledTimes(1);
+  const second = adapter.readSnapshot(SETUP_AGENT_ID);
+  expect(get).toHaveBeenCalledTimes(2);
+  await expect(second).resolves.toEqual(await memory.adapter.readSnapshot(SETUP_AGENT_ID));
+
+  // The retired read's late answer is fenced: its callers are cancelled and the cache keeps the
+  // post-write snapshot.
+  await expect(first).rejects.toThrow();
+  await expect(firstShared).rejects.toThrow();
+  const current = await memory.adapter.readSnapshot(SETUP_AGENT_ID);
+  slow.resolve({ ...current, stage: "needs-computer" });
+  await Promise.resolve();
+  expect(queryClient.getQueryData(queryKeys.agentSetup(SETUP_AGENT_ID))).toEqual(current);
+  expect(get).toHaveBeenCalledTimes(2);
+});
+
+it("starts a post-write snapshot after binding an owned Computer while an old read is in flight", async () => {
+  const seededInventory = await createMemorySetupAdapter({ agent: setupAgent() }).computerAdapter.inventory.computers();
+  const inventory = { computers: [...seededInventory.computers] };
+  const memory = createMemorySetupAdapter({
+    agent: setupAgent({ computer: null }),
+    computers: inventory.computers,
+  });
+  const before = await memory.adapter.readSnapshot(SETUP_AGENT_ID);
+  const preWrite = deferred<AgentSetupSnapshot>();
+  const inventoryGate = deferred<typeof inventory>();
+  const get = vi
+    .spyOn(browserApi, "agentSetup")
+    .mockResolvedValueOnce(before)
+    .mockImplementationOnce(() => preWrite.promise)
+    .mockImplementation((id) => memory.adapter.readSnapshot(id));
+  vi.spyOn(browserApi, "computers")
+    .mockImplementationOnce(() => inventoryGate.promise)
+    .mockImplementation(async () => {
+      const current = await memory.computerAdapter.inventory.computers();
+      return { computers: [...current.computers] };
+    });
+  const bind = vi.spyOn(browserApi, "rebindAgentComputer").mockImplementation(async (id, computerId) => {
+    await memory.computerAdapter.inventory.bindComputer(id, computerId);
+    const agent = memory.inspect().snapshot.agent;
+    return {
+      id: agent.id,
+      name: agent.name,
+      displayName: agent.displayName,
+      runtimeProvider: agent.runtimeProvider,
+      receiveMode: agent.receiveMode,
+      status: agent.status,
+      createdAt: agent.createdAt,
+      updatedAt: agent.updatedAt,
+      createdByUserId: agent.createdBy.userId,
+      computerId,
+      revision: 1,
+      runtimeConfig: { revision: 1, model: null, reasoningEffort: null, instructions: "", maxDurationMs: null },
+    };
+  });
+  await renderInRouter(
+    <>
+      <Capture />
+      <AgentSetupPage agentId={SETUP_AGENT_ID} />
+    </>,
+  );
+  await settle();
+  expect(get).toHaveBeenCalledTimes(1);
+  expect(bind).not.toHaveBeenCalled();
+
+  act(() => window.dispatchEvent(new Event("focus")));
+  await settle();
+  expect(get).toHaveBeenCalledTimes(2);
+  inventoryGate.resolve(inventory);
+  await settle();
+  expect(bind).toHaveBeenCalledTimes(1);
+  expect(memory.inspect().snapshot.computer.kind).toBe("bound");
+  expect(get).toHaveBeenCalledTimes(3);
+
+  preWrite.resolve(before);
+  await settle();
+  expect(screen.getByRole("heading", { name: "Prepare this computer" })).toBeTruthy();
+  expect(client.getQueryData<AgentSetupSnapshot>(queryKeys.agentSetup(SETUP_AGENT_ID))?.computer.kind).toBe("bound");
+});
+
+it("keeps mutation error behavior: a refused write surfaces and the next read still asks", async () => {
+  const queryClient = createQueryClient();
+  const memory = createMemorySetupAdapter({ agent: setupAgent() });
+  const get = vi.spyOn(browserApi, "agentSetup").mockImplementation((id) => memory.adapter.readSnapshot(id));
+  vi.spyOn(browserApi, "createFeishuSetupAttempt").mockRejectedValue(new ApiError(409, "IM_BINDING_UNBIND_REQUIRED"));
+  const adapter = createHttpSetupAdapter(browserApi, queryClient);
+
+  await expect(adapter.startFeishuAttempt(SETUP_AGENT_ID, "create", { kind: "unbound" })).rejects.toBeInstanceOf(
+    ApiError,
+  );
+  await expect(adapter.readSnapshot(SETUP_AGENT_ID)).resolves.toEqual(
+    await memory.adapter.readSnapshot(SETUP_AGENT_ID),
+  );
+  expect(get).toHaveBeenCalledTimes(1);
+});

--- a/apps/web/src/query/agent-sync.ts
+++ b/apps/web/src/query/agent-sync.ts
@@ -1,0 +1,39 @@
+import type { ListAgentsResponse } from "@opentag/shared/browser";
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./keys.js";
+
+/**
+ * One completion path after an Agent write. Child surfaces must not also invalidate a nested key
+ * they already covered: overlapping invalidations cancel the in-flight read they just started.
+ */
+export async function syncAgentQueries(
+  queryClient: QueryClient,
+  agentId: string,
+  options: { readonly computers?: boolean } = {},
+): Promise<void> {
+  const jobs = [
+    queryClient.invalidateQueries({ queryKey: queryKeys.agents.listRoot() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.agents.all(agentId) }),
+  ];
+  if (options.computers) {
+    jobs.push(queryClient.invalidateQueries({ queryKey: queryKeys.computers() }));
+  }
+  await Promise.all(jobs);
+}
+
+/**
+ * Drops a deleted Agent from cached lists without treating the remaining rows as a fresh Server
+ * read. `setQueriesData` would bump `dataUpdatedAt` and let an unchanged peer overrule a newer
+ * per-ID result.
+ */
+export function evictAgentFromLists(queryClient: QueryClient, agentId: string): void {
+  for (const query of queryClient.getQueryCache().findAll({ queryKey: queryKeys.agents.listRoot() })) {
+    const current = query.state.data as ListAgentsResponse | undefined;
+    if (!current) continue;
+    queryClient.setQueryData(
+      query.queryKey,
+      { ...current, agents: current.agents.filter((item) => item.id !== agentId) },
+      { updatedAt: query.state.dataUpdatedAt },
+    );
+  }
+}

--- a/apps/web/src/query/client.ts
+++ b/apps/web/src/query/client.ts
@@ -1,4 +1,5 @@
 import { focusManager, QueryClient } from "@tanstack/react-query";
+import { attachSessionCache } from "./session-cache.js";
 
 /*
  * The cache watches only `visibilitychange` on its own, which fires when a tab is switched but not
@@ -27,25 +28,25 @@ focusManager.setEventListener((handleFocus) => {
  * A silent retry would also hide the first failure of a refresh the caller is waiting on, which is
  * the failure a page has to report.
  *
- * `refetchOnWindowFocus` is off by default and opted into per call site. Only the pages that watch a
- * resource recover — the Agent list, an Agent's detail and settings, and the Computer list behind
- * Agent creation — want a focus to re-read; the rest would be asking the Server for something the
- * Account did not ask to see again.
+ * `refetchOnWindowFocus` is off by default. Ordinary live resources opt in per call site with an
+ * explicit freshness window; configuration, `/me`, and internal previews stay event-driven.
  */
 export function createQueryClient(): QueryClient {
   const isTest = import.meta.env.MODE === "test";
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        // Matches the hook this replaced: a resource is stale as soon as it is read, so mounting a
-        // page always re-reads it, while an already-mounted observer keeps serving what it holds.
-        staleTime: 0,
-        retry: false,
-        refetchOnWindowFocus: false,
-        // A test never simulates coming back online, so subscribing to it only invites a fetch no
-        // test asked for.
-        refetchOnReconnect: !isTest,
+  return attachSessionCache(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          // Live resources override this. Everything else stays stale immediately so a mount that
+          // is not sharing a watched key still re-reads, matching the previous client-wide default.
+          staleTime: 0,
+          retry: false,
+          refetchOnWindowFocus: false,
+          // A test never simulates coming back online, so subscribing to it only invites a fetch no
+          // test asked for. Live resources opt back in explicitly.
+          refetchOnReconnect: !isTest,
+        },
       },
-    },
-  });
+    }),
+  );
 }

--- a/apps/web/src/query/keys.ts
+++ b/apps/web/src/query/keys.ts
@@ -14,6 +14,8 @@ export const queryKeys = {
   internalNavigationVisibility: () => ["internalNavigationVisibility"] as const,
   /** The Account's Computers. The request takes no argument — the Server scopes it to the session. */
   computers: () => ["computers"] as const,
+  computerConnectCode: (connectCodeId: string) => ["computerConnectCodes", connectCodeId] as const,
+  agentSetup: (agentId: string) => ["agentSetup", agentId] as const,
 
   agents: {
     listRoot: () => ["agents", "list"] as const,

--- a/apps/web/src/query/keys.ts
+++ b/apps/web/src/query/keys.ts
@@ -16,6 +16,8 @@ export const queryKeys = {
   computers: () => ["computers"] as const,
   computerConnectCode: (connectCodeId: string) => ["computerConnectCodes", connectCodeId] as const,
   agentSetup: (agentId: string) => ["agentSetup", agentId] as const,
+  /** Every Setup snapshot read, for a write that must retire whichever one is still in flight. */
+  agentSetupRoot: () => ["agentSetup"] as const,
 
   agents: {
     listRoot: () => ["agents", "list"] as const,

--- a/apps/web/src/query/live-resources.test.tsx
+++ b/apps/web/src/query/live-resources.test.tsx
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderInRouter } from "../__tests__/support/router.js";
 import { ApiError, browserApi } from "../api.js";
 import { AgentUsageOverview, AgentUsageTab } from "../features/agent-usage.js";
-import { useAgentListView, useComputersQuery } from "../features/agents/agent-queries.js";
+import { useAgentDetailView, useAgentListView, useComputersQuery } from "../features/agents/agent-queries.js";
 import { AgentTasksSection, TaskDetailPage, TasksPage } from "../features/tasks-page.js";
 import { syncAgentQueries } from "./agent-sync.js";
 import { createQueryClient } from "./client.js";
@@ -147,6 +147,32 @@ function EnrichedListProbe() {
   const state = useAgentListView(accountId);
   return <span data-testid="summary">{state.kind}</span>;
 }
+
+function DetailStateProbe() {
+  const state = useAgentDetailView(agentId, { watched: true, accountId });
+  return <output data-testid="detail-state">{state.kind}</output>;
+}
+
+function DetailNameProbe() {
+  const state = useAgentDetailView(agentId, { watched: true, accountId });
+  return <output data-testid="detail-name">{state.kind === "ready" ? state.value.displayName : state.kind}</output>;
+}
+
+/** Evidence reads the detail view waits on before it can present anything. */
+function stubDetailEvidence() {
+  vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [computer] });
+  vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
+  vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
+}
+
+/** A read that never settles, guarding against fetches the scenario must not make. */
+function neverResolves<T>(): Promise<T> {
+  return new Promise<T>(() => undefined);
+}
+
+const summaryListResult = {
+  agents: [{ ...agentDetail, usage: { windowDays: 30 as const, tasks: 7, failed: 0, tokens: 100_000 } }],
+};
 
 afterEach(() => {
   vi.useRealTimers();
@@ -550,6 +576,273 @@ describe("task and usage live revalidation", () => {
       </>,
     );
     await waitFor(() => expect(screen.queryByText(completedTask.title)).toBeNull());
+  });
+});
+
+describe("home usage summary resilience", () => {
+  it("keeps the displayed totals with a refresh notice when the list refresh fails and the fallback is pending", async () => {
+    vi.spyOn(browserApi, "agents")
+      .mockResolvedValueOnce(summaryListResult)
+      .mockRejectedValue(new ApiError(503, "List temporarily unavailable"));
+    const usageRead = vi.spyOn(browserApi, "agentUsage").mockImplementation(() => neverResolves<AgentUsageDetail>());
+    await renderInRouter(
+      <>
+        <AgentUsageOverview accountId={accountId} agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText("100K")).toBeTruthy();
+    expect(usageRead).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.agents.list(accountId) });
+    });
+
+    // The full read stands in behind the retained summary: the totals and the notice stay while it is pending.
+    await waitFor(() => expect(usageRead).toHaveBeenCalledTimes(1));
+    expect(
+      currentClient.getQueryData<typeof summaryListResult>(queryKeys.agents.list(accountId))?.agents[0]?.usage.tokens,
+    ).toBe(100_000);
+    expect(screen.queryByText("100K")).not.toBeNull();
+    expect(screen.queryByText("Update failed. Showing last available data.")).not.toBeNull();
+  });
+
+  it("keeps the displayed totals when the list refresh and the fallback read both fail transiently", async () => {
+    vi.spyOn(browserApi, "agents")
+      .mockResolvedValueOnce(summaryListResult)
+      .mockRejectedValue(new ApiError(503, "List temporarily unavailable"));
+    const usageRead = vi
+      .spyOn(browserApi, "agentUsage")
+      .mockRejectedValue(new ApiError(503, "Usage temporarily unavailable"));
+    await renderInRouter(
+      <>
+        <AgentUsageOverview accountId={accountId} agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText("100K")).toBeTruthy();
+
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.agents.list(accountId) });
+    });
+
+    await waitFor(() => expect(usageRead).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(currentClient.getQueryState(queryKeys.agents.usage(agentId, 30))?.status).toBe("error"));
+    expect(screen.queryByText("100K")).not.toBeNull();
+    expect(screen.queryByText("Update failed. Showing last available data.")).not.toBeNull();
+  });
+
+  it("withdraws the totals when the list answer turns terminal and lets the full read decide", async () => {
+    vi.spyOn(browserApi, "agents")
+      .mockResolvedValueOnce(summaryListResult)
+      .mockRejectedValue(new ApiError(403, "List access removed"));
+    const usageRead = vi.spyOn(browserApi, "agentUsage").mockImplementation(() => neverResolves<AgentUsageDetail>());
+    await renderInRouter(
+      <>
+        <AgentUsageOverview accountId={accountId} agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText("100K")).toBeTruthy();
+
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.agents.list(accountId) });
+    });
+
+    // A terminal refusal of the list itself is not a transient loss of contact: the summary is
+    // withdrawn and the fallback full read owns what happens next.
+    await waitFor(() => expect(usageRead).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText("100K")).toBeNull();
+  });
+});
+
+describe("observation order arbitrates success against refusal", () => {
+  it("a same-millisecond usage refusal withdraws the data it answered", async () => {
+    const realNow = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(realNow);
+    const view = await renderInRouter(<CaptureClient />);
+    const key = queryKeys.agents.usage(agentId, 30);
+    await currentClient.fetchQuery({ queryKey: key, queryFn: async () => usage });
+    await currentClient
+      .fetchQuery({
+        queryKey: key,
+        queryFn: async () => {
+          throw new ApiError(403, "Usage access removed");
+        },
+      })
+      .catch(() => undefined);
+    vi.spyOn(browserApi, "agentUsage").mockRejectedValue(new ApiError(503, "Still unavailable"));
+    view.rerender(
+      <>
+        <CaptureClient />
+        <AgentUsageOverview agentId={agentId} />
+      </>,
+    );
+    expect(await screen.findByText("Usage access removed")).toBeTruthy();
+    expect(screen.queryByText("428K")).toBeNull();
+  });
+
+  it("a same-millisecond Agent refusal outranks the list row observed before it", async () => {
+    const realNow = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(realNow);
+    const view = await renderInRouter(<CaptureClient />);
+    await currentClient.fetchQuery({
+      queryKey: queryKeys.agents.list(accountId),
+      queryFn: async () => summaryListResult,
+    });
+    await currentClient
+      .fetchQuery({
+        queryKey: queryKeys.agents.detail(agentId),
+        queryFn: async () => {
+          throw new ApiError(403, "Agent access removed");
+        },
+      })
+      .catch(() => undefined);
+    vi.spyOn(browserApi, "agents").mockResolvedValue(summaryListResult);
+    vi.spyOn(browserApi, "agent").mockRejectedValue(new ApiError(503, "Still unavailable"));
+    stubDetailEvidence();
+    view.rerender(
+      <>
+        <CaptureClient />
+        <DetailStateProbe />
+      </>,
+    );
+    await waitFor(() => expect(screen.getByTestId("detail-state").textContent).not.toBe("loading"));
+    expect(screen.getByTestId("detail-state").textContent).toBe("error");
+  });
+
+  it.each([
+    { source: "list" as const, delta: 0 },
+    { source: "detail" as const, delta: 0 },
+    { source: "list" as const, delta: -1_000 },
+    { source: "detail" as const, delta: -1_000 },
+  ])(
+    "a genuinely later Agent read recovers the refusal in observation order (source=$source, clock delta=$delta)",
+    async ({ source, delta }) => {
+      const realNow = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(realNow);
+      const view = await renderInRouter(<CaptureClient />);
+      const listKey = queryKeys.agents.list(accountId);
+      const detailKey = queryKeys.agents.detail(agentId);
+      await currentClient.fetchQuery({ queryKey: listKey, queryFn: async () => summaryListResult });
+      await currentClient
+        .fetchQuery({
+          queryKey: detailKey,
+          queryFn: async () => {
+            throw new ApiError(403, "Denied");
+          },
+        })
+        .catch(() => undefined);
+      // The recovery read may share the refusal's millisecond or carry an earlier wall-clock time;
+      // being observed later is what makes it authoritative. After a backwards clock move the
+      // cached row looks fresh to staleTime, so the recovery read is forced explicitly.
+      clock.mockReturnValue(realNow + delta);
+      const recovered = { ...agentDetail, displayName: "Recovered" };
+      if (source === "list") {
+        await currentClient.invalidateQueries({ queryKey: listKey, refetchType: "none" });
+        await currentClient.fetchQuery({
+          queryKey: listKey,
+          queryFn: async () => ({ agents: [{ ...recovered, usage: summaryListResult.agents[0]?.usage }] }),
+          staleTime: 0,
+        });
+      } else {
+        await currentClient.fetchQuery({ queryKey: detailKey, queryFn: async () => recovered, staleTime: 0 });
+      }
+      vi.spyOn(browserApi, "agents").mockImplementation(() => neverResolves());
+      vi.spyOn(browserApi, "agent").mockImplementation(() => neverResolves());
+      stubDetailEvidence();
+      view.rerender(
+        <>
+          <CaptureClient />
+          <DetailNameProbe />
+        </>,
+      );
+      await waitFor(() => expect(screen.getByTestId("detail-name").textContent).toBe("Recovered"));
+    },
+  );
+
+  it.each([
+    { source: "list" as const, delta: 0 },
+    { source: "detail" as const, delta: 0 },
+    { source: "list" as const, delta: -1_000 },
+    { source: "detail" as const, delta: -1_000 },
+  ])(
+    "a genuinely later usage answer recovers the refusal in observation order (source=$source, clock delta=$delta)",
+    async ({ source, delta }) => {
+      const realNow = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(realNow);
+      const view = await renderInRouter(<CaptureClient />);
+      const listKey = queryKeys.agents.list(accountId);
+      const usageKey = queryKeys.agents.usage(agentId, 30);
+      await currentClient.fetchQuery({ queryKey: listKey, queryFn: async () => summaryListResult });
+      await currentClient
+        .fetchQuery({
+          queryKey: usageKey,
+          queryFn: async () => {
+            throw new ApiError(403, "Denied");
+          },
+        })
+        .catch(() => undefined);
+      clock.mockReturnValue(realNow + delta);
+      const recoveredAgent = summaryListResult.agents[0];
+      if (!recoveredAgent) throw new Error("Expected the fixture Agent");
+      const recoveredSummary = {
+        agents: [{ ...recoveredAgent, usage: { windowDays: 30 as const, tasks: 7, failed: 0, tokens: 777_000 } }],
+      };
+      if (source === "list") {
+        await currentClient.invalidateQueries({ queryKey: listKey, refetchType: "none" });
+        await currentClient.fetchQuery({ queryKey: listKey, queryFn: async () => recoveredSummary, staleTime: 0 });
+      } else {
+        await currentClient.fetchQuery({ queryKey: usageKey, queryFn: async () => usage, staleTime: 0 });
+      }
+      vi.spyOn(browserApi, "agents").mockImplementation(() => neverResolves());
+      vi.spyOn(browserApi, "agentUsage").mockImplementation(() => neverResolves());
+      view.rerender(
+        <>
+          <CaptureClient />
+          <AgentUsageOverview accountId={accountId} agentId={agentId} />
+        </>,
+      );
+      expect(await screen.findByText(source === "list" ? "777K" : "428K")).toBeTruthy();
+    },
+  );
+
+  it.each(["agent", "usage"] as const)("a manual list write cannot resurrect a refused %s", async (resource) => {
+    const realNow = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(realNow);
+    const view = await renderInRouter(<CaptureClient />);
+    const listKey = queryKeys.agents.list(accountId);
+    const detailKey = resource === "agent" ? queryKeys.agents.detail(agentId) : queryKeys.agents.usage(agentId, 30);
+    await currentClient.fetchQuery({ queryKey: listKey, queryFn: async () => summaryListResult });
+    clock.mockReturnValue(realNow + 1);
+    await currentClient
+      .fetchQuery({
+        queryKey: detailKey,
+        queryFn: async () => {
+          throw new ApiError(403, "Denied");
+        },
+      })
+      .catch(() => undefined);
+    // A write the Server never answered keeps its payload's claimed time but no observation order:
+    // it cannot promote the cached list over the refusal, whatever the wall clock says.
+    clock.mockReturnValue(realNow + 2);
+    currentClient.setQueryData(listKey, { ...summaryListResult });
+    vi.spyOn(browserApi, "agents").mockImplementation(() => neverResolves());
+    vi.spyOn(browserApi, "agent").mockImplementation(() => neverResolves());
+    vi.spyOn(browserApi, "agentUsage").mockImplementation(() => neverResolves());
+    stubDetailEvidence();
+    view.rerender(
+      <>
+        <CaptureClient />
+        {resource === "agent" ? <DetailStateProbe /> : <AgentUsageOverview accountId={accountId} agentId={agentId} />}
+      </>,
+    );
+    if (resource === "agent") {
+      await waitFor(() => expect(screen.getByTestId("detail-state").textContent).toBe("error"));
+    } else {
+      expect(await screen.findByText("Denied")).toBeTruthy();
+      expect(screen.queryByText("100K")).toBeNull();
+    }
   });
 });
 

--- a/apps/web/src/query/live-resources.test.tsx
+++ b/apps/web/src/query/live-resources.test.tsx
@@ -1,0 +1,602 @@
+import type {
+  AccountComputerSummary,
+  AgentDetail,
+  AgentUsageDetail,
+  TaskDetail,
+  TaskSummary,
+} from "@opentag/shared/browser";
+import { onlineManager, useQueryClient } from "@tanstack/react-query";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderInRouter } from "../__tests__/support/router.js";
+import { ApiError, browserApi } from "../api.js";
+import { AgentUsageOverview, AgentUsageTab } from "../features/agent-usage.js";
+import { useAgentListView, useComputersQuery } from "../features/agents/agent-queries.js";
+import { AgentTasksSection, TaskDetailPage, TasksPage } from "../features/tasks-page.js";
+import { syncAgentQueries } from "./agent-sync.js";
+import { createQueryClient } from "./client.js";
+import { queryKeys } from "./keys.js";
+import { LIVE_REFETCH_INTERVAL_MS } from "./live.js";
+import { fetchSharedResource } from "./session-cache.js";
+
+const accountId = "0b9c8d7e-6f50-4a1b-8c2d-3e4f50617283";
+const agentId = "3f1d3a2c-1f2e-4a1b-9c3d-5e6f70819a2b";
+const sessionId = "11111111-1111-4111-8111-111111111111";
+const computerId = "8c2b1d4e-5a6f-4b7c-8d9e-0f1a2b3c4d5e";
+
+const computer: AccountComputerSummary = {
+  computerId,
+  displayName: "Ada's Mac",
+  platform: "darwin",
+  connectionStatus: "online",
+  providerReadiness: [{ provider: "codex", status: "ready", observedAt: "2026-08-20T00:00:00.000Z" }],
+  connectedAt: "2026-08-20T00:00:00.000Z",
+  lastSeenAt: "2026-08-20T00:01:00.000Z",
+  observedAt: "2026-08-20T00:01:00.000Z",
+  createdAt: "2026-08-19T00:00:00.000Z",
+  agentIds: [agentId],
+};
+
+const agentDetail: AgentDetail = {
+  id: agentId,
+  name: "reviewer",
+  displayName: "Reviewer",
+  createdBy: { userId: "9a8b7c6d-5e4f-4a3b-8c1d-0e9f8a7b6c5d", displayName: "Ada" },
+  computer: { computerId, displayName: "Ada's Mac", platform: "darwin" },
+  runtimeProvider: "codex",
+  receiveMode: "mention_only",
+  status: "active",
+  createdAt: "2026-08-20T00:00:00.000Z",
+  updatedAt: "2026-08-20T00:00:00.000Z",
+  activity: { state: "idle" },
+};
+
+const task: TaskSummary = {
+  id: sessionId,
+  agent: { id: agentId, name: "atlas", displayName: "Atlas", runtimeProvider: "codex" },
+  source: {
+    provider: "feishu",
+    conversationKind: "dm",
+    channelId: "oc_debug_channel",
+    threadKey: null,
+  },
+  sessionKind: "channel",
+  title: "Investigate the failed deployment",
+  status: "queued",
+  createdAt: "2026-08-27T01:00:00.000Z",
+  endedAt: null,
+  lastActivityAt: "2026-08-27T01:00:00.000Z",
+};
+
+const completedTask: TaskSummary = {
+  ...task,
+  status: "completed",
+  lastActivityAt: "2026-08-27T02:00:00.000Z",
+};
+
+const detail: TaskDetail = {
+  task: completedTask,
+  turns: [
+    {
+      deliveryId: "33333333-3333-4333-8333-333333333333",
+      attention: "direct",
+      delivery: {
+        state: "accepted",
+        attemptCount: 1,
+        acceptedAt: "2026-08-27T01:01:00.000Z",
+        steeredAt: null,
+        expiresAt: "2026-08-28T01:00:00.000Z",
+        reason: null,
+        lastErrorCode: null,
+      },
+      message: {
+        id: "44444444-4444-4444-8444-444444444444",
+        externalMessageId: "om_debug",
+        operation: "created",
+        authorKind: "human",
+        authorDisplayName: "Mia Zhang",
+        fallbackText: "Please investigate the failed deployment.",
+        truncated: false,
+        occurredAt: "2026-08-27T01:00:00.000Z",
+      },
+      absorbedBy: null,
+      report: {
+        turnId: "turn-debug",
+        outcome: "completed",
+        executionEffects: "completed",
+        finalText: "The runtime finished and the provider reply was sent separately.",
+        errorReason: null,
+        usage: { inputTokens: 100, cachedInputTokens: null, outputTokens: 50 },
+        traceSummary: { lastSequence: 4, droppedEvents: 0 },
+        outgoingReplies: null,
+        reportedAt: "2026-08-27T02:00:00.000Z",
+      },
+    },
+  ],
+  internalSessions: [],
+  collaborationMessages: [],
+  nextCursor: null,
+};
+
+const usage: AgentUsageDetail = {
+  windowDays: 30,
+  startedAt: "2026-07-27T00:00:00.000Z",
+  endedAt: "2026-08-25T23:59:59.999Z",
+  tasks: 32,
+  measuredTasks: 31,
+  failed: 0,
+  inputTokens: 400_000,
+  cachedInputTokens: 350_000,
+  outputTokens: 28_000,
+  tokens: 428_000,
+  daily: [],
+};
+
+let currentClient: ReturnType<typeof useQueryClient>;
+function CaptureClient() {
+  currentClient = useQueryClient();
+  return null;
+}
+
+function ComputersProbe({ name }: { name: string }) {
+  const result = useComputersQuery(true);
+  return <span data-testid={name}>{result.isSuccess ? "ready" : "pending"}</span>;
+}
+
+function EnrichedListProbe() {
+  const state = useAgentListView(accountId);
+  return <span data-testid="summary">{state.kind}</span>;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  onlineManager.setOnline(true);
+});
+
+describe("shared live resource queries", () => {
+  it("reuses an in-flight computers read and a just-settled result", async () => {
+    const read = vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [computer] });
+    const view = await renderInRouter(<ComputersProbe name="first" />);
+    await waitFor(() => expect(screen.getByTestId("first").textContent).toBe("ready"));
+    expect(read).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <>
+        <ComputersProbe name="first" />
+        <ComputersProbe name="second" />
+      </>,
+    );
+    await waitFor(() => expect(screen.getByTestId("second").textContent).toBe("ready"));
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("two observers of the same computers key share interval updates", async () => {
+    const read = vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [computer] });
+    vi.useFakeTimers();
+    const view = await renderInRouter(<ComputersProbe name="first" />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    view.rerender(
+      <>
+        <ComputersProbe name="first" />
+        <ComputersProbe name="second" />
+      </>,
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    const before = read.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LIVE_REFETCH_INTERVAL_MS);
+    });
+    expect(read.mock.calls.length - before).toBe(1);
+  });
+
+  it("rereads on focus and reconnect even inside the freshness window", async () => {
+    const read = vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [computer] });
+    await renderInRouter(<ComputersProbe name="first" />);
+    await waitFor(() => expect(screen.getByTestId("first").textContent).toBe("ready"));
+    expect(read).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(2));
+
+    onlineManager.setOnline(false);
+    await act(async () => {
+      onlineManager.setOnline(true);
+    });
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(3));
+  });
+
+  it("shares Computer inventory while loading each Agent's list status evidence", async () => {
+    vi.spyOn(browserApi, "agents").mockResolvedValue({
+      agents: [
+        { ...agentDetail, usage: { windowDays: 30, tasks: 1, failed: 0, tokens: 1 } },
+        {
+          ...agentDetail,
+          id: "22222222-2222-4222-8222-222222222222",
+          usage: { windowDays: 30, tasks: 0, failed: 0, tokens: 0 },
+        },
+      ],
+    });
+    const computers = vi.spyOn(browserApi, "computers").mockResolvedValue({ computers: [computer] });
+    const binding = vi.spyOn(browserApi, "imBinding").mockResolvedValue(undefined);
+    const handoff = vi.spyOn(browserApi, "imBindingHandoff").mockResolvedValue(undefined);
+    await renderInRouter(<EnrichedListProbe />);
+    await waitFor(() => expect(screen.getByTestId("summary").textContent).toBe("ready"));
+    expect(computers).toHaveBeenCalledTimes(1);
+    expect(binding).toHaveBeenCalledTimes(2);
+    expect(handoff).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("task and usage live revalidation", () => {
+  it("rereads the home task list on focus, including a completed DM that received another turn", async () => {
+    const later = {
+      ...completedTask,
+      lastActivityAt: "2026-08-27T03:00:00.000Z",
+      title: "Investigate the failed deployment",
+    };
+    const request = vi
+      .spyOn(browserApi, "tasks")
+      .mockResolvedValueOnce({ tasks: [task], nextCursor: null })
+      .mockResolvedValue({ tasks: [later], nextCursor: null });
+    await renderInRouter(
+      <>
+        <AgentTasksSection agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText(task.title)).toBeTruthy();
+    expect(screen.getByText("Queued")).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(screen.getByText("Completed")).toBeTruthy());
+    expect(request.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("updates an empty task list when the first Task arrives", async () => {
+    vi.spyOn(browserApi, "tasks")
+      .mockResolvedValueOnce({ tasks: [], nextCursor: null })
+      .mockResolvedValue({ tasks: [completedTask], nextCursor: null });
+    await renderInRouter(
+      <>
+        <AgentTasksSection agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText("Message this Agent in your chat app to put it to work.")).toBeTruthy();
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(await screen.findByText(completedTask.title)).toBeTruthy();
+  });
+
+  it("walks infinite pages from the new first-page cursor and blocks load-more while a fetch is active", async () => {
+    const older = { ...task, id: "66666666-6666-4666-8666-666666666666", title: "Older task" };
+    const newest = { ...task, id: "77777777-7777-4777-8777-777777777777", title: "Newest task" };
+    const request = vi
+      .spyOn(browserApi, "tasks")
+      .mockResolvedValueOnce({ tasks: [task], nextCursor: "old-cursor" })
+      .mockResolvedValueOnce({ tasks: [older], nextCursor: null })
+      .mockResolvedValueOnce({ tasks: [newest], nextCursor: "new-cursor" })
+      .mockResolvedValueOnce({ tasks: [task], nextCursor: "new-page-3" });
+    await renderInRouter(
+      <>
+        <AgentTasksSection agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Load more" }));
+    expect(await screen.findByText("Older task")).toBeTruthy();
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.tasks.byAgent(agentId) });
+    });
+    expect(await screen.findByText("Newest task")).toBeTruthy();
+    expect(screen.queryByText("Older task")).toBeNull();
+    expect(request.mock.calls.map(([input]) => input?.cursor)).toEqual([
+      undefined,
+      "old-cursor",
+      undefined,
+      "new-cursor",
+    ]);
+  });
+
+  it("does not start load-more while a refetch is in flight", async () => {
+    let release!: (value: { tasks: TaskSummary[]; nextCursor: string | null }) => void;
+    vi.spyOn(browserApi, "tasks")
+      .mockResolvedValueOnce({ tasks: [completedTask], nextCursor: "next" })
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            release = resolve;
+          }),
+      );
+    await renderInRouter(
+      <>
+        <TasksPage agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByRole("link", { name: completedTask.title })).toBeTruthy();
+    let refetch!: Promise<unknown>;
+    await act(async () => {
+      refetch = currentClient.refetchQueries({ queryKey: queryKeys.tasks.byAgent(agentId) });
+    });
+    await waitFor(() => {
+      const button = screen.getByRole("button", { name: "Load more" });
+      expect(button.hasAttribute("disabled") || button.getAttribute("aria-disabled") === "true").toBe(true);
+    });
+    await act(async () => {
+      release({ tasks: [completedTask], nextCursor: "next" });
+      await refetch;
+    });
+  });
+
+  it("does not cancel an in-flight refetch when Load more is clicked", async () => {
+    let releaseRefetch!: (value: { tasks: TaskSummary[]; nextCursor: string | null }) => void;
+    const request = vi
+      .spyOn(browserApi, "tasks")
+      .mockResolvedValueOnce({ tasks: [completedTask], nextCursor: "next" })
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            releaseRefetch = resolve;
+          }),
+      );
+    await renderInRouter(
+      <>
+        <TasksPage agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByRole("link", { name: completedTask.title })).toBeTruthy();
+    expect(request).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      void currentClient.refetchQueries({ queryKey: queryKeys.tasks.byAgent(agentId) });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls[1]?.[0]?.cursor).toBeUndefined();
+    await act(async () => {
+      releaseRefetch({ tasks: [completedTask], nextCursor: "next" });
+    });
+  });
+
+  it("keeps a terminal task refusal across a later 503 and a remount until an authorized success", async () => {
+    vi.spyOn(browserApi, "tasks")
+      .mockResolvedValueOnce({ tasks: [completedTask], nextCursor: null })
+      .mockRejectedValueOnce(new ApiError(403, "Refused"))
+      .mockRejectedValueOnce(new ApiError(503, "Temporary outage"))
+      .mockResolvedValue({ tasks: [completedTask], nextCursor: null });
+    const view = await renderInRouter(
+      <>
+        <TasksPage agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText(completedTask.title)).toBeTruthy();
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.tasks.byAgent(agentId) });
+    });
+    await waitFor(() => expect(screen.queryByText(completedTask.title)).toBeNull());
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.tasks.byAgent(agentId) });
+    });
+    expect(screen.queryByText(completedTask.title)).toBeNull();
+    expect(screen.queryByText("Temporary outage")).toBeNull();
+
+    view.rerender(
+      <>
+        <TasksPage agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(screen.queryByText(completedTask.title)).toBeNull();
+
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.tasks.byAgent(agentId) });
+    });
+    expect(await screen.findByText(completedTask.title)).toBeTruthy();
+  });
+
+  it("keeps previous tasks on a transient refresh failure and offers recovery", async () => {
+    vi.spyOn(browserApi, "tasks")
+      .mockResolvedValueOnce({ tasks: [completedTask], nextCursor: null })
+      .mockRejectedValueOnce(new ApiError(503, "Temporary outage"));
+    await renderInRouter(
+      <>
+        <TasksPage agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText(completedTask.title)).toBeTruthy();
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.tasks.byAgent(agentId) });
+    });
+    expect(await screen.findByText("Update failed. Showing last available data.")).toBeTruthy();
+    expect(screen.getByText(completedTask.title)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+  });
+
+  it("rereads task details on focus", async () => {
+    const request = vi.spyOn(browserApi, "task").mockResolvedValue(detail);
+    await renderInRouter(<TaskDetailPage taskId={sessionId} />);
+    expect(await screen.findByText(completedTask.title)).toBeTruthy();
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(request.mock.calls.length).toBeGreaterThanOrEqual(2));
+  });
+
+  it("reuses a valid 30-day list summary on the home card and does not seed the detail cache", async () => {
+    vi.spyOn(browserApi, "agents").mockResolvedValue({
+      agents: [{ ...agentDetail, usage: { windowDays: 30, tasks: 32, failed: 0, tokens: 428_000 } }],
+    });
+    const usageRead = vi.spyOn(browserApi, "agentUsage");
+    await renderInRouter(
+      <>
+        <AgentUsageOverview accountId={accountId} agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText("428K")).toBeTruthy();
+    expect(usageRead).not.toHaveBeenCalled();
+    expect(currentClient.getQueryData(queryKeys.agents.usage(agentId, 30))).toBeUndefined();
+  });
+
+  it("still reads full usage for other windows and the usage page", async () => {
+    const usageRead = vi.spyOn(browserApi, "agentUsage").mockResolvedValue(usage);
+    await renderInRouter(<AgentUsageTab agentId={agentId} />);
+    expect(await screen.findByText("428K")).toBeTruthy();
+    expect(usageRead).toHaveBeenCalledWith(agentId, 30);
+  });
+
+  it("keeps a terminal usage refusal across a later 503 until recovery", async () => {
+    vi.spyOn(browserApi, "agentUsage")
+      .mockResolvedValueOnce(usage)
+      .mockRejectedValueOnce(new ApiError(403, "Refused"))
+      .mockRejectedValueOnce(new ApiError(503, "Temporary outage"))
+      .mockResolvedValue(usage);
+    await renderInRouter(
+      <>
+        <AgentUsageOverview agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText("428K")).toBeTruthy();
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.agents.usage(agentId, 30) });
+    });
+    await waitFor(() => expect(screen.queryByText("428K")).toBeNull());
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.agents.usage(agentId, 30) });
+    });
+    expect(screen.queryByText("428K")).toBeNull();
+    await act(async () => {
+      await currentClient.refetchQueries({ queryKey: queryKeys.agents.usage(agentId, 30) });
+    });
+    expect(await screen.findByText("428K")).toBeTruthy();
+  });
+
+  it("does not replace a more recent full usage answer with older list totals", async () => {
+    const listResult = {
+      agents: [{ ...agentDetail, usage: { windowDays: 30 as const, tasks: 7, failed: 0, tokens: 100_000 } }],
+    };
+    vi.spyOn(browserApi, "agents").mockResolvedValue(listResult);
+    vi.spyOn(browserApi, "agentUsage").mockResolvedValue(usage);
+    const view = await renderInRouter(<CaptureClient />);
+    currentClient.setQueryData(queryKeys.agents.list(accountId), listResult, { updatedAt: Date.now() - 1_000 });
+    currentClient.setQueryData(queryKeys.agents.usage(agentId, 30), usage);
+    view.rerender(
+      <>
+        <AgentUsageOverview accountId={accountId} agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText("428K")).toBeTruthy();
+    expect(screen.queryByText("100K")).toBeNull();
+  });
+
+  it("does not restore usage withdrawn by a newer forbidden response from older list totals", async () => {
+    const listResult = {
+      agents: [{ ...agentDetail, usage: { windowDays: 30 as const, tasks: 7, failed: 0, tokens: 100_000 } }],
+    };
+    vi.spyOn(browserApi, "agents").mockResolvedValue(listResult);
+    vi.spyOn(browserApi, "agentUsage").mockRejectedValue(new ApiError(403, "Usage access removed"));
+    const view = await renderInRouter(<CaptureClient />);
+    currentClient.setQueryData(queryKeys.agents.list(accountId), listResult, { updatedAt: Date.now() - 1_000 });
+    await currentClient
+      .fetchQuery({
+        queryKey: queryKeys.agents.usage(agentId, 30),
+        queryFn: () => browserApi.agentUsage(agentId, 30),
+      })
+      .catch(() => undefined);
+    view.rerender(
+      <>
+        <AgentUsageOverview accountId={accountId} agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    expect(await screen.findByText("Usage access removed")).toBeTruthy();
+    expect(screen.queryByText("100K")).toBeNull();
+  });
+
+  it("does not treat setQueryData as an authorized read that retires a task refusal", async () => {
+    const view = await renderInRouter(<CaptureClient />);
+    const key = queryKeys.tasks.byAgent(agentId);
+    const cached = { pages: [{ tasks: [completedTask], nextCursor: null }], pageParams: [undefined] };
+    currentClient.setQueryData(key, cached);
+    await currentClient
+      .fetchQuery({
+        queryKey: key,
+        queryFn: async () => {
+          throw new ApiError(403, "Task access removed");
+        },
+      })
+      .catch(() => undefined);
+    currentClient.setQueryData(key, cached);
+    vi.spyOn(browserApi, "tasks").mockRejectedValue(new ApiError(503, "No current answer"));
+    view.rerender(
+      <>
+        <AgentTasksSection agentId={agentId} />
+        <CaptureClient />
+      </>,
+    );
+    await waitFor(() => expect(screen.queryByText(completedTask.title)).toBeNull());
+  });
+});
+
+describe("session fencing and mutation sync", () => {
+  it("drops a late imperative read after the session is cleared", async () => {
+    const client = createQueryClient();
+    let settle!: (value: { computers: AccountComputerSummary[] }) => void;
+    const pending = new Promise<{ computers: AccountComputerSummary[] }>((resolve) => {
+      settle = resolve;
+    });
+    const read = fetchSharedResource(client, {
+      queryKey: queryKeys.computers(),
+      queryFn: () => pending,
+      staleTime: 0,
+    });
+    client.clear();
+    settle({ computers: [computer] });
+    await expect(read).rejects.toThrow();
+    expect(client.getQueryData(queryKeys.computers())).toBeUndefined();
+  });
+
+  it("does not let an old Account read evict a new Account result for the same key", async () => {
+    const client = createQueryClient();
+    let resolveOld!: (value: { computers: string[] }) => void;
+    const oldNetwork = new Promise<{ computers: string[] }>((resolve) => {
+      resolveOld = resolve;
+    });
+    const key = ["computers", "session-race"];
+    const oldResult = fetchSharedResource(client, { queryKey: key, queryFn: () => oldNetwork }).catch(
+      (error: unknown) => error,
+    );
+    client.clear();
+    client.setQueryData(key, { computers: ["new-account-computer"] });
+    resolveOld({ computers: ["old-account-computer"] });
+    await oldResult;
+    expect(client.getQueryData(key)).toEqual({ computers: ["new-account-computer"] });
+    client.clear();
+  });
+
+  it("invalidates the Agent list and the Agent prefix once after a mutation", async () => {
+    const client = createQueryClient();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    await syncAgentQueries(client, agentId, { computers: true });
+    expect(invalidate.mock.calls.map(([input]) => input?.queryKey)).toEqual([
+      queryKeys.agents.listRoot(),
+      queryKeys.agents.all(agentId),
+      queryKeys.computers(),
+    ]);
+  });
+});

--- a/apps/web/src/query/live.ts
+++ b/apps/web/src/query/live.ts
@@ -1,0 +1,22 @@
+/**
+ * Revalidation for ordinary live resources: Agent identity and activity, Computer inventory,
+ * messaging evidence, Tasks, and usage.
+ *
+ * `staleTime` is the reuse window for a newly mounted consumer of the same key. Interval updates
+ * keep an already-visible observer current. Focus and reconnect re-read immediately, even inside
+ * that window — returning to the tab is a reason to ask again, not a reason to trust the last
+ * successful paint.
+ *
+ * Short-lived workflows (setup snapshots, connection codes, Feishu attempts) keep their own cadence
+ * and only reuse the transport. Configuration, `/me`, and internal previews stay on the client
+ * defaults and do not opt in here.
+ */
+export const LIVE_STALE_TIME_MS = 30_000;
+export const LIVE_REFETCH_INTERVAL_MS = 30_000;
+
+export const liveResourceQueryOptions = {
+  staleTime: LIVE_STALE_TIME_MS,
+  refetchInterval: LIVE_REFETCH_INTERVAL_MS,
+  refetchOnWindowFocus: "always" as const,
+  refetchOnReconnect: "always" as const,
+};

--- a/apps/web/src/query/session-cache.ts
+++ b/apps/web/src/query/session-cache.ts
@@ -1,0 +1,134 @@
+import { hashKey, type QueryClient, type QueryKey } from "@tanstack/react-query";
+import { ApiError } from "../api.js";
+
+interface TerminalRecord {
+  at: number;
+  error: Error;
+}
+
+interface SessionCache {
+  generation: number;
+  terminalErrors: Map<string, TerminalRecord>;
+}
+
+const sessions = new WeakMap<QueryClient, SessionCache>();
+
+function sessionOf(client: QueryClient): SessionCache {
+  const held = sessions.get(client);
+  if (held) return held;
+  const created: SessionCache = { generation: 0, terminalErrors: new Map() };
+  sessions.set(client, created);
+  return created;
+}
+
+/**
+ * Cancels in-flight reads and drops cached results when the Account session ends, so a late
+ * response cannot populate the next Account's cache.
+ */
+export function attachSessionCache(client: QueryClient): QueryClient {
+  sessionOf(client);
+  const originalClear = client.clear.bind(client);
+  client.clear = () => {
+    const session = sessionOf(client);
+    session.generation += 1;
+    session.terminalErrors.clear();
+    void client.cancelQueries();
+    originalClear();
+  };
+  client.getQueryCache().subscribe((event) => recordQueryCacheEvent(client, event));
+  return client;
+}
+
+function recordQueryCacheEvent(
+  client: QueryClient,
+  event: {
+    type: string;
+    action?: { type: string; manual?: boolean };
+    query: { queryKey: QueryKey; state: { dataUpdatedAt: number; error: unknown; errorUpdatedAt: number } };
+  },
+): void {
+  if (event.type !== "updated" || !event.action) return;
+  const { action, query } = event;
+  if (action.type === "success") {
+    // setQueryData is not an authorized Server read; it must not retire a terminal refusal.
+    if (action.manual === true) return;
+    const record = terminalResourceRecord(client, query.queryKey);
+    if (!record || query.state.dataUpdatedAt >= record.at) {
+      clearTerminalResourceError(client, query.queryKey);
+    }
+    return;
+  }
+  if (action.type === "error" && query.state.error instanceof Error) {
+    rememberTerminalResourceError(client, query.queryKey, query.state.error, query.state.errorUpdatedAt);
+  }
+}
+
+export function sessionGeneration(client: QueryClient): number {
+  return sessionOf(client).generation;
+}
+
+function isTerminalError(error: Error): boolean {
+  return error instanceof ApiError && [401, 403, 404, 410].includes(error.status);
+}
+
+export function rememberTerminalResourceError(
+  client: QueryClient,
+  queryKey: QueryKey,
+  error: Error,
+  at = Date.now(),
+): void {
+  if (!isTerminalError(error)) return;
+  sessionOf(client).terminalErrors.set(hashKey(queryKey), { at, error });
+}
+
+export function clearTerminalResourceError(client: QueryClient, queryKey: QueryKey): void {
+  sessionOf(client).terminalErrors.delete(hashKey(queryKey));
+}
+
+export function terminalResourceError(client: QueryClient, queryKey: QueryKey): Error | undefined {
+  return sessionOf(client).terminalErrors.get(hashKey(queryKey))?.error;
+}
+
+export function terminalResourceObservedAt(client: QueryClient, queryKey: QueryKey): number {
+  return sessionOf(client).terminalErrors.get(hashKey(queryKey))?.at ?? 0;
+}
+
+function terminalResourceRecord(client: QueryClient, queryKey: QueryKey): TerminalRecord | undefined {
+  return sessionOf(client).terminalErrors.get(hashKey(queryKey));
+}
+
+/**
+ * An imperative read that shares the QueryClient in-flight slot for `queryKey`, then refuses to
+ * keep the result if the Account session ended while it was in the air. A cancelled generation must
+ * not delete a later Account's query of the same key.
+ */
+export async function fetchSharedResource<T>(
+  client: QueryClient,
+  options: {
+    queryKey: QueryKey;
+    queryFn: () => Promise<T>;
+    staleTime?: number;
+    gcTime?: number;
+  },
+): Promise<T> {
+  const session = sessionOf(client);
+  const generation = session.generation;
+  const ended = () => session.generation !== generation;
+  const result = await client.fetchQuery({
+    queryKey: options.queryKey,
+    staleTime: options.staleTime ?? 0,
+    ...(options.gcTime !== undefined ? { gcTime: options.gcTime } : {}),
+    queryFn: async ({ signal }) => {
+      if (ended() || signal.aborted) throw sessionEndedError();
+      const data = await options.queryFn();
+      if (ended() || signal.aborted) throw sessionEndedError();
+      return data;
+    },
+  });
+  if (ended()) throw sessionEndedError();
+  return result;
+}
+
+function sessionEndedError(): Error {
+  return new Error("The Account session ended");
+}

--- a/apps/web/src/query/session-cache.ts
+++ b/apps/web/src/query/session-cache.ts
@@ -1,14 +1,29 @@
 import { hashKey, type QueryClient, type QueryKey } from "@tanstack/react-query";
 import { ApiError } from "../api.js";
 
-interface TerminalRecord {
-  at: number;
-  error: Error;
+/**
+ * Where one resource answer stands against another. `seq` is observation order: the cache assigns
+ * it when a read actually settles, so two answers landing in the same millisecond — or under a
+ * clock that moved backwards — still order by which was observed later. A `setQueryData` write
+ * preserves the key's previous sequence (or 0 before any read); it never advances observation
+ * order and therefore cannot promote an older answer over a later refusal.
+ */
+export interface ResourceObservation {
+  readonly seq: number;
+  readonly at: number;
+}
+
+export interface TerminalResourceObservation {
+  readonly seq: number;
+  readonly error: Error;
 }
 
 interface SessionCache {
   generation: number;
-  terminalErrors: Map<string, TerminalRecord>;
+  /** The observation clock: bumped once per settled read the cache records, never by the wall clock. */
+  clock: number;
+  successes: Map<string, ResourceObservation>;
+  terminalErrors: Map<string, TerminalResourceObservation>;
 }
 
 const sessions = new WeakMap<QueryClient, SessionCache>();
@@ -16,7 +31,7 @@ const sessions = new WeakMap<QueryClient, SessionCache>();
 function sessionOf(client: QueryClient): SessionCache {
   const held = sessions.get(client);
   if (held) return held;
-  const created: SessionCache = { generation: 0, terminalErrors: new Map() };
+  const created: SessionCache = { generation: 0, clock: 0, successes: new Map(), terminalErrors: new Map() };
   sessions.set(client, created);
   return created;
 }
@@ -31,6 +46,8 @@ export function attachSessionCache(client: QueryClient): QueryClient {
   client.clear = () => {
     const session = sessionOf(client);
     session.generation += 1;
+    session.clock = 0;
+    session.successes.clear();
     session.terminalErrors.clear();
     void client.cancelQueries();
     originalClear();
@@ -44,23 +61,37 @@ function recordQueryCacheEvent(
   event: {
     type: string;
     action?: { type: string; manual?: boolean };
-    query: { queryKey: QueryKey; state: { dataUpdatedAt: number; error: unknown; errorUpdatedAt: number } };
+    query: { queryKey: QueryKey; state: { dataUpdatedAt: number; error: unknown } };
   },
 ): void {
   if (event.type !== "updated" || !event.action) return;
   const { action, query } = event;
   if (action.type === "success") {
-    // setQueryData is not an authorized Server read; it must not retire a terminal refusal.
-    if (action.manual === true) return;
-    const record = terminalResourceRecord(client, query.queryKey);
-    if (!record || query.state.dataUpdatedAt >= record.at) {
-      clearTerminalResourceError(client, query.queryKey);
-    }
+    recordResourceSuccess(client, query.queryKey, query.state.dataUpdatedAt, action.manual === true);
     return;
   }
   if (action.type === "error" && query.state.error instanceof Error) {
-    rememberTerminalResourceError(client, query.queryKey, query.state.error, query.state.errorUpdatedAt);
+    rememberTerminalResourceError(client, query.queryKey, query.state.error);
   }
+}
+
+function recordResourceSuccess(client: QueryClient, queryKey: QueryKey, at: number, manual: boolean): void {
+  const session = sessionOf(client);
+  const key = hashKey(queryKey);
+  if (manual) {
+    // setQueryData is not an authorized Server read: it follows the time its payload claims but
+    // keeps the observation order the key already had, so it neither retires a terminal refusal
+    // nor promotes the row it touches over one the Server answered later.
+    const previous = session.successes.get(key);
+    session.successes.set(key, { seq: previous?.seq ?? 0, at });
+    return;
+  }
+  const observation: ResourceObservation = { seq: session.clock + 1, at };
+  session.clock = observation.seq;
+  session.successes.set(key, observation);
+  // An answer the Server gave after the refusal was observed retires it; anything older never does.
+  const record = session.terminalErrors.get(key);
+  if (record && record.seq < observation.seq) clearTerminalResourceError(client, queryKey);
 }
 
 export function sessionGeneration(client: QueryClient): number {
@@ -71,14 +102,11 @@ function isTerminalError(error: Error): boolean {
   return error instanceof ApiError && [401, 403, 404, 410].includes(error.status);
 }
 
-export function rememberTerminalResourceError(
-  client: QueryClient,
-  queryKey: QueryKey,
-  error: Error,
-  at = Date.now(),
-): void {
+export function rememberTerminalResourceError(client: QueryClient, queryKey: QueryKey, error: Error): void {
   if (!isTerminalError(error)) return;
-  sessionOf(client).terminalErrors.set(hashKey(queryKey), { at, error });
+  const session = sessionOf(client);
+  session.clock += 1;
+  session.terminalErrors.set(hashKey(queryKey), { seq: session.clock, error });
 }
 
 export function clearTerminalResourceError(client: QueryClient, queryKey: QueryKey): void {
@@ -89,12 +117,44 @@ export function terminalResourceError(client: QueryClient, queryKey: QueryKey): 
   return sessionOf(client).terminalErrors.get(hashKey(queryKey))?.error;
 }
 
-export function terminalResourceObservedAt(client: QueryClient, queryKey: QueryKey): number {
-  return sessionOf(client).terminalErrors.get(hashKey(queryKey))?.at ?? 0;
+/** The last successful read the cache observed for this key, or the manual write standing in for one. */
+export function resourceSuccessObservation(client: QueryClient, queryKey: QueryKey): ResourceObservation | undefined {
+  return sessionOf(client).successes.get(hashKey(queryKey));
 }
 
-function terminalResourceRecord(client: QueryClient, queryKey: QueryKey): TerminalRecord | undefined {
+export function terminalResourceObservation(
+  client: QueryClient,
+  queryKey: QueryKey,
+): TerminalResourceObservation | undefined {
   return sessionOf(client).terminalErrors.get(hashKey(queryKey));
+}
+
+/**
+ * True when `candidate` settled the question after `baseline`. Two reads the cache itself observed
+ * order by observation, never by the wall clock; when either side is a write the Server never
+ * answered (seq 0), the times their payloads claim decide, as they did before observation order
+ * existed.
+ */
+export function observedAfter(
+  candidate: ResourceObservation | undefined,
+  baseline: ResourceObservation | undefined,
+): boolean {
+  if (!candidate) return false;
+  if (!baseline) return true;
+  if (candidate.seq > 0 && baseline.seq > 0) return candidate.seq > baseline.seq;
+  return candidate.at > baseline.at;
+}
+
+/**
+ * A terminal refusal stands until a read the Server actually answered settles strictly after it.
+ * Manual writes and answers observed earlier — including one that shares the refusal's
+ * millisecond — never outrank it.
+ */
+export function refusalOutranks(
+  refusal: TerminalResourceObservation | undefined,
+  success: ResourceObservation | undefined,
+): boolean {
+  return refusal !== undefined && (success?.seq ?? 0) <= refusal.seq;
 }
 
 /**


### PR DESCRIPTION
## Summary

The Agent home could keep showing a queued Task after execution completed because its mounted query did not revalidate. Frequently changing resources also used different refresh rules, and the Agent switcher unnecessarily loaded every Agent's status evidence.

This change gives ordinary live resources a shared 30-second freshness and visible refresh policy, with immediate revalidation on focus and reconnect. QueryClient shares results and in-flight reads across the home, lists, details, settings, and connection flows. The switcher reads identity data only; home detail and 30-day usage totals reuse eligible list data without manufacturing a full usage response.

Transient refresh failures retain the previous value with a retry notice, including home usage totals supplied by the Agent list while a fallback read is pending or also fails. Successful reads and terminal refusals are ordered by their actual observation sequence, so same-millisecond responses and clock rollback cannot restore denied data; later successful reads recover it, while manual cache writes do not confer newer authorization. Logout fences late responses from the next Account.

Setup authorization, cancellation, preparation refresh, and Computer binding/repair retire earlier snapshot reads before the subsequent read can reuse them. Messaging completion invalidates Agent, binding, and handoff caches once per binding and credential generation, including OAuth returns, reauthorization between polls, and completion while another Setup prerequisite is unavailable. Ordinary reads still share their in-flight request, and Setup/connection flows retain their existing cadence and retry budgets. Pagination refreshes from current cursors, and mutation completion invalidates each affected resource once.

Refs #585. The agreed inventory and acceptance criteria are recorded in the issue.

## Testing

- `pnpm check`, `pnpm build`, and `pnpm typecheck` — passed; no new complexity exceptions.
- `pnpm test` — passed: 330 repository-script tests and 3,524 package tests, including 863 Web tests. Unchanged packages reuse the Turborepo cache.
- Added 25 permanent regressions covering operation boundaries, transient usage failures, response ordering, authorized recovery, manual cache writes, and messaging completion synchronization.
- Independent adversarial acceptance suite — 30 passed, including delayed pre-write responses, same-tick/clock-rollback recovery, repeat authorization, completion with an offline Computer, and Computer binding.
- `pnpm --filter @opentag/client test:agent-runtime:coverage` — 378 passed; 100% statements, branches, functions, and lines in the configured runtime scope.
- `pnpm --filter @opentag/server test:integration` — 330 passed against local PostgreSQL testcontainers.

## UI validation

The browser and responsive-layout evidence below was collected for the initial implementation at `a6a45c2b`. The current changes preserve markup and styling; the updated state behavior is covered by the component and adversarial tests above.

- Desktop evidence: local browser validation with a synthetic API; kept-open home and Task detail advanced from queued to completed without reload.
- Mobile evidence: local screenshots and DOM width checks at each required width; no horizontal overflow.
- Widths checked (`320px` / `390px` / `768px` / `1440px`): all four.
- States verified: queued, completed, a subsequent turn in the same conversation, transient refresh failure with retained data, and retry recovery. Automated coverage also exercises empty lists, pagination, terminal refusals, and session changes.
- Keyboard/accessibility checks: keyboard navigation to Task detail; refresh notices expose `role="status"` and a keyboard-accessible retry button.
- New reusable block, theme value, or CSS exception: shared resource refresh notice/status components using the existing Banner and Button primitives; no theme values or CSS exceptions.

## Breaking changes

None. No Server API or schema changes.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
