### PR TITLE
fix(client): prepare session runtime after report recovery

### DIFF
--- a/packages/client/src/__tests__/agent-turn-runner.test.ts
+++ b/packages/client/src/__tests__/agent-turn-runner.test.ts
@@ -21,7 +21,11 @@ import type { ProviderCliOutgoingReplyCollectResult } from "../runtime/provider-
 import { ProviderCliTurnPlanError } from "../runtime/provider-cli/turn-plan.js";
 import type { ProviderCliTurnPlanPrepareInput } from "../runtime/provider-cli/turn-plan-manager.js";
 import type { RecordedSteerInput, SessionBindingStore } from "../runtime/session-binding-store.js";
-import { ClientRuntimeProviderStartError, type SessionRuntimeManager } from "../runtime/session-runtime-manager.js";
+import {
+  ClientRuntimeProviderStartError,
+  type SessionRuntimeManager,
+  SessionRuntimeNotPreparedError,
+} from "../runtime/session-runtime-manager.js";
 import type { LiveTurnOwner, TurnCustodyOwner } from "../runtime/turn-custody-owner.js";
 import type { TurnReportOwner } from "../runtime/turn-report-owner.js";
 import { type RecordedLog, recordingLogger } from "./recording-logger.js";
@@ -273,6 +277,16 @@ describe("AgentTurnRunner", () => {
       outcome: "failed",
       executionEffects: "not_started",
       errorReason: "provider_start_failed",
+    });
+    expect(completionForError(new SessionRuntimeNotPreparedError(), undefined)).toEqual({
+      outcome: "failed",
+      executionEffects: "not_started",
+      errorReason: "provider_start_failed",
+    });
+    expect(completionForError(new Error("The Session Agent Runtime has not been prepared"), undefined)).toEqual({
+      outcome: "unknown",
+      executionEffects: "may_have_occurred",
+      errorReason: "turn_state_unknown",
     });
     expect(new AgentRuntimeProviderUnavailableError("claude-code", { ready: false, issues: [] }).message).toContain(
       "not ready",
@@ -544,6 +558,76 @@ describe("AgentTurnRunner", () => {
       }),
     );
   });
