### PR TITLE
fix: accept Slack file shares and expose ingress failures

### DIFF
--- a/packages/server/src/__tests__/fixtures/slack-inbound-file-share-png.json
+++ b/packages/server/src/__tests__/fixtures/slack-inbound-file-share-png.json
@@ -1,0 +1,25 @@
+{
+  "note": "Sanitized production Events API message/file_share shape. Identifiers are anonymous test values.",
+  "event": {
+    "type": "message",
+    "subtype": "file_share",
+    "channel": "D_TEST_DM",
+    "channel_type": "im",
+    "user": "U_TEST_HUMAN",
+    "text": "[synthetic test request]",
+    "ts": "1788958840.759759",
+    "event_ts": "1788958840.759759",
+    "files": [
+      {
+        "id": "F_TEST_1",
+        "name": "colors.png",
+        "mimetype": "image/png",
+        "size": 2877,
+        "mode": "hosted",
+        "file_access": "visible"
+      }
+    ],
+    "upload": false,
+    "display_as_bot": false
+  }
+}

--- a/packages/server/src/__tests__/fixtures/slack-inbound-file-share-text.json
+++ b/packages/server/src/__tests__/fixtures/slack-inbound-file-share-text.json
@@ -1,0 +1,25 @@
+{
+  "note": "Sanitized production Events API message/file_share shape. Identifiers are anonymous test values.",
+  "event": {
+    "type": "message",
+    "subtype": "file_share",
+    "channel": "D_TEST_DM",
+    "channel_type": "im",
+    "user": "U_TEST_HUMAN",
+    "text": "[synthetic test request]",
+    "ts": "1788958812.272619",
+    "event_ts": "1788958812.272619",
+    "files": [
+      {
+        "id": "F_TEST_1",
+        "name": "facts.txt",
+        "mimetype": "text/plain",
+        "size": 149,
+        "mode": "snippet",
+        "file_access": "visible"
+      }
+    ],
+    "upload": false,
+    "display_as_bot": false
+  }
+}

--- a/packages/server/src/__tests__/im-message-inbox.test.ts
+++ b/packages/server/src/__tests__/im-message-inbox.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { type NormalizedInboundImEvent, SLACK_REQUIRED_BOT_SCOPES } from "@opentag/shared";
 import { and, count, eq, isNull } from "drizzle-orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +9,7 @@ import { AgentService } from "../services/agents/index.js";
 import { ApplicationCipher } from "../services/crypto.js";
 import { ImMessageInbox } from "../services/im/index.js";
 import { ImBindingService } from "../services/im-bindings/index.js";
+import { normalizeSlackEnvelope } from "../services/im-bindings/slack/adapter.js";
 import { createUnitDatabase, type UnitDatabase } from "./support/unit-database.js";
 
 const fixedNow = new Date("2026-08-19T00:00:00.000Z");
@@ -131,6 +133,90 @@ describe("ImMessageInbox overflow scheduling", () => {
     } finally {
       delayed.release();
     }
+  });
+});
+
+describe("Slack file_share adapter to inbox", () => {
+  function slackEnvelope(event: Record<string, unknown>, eventId: string) {
+    return {
+      eventId,
+      appId: "A_UNIT_INBOX",
+      teamId: "T_UNIT_INBOX",
+      botUserId: "U_UNIT_INBOX",
+      botId: "B_UNIT_INBOX",
+      event,
+    };
+  }
+
+  it.each([
+    ["text", "1788958812.272619", "file", "facts.txt"],
+    ["png", "1788958840.759759", "image", "colors.png"],
+  ])("persists a production %s file_share DM and skips a self share", async (variant, messageTs, kind, filename) => {
+    const value = await inboxFixture();
+    const fixture = JSON.parse(
+      readFileSync(new URL(`./fixtures/slack-inbound-file-share-${variant}.json`, import.meta.url), "utf8"),
+    ) as { event: Record<string, unknown> };
+    const [event] = normalizeSlackEnvelope(slackEnvelope(fixture.event, "Ev-unit-file-share"));
+    if (!event) throw new Error("file_share fixture was not normalized");
+    const inbox = new ImMessageInbox(unitDatabase.database);
+    const ingested = await inbox.ingest(value.imBindingId, 1, event);
+    expect(ingested).toMatchObject({ duplicate: false, messageId: expect.any(String) });
+    expect(ingested.deliveryIds).toHaveLength(1);
+    const [message] = await unitDatabase.database.select().from(imMessages);
+    expect(message).toMatchObject({
+      channelId: "D_TEST_DM",
+      externalMessageId: messageTs,
+      authorKind: "human",
+      authorExternalId: "U_TEST_HUMAN",
+    });
+    expect(message?.content.resources).toEqual([
+      expect.objectContaining({ providerResourceKey: "F_TEST_1", kind, filename }),
+    ]);
+
+    const [selfEvent] = normalizeSlackEnvelope(
+      slackEnvelope(
+        {
+          type: "message",
+          subtype: "file_share",
+          channel: "D_TEST_DM",
+          channel_type: "im",
+          user: "U_UNIT_INBOX",
+          text: "",
+          ts: "1788958815.000000",
+          files: [{ id: "F_SELF", name: "bot.png", mimetype: "image/png", size: 4 }],
+        },
+        "Ev-unit-self-file-share",
+      ),
+    );
+    if (!selfEvent) throw new Error("self file_share was not normalized");
+    await expect(inbox.ingest(value.imBindingId, 1, selfEvent)).resolves.toEqual({ duplicate: false, deliveryIds: [] });
+    await expect(unitDatabase.database.select().from(imMessages)).resolves.toHaveLength(1);
+  });
+
+  it("dedups a channel file_share and app_mention for the same attachment message", async () => {
+    const value = await inboxFixture();
+    const shared = {
+      channel: "C_UNIT_INBOX",
+      channel_type: "channel",
+      user: "U_HUMAN",
+      text: "<@U_UNIT_INBOX> please review",
+      ts: "1788958900.100000",
+      event_ts: "1788958900.100000",
+      files: [{ id: "F_CHANNEL", name: "facts.txt", mimetype: "text/plain", size: 149 }],
+    };
+    const [messageEvent] = normalizeSlackEnvelope(
+      slackEnvelope({ type: "message", subtype: "file_share", ...shared }, "Ev-unit-message"),
+    );
+    const [mentionEvent] = normalizeSlackEnvelope(
+      slackEnvelope({ type: "app_mention", ...shared }, "Ev-unit-app-mention"),
+    );
+    if (!messageEvent || !mentionEvent) throw new Error("message/app_mention pair was not normalized");
+    const inbox = new ImMessageInbox(unitDatabase.database);
+    const first = await inbox.ingest(value.imBindingId, 1, messageEvent);
+    const second = await inbox.ingest(value.imBindingId, 1, mentionEvent);
+    expect(first).toMatchObject({ duplicate: false, messageId: expect.any(String) });
+    expect(second).toEqual({ duplicate: true, messageId: first.messageId, deliveryIds: [] });
+    await expect(unitDatabase.database.select().from(imMessages)).resolves.toHaveLength(1);
   });
 });
 

