### PR TITLE
chore(release): prepare CLI 0.0.4

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-tag",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "description": "OpenTag command-line interface for connecting team messaging with AI coding agents.",
   "keywords": [


### PR DESCRIPTION
## Summary

Prepare the stable OpenTag CLI 0.0.4 release from main `aee38b8327966a4c6b6ebb9cefe8c0a42cd4ffe1`. The protected production tag must match the source manifest, so this changes only `apps/cli/package.json` from 0.0.3 to 0.0.4.

The CLI release includes already-merged Provider CLI retry-budget fixes (#573), Context Tree configuration access fixes (#562), and Context Tree 0.1.12 (#577). The version-independent test fixtures introduced in #575 pass without further changes. No product code, dependencies, workflows, or policies are changed by this PR.

## Testing

[Current-head CI](https://github.com/first-tree-ai/opentag/actions/runs/34450931138) passed for `b51080fe5023ed0bf8dc6bac36d16f62f5689df5`, including the full unit suite, 330 PostgreSQL integration tests, 378 Agent Runtime tests at 100% coverage, Node 22.22.2 / 24 / 26 compatibility, and CLI/browser/container smokes. Patch Coverage, Quality Scoreboard, Docker PR image build, and ownership-gate also passed.

- `pnpm check`, `pnpm build`, `pnpm typecheck`, and the complete `pnpm test` passed, including all 434 CLI tests.
- PostgreSQL integration: all 330 tests passed locally.
- Agent Runtime coverage: all 378 tests passed with 100% statements, branches, functions, and lines.
- Four version-related CLI suites: all 40 tests passed with source version 0.0.4.
- Source CLI tarball smoke and production version/tag coordinate validation passed for 0.0.4. Locally, Turbo reused unchanged package test inputs; the CLI, Web, integration, coverage, and explicit smoke suites executed fresh.
- In a separate checkout with the same base and source manifest, actual production `open-tag@0.0.4` build, pack/isolated-install smoke, and portable relocation/Context Tree smoke passed. This supplements CI's fixed 0.0.2 production-channel fixture.

The protected tag and publishing workflows are separate release steps after merge and exact-commit CI/image verification. No production tag or publication is created by this PR.

## Breaking changes

None introduced by this version-only preparation change.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Existing tests cover the version-dependent behavior; no documentation changes are required.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
