### PR TITLE
fix(web): preserve theme styling and report external attribute changes

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="opentag" data-mode="light">
+<html lang="en" data-opentag-theme="opentag" data-opentag-mode="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/messages/common/en.json
+++ b/apps/web/messages/common/en.json
@@ -7,6 +7,8 @@
   "common_add": "Add",
   "common_agent_setup_lab": "Agent Setup lab",
   "common_agent_setup_lab_description": "The Agent Setup presentation against its in-memory adapter, reaching no Server.",
+  "common_appearance_changed_description": "The page appearance settings were modified. If the page looks wrong or does not respond as expected, temporarily disable browser extensions that may affect this site, then refresh the page.",
+  "common_appearance_changed_title": "Page appearance settings changed",
   "common_back": "Back",
   "common_cancel": "Cancel",
   "common_close": "Close",

--- a/apps/web/messages/common/zh.json
+++ b/apps/web/messages/common/zh.json
@@ -7,6 +7,8 @@
   "common_add": "添加",
   "common_agent_setup_lab": "Agent Setup 实验室",
   "common_agent_setup_lab_description": "使用内存 Adapter 展示 Agent Setup，不会访问 Server。",
+  "common_appearance_changed_description": "检测到页面显示设置被修改。如果页面显示或操作异常，请暂时关闭可能影响此网站的浏览器扩展，然后刷新页面。",
+  "common_appearance_changed_title": "页面显示设置发生变化",
   "common_back": "返回",
   "common_cancel": "取消",
   "common_close": "关闭",

--- a/apps/web/src/__tests__/setup.ts
+++ b/apps/web/src/__tests__/setup.ts
@@ -1,5 +1,5 @@
 import { cleanup } from "@testing-library/react";