--- a/packages/server/src/__tests__/im-resource-api.test.ts
+++ b/packages/server/src/__tests__/im-resource-api.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import type { UserAuthService } from "../services/auth/index.js";
 import { AuthServiceError } from "../services/auth/index.js";
+import { ImBindingServiceError } from "../services/im-bindings/index.js";
 
 const accountId = "53e2babe-e4ac-4e2c-b7d1-d092d5a4568e";
 const computerId = "59ea83c3-0452-4fdb-a81b-e8037e91cd1b";
@@ -41,7 +42,11 @@ function resourceUrl(overrides: Partial<Parameters<typeof runtimeImResourcePath>
   });
 }
 
-function createResourceApp(resource: Record<string, unknown>, verifyMachineToken?: ReturnType<typeof vi.fn>) {
+function createResourceApp(
+  resource: Record<string, unknown>,
+  verifyMachineToken?: ReturnType<typeof vi.fn>,
+  loggerStream?: { write(chunk: string): void },
+) {
   const resources = { open: vi.fn().mockResolvedValue(resource) };
   const machineAuth = {
     verifyMachineToken:
@@ -53,6 +58,7 @@ function createResourceApp(resource: Record<string, unknown>, verifyMachineToken
       }),
   };
   const app = createApp({
+    loggerStream,
     authService: authService(),
     machineAuthService: machineAuth as never,
     imResourceService: resources as never,
@@ -103,6 +109,29 @@ describe("IM resource HTTP API", () => {
       imMessageId,
       2,
     );
+  });
+
+  it("correlates an attachment read failure with the message through existing HTTP logs", async () => {
+    const chunks: string[] = [];
+    const { app, resources } = createResourceApp({}, undefined, {
+      write: (chunk) => {
+        chunks.push(chunk);
+      },
+    });
+    resources.open.mockRejectedValue(
+      new ImBindingServiceError("VALIDATION_ERROR", 413, "The IM resource exceeds the size limit"),
+    );
+
+    const response = await app.inject({ method: "GET", url: resourceUrl(), headers: authorization });
+
+    expect(response.statusCode).toBe(413);
+    expect(resources.open).toHaveBeenCalledTimes(1);
+    const logs = chunks.join("");
+    expect(logs).toContain(imMessageId);
+    expect(logs).toContain(response.headers["x-request-id"]);
+    expect(logs).toContain('"code":"VALIDATION_ERROR"');
+    expect(logs).toContain('"statusCode":413');
+    expect(logs).not.toContain("Bearer access");
   });
 
   it("falls back to a safe media type and omits absent optional metadata", async () => {

--- a/packages/server/src/__tests__/slack-adapter.test.ts
+++ b/packages/server/src/__tests__/slack-adapter.test.ts
@@ -1,4 +1,5 @@
 import { createHmac } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { Readable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
@@ -6,6 +7,23 @@ import { ExternalCallPolicy } from "../services/im/external-call-policy.js";
 import { normalizeSlackEnvelope, SlackAdapter } from "../services/im-bindings/slack/adapter.js";
 import { DefaultSlackApiClient, SLACK_WEB_CLIENT_OPTIONS } from "../services/im-bindings/slack/default-api-client.js";
 import { preparseSlackRoute, verifySlackSignature } from "../services/im-bindings/slack/signature.js";
+
+function loadSlackFileShareFixture(name: "slack-inbound-file-share-png.json" | "slack-inbound-file-share-text.json") {
+  return JSON.parse(readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8")) as {
+    event: Record<string, unknown>;
+  };
+}
+
+function slackEnvelope(event: Record<string, unknown>, eventId = "Ev-file-share") {
+  return {
+    eventId,
+    appId: "A1",
+    teamId: "T1",
+    botUserId: "U_BOT",
+    botId: "B_BOT",
+    event,
+  };
+}
 
 describe("Slack installed-binding adapter", () => {
   it("derives installation identity and granted scopes from Slack instead of browser input", async () => {
@@ -524,6 +542,68 @@ describe("Slack installed-binding adapter", () => {
       event: { type: "message", channel: "C1", ts: "3", text: large },
     });
     expect(bounded?.message.content).toMatchObject({ truncated: true });
+  });
+
+  it("normalizes sanitized production file_share fixtures, empty bodies, and self authors", () => {
+    const textFixture = loadSlackFileShareFixture("slack-inbound-file-share-text.json");
+    const [textEvent] = normalizeSlackEnvelope(slackEnvelope(textFixture.event, "Ev-text"));
+    expect(textEvent).toMatchObject({
+      conversation: { externalId: "D_TEST_DM", kind: "dm" },
+      message: {
+        operation: "created",
+        externalId: "1788958812.272619",
+        author: { externalId: "U_TEST_HUMAN", kind: "human", isSelf: false },
+        content: { fallbackText: "[synthetic test request]" },
+        resources: [{ providerResourceKey: "F_TEST_1", kind: "file", filename: "facts.txt", mediaType: "text/plain" }],
+      },
+    });
+
+    const pngFixture = loadSlackFileShareFixture("slack-inbound-file-share-png.json");
+    const [pngEvent] = normalizeSlackEnvelope(slackEnvelope(pngFixture.event, "Ev-png"));
+    expect(pngEvent).toMatchObject({
+      conversation: { kind: "dm" },
+      message: {
+        author: { kind: "human", isSelf: false },
+        resources: [{ providerResourceKey: "F_TEST_1", kind: "image", filename: "colors.png", mediaType: "image/png" }],
+      },
+    });
+
+    const [emptyBody] = normalizeSlackEnvelope(
+      slackEnvelope({ ...textFixture.event, text: "", ts: "1788958813.000000", event_ts: "1788958813.000000" }),
+    );
+    expect(emptyBody).toMatchObject({
+      message: {
+        operation: "created",
+        content: { fallbackText: "" },
+        resources: [{ providerResourceKey: "F_TEST_1", kind: "file" }],
+      },
+    });
+
+    const [selfShare] = normalizeSlackEnvelope(
+      slackEnvelope({
+        type: "message",
+        subtype: "file_share",
+        channel: "D_TEST_DM",
+        channel_type: "im",
+        user: "U_BOT",
+        text: "",
+        ts: "1788958814.000000",
+        files: [{ id: "F_SELF", name: "bot.png", mimetype: "image/png", size: 12 }],
+      }),
+    );
+    expect(selfShare).toMatchObject({
+      message: { author: { externalId: "U_BOT", kind: "human", isSelf: true }, resources: [{ kind: "image" }] },
+    });
+  });
+
+  it.each([
+    [{ type: "message", subtype: "channel_join", channel: "C1", ts: "1.0" }, "unsupported_subtype"],
+    [{ type: "message", channel: "C1" }, "malformed_supported_event"],
+    [{ type: "reaction_added", reaction: "thumbsup" }, "unsupported_event_type"],
+  ])("reports why a rejected event produces no message: %s", (event, reason) => {
+    const onRejected = vi.fn();
+    expect(normalizeSlackEnvelope(slackEnvelope({ ...event, text: "canary-secret-text" }), onRejected)).toEqual([]);
+    expect(onRejected).toHaveBeenCalledExactlyOnceWith(reason);
   });
 
   it("registers the raw-body route without breaking adjacent JSON parsing", async () => {

--- a/packages/server/src/__tests__/slack-events.test.ts
+++ b/packages/server/src/__tests__/slack-events.test.ts
@@ -1,7 +1,9 @@
 import { createHmac } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
+import { SlackAdapter } from "../services/im-bindings/slack/adapter.js";
 
 const now = new Date("2026-08-20T00:00:00.000Z");
 const timestamp = String(Math.floor(now.getTime() / 1000));
@@ -51,7 +53,43 @@ function matchingBotAuthorization() {
   return [{ team_id: installation().teamId, user_id: installation().botUserId, is_bot: true }];
 }
 
-function createServices(overrides: Record<string, unknown> = {}, loggerStream?: Writable) {
+function loadSlackFileShareFixture(name: "slack-inbound-file-share-png.json" | "slack-inbound-file-share-text.json") {
+  return JSON.parse(readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8")) as {
+    event: Record<string, unknown>;
+  };
+}
+
+function capturingLogger() {
+  let logs = "";
+  const loggerStream = new Writable({
+    write(chunk, _encoding, callback) {
+      logs += chunk.toString();
+      callback();
+    },
+  });
+  return {
+    loggerStream,
+    read: () => logs,
+  };
+}
+
+function realSlackAdapter() {
+  const current = installation();
+  return new SlackAdapter({
+    api: { authTest: vi.fn(), fetchResource: vi.fn() } as never,
+    token: current.botAccessToken,
+    appId: current.appId,
+    teamId: current.teamId,
+    botUserId: current.botUserId,
+    botId: current.botId,
+  });
+}
+
+function createServices(
+  overrides: Record<string, unknown> = {},
+  loggerStream: Writable = new Writable({ write: (_chunk, _encoding, callback) => callback() }),
+  options: { realAdapter?: boolean } = {},
+) {
   const current = installation();
   const routed = defaultRoute();
   const imBindings = {
@@ -63,9 +101,11 @@ function createServices(overrides: Record<string, unknown> = {}, loggerStream?: 
     disableSlackInstallationFromProvider: vi.fn().mockResolvedValue(true),
     requireSlackInstallationReauthorization: vi.fn().mockResolvedValue(true),
   };
-  const inbox = { ingest: vi.fn().mockResolvedValue(undefined) };
+  const inbox = {
+    ingest: vi.fn().mockResolvedValue({ duplicate: false, messageId: "msg-1", deliveryIds: ["del-1"] }),
+  };
   const adapter = { normalizeInbound: vi.fn().mockReturnValue([]) };
-  const createAdapter = vi.fn(() => adapter);
+  const createAdapter = vi.fn(() => (options.realAdapter ? realSlackAdapter() : adapter));
   const app = createApp({
     loggerStream,
     slackEvents: {
@@ -286,7 +326,8 @@ describe("Slack Events API ingress", () => {
     ["wrong Team", [{ team_id: "T2", user_id: "U_BOT", is_bot: true }]],
     ["wrong Bot User", [{ team_id: "T1", user_id: "U_OTHER", is_bot: true }]],
   ])("rejects %s authorizations before ordinary event side effects", async (_label, authorizations) => {
-    const { app, imBindings, inbox, createAdapter } = createServices();
+    const captured = capturingLogger();
+    const { app, imBindings, inbox, createAdapter } = createServices({}, captured.loggerStream);
     const response = await app.inject(
       signedRequest({
         type: "event_callback",
@@ -305,10 +346,12 @@ describe("Slack Events API ingress", () => {
     expect(imBindings.requireSlackInstallationReauthorization).not.toHaveBeenCalled();
     expect(createAdapter).not.toHaveBeenCalled();
     expect(inbox.ingest).not.toHaveBeenCalled();
+    expect(captured.read()).toContain('"reason":"identity_mismatch"');
   });
 
   it("acknowledges a stale generation without running event side effects", async () => {
-    const { app, imBindings, inbox, createAdapter } = createServices();
+    const captured = capturingLogger();
+    const { app, imBindings, inbox, createAdapter } = createServices({}, captured.loggerStream);
     imBindings.recordSlackInstallationIdentityClosure.mockResolvedValue(false);
     const response = await app.inject(
       signedRequest({
@@ -328,10 +371,12 @@ describe("Slack Events API ingress", () => {
     expect(imBindings.disableSlackInstallationFromProvider).not.toHaveBeenCalled();
     expect(createAdapter).not.toHaveBeenCalled();
     expect(inbox.ingest).not.toHaveBeenCalled();
+    expect(captured.read()).toContain('"reason":"generation_changed"');
   });
 
   it("acknowledges verified events without delivery when no default Agent route exists", async () => {
-    const { app, imBindings, inbox, createAdapter } = createServices();
+    const captured = capturingLogger();
+    const { app, imBindings, inbox, createAdapter } = createServices({}, captured.loggerStream);
     imBindings.resolveSlackDefaultRoute.mockResolvedValue(undefined);
     const response = await app.inject(
       signedRequest({
@@ -348,6 +393,7 @@ describe("Slack Events API ingress", () => {
     expect(imBindings.resolveSlackDefaultRoute).toHaveBeenCalledWith(installation().installationId);
     expect(createAdapter).not.toHaveBeenCalled();
     expect(inbox.ingest).not.toHaveBeenCalled();
+    expect(captured.read()).toContain('"reason":"no_route"');
   });
 
   it("disables an uninstalled binding and fences Slack token revocation", async () => {
@@ -424,15 +470,18 @@ describe("Slack Events API ingress", () => {
 
     expect(response.statusCode).toBe(200);
     expect(createAdapter).toHaveBeenCalledWith(current);
-    expect(adapter.normalizeInbound).toHaveBeenCalledWith({
-      eventId: "Ev1",
-      appId: current.appId,
-      teamId: current.teamId,
-      botUserId: current.botUserId,
-      botId: current.botId,
-      event: envelope.event,
-      eventTime: envelope.event_time,
-    });
+    expect(adapter.normalizeInbound).toHaveBeenCalledWith(
+      {
+        eventId: "Ev1",
+        appId: current.appId,
+        teamId: current.teamId,
+        botUserId: current.botUserId,
+        botId: current.botId,
+        event: envelope.event,
+        eventTime: envelope.event_time,
+      },
+      expect.any(Function),
+    );
     expect(inbox.ingest.mock.calls).toEqual([
       [defaultRoute().imBindingId, current.generation, events[0], undefined, { provider: "slack" }],
       [defaultRoute().imBindingId, current.generation, events[1], undefined, { provider: "slack" }],
@@ -567,5 +616,199 @@ describe("Slack Events API ingress", () => {
     expect(response.statusCode).toBe(200);
     expect(createAdapter).not.toHaveBeenCalled();
     expect(inbox.ingest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["text", "slack-inbound-file-share-text.json" as const, "file"],
+    ["png", "slack-inbound-file-share-png.json" as const, "image"],
+  ])("ingests a sanitized production %s file_share fixture through Events", async (_label, fixtureName, kind) => {
+    const captured = capturingLogger();
+    const { app, inbox, createAdapter } = createServices({}, captured.loggerStream, { realAdapter: true });
+    const fixture = loadSlackFileShareFixture(fixtureName);
+    const eventId = `Ev-file-share-${_label}`;
+    const response = await app.inject(
+      signedRequest({
+        type: "event_callback",
+        api_app_id: "A1",
+        team_id: "T1",
+        authorizations: matchingBotAuthorization(),
+        event_id: eventId,
+        event: fixture.event,
+      }),
+    );
+    expect(response.statusCode).toBe(200);
+    expect(createAdapter).toHaveBeenCalled();
+    expect(inbox.ingest).toHaveBeenCalledTimes(1);
+    expect(inbox.ingest.mock.calls[0]?.[2]).toMatchObject({
+      conversation: { kind: "dm" },
+      message: {
+        operation: "created",
+        author: { kind: "human", isSelf: false },
+        resources: [{ kind, providerResourceKey: "F_TEST_1" }],
+      },
+    });
+    const logs = captured.read();
+    expect(logs).toContain(`"eventId":"${eventId}"`);
+    expect(logs).toContain("Slack inbound inbox result");
+    expect(logs).toContain('"messageId":"msg-1"');
+    expect(logs).toContain('"del-1"');
+    expect(logs).not.toContain("[synthetic test request]");
+    expect(logs).not.toContain("xoxb-sensitive");
+    expect(logs).not.toContain("signing-sensitive");
+  });
+
+  it("ingests an empty file_share body and logs ignored or invalid input without leaking canaries", async () => {
+    const captured = capturingLogger();
+    const { app, inbox } = createServices({}, captured.loggerStream, { realAdapter: true });
+    const fixture = loadSlackFileShareFixture("slack-inbound-file-share-text.json");
+    const empty = await app.inject(
+      signedRequest({
+        type: "event_callback",
+        api_app_id: "A1",
+        team_id: "T1",
+        authorizations: matchingBotAuthorization(),
+        event_id: "Ev-empty-file-share",
+        event: { ...fixture.event, text: "" },
+      }),
+    );
+    expect(empty.statusCode).toBe(200);
+    expect(inbox.ingest.mock.calls[0]?.[2]).toMatchObject({
+      message: { content: { fallbackText: "" }, resources: [{ providerResourceKey: "F_TEST_1" }] },
+    });
+
+    const canary = "canary-secret-text";
+    const privateUrl = "https://files.slack.com/private/canary-token";
+    const ignored = await app.inject(
+      signedRequest({
+        type: "event_callback",
+        api_app_id: "A1",
+        team_id: "T1",
+        authorizations: matchingBotAuthorization(),
+        event_id: "Ev-ignored-subtype",
+        event: {
+          type: "message",
+          subtype: "channel_join",
+          channel: "C1",
+          ts: "1.0",
+          text: canary,
+          files: [{ id: "F1", url_private: privateUrl }],
+        },
+      }),
+    );
+    expect(ignored.statusCode).toBe(200);
+    const malformed = await app.inject(
+      signedRequest({
+        type: "event_callback",
+        api_app_id: "A1",
+        team_id: "T1",
+        authorizations: matchingBotAuthorization(),
+        event_id: "Ev-malformed",
+        event: { type: "message", channel: "C1", text: canary },
+      }),
+    );
+    expect(malformed.statusCode).toBe(200);
+    expect(inbox.ingest).toHaveBeenCalledTimes(1);
+    const logs = captured.read();
+    expect(logs).toContain('"reason":"unsupported_subtype"');
+    expect(logs).toContain('"reason":"malformed_supported_event"');
+    expect(logs).not.toContain(canary);
+    expect(logs).not.toContain(privateUrl);
+    expect(logs).not.toContain("canary-token");
+  });
+
+  it("does not ingest a signed receipt retry twice and logs self file_share unchanged", async () => {
+    const receipts = {
+      claim: vi
+        .fn()
+        .mockResolvedValueOnce({ accepted: true, duplicate: false, receiptId: "receipt-share" })
+        .mockResolvedValueOnce({
+          accepted: false,
+          duplicate: true,
+          receiptId: "receipt-share",
+          status: "processed",
+        }),
+      markProcessed: vi.fn().mockResolvedValue(undefined),
+      markFailed: vi.fn(),
+    };
+    const captured = capturingLogger();
+    const { app, inbox } = createServices({ receipts: receipts as never }, captured.loggerStream, {
+      realAdapter: true,
+    });
+    const fixture = loadSlackFileShareFixture("slack-inbound-file-share-text.json");
+    const envelope = {
+      type: "event_callback",
+      api_app_id: "A1",
+      team_id: "T1",
+      authorizations: matchingBotAuthorization(),
+      event_id: "Ev-receipt-retry",
+      event: fixture.event,
+    };
+    expect((await app.inject(signedRequest(envelope))).statusCode).toBe(200);
+    await vi.waitFor(() => expect(inbox.ingest).toHaveBeenCalledTimes(1));
+    expect((await app.inject(signedRequest(envelope))).statusCode).toBe(200);
+    expect(inbox.ingest).toHaveBeenCalledTimes(1);
+    expect(captured.read()).toContain('"reason":"duplicate_receipt"');
+
+    const selfCaptured = capturingLogger();
+    const selfServices = createServices({}, selfCaptured.loggerStream, { realAdapter: true });
+    const selfResponse = await selfServices.app.inject(
+      signedRequest({
+        type: "event_callback",
+        api_app_id: "A1",
+        team_id: "T1",
+        authorizations: matchingBotAuthorization(),
+        event_id: "Ev-self-file-share",
+        event: {
+          type: "message",
+          subtype: "file_share",
+          channel: "D1",
+          channel_type: "im",
+          user: installation().botUserId,
+          text: "",
+          ts: "2.0",
+          files: [{ id: "F_SELF", name: "bot.png", mimetype: "image/png", size: 4 }],
+        },
+      }),
+    );
+    expect(selfResponse.statusCode).toBe(200);
+    expect(selfServices.inbox.ingest.mock.calls[0]?.[2]).toMatchObject({
+      message: { author: { externalId: installation().botUserId, isSelf: true } },
+    });
+  });
+
+  it("observes background processing and receipt persistence failures without leaking error strings", async () => {
+    const captured = capturingLogger();
+    const receipts = {
+      claim: vi.fn().mockResolvedValue({ accepted: true, duplicate: false, receiptId: "receipt-fail" }),
+      markProcessed: vi.fn().mockResolvedValue(undefined),
+      markFailed: vi.fn().mockRejectedValue(new Error("password=super-secret-db-url")),
+    };
+    const { app, inbox } = createServices({ receipts: receipts as never }, captured.loggerStream, {
+      realAdapter: true,
+    });
+    inbox.ingest.mockRejectedValue(new Error("provider processing failed https://files.slack.com/private/x"));
+    const response = await app.inject(
+      signedRequest({
+        type: "event_callback",
+        api_app_id: "A1",
+        team_id: "T1",
+        authorizations: matchingBotAuthorization(),
+        event_id: "Ev-down",
+        event: loadSlackFileShareFixture("slack-inbound-file-share-text.json").event,
+      }),
+    );
+    expect(response.statusCode).toBe(200);
+    await vi.waitFor(() => expect(receipts.markFailed).toHaveBeenCalled());
+    expect(inbox.ingest).toHaveBeenCalledTimes(1);
+    const logs = captured.read();
+    expect(logs).toContain("Slack inbound processing failed");
+    expect(logs).toContain('"reason":"processing_failed"');
+    expect(logs).toContain('"stage":"inbox"');
+    expect(logs).toContain("Slack inbound receipt persistence failed");
+    expect(logs).toContain('"reason":"receipt_persist_failed"');
+    expect(logs).not.toContain("provider processing failed");
+    expect(logs).not.toContain("https://files.slack.com/private/x");
+    expect(logs).not.toContain("password=super-secret-db-url");
+    expect(logs).not.toContain("xoxb-sensitive");
   });
 });

--- a/packages/server/src/api/slack-events.ts
+++ b/packages/server/src/api/slack-events.ts
@@ -1,5 +1,6 @@
 import { AGENT_SLACK_EVENTS_TEMPLATE, SLACK_EVENTS_PATH } from "@opentag/shared";
 import type { FastifyInstance, FastifyReply } from "fastify";
+import { createServiceLoggerPort } from "../observability/service-logger.js";
 import type { ImMessageInbox } from "../services/im/index.js";
 import type { ImBindingService, SlackInstallationIngress } from "../services/im-bindings/index.js";
 import type { SlackAdapter } from "../services/im-bindings/slack/adapter.js";
@@ -20,7 +21,7 @@ interface SlackEnvelopeBase {
 class SlackEventProcessingError extends Error {
   readonly code = "SLACK_EVENT_PROCESSING_FAILED";
 
-  constructor() {
+  constructor(readonly stage: "normalize" | "inbox") {
     super("SLACK_EVENT_PROCESSING_FAILED");
     this.name = "SlackEventProcessingError";
   }
@@ -52,7 +53,17 @@ export interface SlackEventsRouteOptions extends SlackEventsReceiptOptions {
   now?: () => Date;
 }
 
+function slackEventLogContext(installation: SlackInstallationIngress, envelope: SlackEnvelopeBase) {
+  return {
+    provider: "slack",
+    eventId: envelope.event_id?.slice(0, 128),
+    installationId: installation.installationId,
+    generation: installation.generation,
+  };
+}
+
 export function registerSlackEventsRoute(app: FastifyInstance, options: SlackEventsRouteOptions): void {
+  const logger = createServiceLoggerPort(() => app.log, "slack-events");
   app.removeContentTypeParser("application/json");
   app.addContentTypeParser(
     "application/json",
@@ -110,36 +121,71 @@ export function registerSlackEventsRoute(app: FastifyInstance, options: SlackEve
         authorization.team_id === installation.teamId &&
         authorization.user_id === installation.botUserId,
     );
-    if (!identityClosed) return reply.code(401).send({ error: "binding_mismatch" });
+    const logContext = slackEventLogContext(installation, envelope);
+    if (!identityClosed) {
+      logger.info(
+        { ...logContext, stage: "authorize", outcome: "ignored", reason: "identity_mismatch" },
+        "Slack inbound ignored",
+      );
+      return reply.code(401).send({ error: "binding_mismatch" });
+    }
     if (
       !(await options.imBindings.recordSlackInstallationIdentityClosure(
         installation.installationId,
         installation.generation,
       ))
     ) {
+      logger.info(
+        { ...logContext, stage: "authorize", outcome: "ignored", reason: "generation_changed" },
+        "Slack inbound ignored",
+      );
       return reply.code(200).send({ ok: true });
     }
     const routed = await options.imBindings.resolveSlackDefaultRoute(installation.installationId);
-    if (!routed) return reply.code(200).send({ ok: true });
+    if (!routed) {
+      logger.info({ ...logContext, stage: "route", outcome: "ignored", reason: "no_route" }, "Slack inbound ignored");
+      return reply.code(200).send({ ok: true });
+    }
 
+    let stage: "normalize" | "inbox" = "normalize";
     try {
       const adapter = options.createAdapter(installation);
-      const events = adapter.normalizeInbound({
-        eventId: envelope.event_id,
-        appId: installation.appId,
-        teamId: installation.teamId,
-        botUserId: installation.botUserId,
-        botId: installation.botId,
-        event: envelope.event,
-        eventTime: envelope.event_time,
-      });
+      const events = adapter.normalizeInbound(
+        {
+          eventId: envelope.event_id,
+          appId: installation.appId,
+          teamId: installation.teamId,
+          botUserId: installation.botUserId,
+          botId: installation.botId,
+          event: envelope.event,
+          eventTime: envelope.event_time,
+        },
+        (reason) => {
+          const invalid = reason === "malformed_supported_event";
+          logger[invalid ? "warn" : "info"](
+            { ...logContext, stage, outcome: invalid ? "invalid" : "ignored", reason },
+            "Slack inbound rejected",
+          );
+        },
+      );
+      stage = "inbox";
       for (const event of events) {
-        await options.inbox.ingest(routed.imBindingId, installation.generation, event, undefined, {
+        const result = await options.inbox.ingest(routed.imBindingId, installation.generation, event, undefined, {
           provider: "slack",
         });
+        logger.info(
+          {
+            ...logContext,
+            stage,
+            messageId: result?.messageId,
+            deliveryIds: result?.deliveryIds,
+            duplicate: result?.duplicate,
+          },
+          "Slack inbound inbox result",
+        );
       }
     } catch {
-      throw new SlackEventProcessingError();
+      throw new SlackEventProcessingError(stage);
     }
     return reply.code(200).send({ ok: true });
   };
@@ -157,21 +203,46 @@ export function registerSlackEventsRoute(app: FastifyInstance, options: SlackEve
       credentialGeneration: installation.generation,
       eventId: envelope.event_id,
     });
-    if (!claim.accepted || !claim.receiptId) return reply.code(200).send({ ok: true });
+    const logContext = { ...slackEventLogContext(installation, envelope), receiptId: claim.receiptId };
+    if (!claim.accepted || !claim.receiptId) {
+      logger.info(
+        { ...logContext, stage: "receipt", outcome: "ignored", reason: "duplicate_receipt" },
+        "Slack inbound ignored",
+      );
+      return reply.code(200).send({ ok: true });
+    }
     // A real reply object cannot be used after the HTTP request is acknowledged. The work function
     // only uses it to construct status responses, so this sink keeps those responses off the wire.
     const backgroundReply = {
       code: () => backgroundReply,
       send: () => backgroundReply,
     } as unknown as FastifyReply;
+    let stage = "process";
     void processEnvelope(installation, envelope, backgroundReply)
-      .then(() => options.receipts?.markProcessed(claim.receiptId as string))
+      .then(() => {
+        stage = "receipt";
+        return options.receipts?.markProcessed(claim.receiptId as string);
+      })
       .catch(async (error: unknown) => {
         const code =
           error && typeof error === "object" && "code" in error && typeof error.code === "string"
             ? error.code
             : "SLACK_EVENT_PROCESSING_FAILED";
-        await options.receipts?.markFailed(claim.receiptId as string, code).catch(() => undefined);
+        logger.error(
+          {
+            ...logContext,
+            stage: error instanceof SlackEventProcessingError ? error.stage : stage,
+            outcome: "failed",
+            reason: "processing_failed",
+          },
+          "Slack inbound processing failed",
+        );
+        await options.receipts?.markFailed(claim.receiptId as string, code).catch(() => {
+          logger.error(
+            { ...logContext, stage: "receipt", outcome: "failed", reason: "receipt_persist_failed" },
+            "Slack inbound receipt persistence failed",
+          );
+        });
       });
     return reply.code(200).send({ ok: true });
   };

--- a/packages/server/src/services/im-bindings/slack/adapter.ts
+++ b/packages/server/src/services/im-bindings/slack/adapter.ts
@@ -112,11 +112,28 @@ function boundedText(value: string): { text: string; truncated: boolean } {
   return { text: new TextDecoder().decode(encoded.subarray(0, 24 * 1024)), truncated: true };
 }
 
-export function normalizeSlackEnvelope(envelope: VerifiedSlackEnvelope): NormalizedInboundImEvent[] {
+type SlackNormalizationRejection = "malformed_supported_event" | "unsupported_event_type" | "unsupported_subtype";
+type OnSlackNormalizationRejected = (reason: SlackNormalizationRejection) => void;
+
+function invalidSlackEventReason(event: unknown): SlackNormalizationRejection {
+  const type = event && typeof event === "object" && "type" in event ? event.type : undefined;
+  return type === "message" || type === "app_mention" ? "malformed_supported_event" : "unsupported_event_type";
+}
+
+export function normalizeSlackEnvelope(
+  envelope: VerifiedSlackEnvelope,
+  onRejected?: OnSlackNormalizationRejected,
+): NormalizedInboundImEvent[] {
   const parsed = SlackMessageEventSchema.safeParse(envelope.event);
-  if (!parsed.success) return [];
+  if (!parsed.success) {
+    onRejected?.(invalidSlackEventReason(envelope.event));
+    return [];
+  }
   const event = parsed.data;
-  if (event.subtype && !["message_changed", "message_deleted", "bot_message"].includes(event.subtype)) return [];
+  if (event.subtype && !["message_changed", "message_deleted", "bot_message", "file_share"].includes(event.subtype)) {
+    onRejected?.("unsupported_subtype");
+    return [];
+  }
   const operation =
     event.subtype === "message_deleted" ? "deleted" : event.subtype === "message_changed" ? "edited" : "created";
   const nested = operation === "edited" ? event.message : operation === "deleted" ? event.previous_message : undefined;
@@ -222,8 +239,11 @@ export class SlackAdapter implements ImProviderAdapter<VerifiedSlackEnvelope> {
     return { externalAppId: this.#appId, externalTeamId: identity.teamId, externalBotId: identity.botUserId };
   }
 
-  normalizeInbound(input: VerifiedSlackEnvelope): NormalizedInboundImEvent[] {
-    return normalizeSlackEnvelope(input);
+  normalizeInbound(
+    input: VerifiedSlackEnvelope,
+    onRejected?: OnSlackNormalizationRejected,
+  ): NormalizedInboundImEvent[] {
+    return normalizeSlackEnvelope(input, onRejected);
   }
 
   fetchResource(input: ProviderResourceInput): Promise<ReadableResource> {

--- a/scripts/complexity-baseline.json
+++ b/scripts/complexity-baseline.json
@@ -594,13 +594,13 @@
       "id": "packages/server/src/api/slack-events.ts#callback",
       "path": "packages/server/src/api/slack-events.ts",
       "symbol": "callback",
-      "complexity": 20
+      "complexity": 27
     },
     {
       "id": "packages/server/src/api/slack-events.ts#callback~2",
       "path": "packages/server/src/api/slack-events.ts",
       "symbol": "callback",
-      "complexity": 27
+      "complexity": 20
     },
     {
       "id": "packages/server/src/api/slack-events.ts#callback~3",


### PR DESCRIPTION
## Summary

Slack DM uploads with `subtype=file_share` were silently discarded before reaching the inbox. Accept that subtype through the existing message and attachment pipeline, including empty-body uploads, and record ingress rejection reasons, message/delivery identifiers, and asynchronous processing failures through the existing safe logger.

Related to #584. Existing routing, self-message filtering, receipt deduplication, and retry behavior remain in use. The complexity baseline only reorders two anonymous-function entries; the underlying scores remain 20, 21, and 27.

## Testing

Validated commit `b2d0b72b9da72c1ff06d6dc757a0238507d5194a` with Node 24.19.0 and pnpm 10.12.1:

- `pnpm check`, `pnpm build`, and `pnpm typecheck` pass.
- `pnpm test`: 330 script tests and 3,484 Vitest tests pass.
- `pnpm --filter @opentag/client test:agent-runtime:coverage` passes.
- `pnpm --filter @opentag/server test:integration`: 330 tests pass.
- Sanitized production text/PNG fixtures produce zero normalized messages before the fix and one each afterward. Regression coverage includes inbox persistence, empty-body attachments, self messages, webhook retries, channel message/app_mention deduplication, and safe failure logs.

No deployment or fresh production upload acceptance has been performed. The earlier production uploads reproduced the original failure; #584 remains open pending deployed-version acceptance.

## Breaking changes

None.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no documentation changes).
