### PR TITLE
chore(release): prepare CLI 0.0.5

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-tag",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "description": "OpenTag command-line interface for connecting team messaging with AI coding agents.",
   "keywords": [


### PR DESCRIPTION
Prepare OpenTag CLI 0.0.5 from main revision 6e3271ff742462e49903a9121588e4a452f534ab. Only the source CLI version changes from 0.0.4 to 0.0.5; the source package remains private. The release includes the published CLI and the corresponding production Server/Web image.

Validation on this base:
- Frozen install, pnpm check, build, typecheck, 332 script tests and 3,624 package unit tests passed.
- Agent Runtime: 386 tests passed, with 100% statements, branches, functions and lines.
- PostgreSQL integration: 334 tests passed using the equivalent single-worker Vitest command.
- Source CLI pack smoke and isolated production open-tag@0.0.5 build, typecheck, tarball installation and portable application smoke passed.

The base dependency-update CI reported 40 unverified secret candidates in the auto-generated merge commit message. An exact-range local scan resolved them to 10 public upstream Git commit IDs, each independently verified against the upstream GitHub commit API; the repeated findings are detector/decoder variants. No credential was found in the changed source files. Scanner configuration and branch protection remain unchanged. The merged release revision must pass all normal CI before publishing.