-import { afterEach, vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 import { resetReportedMilestones } from "../analytics/milestones.js";
 import { overwriteGetLocale, overwriteSetLocale } from "../paraglide/runtime.js";
 
@@ -59,6 +59,15 @@ class TestResizeObserver {
 vi.stubGlobal("ResizeObserver", TestResizeObserver);
 
 vi.stubGlobal("fetch", vi.fn());
+
+beforeEach(() => {
+  // Model the static index.html scaffold: OpenTag's namespaced theme identity is present and the
+  // generic attributes are absent. Tests that exercise the theme integrity notice rewrite them.
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.removeAttribute("data-mode");
+  document.documentElement.setAttribute("data-opentag-theme", "opentag");
+  document.documentElement.setAttribute("data-opentag-mode", "light");
+});
 
 afterEach(async () => {
   cleanup();

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -10,9 +10,11 @@
 @source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
 
 /* OpenTag brand tokens. Keep usage constraints next to the values so a new surface does not
- * accidentally turn an inaccessible accent into body copy. */
-:root[data-theme="opentag"],
-[data-theme="opentag"] {
+ * accidentally turn an inaccessible accent into body copy.
+ * The namespaced attribute is the theme identity: third-party code that rewrites the generic
+ * data-theme or data-mode attributes must not be able to strip the OpenTag palette. */
+:root[data-opentag-theme="opentag"],
+[data-opentag-theme="opentag"] {
   --brand: #8fdd14; /* logo green — fills, color blocks, icons ONLY; never a text color */
   --brand-display: #649a0e; /* display green — text at >= 24px only (large headings) */
   --brand-ink: #3a5c04; /* body-level green — green text at normal sizes uses this */
@@ -34,8 +36,8 @@
 
 /* Kumo semantic base. These aliases make the application canvas, surfaces, text, and borders
  * inherit the OpenTag palette without changing Kumo component internals. */
-:root[data-theme="opentag"],
-[data-theme="opentag"] {
+:root[data-opentag-theme="opentag"],
+[data-opentag-theme="opentag"] {
   --color-kumo-canvas: var(--bg);
   --color-kumo-elevated: var(--surface-elevated);
   --color-kumo-recessed: var(--surface-recessed);

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -61,14 +61,15 @@
   --text-color-kumo-link: var(--brand-ink);
 }
 
-/* Select the supplied artwork from the app theme, including locally themed surfaces. */
+/* Select the supplied artwork from the app theme, including locally themed surfaces. The :root
+ * default keeps the light artwork readable when the namespaced theme identity is missing. */
 :root,
-[data-mode="light"] {
+[data-opentag-mode="light"] {
   --opentag-logo-light-display: block;
   --opentag-logo-dark-display: none;
 }
 
-[data-mode="dark"] {
+[data-opentag-mode="dark"] {
   --opentag-logo-light-display: none;
   --opentag-logo-dark-display: block;
 }

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -4,6 +4,7 @@ import { Link as RouterLink, RouterProvider } from "@tanstack/react-router";
 import { forwardRef, useEffect, useState } from "react";
 import { installRouteAnalytics } from "./analytics/route-analytics.js";
 import { AppErrorBoundary } from "./features/error-boundary.js";
+import { ThemeIntegrityNotice } from "./features/theme-integrity-notice.js";
 import { createQueryClient } from "./query/client.js";
 import { type AppRouter, createAppRouter } from "./router.js";
 
@@ -44,6 +45,8 @@ export function App({ router }: { router?: AppRouter } = {}) {
       <QueryClientProvider client={queryClient}>
         <LinkProvider component={AppLink}>
           <TooltipProvider>
+            {/* Mounted once above the routes so a route change keeps the dismissal. */}
+            <ThemeIntegrityNotice />
             <RouterProvider router={instance} />
           </TooltipProvider>
         </LinkProvider>

--- a/apps/web/src/assets/opentag/README.md
+++ b/apps/web/src/assets/opentag/README.md
@@ -3,7 +3,7 @@
 Official SVG files supplied in `OpenTag-SVG-Essentials-2/opentag_svg` on 2026-09-11. These copies retain the original
 paths, colors, proportions, and transparent backgrounds. A nonvisual `OpenTag` title was added to files that lacked one.
 
-`ui/opentag-logo.tsx` selects the light or dark artwork using the app's `data-mode` theme:
+`ui/opentag-logo.tsx` selects the light or dark artwork using the app's `data-opentag-mode` theme:
 
 - `lockup-*-transparent.svg`: combined logo and lettering on the sign-in and registration page.
 - `logo-*-transparent.svg`: the standalone OpenTag mark in shared brand treatments.

--- a/apps/web/src/features/theme-integrity-notice.test.tsx
+++ b/apps/web/src/features/theme-integrity-notice.test.tsx
@@ -1,0 +1,156 @@
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installApi, resetWebAppState } from "../__tests__/support/app-fixtures.js";
+import { App } from "../app.js";
+import { ThemeIntegrityNotice } from "./theme-integrity-notice.js";
+
+const root = () => document.documentElement;
+
+/** MutationObserver batches are delivered asynchronously; give one task turn before asserting. */
+async function flushMutations() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("ThemeIntegrityNotice", () => {
+  it("stays silent on a clean document, same-value writes, and unrelated mutations", async () => {
+    render(<ThemeIntegrityNotice />);
+    expect(screen.queryByRole("status")).toBeNull();
+
+    await act(async () => {
+      // Unrelated attributes, classes, and same-value writes of the watched attributes.
+      root().setAttribute("lang", "zh");
+      root().setAttribute("class", "embedded");
+      root().setAttribute("data-ui", "outside");
+      root().setAttribute("data-opentag-theme", "opentag");
+      root().setAttribute("data-opentag-mode", "light");
+    });
+    await flushMutations();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("reports drift that already happened before the mount without rewriting it", () => {
+    root().setAttribute("data-theme", "light");
+    render(<ThemeIntegrityNotice />);
+    expect(screen.getByRole("status").textContent).toContain("Page appearance settings changed");
+    // The detector only reads: the root keeps exactly the values outside code left behind.
+    expect(root().getAttribute("data-theme")).toBe("light");
+    expect(root().getAttribute("data-opentag-theme")).toBe("opentag");
+    expect(root().getAttribute("data-opentag-mode")).toBe("light");
+  });
+
+  it("reports a missing OpenTag theme identity before the mount", () => {
+    root().removeAttribute("data-opentag-theme");
+    render(<ThemeIntegrityNotice />);
+    expect(screen.getByRole("status").textContent).toContain("Page appearance settings changed");
+  });
+
+  it.each([
+    ["data-theme", "light"],
+    ["data-mode", "dark"],
+    ["data-opentag-theme", "light"],
+    ["data-opentag-mode", "dark"],
+  ])("reports a later write to %s", async (attribute, value) => {
+    render(<ThemeIntegrityNotice />);
+    await act(async () => {
+      root().setAttribute(attribute, value);
+    });
+    expect((await screen.findByRole("status")).textContent).toContain("Page appearance settings changed");
+  });
+
+  it("reports a change that was restored inside the same mutation batch", async () => {
+    render(<ThemeIntegrityNotice />);
+    await act(async () => {
+      root().setAttribute("data-theme", "light");
+      root().removeAttribute("data-theme");
+    });
+    expect((await screen.findByRole("status")).textContent).toContain("Page appearance settings changed");
+  });
+
+  it("reports a restored own-theme write without rewriting any root attribute itself", async () => {
+    render(<ThemeIntegrityNotice />);
+    await act(async () => {
+      root().setAttribute("data-opentag-theme", "light");
+      root().setAttribute("data-opentag-theme", "opentag");
+    });
+    await screen.findByRole("status");
+    // The restored value is the one outside code left behind, not something the detector wrote.
+    expect(root().getAttribute("data-opentag-theme")).toBe("opentag");
+    expect(root().getAttribute("data-opentag-mode")).toBe("light");
+    expect(root().getAttribute("data-theme")).toBeNull();
+  });
+
+  it("hides on dismissal and does not warn again on this mount", async () => {
+    root().setAttribute("data-theme", "light");
+    render(<ThemeIntegrityNotice />);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("status")).toBeNull();
+
+    await act(async () => {
+      root().setAttribute("data-mode", "dark");
+    });
+    await flushMutations();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("announces politely from a local light-theme wrapper", () => {
+    root().setAttribute("data-theme", "light");
+    render(<ThemeIntegrityNotice />);
+    const notice = screen.getByRole("status");
+    const wrapper = notice.closest('[data-ui="theme-integrity-notice"]') as HTMLElement;
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.getAttribute("data-opentag-theme")).toBe("opentag");
+    expect(wrapper.getAttribute("data-opentag-mode")).toBe("light");
+  });
+
+  it("disconnects on unmount and mounts cleanly under StrictMode", async () => {
+    const disconnect = vi.spyOn(MutationObserver.prototype, "disconnect");
+    const { unmount } = render(
+      <StrictMode>
+        <ThemeIntegrityNotice />
+      </StrictMode>,
+    );
+    await act(async () => {
+      root().setAttribute("data-theme", "light");
+    });
+    // Exactly one notice even though StrictMode runs the effect twice.
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+    unmount();
+    // The StrictMode remount cleanup and the final unmount both disconnect.
+    expect(disconnect).toHaveBeenCalled();
+    await act(async () => {
+      root().setAttribute("data-mode", "dark");
+    });
+    await flushMutations();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("surfaces through the App above the route content and keeps dismissal across navigation", async () => {
+    installApi();
+    resetWebAppState();
+    root().setAttribute("data-theme", "light");
+    render(<App />);
+
+    // The App renders other polite live regions (for example the route loader), so the notice is
+    // located through its own wrapper.
+    const noticeWrapper = await screen.findByText("Page appearance settings changed").then((title) => {
+      const wrapper = title.closest('[data-ui="theme-integrity-notice"]');
+      if (!wrapper) throw new Error("notice wrapper missing");
+      return wrapper as HTMLElement;
+    });
+    const notice = within(noticeWrapper).getByRole("status");
+    const main = await screen.findByRole("main");
+    expect(notice.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    fireEvent.click(within(noticeWrapper).getByRole("button", { name: "Close" }));
+    expect(document.querySelector('[data-ui="theme-integrity-notice"]')).toBeNull();
+
+    fireEvent.click(await screen.findByRole("link", { name: "Open Reviewer" }));
+    await screen.findByRole("heading", { name: "Reviewer" });
+    expect(document.querySelector('[data-ui="theme-integrity-notice"]')).toBeNull();
+  });
+});

--- a/apps/web/src/features/theme-integrity-notice.tsx
+++ b/apps/web/src/features/theme-integrity-notice.tsx
@@ -72,7 +72,18 @@ export function ThemeIntegrityNotice() {
 
   if (!tampered || dismissed) return null;
   return (
-    <div data-opentag-mode="light" data-opentag-theme="opentag" data-ui="theme-integrity-notice">
+    /*
+     * The wrapper's local theme scope does not cover Kumo status tokens: a root rewritten into a
+     * generic dark mode would re-theme the warning banner into poor contrast over the warm light
+     * page. Keep the banner surface on existing Kumo/Tailwind light palette primitives — static
+     * strings so Tailwind emits them, the same pattern as the button emphasis adapter.
+     */
+    <div
+      className="[color-scheme:light] [--text-color-kumo-warning:var(--color-orange-800)] [--color-kumo-warning-tint:var(--color-yellow-100)]"
+      data-opentag-mode="light"
+      data-opentag-theme="opentag"
+      data-ui="theme-integrity-notice"
+    >
       <Banner
         action={
           <Button

--- a/apps/web/src/features/theme-integrity-notice.tsx
+++ b/apps/web/src/features/theme-integrity-notice.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import * as m from "../paraglide/messages.js";
+import { Banner, Button, Icon } from "../ui/design-system.js";
+
+/*
+ * The document's theme identity lives on the root element's data-opentag-* attributes (see
+ * app.css). Outside code can rewrite those attributes — or set the generic data-theme/data-mode
+ * the scaffold deliberately leaves unset — and detach the palette. This observer watches exactly
+ * those four attributes on the root element only: no subtree, style, class, or content scanning,
+ * so the notice's own local theme attributes below can never trip it. It only reads; rewriting a
+ * root attribute would fight the same outside code for control of the document.
+ */
+const WATCHED_ATTRIBUTES = ["data-theme", "data-mode", "data-opentag-theme", "data-opentag-mode"] as const;
+
+type WatchedAttribute = (typeof WATCHED_ATTRIBUTES)[number];
+
+/** The scaffold index.html ships: generic attributes absent, OpenTag's own pinned to light. */
+const EXPECTED_VALUES: Record<WatchedAttribute, string | null> = {
+  "data-theme": null,
+  "data-mode": null,
+  "data-opentag-theme": "opentag",
+  "data-opentag-mode": "light",
+};
+
+function hasDrifted(): boolean {
+  return WATCHED_ATTRIBUTES.some(
+    (attribute) => document.documentElement.getAttribute(attribute) !== EXPECTED_VALUES[attribute],
+  );
+}
+
+function recordsDrift(records: MutationRecord[]): boolean {
+  // The final snapshot first: a change that is still in effect when the batch is delivered.
+  if (hasDrifted()) return true;
+  // A change restored inside the same batch leaves no trace in the final values; the records'
+  // old values are the only place it still shows.
+  return records.some((record) => {
+    if (record.type !== "attributes") return false;
+    const attribute = record.attributeName ?? "";
+    if (!(WATCHED_ATTRIBUTES as readonly string[]).includes(attribute)) return false;
+    return record.oldValue !== EXPECTED_VALUES[attribute as WatchedAttribute];
+  });
+}
+
+/**
+ * One dismissible warning per App mount when the document's theme attributes drift from the
+ * shipped scaffold. Rendered in normal flow above the route content; the wrapper republishes the
+ * light theme locally so the notice keeps its palette even if the root attributes are gone.
+ */
+export function ThemeIntegrityNotice() {
+  const [tampered, setTampered] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    // Drift that predates React (an early content script) is visible in the initial snapshot, so
+    // check before observing. Once drift is found there is nothing more to watch for this mount.
+    if (hasDrifted()) {
+      setTampered(true);
+      return;
+    }
+    const observer = new MutationObserver((records) => {
+      if (!recordsDrift(records)) return;
+      setTampered(true);
+      observer.disconnect();
+    });
+    observer.observe(document.documentElement, {
+      attributeFilter: [...WATCHED_ATTRIBUTES],
+      attributeOldValue: true,
+      attributes: true,
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  if (!tampered || dismissed) return null;
+  return (
+    <div data-opentag-mode="light" data-opentag-theme="opentag" data-ui="theme-integrity-notice">
+      <Banner
+        action={
+          <Button
+            aria-label={m.common_close()}
+            onClick={() => setDismissed(true)}
+            shape="square"
+            size="compact"
+            variant="ghost"
+          >
+            <Icon name="close" />
+          </Button>
+        }
+        description={m.common_appearance_changed_description()}
+        role="status"
+        title={m.common_appearance_changed_title()}
+        variant="alert"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/onboarding-v2/layout.test.ts
+++ b/apps/web/src/onboarding-v2/layout.test.ts
@@ -42,8 +42,8 @@ describe("onboarding flow layout", () => {
     expect(declarationValue(".otv2-codex-mark--dark", "display")).toBe("none");
 
     const stylesheetText = stylesheet.toString();
-    expect(stylesheetText).toContain('[data-mode="dark"] .otv2-codex-mark--light');
-    expect(stylesheetText).toContain('[data-mode="dark"] .otv2-codex-mark--dark');
+    expect(stylesheetText).toContain('[data-opentag-mode="dark"] .otv2-codex-mark--light');
+    expect(stylesheetText).toContain('[data-opentag-mode="dark"] .otv2-codex-mark--dark');
     expect(stylesheetText).not.toContain("prefers-color-scheme");
   });
 

--- a/apps/web/src/onboarding-v2/onboarding-v2.css
+++ b/apps/web/src/onboarding-v2/onboarding-v2.css
@@ -23,15 +23,15 @@
   display: none;
 }
 
-:root[data-theme="opentag"][data-mode="dark"] .otv2-codex-mark--light,
-[data-theme="opentag"][data-mode="dark"] .otv2-codex-mark--light,
-[data-theme="opentag"] [data-mode="dark"] .otv2-codex-mark--light {
+:root[data-opentag-theme="opentag"][data-opentag-mode="dark"] .otv2-codex-mark--light,
+[data-opentag-theme="opentag"][data-opentag-mode="dark"] .otv2-codex-mark--light,
+[data-opentag-theme="opentag"] [data-opentag-mode="dark"] .otv2-codex-mark--light {
   display: none;
 }
 
-:root[data-theme="opentag"][data-mode="dark"] .otv2-codex-mark--dark,
-[data-theme="opentag"][data-mode="dark"] .otv2-codex-mark--dark,
-[data-theme="opentag"] [data-mode="dark"] .otv2-codex-mark--dark {
+:root[data-opentag-theme="opentag"][data-opentag-mode="dark"] .otv2-codex-mark--dark,
+[data-opentag-theme="opentag"][data-opentag-mode="dark"] .otv2-codex-mark--dark,
+[data-opentag-theme="opentag"] [data-opentag-mode="dark"] .otv2-codex-mark--dark {
   display: block;
 }
 

--- a/apps/web/src/ui/KUMO.md
+++ b/apps/web/src/ui/KUMO.md
@@ -79,6 +79,11 @@ element only — initial state plus later mutations, including a value changed a
 one mutation batch — and shows one dismissible, localized warning per App mount when they drift
 from the shipped scaffold. It is deliberately read-only: it never rewrites a root attribute, and
 it does not attempt to detect arbitrary injected styles or other DOM modifications exhaustively.
+Kumo status tokens are not part of the notice's local theme scope, so the wrapper additionally
+pins the banner's warning text and tint through component-local Tailwind arbitrary properties
+(with `color-scheme: light`) on existing Kumo/Tailwind light palette primitives — otherwise a
+generic dark mode written onto the root re-themes the banner into poor contrast over the warm
+light page.
 
 ## Router links and overlays
 

--- a/apps/web/src/ui/KUMO.md
+++ b/apps/web/src/ui/KUMO.md
@@ -62,11 +62,23 @@ buttons at runtime, so the adapter replaces that mix with reviewed primary and
 danger gradients. The theme contrast test verifies every rendered gradient
 endpoint for normal-text WCAG AA, not only the source accent.
 
-The theme uses explicit `data-theme="opentag"` and `data-mode="light|dark"`
-attributes. The product currently ships light mode; dark values remain available
-for compatibility and future completion, not as a supported product theme.
+The theme uses explicit `data-opentag-theme="opentag"` and `data-opentag-mode="light|dark"`
+attributes, set statically on `<html>` in `index.html`. The namespacing keeps third-party code
+that rewrites the generic `data-theme` or `data-mode` attributes from detaching OpenTag's
+selectors from the document, and tokens stay on the root element so body-mounted Dialog, Select,
+and Tooltip portals inherit them. Emphasis buttons additionally carry literal light-palette
+fallbacks inside their `var(--opentag-button-…, …)` overrides — in `buttonClassName` they must be
+static strings for Tailwind scanning — so an emphasis surface stays accessible even when no
+ancestor resolves the OpenTag tokens. The product currently ships light mode; dark values remain
+available for compatibility and future completion, not as a supported product theme.
 Brand values were chosen for readable text and button contrast in both modes;
 do not add raw colour literals to page components.
+
+`src/features/theme-integrity-notice.tsx` watches the same four theme attributes on the root
+element only — initial state plus later mutations, including a value changed and restored within
+one mutation batch — and shows one dismissible, localized warning per App mount when they drift
+from the shipped scaffold. It is deliberately read-only: it never rewrites a root attribute, and
+it does not attempt to detect arbitrary injected styles or other DOM modifications exhaustively.
 
 ## Router links and overlays
 

--- a/apps/web/src/ui/design-system.test.tsx
+++ b/apps/web/src/ui/design-system.test.tsx
@@ -16,6 +16,7 @@ import {
   StatusIndicator,
   Tabs,
 } from "./design-system.js";
+import { kumoThemeTokens } from "./kumo-theme.tokens.js";
 
 describe("Kumo semantic adapter", () => {
   it("maps legacy button intents to Kumo variants", () => {
@@ -47,10 +48,14 @@ describe("Kumo semantic adapter", () => {
     );
     const primary = screen.getByRole("button", { name: "Create" });
     const danger = screen.getByRole("button", { name: "Delete" });
-    expect(primary.className).toContain("[--kumo-button-emphasis-bg:var(--opentag-button-primary-bg)]");
-    expect(danger.className).toContain("[--kumo-button-emphasis-bg:var(--opentag-button-danger-bg)]");
-    expect(primary.style.getPropertyValue("--kumo-button-emphasis-bg")).toBe("var(--opentag-button-primary-bg)");
-    expect(danger.style.getPropertyValue("--kumo-button-emphasis-bg")).toBe("var(--opentag-button-danger-bg)");
+    expect(primary.className).toContain("[--kumo-button-emphasis-bg:var(--opentag-button-primary-bg,#3a5c04)]");
+    expect(danger.className).toContain("[--kumo-button-emphasis-bg:var(--opentag-button-danger-bg,#b42318)]");
+    expect(primary.style.getPropertyValue("--kumo-button-emphasis-bg")).toBe(
+      `var(--opentag-button-primary-bg, ${kumoThemeTokens.light.buttonBackground})`,
+    );
+    expect(danger.style.getPropertyValue("--kumo-button-emphasis-bg")).toBe(
+      `var(--opentag-button-danger-bg, ${kumoThemeTokens.light.dangerButtonBackground})`,
+    );
   });
 
   it("provides labelled Kumo tabs and settings rows", () => {

--- a/apps/web/src/ui/design-system.tsx
+++ b/apps/web/src/ui/design-system.tsx
@@ -90,6 +90,7 @@ import {
   useRef,
 } from "react";
 import * as m from "../paraglide/messages.js";
+import { kumoThemeTokens } from "./kumo-theme.tokens.js";
 
 export {
   Banner,
@@ -169,13 +170,18 @@ export function buttonClassName({
   size?: ButtonProps["size"];
   variant?: ButtonVariant;
 } = {}): string {
+  // Tailwind arbitrary properties must stay static strings, so the literal fallbacks below
+  // repeat the reviewed light palette from kumo-theme.tokens.ts; the theme identity test
+  // rejects any drift. The fallback keeps an emphasis button on an accessible surface even
+  // when no ancestor resolves the OpenTag token (for example a portal mounted outside the
+  // themed root, or third-party markup sitting above it).
   return classes(
     buttonVariants({ variant: kumoButtonVariant(variant), size: size === "compact" ? "sm" : "base" }),
     "justify-center",
     variant === "primary" &&
-      "[--kumo-button-emphasis-bg:var(--opentag-button-primary-bg)] [--kumo-button-emphasis-gradient-end:var(--opentag-button-primary-gradient-end)] [--kumo-button-emphasis-gradient-start:var(--opentag-button-primary-gradient-start)] [--kumo-button-emphasis-ring:var(--opentag-button-primary-ring)]",
+      "[--kumo-button-emphasis-bg:var(--opentag-button-primary-bg,#3a5c04)] [--kumo-button-emphasis-gradient-end:var(--opentag-button-primary-gradient-end,#3a5c04)] [--kumo-button-emphasis-gradient-start:var(--opentag-button-primary-gradient-start,#4b7308)] [--kumo-button-emphasis-ring:var(--opentag-button-primary-ring,#2f4a03)]",
     variant === "danger" &&
-      "[--kumo-button-emphasis-bg:var(--opentag-button-danger-bg)] [--kumo-button-emphasis-gradient-end:var(--opentag-button-danger-gradient-end)] [--kumo-button-emphasis-gradient-start:var(--opentag-button-danger-gradient-start)] [--kumo-button-emphasis-ring:var(--opentag-button-danger-ring)]",
+      "[--kumo-button-emphasis-bg:var(--opentag-button-danger-bg,#b42318)] [--kumo-button-emphasis-gradient-end:var(--opentag-button-danger-gradient-end,#a61b13)] [--kumo-button-emphasis-gradient-start:var(--opentag-button-danger-gradient-start,#c12c20)] [--kumo-button-emphasis-ring:var(--opentag-button-danger-ring,#88180f)]",
     className,
   );
 }
@@ -187,14 +193,33 @@ type EmphasisButtonStyle = CSSProperties & {
   "--kumo-button-emphasis-ring": string;
 };
 
+/* Literal fallbacks come from the canonical light palette so the inline custom properties stay
+ * as accessible as the themed value when the token itself cannot resolve. Dark scopes keep
+ * working because a defined token always wins over the fallback. */
+const emphasisFallbacks = {
+  primary: {
+    bg: kumoThemeTokens.light.buttonBackground,
+    gradientEnd: kumoThemeTokens.light.buttonGradientEnd,
+    gradientStart: kumoThemeTokens.light.buttonGradientStart,
+    ring: kumoThemeTokens.light.buttonRing,
+  },
+  danger: {
+    bg: kumoThemeTokens.light.dangerButtonBackground,
+    gradientEnd: kumoThemeTokens.light.dangerButtonGradientEnd,
+    gradientStart: kumoThemeTokens.light.dangerButtonGradientStart,
+    ring: kumoThemeTokens.light.dangerButtonRing,
+  },
+} as const;
+
 function emphasisButtonStyle(variant: ButtonVariant): EmphasisButtonStyle | undefined {
   const intent = variant === "primary" ? "primary" : variant === "danger" ? "danger" : undefined;
   if (!intent) return undefined;
+  const fallback = emphasisFallbacks[intent];
   return {
-    "--kumo-button-emphasis-bg": `var(--opentag-button-${intent}-bg)`,
-    "--kumo-button-emphasis-gradient-end": `var(--opentag-button-${intent}-gradient-end)`,
-    "--kumo-button-emphasis-gradient-start": `var(--opentag-button-${intent}-gradient-start)`,
-    "--kumo-button-emphasis-ring": `var(--opentag-button-${intent}-ring)`,
+    "--kumo-button-emphasis-bg": `var(--opentag-button-${intent}-bg, ${fallback.bg})`,
+    "--kumo-button-emphasis-gradient-end": `var(--opentag-button-${intent}-gradient-end, ${fallback.gradientEnd})`,
+    "--kumo-button-emphasis-gradient-start": `var(--opentag-button-${intent}-gradient-start, ${fallback.gradientStart})`,
+    "--kumo-button-emphasis-ring": `var(--opentag-button-${intent}-ring, ${fallback.ring})`,
   };
 }
 

--- a/apps/web/src/ui/kumo-contract.test.ts
+++ b/apps/web/src/ui/kumo-contract.test.ts
@@ -180,6 +180,9 @@ describe("Kumo integration contract", () => {
       "setup/setup.css",
       "ui/kumo-theme.css",
       "ui/kumo-theme.tokens.ts",
+      // Button emphasis fallbacks must be literal because Tailwind only scans static class
+      // strings; theme-identity.test pins them to the canonical kumoThemeTokens.light values.
+      "ui/design-system.tsx",
       // Google's provider identity has reviewed colors independent of the OpenTag semantic palette.
       "features/auth/google-sign-in.css",
     ]);

--- a/apps/web/src/ui/kumo-theme.css
+++ b/apps/web/src/ui/kumo-theme.css
@@ -1,6 +1,6 @@
 /* Generated from kumo-theme.tokens.ts. Do not edit node_modules Kumo styles. */
-:root[data-theme="opentag"],
-[data-theme="opentag"] {
+:root[data-opentag-theme="opentag"],
+[data-opentag-theme="opentag"] {
   --color-kumo-brand: #3a5c04;
   --color-kumo-brand-hover: #2f4a03;
   --text-color-kumo-brand: #3a5c04;
@@ -16,9 +16,9 @@
   --opentag-button-danger-ring: #88180f;
 }
 
-:root[data-theme="opentag"][data-mode="dark"],
-[data-theme="opentag"][data-mode="dark"],
-[data-theme="opentag"] [data-mode="dark"] {
+:root[data-opentag-theme="opentag"][data-opentag-mode="dark"],
+[data-opentag-theme="opentag"][data-opentag-mode="dark"],
+[data-opentag-theme="opentag"] [data-opentag-mode="dark"] {
   --color-kumo-brand: #8fdd14;
   --color-kumo-brand-hover: #a8ec45;
   --text-color-kumo-brand: #8fdd14;

--- a/apps/web/src/ui/kumo-theme.tokens.test.ts
+++ b/apps/web/src/ui/kumo-theme.tokens.test.ts
@@ -54,8 +54,8 @@ describe("OpenTag Kumo theme contrast", () => {
 function runtimeThemeTokens(mode: ThemeMode): RuntimeThemeTokens {
   const declarations = new Map<string, string>();
   stylesheet.walkRules((rule) => {
-    if (!rule.selectors.some((selector) => selector.includes('[data-theme="opentag"]'))) return;
-    const darkRule = rule.selectors.some((selector) => selector.includes('[data-mode="dark"]'));
+    if (!rule.selectors.some((selector) => selector.includes('[data-opentag-theme="opentag"]'))) return;
+    const darkRule = rule.selectors.some((selector) => selector.includes('[data-opentag-mode="dark"]'));
     if (darkRule !== (mode === "dark")) return;
     rule.walkDecls((declaration) => {
       declarations.set(declaration.prop, declaration.value);

--- a/apps/web/src/ui/theme-identity.test.tsx
+++ b/apps/web/src/ui/theme-identity.test.tsx
@@ -1,0 +1,204 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { render, screen } from "@testing-library/react";
+import postcss, { type Root } from "postcss";
+import { afterEach, describe, expect, it } from "vitest";
+import { Button, buttonClassName, Dialog } from "./design-system.js";
+import { kumoThemeTokens } from "./kumo-theme.tokens.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const webRoot = resolve(here, "..", "..");
+const sourceRoot = resolve(webRoot, "src");
+const indexHtml = readFileSync(resolve(webRoot, "index.html"), "utf8");
+const kumoThemeCss = postcss.parse(readFileSync(resolve(here, "kumo-theme.css"), "utf8"));
+const designSystemSource = readFileSync(resolve(here, "design-system.tsx"), "utf8");
+const stylesheets = readdirSync(sourceRoot, { recursive: true, withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith(".css"))
+  .map((entry) => ({
+    path: relative(sourceRoot, resolve(entry.parentPath, entry.name)).replaceAll("\\", "/"),
+    root: postcss.parse(readFileSync(resolve(entry.parentPath, entry.name), "utf8")),
+  }));
+
+const THEME_ATTRIBUTE = "data-opentag-theme";
+const MODE_ATTRIBUTE = "data-opentag-mode";
+const themedRootSelector = `[${THEME_ATTRIBUTE}="opentag"]`;
+
+/** Applies the `<html>` attributes from the static index.html to the test document. */
+function applyStaticThemeIdentity(): void {
+  const attributes = indexHtml.match(/<html\b([^>]*)>/)?.[1] ?? "";
+  for (const match of attributes.matchAll(/([\w-]+)="([^"]*)"/g)) {
+    const name = match[1];
+    const value = match[2];
+    if (!name || value === undefined) continue;
+    document.documentElement.setAttribute(name, value);
+  }
+}
+
+/** Compound selectors only — the ones that can match the root element directly. */
+function compoundSelectors(stylesheet: Root): string[] {
+  const selectors: string[] = [];
+  stylesheet.walkRules((rule) => {
+    for (const selector of rule.selectors) {
+      if (!selector.includes(" ")) selectors.push(selector);
+    }
+  });
+  return selectors;
+}
+
+afterEach(() => {
+  for (const name of [THEME_ATTRIBUTE, MODE_ATTRIBUTE, "data-theme", "data-mode", "lang"]) {
+    document.documentElement.removeAttribute(name);
+  }
+});
+
+describe("OpenTag theme identity", () => {
+  it("initializes the namespaced theme identity statically in index.html", () => {
+    const htmlTag = indexHtml.match(/<html\b[^>]*>/)?.[0] ?? "";
+    expect(htmlTag).toContain(`${THEME_ATTRIBUTE}="opentag"`);
+    expect(htmlTag).toContain(`${MODE_ATTRIBUTE}="light"`);
+    // The generic attributes stay unset: they belong to outside code, never to the app theme.
+    expect(htmlTag).not.toMatch(/\sdata-theme[=\s]/);
+    expect(htmlTag).not.toMatch(/\sdata-mode[=\s]/);
+  });
+
+  it("keys theme state only on the namespaced attributes across application stylesheets", () => {
+    expect(stylesheets.length).toBeGreaterThan(0);
+    for (const { path, root } of stylesheets) {
+      root.walkRules((rule) => {
+        for (const selector of rule.selectors) {
+          expect(selector, `${path} keys on a generic attribute: ${selector}`).not.toMatch(
+            /\[data-(?:theme|mode)[\]=~|^$*]/,
+          );
+        }
+      });
+    }
+    // The supported scoped dark override keeps its nested form under the namespaced attributes.
+    expect(kumoThemeCss.toString()).toContain(`${themedRootSelector} [${MODE_ATTRIBUTE}="dark"]`);
+  });
+
+  it("scopes every palette token declaration to the namespaced theme attribute", () => {
+    let checked = 0;
+    for (const { path, root } of stylesheets) {
+      root.walkRules((rule) => {
+        let declaresPalette = false;
+        rule.walkDecls((declaration) => {
+          if (
+            declaration.prop === "--brand" ||
+            declaration.prop === "--color-kumo-canvas" ||
+            declaration.prop.startsWith("--opentag-")
+          ) {
+            declaresPalette = true;
+          }
+        });
+        if (!declaresPalette) return;
+        checked += 1;
+        for (const selector of rule.selectors) {
+          expect(selector, `${path} declares palette tokens outside the theme scope: ${selector}`).toContain(
+            themedRootSelector,
+          );
+        }
+      });
+    }
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  it("keeps OpenTag selectors matching the root when the generic theme attributes change", () => {
+    applyStaticThemeIdentity();
+    const root = document.documentElement;
+    const lightSelectors = compoundSelectors(kumoThemeCss).filter(
+      (selector) => !selector.includes(`[${MODE_ATTRIBUTE}="dark"]`),
+    );
+    const darkSelectors = compoundSelectors(kumoThemeCss).filter((selector) =>
+      selector.includes(`[${MODE_ATTRIBUTE}="dark"]`),
+    );
+    expect(lightSelectors.length).toBeGreaterThan(0);
+    expect(darkSelectors.length).toBeGreaterThan(0);
+
+    for (const selector of lightSelectors) expect(root.matches(selector), selector).toBe(true);
+    for (const selector of darkSelectors) expect(root.matches(selector), selector).toBe(false);
+
+    // Outside code rewriting the generic attributes must not detach or re-mode the app theme.
+    root.setAttribute("data-theme", "light");
+    root.setAttribute("data-mode", "dark");
+    for (const selector of lightSelectors) expect(root.matches(selector), selector).toBe(true);
+    for (const selector of darkSelectors) expect(root.matches(selector), selector).toBe(false);
+  });
+
+  it("lets body-mounted portals inherit the root theme scope", () => {
+    applyStaticThemeIdentity();
+    // Even with the generic attributes overwritten, the themed root stays the token ancestor.
+    document.documentElement.setAttribute("data-theme", "light");
+    render(
+      <Dialog title="Theme probe" onClose={() => undefined}>
+        <Button>Continue</Button>
+      </Dialog>,
+    );
+    const dialog = screen.getByRole("dialog");
+    // jsdom does not compute styles; this asserts the DOM contract that custom-property
+    // inheritance relies on: a portal mounted on body still descends from the themed root.
+    expect(document.body.contains(dialog)).toBe(true);
+    expect(dialog.closest(themedRootSelector)).toBe(document.documentElement);
+  });
+});
+
+describe("emphasis button fallbacks", () => {
+  const emphasisContracts = [
+    {
+      intent: "primary",
+      tokens: [
+        ["bg", "buttonBackground"],
+        ["gradient-start", "buttonGradientStart"],
+        ["gradient-end", "buttonGradientEnd"],
+        ["ring", "buttonRing"],
+      ],
+    },
+    {
+      intent: "danger",
+      tokens: [
+        ["bg", "dangerButtonBackground"],
+        ["gradient-start", "dangerButtonGradientStart"],
+        ["gradient-end", "dangerButtonGradientEnd"],
+        ["ring", "dangerButtonRing"],
+      ],
+    },
+  ] as const;
+
+  it("resolves every emphasis custom property with a canonical light-palette fallback", () => {
+    render(
+      <>
+        <Button variant="primary">Create</Button>
+        <Button variant="danger">Delete</Button>
+      </>,
+    );
+    const buttons = {
+      danger: screen.getByRole("button", { name: "Delete" }),
+      primary: screen.getByRole("button", { name: "Create" }),
+    } as const;
+    for (const { intent, tokens } of emphasisContracts) {
+      for (const [slot, tokenName] of tokens) {
+        const token = `--opentag-button-${intent}-${slot}`;
+        const fallback: string = kumoThemeTokens.light[tokenName];
+        // Button sets the override inline; links receive it through buttonClassName instead.
+        expect(buttons[intent].style.getPropertyValue(`--kumo-button-emphasis-${slot}`)).toBe(
+          `var(${token}, ${fallback})`,
+        );
+        expect(buttonClassName({ variant: intent })).toContain(
+          `[--kumo-button-emphasis-${slot}:var(${token},${fallback})]`,
+        );
+      }
+    }
+  });
+
+  it("pins every raw color literal in the adapter to the canonical light palette", () => {
+    // Tailwind only scans static class strings, so the buttonClassName fallbacks repeat palette
+    // literals; any other raw color in the adapter is a contract breach. The fallback set is
+    // exactly the WCAG-verified light button surfaces from the contrast test.
+    const paletteValues = new Set<string>(Object.values(kumoThemeTokens.light));
+    const literals = designSystemSource.match(/#[\da-f]{6}\b/gi) ?? [];
+    expect(literals.length).toBeGreaterThan(0);
+    for (const literal of literals) {
+      expect(paletteValues.has(literal.toLowerCase()), literal).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/ui/theme-identity.test.tsx
+++ b/apps/web/src/ui/theme-identity.test.tsx
@@ -83,10 +83,12 @@ describe("OpenTag theme identity", () => {
       root.walkRules((rule) => {
         let declaresPalette = false;
         rule.walkDecls((declaration) => {
+          // The OpenTag palette is the button surfaces; --opentag-logo-*-display flags are layout
+          // switches with light defaults on :root, not colors, so they stay out of this scope.
           if (
             declaration.prop === "--brand" ||
             declaration.prop === "--color-kumo-canvas" ||
-            declaration.prop.startsWith("--opentag-")
+            declaration.prop.startsWith("--opentag-button-")
           ) {
             declaresPalette = true;
           }

--- a/e2e/tests/app.spec.ts
+++ b/e2e/tests/app.spec.ts
@@ -53,7 +53,7 @@ test("Agent Setup renders the destination step and contains the Codex mark", asy
 
   await expectContainedDimensions();
   await page.emulateMedia({ colorScheme: "dark" });
-  await expect(page.locator("html")).toHaveAttribute("data-mode", "light");
+  await expect(page.locator("html")).toHaveAttribute("data-opentag-mode", "light");
   await expect(lightMark).toHaveCSS("display", "block");
   await expect(darkMark).toHaveCSS("display", "none");
   await page.setViewportSize({ width: 390, height: 844 });


### PR DESCRIPTION
## Summary

External code overwriting `html[data-theme]` could detach OpenTag's palette and leave the onboarding Continue button as white text on a transparent background. Move app, onboarding, and official-artwork theme selectors to `data-opentag-theme` / `data-opentag-mode`, and give shared primary/danger buttons literal palette fallbacks.

Add a dismissible, localized notice when the four related root attributes differ from the shipped scaffold, including preexisting conflicts and changes restored within one mutation batch. The notice keeps its own local theme and warning colors even when generic dark mode is injected, preserves focus and interaction, and stays dismissed across client-side navigation. It never rewrites attributes and does not claim to detect every injected stylesheet or identify an extension.

## Testing

- `pnpm install`, `pnpm check`, `pnpm build`, `pnpm typecheck`: passed.
- `pnpm test`: passed, 330 script tests and 3,565 package tests (including 883 Web tests).
- Before the final component-local CSS adjustment, `pnpm --filter @opentag/client test:agent-runtime:coverage`: 386 tests passed; statements, branches, functions, and lines all 100%.
- Before that CSS adjustment, `pnpm --filter @opentag/server test:integration`: the first parallel run hit two container-startup timeouts before assertions and was stopped. A standalone container probe passed, then the complete suite passed serially with `pnpm --filter @opentag/server exec vitest run src/__tests__/integration --maxWorkers=1`: 330/330 tests. No server code, timeout, or assertion changed.
- Targeted theme identity / notice / Kumo contract tests: 32/32 passed. Generic attribute mutation tests only; no extension-specific regression added.
- Commit and push hooks passed.

## UI validation

Production build at `b98289b78489c7105e558344db8623c4922fd0a4`, inspected using isolated native Chrome for Testing 151 on macOS. No browser extension was enabled.

- Desktop evidence: captured a 1440 × 900 full-page screenshot with generic `data-theme=kumo` and `data-mode=dark`; measured button background/foreground and warning colors. The warning retains 6.86:1 text contrast, and the official light artwork remains selected.
- Mobile evidence: captured the 320px layout and inspected 390px; the localized warning wraps without covering Continue. Screenshots and measurements are retained in this task's local review artifacts.
- Widths checked: `320px` / `390px` / `768px` / `1440px`; document scroll width equals viewport width at each size. The notice adds normal-flow vertical space.
- States verified: clean reload; 2,000 same-value attribute writes without false positives; simultaneous generic theme/mode rewrite; deletion of both namespaced attributes; dismissal followed by further writes; and a changed-and-restored mutation batch. The final production build was reloaded to remove all temporary browser trial styles.
- Keyboard/accessibility checks: focus returns to the selected local Computer; Tab reaches Continue and Enter advances while the notice is visible. The close button works; the notice uses a polite status role. Screen-reader spoken output was not tested.
- New reusable block, theme value, or CSS exception: app-level `ThemeIntegrityNotice`, namespaced identity, and button fallbacks using the existing reviewed palette. Notice-local properties use existing Kumo/Tailwind warning primitives. No global CSS exception, vendor edit, new dependency, or new color literal.

## Breaking changes

None to public APIs. Internal theme selectors now use the OpenTag namespace; theme documentation and generic selector contracts are updated.

## Checklist

- [x] The change is focused and contains no unrelated work.
- [x] Tests and documentation cover the changed behavior.
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` pass.
- [x] No credentials, private data, or generated build output are included.
- [x] Canonical English docs and Chinese mirrors are synchronized when applicable.