+
+  it.each(["sessionKind", "ensureRuntime"] as const)(
+    "reports an unprepared Session Runtime from %s as a typed pre-execution failure",
+    async (guard) => {
+      const logs: RecordedLog[] = [];
+      const privateDetail = "private-runtime-detail-that-must-not-be-logged";
+      const unprepared = new SessionRuntimeNotPreparedError();
+      unprepared.message = privateDetail;
+      unprepared.cause = new Error(privateDetail);
+      const ensureRuntime = vi.fn(async () => {
+        throw unprepared;
+      });
+      const turnPlan = {
+        prepare: vi.fn(async () => undefined),
+        cleanup: vi.fn(async () => undefined),
+      };
+      const create = vi.fn((input) => ({
+        ...input,
+        type: "turn:report",
+        requestId: randomUUID(),
+        resultHash: "e".repeat(64),
+      }));
+      const submit = vi.fn(async () => undefined);
+      const environment = credentialEnvironment();
+      const runner = new AgentTurnRunner({
+        bindingStore: { updateUnresolved: vi.fn(async () => undefined) } as unknown as SessionBindingStore,
+        connection: { send: vi.fn(async () => undefined) },
+        custody: {
+          markReporting: vi.fn(async () => undefined),
+          recordResult: vi.fn(),
+        } as unknown as TurnCustodyOwner,
+        logger: recordingLogger(logs),
+        reportOwner: { create, submit } as unknown as TurnReportOwner,
+        runtimeManager: {
+          sessionKind: () => {
+            throw unprepared;
+          },
+          ensureRuntime,
+        } as unknown as SessionRuntimeManager,
+        credentialEnvironment: environment,
+        ...(guard === "sessionKind" ? { turnPlan } : {}),
+      });
+
+      runner.start(liveOwner(delivery()));
+      await runner.settled();
+
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: "failed",
+          executionEffects: "not_started",
+          errorReason: "provider_start_failed",
+        }),
+      );
+      expect(submit).toHaveBeenCalledOnce();
+      expect(turnPlan.prepare).not.toHaveBeenCalled();
+      if (guard === "sessionKind") expect(ensureRuntime).not.toHaveBeenCalled();
+      const failure = logs.find((entry) => entry.message === "Turn failed");
+      expect(failure).toMatchObject({
+        level: "warn",
+        fields: {
+          errorCode: "session_runtime_not_prepared",
+          errorReason: "provider_start_failed",
+          outcome: "failed",
+        },
+      });
+      // Only the allowlisted code is logged: no arbitrary error text, paths, or cause content.
+      expect(failure?.fields).not.toHaveProperty("error");
+      expect(JSON.stringify(logs)).not.toContain(privateDetail);
+    },
+  );
 
   it("prepares a visible Turn plan before Agent Runtime and refuses drifted selections without starting it", async () => {
     const order: string[] = [];

--- a/packages/client/src/__tests__/client-turn.integration.test.ts
+++ b/packages/client/src/__tests__/client-turn.integration.test.ts
@@ -2,11 +2,13 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import type {
-  DirectImMessageDeliveryRequest,
-  EffectiveRuntimeSnapshot,
-  SessionReconcileRequest,
-  TurnReportRequest,
+import {
+  computeDirectInputHash,
+  computeTurnResultHash,
+  type DirectImMessageDeliveryRequest,
+  type EffectiveRuntimeSnapshot,
+  type SessionReconcileRequest,
+  type TurnReportRequest,
 } from "@opentag/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentRuntimeFactory } from "../agent-runtime/types.js";
@@ -249,6 +251,132 @@ describe("Agent Runtime Client Turn vertical", () => {
     await fixture.record(report);
     await fixture.runtimeManager.close();
   });
+
+  it.each(["accepted", "starting", "running", "reporting"] as const)(
+    "reprepares the missing Session Runtime after a replayed %s Turn report",
+    async (phase) => {
+      const fixture = await recoveryFixture(phase);
+
+      // Cold start: the durable unresolved Turn fences the Session for report recovery.
+      const coldRequest = fixture.reconcile();
+      const cold = await fixture.reconciler.reconcile(coldRequest);
+      expect(cold).toMatchObject({
+        status: "recovery_required",
+        reason: "unresolved_turn",
+        turn: { deliveryId: "delivery-1", turnId: "turn-1" },
+      });
+      expect(fixture.prepareSpy).toHaveBeenCalledTimes(1);
+
+      const prepared = await fixture.recovery.prepare(coldRequest, cold);
+      expect(prepared.retainedReports).toHaveLength(1);
+      if (phase !== "reporting") {
+        expect((await fixture.store.read("agent-1", "session-1"))?.unresolvedTurn).toMatchObject({
+          phase: "reporting",
+          report: fixture.expectedRecoveryReport,
+        });
+      }
+      fixture.recovery.afterReconciled(coldRequest, prepared);
+      await vi.waitFor(() => expect(fixture.connection.reports()).toHaveLength(1));
+      const replayed = fixture.connection.reports()[0];
+      expect(replayed).toMatchObject({
+        deliveryId: "delivery-1",
+        turnId: "turn-1",
+        ...fixture.expectedRecoveryReport,
+      });
+      if (!replayed) throw new Error("Expected a replayed Turn Report");
+
+      // While the replayed report awaits its ACK the fence holds: repeated reconciles keep
+      // demanding recovery, new deliveries are rejected, and no provider is ever started.
+      await expect(fixture.reconciler.reconcile(fixture.reconcile())).resolves.toMatchObject({
+        status: "recovery_required",
+        turn: { deliveryId: "delivery-1", turnId: "turn-1" },
+      });
+      const held = delivery(fixture.runtime, "delivery-2", "held behind the fence");
+      expect(fixture.reconciler.checkDelivery(held)).toBe("session_recovery_required");
+      await expect(fixture.custody.accept(held)).resolves.toMatchObject({
+        result: { status: "rejected", reason: "session_recovery_required" },
+      });
+      expect(fixture.clients).toHaveLength(0);
+      expect(fixture.providerReadyCalls()).toBe(0);
+
+      // The ACK records the replayed report and lifts the recovery fence.
+      await fixture.reportOwner.handleResult({
+        type: "turn:report:result",
+        requestId: replayed.requestId,
+        turnId: replayed.turnId,
+        status: "recorded",
+        resultHash: replayed.resultHash,
+      });
+      await vi.waitFor(() => expect(fixture.reconciler.protectedWorkSnapshot().recoveries).toHaveLength(0));
+      expect((await fixture.store.read("agent-1", "session-1"))?.unresolvedTurn).toBeUndefined();
+
+      // An unchanged reconcile must re-prepare the missing runtime entry without starting the provider.
+      await expect(fixture.reconciler.reconcile(fixture.reconcile())).resolves.toMatchObject({ status: "ready" });
+      expect(fixture.prepareSpy).toHaveBeenCalledTimes(2);
+      expect(fixture.runtimeManager.requiresSessionPreparation(fixture.reconcile())).toBe(false);
+      expect(fixture.clients).toHaveLength(0);
+
+      // Repeated unchanged reconciles stay ready without redundant preparation.
+      await expect(fixture.reconciler.reconcile(fixture.reconcile())).resolves.toMatchObject({ status: "ready" });
+      expect(fixture.prepareSpy).toHaveBeenCalledTimes(2);
+
+      // The next Turn resumes the retained provider thread and runs to completion.
+      const decision = await fixture.custody.accept(delivery(fixture.runtime, "delivery-3", "after recovery"));
+      expect(decision.result).toMatchObject({ status: "accepted" });
+      await decision.onAcceptedSent?.();
+      await vi.waitFor(() => expect(fixture.connection.reports().length).toBeGreaterThan(1));
+      const report = fixture.connection.reports()[1];
+      expect(report).toMatchObject({
+        deliveryId: "delivery-3",
+        outcome: "completed",
+        executionEffects: "completed",
+        finalText: "answer-1",
+      });
+      expect(fixture.clients).toHaveLength(1);
+      expect(fixture.clients[0]?.threadId).toBe("retained-thread-before-restart");
+      expect(fixture.clients[0]?.methods).toContain("thread/resume");
+      expect(fixture.clients[0]?.methods).not.toContain("thread/start");
+      if (!report) throw new Error("Expected the post-recovery Turn Report");
+      await fixture.reportOwner.handleResult({
+        type: "turn:report:result",
+        requestId: report.requestId,
+        turnId: report.turnId,
+        status: "recorded",
+        resultHash: report.resultHash,
+      });
+      await vi.waitFor(() => expect(fixture.custody.admission.snapshot().client).toBe(0));
+      const recorded = await fixture.store.read("agent-1", "session-1");
+      expect(recorded?.unresolvedTurn).toBeUndefined();
+      expect(recorded?.runtimeBinding).toEqual(fixture.retainedBinding);
+      expect(recorded?.recentRecordedInputs.at(-1)?.report).toEqual(report);
+      await expect(fixture.reconciler.reconcile(fixture.reconcile())).resolves.toMatchObject({ status: "ready" });
+      await fixture.runtimeManager.ensureRuntime("session-1");
+      expect(fixture.prepareSpy).toHaveBeenCalledTimes(2);
+      expect(fixture.clients).toHaveLength(1);
+      await fixture.runtimeManager.close();
+    },
+  );
+
+  it("keeps a healthy Session Runtime ready without redundant preparation or provider rebuild", async () => {
+    const fixture = await runtimeFixture();
+    await fixture.runtimeManager.ensureRuntime("session-1");
+    const prepareSpy = vi.spyOn(fixture.runtimeManager, "prepareSession");
+
+    await expect(
+      fixture.reconciler.reconcile({ ...fixture.reconcileRequest, requestId: randomUUID() }),
+    ).resolves.toMatchObject({ status: "ready" });
+    await expect(
+      fixture.reconciler.reconcile({ ...fixture.reconcileRequest, requestId: randomUUID() }),
+    ).resolves.toMatchObject({ status: "ready" });
+
+    expect(prepareSpy).not.toHaveBeenCalled();
+    expect(fixture.runtimeManager.requiresSessionPreparation(fixture.reconcileRequest)).toBe(false);
+    await fixture.runtimeManager.ensureRuntime("session-1");
+    expect(fixture.clients).toHaveLength(1);
+    expect(fixture.clients[0]?.methods).toContain("thread/start");
+    expect(fixture.clients[0]?.methods).not.toContain("thread/resume");
+    await fixture.runtimeManager.close();
+  });
 });
 
 async function runtimeFixture(
@@ -270,15 +398,7 @@ async function runtimeFixture(
   const logs: RecordedLog[] = [];
   const factory: AgentRuntimeFactory =
     provider === "codex"
-      ? new CodexAgentRuntimeFactory({
-          clientVersion: "0.0.1",
-          createClient: (cwd) => {
-            const client = new ScriptedTurnClient(cwd, terminalGate);
-            clients.push(client);
-            return client;
-          },
-          probeRunner: async () => ({ appServer: true, credential: true, experimentalTools: true, version: "test" }),
-        })
+      ? codexFactory(clients, terminalGate)
       : new ClaudeCodeAgentRuntimeFactory({
           createSessionId: () => "11111111-1111-4111-8111-111111111111",
           createProcess: (_cwd, args) => {
@@ -298,6 +418,7 @@ async function runtimeFixture(
         });
   const providers = await providerRegistry(factory);
   const runtimeManager = new SessionRuntimeManager({
+    home,
     bindingStore: store,
     ensureProviderReady: (providerId, signal) => providers.ensureReady(providerId, signal),
     providers,
@@ -387,6 +508,179 @@ async function runtimeFixture(
   };
 }
 
+function codexFactory(
+  clients: ScriptedTurnClient[],
+  terminalGate: Promise<void>,
+  newThreadId = "thread-1",
+): AgentRuntimeFactory {
+  return new CodexAgentRuntimeFactory({
+    clientVersion: "0.0.1",
+    createClient: (cwd) => {
+      const client = new ScriptedTurnClient(cwd, terminalGate, newThreadId);
+      clients.push(client);
+      return client;
+    },
+    probeRunner: async () => ({ appServer: true, credential: true, experimentalTools: true, version: "test" }),
+  });
+}
+
+/**
+ * Two daemon lifetimes over one durable home: the first prepares the Session and persists a
+ * provider thread binding, then survives only as durable state; the second rebuilds every
+ * in-memory component the way a cold start does, with the interrupted Turn still unresolved.
+ */
+async function recoveryFixture(phase: "accepted" | "starting" | "running" | "reporting") {
+  const home = await mkdtemp(resolve(tmpdir(), "opentag-runtime-recovery-"));
+  directories.push(home);
+  const computerId = randomUUID();
+  const runtime = snapshot(1, "codex");
+  const reconcile = (): SessionReconcileRequest => ({
+    type: "session:reconcile",
+    requestId: randomUUID(),
+    installationId: computerId,
+    sessionId: "session-1",
+    agentId: "agent-1",
+    placementGeneration: 1,
+    desired: "ready",
+    runtime,
+  });
+
+  // Previous daemon lifetime: prepare the Session and persist the provider thread binding.
+  const seedStore = new SessionBindingStore({ home, providerArtifactIdentity: () => "a".repeat(64) });
+  const seedWorkspace = new AgentWorkspaceManager({ home, bindingStore: seedStore });
+  const seedClients: ScriptedTurnClient[] = [];
+  const seedProviders = await providerRegistry(
+    codexFactory(seedClients, Promise.resolve(), "retained-thread-before-restart"),
+  );
+  const seedManager = new SessionRuntimeManager({
+    home,
+    bindingStore: seedStore,
+    ensureProviderReady: (providerId, signal) => seedProviders.ensureReady(providerId, signal),
+    providers: seedProviders,
+    providerEnvironmentPath: () => "/tmp/provider-env.sh",
+    workspace: seedWorkspace,
+  });
+  const seedReconciler = new SessionReconciler({
+    installationId: computerId,
+    preparation: seedManager,
+    localPolicy: seedManager,
+  });
+  await seedReconciler.reconcile(reconcile());
+  await seedManager.ensureRuntime("session-1");
+  await seedManager.close();
+  expect(seedClients[0]?.threadId).toBe("retained-thread-before-restart");
+  const retainedBinding = (await seedStore.read("agent-1", "session-1"))?.runtimeBinding;
+  expect(retainedBinding).toBeDefined();
+
+  // The interrupted Turn survives only as durable custody in the Session binding.
+  const interrupted = delivery(runtime, "delivery-1", "interrupted");
+  await seedStore.recordAccepted(interrupted, computeDirectInputHash(interrupted), "turn-1");
+  if (phase !== "accepted") await seedStore.updateUnresolved("agent-1", "session-1", "turn-1", "starting");
+  if (phase === "running" || phase === "reporting") {
+    await seedStore.updateUnresolved("agent-1", "session-1", "turn-1", "running");
+  }
+  if (phase === "reporting") {
+    const reportInput = {
+      deliveryId: "delivery-1",
+      turnId: "turn-1",
+      sessionId: "session-1",
+      agentId: "agent-1",
+      placementGeneration: 1,
+      outcome: "completed" as const,
+      executionEffects: "completed" as const,
+      finalText: "interrupted answer",
+      traceSummary: { lastSequence: 0, droppedEvents: 0 },
+    };
+    const report: TurnReportRequest = {
+      type: "turn:report",
+      requestId: randomUUID(),
+      ...reportInput,
+      resultHash: computeTurnResultHash(reportInput),
+    };
+    await seedStore.updateUnresolved("agent-1", "session-1", "turn-1", "reporting", {
+      report,
+      resultHash: report.resultHash,
+    });
+  }
+  const expectedRecoveryReport =
+    phase === "accepted"
+      ? { outcome: "failed", executionEffects: "not_started", errorReason: "provider_start_failed" }
+      : phase === "reporting"
+        ? { outcome: "completed", executionEffects: "completed", finalText: "interrupted answer" }
+        : { outcome: "unknown", executionEffects: "may_have_occurred", errorReason: "turn_state_unknown" };
+
+  // Restart: every in-memory component is rebuilt over the same durable home.
+  const store = new SessionBindingStore({ home, providerArtifactIdentity: () => "a".repeat(64) });
+  const workspace = new AgentWorkspaceManager({ home, bindingStore: store });
+  const connection = new FakeConnection();
+  const reportOwner = new TurnReportOwner({ connection });
+  const clients: ScriptedTurnClient[] = [];
+  const providers = await providerRegistry(codexFactory(clients, Promise.resolve()));
+  let providerReadyCalls = 0;
+  const runtimeManager = new SessionRuntimeManager({
+    home,
+    bindingStore: store,
+    ensureProviderReady: (providerId, signal) => {
+      providerReadyCalls += 1;
+      return providers.ensureReady(providerId, signal);
+    },
+    providers,
+    providerEnvironmentPath: () => "/tmp/provider-env.sh",
+    workspace,
+  });
+  const reconciler = new SessionReconciler({
+    installationId: computerId,
+    preparation: runtimeManager,
+    localPolicy: runtimeManager,
+  });
+  const logs: RecordedLog[] = [];
+  let runner: AgentTurnRunner;
+  const custody = new TurnCustodyOwner({
+    bindingStore: store,
+    reconciler,
+    id: (() => {
+      let next = 1;
+      return () => {
+        next += 1;
+        return `turn-${next}`;
+      };
+    })(),
+    start: (owner) => runner.start(owner),
+  });
+  runner = new AgentTurnRunner({
+    bindingStore: store,
+    connection,
+    custody,
+    reportOwner,
+    runtimeManager,
+    credentialEnvironment: {
+      prepare: async () => ({ path: "/tmp/provider-env.sh", provider: "slack" }),
+      cleanup: async () => undefined,
+    },
+    logger: recordingLogger(logs),
+  });
+  const recovery = new MvpTurnReportRecovery({ bindingStore: store, reconciler, reportOwner });
+  const prepareSpy = vi.spyOn(runtimeManager, "prepareSession");
+  return {
+    clients,
+    connection,
+    custody,
+    expectedRecoveryReport,
+    retainedBinding,
+    logs,
+    prepareSpy,
+    providerReadyCalls: () => providerReadyCalls,
+    reconcile,
+    reconciler,
+    recovery,
+    reportOwner,
+    runner,
+    runtime,
+    runtimeManager,
+    store,
+  };
+}
+
 async function providerRegistry(factory: AgentRuntimeFactory): Promise<AgentRuntimeProviderRegistry> {
   const providers = new AgentRuntimeProviderRegistry([
     {
@@ -438,6 +732,7 @@ class ScriptedTurnClient implements InteractiveCodexAppServerClient {
   readonly cwd: string;
   readonly methods: string[] = [];
   readonly #terminalGate: Promise<void>;
+  readonly #newThreadId: string;
   #listener?: (message: CodexAppServerMessage) => void;
   #turn = 0;
   closed = false;
@@ -445,9 +740,10 @@ class ScriptedTurnClient implements InteractiveCodexAppServerClient {
   threadId?: string;
   developerInstructions?: string;
 
-  constructor(cwd: string, terminalGate: Promise<void>) {
+  constructor(cwd: string, terminalGate: Promise<void>, newThreadId: string) {
     this.cwd = cwd;
     this.#terminalGate = terminalGate;
+    this.#newThreadId = newThreadId;
   }
 
   async initialize(): Promise<void> {
@@ -458,7 +754,7 @@ class ScriptedTurnClient implements InteractiveCodexAppServerClient {
     this.methods.push(method);
     if (method === "thread/start" || method === "thread/resume") {
       const input = params as { cwd: string; developerInstructions: string; threadId?: string };
-      this.threadId = input.threadId ?? "thread-1";
+      this.threadId = input.threadId ?? this.#newThreadId;
       this.developerInstructions = input.developerInstructions;
       return {
         thread: { id: this.threadId, ephemeral: false },

--- a/packages/client/src/__tests__/session-runtime-manager.test.ts
+++ b/packages/client/src/__tests__/session-runtime-manager.test.ts
@@ -29,6 +29,7 @@ import { SessionReconciler } from "../runtime/session-reconciler.js";
 import {
   SessionRuntimeManager as ProductionSessionRuntimeManager,
   type SessionRuntimeManagerOptions,
+  SessionRuntimeNotPreparedError,
 } from "../runtime/session-runtime-manager.js";
 
 class SessionRuntimeManager extends ProductionSessionRuntimeManager {
@@ -85,7 +86,8 @@ describe("SessionRuntimeManager", () => {
       sessionCliProof: { proofId: randomUUID(), token: "p".repeat(32) },
     };
 
-    expect(manager.requiresSessionPreparation(request)).toBe(false);
+    // Without a managed runtime entry the Session always requires preparation.
+    expect(manager.requiresSessionPreparation(request)).toBe(true);
     await expect(reconciler.reconcile(request)).resolves.toMatchObject({ status: "ready" });
     expect(manager.sessionKind(request.sessionId)).toBe("internal");
     await manager.ensureRuntime(request.sessionId);
@@ -476,7 +478,7 @@ describe("SessionRuntimeManager", () => {
     });
     const first = reconcile(computerId, snapshot(1));
 
-    expect(() => manager.sessionKind(first.sessionId)).toThrow("has not been prepared");
+    expect(() => manager.sessionKind(first.sessionId)).toThrow(SessionRuntimeNotPreparedError);
     await expect(reconciler.reconcile(first)).resolves.toMatchObject({ status: "ready" });
     expect(manager.sessionKind(first.sessionId)).toBe("visible");
     await manager.ensureRuntime("session-1");
@@ -569,8 +571,11 @@ describe("SessionRuntimeManager", () => {
       "configuration_unsupported",
     );
     expect(() => registered.runtime("missing")).toThrow("not ready");
-    await expect(registered.ensureRuntime("missing")).rejects.toThrow("not been prepared");
-    expect(() => registered.cwd("missing")).toThrow("not been prepared");
+    const unprepared = await registered.ensureRuntime("missing").catch((error: unknown) => error);
+    expect(unprepared).toBeInstanceOf(SessionRuntimeNotPreparedError);
+    expect((unprepared as SessionRuntimeNotPreparedError).code).toBe("session_runtime_not_prepared");
+    expect((unprepared as Error).message).toBe("The Session Agent Runtime has not been prepared");
+    expect(() => registered.cwd("missing")).toThrow(SessionRuntimeNotPreparedError);
     expect(() => registered.observe("missing", () => undefined)).toThrow("not ready");
     const stopSession = vi.fn(async () => undefined);
     const cleanupProviderEnvironment = vi.fn(async () => undefined);
@@ -584,6 +589,25 @@ describe("SessionRuntimeManager", () => {
     await expect(stoppable.stopSession("missing", 1)).resolves.toBeUndefined();
     expect(stopSession).toHaveBeenCalledWith("missing", 1);
     expect(cleanupProviderEnvironment).toHaveBeenCalledWith("missing");
+  });
+
+  it("fails an unprepared Session before any provider readiness probe or factory call", async () => {
+    const ensureProviderReady = vi.fn(async () => undefined);
+    const factory = new FakeFactory();
+    const manager = new ProductionSessionRuntimeManager({
+      bindingStore: {} as SessionBindingStore,
+      ensureProviderReady,
+      providers: await providerRegistry(factory),
+      providerEnvironmentPath: () => "/tmp/provider-env.sh",
+      workspace: {} as AgentWorkspaceManager,
+    });
+
+    await expect(manager.ensureRuntime("missing")).rejects.toThrow(SessionRuntimeNotPreparedError);
+    expect(() => manager.sessionKind("missing")).toThrow(SessionRuntimeNotPreparedError);
+    expect(() => manager.cwd("missing")).toThrow(SessionRuntimeNotPreparedError);
+    expect(ensureProviderReady).not.toHaveBeenCalled();
+    expect(factory.created).toHaveLength(0);
+    expect(factory.resumed).toHaveLength(0);
   });
 
   it("closes a runtime that cannot produce a durable binding", async () => {

--- a/packages/client/src/runtime/agent-turn-runner.ts
+++ b/packages/client/src/runtime/agent-turn-runner.ts
@@ -34,7 +34,11 @@ import type { ProviderCliTurnPlanPrepareInput } from "./provider-cli/turn-plan-m
 import { buildProviderOutboxInstructions } from "./provider-outbox-instructions.js";
 import type { RuntimeConnection } from "./runtime-connection.js";
 import type { SessionBindingStore } from "./session-binding-store.js";
-import { ClientRuntimeProviderStartError, type SessionRuntimeManager } from "./session-runtime-manager.js";
+import {
+  ClientRuntimeProviderStartError,
+  type SessionRuntimeManager,
+  SessionRuntimeNotPreparedError,
+} from "./session-runtime-manager.js";
 import { TurnTraceBuffer } from "./trace-buffer.js";
 import type { LiveTurnOwner, TurnCustodyOwner } from "./turn-custody-owner.js";
 import type { TurnReportOwner } from "./turn-report-owner.js";
@@ -510,6 +514,9 @@ function errorFieldsForLog(error: unknown): { errorCode?: string } {
   if (error instanceof ImCredentialEnvironmentError || error instanceof ProviderCliTurnPlanError) {
     return { errorCode: error.code };
   }
+  if (error instanceof SessionRuntimeNotPreparedError) {
+    return { errorCode: error.code };
+  }
   return {};
 }
 
@@ -533,6 +540,10 @@ export function completionForError(error: unknown, abortReason: unknown): TurnCo
     };
   }
   if (error instanceof ClientRuntimeProviderStartError) {
+    return { outcome: "failed", executionEffects: "not_started", errorReason: "provider_start_failed" };
+  }
+  if (error instanceof SessionRuntimeNotPreparedError) {
+    // The runner accesses Session metadata and ensures its runtime before dispatching the prompt.
     return { outcome: "failed", executionEffects: "not_started", errorReason: "provider_start_failed" };
   }
   return { outcome: "unknown", executionEffects: "may_have_occurred", errorReason: "turn_state_unknown" };

--- a/packages/client/src/runtime/session-runtime-manager.ts
+++ b/packages/client/src/runtime/session-runtime-manager.ts
@@ -46,6 +46,19 @@ export class ClientRuntimeProviderStartError extends Error {
   }
 }
 
+/**
+ * The manager has no prepared runtime entry for a Session. The fixed code identifies this
+ * local readiness failure in logs without including paths, credentials, or cause content.
+ */
+export class SessionRuntimeNotPreparedError extends Error {
+  readonly code = "session_runtime_not_prepared" as const;
+
+  constructor() {
+    super("The Session Agent Runtime has not been prepared");
+    this.name = "SessionRuntimeNotPreparedError";
+  }
+}
+
 export interface SessionRuntimeManagerOptions {
   readonly bindingStore: SessionBindingStore;
   readonly cliCommand?: string;
@@ -126,7 +139,9 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
 
   requiresSessionPreparation(request: SessionReconcileRequest): boolean {
     const current = this.#sessions.get(request.sessionId);
-    if (!current) return false;
+    // A missing entry always requires preparation: report recovery can leave the Reconciler
+    // holding a ready Session whose runtime entry this manager never recorded.
+    if (!current) return true;
     return current.proofId !== request.sessionCliProof?.proofId;
   }
 
@@ -209,7 +224,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   async ensureRuntime(sessionId: string, signal?: AbortSignal): Promise<AgentRuntime> {
     this.#assertOpen();
     const managed = this.#sessions.get(sessionId);
-    if (!managed) throw new Error("The Session Agent Runtime has not been prepared");
+    if (!managed) throw new SessionRuntimeNotPreparedError();
     await this.#ensureProviderReady(managed.providerId, signal);
     this.#assertOpen();
     if (managed.runtime && managed.runtime.state.phase !== "closed") return managed.runtime;
@@ -230,7 +245,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
 
   sessionKind(sessionId: string): "visible" | "internal" {
     const managed = this.#sessions.get(sessionId);
-    if (!managed) throw new Error("The Session Agent Runtime has not been prepared");
+    if (!managed) throw new SessionRuntimeNotPreparedError();
     return managed.sessionKind;
   }
 
@@ -389,7 +404,7 @@ export class SessionRuntimeManager implements RuntimePreparation, RuntimeLocalPo
   cwd(sessionId: string): string {
     this.#assertOpen();
     const managed = this.#sessions.get(sessionId);
-    if (!managed) throw new Error("The Session Agent Runtime has not been prepared");
+    if (!managed) throw new SessionRuntimeNotPreparedError();
     return managed.cwd;
   }
 


### PR DESCRIPTION
## Summary

After a daemon restart with an unresolved Turn, report replay could clear the recovery fence while the runtime manager still had no prepared Session. An unchanged reconcile then reported ready without preparing it, and the next message failed before provider execution.

- Request preparation when the manager's Session entry is absent. The existing recovery fence still blocks delivery until the old report is acknowledged, and the original provider binding is resumed.
- Classify the typed local readiness failure as `failed / not_started / provider_start_failed`, with the fixed `session_runtime_not_prepared` warning code. Arbitrary exceptions retain the conservative unknown classification, and error messages/causes are not added to these logs.
- Extend the existing Client Turn integration fixture through two daemon lifetimes, all four unresolved phases, report ACK, unchanged reconcile, preserved Codex thread identity, and completion/ACK of the next Turn. Repeated reconciliation and a healthy runtime must not be rebuilt.

Refs #591. The issue and this PR belong to existing Codex task `01a08a34-16bd-7610-aedc-ff51dc0b0db1`.

## Testing

- The final integration tests fail on the old missing-entry logic in all four pending phases (4 failed, 9 passed); the fix passes all 13 tests. An always-prepare mutation fails 5 tests, including the healthy-runtime check.
- Agent Runtime coverage: all four metrics remain 100%. Tests also verify safe logging with a poisoned message/cause and conservative classification of an untyped error with the same text.
- `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass (full Client suite: 1101 tests). Unchanged package tests reuse valid Turbo cache entries.
- `pnpm --filter @opentag/client test:agent-runtime:coverage` passes: 386 tests and 100% statements, branches, functions, and lines.
- `pnpm --filter @opentag/server test:integration` passes: 330 tests across 18 PostgreSQL suites.

Provider transport/probes and IM credentials are controlled test boundaries. These are repository component regressions; real staging Slack restart/recovery acceptance remains with the overall release regression task after an authorized deployment.

## Breaking changes

None. No wire schema, persistence schema, dependency, or deployment changes.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable (no documentation changes).
